### PR TITLE
Test: perf_microbenchmark: add op_to_op_latency benchmark

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -43,6 +43,7 @@ cmake --build build_Release --target test_op_to_op_latency -j
 ```bash
 export TT_METAL_HOME=$(pwd)
 export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1   # needed for chip-level dispatch markers used by --use-realtime-profiler
 
 cmake --build build_Release --target test_op_to_op_latency -j
 
@@ -55,6 +56,27 @@ cmake --build build_Release --target test_op_to_op_latency -j
 
 python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py \
   --input-file "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv"
+```
+
+### Recommended steady-state configuration
+
+For a representative measurement (per-trid double-buffered reader, writer flushed on back-pressure,
+end-of-kernel `noc_async_writes_flushed` instead of full barrier, trace mode with warmup, drop the
+first two transitions in the export):
+
+```bash
+./build_Release/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency \
+  --num-active-cores 80 \
+  --input-cb-depth-tiles 12 --output-cb-depth-tiles 16 \
+  --num-pages-per-core 16 --compute-nops 2000 \
+  --num-programs 8 --use-trace --trace-warmup-replays 2 \
+  --reader-dbuf-trid --reader-trid-in-flight 2 --reader-push-tiles 2 \
+  --writer-flush-on-pressure --writer-end-barrier-mode 1 \
+  --use-device-profiler --use-realtime-profiler
+
+python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py \
+  --input-file "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv" \
+  --min-prog-id 3
 ```
 
 ### Multiple runs (recommended for HW review)
@@ -113,32 +135,76 @@ Optional: `export TT_METAL_PROFILER_CPP_POST_PROCESS=1` for kernel-duration summ
 | flag | default | meaning |
 |---|---:|---|
 | `--num-pages-per-core N` | 4 | interleaved DRAM pages per core (≥ 1) |
+| `--num-active-cores N` | 0 (full grid) | cap active cores; 0 uses the full worker grid. Used for core-count sweeps |
 | `--reader-push-tiles N` | 2 | reader `reserve_back` / push chunk size |
-| `--input-cb-depth-tiles N` | 0 (auto 2×push) | input CB depth in tiles (output CB stays 2) |
-| `--reader-batch-push` | off | reserve N, read all, `push_back(N)`; default is read+`push_back(1)` per tile in chunk |
+| `--input-cb-depth-tiles N` | 0 (auto 2×push) | input CB depth in tiles |
+| `--output-cb-depth-tiles N` | 0 (default 2) | output CB depth in tiles |
+| `--reader-batch-push` | off | reader mode 1: reserve N, read all, single barrier, `push_back(N)` |
+| `--reader-dbuf-trid` | off | reader mode 2: per-trid double-buffer (TRID A/B alternating across two CB slots). Requires `input_cb_depth ≥ 2 × reader_trid_in_flight × page_size_tiles` |
+| `--reader-trid-in-flight N` | 2 | reads in flight per TRID when reader mode 2 is on (bump for higher per-core BW; needs deeper input CB) |
+| `--page-size-tiles N` | 1 | DRAM page size in tiles (requires `--reader-dbuf-trid` when > 1) |
 | `--compute-nops N` | 0 | `TTI_NOP`s per tile; tune so math work is comfortably > 10 µs |
 | `--num-programs N` | 8 | back-to-back enqueues per measurement |
 | `--use-trace` | off | capture-once / replay-once instead of FD loop |
+| `--trace-warmup-replays N` | 0 | untimed trace replays before the measured replay (reach steady-state trace path; use 2 for steady-state runs) |
 | `--use-device-profiler` | off | dump `profile_log_device.csv` after `Finish` |
-| `--use-realtime-profiler` | off | log per-chip program gaps after timed section (see below) |
+| `--use-realtime-profiler` | off | log per-chip dispatch done/go after timed section (see below) |
 | `--no-warmup` | off | skip untimed warmup enqueue |
 | `--trace-region-size N` | 1 MiB | trace buffer (bytes) |
 | `--device-id N` | 0 | physical device |
-| `--output-cb-depth-tiles N` | 0 (default 2) | output CB depth in tiles |
-| `--buffer-tune` | off | sweep input CB depth for DRAM BW, then op-to-op at smallest depth at peak BW |
-| `--buffer-tune-input-depths LIST` | `2,4,6,8,12,16,24,32` | comma-separated depths for BW sweep |
-| `--buffer-tune-output-depths LIST` | (none) | optional output CB depth sweep after input tune |
-| `--buffer-tune-pages-per-core N` | 32 | tiles/core during BW phase (NOP compute → DRAM bound) |
-| `--buffer-tune-bw-tolerance PCT` | 2 | depths within PCT% of peak BW count as “at peak” |
+| `--read-only` | off | reader pops, writer skips DRAM writes. `bytes_per_program` drops from `2× tiles× tile_size` to `1×` (reads only) |
+| `--writer-flush-on-pressure` | off | writer only calls `noc_async_writes_flushed` when the output CB is about to back-pressure, instead of every tile |
+| `--writer-end-barrier-mode N` | 0 | end-of-kernel synchronization: 0 = `noc_async_write_barrier` (waits for DRAM ACK), 1 = `noc_async_writes_flushed` (waits for L1 drain only), 2 = none |
+| `--cross-program-dram-offset` | off | each program reads/writes a disjoint DRAM tile slice (host allocates `(num_programs+1)×` size). Use to avoid trace replay reusing warm DRAM rows across programs |
+| `--buffer-tune` | off | sweep CB depths for DRAM BW, then run op-to-op at the smallest depth within tolerance of peak BW |
+| `--buffer-tune-grid` | off | full input × output CB grid sweep (requires `--buffer-tune-output-depths`) |
+| `--buffer-tune-bw-only` | off | exit after the BW sweep, skip the latency phase (useful for chart scripts that drive their own latency runs) |
+| `--buffer-tune-input-depths LIST` | `2,4,6,8,12,16,24,32` | comma-separated depths for the input CB sweep |
+| `--buffer-tune-output-depths LIST` | (none) | optional output CB depth sweep after input tune (required for `--buffer-tune-grid`) |
+| `--buffer-tune-pages-per-core N` | 32 | tiles/core during the BW phase (NOP compute → DRAM bound) |
+| `--buffer-tune-bw-tolerance PCT` | 2 | depths within PCT% of peak BW count as "at peak" |
 
 ## Buffer tune (`--buffer-tune`)
 
 1. Reader **push-2** (double buffer), **compute-nops 0**, large `--buffer-tune-pages-per-core`.
-2. For each `--buffer-tune-input-depths` value: one timed program, log **`dram_pipeline_gbps`** (read+write bytes / wall time).
-3. Pick **smallest** input depth within tolerance of peak BW.
-4. Re-run **`--num-programs`** with `--num-pages-per-core` / `--compute-nops` from the normal CLI (latency phase) and optional profilers.
+2. For each `--buffer-tune-input-depths` value: one timed program, log **`dram_pipeline_gbps`** = `bytes_per_program / elapsed_us`.
+   - `bytes_per_program = 2 × tiles × tile_size` (reads + writes summed); drops to `1×` when `--read-only` is set.
+   - `elapsed_us` is wall-clock from right before `replay_mesh_trace` to right after `Finish(cq)`. With `num_programs=1` in the tune phase there are no inter-program gaps in the window — but trace replay invocation + dispatch + drain are still in there. Not kernel-only zone widths.
+3. Pick **smallest** input depth within `--buffer-tune-bw-tolerance` percent of peak BW.
+4. If `--buffer-tune-output-depths` is set, repeat for the output CB at the best input depth. With `--buffer-tune-grid`, sweep the full input × output product instead.
+5. Re-run with `--num-programs` / `--num-pages-per-core` / `--compute-nops` from the normal CLI (latency phase) and optional profilers. Skip the latency phase with `--buffer-tune-bw-only`.
 
-Parse results: `grep BUFFER_TUNE` in the test log. Helper script: `run_buffer_tune.sh`.
+Parse results: `grep BUFFER_TUNE` in the test log. Helper scripts: `run_buffer_tune.sh`, `run_cb_grid_sweep.sh`, `pick_grid_min_cb.py`.
+
+## Reader modes
+
+| mode | flag | behavior |
+|---|---|---|
+| 0 (default) | (none) | push-1 incremental: `reserve_back(push_tiles)`, read + `noc_async_read_barrier` + `push_back(1)` per tile |
+| 1 | `--reader-batch-push` | reserve `push_tiles`, read all, single barrier, `push_back(push_tiles)` |
+| 2 | `--reader-dbuf-trid` | per-trid double-buffer: TRID A and TRID B alternate across two CB slots, with up to `--reader-trid-in-flight` reads per TRID in flight. Highest per-core BW; requires `input_cb_depth ≥ 2 × trid_in_flight × page_size_tiles` |
+
+## Writer modes
+
+| flag | behavior |
+|---|---|
+| (default) | `noc_async_writes_flushed` after every tile, `noc_async_write_barrier` at kernel end |
+| `--writer-flush-on-pressure` | only flush when the output CB is about to back-pressure |
+| `--writer-end-barrier-mode 0` | end-of-kernel `noc_async_write_barrier` (default; waits for DRAM ACK) |
+| `--writer-end-barrier-mode 1` | end-of-kernel `noc_async_writes_flushed` (waits only for L1 drain; safe when the next consumer tolerates non-ACK'd data) |
+| `--writer-end-barrier-mode 2` | no end-of-kernel synchronization (experiment only — next program may overlap with in-flight DRAM writes) |
+
+## Steady-state runs
+
+Trace replay needs a couple of untimed warmup replays before timings stabilize, and the first one
+or two program transitions in any replay include trace-start artifacts. The recommended steady-state
+recipe is:
+
+- `--use-trace --trace-warmup-replays 2`
+- `--num-programs 8` (so there are at least 6 clean transitions)
+- pass `--min-prog-id 3` to `export_op_to_op_profiler_csv.py` to skip transitions where `from_prog_id < 3`
+
+`run_op_to_op_validation.sh` and `run_op_to_op_chart_sweep.sh` apply this recipe automatically.
 
 ## Program-level gaps (real-time profiler)
 
@@ -162,12 +228,62 @@ Do **not** use `DeviceZoneScopedMainN` in compute `kernel_main` (breaks `TRISC-K
 marker pairing). Wrap unpack/pack timestamps in `UNPACK(...)` / `PACK(...)` so each
 marker appears only on the intended TRISC.
 
+## Sweep scripts
+
+All sweep scripts write per-config runs under `generated/profiler/op_to_op_runs/<batch>/` and a
+`chart_data.csv` per batch. Re-run each phase individually with the `BUILD=0` env var if you've
+already compiled the test binary.
+
+| Script | Purpose |
+|---|---|
+| `run_op_to_op_multi.sh` | Run benchmark `N` times for one config (env-driven: `CONFIG_LABEL`, `EXTRA_ARGS`, `TILES_PER_CORE`, `INPUT_CB_DEPTH`, `READER_PUSH`, `MIN_PROG_ID`); aggregates per-run CSVs |
+| `run_op_to_op_validation.sh` | Steady-state validation wrapper: 2 trace warmup replays + 8 programs + `--min-prog-id 3`; reports clean chip dispatch done/go |
+| `run_op_to_op_chart_sweep.sh` | Full sweep across `{1, 2, 4, 10, 20, 40, 80, 110}` cores: buffer-tune for smallest CB at peak BW, then steady-state latency at that CB. Produces `chart_data.csv` ready to plot |
+| `run_op_to_op_all_configs.sh` | Compare baseline push-1 vs push-2 (incremental & batch) vs push-2 BW-tuned, side-by-side |
+| `run_buffer_tune.sh` | End-to-end BW-then-latency recipe (input depth sweep → smallest depth at peak → latency at that depth) |
+| `run_cb_grid_sweep.sh` | Standalone grid CB sweep (input × output) |
+| `run_extra_cores_chart.sh` | Extra core-count points for denser BW scaling |
+| `run_batch2_sweep.sh` | Read-only BW sweep on a dense core grid (`--read-only`) |
+| `run_batch3_compute_sweep.sh` | Vary `--compute-nops` to find the compute-bound knee |
+| `run_batch4_chart_sweep.sh` | Grid CB tune + writer flush-on-pressure across all core counts |
+| `run_batch5_chart_sweep.sh` | Full recipe: grid peak BW, then smallest input then output CB still within tolerance |
+| `run_batch6_pareto.sh` | BW/latency Pareto sweep at 80c and 110c (full CB matrix) |
+| `run_batch7_dram_offset.sh` | Same as batch 4 but with `--cross-program-dram-offset` so each program reads a disjoint DRAM slice |
+| `run_batch7_pareto.sh` | Batch 6 Pareto sweep + `--cross-program-dram-offset` |
+| `run_batch8_barrier.sh` | Sweep `--writer-end-barrier-mode {0,1,2}` at BW-optimal CBs (batch 4 picks) |
+| `run_batch8b_barrier_b1cb.sh` | Sweep `--writer-end-barrier-mode {0,1,2}` at latency-optimal CBs (batch 1 picks). Use this for the barrier study, not batch 8 |
+
+## Analysis scripts
+
+| Script | Purpose |
+|---|---|
+| `export_op_to_op_profiler_csv.py` | Main exporter: turns `profile_log_device.csv` (+ `profile_log_device_rt.csv`) into per-transition gap tables, summaries, timeline, and dispatch gaps. Drop trace-start transitions with `--min-prog-id N`. Aggregate across runs with `--aggregate-runs-dir DIR`. |
+| `export_op_to_op_gaps_csvlite.py` | Pandas-free fallback for the same per-transition gap CSV. Used by `run_op_to_op_multi.sh` if the pandas exporter fails (e.g. environments without pandas) |
+| `pick_grid_min_cb.py` | Parse `BUFFER_TUNE` log lines and pick the smallest input CB then smallest output CB still within tolerance of peak BW |
+| `decompose_op_to_op_gap.py` | Split the op-to-op gap into chronological components: writer tail (`pack_finish → brisc_done`), dispatch (`brisc_done → brisc_go`), first DRAM (`brisc_go → read_after_barrier`), DRAM-to-compute (`read_after_barrier → unpack_tile_0`). Parametrized via `BATCH_PREFIX` / `OUT_DIR_NAME` / `MIN_PROG_ID` env vars |
+| `build_share_tables.py` | Consolidate all batch result CSVs into a single sheet-ready CSV with per-batch headers |
+| `rebuild_batch{2,3,4,5,7}_*.py` | Rebuild comparison tables for a given batch from saved per-run CSVs (no re-run needed) |
+
 ## Files
 
 ```
-test_op_to_op_latency.cpp
-export_op_to_op_profiler_csv.py
-kernels/reader_interleaved.cpp
-kernels/writer_interleaved.cpp
-kernels/compute_copy_with_nops.cpp
+test_op_to_op_latency.cpp                 host test binary
+kernels/
+├── reader_interleaved.cpp                NCRISC reader (modes 0/1/2 + cross-program offset)
+├── writer_interleaved.cpp                BRISC writer (flush mode + end-barrier mode + cross-program offset)
+└── compute_copy_with_nops.cpp            TRISC copy + tunable NOPs
+export_op_to_op_profiler_csv.py           main exporter (pandas)
+export_op_to_op_gaps_csvlite.py           pandas-free fallback exporter
+pick_grid_min_cb.py                       CB picker from BUFFER_TUNE log lines
+decompose_op_to_op_gap.py                 op-to-op gap component breakdown
+build_share_tables.py                     consolidate batch CSVs for sharing
+run_op_to_op_multi.sh                     run-N-times wrapper
+run_op_to_op_validation.sh                steady-state validation wrapper
+run_op_to_op_chart_sweep.sh               full BW × latency × cores sweep
+run_op_to_op_all_configs.sh               reader-mode comparison sweep
+run_buffer_tune.sh                        end-to-end buffer tune recipe
+run_cb_grid_sweep.sh                      standalone CB grid sweep
+run_extra_cores_chart.sh                  extra core-count BW points
+run_batch{2,3,4,5,6,7,7_pareto,8,8b}*.sh  batch-specific sweeps (see Sweep scripts table)
+rebuild_batch{2,3,4,5,7}_*.py             rebuild comparison tables from saved runs
 ```

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -14,8 +14,16 @@ On every Tensix core of the chip, run a textbook three-kernel pipeline:
 reader (NOC1 / RISCV1) ──CB_in──▶  compute (3 TRISCs) ──CB_out──▶  writer (NOC0 / RISCV0)
    noc_async_read_tile              copy_tile                       noc_async_write_tile
    from interleaved DRAM            + N × TTI_NOP                   + noc_async_write_barrier
-                                    (DeviceZoneScopedMainN("MATH"))
+                                    profiler zones:
+                                      DeviceZoneScopedMainN("MATH-KERNEL")  (outer, 1 per program)
+                                      DeviceZoneScopedN     ("MATH")        (inner, 1 per tile)
+                                      DeviceTimestampedData ("TILE_IDX", i) (per-tile loop index)
 ```
+
+The inner `MATH` zone opens **after** `cb_wait_front` and `cb_reserve_back`, so
+its start cycle marks the moment data is available to the tensix and there is
+output-CB space to write into — i.e. the earliest point at which math can
+actually begin.
 
 Pages are interleaved across all DRAM banks; work is split across all
 worker cores via `split_work_to_cores`. The same `MeshWorkload` is enqueued
@@ -71,19 +79,30 @@ ls $TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv
 $TT_METAL_HOME/tools/tracy/process_device_log.py
 ```
 
-Filter the rows for zone name `MATH`. For each (core, TRISC) pair, the
-sequence of `MATH_begin` / `MATH_end` cycles gives one pair per program-run.
-The op-to-op latency for program `n+1` on a given core is:
+There are two granularities of zone in the CSV:
 
-```
-op_to_op_latency_cycles = MATH_begin[n+1] - MATH_end[n]
-```
+* `MATH-KERNEL` — one per (core, TRISC, program-run). Wraps the entire
+  kernel invocation. Backed by `DeviceZoneScopedMainN` (a guaranteed L1
+  slot), so it survives buffer pressure and is the most reliable zone to
+  use for op-to-op latency at program granularity:
 
+  ```
+  op_to_op_latency_cycles = MATH-KERNEL_begin[n+1] - MATH-KERNEL_end[n]
+  ```
+
+* `MATH` — one per tile per program-run, paired with a
+  `TILE_IDX` timestamped-data entry that records the tile index. Use
+  these if you want a finer-grained view (e.g. excluding kernel setup
+  from the first-tile measurement, or comparing per-tile MATH duration
+  across iterations to confirm the NOP delay is the dominant term).
+
+For each (core, TRISC) row, sort by cycle and pair `_begin` / `_end`.
 Convert cycles to microseconds with the device clock frequency that
 `get_tt_npu_clock` reports (the test logs `Clock` for convenience).
 
-Use the `MATH` row of the CSV for "math TRISC" semantics, or the `PACK`
-row if you want "data committed to L1 ready for the writer" semantics.
+Use the `MATH` TRISC row of the CSV for "math TRISC" semantics, or the
+`PACK` TRISC row if you want "data committed to L1 ready for the writer"
+semantics.
 
 ## Files
 
@@ -92,5 +111,6 @@ test_op_to_op_latency.cpp          host program
 kernels/
   reader_interleaved.cpp           NOC1 reader, TensorAccessor + noc_async_read_tile
   writer_interleaved.cpp           NOC0 writer, noc_async_write_tile + barrier
-  compute_copy_with_nops.cpp       copy_tile + N×TTI_NOP, wrapped in DeviceZoneScopedMainN("MATH")
+  compute_copy_with_nops.cpp       copy_tile + N×TTI_NOP; outer MATH-KERNEL zone +
+                                   per-tile MATH zone + TILE_IDX timestamped data
 ```

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -1,0 +1,96 @@
+# `op_to_op_latency` — back-to-back program latency benchmark
+
+Measures the latency between when one program's math finishes and when the
+next program's math starts on the chip. This gap is firmware tear-down +
+dispatch + barrier overhead, and is what the HW team needs to characterize
+in order to evaluate optimisations like virtualised init registers and
+relaxed end-of-op barriers.
+
+## What the benchmark does
+
+On every Tensix core of the chip, run a textbook three-kernel pipeline:
+
+```
+reader (NOC1 / RISCV1) ──CB_in──▶  compute (3 TRISCs) ──CB_out──▶  writer (NOC0 / RISCV0)
+   noc_async_read_tile              copy_tile                       noc_async_write_tile
+   from interleaved DRAM            + N × TTI_NOP                   + noc_async_write_barrier
+                                    (DeviceZoneScopedMainN("MATH"))
+```
+
+Pages are interleaved across all DRAM banks; work is split across all
+worker cores via `split_work_to_cores`. The same `MeshWorkload` is enqueued
+back-to-back `--num-programs N` times, in either Fast-Dispatch mode (host
+issues N enqueues) or Trace mode (capture once, replay once with all N
+enqueues recorded).
+
+## Build
+
+```bash
+# functional build (markers will be compiled out as no-ops):
+cmake --build build --target test_op_to_op_latency -j
+
+# profiler-enabled build (required to actually capture op-to-op timing):
+./build_metal.sh --enable-profiler --build-tests
+cmake --build build --target test_op_to_op_latency -j
+```
+
+## Run
+
+```bash
+TT_METAL_HOME=$(pwd) \
+TT_METAL_DEVICE_PROFILER=1 \
+  ./build/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency \
+    --use-trace \
+    --num-programs 8 \
+    --compute-nops 2000 \
+    --use-device-profiler
+```
+
+### CLI flags
+
+| flag | default | meaning |
+|---|---:|---|
+| `--num-pages-per-core N` | 2 | interleaved DRAM pages per core (≥ 1) |
+| `--compute-nops N` | 0 | `TTI_NOP`s per tile in compute kernel; tune so the `MATH` zone is comfortably > 10us (use Tracy to confirm) |
+| `--num-programs N` | 8 | back-to-back enqueues per measurement |
+| `--use-trace` | off | capture-once / replay-once instead of FD-mode loop |
+| `--use-device-profiler` | off | dump `profile_log_device.csv` after Finish (requires profiler build + `TT_METAL_DEVICE_PROFILER=1`) |
+| `--no-warmup` | off | skip the untimed warmup enqueue |
+| `--trace-region-size N` | 1 MiB | trace buffer size (bytes); bump if `--num-programs` is very large |
+| `--device-id N` | 0 | which physical device |
+
+## Extracting op-to-op latency from the CSV
+
+After a `--use-device-profiler` run:
+
+```bash
+# raw CSV is here:
+ls $TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv
+
+# pretty-printed analysis:
+$TT_METAL_HOME/tools/tracy/process_device_log.py
+```
+
+Filter the rows for zone name `MATH`. For each (core, TRISC) pair, the
+sequence of `MATH_begin` / `MATH_end` cycles gives one pair per program-run.
+The op-to-op latency for program `n+1` on a given core is:
+
+```
+op_to_op_latency_cycles = MATH_begin[n+1] - MATH_end[n]
+```
+
+Convert cycles to microseconds with the device clock frequency that
+`get_tt_npu_clock` reports (the test logs `Clock` for convenience).
+
+Use the `MATH` row of the CSV for "math TRISC" semantics, or the `PACK`
+row if you want "data committed to L1 ready for the writer" semantics.
+
+## Files
+
+```
+test_op_to_op_latency.cpp          host program
+kernels/
+  reader_interleaved.cpp           NOC1 reader, TensorAccessor + noc_async_read_tile
+  writer_interleaved.cpp           NOC0 writer, noc_async_write_tile + barrier
+  compute_copy_with_nops.cpp       copy_tile + N×TTI_NOP, wrapped in DeviceZoneScopedMainN("MATH")
+```

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -14,10 +14,9 @@ On every Tensix core of the chip, run a textbook three-kernel pipeline:
 reader (NOC1 / RISCV1) ──CB_in──▶  compute (3 TRISCs) ──CB_out──▶  writer (NOC0 / RISCV0)
    noc_async_read_tile              copy_tile                       noc_async_write_tile
    from interleaved DRAM            + N × TTI_NOP                   + noc_async_write_barrier
-                                    profiler zones:
-                                      DeviceZoneScopedMainN("MATH-KERNEL")  (outer, 1 per program)
-                                      DeviceZoneScopedN     ("MATH")        (inner, 1 per tile)
-                                      DeviceTimestampedData ("TILE_IDX", i) (per-tile loop index)
+                                    profiler (device CSV):
+                                      TRISC-KERNEL  (firmware trisck.cc — wraps user kernel)
+                                      DeviceZoneScopedN("MATH") + TILE_IDX (per tile, user kernel)
 ```
 
 The inner `MATH` zone opens **after** `cb_wait_front` and `cb_reserve_back`, so
@@ -34,12 +33,16 @@ enqueues recorded).
 ## Build
 
 ```bash
-# functional build (markers will be compiled out as no-ops):
-cmake --build build --target test_op_to_op_latency -j
+# Default Metal build has Tracy ON (`ENABLE_TRACY` defaults ON; do not pass
+# `build_metal.sh --disable-profiler`). Device/kernel zones are compiled into
+# kernels at JIT time only when `TT_METAL_DEVICE_PROFILER=1` is set **before**
+# the process starts (see tt_metal/llrt/rtoptions.cpp). Re-run after exporting
+# that env so kernels rebuild with `-DPROFILE_KERNEL=...`; clear the JIT cache
+# if an old non-profiler kernel keeps getting picked up:
+#   rm -rf ~/.cache/tt-metal-cache "$TT_METAL_CACHE"
 
-# profiler-enabled build (required to actually capture op-to-op timing):
-./build_metal.sh --enable-profiler --build-tests
-cmake --build build --target test_op_to_op_latency -j
+./build_metal.sh --build-tests
+cmake --build build_Release --target test_op_to_op_latency -j
 ```
 
 ## Run
@@ -62,10 +65,42 @@ TT_METAL_DEVICE_PROFILER=1 \
 | `--compute-nops N` | 0 | `TTI_NOP`s per tile in compute kernel; tune so the `MATH` zone is comfortably > 10us (use Tracy to confirm) |
 | `--num-programs N` | 8 | back-to-back enqueues per measurement |
 | `--use-trace` | off | capture-once / replay-once instead of FD-mode loop |
-| `--use-device-profiler` | off | dump `profile_log_device.csv` after Finish (requires profiler build + `TT_METAL_DEVICE_PROFILER=1`) |
+| `--use-device-profiler` | off | dump `profile_log_device.csv` after Finish (Tracy-enabled build — default unless `build_metal.sh --disable-profiler`; export `TT_METAL_DEVICE_PROFILER=1` **before** starting the process) |
+| `--use-realtime-profiler` | off | register the [real-time profiler](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/real_time_profiler/getting-started.md) callback for the **timed** enqueue burst; after `Finish`, logs per-chip op-to-op gaps (`next start − previous end`, ns). Inactive on some dispatch setups — check logs if no gaps appear. |
 | `--no-warmup` | off | skip the untimed warmup enqueue |
 | `--trace-region-size N` | 1 MiB | trace buffer size (bytes); bump if `--num-programs` is very large |
 | `--device-id N` | 0 | which physical device |
+
+## Program-level op-to-op (real-time profiler)
+
+Pass **`--use-realtime-profiler`** to register `RegisterProgramRealtimeProfilerCallback`
+for the **timed** portion only (after warmup). In FD mode that is the `N` back-to-back
+`EnqueueMeshWorkload` calls plus `Finish`. In trace mode it is **replay + `Finish`**
+only (capture is outside the callback window so RT records are not polluted by the
+capture pass). When the device is supported, the test logs per-chip statistics for
+**gap = next program `start_timestamp` − previous program `end_timestamp`** (nanoseconds),
+matching Mo’s op2op definition. See
+[getting-started.md](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/real_time_profiler/getting-started.md).
+This is independent of `--use-device-profiler` (kernel CSV zones).
+
+The benchmark sets **`Program::set_runtime_id(1)`** before enqueue: the RT receiver
+ignores pages whose id is **0** (reserved for non-program traffic), and new programs
+default to runtime id 0 — without a non-zero id you would see **“got 0 record(s)”**
+even when the profiler is active.
+
+**Example observed output** (Blackhole, chip 0, FD, `--num-programs 8`,
+`--compute-nops 1000`, `--use-realtime-profiler`; numbers vary by chip,
+firmware, and load):
+
+```text
+Real-time profiler chip 0: 8 op-to-op gap(s) — min 1265.94 ns, max 78903.69 ns, mean 12339.28 ns
+FD back-to-back: 8 programs in 84 us (avg 10.50 us/program)
+```
+
+So in that run, device-side **gap = next program start − previous program end**
+averaged **~12.3 µs** per chip-0 pair, with one **~79 µs** outlier and a **~1.3 µs**
+shortest gap. Host wall time for the same burst was **84 µs** total (**~10.5 µs**
+per enqueue including all work), which is a different quantity from the RT gap.
 
 ## Extracting op-to-op latency from the CSV
 
@@ -79,22 +114,24 @@ ls $TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv
 $TT_METAL_HOME/tools/tracy/process_device_log.py
 ```
 
-There are two granularities of zone in the CSV:
+There are two useful zone families in the CSV:
 
-* `MATH-KERNEL` — one per (core, TRISC, program-run). Wraps the entire
-  kernel invocation. Backed by `DeviceZoneScopedMainN` (a guaranteed L1
-  slot), so it survives buffer pressure and is the most reliable zone to
-  use for op-to-op latency at program granularity:
+* **`TRISC-KERNEL`** — emitted by firmware around `run_kernel()` on each TRISC
+  (`tt_metal/hw/firmware/src/tt-1xx/trisck.cc`). One begin/end pair per TRISC
+  per program-run for the whole user kernel body. Safe for a coarse
+  “kernel ran” envelope. Do **not** add `DeviceZoneScopedMainN` in user TRISC
+  `kernel_main`: it nests inside `TRISC-KERNEL` and `MainN`’s destructor calls
+  `finish_profiler()` while the parent zone is still open, which breaks host
+  marker pairing (`TT_FATAL: Start and end marker IDs do not match`).
 
-  ```
-  op_to_op_latency_cycles = MATH-KERNEL_begin[n+1] - MATH-KERNEL_end[n]
-  ```
+* **`MATH`** — one per tile per program-run on each TRISC, with a **`TILE_IDX`**
+  timestamped-data row for loop index `i`. The inner `MATH` zone opens **after**
+  `cb_wait_front` and `cb_reserve_back`, so its start marks when data is in L1
+  and output CB space exists.
 
-* `MATH` — one per tile per program-run, paired with a
-  `TILE_IDX` timestamped-data entry that records the tile index. Use
-  these if you want a finer-grained view (e.g. excluding kernel setup
-  from the first-tile measurement, or comparing per-tile MATH duration
-  across iterations to confirm the NOP delay is the dominant term).
+**Program-level op-to-op between host enqueues** (Mo’s metric) is best taken
+from **`--use-realtime-profiler`** (`ProgramRealtimeRecord`), not from nesting
+another `MainN` zone in this compute kernel.
 
 For each (core, TRISC) row, sort by cycle and pair `_begin` / `_end`.
 Convert cycles to microseconds with the device clock frequency that
@@ -111,6 +148,6 @@ test_op_to_op_latency.cpp          host program
 kernels/
   reader_interleaved.cpp           NOC1 reader, TensorAccessor + noc_async_read_tile
   writer_interleaved.cpp           NOC0 writer, noc_async_write_tile + barrier
-  compute_copy_with_nops.cpp       copy_tile + N×TTI_NOP; outer MATH-KERNEL zone +
-                                   per-tile MATH zone + TILE_IDX timestamped data
+  compute_copy_with_nops.cpp       copy_tile + N×TTI_NOP; per-tile MATH + TILE_IDX
+                                   (no DeviceZoneScopedMainN — see README)
 ```

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -1,153 +1,108 @@
 # `op_to_op_latency` — back-to-back program latency benchmark
 
-Measures the latency between when one program's math finishes and when the
-next program's math starts on the chip. This gap is firmware tear-down +
-dispatch + barrier overhead, and is what the HW team needs to characterize
-in order to evaluate optimisations like virtualised init registers and
-relaxed end-of-op barriers.
+Measures per-core latency from when one program finishes (pack pushed its last
+tile) to when the next program starts compute (unpack begins tile 0).
 
 ## What the benchmark does
 
-On every Tensix core of the chip, run a textbook three-kernel pipeline:
+On every Tensix core:
 
 ```
-reader (NOC1 / RISCV1) ──CB_in──▶  compute (3 TRISCs) ──CB_out──▶  writer (NOC0 / RISCV0)
-   noc_async_read_tile              copy_tile                       noc_async_write_tile
-   from interleaved DRAM            + N × TTI_NOP                   + noc_async_write_barrier
-                                    profiler (device CSV):
-                                      TRISC-KERNEL  (firmware trisck.cc — wraps user kernel)
-                                      DeviceZoneScopedN("MATH") + TILE_IDX (per tile, user kernel)
+reader (NOC1) ──CB_in──▶ compute (3 TRISCs) ──CB_out──▶ writer (NOC0)
+   interleaved DRAM       UNPACK / MATH / PACK         write + barrier
 ```
 
-The inner `MATH` zone opens **after** `cb_wait_front` and `cb_reserve_back`, so
-its start cycle marks the moment data is available to the tensix and there is
-output-CB space to write into — i.e. the earliest point at which math can
-actually begin.
+Compute kernel profiler markers (device CSV):
 
-Pages are interleaved across all DRAM banks; work is split across all
-worker cores via `split_work_to_cores`. The same `MeshWorkload` is enqueued
-back-to-back `--num-programs N` times, in either Fast-Dispatch mode (host
-issues N enqueues) or Trace mode (capture once, replay once with all N
-enqueues recorded).
+| TRISC | Role | Marker |
+|-------|------|--------|
+| TRISC_0 | Unpack | `TILE_IDX` = *i* at tile *i* compute start (`UNPACK(...)`) |
+| TRISC_1 | Math | optional `MATH` zones around copy + NOPs |
+| TRISC_2 | Pack | `FINISH_LAST_PUSH` once at kernel exit, outside the tile loop (`PACK(...)`) |
+
+All launches also emit `PROG_ID` (0 = warmup / pre-compile, 1..N = timed).
+
+The same `MeshWorkload` is enqueued back-to-back `--num-programs N` times, in
+Fast-Dispatch mode or Trace mode (capture once, replay once).
 
 ## Build
 
 ```bash
-# Default Metal build has Tracy ON (`ENABLE_TRACY` defaults ON; do not pass
-# `build_metal.sh --disable-profiler`). Device/kernel zones are compiled into
-# kernels at JIT time only when `TT_METAL_DEVICE_PROFILER=1` is set **before**
-# the process starts (see tt_metal/llrt/rtoptions.cpp). Re-run after exporting
-# that env so kernels rebuild with `-DPROFILE_KERNEL=...`; clear the JIT cache
-# if an old non-profiler kernel keeps getting picked up:
+# Kernels pick up PROFILE_KERNEL only if TT_METAL_DEVICE_PROFILER=1 is set
+# before the process starts. Clear JIT cache after changing profiler macros:
 #   rm -rf ~/.cache/tt-metal-cache "$TT_METAL_CACHE"
 
 ./build_metal.sh --build-tests
 cmake --build build_Release --target test_op_to_op_latency -j
 ```
 
-## Run
+## Quick start
 
 ```bash
-TT_METAL_HOME=$(pwd) \
-TT_METAL_DEVICE_PROFILER=1 \
-  ./build/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency \
-    --use-trace \
-    --num-programs 8 \
-    --compute-nops 2000 \
-    --use-device-profiler
+export TT_METAL_HOME=$(pwd)
+export TT_METAL_DEVICE_PROFILER=1
+
+cmake --build build_Release --target test_op_to_op_latency -j
+
+./build_Release/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency \
+  --use-trace \
+  --num-programs 2 \
+  --compute-nops 1000 \
+  --use-device-profiler
+
+python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py \
+  --input-file "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv"
 ```
 
-### CLI flags
+**Outputs** (`generated/profiler/.logs/`):
+
+| File | Contents |
+|------|----------|
+| `profile_log_device.csv` | Raw device profiler log |
+| `profile_log_device_op_to_op_summary_chip.csv` | All-cores gap stats (mean/median/min/max) |
+| `profile_log_device_op_to_op_summary_per_core.csv` | Per-core averages across program transitions |
+| `profile_log_device_op_to_op_gaps.csv` | Per core: pack finish prog *k* → unpack tile 0 prog *k+1* |
+| `profile_log_device_op_to_op_tiles.csv` | TRISC_0: per-tile `unpack_start_cycles` |
+| `profile_log_device_op_to_op_prog_ids.csv` | `PROG_ID` rows (TRISC_0) |
+
+**Op-to-op gap:** `TRISC_0` `TILE_IDX` (`data`=0) of program *k+1* minus `TRISC_2`
+`FINISH_LAST_PUSH` of program *k* (export script; `--min-prog-id 1` skips id 0).
+
+Optional: `export TT_METAL_PROFILER_CPP_POST_PROCESS=1` for kernel-duration summary in the test log.
+
+## CLI flags
 
 | flag | default | meaning |
 |---|---:|---|
 | `--num-pages-per-core N` | 2 | interleaved DRAM pages per core (≥ 1) |
-| `--compute-nops N` | 0 | `TTI_NOP`s per tile in compute kernel; tune so the `MATH` zone is comfortably > 10us (use Tracy to confirm) |
+| `--compute-nops N` | 0 | `TTI_NOP`s per tile; tune so math work is comfortably > 10 µs |
 | `--num-programs N` | 8 | back-to-back enqueues per measurement |
-| `--use-trace` | off | capture-once / replay-once instead of FD-mode loop |
-| `--use-device-profiler` | off | dump `profile_log_device.csv` after Finish (Tracy-enabled build — default unless `build_metal.sh --disable-profiler`; export `TT_METAL_DEVICE_PROFILER=1` **before** starting the process) |
-| `--use-realtime-profiler` | off | register the [real-time profiler](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/real_time_profiler/getting-started.md) callback for the **timed** enqueue burst; after `Finish`, logs per-chip op-to-op gaps (`next start − previous end`, ns). Inactive on some dispatch setups — check logs if no gaps appear. |
-| `--no-warmup` | off | skip the untimed warmup enqueue |
-| `--trace-region-size N` | 1 MiB | trace buffer size (bytes); bump if `--num-programs` is very large |
-| `--device-id N` | 0 | which physical device |
+| `--use-trace` | off | capture-once / replay-once instead of FD loop |
+| `--use-device-profiler` | off | dump `profile_log_device.csv` after `Finish` |
+| `--use-realtime-profiler` | off | log per-chip program gaps after timed section (see below) |
+| `--no-warmup` | off | skip untimed warmup enqueue |
+| `--trace-region-size N` | 1 MiB | trace buffer (bytes) |
+| `--device-id N` | 0 | physical device |
 
-## Program-level op-to-op (real-time profiler)
+## Program-level gaps (real-time profiler)
 
-Pass **`--use-realtime-profiler`** to register `RegisterProgramRealtimeProfilerCallback`
-for the **timed** portion only (after warmup). In FD mode that is the `N` back-to-back
-`EnqueueMeshWorkload` calls plus `Finish`. In trace mode it is **replay + `Finish`**
-only (capture is outside the callback window so RT records are not polluted by the
-capture pass). When the device is supported, the test logs per-chip statistics for
-**gap = next program `start_timestamp` − previous program `end_timestamp`** (nanoseconds),
-matching Mo’s op2op definition. See
-[getting-started.md](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/real_time_profiler/getting-started.md).
-This is independent of `--use-device-profiler` (kernel CSV zones).
+`--use-realtime-profiler` logs chip-level **next program start − previous program end**
+(nanoseconds) for the timed section only. Separate from the device CSV; not written to
+a file by this test. See
+[real_time_profiler/getting-started.md](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/real_time_profiler/getting-started.md).
 
-The benchmark sets **`Program::set_runtime_id(1)`** before enqueue: the RT receiver
-ignores pages whose id is **0** (reserved for non-program traffic), and new programs
-default to runtime id 0 — without a non-zero id you would see **“got 0 record(s)”**
-even when the profiler is active.
+## Kernel profiler notes
 
-**Example observed output** (Blackhole, chip 0, FD, `--num-programs 8`,
-`--compute-nops 1000`, `--use-realtime-profiler`; numbers vary by chip,
-firmware, and load):
-
-```text
-Real-time profiler chip 0: 8 op-to-op gap(s) — min 1265.94 ns, max 78903.69 ns, mean 12339.28 ns
-FD back-to-back: 8 programs in 84 us (avg 10.50 us/program)
-```
-
-So in that run, device-side **gap = next program start − previous program end**
-averaged **~12.3 µs** per chip-0 pair, with one **~79 µs** outlier and a **~1.3 µs**
-shortest gap. Host wall time for the same burst was **84 µs** total (**~10.5 µs**
-per enqueue including all work), which is a different quantity from the RT gap.
-
-## Extracting op-to-op latency from the CSV
-
-After a `--use-device-profiler` run:
-
-```bash
-# raw CSV is here:
-ls $TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv
-
-# pretty-printed analysis:
-$TT_METAL_HOME/tools/tracy/process_device_log.py
-```
-
-There are two useful zone families in the CSV:
-
-* **`TRISC-KERNEL`** — emitted by firmware around `run_kernel()` on each TRISC
-  (`tt_metal/hw/firmware/src/tt-1xx/trisck.cc`). One begin/end pair per TRISC
-  per program-run for the whole user kernel body. Safe for a coarse
-  “kernel ran” envelope. Do **not** add `DeviceZoneScopedMainN` in user TRISC
-  `kernel_main`: it nests inside `TRISC-KERNEL` and `MainN`’s destructor calls
-  `finish_profiler()` while the parent zone is still open, which breaks host
-  marker pairing (`TT_FATAL: Start and end marker IDs do not match`).
-
-* **`MATH`** — one per tile per program-run on each TRISC, with a **`TILE_IDX`**
-  timestamped-data row for loop index `i`. The inner `MATH` zone opens **after**
-  `cb_wait_front` and `cb_reserve_back`, so its start marks when data is in L1
-  and output CB space exists.
-
-**Program-level op-to-op between host enqueues** (Mo’s metric) is best taken
-from **`--use-realtime-profiler`** (`ProgramRealtimeRecord`), not from nesting
-another `MainN` zone in this compute kernel.
-
-For each (core, TRISC) row, sort by cycle and pair `_begin` / `_end`.
-Convert cycles to microseconds with the device clock frequency that
-`get_tt_npu_clock` reports (the test logs `Clock` for convenience).
-
-Use the `MATH` TRISC row of the CSV for "math TRISC" semantics, or the
-`PACK` TRISC row if you want "data committed to L1 ready for the writer"
-semantics.
+Do **not** use `DeviceZoneScopedMainN` in compute `kernel_main` (breaks `TRISC-KERNEL`
+marker pairing). Wrap unpack/pack timestamps in `UNPACK(...)` / `PACK(...)` so each
+marker appears only on the intended TRISC.
 
 ## Files
 
 ```
-test_op_to_op_latency.cpp          host program
-kernels/
-  reader_interleaved.cpp           NOC1 reader, TensorAccessor + noc_async_read_tile
-  writer_interleaved.cpp           NOC0 writer, noc_async_write_tile + barrier
-  compute_copy_with_nops.cpp       copy_tile + N×TTI_NOP; per-tile MATH + TILE_IDX
-                                   (no DeviceZoneScopedMainN — see README)
+test_op_to_op_latency.cpp
+export_op_to_op_profiler_csv.py
+kernels/reader_interleaved.cpp
+kernels/writer_interleaved.cpp
+kernels/compute_copy_with_nops.cpp
 ```

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -19,8 +19,10 @@ Compute kernel profiler markers (device CSV):
 | TRISC_0 | Unpack | `TILE_IDX` = *i* at tile *i* compute start (`UNPACK(...)`) |
 | TRISC_1 | Math | optional `MATH` zones around copy + NOPs |
 | TRISC_2 | Pack | `FINISH_LAST_PUSH` once at kernel exit, outside the tile loop (`PACK(...)`) |
+| NCRISC (or RISCV_1) | Reader | `NCRISC_GO` / `NCRISC_DONE` at kernel entry/exit; `READ_BEFORE/AFTER_BARRIER` on tile 0 |
+| BRISC (or RISCV_0) | Writer | `BRISC_GO` / `BRISC_DONE` at kernel entry/exit; `WRITE_BEFORE/AFTER_BARRIER` on last tile |
 
-All launches also emit `PROG_ID` (0 = warmup / pre-compile, 1..N = timed).
+All kernels emit `PROG_ID` (0 = warmup / pre-compile, 1..N = timed).
 
 The same `MeshWorkload` is enqueued back-to-back `--num-programs N` times, in
 Fast-Dispatch mode or Trace mode (capture once, replay once).
@@ -48,10 +50,28 @@ cmake --build build_Release --target test_op_to_op_latency -j
   --use-trace \
   --num-programs 2 \
   --compute-nops 1000 \
-  --use-device-profiler
+  --use-device-profiler \
+  --use-realtime-profiler
 
 python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py \
   --input-file "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv"
+```
+
+### Multiple runs (recommended for HW review)
+
+```bash
+chmod +x tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
+./tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh 5
+```
+
+Writes `generated/profiler/op_to_op_runs/run_1/` … `run_5/` (raw logs + exported CSVs) and
+`multi_run_device_op_to_op_gap.csv` / `multi_run_dispatch_done_to_go.csv` with min/max/mean/std
+printed at the end.
+
+To regather a single run after kernel changes, clear JIT cache then repeat quick start:
+
+```bash
+rm -rf ~/.cache/tt-metal-cache "${TT_METAL_CACHE:-}"
 ```
 
 **Outputs** (`generated/profiler/.logs/`):
@@ -62,6 +82,24 @@ python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_t
 | `profile_log_device_op_to_op_summary_chip.csv` | All-cores gap stats (mean/median/min/max) |
 | `profile_log_device_op_to_op_summary_per_core.csv` | Per-core averages across program transitions |
 | `profile_log_device_op_to_op_gaps.csv` | Per core: pack finish prog *k* → unpack tile 0 prog *k+1* |
+| `profile_log_device_op_to_op_timeline.csv` | Gaps + read/write before/after barrier + chip `go`/`done`/`gap` |
+| `profile_log_device_op_to_op_complete.csv` | Same as timeline (full transition picture for HW) |
+
+Buffering columns on timeline/complete (for DRAM read-before-compute questions):
+
+| Column | Meaning |
+|--------|---------|
+| `input_cb_depth_tiles` / `input_cb_double_buffered` | CB config (default depth 4 = 2× push chunk) |
+| `reader_push_tiles_per_chunk` / `reader_batch_push` | Reader `reserve_back(N)` pattern (default push 2, incremental) |
+| `tiles_per_core` | Tiles per core per program (default 4) |
+| `per_tile_dram_read_barrier` | Benchmark uses `noc_async_read_barrier` every tile |
+| `tile0_dram_buffering_latency_us` | Prog *k+1* tile 0: `READ_AFTER` − `READ_BEFORE` (DRAM read + barrier) |
+| `read_after_to_unpack_tile0_us` | Buffer ready → `TILE_IDX` tile 0 (CB wait + handoff to unpack) |
+| `device_gap_excluding_tile0_dram_buffer_us` | Full device op-to-op gap minus tile-0 DRAM buffering |
+| `tile0_dram_buffer_fraction_of_device_gap` | How much of the gap is tile-0 read+barrier |
+| `profile_log_device_op_to_op_rt_programs.csv` | Per program: `go_cycles`, `done_cycles`, `program_duration_ns`, `gap_to_next_go_ns` |
+| `profile_log_device_op_to_op_dispatch_gaps.csv` | Chip-level RT: previous `done` → next `go` (needs `--use-realtime-profiler`) |
+| `profile_log_device_rt.csv` | Raw RT profiler records (go/done cycles per program) |
 | `profile_log_device_op_to_op_tiles.csv` | TRISC_0: per-tile `unpack_start_cycles` |
 | `profile_log_device_op_to_op_prog_ids.csv` | `PROG_ID` rows (TRISC_0) |
 
@@ -74,7 +112,10 @@ Optional: `export TT_METAL_PROFILER_CPP_POST_PROCESS=1` for kernel-duration summ
 
 | flag | default | meaning |
 |---|---:|---|
-| `--num-pages-per-core N` | 2 | interleaved DRAM pages per core (≥ 1) |
+| `--num-pages-per-core N` | 4 | interleaved DRAM pages per core (≥ 1) |
+| `--reader-push-tiles N` | 2 | reader `reserve_back` / push chunk size |
+| `--input-cb-depth-tiles N` | 0 (auto 2×push) | input CB depth in tiles (output CB stays 2) |
+| `--reader-batch-push` | off | reserve N, read all, `push_back(N)`; default is read+`push_back(1)` per tile in chunk |
 | `--compute-nops N` | 0 | `TTI_NOP`s per tile; tune so math work is comfortably > 10 µs |
 | `--num-programs N` | 8 | back-to-back enqueues per measurement |
 | `--use-trace` | off | capture-once / replay-once instead of FD loop |
@@ -83,12 +124,36 @@ Optional: `export TT_METAL_PROFILER_CPP_POST_PROCESS=1` for kernel-duration summ
 | `--no-warmup` | off | skip untimed warmup enqueue |
 | `--trace-region-size N` | 1 MiB | trace buffer (bytes) |
 | `--device-id N` | 0 | physical device |
+| `--output-cb-depth-tiles N` | 0 (default 2) | output CB depth in tiles |
+| `--buffer-tune` | off | sweep input CB depth for DRAM BW, then op-to-op at smallest depth at peak BW |
+| `--buffer-tune-input-depths LIST` | `2,4,6,8,12,16,24,32` | comma-separated depths for BW sweep |
+| `--buffer-tune-output-depths LIST` | (none) | optional output CB depth sweep after input tune |
+| `--buffer-tune-pages-per-core N` | 32 | tiles/core during BW phase (NOP compute → DRAM bound) |
+| `--buffer-tune-bw-tolerance PCT` | 2 | depths within PCT% of peak BW count as “at peak” |
+
+## Buffer tune (`--buffer-tune`)
+
+1. Reader **push-2** (double buffer), **compute-nops 0**, large `--buffer-tune-pages-per-core`.
+2. For each `--buffer-tune-input-depths` value: one timed program, log **`dram_pipeline_gbps`** (read+write bytes / wall time).
+3. Pick **smallest** input depth within tolerance of peak BW.
+4. Re-run **`--num-programs`** with `--num-pages-per-core` / `--compute-nops` from the normal CLI (latency phase) and optional profilers.
+
+Parse results: `grep BUFFER_TUNE` in the test log. Helper script: `run_buffer_tune.sh`.
 
 ## Program-level gaps (real-time profiler)
 
-`--use-realtime-profiler` logs chip-level **next program start − previous program end**
-(nanoseconds) for the timed section only. Separate from the device CSV; not written to
-a file by this test. See
+`--use-realtime-profiler` records **done → go** at **chip dispatch** (not
+per-core): `go_cycles` = program start, `done_cycles` = program end. Device CSV also has
+per-core `BRISC_GO`/`BRISC_DONE` (writer) and `NCRISC_GO`/`NCRISC_DONE` (reader) at kernel
+entry/exit. Export reports
+**`dispatch_gap_cycles` = next `go` − previous `done`** (typically **~550–700 ns** on
+Blackhole; run-to-run variation is normal). This is separate from the **~4–5 µs** device
+op-to-op gap (pack finish → next unpack tile 0 on all cores in parallel).
+
+The test logs each program’s go/done and writes `profile_log_device_rt.csv`.
+`export_op_to_op_profiler_csv.py` emits `*_rt_programs.csv`, `*_dispatch_gaps.csv`, and
+merges `chip_dispatch_*` columns into timeline/complete CSVs. Duplicate consecutive
+`program_id` rows from trace replay are collapsed/skipped. See
 [real_time_profiler/getting-started.md](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/real_time_profiler/getting-started.md).
 
 ## Kernel profiler notes

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/chart_n_vs_skew.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/chart_n_vs_skew.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Dual-axis chart: at a fixed (saturated) core count, aggregate read BW falls with N while
+starvation rises -- showing the BW drop is a skew tax, not a throughput collapse. The 'fair'
+line (median per-core BW x cores) rises with N; the gap to actual aggregate is the skew tax."""
+import argparse
+from pathlib import Path
+import pandas as pd
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--csv", type=Path, required=True)
+ap.add_argument("--cores", type=int, nargs="+", default=[56])
+ap.add_argument("--out", type=Path, required=True)
+args = ap.parse_args()
+
+df = pd.read_csv(args.csv)
+fig, axes = plt.subplots(1, len(args.cores), figsize=(7 * len(args.cores), 5), squeeze=False)
+for ax, c in zip(axes[0], args.cores):
+    s = df[df.cores == c].sort_values("N")
+    fair = c * s["per_core_read_med"]
+    ax.plot(
+        s["N"], s["agg_read_gbps"], "o-", color="C0", lw=2, label="aggregate read BW (actual, gated by slowest core)"
+    )
+    ax.plot(s["N"], fair, "s--", color="C2", lw=1.5, label="'fair' BW = median per-core × cores (no skew)")
+    ax.fill_between(s["N"], s["agg_read_gbps"], fair, color="C3", alpha=0.12)
+    ax.set_xlabel("N (reader trid in-flight)")
+    ax.set_ylabel("read BW (GB/s)", color="C0")
+    ax.set_title(f"cores={c}: BW drop with N is skew, not throughput loss")
+    ax.set_xscale("log", base=2)
+    ax.set_xticks(s["N"])
+    ax.set_xticklabels(s["N"])
+    ax.set_ylim(0, max(fair.max(), s["agg_read_gbps"].max()) * 1.1)
+    ax.grid(True, alpha=0.3)
+
+    ax2 = ax.twinx()
+    ax2.plot(s["N"], s["starvation_ratio"], "^-", color="C1", lw=2, label="starvation ratio (fastest/slowest core)")
+    ax2.set_ylabel("starvation ratio (fastest ÷ slowest core)", color="C1")
+    ax2.set_ylim(1.0, s["starvation_ratio"].max() * 1.1)
+
+    l1, lab1 = ax.get_legend_handles_labels()
+    l2, lab2 = ax2.get_legend_handles_labels()
+    ax.legend(l1 + l2, lab1 + lab2, loc="lower center", fontsize=8, framealpha=0.9)
+
+fig.tight_layout()
+fig.savefig(args.out, dpi=130)
+print(f"wrote {args.out}")

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
@@ -8,18 +8,23 @@
 
 Emits one chart-ready CSV row (per config = core count x barrier mode) with:
   agg_read_gbps        aggregate read BW across active cores (device-marker span)
-  op_to_op_us          done/go dispatch hop (DISP_DONE_OBSERVED -> WORKER_GO_OBSERVED)
-  math_to_math_us      last-math(A) -> first-math(B): FINISH_LAST_PUSH(k) -> TILE_IDX0(k+1)
+  official_op2op_us    op2op via official tools/tracy methodology (standard KERNEL zones):
+                       {risc}-KERNEL ZONE_END(k) -> DM-KERNEL ZONE_START(k+1); '_min' == tracy Min
+  device_kernel_dur_us first KERNEL start -> last KERNEL end across riscs (op kernel span)
+  m2m_*                math-to-math brackets: bubble / skew_env / within / finish+start skew
+  read_fill_head_us    READ_BEFORE_BARRIER -> TILE_IDX[0] (reader latency before first math)
   reader_to_writer_us  NCRISC_DONE -> BRISC_DONE (write-side tail after reads finish)
   write_tail_us        WRITE_BEFORE_BARRIER -> WRITE_AFTER_BARRIER (end barrier/flush)
   *_max                worst-core value (NoC-torus starvation tail)
   reader_done_spread_us / writer_done_spread_us
                        max-min completion time across cores per program (late-core skew)
 
+All metrics derive from standard profiler zones + test-side kernel markers only -- no custom
+FW/dispatch markers (those were reverted out of tt_metal/). For absolute (unpolluted) op2op use
+the realtime profiler (--use-realtime-profiler -> profile_log_device_rt.csv gap_to_next_go).
 All latencies are per-core medians over steady-state program transitions unless noted.
 Run the test WITHOUT --read-only (writer must do real DRAM writes), with
-TT_METAL_DEVICE_PROFILER=1 + TT_METAL_DEVICE_PROFILER_DISPATCH=1 and --use-device-profiler.
-See [[goal-reduce-math-to-math-latency]].
+TT_METAL_DEVICE_PROFILER=1 and --use-device-profiler. See [[goal-reduce-math-to-math-latency]].
 """
 
 from __future__ import annotations
@@ -40,7 +45,6 @@ from export_op_to_op_profiler_csv import (  # noqa: E402
     parse_chip_freq_mhz,
     walk_barrier_markers,
     walk_core_markers,
-    walk_done_to_go,
 )
 
 DEFAULT_TILE_BYTES = 2048
@@ -151,6 +155,63 @@ def completion_spread_us(done_d: dict, freq_mhz: float, min_prog: int):
     return [(max(v) - min(v)) / freq_mhz for v in by_prog.values() if len(v) > 1]
 
 
+KERNEL_ZONES = ("BRISC-KERNEL", "NCRISC-KERNEL", "TRISC-KERNEL")
+DM_KERNEL_ZONES = ("BRISC-KERNEL", "NCRISC-KERNEL")
+
+
+def official_kernel_metrics(df, freq_mhz: float, max_gap_us: float = 50.0):
+    """Reproduce the tools/tracy methodology (device_post_proc_config.py) from the standard
+    auto-emitted KERNEL zones -- no custom markers, comparable to process_device_log.py / Tracy.
+
+      op2op              : per core, adjacent ops -> first DM-KERNEL start(k+1) - last KERNEL end(k)
+                           (device_post_proc_config 'op2op'). Steady-state value; the max_gap_us cap
+                           drops trace-instance boundaries that inflate the tool's Average/Max.
+      device_kernel_dur  : per op, last KERNEL end - first KERNEL start across riscs
+                           (device_post_proc_config 'device_kernel_duration').
+
+    Segments ops by the start->end->start transition per core (no PROG_ID needed, so robust to
+    trace capture/replay duplicate program ids). Returns (op2op_us list, kernel_dur_us list)."""
+    z = df[df["zone name"].isin(KERNEL_ZONES) & df["type"].isin(["ZONE_START", "ZONE_END"])]
+    op2op, kdur = [], []
+    cap = max_gap_us * freq_mhz
+    for _key, g in z.groupby(["PCIe slot", "core_x", "core_y"], sort=False):
+        evs = sorted(
+            (
+                int(r["time[cycles since reset]"]),
+                r["type"] == "ZONE_START",
+                r["zone name"] in DM_KERNEL_ZONES,
+            )
+            for _, r in g.iterrows()
+        )
+        ops = []  # each: {start, dm, end}
+        cur = None
+        prev_was_end = False
+        for t, is_start, is_dm in evs:
+            if is_start:
+                if cur is None or prev_was_end:  # first start after a run of ends = new op
+                    if cur is not None:
+                        ops.append(cur)
+                    cur = {"start": t, "dm": t if is_dm else None, "end": None}
+                elif is_dm and cur["dm"] is None:
+                    cur["dm"] = t
+                prev_was_end = False
+            else:
+                if cur is not None:
+                    cur["end"] = t
+                prev_was_end = True
+        if cur is not None:
+            ops.append(cur)
+        for o in ops:
+            if o["end"] is not None:
+                kdur.append((o["end"] - o["start"]) / freq_mhz)
+        for a, b in zip(ops, ops[1:]):
+            if a["end"] is not None and b["dm"] is not None:
+                gap = b["dm"] - a["end"]
+                if 0 < gap < cap:
+                    op2op.append(gap / freq_mhz)
+    return op2op, kdur
+
+
 def m2m_brackets(pack: dict, unp0: dict, freq_mhz: float, min_prog: int):
     """Decompose the math-to-math interval per consecutive op pair (k -> k+1).
 
@@ -215,7 +276,6 @@ def main() -> int:
 
     pack_finish, unpack0, _ = walk_core_markers(df)
     barriers = walk_barrier_markers(df)
-    dg = walk_done_to_go(df, freq, args.min_prog_id)
     spans = walk_spans(df, READ_RISC_TYPES, "READ_BEFORE_BARRIER", "READ_LAST_BARRIER", args.min_prog_id)
     wspans = walk_spans(df, WRITE_RISC_TYPES, "WRITE_BEFORE_BARRIER", "WRITE_AFTER_BARRIER", args.min_prog_id)
 
@@ -262,8 +322,11 @@ def main() -> int:
     wtail = per_core_diff_us(barriers["write_after"], barriers["write_before"], freq, args.min_prog_id)
     rd_spread = completion_spread_us(barriers["ncrisc_done"], freq, args.min_prog_id)
     wr_spread = completion_spread_us(barriers["brisc_done"], freq, args.min_prog_id)
-    o2o_med = float(dg["dg_median_ns"].median()) / 1000.0 if not dg.empty else float("nan")
-    o2o_last = float(dg["dg_last_ns"].median()) / 1000.0 if not dg.empty else float("nan")
+    # Op2op + kernel duration via the OFFICIAL tools/tracy methodology from the standard
+    # auto-emitted KERNEL zones (comparable to process_device_log.py / Tracy). No custom FW or
+    # dispatch markers -- those were reverted out of tt_metal/; the realtime profiler
+    # (--use-realtime-profiler -> profile_log_device_rt.csv) gives the unpolluted absolute op2op.
+    off_op2op, off_kdur = official_kernel_metrics(df, freq, max_gap_us=50.0)
     # Per-core op duration (reader start NCRISC_GO -> writer done BRISC_DONE) to normalize
     # the spread: absolute spread (us) scales with per-core work, so report it as a % of
     # the typical core's op time for comparability across work sizes / NOP counts.
@@ -282,8 +345,11 @@ def main() -> int:
         "per_core_gbps_median": round(median(per_core_bw), 3),
         "per_core_gbps_max": round(pc_max, 3),
         "starvation_ratio": round(starv, 3),
-        "op_to_op_us": round(o2o_med, 4),
-        "op_to_op_last_us": round(o2o_last, 4),
+        # OFFICIAL tools/tracy methodology (standard KERNEL zones; Tracy / process_device_log.py
+        # comparable) -- canonical op2op + kernel duration, no custom markers:
+        "official_op2op_us": round(median(off_op2op), 4),  # steady-state median
+        "official_op2op_min_us": round(min(off_op2op) if off_op2op else float("nan"), 4),  # == tracy 'Min'
+        "device_kernel_dur_us": round(median(off_kdur), 4),
         # math-to-math, three brackets (all per-pair medians):
         "m2m_bubble_us": round(median(mb["bubble"]), 4),  # global idle window (== old math_to_math_us)
         "m2m_skew_env_us": round(median(mb["skew_env"]), 4),  # first-finish -> last-start (cross-core)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
@@ -151,23 +151,42 @@ def completion_spread_us(done_d: dict, freq_mhz: float, min_prog: int):
     return [(max(v) - min(v)) / freq_mhz for v in by_prog.values() if len(v) > 1]
 
 
-def global_bubbles_us(pack: dict, unp0: dict, freq_mhz: float, min_prog: int):
-    """True inter-op math-to-math: last core to finish pack(k) -> first core to start
-    unpack(k+1). The window where NO core does math. Excludes intra-op cross-core skew
-    (that is execution time of the gating core, not inter-op latency). Consecutive progs
-    only (skips the trace capture->replay boundary)."""
+def m2m_brackets(pack: dict, unp0: dict, freq_mhz: float, min_prog: int):
+    """Decompose the math-to-math interval per consecutive op pair (k -> k+1).
+
+    Four cross-core fenceposts: F=pack_finish(k) (last-math), S=unpack0(k+1) (first-math).
+      F_min/F_max = first/last core to FINISH op k     S_min/S_max = first/last core to START op k+1
+    Returns per-pair lists (us):
+      bubble     = S_min - F_max   global idle window: NO core doing math (raw, may be <0 if ops overlap)
+      skew_env   = S_max - F_min   first core to finish -> last core to start (full cross-core envelope)
+      finish_skew= F_max - F_min   spread of op-k completion across cores
+      start_skew = S_max - S_min   spread of op-(k+1) start across cores
+    Identity: skew_env = finish_skew + bubble + start_skew.
+    Plus within-core gap (same core's unpack0(k+1) - pack_finish(k)) across all core/pair samples.
+    Consecutive progs only (skips the trace capture->replay boundary)."""
     progs = sorted({k[3] for k in pack if k[3] >= min_prog})
-    out = []
+    bubble, skew_env, finish_skew, start_skew, within = [], [], [], [], []
     for a, b in zip(progs, progs[1:]):
         if b != a + 1:
             continue
-        pk = [v for k, v in pack.items() if k[3] == a]
-        un = [v for k, v in unp0.items() if k[3] == b]
-        if pk and un:
-            bub = (min(un) - max(pk)) / freq_mhz
-            if bub > 0:
-                out.append(bub)
-    return out
+        fin = {k[:3]: v for k, v in pack.items() if k[3] == a}
+        sta = {k[:3]: v for k, v in unp0.items() if k[3] == b}
+        if not fin or not sta:
+            continue
+        F, S = list(fin.values()), list(sta.values())
+        bubble.append((min(S) - max(F)) / freq_mhz)
+        skew_env.append((max(S) - min(F)) / freq_mhz)
+        finish_skew.append((max(F) - min(F)) / freq_mhz)
+        start_skew.append((max(S) - min(S)) / freq_mhz)
+        for c in fin.keys() & sta.keys():
+            within.append((sta[c] - fin[c]) / freq_mhz)
+    return {
+        "bubble": bubble,
+        "skew_env": skew_env,
+        "finish_skew": finish_skew,
+        "start_skew": start_skew,
+        "within": within,
+    }
 
 
 def main() -> int:
@@ -232,9 +251,9 @@ def main() -> int:
                 fh.write(f"{cx},{cy},{g:.3f},{(g / pc_max if pc_max else float('nan')):.3f}\n")
         print(f"wrote per-core BW-vs-position to {args.per_core_csv} ({len(rows)} cores)")
 
-    # math-to-math = global inter-op bubble (true latency); NOT the per-core gap (which
-    # counts fast cores idling at done/go = op execution skew, reported separately).
-    m2m = global_bubbles_us(pack_finish, unpack0, freq, args.min_prog_id)
+    # math-to-math brackets: global bubble + cross-core skew envelope + within-core gap.
+    # See m2m_brackets(): skew_env = finish_skew + bubble + start_skew.
+    mb = m2m_brackets(pack_finish, unpack0, freq, args.min_prog_id)
     # read-fill head: first read issued (READ_BEFORE_BARRIER) -> compute gets tile 0
     # (TILE_IDX[0]). This is the first per-trid BATCH (N=trid_in_flight reads) landing +
     # barrier + push, i.e. the reader latency that defers math start (grows with N, not CB depth).
@@ -265,8 +284,13 @@ def main() -> int:
         "starvation_ratio": round(starv, 3),
         "op_to_op_us": round(o2o_med, 4),
         "op_to_op_last_us": round(o2o_last, 4),
-        "math_to_math_us": round(median(m2m), 4),
-        "math_to_math_max_us": round(vmax(m2m), 4),
+        # math-to-math, three brackets (all per-pair medians):
+        "m2m_bubble_us": round(median(mb["bubble"]), 4),  # global idle window (== old math_to_math_us)
+        "m2m_skew_env_us": round(median(mb["skew_env"]), 4),  # first-finish -> last-start (cross-core)
+        "m2m_within_med_us": round(median(mb["within"]), 4),  # same-core gap, typical
+        "m2m_within_max_us": round(vmax(mb["within"]), 4),  # same-core gap, worst core
+        "finish_skew_us": round(median(mb["finish_skew"]), 4),  # op-k completion spread
+        "start_skew_us": round(median(mb["start_skew"]), 4),  # op-(k+1) start spread
         "read_fill_head_us": round(median(read_fill), 4),
         "reader_to_writer_us": round(median(r2w), 4),
         "reader_to_writer_max_us": round(vmax(r2w), 4),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
@@ -241,6 +241,15 @@ def main() -> int:
     wr_spread = completion_spread_us(barriers["brisc_done"], freq, args.min_prog_id)
     o2o_med = float(dg["dg_median_ns"].median()) / 1000.0 if not dg.empty else float("nan")
     o2o_last = float(dg["dg_last_ns"].median()) / 1000.0 if not dg.empty else float("nan")
+    # Per-core op duration (reader start NCRISC_GO -> writer done BRISC_DONE) to normalize
+    # the spread: absolute spread (us) scales with per-core work, so report it as a % of
+    # the typical core's op time for comparability across work sizes / NOP counts.
+    op_durs = per_core_diff_us(barriers["brisc_done"], barriers["ncrisc_go"], freq, args.min_prog_id)
+    op_dur_med = median(op_durs)
+    wr_spread_med = median(wr_spread)
+    wr_spread_pct = (
+        (wr_spread_med / op_dur_med * 100.0) if (op_dur_med == op_dur_med and op_dur_med > 0) else float("nan")
+    )
 
     row = {
         "agg_total_gbps": round(agg_total, 3),
@@ -261,6 +270,10 @@ def main() -> int:
         # op execution skew (NoC starvation), distinct from inter-op latency above:
         "reader_done_spread_us": round(median(rd_spread), 4),
         "writer_done_spread_us": round(median(wr_spread), 4),
+        "op_duration_us": round(op_dur_med, 3),
+        # normalized spread: writer done-spread as a % of the per-core op duration (work-size
+        # independent, so comparable across core counts and NOP counts).
+        "writer_spread_pct": round(wr_spread_pct, 2),
     }
 
     label = {}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Decompose one op_to_op_latency run into BW + latency components for charting.
+
+Emits one chart-ready CSV row (per config = core count x barrier mode) with:
+  agg_read_gbps        aggregate read BW across active cores (device-marker span)
+  op_to_op_us          done/go dispatch hop (DISP_DONE_OBSERVED -> WORKER_GO_OBSERVED)
+  math_to_math_us      last-math(A) -> first-math(B): FINISH_LAST_PUSH(k) -> TILE_IDX0(k+1)
+  reader_to_writer_us  NCRISC_DONE -> BRISC_DONE (write-side tail after reads finish)
+  write_tail_us        WRITE_BEFORE_BARRIER -> WRITE_AFTER_BARRIER (end barrier/flush)
+  *_max                worst-core value (NoC-torus starvation tail)
+  reader_done_spread_us / writer_done_spread_us
+                       max-min completion time across cores per program (late-core skew)
+
+All latencies are per-core medians over steady-state program transitions unless noted.
+Run the test WITHOUT --read-only (writer must do real DRAM writes), with
+TT_METAL_DEVICE_PROFILER=1 + TT_METAL_DEVICE_PROFILER_DISPATCH=1 and --use-device-profiler.
+See [[goal-reduce-math-to-math-latency]].
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import (  # noqa: E402
+    DEFAULT_LOG,
+    READ_RISC_TYPES,
+    WRITE_RISC_TYPES,
+    load_profiler_csv,
+    parse_chip_freq_mhz,
+    walk_barrier_markers,
+    walk_core_markers,
+    walk_done_to_go,
+)
+
+DEFAULT_TILE_BYTES = 2048
+
+
+def walk_spans(df, risc_types, start_zone: str, end_zone: str, min_prog: int):
+    """Per (chip, core, prog) start/end cycle span for a marker pair on given RISCs.
+    Used for read (NCRISC: READ_BEFORE->READ_LAST) and write (BRISC: WRITE_BEFORE->WRITE_AFTER)."""
+    zones = {"PROG_ID", start_zone, end_zone}
+    m = df[df["zone name"].isin(zones) & df["RISC processor type"].isin(risc_types)].copy()
+    m = m.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
+    rows = []
+    for (chip, cx, cy, _r), g in m.groupby(["PCIe slot", "core_x", "core_y", "RISC processor type"], sort=False):
+        prog = None
+        start = None
+        for _, row in g.iterrows():
+            z = row["zone name"]
+            t = int(row["time[cycles since reset]"])
+            if z == "PROG_ID":
+                prog = int(row["data"])
+                start = None
+            elif prog is None:
+                continue
+            elif z == start_zone:
+                start = t
+            elif z == end_zone and start is not None:
+                if prog >= min_prog:
+                    rows.append(
+                        {
+                            "chip": chip,
+                            "core_x": cx,
+                            "core_y": cy,
+                            "prog_id": prog,
+                            "start_cycles": start,
+                            "end_cycles": t,
+                            "duration_cycles": t - start,
+                        }
+                    )
+                start = None
+    return pd.DataFrame(rows)
+
+
+def _series(xs):
+    return pd.Series([float(x) for x in xs if x is not None and x == x])
+
+
+def median(xs):
+    s = _series(xs)
+    return float(s.median()) if len(s) else float("nan")
+
+
+def vmax(xs):
+    s = _series(xs)
+    return float(s.max()) if len(s) else float("nan")
+
+
+def aggregate_read_gbps(spans: pd.DataFrame, num_cores: int, bytes_per_core: int, freq_mhz: float) -> float:
+    """Total bytes / union span (min start -> max end), per execution instance, median.
+
+    Trace capture + replay run each prog id twice ~ms apart; split by start-time gaps so
+    the union span is within one execution, not across both.
+    """
+    if spans.empty:
+        return float("nan")
+    freq_ghz = freq_mhz / 1000.0
+    gap = max(5.0 * float(spans["duration_cycles"].median()), 1.0)
+    s = spans.sort_values(["prog_id", "start_cycles"]).reset_index(drop=True)
+    aggs = []
+    cur = []
+    prev_prog = prev_start = None
+    for _, r in s.iterrows():
+        prog, st = int(r["prog_id"]), int(r["start_cycles"])
+        new_inst = (prog != prev_prog) or (prev_start is not None and (st - prev_start) > gap)
+        if new_inst and cur:
+            aggs.append(cur)
+            cur = []
+        cur.append(r)
+        prev_prog, prev_start = prog, st
+    if cur:
+        aggs.append(cur)
+    gbps = []
+    for inst in aggs:
+        ncores = len({(int(r["chip"]), int(r["core_x"]), int(r["core_y"])) for r in inst})
+        union = max(int(r["end_cycles"]) for r in inst) - min(int(r["start_cycles"]) for r in inst)
+        if union > 0:
+            gbps.append(ncores * bytes_per_core / (union / freq_ghz))
+    return float(pd.Series(gbps).median()) if gbps else float("nan")
+
+
+def per_core_diff_us(end_d: dict, start_d: dict, freq_mhz: float, min_prog: int):
+    """end_d[key] - start_d[key] in us, for keys (chip,cx,cy,prog) present in both, prog>=min."""
+    out = []
+    for k, e in end_d.items():
+        if k[3] < min_prog:
+            continue
+        if k in start_d:
+            out.append((int(e) - int(start_d[k])) / freq_mhz)
+    return out
+
+
+def completion_spread_us(done_d: dict, freq_mhz: float, min_prog: int):
+    """Per program: (max - min) completion time across cores -> late-core skew."""
+    by_prog: dict = {}
+    for (chip, cx, cy, prog), t in done_d.items():
+        if prog < min_prog:
+            continue
+        by_prog.setdefault(prog, []).append(int(t))
+    return [(max(v) - min(v)) / freq_mhz for v in by_prog.values() if len(v) > 1]
+
+
+def global_bubbles_us(pack: dict, unp0: dict, freq_mhz: float, min_prog: int):
+    """True inter-op math-to-math: last core to finish pack(k) -> first core to start
+    unpack(k+1). The window where NO core does math. Excludes intra-op cross-core skew
+    (that is execution time of the gating core, not inter-op latency). Consecutive progs
+    only (skips the trace capture->replay boundary)."""
+    progs = sorted({k[3] for k in pack if k[3] >= min_prog})
+    out = []
+    for a, b in zip(progs, progs[1:]):
+        if b != a + 1:
+            continue
+        pk = [v for k, v in pack.items() if k[3] == a]
+        un = [v for k, v in unp0.items() if k[3] == b]
+        if pk and un:
+            bub = (min(un) - max(pk)) / freq_mhz
+            if bub > 0:
+                out.append(bub)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Decompose one op_to_op run into BW + latency columns.")
+    ap.add_argument("--input-file", type=Path, default=None, help=f"default $TT_METAL_HOME/{DEFAULT_LOG}")
+    ap.add_argument("--pages-per-core", type=int, required=True)
+    ap.add_argument("--tile-bytes", type=int, default=DEFAULT_TILE_BYTES)
+    ap.add_argument("--num-cores", type=int, required=True)
+    ap.add_argument("--min-prog-id", type=int, default=1)
+    ap.add_argument("--csv-out", type=Path, default=None, help="append one row here (writes header if new)")
+    ap.add_argument(
+        "--per-core-csv",
+        type=Path,
+        default=None,
+        help="write per-core read BW vs position (core_x,core_y,read_gbps,frac_of_max) for plotting starvation",
+    )
+    ap.add_argument("--label", default="", help="leading k=v;k=v fields to record (e.g. cores=8;mode=full;in_cb=16)")
+    args = ap.parse_args()
+
+    log = (args.input_file or Path(os.environ.get("TT_METAL_HOME", ".")) / DEFAULT_LOG).resolve()
+    if not log.is_file():
+        print(f"Input not found: {log}", file=sys.stderr)
+        return 1
+    freq = parse_chip_freq_mhz(log)
+    df = load_profiler_csv(log)
+
+    pack_finish, unpack0, _ = walk_core_markers(df)
+    barriers = walk_barrier_markers(df)
+    dg = walk_done_to_go(df, freq, args.min_prog_id)
+    spans = walk_spans(df, READ_RISC_TYPES, "READ_BEFORE_BARRIER", "READ_LAST_BARRIER", args.min_prog_id)
+    wspans = walk_spans(df, WRITE_RISC_TYPES, "WRITE_BEFORE_BARRIER", "WRITE_AFTER_BARRIER", args.min_prog_id)
+
+    bytes_per_core = args.pages_per_core * args.tile_bytes
+    freq_ghz = freq / 1000.0
+    agg_bw = aggregate_read_gbps(spans, args.num_cores, bytes_per_core, freq)
+    agg_wbw = aggregate_read_gbps(wspans, args.num_cores, bytes_per_core, freq)
+    agg_total = (agg_bw + agg_wbw) if (agg_bw == agg_bw and agg_wbw == agg_wbw) else float("nan")
+
+    # Per-core read-BW distribution -> quantifies reader starvation/serialization.
+    pcbw: dict = {}
+    if not spans.empty:
+        for _, r in spans.iterrows():
+            k = (int(r["chip"]), int(r["core_x"]), int(r["core_y"]))
+            dur = int(r["duration_cycles"])
+            if dur > 0:
+                pcbw.setdefault(k, []).append(bytes_per_core / (dur / freq_ghz))
+    per_core_bw = [float(pd.Series(v).median()) for v in pcbw.values()]
+    pc_min = min(per_core_bw) if per_core_bw else float("nan")
+    pc_max = max(per_core_bw) if per_core_bw else float("nan")
+    # starvation_ratio = fastest-core BW / slowest-core BW (1.0 = perfectly fair, >1 worse)
+    starv = (pc_max / pc_min) if (per_core_bw and pc_min > 0) else float("nan")
+
+    if args.per_core_csv is not None:
+        args.per_core_csv.parent.mkdir(parents=True, exist_ok=True)
+        rows = sorted(
+            ((cx, cy, float(pd.Series(v).median())) for (chip, cx, cy), v in pcbw.items()),
+            key=lambda r: (r[1], r[0]),  # by row (y) then column (x)
+        )
+        with args.per_core_csv.open("w") as fh:
+            fh.write("core_x,core_y,read_gbps,frac_of_max\n")
+            for cx, cy, g in rows:
+                fh.write(f"{cx},{cy},{g:.3f},{(g / pc_max if pc_max else float('nan')):.3f}\n")
+        print(f"wrote per-core BW-vs-position to {args.per_core_csv} ({len(rows)} cores)")
+
+    # math-to-math = global inter-op bubble (true latency); NOT the per-core gap (which
+    # counts fast cores idling at done/go = op execution skew, reported separately).
+    m2m = global_bubbles_us(pack_finish, unpack0, freq, args.min_prog_id)
+    r2w = per_core_diff_us(barriers["brisc_done"], barriers["ncrisc_done"], freq, args.min_prog_id)
+    wtail = per_core_diff_us(barriers["write_after"], barriers["write_before"], freq, args.min_prog_id)
+    rd_spread = completion_spread_us(barriers["ncrisc_done"], freq, args.min_prog_id)
+    wr_spread = completion_spread_us(barriers["brisc_done"], freq, args.min_prog_id)
+    o2o_med = float(dg["dg_median_ns"].median()) / 1000.0 if not dg.empty else float("nan")
+    o2o_last = float(dg["dg_last_ns"].median()) / 1000.0 if not dg.empty else float("nan")
+
+    row = {
+        "agg_total_gbps": round(agg_total, 3),
+        "agg_read_gbps": round(agg_bw, 3),
+        "agg_write_gbps": round(agg_wbw, 3),
+        "per_core_gbps_min": round(pc_min, 3),
+        "per_core_gbps_median": round(median(per_core_bw), 3),
+        "per_core_gbps_max": round(pc_max, 3),
+        "starvation_ratio": round(starv, 3),
+        "op_to_op_us": round(o2o_med, 4),
+        "op_to_op_last_us": round(o2o_last, 4),
+        "math_to_math_us": round(median(m2m), 4),
+        "math_to_math_max_us": round(vmax(m2m), 4),
+        "reader_to_writer_us": round(median(r2w), 4),
+        "reader_to_writer_max_us": round(vmax(r2w), 4),
+        "write_tail_us": round(median(wtail), 4),
+        "write_tail_max_us": round(vmax(wtail), 4),
+        # op execution skew (NoC starvation), distinct from inter-op latency above:
+        "reader_done_spread_us": round(median(rd_spread), 4),
+        "writer_done_spread_us": round(median(wr_spread), 4),
+    }
+
+    label = {}
+    for kv in args.label.split(";"):
+        if "=" in kv:
+            k, v = kv.split("=", 1)
+            label[k.strip()] = v.strip()
+
+    print(f"freq={freq:.1f}MHz  cores={args.num_cores}  bytes/core={bytes_per_core}")
+    for k, v in row.items():
+        print(f"  {k:26s} {v}")
+
+    # Columns kept in stdout (driver greps agg_read/agg_total during tuning) but dropped
+    # from the chart CSV as noise -- per-core BW detail and the read/write BW split;
+    # agg_total + starvation_ratio (+ peak_read_gbps from the label) carry the signal.
+    csv_drop = {"agg_read_gbps", "agg_write_gbps", "per_core_gbps_min", "per_core_gbps_median", "per_core_gbps_max"}
+    if args.csv_out is not None:
+        cols = [c for c in (list(label.keys()) + list(row.keys())) if c not in csv_drop]
+        new = not args.csv_out.exists()
+        args.csv_out.parent.mkdir(parents=True, exist_ok=True)
+        with args.csv_out.open("a") as fh:
+            if new:
+                fh.write(",".join(cols) + "\n")
+            fh.write(",".join(str(label.get(c, row.get(c, ""))) for c in cols) + "\n")
+        print(f"appended row to {args.csv_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_latency_bw.py
@@ -235,6 +235,10 @@ def main() -> int:
     # math-to-math = global inter-op bubble (true latency); NOT the per-core gap (which
     # counts fast cores idling at done/go = op execution skew, reported separately).
     m2m = global_bubbles_us(pack_finish, unpack0, freq, args.min_prog_id)
+    # read-fill head: first read issued (READ_BEFORE_BARRIER) -> compute gets tile 0
+    # (TILE_IDX[0]). This is the first per-trid BATCH (N=trid_in_flight reads) landing +
+    # barrier + push, i.e. the reader latency that defers math start (grows with N, not CB depth).
+    read_fill = per_core_diff_us(unpack0, barriers["read_before"], freq, args.min_prog_id)
     r2w = per_core_diff_us(barriers["brisc_done"], barriers["ncrisc_done"], freq, args.min_prog_id)
     wtail = per_core_diff_us(barriers["write_after"], barriers["write_before"], freq, args.min_prog_id)
     rd_spread = completion_spread_us(barriers["ncrisc_done"], freq, args.min_prog_id)
@@ -263,6 +267,7 @@ def main() -> int:
         "op_to_op_last_us": round(o2o_last, 4),
         "math_to_math_us": round(median(m2m), 4),
         "math_to_math_max_us": round(vmax(m2m), 4),
+        "read_fill_head_us": round(median(read_fill), 4),
         "reader_to_writer_us": round(median(r2w), 4),
         "reader_to_writer_max_us": round(vmax(r2w), 4),
         "write_tail_us": round(median(wtail), 4),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_op_to_op_gap.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_op_to_op_gap.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Decompose the op-to-op gap into its sub-components using existing batch8
+profile_log_device_op_to_op_complete.csv files. No new measurements needed —
+the device profiler already records every timestamp we need.
+
+Gap timeline (chronological, kernel N -> kernel N+1):
+
+   pack_finish(N)                          <-- gap starts (compute N done)
+       |
+       |  A. WRITER_TAIL = brisc_done(N) - pack_finish(N)
+       |     "How long after compute is done does the writer take to exit?"
+       |     This is where the end-of-kernel barrier wait lives, plus any
+       |     residual writes left to drain from the CB.
+       v
+   brisc_done(N)
+       |
+       |  B. DISPATCH = brisc_go(N+1) - brisc_done(N) = brisc_done_to_go_us (= "dg")
+       |     Pure dispatch path. Includes init-register load for kernel N+1.
+       |     ** This is what HW init-register virtualization attacks. **
+       v
+   brisc_go(N+1)
+       |
+       |  C. READER_FIRST_DRAM = read_after_barrier(N+1) - brisc_go(N+1)
+       |     BRISC startup + first DRAM read issued + DRAM round-trip for tile 0.
+       v
+   read_after_barrier(N+1)
+       |
+       |  D. DRAM_TO_UNPACK = read_after_to_unpack_tile0_us
+       |     First tile in L1 -> compute pulls it.
+       v
+   unpack_tile0_start(N+1)                 <-- gap ends (compute N+1 starts)
+
+   gap_us = A + B + C + D  (verified within rounding)
+"""
+
+from __future__ import annotations
+
+import csv
+import glob
+import os
+import statistics as st
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TT_METAL_HOME = SCRIPT_DIR.parents[4]
+RUNS_BASE = TT_METAL_HOME / "generated/profiler/op_to_op_runs"
+OUT_DIR = RUNS_BASE / "batch8"
+OUT_CSV = OUT_DIR / "gap_decomposition.csv"
+MIN_PROG_ID = 3
+
+CORE_COUNTS = [1, 2, 4, 10, 20, 40, 80, 110]
+MODES = [(0, "barrier"), (1, "flushed")]
+
+
+def _f(row: dict, key: str) -> float:
+    v = row.get(key, "")
+    try:
+        return float(v) if v not in ("", "nan", None) else float("nan")
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def decompose_row(row: dict) -> dict:
+    pack_finish = _f(row, "pack_finish_us")
+    brisc_done = _f(row, "brisc_done_us")
+    brisc_go = _f(row, "brisc_go_us")
+    read_after = _f(row, "read_after_barrier_us")
+
+    A = brisc_done - pack_finish
+    B = _f(row, "brisc_done_to_go_us")
+    C = read_after - brisc_go
+    D = _f(row, "read_after_to_unpack_tile0_us")
+    gap = _f(row, "gap_us")
+
+    return {
+        "A_writer_tail": A,
+        "B_dispatch": B,
+        "C_reader_first_dram": C,
+        "D_dram_to_unpack": D,
+        "gap_us": gap,
+    }
+
+
+def load_runs(cores: int, mode: int) -> list[dict]:
+    pattern = str(RUNS_BASE / f"batch8_c{cores}_m{mode}" / "run_*" / "profile_log_device_op_to_op_complete.csv")
+    paths = sorted(glob.glob(pattern))
+    out: list[dict] = []
+    for p in paths:
+        with open(p) as fh:
+            for row in csv.DictReader(fh):
+                try:
+                    if int(float(row.get("from_prog_id", 0))) < MIN_PROG_ID:
+                        continue
+                except (TypeError, ValueError):
+                    continue
+                out.append(row)
+    return out
+
+
+def median(values: list[float]) -> float:
+    values = [v for v in values if v == v]
+    return st.median(values) if values else float("nan")
+
+
+def aggregate(rows: list[dict]) -> dict:
+    decomp = [decompose_row(r) for r in rows]
+    keys = decomp[0].keys() if decomp else []
+    return {k: median([d[k] for d in decomp]) for k in keys}
+
+
+def fmt(v: float, digits: int = 3) -> str:
+    return f"{v:.{digits}f}" if v == v else ""
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    fields = [
+        "cores",
+        "mode",
+        "gap_us",
+        "A_writer_tail_us",
+        "A_pct",
+        "B_dispatch_us",
+        "B_pct",
+        "C_reader_first_dram_us",
+        "C_pct",
+        "D_dram_to_unpack_us",
+        "D_pct",
+        "n_transitions",
+    ]
+    table_rows = []
+
+    for cores in CORE_COUNTS:
+        for mode_id, mode_label in MODES:
+            rows = load_runs(cores, mode_id)
+            if not rows:
+                continue
+            agg = aggregate(rows)
+            gap = agg["gap_us"]
+
+            def pct(v):
+                return f"{(v / gap) * 100:.1f}" if gap and gap == gap and v == v else ""
+
+            table_rows.append(
+                {
+                    "cores": cores,
+                    "mode": mode_label,
+                    "gap_us": fmt(gap),
+                    "A_writer_tail_us": fmt(agg["A_writer_tail"]),
+                    "A_pct": pct(agg["A_writer_tail"]),
+                    "B_dispatch_us": fmt(agg["B_dispatch"]),
+                    "B_pct": pct(agg["B_dispatch"]),
+                    "C_reader_first_dram_us": fmt(agg["C_reader_first_dram"]),
+                    "C_pct": pct(agg["C_reader_first_dram"]),
+                    "D_dram_to_unpack_us": fmt(agg["D_dram_to_unpack"]),
+                    "D_pct": pct(agg["D_dram_to_unpack"]),
+                    "n_transitions": str(len(rows)),
+                }
+            )
+
+    with open(OUT_CSV, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(table_rows)
+
+    print(f"\nWrote {OUT_CSV}\n")
+
+    # Print compact summary: just the 4 top-level components per (cores,mode)
+    print(
+        f"{'cores':>6} {'mode':>8} {'gap us':>8} | {'A writer':>9} ({'%':>4}) {'B disp':>7} ({'%':>4}) {'C rdr+DRAM':>11} ({'%':>4}) {'D rd→cmp':>9} ({'%':>4})"
+    )
+    print(
+        f"{'-'*6:>6} {'-'*8:>8} {'-'*8:>8} | {'-'*9:>9}  {'-'*4:>4}  {'-'*7:>7}  {'-'*4:>4}  {'-'*11:>11}  {'-'*4:>4}  {'-'*9:>9}  {'-'*4:>4}"
+    )
+    for r in table_rows:
+        print(
+            f"{r['cores']:>6} {r['mode']:>8} {r['gap_us']:>8} | "
+            f"{r['A_writer_tail_us']:>9} ({r['A_pct']:>3}%) "
+            f"{r['B_dispatch_us']:>7} ({r['B_pct']:>3}%) "
+            f"{r['C_reader_first_dram_us']:>11} ({r['C_pct']:>3}%) "
+            f"{r['D_dram_to_unpack_us']:>9} ({r['D_pct']:>3}%)"
+        )
+
+    # Per-component delta when switching mode 0 (barrier) -> mode 1 (flushed).
+    # Tells us *which* sub-component shrunk to deliver B8's win.
+    print(f"\n{'-'*94}")
+    print("Where Batch 8's mode-1 win comes from (Δ = mode_1 - mode_0, in us):")
+    print(f"{'cores':>6} {'Δ gap':>9} | {'Δ A writer':>11} {'Δ B disp':>10} {'Δ C rdr+DRAM':>13} {'Δ D rd→cmp':>12}")
+    for cores in CORE_COUNTS:
+        m0 = next((r for r in table_rows if r["cores"] == cores and r["mode"] == "barrier"), None)
+        m1 = next((r for r in table_rows if r["cores"] == cores and r["mode"] == "flushed"), None)
+        if not m0 or not m1:
+            continue
+
+        def d(key):
+            a = float(m1[key] or "nan")
+            b = float(m0[key] or "nan")
+            return a - b if a == a and b == b else float("nan")
+
+        print(
+            f"{cores:>6} {d('gap_us'):>+9.3f} | "
+            f"{d('A_writer_tail_us'):>+11.3f} "
+            f"{d('B_dispatch_us'):>+10.3f} "
+            f"{d('C_reader_first_dram_us'):>+13.3f} "
+            f"{d('D_dram_to_unpack_us'):>+12.3f}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_op_to_op_gap.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/decompose_op_to_op_gap.py
@@ -46,9 +46,10 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 TT_METAL_HOME = SCRIPT_DIR.parents[4]
 RUNS_BASE = TT_METAL_HOME / "generated/profiler/op_to_op_runs"
-OUT_DIR = RUNS_BASE / "batch8"
+BATCH_PREFIX = os.environ.get("BATCH_PREFIX", "batch8")
+OUT_DIR = RUNS_BASE / os.environ.get("OUT_DIR_NAME", BATCH_PREFIX)
 OUT_CSV = OUT_DIR / "gap_decomposition.csv"
-MIN_PROG_ID = 3
+MIN_PROG_ID = int(os.environ.get("MIN_PROG_ID", "3"))
 
 CORE_COUNTS = [1, 2, 4, 10, 20, 40, 80, 110]
 MODES = [(0, "barrier"), (1, "flushed")]
@@ -84,7 +85,7 @@ def decompose_row(row: dict) -> dict:
 
 
 def load_runs(cores: int, mode: int) -> list[dict]:
-    pattern = str(RUNS_BASE / f"batch8_c{cores}_m{mode}" / "run_*" / "profile_log_device_op_to_op_complete.csv")
+    pattern = str(RUNS_BASE / f"{BATCH_PREFIX}_c{cores}_m{mode}" / "run_*" / "profile_log_device_op_to_op_complete.csv")
     paths = sorted(glob.glob(pattern))
     out: list[dict] = []
     for p in paths:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_gaps_csvlite.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_gaps_csvlite.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Pandas-free export of op-to-op gap + done/go metrics from profile_log_device.csv."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import statistics as st
+import sys
+from pathlib import Path
+
+UNPACK_RISC = "TRISC_0"
+PACK_RISC = "TRISC_2"
+
+
+def parse_chip_freq_mhz(log_path: Path) -> float:
+    with log_path.open() as f:
+        header = f.readline()
+    match = re.search(r"CHIP_FREQ\[MHz\]:\s*([0-9.]+)", header)
+    if not match:
+        raise ValueError(f"Could not parse CHIP_FREQ from {log_path}")
+    return float(match.group(1))
+
+
+def iter_markers(log_path: Path):
+    with log_path.open(newline="") as f:
+        f.readline()
+        for row in csv.DictReader(f):
+            yield row
+
+
+def walk_core_markers(log_path: Path):
+    pack_finish: dict[tuple, int] = {}
+    unpack_tile0_start: dict[tuple, int] = {}
+    cur_prog: dict[tuple, int | None] = {}
+
+    for row in iter_markers(log_path):
+        zone = row["zone name"].strip()
+        risc = row["RISC processor type"].strip()
+        if zone not in ("PROG_ID", "TILE_IDX", "FINISH_LAST_PUSH"):
+            continue
+        if risc not in (UNPACK_RISC, PACK_RISC):
+            continue
+
+        chip = int(row["PCIe slot"])
+        core_x = int(row["core_x"])
+        core_y = int(row["core_y"])
+        t = int(row["time[cycles since reset]"])
+        data = int(float(row["data"])) if row["data"] else 0
+        key = (chip, core_x, core_y, risc)
+
+        if zone == "PROG_ID" and risc == UNPACK_RISC:
+            cur_prog[(chip, core_x, core_y)] = data
+        elif zone == "TILE_IDX" and risc == UNPACK_RISC and data == 0:
+            p = cur_prog.get((chip, core_x, core_y))
+            if p is not None:
+                unpack_tile0_start[(chip, core_x, core_y, p)] = t
+        elif zone == "FINISH_LAST_PUSH" and risc == PACK_RISC:
+            p = cur_prog.get((chip, core_x, core_y))
+            if p is None:
+                p = data
+            pack_finish[(chip, core_x, core_y, p)] = t
+
+    return pack_finish, unpack_tile0_start
+
+
+def compute_gaps(
+    pack_finish: dict[tuple, int],
+    unpack_tile0_start: dict[tuple, int],
+    min_prog_id: int,
+) -> list[dict]:
+    cores = {(k[0], k[1], k[2]) for k in pack_finish} | {(k[0], k[1], k[2]) for k in unpack_tile0_start}
+    rows: list[dict] = []
+
+    for chip, core_x, core_y in sorted(cores):
+        prog_ids = sorted(
+            {p for c, x, y, p in pack_finish if (c, x, y) == (chip, core_x, core_y) and p >= min_prog_id}
+            | {p for c, x, y, p in unpack_tile0_start if (c, x, y) == (chip, core_x, core_y) and p >= min_prog_id}
+        )
+        for from_prog, to_prog in zip(prog_ids, prog_ids[1:]):
+            end_key = (chip, core_x, core_y, from_prog)
+            start_key = (chip, core_x, core_y, to_prog)
+            if end_key not in pack_finish or start_key not in unpack_tile0_start:
+                continue
+            end_cycles = pack_finish[end_key]
+            start_cycles = unpack_tile0_start[start_key]
+            rows.append(
+                {
+                    "chip": chip,
+                    "core_x": core_x,
+                    "core_y": core_y,
+                    "from_prog_id": from_prog,
+                    "to_prog_id": to_prog,
+                    "pack_finish_cycles": end_cycles,
+                    "unpack_tile0_start_cycles": start_cycles,
+                    "gap_cycles": start_cycles - end_cycles,
+                }
+            )
+    return rows
+
+
+def walk_done_to_go(log_path: Path, freq_mhz: float, min_prog_id: int) -> dict[tuple[int, int], dict]:
+    disp_done: list[tuple[int, int, int]] = []
+    disp_go: list[tuple[int, int]] = []
+    worker_go: list[tuple[int, int, int, int]] = []
+    dispatch_cores: set[tuple[int, int, int]] = set()
+
+    for row in iter_markers(log_path):
+        zone = row["zone name"].strip()
+        if zone not in ("DISP_DONE_OBSERVED", "DISP_GO_ISSUED", "WORKER_GO_OBSERVED"):
+            continue
+        chip = int(row["PCIe slot"])
+        core_x = int(row["core_x"])
+        core_y = int(row["core_y"])
+        t = int(row["time[cycles since reset]"])
+        data = int(float(row["data"])) if row["data"] else 0
+        if zone == "DISP_DONE_OBSERVED":
+            disp_done.append((chip, t, data))
+            dispatch_cores.add((chip, core_x, core_y))
+        elif zone == "DISP_GO_ISSUED":
+            disp_go.append((chip, t))
+        elif zone == "WORKER_GO_OBSERVED":
+            if (chip, core_x, core_y) in dispatch_cores:
+                continue
+            worker_go.append((chip, core_x, core_y, t))
+
+    window_cycles = int(3000.0 / 1000.0 * freq_mhz)
+    out: dict[tuple[int, int], dict] = {}
+
+    disp_done_by_chip: dict[int, list[tuple[int, int]]] = {}
+    for chip, t, pid in disp_done:
+        disp_done_by_chip.setdefault(chip, []).append((t, pid))
+
+    disp_go_by_chip: dict[int, list[int]] = {}
+    for chip, t in disp_go:
+        disp_go_by_chip.setdefault(chip, []).append(t)
+
+    worker_by_chip: dict[int, list[int]] = {}
+    for chip, _x, _y, t in worker_go:
+        worker_by_chip.setdefault(chip, []).append(t)
+
+    for chip, events in disp_done_by_chip.items():
+        wg = sorted(worker_by_chip.get(chip, []))
+        dg = sorted(disp_go_by_chip.get(chip, []))
+        for d_t, d_pid in sorted(events):
+            if d_pid < min_prog_id:
+                continue
+            lo, hi = d_t, d_t + window_cycles
+            deltas = [w - d_t for w in wg if lo < w < hi]
+            if not deltas:
+                continue
+            dg_after = [g for g in dg if g > d_t]
+            issue_cycles = (dg_after[0] - d_t) if dg_after else None
+            out[(chip, d_pid)] = {
+                "dg_issue_ns": (issue_cycles / freq_mhz * 1000.0) if issue_cycles is not None else "",
+                "dg_first_ns": min(deltas) / freq_mhz * 1000.0,
+                "dg_median_ns": st.median(deltas) / freq_mhz * 1000.0,
+                "dg_last_ns": max(deltas) / freq_mhz * 1000.0,
+            }
+    return out
+
+
+def export_log(log_path: Path, output_path: Path, min_prog_id: int) -> int:
+    freq_mhz = parse_chip_freq_mhz(log_path)
+    pack_finish, unpack_tile0 = walk_core_markers(log_path)
+    gaps = compute_gaps(pack_finish, unpack_tile0, min_prog_id)
+    dg_lookup = walk_done_to_go(log_path, freq_mhz, min_prog_id)
+
+    fieldnames = [
+        "chip",
+        "core_x",
+        "core_y",
+        "from_prog_id",
+        "to_prog_id",
+        "gap_cycles",
+        "gap_us",
+        "dg_issue_ns",
+        "dg_first_ns",
+        "dg_median_ns",
+        "dg_last_ns",
+        "_dg_issue_ns",
+        "_dg_first_ns",
+        "_dg_median_ns",
+        "_dg_last_ns",
+    ]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for row in gaps:
+            gap_us = row["gap_cycles"] / freq_mhz
+            dg = dg_lookup.get((row["chip"], row["to_prog_id"]), {})
+            w.writerow(
+                {
+                    "chip": row["chip"],
+                    "core_x": row["core_x"],
+                    "core_y": row["core_y"],
+                    "from_prog_id": row["from_prog_id"],
+                    "to_prog_id": row["to_prog_id"],
+                    "gap_cycles": row["gap_cycles"],
+                    "gap_us": gap_us,
+                    "dg_issue_ns": dg.get("dg_issue_ns", ""),
+                    "dg_first_ns": dg.get("dg_first_ns", ""),
+                    "dg_median_ns": dg.get("dg_median_ns", ""),
+                    "dg_last_ns": dg.get("dg_last_ns", ""),
+                    "_dg_issue_ns": dg.get("dg_issue_ns", ""),
+                    "_dg_first_ns": dg.get("dg_first_ns", ""),
+                    "_dg_median_ns": dg.get("dg_median_ns", ""),
+                    "_dg_last_ns": dg.get("dg_last_ns", ""),
+                }
+            )
+    return len(gaps)
+
+
+def median_of(values: list[float]) -> float:
+    vals = [v for v in values if v == v]
+    return st.median(vals) if vals else float("nan")
+
+
+def aggregate_runs(run_dirs: list[Path], min_prog_id: int) -> dict[str, float]:
+    op2op, dg_first, dg_median, dg_last, dg_issue = [], [], [], [], []
+    for run_dir in run_dirs:
+        complete = run_dir / "profile_log_device_op_to_op_complete.csv"
+        log = run_dir / "profile_log_device.csv"
+        if not complete.is_file() and log.is_file():
+            export_log(log, complete, min_prog_id)
+        if not complete.is_file():
+            continue
+        with complete.open(newline="") as f:
+            for row in csv.DictReader(f):
+                if int(float(row["from_prog_id"])) < min_prog_id:
+                    continue
+                op2op.append(float(row["gap_us"]))
+                for src, dst in (
+                    ("dg_first_ns", dg_first),
+                    ("dg_median_ns", dg_median),
+                    ("dg_last_ns", dg_last),
+                    ("dg_issue_ns", dg_issue),
+                    ("_dg_median_ns", dg_median),
+                ):
+                    if src in row and row[src] not in ("", "nan"):
+                        try:
+                            dst.append(float(row[src]))
+                        except ValueError:
+                            pass
+    return {
+        "op2op_us_median": median_of(op2op),
+        "dg_first_ns": median_of(dg_first),
+        "dg_median_ns": median_of(dg_median),
+        "dg_last_ns": median_of(dg_last),
+        "dg_issue_ns": median_of(dg_issue),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-file", type=Path, required=True)
+    parser.add_argument("--output-file", type=Path)
+    parser.add_argument("--min-prog-id", type=int, default=3)
+    parser.add_argument("--aggregate-runs-dir", type=Path)
+    args = parser.parse_args()
+
+    if args.aggregate_runs_dir is not None:
+        runs = sorted(p for p in args.aggregate_runs_dir.glob("run_*") if p.is_dir())
+        stats = aggregate_runs(runs, args.min_prog_id)
+        print(f"op2op={stats['op2op_us_median']:.3f}us " f"dg_median={stats['dg_median_ns']:.0f}ns n_runs={len(runs)}")
+        return 0
+
+    out = args.output_file or args.input_file.parent / "profile_log_device_op_to_op_complete.csv"
+    n = export_log(args.input_file, out, args.min_prog_id)
+    print(f"Wrote {n} gap rows -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
@@ -97,9 +97,109 @@ def walk_core_markers(df: pd.DataFrame) -> tuple[dict, dict, pd.DataFrame]:
     return pack_finish, unpack_tile0_start, pd.DataFrame(tile_rows)
 
 
+def walk_done_to_go(df: pd.DataFrame, freq_mhz: float, min_prog_id: int) -> pd.DataFrame:
+    """Done/go decomposition: "MCAST GO issue cost + done counting in dispatch
+    core". On BH this materialises as the NoC-propagation interval "dispatch
+    sees workers done -> a worker observes the new GO multicast".
+
+    We have three event markers (all on the same chip clock domain):
+      - DISP_DONE_OBSERVED (dispatch_s):   wait_for_workers spin exits.
+      - DISP_GO_ISSUED    (dispatch_s):    MCAST GO write fired to NoC
+                                            (registers programmed, returns
+                                             before propagation completes).
+      - WORKER_GO_OBSERVED (per worker):   GO spin exits + scope start +
+                                            host_assigned_id read.
+
+    Reported per (chip, dispatch DISP_DONE timestamp):
+      dg_issue_ns    = DISP_GO_ISSUED - DISP_DONE_OBSERVED on dispatch_s.
+                        Pure single-write fire cost (~30 cycles on BH).
+      dg_first_ns    = min over workers of
+                       (WORKER_GO_OBSERVED - DISP_DONE_OBSERVED).
+                        Nearest worker observes GO.
+      dg_median_ns   = median over workers (typical worker)
+      dg_last_ns     = max over workers (farthest worker; ~= our old
+                        brisc_fw_done_to_go_us upper bound)
+
+    Requires TT_METAL_DEVICE_PROFILER_DISPATCH=1 at runtime so dispatch_s
+    markers land in profile_log_device.csv.
+
+    `min_prog_id` filters the dispatch program-id tag (popped_pid). Trace
+    boundaries (>3 us idle) are dropped automatically.
+    """
+    disp_done = df[df["zone name"] == "DISP_DONE_OBSERVED"].copy()
+    disp_go = df[df["zone name"] == "DISP_GO_ISSUED"].copy()
+    worker_go = df[df["zone name"] == "WORKER_GO_OBSERVED"].copy()
+    if disp_done.empty or worker_go.empty:
+        return pd.DataFrame()
+    # The dispatch_s core appears in both DISP_* and (sometimes, on startup)
+    # WORKER_GO_OBSERVED if FW happens to log it. Identify dispatch cores per chip
+    # and exclude them from the worker pool.
+    dispatch_cores = disp_done.groupby("PCIe slot")[["core_x", "core_y"]].agg(lambda s: list(s.unique())).reset_index()
+    worker_go = worker_go.copy()
+    # Drop rows where worker is actually a dispatch core for the same chip.
+    dispatch_set: set[tuple] = set()
+    for _, r in disp_done[["PCIe slot", "core_x", "core_y"]].drop_duplicates().iterrows():
+        dispatch_set.add((int(r["PCIe slot"]), int(r["core_x"]), int(r["core_y"])))
+    worker_go = worker_go[
+        ~worker_go.apply(lambda r: (int(r["PCIe slot"]), int(r["core_x"]), int(r["core_y"])) in dispatch_set, axis=1)
+    ]
+
+    # 10 us window cap (in cycles). Anything beyond is a trace boundary, not a real transition.
+    window_cycles = int(3000.0 / 1000.0 * freq_mhz)  # 3 us = ~4050 cycles @ 1.35 GHz
+
+    rows: list[dict] = []
+    for chip, dd_chip in disp_done.groupby("PCIe slot"):
+        dd_chip = dd_chip.sort_values("time[cycles since reset]").reset_index(drop=True)
+        dg_chip = disp_go[disp_go["PCIe slot"] == chip].sort_values("time[cycles since reset]").reset_index(drop=True)
+        wg_chip = worker_go[worker_go["PCIe slot"] == chip].copy()
+        wg_t = wg_chip["time[cycles since reset]"].astype("int64").values
+        for i, drow in dd_chip.iterrows():
+            d_t = int(drow["time[cycles since reset]"])
+            d_pid = int(drow["data"])
+            if d_pid < min_prog_id:
+                continue
+            # Worker events RIGHT AFTER this DISP_DONE, within window.
+            lo, hi = d_t, d_t + window_cycles
+            mask = (wg_t > lo) & (wg_t < hi)
+            deltas = wg_t[mask] - d_t
+            if len(deltas) == 0:
+                continue
+            # Find DISP_GO_ISSUED that immediately follows.
+            dg_after = dg_chip[dg_chip["time[cycles since reset]"] > d_t]
+            if len(dg_after) > 0:
+                go_t = int(dg_after.iloc[0]["time[cycles since reset]"])
+                issue_cycles = go_t - d_t
+            else:
+                go_t = pd.NA
+                issue_cycles = pd.NA
+            rows.append(
+                {
+                    "chip": chip,
+                    "program_id": d_pid,
+                    "done_observed_cycles": d_t,
+                    "n_workers_responded": int(len(deltas)),
+                    "dg_issue_cycles": issue_cycles,
+                    "dg_issue_ns": (issue_cycles / freq_mhz * 1000.0) if issue_cycles is not pd.NA else pd.NA,
+                    "dg_first_cycles": int(deltas.min()),
+                    "dg_first_ns": float(deltas.min()) / freq_mhz * 1000.0,
+                    "dg_median_cycles": int(pd.Series(deltas).median()),
+                    "dg_median_ns": float(pd.Series(deltas).median()) / freq_mhz * 1000.0,
+                    "dg_last_cycles": int(deltas.max()),
+                    "dg_last_ns": float(deltas.max()) / freq_mhz * 1000.0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
 def walk_barrier_markers(df: pd.DataFrame) -> dict[str, dict[tuple, int]]:
-    """Per (chip, core_x, core_y, prog_id) timestamps for reader/writer barriers and go/done."""
-    zones = [
+    """Per (chip, core_x, core_y, prog_id) timestamps for reader/writer barriers and go/done.
+
+    BRISC-FW zone (firmware scope around each program's kernel launch path) is also
+    captured, separately from the user BRISC_GO/BRISC_DONE markers emitted from
+    inside our writer kernel. The FW.start fires before PROG_ID is read, so we
+    forward-tag pending FW.start with the next PROG_ID we see.
+    """
+    user_zones = [
         "PROG_ID",
         "READ_BEFORE_BARRIER",
         "READ_AFTER_BARRIER",
@@ -110,7 +210,10 @@ def walk_barrier_markers(df: pd.DataFrame) -> dict[str, dict[tuple, int]]:
         "NCRISC_GO",
         "NCRISC_DONE",
     ]
-    markers = df[(df["zone name"].isin(zones)) & (df["RISC processor type"].isin(DATAFLOW_RISC_TYPES))].copy()
+    fw_zones = ["BRISC-FW", "NCRISC-FW"]
+    markers = df[
+        (df["zone name"].isin(user_zones + fw_zones)) & (df["RISC processor type"].isin(DATAFLOW_RISC_TYPES))
+    ].copy()
     markers = markers.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
 
     keys = [
@@ -122,6 +225,10 @@ def walk_barrier_markers(df: pd.DataFrame) -> dict[str, dict[tuple, int]]:
         "brisc_done",
         "ncrisc_go",
         "ncrisc_done",
+        "brisc_fw_start",
+        "brisc_fw_end",
+        "ncrisc_fw_start",
+        "ncrisc_fw_end",
     ]
     out: dict[str, dict[tuple, int]] = {k: {} for k in keys}
     group_cols = ["PCIe slot", "core_x", "core_y", "RISC processor type"]
@@ -131,11 +238,28 @@ def walk_barrier_markers(df: pd.DataFrame) -> dict[str, dict[tuple, int]]:
         is_reader = risc in READ_RISC_TYPES
         is_writer = risc in WRITE_RISC_TYPES
         current_prog: int | None = None
+        pending_fw_start: int | None = None
         for _, row in group.iterrows():
             zone = row["zone name"]
             time_cycles = int(row["time[cycles since reset]"])
+            zone_type = row.get("type", "")
+            if zone == "BRISC-FW" and zone_type == "ZONE_START" and is_writer:
+                pending_fw_start = time_cycles
+                current_prog = None
+                continue
+            if zone == "NCRISC-FW" and zone_type == "ZONE_START" and is_reader:
+                pending_fw_start = time_cycles
+                current_prog = None
+                continue
             if zone == "PROG_ID":
                 current_prog = int(row["data"])
+                if pending_fw_start is not None:
+                    tkey = (chip, core_x, core_y, current_prog)
+                    if is_writer:
+                        out["brisc_fw_start"][tkey] = pending_fw_start
+                    elif is_reader:
+                        out["ncrisc_fw_start"][tkey] = pending_fw_start
+                    pending_fw_start = None
                 continue
             if current_prog is None:
                 continue
@@ -156,6 +280,12 @@ def walk_barrier_markers(df: pd.DataFrame) -> dict[str, dict[tuple, int]]:
                 out["ncrisc_go"][tkey] = time_cycles
             elif zone == "NCRISC_DONE" and is_reader:
                 out["ncrisc_done"][tkey] = time_cycles
+            elif zone == "BRISC-FW" and zone_type == "ZONE_END" and is_writer:
+                out["brisc_fw_end"][tkey] = time_cycles
+                current_prog = None
+            elif zone == "NCRISC-FW" and zone_type == "ZONE_END" and is_reader:
+                out["ncrisc_fw_end"][tkey] = time_cycles
+                current_prog = None
 
     return out
 
@@ -348,11 +478,25 @@ def build_timeline(gaps: pd.DataFrame, barriers: dict[str, dict[tuple, int]], fr
         rec["brisc_go_cycles"] = barriers["brisc_go"].get(k_start)
         rec["ncrisc_done_cycles"] = barriers["ncrisc_done"].get(k_end)
         rec["ncrisc_go_cycles"] = barriers["ncrisc_go"].get(k_start)
+        # FW-level zone bounds: FW.start fires BEFORE our user BRISC_GO marker
+        # (FW kernel-launch dispatch path runs in between). FW done->go is a
+        # tighter "done/go" interval: prev FW signaled done -> next FW received
+        # GO and entered scope. Excludes our pre-marker user code (~75 ns) and
+        # the FW kernel-launch prelude (~0.5-1 us) that inflates user done->go.
+        rec["brisc_fw_start_cycles"] = barriers["brisc_fw_start"].get(k_start)
+        rec["brisc_fw_end_cycles"] = barriers["brisc_fw_end"].get(k_end)
+        rec["ncrisc_fw_start_cycles"] = barriers["ncrisc_fw_start"].get(k_start)
+        rec["ncrisc_fw_end_cycles"] = barriers["ncrisc_fw_end"].get(k_end)
         bd = rec.get("brisc_done_cycles")
         bg = rec.get("brisc_go_cycles")
         if bd is not None and bg is not None and not (pd.isna(bd) or pd.isna(bg)):
             rec["brisc_done_to_go_cycles"] = int(bg) - int(bd)
             rec["brisc_done_to_go_us"] = rec["brisc_done_to_go_cycles"] / freq_mhz
+        bfs = rec.get("brisc_fw_start_cycles")
+        bfe = rec.get("brisc_fw_end_cycles")
+        if bfs is not None and bfe is not None and not (pd.isna(bfs) or pd.isna(bfe)):
+            rec["brisc_fw_done_to_go_cycles"] = int(bfs) - int(bfe)
+            rec["brisc_fw_done_to_go_us"] = rec["brisc_fw_done_to_go_cycles"] / freq_mhz
         rb = rec.get("read_before_barrier_cycles")
         ra = rec.get("read_after_barrier_cycles")
         if rb is not None and ra is not None and not (pd.isna(rb) or pd.isna(ra)):
@@ -583,8 +727,32 @@ def print_done_go_validation_summary(
         if not bg.empty:
             bg_ns = bg * 1000.0
             print(
-                f"  brisc_done_to_go (per-core device): median={bg.median():.3f} us ({bg_ns.median():.1f} ns) "
+                f"  brisc_done_to_go (per-core USER markers, includes ~0.5-1us FW prelude): "
+                f"median={bg.median():.3f} us ({bg_ns.median():.1f} ns) "
                 f"min={bg.min():.3f} max={bg.max():.3f} n={len(bg)}"
+            )
+    if not timeline.empty and "brisc_fw_done_to_go_us" in timeline.columns:
+        fbg = pd.to_numeric(timeline["brisc_fw_done_to_go_us"], errors="coerce").dropna()
+        if not fbg.empty:
+            fbg_ns = fbg * 1000.0
+            print(
+                f"  brisc_FW_done_to_go (per-core FW worker round-trip): "
+                f"median={fbg.median():.3f} us ({fbg_ns.median():.1f} ns) "
+                f"min={fbg.min():.3f} max={fbg.max():.3f} n={len(fbg)}"
+            )
+    if not timeline.empty and "dg_first_ns" in timeline.columns:
+        for col, label in [
+            ("dg_issue_ns", "dispatch issue only  "),
+            ("dg_first_ns", "first worker sees GO "),
+            ("dg_median_ns", "median worker sees GO"),
+            ("dg_last_ns", "last worker sees GO  "),
+        ]:
+            v = pd.to_numeric(timeline[col], errors="coerce").dropna()
+            if v.empty:
+                continue
+            print(
+                f"  done_to_go [{label}]: "
+                f"median={v.median():.0f} ns  min={v.min():.0f}  max={v.max():.0f}  n={len(v)}"
             )
     if not timeline.empty and "gap_us" in timeline.columns:
         gap = pd.to_numeric(timeline["gap_us"], errors="coerce").dropna()
@@ -770,6 +938,20 @@ def main() -> int:
     rt_gaps, rt_skipped = build_rt_dispatch_gaps(rt_df, freq_mhz, args.min_prog_id)
     rt_programs = build_rt_program_table(rt_df, args.min_prog_id, freq_mhz)
     timeline = merge_dispatch_into_timeline(timeline, rt_gaps, rt_df, freq_mhz)
+    dg_table = walk_done_to_go(df, freq_mhz, args.min_prog_id)
+    if not dg_table.empty and not timeline.empty:
+        # Map per (chip, to_prog_id) -> done/go for that transition's GO.
+        # We surface four columns:
+        #  - dg_issue_ns   : dispatch-only MCAST issue cost (~30 ns BH)
+        #  - dg_first_ns   : nearest worker observes GO
+        #  - dg_median_ns  : median worker observes GO
+        #  - dg_last_ns    : farthest worker observes GO
+        lookup = {(int(r.chip), int(r.program_id)): r for _, r in dg_table.iterrows()}
+        for col in ["dg_issue_ns", "dg_first_ns", "dg_median_ns", "dg_last_ns"]:
+            timeline[col] = timeline.apply(
+                lambda r: lookup.get((int(r["chip"]), int(r["to_prog_id"])), pd.Series()).get(col, pd.NA),
+                axis=1,
+            )
     timeline = add_buffering_context_columns(
         timeline,
         freq_mhz,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
@@ -208,6 +208,9 @@ def build_rt_dispatch_gaps(rt_df: pd.DataFrame, freq_mhz: float, min_prog_id: in
             gap_cycles = go[i + 1] - done[i]
             if gap_cycles < 0:
                 continue
+            # Steady-state only: consecutive program ids (skip trace wrap e.g. 8→3).
+            if pids[i + 1] != pids[i] + 1:
+                continue
             ghz = rt_freq_ghz(rt_df, freq_mhz)
             gap_ns = rt_cycles_to_ns(gap_cycles, ghz)
             rows.append(
@@ -561,6 +564,37 @@ def build_chip_summary(gaps: pd.DataFrame) -> pd.DataFrame:
     return summary
 
 
+def print_done_go_validation_summary(
+    timeline: pd.DataFrame, rt_gaps: pd.DataFrame, min_prog_id: int, freq_mhz: float
+) -> None:
+    """Summarize done/go metrics: chip dispatch (WH ~500-800ns) vs per-core BRISC FW."""
+    print(f"Done/go validation (min_prog_id>={min_prog_id}, freq={freq_mhz:.1f} MHz):")
+    if not rt_gaps.empty and "dispatch_gap_us" in rt_gaps.columns:
+        dg = rt_gaps["dispatch_gap_us"]
+        dg_ns = dg * 1000.0
+        print(
+            f"  chip_dispatch done→go (RT): median={dg.median():.3f} us ({dg_ns.median():.1f} ns) "
+            f"min={dg.min():.3f} max={dg.max():.3f} n={len(dg)}"
+        )
+    else:
+        print("  chip_dispatch done→go (RT): no data")
+    if not timeline.empty and "brisc_done_to_go_us" in timeline.columns:
+        bg = pd.to_numeric(timeline["brisc_done_to_go_us"], errors="coerce").dropna()
+        if not bg.empty:
+            bg_ns = bg * 1000.0
+            print(
+                f"  brisc_done_to_go (per-core device): median={bg.median():.3f} us ({bg_ns.median():.1f} ns) "
+                f"min={bg.min():.3f} max={bg.max():.3f} n={len(bg)}"
+            )
+    if not timeline.empty and "gap_us" in timeline.columns:
+        gap = pd.to_numeric(timeline["gap_us"], errors="coerce").dropna()
+        if not gap.empty:
+            print(
+                f"  op2op gap_us (pack finish→unpack tile0): median={gap.median():.3f} us "
+                f"min={gap.min():.3f} max={gap.max():.3f} n={len(gap)}"
+            )
+
+
 def print_dispatch_summary(rt_programs: pd.DataFrame, rt_gaps: pd.DataFrame) -> None:
     if rt_programs.empty and rt_gaps.empty():
         print("No real-time profiler data (run test with --use-realtime-profiler).", file=sys.stderr)
@@ -795,6 +829,8 @@ def main() -> int:
         print(f"  All cores mean_gap_us={chip.iloc[0]['mean_gap_us']:.3f} median={chip.iloc[0]['median_gap_us']:.3f}")
     print()
     print_buffering_summary(timeline)
+    print()
+    print_done_go_validation_summary(timeline, rt_gaps, args.min_prog_id, freq_mhz)
     print()
     print_dispatch_summary(rt_programs, rt_gaps)
     return 0

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export op-to-op latency tables from profile_log_device.csv.
+
+Per-core op-to-op gap (program k -> k+1):
+  TRISC_2 FINISH_LAST_PUSH at end of pack TRISC kernel (program k)
+  to TRISC_0 TILE_IDX for tile 0 when program k+1's compute starts.
+
+Example:
+  python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py \\
+    --input-file "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv"
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+DEFAULT_LOG = "generated/profiler/.logs/profile_log_device.csv"
+UNPACK_RISC = "TRISC_0"
+PACK_RISC = "TRISC_2"
+
+
+def parse_chip_freq_mhz(log_path: Path) -> float:
+    with log_path.open() as f:
+        header = f.readline()
+    match = re.search(r"CHIP_FREQ\[MHz\]:\s*([0-9.]+)", header)
+    if not match:
+        raise ValueError(f"Could not parse CHIP_FREQ from first line of {log_path}")
+    return float(match.group(1))
+
+
+def load_profiler_csv(log_path: Path) -> pd.DataFrame:
+    df = pd.read_csv(log_path, skiprows=1)
+    df.columns = df.columns.str.strip()
+    return df
+
+
+def walk_core_markers(df: pd.DataFrame) -> tuple[dict, dict, pd.DataFrame]:
+    """Return per-core program finish (pack) and first-tile start (unpack) times."""
+    markers = df[
+        (df["zone name"].isin(["PROG_ID", "TILE_IDX", "FINISH_LAST_PUSH"]))
+        & (df["RISC processor type"].isin([UNPACK_RISC, PACK_RISC]))
+    ].copy()
+    markers = markers.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
+
+    # (chip, core_x, core_y, prog_id) -> cycles
+    pack_finish: dict[tuple, int] = {}
+    unpack_tile0_start: dict[tuple, int] = {}
+    tile_rows: list[dict] = []
+
+    group_cols = ["PCIe slot", "core_x", "core_y", "RISC processor type"]
+    for key, group in markers.groupby(group_cols, sort=False):
+        chip, core_x, core_y, risc = key
+        current_prog: int | None = None
+
+        for _, row in group.iterrows():
+            zone = row["zone name"]
+            time_cycles = int(row["time[cycles since reset]"])
+            data = int(row["data"])
+
+            if zone == "PROG_ID":
+                current_prog = data
+            elif zone == "TILE_IDX" and risc == UNPACK_RISC:
+                if current_prog is None:
+                    continue
+                tile_rows.append(
+                    {
+                        "chip": chip,
+                        "core_x": core_x,
+                        "core_y": core_y,
+                        "prog_id": current_prog,
+                        "tile_idx": data,
+                        "unpack_start_cycles": time_cycles,
+                    }
+                )
+                if data == 0:
+                    unpack_tile0_start[(chip, core_x, core_y, current_prog)] = time_cycles
+            elif zone == "FINISH_LAST_PUSH" and risc == PACK_RISC:
+                if current_prog is None:
+                    current_prog = data
+                pack_finish[(chip, core_x, core_y, current_prog)] = time_cycles
+
+    return pack_finish, unpack_tile0_start, pd.DataFrame(tile_rows)
+
+
+def compute_gaps(
+    pack_finish: dict[tuple, int],
+    unpack_tile0_start: dict[tuple, int],
+    min_prog_id: int,
+) -> pd.DataFrame:
+    cores = {(k[0], k[1], k[2]) for k in pack_finish} | {(k[0], k[1], k[2]) for k in unpack_tile0_start}
+    gap_rows: list[dict] = []
+
+    for chip, core_x, core_y in sorted(cores):
+        prog_ids = sorted(
+            {p for (c, x, y, p) in pack_finish if (c, x, y) == (chip, core_x, core_y) and p >= min_prog_id}
+            | {p for (c, x, y, p) in unpack_tile0_start if (c, x, y) == (chip, core_x, core_y) and p >= min_prog_id}
+        )
+        for from_prog, to_prog in zip(prog_ids, prog_ids[1:]):
+            end_key = (chip, core_x, core_y, from_prog)
+            start_key = (chip, core_x, core_y, to_prog)
+            if end_key not in pack_finish or start_key not in unpack_tile0_start:
+                continue
+            end_cycles = pack_finish[end_key]
+            start_cycles = unpack_tile0_start[start_key]
+            gap_rows.append(
+                {
+                    "chip": chip,
+                    "core_x": core_x,
+                    "core_y": core_y,
+                    "from_prog_id": from_prog,
+                    "to_prog_id": to_prog,
+                    "pack_finish_cycles": end_cycles,
+                    "unpack_tile0_start_cycles": start_cycles,
+                    "gap_cycles": start_cycles - end_cycles,
+                }
+            )
+
+    return pd.DataFrame(gap_rows)
+
+
+def build_prog_table(df: pd.DataFrame) -> pd.DataFrame:
+    progs = df[(df["zone name"] == "PROG_ID") & (df["RISC processor type"] == UNPACK_RISC)].copy()
+    if progs.empty:
+        progs = df[df["zone name"] == "PROG_ID"].copy()
+    rows = []
+    for _, row in progs.iterrows():
+        rows.append(
+            {
+                "chip": row["PCIe slot"],
+                "core_x": row["core_x"],
+                "core_y": row["core_y"],
+                "risc": row["RISC processor type"],
+                "prog_id": int(row["data"]),
+                "time_cycles": int(row["time[cycles since reset]"]),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def add_gap_us(gaps: pd.DataFrame, freq_mhz: float) -> pd.DataFrame:
+    out = gaps.copy()
+    if not out.empty:
+        out["gap_us"] = out["gap_cycles"] / freq_mhz
+    return out
+
+
+def build_per_core_summary(gaps: pd.DataFrame) -> pd.DataFrame:
+    """Mean/min/max gap per (core_x, core_y) across program transitions."""
+    if gaps.empty:
+        return pd.DataFrame()
+    summary = (
+        gaps.groupby(["chip", "core_x", "core_y"], as_index=False)
+        .agg(
+            num_transitions=("gap_us", "count"),
+            mean_gap_us=("gap_us", "mean"),
+            min_gap_us=("gap_us", "min"),
+            max_gap_us=("gap_us", "max"),
+            mean_gap_cycles=("gap_cycles", "mean"),
+        )
+        .sort_values(["core_x", "core_y"])
+    )
+    for col in ("mean_gap_us", "min_gap_us", "max_gap_us", "mean_gap_cycles"):
+        summary[col] = summary[col].round(3)
+    return summary
+
+
+def build_chip_summary(gaps: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate across all cores and all gap rows."""
+    if gaps.empty:
+        return pd.DataFrame()
+    us = gaps["gap_us"]
+    summary = pd.DataFrame(
+        [
+            {
+                "num_cores": int(gaps.groupby(["core_x", "core_y"]).ngroups),
+                "num_gap_rows": len(gaps),
+                "mean_gap_us": round(float(us.mean()), 3),
+                "median_gap_us": round(float(us.median()), 3),
+                "min_gap_us": round(float(us.min()), 3),
+                "max_gap_us": round(float(us.max()), 3),
+                "std_gap_us": round(float(us.std()), 3) if len(us) > 1 else 0.0,
+            }
+        ]
+    )
+    return summary
+
+
+def print_gap_summary(gaps: pd.DataFrame, freq_mhz: float) -> None:
+    if gaps.empty:
+        print("No op-to-op gaps (need TRISC_2 FINISH_LAST_PUSH and TRISC_0 TILE_IDX tile 0).", file=sys.stderr)
+        return
+
+    print(f"Chip frequency: {freq_mhz:.3f} MHz")
+    print(f"Gap = TRISC_0 TILE_IDX (tile 0) of program k+1 − TRISC_2 FINISH_LAST_PUSH of program k")
+    print(f"Cores with gaps: {gaps.groupby(['core_x', 'core_y']).ngroups}")
+    print(f"Total gap rows: {len(gaps)}")
+
+    us = gaps["gap_cycles"] / freq_mhz
+    print(f"  gap_us min={us.min():.2f} max={us.max():.2f} mean={us.mean():.2f} median={us.median():.2f}")
+
+    first = gaps.sort_values(["core_x", "core_y", "from_prog_id"]).iloc[0]
+    print(
+        f"Example core ({int(first.core_x)},{int(first.core_y)}): "
+        f"prog {int(first.from_prog_id)}→{int(first.to_prog_id)} "
+        f"gap={int(first.gap_cycles)} cycles ({first.gap_cycles / freq_mhz:.2f} us)"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export op-to-op latency CSVs from device profiler log.")
+    parser.add_argument("--input-file", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument(
+        "--min-prog-id",
+        type=int,
+        default=1,
+        help="Exclude program ids below this (default 1 skips pre-compile PROG_ID=0)",
+    )
+    args = parser.parse_args()
+
+    import os
+
+    log_path = args.input_file or Path(os.environ.get("TT_METAL_HOME", ".")) / DEFAULT_LOG
+    log_path = log_path.resolve()
+    if not log_path.is_file():
+        print(f"Input not found: {log_path}", file=sys.stderr)
+        return 1
+
+    output_dir = args.output_dir or log_path.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = log_path.stem
+
+    freq_mhz = parse_chip_freq_mhz(log_path)
+    df = load_profiler_csv(log_path)
+
+    pack_finish, unpack_tile0_start, tiles = walk_core_markers(df)
+    gaps = compute_gaps(pack_finish, unpack_tile0_start, args.min_prog_id)
+    gaps_out = add_gap_us(gaps, freq_mhz)
+    progs = build_prog_table(df)
+
+    tiles_path = output_dir / f"{stem}_op_to_op_tiles.csv"
+    gaps_path = output_dir / f"{stem}_op_to_op_gaps.csv"
+    progs_path = output_dir / f"{stem}_op_to_op_prog_ids.csv"
+    summary_chip_path = output_dir / f"{stem}_op_to_op_summary_chip.csv"
+    summary_per_core_path = output_dir / f"{stem}_op_to_op_summary_per_core.csv"
+
+    tiles.to_csv(tiles_path, index=False)
+    gaps_out.to_csv(gaps_path, index=False)
+    progs.to_csv(progs_path, index=False)
+    build_chip_summary(gaps_out).to_csv(summary_chip_path, index=False)
+    build_per_core_summary(gaps_out).to_csv(summary_per_core_path, index=False)
+
+    print(f"Wrote {summary_chip_path}")
+    print(f"Wrote {summary_per_core_path}")
+    print(f"Wrote {gaps_path} ({len(gaps_out)} rows)")
+    print(f"Wrote {tiles_path} ({len(tiles)} rows)")
+    print(f"Wrote {progs_path} ({len(progs)} rows)")
+    print()
+    print_gap_summary(gaps_out, freq_mhz)
+    if not gaps_out.empty:
+        chip = build_chip_summary(gaps_out)
+        print(f"  All cores mean_gap_us={chip.iloc[0]['mean_gap_us']:.3f} median={chip.iloc[0]['median_gap_us']:.3f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
@@ -25,8 +25,13 @@ from pathlib import Path
 import pandas as pd
 
 DEFAULT_LOG = "generated/profiler/.logs/profile_log_device.csv"
+DEFAULT_RT_LOG = "generated/profiler/.logs/profile_log_device_rt.csv"
 UNPACK_RISC = "TRISC_0"
 PACK_RISC = "TRISC_2"
+# Dataflow kernels: Blackhole uses BRISC (writer) / NCRISC (reader); other arches may use RISCV_*.
+READ_RISC_TYPES = frozenset({"NCRISC", "RISCV_1"})
+WRITE_RISC_TYPES = frozenset({"BRISC", "RISCV_0"})
+DATAFLOW_RISC_TYPES = READ_RISC_TYPES | WRITE_RISC_TYPES
 
 
 def parse_chip_freq_mhz(log_path: Path) -> float:
@@ -90,6 +95,358 @@ def walk_core_markers(df: pd.DataFrame) -> tuple[dict, dict, pd.DataFrame]:
                 pack_finish[(chip, core_x, core_y, current_prog)] = time_cycles
 
     return pack_finish, unpack_tile0_start, pd.DataFrame(tile_rows)
+
+
+def walk_barrier_markers(df: pd.DataFrame) -> dict[str, dict[tuple, int]]:
+    """Per (chip, core_x, core_y, prog_id) timestamps for reader/writer barriers and go/done."""
+    zones = [
+        "PROG_ID",
+        "READ_BEFORE_BARRIER",
+        "READ_AFTER_BARRIER",
+        "WRITE_BEFORE_BARRIER",
+        "WRITE_AFTER_BARRIER",
+        "BRISC_GO",
+        "BRISC_DONE",
+        "NCRISC_GO",
+        "NCRISC_DONE",
+    ]
+    markers = df[(df["zone name"].isin(zones)) & (df["RISC processor type"].isin(DATAFLOW_RISC_TYPES))].copy()
+    markers = markers.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
+
+    keys = [
+        "read_before",
+        "read_after",
+        "write_before",
+        "write_after",
+        "brisc_go",
+        "brisc_done",
+        "ncrisc_go",
+        "ncrisc_done",
+    ]
+    out: dict[str, dict[tuple, int]] = {k: {} for k in keys}
+    group_cols = ["PCIe slot", "core_x", "core_y", "RISC processor type"]
+
+    for key, group in markers.groupby(group_cols, sort=False):
+        chip, core_x, core_y, risc = key
+        is_reader = risc in READ_RISC_TYPES
+        is_writer = risc in WRITE_RISC_TYPES
+        current_prog: int | None = None
+        for _, row in group.iterrows():
+            zone = row["zone name"]
+            time_cycles = int(row["time[cycles since reset]"])
+            if zone == "PROG_ID":
+                current_prog = int(row["data"])
+                continue
+            if current_prog is None:
+                continue
+            tkey = (chip, core_x, core_y, current_prog)
+            if zone == "READ_BEFORE_BARRIER" and is_reader:
+                out["read_before"][tkey] = time_cycles
+            elif zone == "READ_AFTER_BARRIER" and is_reader:
+                out["read_after"][tkey] = time_cycles
+            elif zone == "WRITE_BEFORE_BARRIER" and is_writer:
+                out["write_before"][tkey] = time_cycles
+            elif zone == "WRITE_AFTER_BARRIER" and is_writer:
+                out["write_after"][tkey] = time_cycles
+            elif zone == "BRISC_GO" and is_writer:
+                out["brisc_go"][tkey] = time_cycles
+            elif zone == "BRISC_DONE" and is_writer:
+                out["brisc_done"][tkey] = time_cycles
+            elif zone == "NCRISC_GO" and is_reader:
+                out["ncrisc_go"][tkey] = time_cycles
+            elif zone == "NCRISC_DONE" and is_reader:
+                out["ncrisc_done"][tkey] = time_cycles
+
+    return out
+
+
+def load_rt_profiler_csv(rt_path: Path) -> pd.DataFrame:
+    if not rt_path.is_file():
+        return pd.DataFrame()
+    return pd.read_csv(rt_path)
+
+
+def dedupe_rt_records(rt_df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    """Collapse consecutive RT records with the same program_id (common in trace replay)."""
+    if rt_df.empty:
+        return rt_df, 0
+    deduped_rows: list[pd.Series] = []
+    collapsed = 0
+    for _, group in rt_df.groupby("chip_id"):
+        records = group.sort_values("go_cycles")
+        kept: list[pd.Series] = []
+        for _, row in records.iterrows():
+            if kept and int(row["program_id"]) == int(kept[-1]["program_id"]):
+                kept[-1] = row
+                collapsed += 1
+            else:
+                kept.append(row)
+        deduped_rows.extend(kept)
+    if not deduped_rows:
+        return pd.DataFrame(), collapsed
+    return pd.DataFrame(deduped_rows), collapsed
+
+
+def build_rt_dispatch_gaps(rt_df: pd.DataFrame, freq_mhz: float, min_prog_id: int) -> tuple[pd.DataFrame, int]:
+    """Chip-level done (end) -> go (next start) from real-time profiler records."""
+    if rt_df.empty:
+        return pd.DataFrame(), 0
+    rt_df, collapsed = dedupe_rt_records(rt_df)
+    rt_mhz = rt_freq_mhz(rt_df, freq_mhz)
+    rows: list[dict] = []
+    skipped_same_pid = 0
+    for chip_id, group in rt_df.groupby("chip_id"):
+        records = group.sort_values("go_cycles")
+        records = records[records["program_id"] >= min_prog_id]
+        go = records["go_cycles"].astype(int).tolist()
+        done = records["done_cycles"].astype(int).tolist()
+        pids = records["program_id"].astype(int).tolist()
+        for i in range(len(pids) - 1):
+            if pids[i] == pids[i + 1]:
+                skipped_same_pid += 1
+                continue
+            gap_cycles = go[i + 1] - done[i]
+            if gap_cycles < 0:
+                continue
+            ghz = rt_freq_ghz(rt_df, freq_mhz)
+            gap_ns = rt_cycles_to_ns(gap_cycles, ghz)
+            rows.append(
+                {
+                    "chip": chip_id,
+                    "from_prog_id": pids[i],
+                    "to_prog_id": pids[i + 1],
+                    "done_cycles": done[i],
+                    "go_cycles": go[i + 1],
+                    "dispatch_gap_cycles": gap_cycles,
+                    "dispatch_gap_ns": gap_ns,
+                    "dispatch_gap_us": gap_ns / 1000.0,
+                }
+            )
+    return pd.DataFrame(rows), collapsed + skipped_same_pid
+
+
+def rt_freq_ghz(rt_df: pd.DataFrame, fallback_mhz: float) -> float:
+    if rt_df.empty or "frequency_ghz" not in rt_df.columns:
+        return fallback_mhz / 1000.0
+    ghz = float(rt_df["frequency_ghz"].iloc[0])
+    return ghz if ghz > 0.0 else fallback_mhz / 1000.0
+
+
+def rt_freq_mhz(rt_df: pd.DataFrame, fallback_mhz: float) -> float:
+    return rt_freq_ghz(rt_df, fallback_mhz) * 1000.0
+
+
+def rt_cycles_to_ns(cycles: int, ghz: float) -> float:
+    """RT profiler: duration_ns = cycles / frequency_ghz (see test RT CSV writer)."""
+    return float(cycles) / ghz if ghz > 0.0 else 0.0
+
+
+def build_rt_program_table(rt_df: pd.DataFrame, min_prog_id: int, freq_mhz: float) -> pd.DataFrame:
+    """Per-program chip dispatch timestamps: go (start) and done (end)."""
+    if rt_df.empty:
+        return pd.DataFrame()
+    rt_df, _ = dedupe_rt_records(rt_df)
+    ghz = rt_freq_ghz(rt_df, freq_mhz)
+    rows: list[dict] = []
+    for chip_id, group in rt_df.groupby("chip_id"):
+        records = group.sort_values("go_cycles")
+        records = records[records["program_id"] >= min_prog_id]
+        for _, row in records.iterrows():
+            go = int(row["go_cycles"])
+            done = int(row["done_cycles"])
+            duration_cycles = done - go if done >= go else 0
+            if "duration_ns" in row and pd.notna(row["duration_ns"]):
+                duration_ns = float(row["duration_ns"])
+            else:
+                duration_ns = rt_cycles_to_ns(duration_cycles, ghz)
+            gap_next = (
+                int(row["gap_to_next_go_cycles"])
+                if "gap_to_next_go_cycles" in row.index and pd.notna(row["gap_to_next_go_cycles"])
+                else 0
+            )
+            gap_next_ns = rt_cycles_to_ns(gap_next, ghz) if gap_next > 0 else 0.0
+            rows.append(
+                {
+                    "chip": chip_id,
+                    "program_id": int(row["program_id"]),
+                    "go_cycles": go,
+                    "done_cycles": done,
+                    "program_duration_cycles": duration_cycles,
+                    "program_duration_ns": duration_ns,
+                    "program_duration_us": duration_ns / 1000.0,
+                    "gap_to_next_go_cycles": gap_next,
+                    "gap_to_next_go_ns": gap_next_ns,
+                    "frequency_ghz": ghz,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def merge_dispatch_into_timeline(
+    timeline: pd.DataFrame, rt_gaps: pd.DataFrame, rt_df: pd.DataFrame, device_freq_mhz: float
+) -> pd.DataFrame:
+    """Attach chip-level dispatch done/go stamps to each per-core transition row."""
+    if timeline.empty:
+        return timeline
+    out = timeline.copy()
+    for col in (
+        "chip_dispatch_done_cycles",
+        "chip_dispatch_go_cycles",
+        "chip_dispatch_gap_cycles",
+        "chip_dispatch_gap_ns",
+        "chip_dispatch_gap_us",
+    ):
+        out[col] = pd.NA
+    if rt_gaps.empty:
+        return out
+    lookup = {(int(r.chip), int(r.from_prog_id), int(r.to_prog_id)): r for _, r in rt_gaps.iterrows()}
+    for idx, row in out.iterrows():
+        key = (int(row["chip"]), int(row["from_prog_id"]), int(row["to_prog_id"]))
+        if key not in lookup:
+            continue
+        d = lookup[key]
+        done_c = int(d["done_cycles"])
+        go_c = int(d["go_cycles"])
+        gap_c = int(d["dispatch_gap_cycles"])
+        out.at[idx, "chip_dispatch_done_cycles"] = done_c
+        out.at[idx, "chip_dispatch_go_cycles"] = go_c
+        out.at[idx, "chip_dispatch_gap_cycles"] = gap_c
+        gap_ns = float(d["dispatch_gap_ns"]) if "dispatch_gap_ns" in d else float(d["dispatch_gap_us"]) * 1000.0
+        out.at[idx, "chip_dispatch_gap_ns"] = gap_ns
+        out.at[idx, "chip_dispatch_gap_us"] = gap_ns / 1000.0
+    return out
+
+
+def build_timeline(gaps: pd.DataFrame, barriers: dict[str, dict[tuple, int]], freq_mhz: float) -> pd.DataFrame:
+    """Merge pack→unpack gaps with reader/writer barrier timestamps per transition."""
+    if gaps.empty:
+        return pd.DataFrame()
+    rows: list[dict] = []
+    for _, row in gaps.iterrows():
+        chip, core_x, core_y = int(row.chip), int(row.core_x), int(row.core_y)
+        from_prog, to_prog = int(row.from_prog_id), int(row.to_prog_id)
+        k_end = (chip, core_x, core_y, from_prog)
+        k_start = (chip, core_x, core_y, to_prog)
+        rec = row.to_dict()
+        rec["write_before_barrier_cycles"] = barriers["write_before"].get(k_end)
+        rec["write_after_barrier_cycles"] = barriers["write_after"].get(k_end)
+        rec["read_before_barrier_cycles"] = barriers["read_before"].get(k_start)
+        rec["read_after_barrier_cycles"] = barriers["read_after"].get(k_start)
+        rec["brisc_done_cycles"] = barriers["brisc_done"].get(k_end)
+        rec["brisc_go_cycles"] = barriers["brisc_go"].get(k_start)
+        rec["ncrisc_done_cycles"] = barriers["ncrisc_done"].get(k_end)
+        rec["ncrisc_go_cycles"] = barriers["ncrisc_go"].get(k_start)
+        bd = rec.get("brisc_done_cycles")
+        bg = rec.get("brisc_go_cycles")
+        if bd is not None and bg is not None and not (pd.isna(bd) or pd.isna(bg)):
+            rec["brisc_done_to_go_cycles"] = int(bg) - int(bd)
+            rec["brisc_done_to_go_us"] = rec["brisc_done_to_go_cycles"] / freq_mhz
+        rb = rec.get("read_before_barrier_cycles")
+        ra = rec.get("read_after_barrier_cycles")
+        if rb is not None and ra is not None and not (pd.isna(rb) or pd.isna(ra)):
+            rb_i, ra_i = int(rb), int(ra)
+            rec["read_barrier_cycles"] = ra_i - rb_i
+            rec["read_barrier_us"] = rec["read_barrier_cycles"] / freq_mhz
+        pf = rec.get("pack_finish_cycles")
+        if pf is not None and ra is not None and not (pd.isna(pf) or pd.isna(ra)):
+            rec["pack_finish_to_read_after_cycles"] = int(ra) - int(pf)
+            rec["pack_finish_to_read_after_us"] = rec["pack_finish_to_read_after_cycles"] / freq_mhz
+        wb = rec.get("write_before_barrier_cycles")
+        wa = rec.get("write_after_barrier_cycles")
+        if wb is not None and wa is not None and not (pd.isna(wb) or pd.isna(wa)):
+            rec["write_barrier_cycles"] = int(wa) - int(wb)
+            rec["write_barrier_us"] = rec["write_barrier_cycles"] / freq_mhz
+        rows.append(rec)
+    out = pd.DataFrame(rows)
+    if not out.empty and "gap_us" in out.columns:
+        for col in out.columns:
+            if col.endswith("_cycles") and col != "gap_cycles":
+                us_col = col.replace("_cycles", "_us")
+                if us_col not in out.columns and out[col].notna().any():
+                    out[us_col] = out[col] / freq_mhz
+    return out
+
+
+def add_buffering_context_columns(
+    timeline: pd.DataFrame,
+    freq_mhz: float,
+    *,
+    input_cb_depth_tiles: int,
+    tiles_per_core: int,
+    reader_push_tile_count: int,
+    reader_batch_push: bool,
+) -> pd.DataFrame:
+    """Annotate timeline for HW review: CB config + derived buffering vs full op-to-op gap."""
+    if timeline.empty:
+        return timeline
+    out = timeline.copy()
+    out["input_cb_depth_tiles"] = input_cb_depth_tiles
+    out["tiles_per_core"] = tiles_per_core
+    out["reader_push_tiles_per_chunk"] = reader_push_tile_count
+    out["reader_batch_push"] = reader_batch_push
+    out["input_cb_double_buffered"] = input_cb_depth_tiles >= 2
+    out["per_tile_dram_read_barrier"] = True
+
+    # Tile 0 of program k+1: DRAM read + noc_async_read_barrier (READ_BEFORE → READ_AFTER).
+    if "read_barrier_us" in out.columns:
+        out["tile0_dram_buffering_latency_us"] = out["read_barrier_us"]
+    else:
+        out["tile0_dram_buffering_latency_us"] = pd.NA
+
+    if "read_after_barrier_cycles" in out.columns and "unpack_tile0_start_cycles" in out.columns:
+        ra = out["read_after_barrier_cycles"]
+        u0 = out["unpack_tile0_start_cycles"]
+        mask = ra.notna() & u0.notna()
+        out["read_after_to_unpack_tile0_us"] = pd.NA
+        out.loc[mask, "read_after_to_unpack_tile0_us"] = (u0[mask].astype(int) - ra[mask].astype(int)) / freq_mhz
+
+    if "gap_us" in out.columns and "tile0_dram_buffering_latency_us" in out.columns:
+        buf = out["tile0_dram_buffering_latency_us"]
+        gap = out["gap_us"]
+        mask = buf.notna() & gap.notna()
+        out["device_gap_excluding_tile0_dram_buffer_us"] = pd.NA
+        out.loc[mask, "device_gap_excluding_tile0_dram_buffer_us"] = gap[mask] - buf[mask]
+        out["tile0_dram_buffer_fraction_of_device_gap"] = pd.NA
+        out.loc[mask & (gap[mask] > 0), "tile0_dram_buffer_fraction_of_device_gap"] = buf[mask] / gap[mask]
+
+    return out
+
+
+def print_buffering_summary(timeline: pd.DataFrame) -> None:
+    if timeline.empty or "tile0_dram_buffering_latency_us" not in timeline.columns:
+        return
+    buf = timeline["tile0_dram_buffering_latency_us"].dropna()
+    if buf.empty:
+        return
+    depth = int(timeline["input_cb_depth_tiles"].iloc[0])
+    tiles = int(timeline["tiles_per_core"].iloc[0])
+    dbl = bool(timeline["input_cb_double_buffered"].iloc[0])
+    push = (
+        int(timeline["reader_push_tiles_per_chunk"].iloc[0]) if "reader_push_tiles_per_chunk" in timeline.columns else 2
+    )
+    batch = bool(timeline["reader_batch_push"].iloc[0]) if "reader_batch_push" in timeline.columns else False
+    print(
+        f"Buffering context: input CB depth={depth} tiles, {tiles} tiles/core, reader_push={push}, "
+        f"reader_batch_push={batch}, per-tile DRAM read barrier=True"
+    )
+    print(
+        f"  tile0_dram_buffering_latency_us (prog k+1 tile 0 read+barrier): "
+        f"median={buf.median():.3f} mean={buf.mean():.3f} min={buf.min():.3f} max={buf.max():.3f}"
+    )
+    if "device_gap_excluding_tile0_dram_buffer_us" in timeline.columns:
+        rest = timeline["device_gap_excluding_tile0_dram_buffer_us"].dropna()
+        if not rest.empty:
+            print(
+                f"  device_gap_excluding_tile0_dram_buffer_us (pack finish→unpack tile0 minus above): "
+                f"median={rest.median():.3f} mean={rest.mean():.3f}"
+            )
+    if "read_after_to_unpack_tile0_us" in timeline.columns:
+        handoff = timeline["read_after_to_unpack_tile0_us"].dropna()
+        if not handoff.empty:
+            print(
+                f"  read_after_to_unpack_tile0_us (buffer ready→compute TILE_IDX): "
+                f"median={handoff.median():.3f} mean={handoff.mean():.3f}"
+            )
 
 
 def compute_gaps(
@@ -195,6 +552,82 @@ def build_chip_summary(gaps: pd.DataFrame) -> pd.DataFrame:
     return summary
 
 
+def print_dispatch_summary(rt_programs: pd.DataFrame, rt_gaps: pd.DataFrame) -> None:
+    if rt_programs.empty and rt_gaps.empty():
+        print("No real-time profiler data (run test with --use-realtime-profiler).", file=sys.stderr)
+        return
+    print(
+        "Chip dispatch (RT profiler): go/done at chip enqueue; device BRISC_GO/DONE and NCRISC_GO/DONE "
+        "are per-core dataflow kernel entry/exit in the CSV"
+    )
+    if not rt_programs.empty:
+        for _, row in rt_programs.iterrows():
+            gap_str = ""
+            if int(row.get("gap_to_next_go_cycles", 0)) > 0:
+                gap_str = f", gap_to_next_go={int(row.gap_to_next_go_cycles)} cycles ({row.gap_to_next_go_ns:.1f} ns)"
+            print(
+                f"  chip {int(row.chip)} prog {int(row.program_id)}: "
+                f"go_cycles={int(row.go_cycles)} done_cycles={int(row.done_cycles)}, "
+                f"duration={row.program_duration_ns:.1f} ns ({row.program_duration_us:.3f} us){gap_str}"
+            )
+    if not rt_gaps.empty:
+        for _, row in rt_gaps.iterrows():
+            gap_ns = (
+                float(row["dispatch_gap_ns"]) if "dispatch_gap_ns" in row else float(row["dispatch_gap_us"]) * 1000.0
+            )
+            print(
+                f"  transition {int(row.from_prog_id)}→{int(row.to_prog_id)}: "
+                f"done→go gap={int(row.dispatch_gap_cycles)} cycles ({gap_ns:.1f} ns)"
+            )
+
+
+def aggregate_multi_run_summaries(runs_dir: Path, output_dir: Path) -> None:
+    """Read per-run summary CSVs under runs_dir/run_* and write combined stats."""
+    run_dirs = sorted(p for p in runs_dir.iterdir() if p.is_dir() and p.name.startswith("run_"))
+    if not run_dirs:
+        print(f"No run_* directories under {runs_dir}", file=sys.stderr)
+        return
+
+    device_rows: list[dict] = []
+    dispatch_rows: list[dict] = []
+    for run_dir in run_dirs:
+        run_name = run_dir.name
+        chip_path = next(run_dir.glob("*_op_to_op_summary_chip.csv"), None)
+        dispatch_path = next(run_dir.glob("*_op_to_op_dispatch_gaps.csv"), None)
+        if chip_path and chip_path.is_file():
+            chip = pd.read_csv(chip_path).iloc[0]
+            device_rows.append({"run": run_name, **chip.to_dict()})
+        if dispatch_path and dispatch_path.is_file():
+            disp = pd.read_csv(dispatch_path)
+            for _, row in disp.iterrows():
+                dispatch_rows.append({"run": run_name, **row.to_dict()})
+
+    if device_rows:
+        device_df = pd.DataFrame(device_rows)
+        out_path = output_dir / "multi_run_device_op_to_op_gap.csv"
+        device_df.to_csv(out_path, index=False)
+        print(f"Wrote {out_path} ({len(device_df)} runs)")
+        for col in ("mean_gap_us", "median_gap_us"):
+            if col in device_df.columns:
+                s = device_df[col]
+                print(
+                    f"  device {col} across runs: min={s.min():.3f} max={s.max():.3f} "
+                    f"mean={s.mean():.3f} std={s.std():.3f}"
+                )
+
+    if dispatch_rows:
+        dispatch_df = pd.DataFrame(dispatch_rows)
+        out_path = output_dir / "multi_run_dispatch_done_to_go.csv"
+        dispatch_df.to_csv(out_path, index=False)
+        print(f"Wrote {out_path} ({len(dispatch_df)} rows)")
+        if "dispatch_gap_us" in dispatch_df.columns:
+            s = dispatch_df["dispatch_gap_us"]
+            print(
+                f"  dispatch done→go us across runs: min={s.min():.3f} max={s.max():.3f} "
+                f"mean={s.mean():.3f} std={s.std():.3f}"
+            )
+
+
 def print_gap_summary(gaps: pd.DataFrame, freq_mhz: float) -> None:
     if gaps.empty:
         print("No op-to-op gaps (need TRISC_2 FINISH_LAST_PUSH and TRISC_0 TILE_IDX tile 0).", file=sys.stderr)
@@ -219,6 +652,9 @@ def print_gap_summary(gaps: pd.DataFrame, freq_mhz: float) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Export op-to-op latency CSVs from device profiler log.")
     parser.add_argument("--input-file", type=Path, default=None)
+    parser.add_argument(
+        "--rt-input-file", type=Path, default=None, help="profile_log_device_rt.csv from --use-realtime-profiler"
+    )
     parser.add_argument("--output-dir", type=Path, default=None)
     parser.add_argument(
         "--min-prog-id",
@@ -226,9 +662,45 @@ def main() -> int:
         default=1,
         help="Exclude program ids below this (default 1 skips pre-compile PROG_ID=0)",
     )
+    parser.add_argument(
+        "--aggregate-runs-dir",
+        type=Path,
+        default=None,
+        help="Parent directory containing run_1, run_2, ... subdirs; write multi-run summary CSVs and exit",
+    )
+    parser.add_argument(
+        "--input-cb-depth-tiles",
+        type=int,
+        default=4,
+        help="Input circular buffer depth in tiles (benchmark default: 4 = 2x --reader-push-tiles)",
+    )
+    parser.add_argument(
+        "--tiles-per-core",
+        type=int,
+        default=4,
+        help="Tiles processed per core per program (benchmark --num-pages-per-core default)",
+    )
+    parser.add_argument(
+        "--reader-push-tiles",
+        type=int,
+        default=2,
+        help="Reader reserve/read/push chunk size (benchmark --reader-push-tiles)",
+    )
+    parser.add_argument(
+        "--reader-batch-push",
+        action="store_true",
+        help="Set if benchmark was run with --reader-batch-push",
+    )
     args = parser.parse_args()
 
     import os
+
+    if args.aggregate_runs_dir is not None:
+        runs_dir = args.aggregate_runs_dir.resolve()
+        out_dir = args.output_dir or runs_dir
+        out_dir.mkdir(parents=True, exist_ok=True)
+        aggregate_multi_run_summaries(runs_dir, out_dir)
+        return 0
 
     log_path = args.input_file or Path(os.environ.get("TT_METAL_HOME", ".")) / DEFAULT_LOG
     log_path = log_path.resolve()
@@ -244,32 +716,78 @@ def main() -> int:
     df = load_profiler_csv(log_path)
 
     pack_finish, unpack_tile0_start, tiles = walk_core_markers(df)
+    barriers = walk_barrier_markers(df)
     gaps = compute_gaps(pack_finish, unpack_tile0_start, args.min_prog_id)
     gaps_out = add_gap_us(gaps, freq_mhz)
+    timeline = build_timeline(gaps_out, barriers, freq_mhz)
     progs = build_prog_table(df)
+
+    rt_path = args.rt_input_file or (log_path.parent / "profile_log_device_rt.csv")
+    rt_df = load_rt_profiler_csv(rt_path.resolve())
+    rt_gaps, rt_skipped = build_rt_dispatch_gaps(rt_df, freq_mhz, args.min_prog_id)
+    rt_programs = build_rt_program_table(rt_df, args.min_prog_id, freq_mhz)
+    timeline = merge_dispatch_into_timeline(timeline, rt_gaps, rt_df, freq_mhz)
+    timeline = add_buffering_context_columns(
+        timeline,
+        freq_mhz,
+        input_cb_depth_tiles=args.input_cb_depth_tiles,
+        tiles_per_core=args.tiles_per_core,
+        reader_push_tile_count=args.reader_push_tiles,
+        reader_batch_push=args.reader_batch_push,
+    )
+    if rt_skipped > 0:
+        print(
+            f"RT dispatch: skipped {rt_skipped} duplicate program_id transition(s) "
+            "(trace replay may emit repeated host runtime ids; use rows where from_prog_id < to_prog_id)",
+            file=sys.stderr,
+        )
 
     tiles_path = output_dir / f"{stem}_op_to_op_tiles.csv"
     gaps_path = output_dir / f"{stem}_op_to_op_gaps.csv"
+    timeline_path = output_dir / f"{stem}_op_to_op_timeline.csv"
     progs_path = output_dir / f"{stem}_op_to_op_prog_ids.csv"
     summary_chip_path = output_dir / f"{stem}_op_to_op_summary_chip.csv"
     summary_per_core_path = output_dir / f"{stem}_op_to_op_summary_per_core.csv"
+    rt_gaps_path = output_dir / f"{stem}_op_to_op_dispatch_gaps.csv"
+    rt_programs_path = output_dir / f"{stem}_op_to_op_rt_programs.csv"
+    complete_path = output_dir / f"{stem}_op_to_op_complete.csv"
 
     tiles.to_csv(tiles_path, index=False)
     gaps_out.to_csv(gaps_path, index=False)
+    timeline.to_csv(timeline_path, index=False)
+    timeline.to_csv(complete_path, index=False)
     progs.to_csv(progs_path, index=False)
     build_chip_summary(gaps_out).to_csv(summary_chip_path, index=False)
     build_per_core_summary(gaps_out).to_csv(summary_per_core_path, index=False)
+    if not rt_gaps.empty:
+        rt_gaps.to_csv(rt_gaps_path, index=False)
+    if not rt_programs.empty:
+        rt_programs.to_csv(rt_programs_path, index=False)
 
     print(f"Wrote {summary_chip_path}")
     print(f"Wrote {summary_per_core_path}")
     print(f"Wrote {gaps_path} ({len(gaps_out)} rows)")
+    print(f"Wrote {timeline_path} ({len(timeline)} rows, per-core + barriers + chip dispatch go/done)")
+    print(f"Wrote {complete_path} (same columns as timeline — full picture for HW review)")
     print(f"Wrote {tiles_path} ({len(tiles)} rows)")
     print(f"Wrote {progs_path} ({len(progs)} rows)")
+    if not rt_gaps.empty:
+        print(f"Wrote {rt_gaps_path} ({len(rt_gaps)} rows, chip-level done→go)")
+    elif args.rt_input_file or rt_path.is_file():
+        print(f"No RT dispatch gaps (check {rt_path})", file=sys.stderr)
+    else:
+        print("No RT CSV (re-run test with --use-realtime-profiler)", file=sys.stderr)
+    if not rt_programs.empty:
+        print(f"Wrote {rt_programs_path} ({len(rt_programs)} programs, go/done per enqueue)")
     print()
     print_gap_summary(gaps_out, freq_mhz)
     if not gaps_out.empty:
         chip = build_chip_summary(gaps_out)
         print(f"  All cores mean_gap_us={chip.iloc[0]['mean_gap_us']:.3f} median={chip.iloc[0]['median_gap_us']:.3f}")
+    print()
+    print_buffering_summary(timeline)
+    print()
+    print_dispatch_summary(rt_programs, rt_gaps)
     return 0
 
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
@@ -314,6 +314,15 @@ def merge_dispatch_into_timeline(
         gap_ns = float(d["dispatch_gap_ns"]) if "dispatch_gap_ns" in d else float(d["dispatch_gap_us"]) * 1000.0
         out.at[idx, "chip_dispatch_gap_ns"] = gap_ns
         out.at[idx, "chip_dispatch_gap_us"] = gap_ns / 1000.0
+
+    # NOTE on BRISC firmware prelude:
+    #   RT-profiler chip_dispatch_go_cycles and device-profiler brisc_go_cycles
+    #   are on different cycle counters / epochs and CANNOT be subtracted to
+    #   get a per-core "FW prelude" without an explicit sync offset (which
+    #   the current CSVs don't expose). Use `brisc_done_to_go_us` instead —
+    #   that is per-core BRISC kernel-exit(k) → BRISC kernel-entry(k+1) on
+    #   the same device-cycle counter, which is the per-core firmware +
+    #   dispatch transition window we actually want.
     return out
 
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py
@@ -134,7 +134,6 @@ def walk_done_to_go(df: pd.DataFrame, freq_mhz: float, min_prog_id: int) -> pd.D
     # The dispatch_s core appears in both DISP_* and (sometimes, on startup)
     # WORKER_GO_OBSERVED if FW happens to log it. Identify dispatch cores per chip
     # and exclude them from the worker pool.
-    dispatch_cores = disp_done.groupby("PCIe slot")[["core_x", "core_y"]].agg(lambda s: list(s.unique())).reset_index()
     worker_go = worker_go.copy()
     # Drop rows where worker is actually a dispatch core for the same chip.
     dispatch_set: set[tuple] = set()
@@ -167,10 +166,8 @@ def walk_done_to_go(df: pd.DataFrame, freq_mhz: float, min_prog_id: int) -> pd.D
             # Find DISP_GO_ISSUED that immediately follows.
             dg_after = dg_chip[dg_chip["time[cycles since reset]"] > d_t]
             if len(dg_after) > 0:
-                go_t = int(dg_after.iloc[0]["time[cycles since reset]"])
-                issue_cycles = go_t - d_t
+                issue_cycles = int(dg_after.iloc[0]["time[cycles since reset]"]) - d_t
             else:
-                go_t = pd.NA
                 issue_cycles = pd.NA
             rows.append(
                 {
@@ -322,7 +319,6 @@ def build_rt_dispatch_gaps(rt_df: pd.DataFrame, freq_mhz: float, min_prog_id: in
     if rt_df.empty:
         return pd.DataFrame(), 0
     rt_df, collapsed = dedupe_rt_records(rt_df)
-    rt_mhz = rt_freq_mhz(rt_df, freq_mhz)
     rows: list[dict] = []
     skipped_same_pid = 0
     for chip_id, group in rt_df.groupby("chip_id"):
@@ -576,7 +572,6 @@ def print_buffering_summary(timeline: pd.DataFrame) -> None:
         return
     depth = int(timeline["input_cb_depth_tiles"].iloc[0])
     tiles = int(timeline["tiles_per_core"].iloc[0])
-    dbl = bool(timeline["input_cb_double_buffered"].iloc[0])
     push = (
         int(timeline["reader_push_tiles_per_chunk"].iloc[0]) if "reader_push_tiles_per_chunk" in timeline.columns else 2
     )

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
@@ -15,6 +15,12 @@
 //   0: input  CB id
 //   1: output CB id
 //   2: NUM_NOPS_PER_TILE  (tunable; 0 disables the spin)
+//   3: PROFILE_PER_TILE   (1 = stamp TILE_IDX + MATH zone every tile, for latency
+//                          analysis; 0 = lean mode for bandwidth measurement: stamp
+//                          TILE_IDX only for tile 0 and drop the per-tile MATH zone so
+//                          the per-tile profiler writes don't pace the consumer and
+//                          back-pressure the reader. Compute cost is then copy + NOPs
+//                          only, which is what we want when balancing NOPs vs read BW.)
 //
 // Runtime args:
 //   0: n_tiles
@@ -33,6 +39,7 @@ void kernel_main() {
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_out = get_compile_time_arg_val(1);
     constexpr uint32_t num_nops_per_tile = get_compile_time_arg_val(2);
+    constexpr uint32_t profile_per_tile = get_compile_time_arg_val(3);
 
     const uint32_t n_tiles = get_arg_val<uint32_t>(0);
     const uint32_t program_id = get_arg_val<uint32_t>(1);
@@ -42,28 +49,43 @@ void kernel_main() {
 
     DeviceTimestampedData("PROG_ID", program_id);
 
+    // The actual per-tile consumer work: copy CB_in -> dst regs (+ NOP spin) -> CB_out.
+    // Kept identical across profiling modes so lean mode changes only instrumentation.
+    auto copy_one_tile = [&]() {
+        tile_regs_acquire();
+        copy_tile(cb_in, /*tile_index=*/0, /*dst_index=*/0);
+
+#pragma GCC unroll 65534
+        for (uint32_t j = 0; j < num_nops_per_tile; ++j) {
+            TTI_NOP;
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(/*src_index=*/0, cb_out);
+        tile_regs_release();
+    };
+
     for (uint32_t i = 0; i < n_tiles; ++i) {
         cb_wait_front(cb_in, 1);
         cb_reserve_back(cb_out, 1);
 
-        UNPACK(DeviceTimestampedData("TILE_IDX", i));
-
-        {
-            DeviceZoneScopedN("MATH");
-
-            tile_regs_acquire();
-            copy_tile(cb_in, /*tile_index=*/0, /*dst_index=*/0);
-
-#pragma GCC unroll 65534
-            for (uint32_t j = 0; j < num_nops_per_tile; ++j) {
-                TTI_NOP;
+        // Per-tile TILE_IDX marker only in profiling mode; lean mode keeps just tile 0
+        // (op-to-op latency needs the program's first-tile compute start).
+        if constexpr (profile_per_tile) {
+            UNPACK(DeviceTimestampedData("TILE_IDX", i));
+        } else {
+            if (i == 0) {
+                UNPACK(DeviceTimestampedData("TILE_IDX", i));
             }
+        }
 
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile(/*src_index=*/0, cb_out);
-            tile_regs_release();
+        if constexpr (profile_per_tile) {
+            DeviceZoneScopedN("MATH");
+            copy_one_tile();
+        } else {
+            copy_one_tile();
         }
 
         cb_push_back(cb_out, 1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
@@ -6,21 +6,10 @@
 //
 // For each of `n_tiles` tiles the kernel:
 //   1. waits for one tile in the input CB and for output-CB space,
-//   2. opens the per-tile MATH profiler zone (so the start timestamp marks
-//      the moment data is actually available to the tensix and there is
-//      space to write the result -- i.e. the earliest point at which
-//      real math work can begin),
-//   3. issues a real copy_tile so the unpacker / math / packer all run
-//      (matches the SFPU/FPU work an actual op would do),
-//   4. spins on a tunable, unrolled loop of TTI_NOPs to stretch the kernel
-//      runtime to a configurable target (~10us per program is typical).
-//      TTI_NOP expands to `__asm__ __volatile__(".ttinsn ...")` -- the
-//      __volatile__ qualifier prevents the compiler from removing or
-//      reordering the asm statement, so the loop body cannot be optimised
-//      out regardless of optimisation level.
-//   5. packs the result and pushes the tile to the output CB (after the
-//      MATH zone has closed, since cb_push_back / cb_pop_front are
-//      dataflow signalling, not math).
+//   2. UNPACK stamps TILE_IDX when tile i compute starts (TRISC_0 only),
+//   3. copy_tile + N×TTI_NOP on math TRISC,
+//   4. pack_tile pushes to the output CB (pack TRISC),
+//   5. PACK stamps FINISH_LAST_PUSH once at kernel exit (TRISC_2 only), outside the tile loop.
 //
 // Compile-time args:
 //   0: input  CB id
@@ -28,29 +17,11 @@
 //   2: NUM_NOPS_PER_TILE  (tunable; 0 disables the spin)
 //
 // Runtime args:
-//   0: n_tiles  (per-core slice size)
+//   0: n_tiles
+//   1: program_id  (PROG_ID in device CSV; 0 = pre-compile / warmup)
 //
-// Profiling layout (per-core, per-TRISC, per-program-run):
-//
-//   * Do **not** use DeviceZoneScopedMainN here: user `kernel_main` runs
-//     inside firmware `DeviceZoneScopedMainChildN("TRISC-KERNEL")`
-//     (tt_metal/hw/firmware/src/tt-1xx/trisck.cc). MainN uses guaranteed
-//     slot index 0 whose destructor calls finish_profiler() while the
-//     parent TRISC-KERNEL zone is still open, which breaks host-side
-//     start/end pairing (TT_FATAL: marker IDs do not match).
-//
-//   * One `MATH` zone per tile via DeviceZoneScopedN (rolling buffer).
-//
-//   * `DeviceTimestampedData("TILE_IDX", i)` next to each MATH zone for
-//     iteration index in profile_log_device.csv.
-//
-// Program-level op-to-op (between enqueued programs): use the host
-// `--use-realtime-profiler` path (ProgramRealtimeRecord), not an extra
-// outer kernel zone here.
-//
-// All profiler macros are no-ops when kernels are not JIT-built with
-// PROFILE_KERNEL (see TT_METAL_DEVICE_PROFILER=1 in rtoptions); no #ifdef
-// gating is required on our side.
+// Do **not** use DeviceZoneScopedMainN in compute kernel_main (breaks TRISC-KERNEL
+// marker pairing). Program-level host gaps: --use-realtime-profiler.
 
 #include <cstdint>
 #include "api/compute/compute_kernel_api.h"
@@ -64,17 +35,21 @@ void kernel_main() {
     constexpr uint32_t num_nops_per_tile = get_compile_time_arg_val(2);
 
     const uint32_t n_tiles = get_arg_val<uint32_t>(0);
+    const uint32_t program_id = get_arg_val<uint32_t>(1);
 
     unary_op_init_common(cb_in, cb_out);
     copy_tile_init(cb_in);
+
+    DeviceTimestampedData("PROG_ID", program_id);
 
     for (uint32_t i = 0; i < n_tiles; ++i) {
         cb_wait_front(cb_in, 1);
         cb_reserve_back(cb_out, 1);
 
+        UNPACK(DeviceTimestampedData("TILE_IDX", i));
+
         {
             DeviceZoneScopedN("MATH");
-            DeviceTimestampedData("TILE_IDX", i);
 
             tile_regs_acquire();
             copy_tile(cb_in, /*tile_index=*/0, /*dst_index=*/0);
@@ -94,4 +69,6 @@ void kernel_main() {
         cb_push_back(cb_out, 1);
         cb_pop_front(cb_in, 1);
     }
+
+    PACK(DeviceTimestampedData("FINISH_LAST_PUSH", program_id));
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// "NOP math" compute kernel for the op-to-op latency benchmark.
+//
+// For each of `n_tiles` tiles the kernel:
+//   1. waits for one tile in the input CB,
+//   2. issues a real copy_tile so the unpacker / math / packer all run
+//      (matches the SFPU/FPU work an actual op would do),
+//   3. spins on a tunable, unrolled loop of TTI_NOPs to stretch the kernel
+//      runtime to a configurable target (Almeet wants ~10us per program).
+//      TTI_NOP is inline assembly so the compiler can not optimise it away,
+//   4. packs the result and pushes the tile to the output CB.
+//
+// Compile-time args:
+//   0: input  CB id
+//   1: output CB id
+//   2: NUM_NOPS_PER_TILE  (tunable; 0 disables the spin)
+//
+// Runtime args:
+//   0: n_tiles  (per-core slice size)
+//
+// Step 4: each iteration of the per-tile loop is wrapped in
+// DeviceZoneScopedMainN("MATH"). This emits a "MATH_begin" hardware-cycle
+// timestamp on entry and a "MATH_end" timestamp on exit, on every TRISC
+// (UNPACK / MATH / PACK), per tile, per program-run, per core. Combined with
+// running N back-to-back programs (FD or trace mode), the host can read the
+// CSV via ReadMeshDeviceProfilerResults and compute:
+//   op_to_op_latency_per_core = MATH_begin[program N+1] - MATH_end[program N]
+// using either the MATH-trisc or PACK-trisc rows of the CSV depending on
+// what "math finished" means for the analysis.
+//
+// The macro is a no-op when the binary is not built with --enable-profiler;
+// no #ifdef gating is required on our side.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(1);
+    constexpr uint32_t num_nops_per_tile = get_compile_time_arg_val(2);
+
+    const uint32_t n_tiles = get_arg_val<uint32_t>(0);
+
+    unary_op_init_common(cb_in, cb_out);
+    copy_tile_init(cb_in);
+
+    for (uint32_t i = 0; i < n_tiles; ++i) {
+        DeviceZoneScopedMainN("MATH");
+
+        cb_wait_front(cb_in, 1);
+        cb_reserve_back(cb_out, 1);
+
+        tile_regs_acquire();
+        copy_tile(cb_in, /*tile_index=*/0, /*dst_index=*/0);
+
+#pragma GCC unroll 65534
+        for (uint32_t j = 0; j < num_nops_per_tile; ++j) {
+            TTI_NOP;
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(/*src_index=*/0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, 1);
+        cb_pop_front(cb_in, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
@@ -32,28 +32,25 @@
 //
 // Profiling layout (per-core, per-TRISC, per-program-run):
 //
-//   * One outer `MATH-KERNEL` zone wraps the whole kernel invocation.
-//     This uses DeviceZoneScopedMainN, which writes to a fixed
-//     "guaranteed" L1 slot, so it survives buffer pressure and gives a
-//     single guaranteed pair of start/end cycles per program-run.
+//   * Do **not** use DeviceZoneScopedMainN here: user `kernel_main` runs
+//     inside firmware `DeviceZoneScopedMainChildN("TRISC-KERNEL")`
+//     (tt_metal/hw/firmware/src/tt-1xx/trisck.cc). MainN uses guaranteed
+//     slot index 0 whose destructor calls finish_profiler() while the
+//     parent TRISC-KERNEL zone is still open, which breaks host-side
+//     start/end pairing (TT_FATAL: marker IDs do not match).
 //
-//   * One inner `MATH` zone per per-tile iteration. This uses
-//     DeviceZoneScopedN, which appends to the rolling marker buffer,
-//     so each iteration produces a distinct entry in the CSV (the
-//     `Main` variant would overwrite the fixed slot every iteration
-//     and only the last tile's timestamps would survive).
+//   * One `MATH` zone per tile via DeviceZoneScopedN (rolling buffer).
 //
-//   * Alongside each `MATH` zone, `DeviceTimestampedData("TILE_IDX", i)`
-//     records the runtime loop index `i`. Post-processing can match
-//     each MATH zone in profile_log_device.csv to its tile index, so
-//     "first iteration" vs "last iteration" is easily disambiguated.
+//   * `DeviceTimestampedData("TILE_IDX", i)` next to each MATH zone for
+//     iteration index in profile_log_device.csv.
 //
-// Op-to-op latency for program N+1 on a given core is then:
-//   op_to_op_latency = MATH_KERNEL_begin[N+1] - MATH_KERNEL_end[N]
-// (or use the per-tile MATH zones if you need finer-grained breakdown).
+// Program-level op-to-op (between enqueued programs): use the host
+// `--use-realtime-profiler` path (ProgramRealtimeRecord), not an extra
+// outer kernel zone here.
 //
-// All profiler macros are no-ops when the binary is not built with
-// --enable-profiler; no #ifdef gating is required on our side.
+// All profiler macros are no-ops when kernels are not JIT-built with
+// PROFILE_KERNEL (see TT_METAL_DEVICE_PROFILER=1 in rtoptions); no #ifdef
+// gating is required on our side.
 
 #include <cstdint>
 #include "api/compute/compute_kernel_api.h"
@@ -67,8 +64,6 @@ void kernel_main() {
     constexpr uint32_t num_nops_per_tile = get_compile_time_arg_val(2);
 
     const uint32_t n_tiles = get_arg_val<uint32_t>(0);
-
-    DeviceZoneScopedMainN("MATH-KERNEL");
 
     unary_op_init_common(cb_in, cb_out);
     copy_tile_init(cb_in);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
@@ -5,13 +5,22 @@
 // "NOP math" compute kernel for the op-to-op latency benchmark.
 //
 // For each of `n_tiles` tiles the kernel:
-//   1. waits for one tile in the input CB,
-//   2. issues a real copy_tile so the unpacker / math / packer all run
+//   1. waits for one tile in the input CB and for output-CB space,
+//   2. opens the per-tile MATH profiler zone (so the start timestamp marks
+//      the moment data is actually available to the tensix and there is
+//      space to write the result -- i.e. the earliest point at which
+//      real math work can begin),
+//   3. issues a real copy_tile so the unpacker / math / packer all run
 //      (matches the SFPU/FPU work an actual op would do),
-//   3. spins on a tunable, unrolled loop of TTI_NOPs to stretch the kernel
-//      runtime to a configurable target (Almeet wants ~10us per program).
-//      TTI_NOP is inline assembly so the compiler can not optimise it away,
-//   4. packs the result and pushes the tile to the output CB.
+//   4. spins on a tunable, unrolled loop of TTI_NOPs to stretch the kernel
+//      runtime to a configurable target (~10us per program is typical).
+//      TTI_NOP expands to `__asm__ __volatile__(".ttinsn ...")` -- the
+//      __volatile__ qualifier prevents the compiler from removing or
+//      reordering the asm statement, so the loop body cannot be optimised
+//      out regardless of optimisation level.
+//   5. packs the result and pushes the tile to the output CB (after the
+//      MATH zone has closed, since cb_push_back / cb_pop_front are
+//      dataflow signalling, not math).
 //
 // Compile-time args:
 //   0: input  CB id
@@ -21,18 +30,30 @@
 // Runtime args:
 //   0: n_tiles  (per-core slice size)
 //
-// Step 4: each iteration of the per-tile loop is wrapped in
-// DeviceZoneScopedMainN("MATH"). This emits a "MATH_begin" hardware-cycle
-// timestamp on entry and a "MATH_end" timestamp on exit, on every TRISC
-// (UNPACK / MATH / PACK), per tile, per program-run, per core. Combined with
-// running N back-to-back programs (FD or trace mode), the host can read the
-// CSV via ReadMeshDeviceProfilerResults and compute:
-//   op_to_op_latency_per_core = MATH_begin[program N+1] - MATH_end[program N]
-// using either the MATH-trisc or PACK-trisc rows of the CSV depending on
-// what "math finished" means for the analysis.
+// Profiling layout (per-core, per-TRISC, per-program-run):
 //
-// The macro is a no-op when the binary is not built with --enable-profiler;
-// no #ifdef gating is required on our side.
+//   * One outer `MATH-KERNEL` zone wraps the whole kernel invocation.
+//     This uses DeviceZoneScopedMainN, which writes to a fixed
+//     "guaranteed" L1 slot, so it survives buffer pressure and gives a
+//     single guaranteed pair of start/end cycles per program-run.
+//
+//   * One inner `MATH` zone per per-tile iteration. This uses
+//     DeviceZoneScopedN, which appends to the rolling marker buffer,
+//     so each iteration produces a distinct entry in the CSV (the
+//     `Main` variant would overwrite the fixed slot every iteration
+//     and only the last tile's timestamps would survive).
+//
+//   * Alongside each `MATH` zone, `DeviceTimestampedData("TILE_IDX", i)`
+//     records the runtime loop index `i`. Post-processing can match
+//     each MATH zone in profile_log_device.csv to its tile index, so
+//     "first iteration" vs "last iteration" is easily disambiguated.
+//
+// Op-to-op latency for program N+1 on a given core is then:
+//   op_to_op_latency = MATH_KERNEL_begin[N+1] - MATH_KERNEL_end[N]
+// (or use the per-tile MATH zones if you need finer-grained breakdown).
+//
+// All profiler macros are no-ops when the binary is not built with
+// --enable-profiler; no #ifdef gating is required on our side.
 
 #include <cstdint>
 #include "api/compute/compute_kernel_api.h"
@@ -47,28 +68,33 @@ void kernel_main() {
 
     const uint32_t n_tiles = get_arg_val<uint32_t>(0);
 
+    DeviceZoneScopedMainN("MATH-KERNEL");
+
     unary_op_init_common(cb_in, cb_out);
     copy_tile_init(cb_in);
 
     for (uint32_t i = 0; i < n_tiles; ++i) {
-        DeviceZoneScopedMainN("MATH");
-
         cb_wait_front(cb_in, 1);
         cb_reserve_back(cb_out, 1);
 
-        tile_regs_acquire();
-        copy_tile(cb_in, /*tile_index=*/0, /*dst_index=*/0);
+        {
+            DeviceZoneScopedN("MATH");
+            DeviceTimestampedData("TILE_IDX", i);
+
+            tile_regs_acquire();
+            copy_tile(cb_in, /*tile_index=*/0, /*dst_index=*/0);
 
 #pragma GCC unroll 65534
-        for (uint32_t j = 0; j < num_nops_per_tile; ++j) {
-            TTI_NOP;
+            for (uint32_t j = 0; j < num_nops_per_tile; ++j) {
+                TTI_NOP;
+            }
+
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(/*src_index=*/0, cb_out);
+            tile_regs_release();
         }
-
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile(/*src_index=*/0, cb_out);
-        tile_regs_release();
 
         cb_push_back(cb_out, 1);
         cb_pop_front(cb_in, 1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -158,12 +158,17 @@ void kernel_main() {
             drain_trid ^= 1u;
         }
 
-        // Tail: drain the final in-flight batch (may be partial).
+        // Tail: drain the final in-flight batch (may be partial). The barrier here
+        // completes the last outstanding reads, so it is the read-bandwidth end point:
+        // BW = bytes_read / (READ_LAST_BARRIER - READ_BEFORE_BARRIER). The interval
+        // spans first-read-issued to last-read-complete, so it still pays the pipeline
+        // fill/drain latency tax at each end (small vs the steady-state middle).
         noc_async_read_barrier_with_trid(drain_trid);
         if (pushed == 0) {
             // n_pages <= N: head never ran, so emit the first-read marker here.
             DeviceTimestampedData("READ_AFTER_BARRIER", effective_start_tile_id);
         }
+        DeviceTimestampedData("READ_LAST_BARRIER", effective_start_tile_id);
         cb_push_back(cb_in, (n_pages - pushed) * tiles_per_page);
 
         DeviceTimestampedData("NCRISC_DONE", program_id);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -6,17 +6,23 @@
 //
 // Runtime args:
 //   0: src_addr
-//   1: n_tiles                (logical tiles to read; must be a multiple of tiles_per_page)
+//   1: n_tiles                (logical tiles to read; must be a multiple of TILES_PER_PAGE)
 //   2: start_tile_id          (in tiles)
 //   3: program_id
-//   4: push_tile_count        (chunk size in tiles for modes 0/1; ignored for mode 2)
-//   5: reader_mode            (0 = reserve N, read+push one-by-one with a global barrier
+//
+// Compile-time args (see TensorAccessorArgs<1> for src accessor):
+//   0: cb_in
+//   1: READER_MODE            (0 = reserve N, read+push one-by-one with a global barrier
 //                              1 = reserve N, read all, single barrier, push N
-//                              2 = per-trid double buffer: two slots, alternating trids 1 and 2,
-//                                  barrier on one trid while the other read is in flight)
-//   6: tiles_per_page         (DRAM page size in tiles; one noc_async_read_tile pulls a page
+//                              2 = per-trid double-buffer: keep TRID_IN_FLIGHT reads in flight
+//                                  under TRID_A and TRID_B, barrier on a TRID drains all its
+//                                  reads, then refill before switching to the other TRID)
+//   2: PUSH_TILE_COUNT        (chunk size in tiles for modes 0/1; ignored for mode 2)
+//   3: TILES_PER_PAGE         (DRAM page size in tiles; one noc_async_read_tile pulls a page
 //                              = this many tiles in one NoC transaction; CB still has 1 tile
 //                              per page, so we push this many CB pages per DRAM page read)
+//   4: TRID_IN_FLIGHT         (reads in flight per TRID for mode 2; CB depth must be
+//                              >= 2 * TRID_IN_FLIGHT * TILES_PER_PAGE)
 //
 // Profiler on first tile of the slice only: READ_BEFORE_BARRIER / READ_AFTER_BARRIER.
 
@@ -29,20 +35,23 @@ void kernel_main() {
     const uint32_t n_tiles = get_arg_val<uint32_t>(1);
     const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
     const uint32_t program_id = get_arg_val<uint32_t>(3);
-    const uint32_t push_tile_count = get_arg_val<uint32_t>(4);
-    const uint32_t reader_mode = get_arg_val<uint32_t>(5);
-    const uint32_t tiles_per_page_rt = get_arg_val<uint32_t>(6);
-    const uint32_t tiles_per_page = tiles_per_page_rt > 0 ? tiles_per_page_rt : 1;
 
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr uint32_t READER_MODE = get_compile_time_arg_val(1);
+    constexpr uint32_t PUSH_TILE_COUNT = get_compile_time_arg_val(2);
+    constexpr uint32_t TILES_PER_PAGE = get_compile_time_arg_val(3);
+    constexpr uint32_t TRID_IN_FLIGHT = get_compile_time_arg_val(4);
+    constexpr auto src_args = TensorAccessorArgs<5>();
+
+    constexpr uint32_t chunk_size = PUSH_TILE_COUNT > 0 ? PUSH_TILE_COUNT : 1;
+    constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
+    constexpr uint32_t trid_in_flight = TRID_IN_FLIGHT > 0 ? TRID_IN_FLIGHT : 1;
 
     const auto src = TensorAccessor(src_args, src_addr);
 
     DeviceTimestampedData("PROG_ID", program_id);
     DeviceTimestampedData("NCRISC_GO", program_id);
 
-    const uint32_t chunk_size = push_tile_count > 0 ? push_tile_count : 1;
     const uint32_t end_tile_id = start_tile_id + n_tiles;
     const uint32_t tile_bytes = get_local_cb_interface(cb_in).fifo_page_size;
 
@@ -52,73 +61,125 @@ void kernel_main() {
     const uint32_t n_pages = n_tiles / tiles_per_page;
     const uint32_t end_page_id = start_page_id + n_pages;
 
-    if (reader_mode == 2) {
-        // Per-trid double-buffer: exactly two slots in the CB (depth=2),
-        // alternating trids 1 and 2 (slot 0 always uses TRID_A, slot 1 always
-        // uses TRID_B). We track the two slot addresses explicitly because
-        // get_write_ptr cannot tell us where the in-flight read is going.
+    if constexpr (READER_MODE == 2) {
+        // Per-trid double-buffer with N = TRID_IN_FLIGHT reads in flight per TRID.
+        //
+        // Slot layout (depth = 2*N*tiles_per_page, asserted on host):
+        //   slots [0..N-1]     are owned by TRID_A
+        //   slots [N..2N-1]    are owned by TRID_B
+        //
+        // Why this works with the CB:
+        //   cb_reserve_back / cb_push_back only track a FIFO count (depth - filled);
+        //   they don't know which physical slot we're writing. But since we always
+        //   push in strict A, B, A, B, ... order, the consumer pops in that same
+        //   order. So when cb_reserve_back(N*tpp) unblocks we know the N "oldest"
+        //   slots have been freed - and those are exactly the slots of whichever
+        //   side we are about to refill.
         //
         // Sequence:
-        //   issue read tile 0 -> slot 0 (TRID_A)
-        //   issue read tile 1 -> slot 1 (TRID_B)
-        //   loop:
-        //     barrier(TRID_A) -> push slot 0 -> compute consumes tile 0
-        //     wait for slot 0 to be free (cb_reserve_back gates on consumer)
-        //     issue next tile -> slot 0 (TRID_A) — overlaps with compute
-        //     barrier(TRID_B) -> push slot 1 -> compute consumes tile 1
-        //     wait for slot 1 to be free
-        //     issue next tile -> slot 1 (TRID_B)
+        //   1. cb_reserve_back(2*N*tpp), issue N TRID_A reads to slots 0..N-1,
+        //      issue N TRID_B reads to slots N..2N-1.
+        //   2. barrier(A), push N tiles_per_page pages.   <-- consumer starts eating A
+        //   3. barrier(B), push N tiles_per_page pages.   <-- consumer keeps eating
+        //   4. Steady loop:
+        //        cb_reserve_back(N*tpp)  // wait for consumer to free A's slots
+        //        refill N TRID_A reads to slots 0..N-1
+        //        barrier(A), push N
+        //        cb_reserve_back(N*tpp)  // wait for consumer to free B's slots
+        //        refill N TRID_B reads to slots N..2N-1
+        //        barrier(B), push N
         constexpr uint32_t TRID_A = 1;
         constexpr uint32_t TRID_B = 2;
-        const uint32_t trids[2] = {TRID_A, TRID_B};
-
-        if (n_pages == 0) {
-            DeviceTimestampedData("NCRISC_DONE", program_id);
-            return;
-        }
+        constexpr uint32_t N = trid_in_flight;
 
         const uint32_t page_bytes = tiles_per_page * tile_bytes;
-        // Each slot holds one DRAM page (= tiles_per_page CB pages).
-        const uint32_t initial_fill_pages = n_pages >= 2 ? 2 : 1;
+
+        // Initial reservation: up to 2N pages worth (clipped by what we'll actually fill).
+        const uint32_t initial_fill_pages = (n_pages < 2u * N) ? n_pages : (2u * N);
         cb_reserve_back(cb_in, initial_fill_pages * tiles_per_page);
         const uint32_t cb_base = get_write_ptr(cb_in);
-        const uint32_t slot_addrs[2] = {cb_base, cb_base + page_bytes};
 
         DeviceTimestampedData("READ_BEFORE_BARRIER", start_tile_id);
 
+        uint32_t next_page_id = start_page_id;
+        uint32_t pages_pushed = 0;
+
+        // Initial fill: up to N TRID_A reads to slots 0..N-1.
+        uint32_t a_count = 0;
         noc_async_read_set_trid(TRID_A);
-        noc_async_read_tile(start_page_id, src, slot_addrs[0]);
-        if (initial_fill_pages == 2) {
-            noc_async_read_set_trid(TRID_B);
-            noc_async_read_tile(start_page_id + 1, src, slot_addrs[1]);
+        while (a_count < N && next_page_id < end_page_id) {
+            noc_async_read_tile(next_page_id, src, cb_base + a_count * page_bytes);
+            ++next_page_id;
+            ++a_count;
+        }
+        // Initial fill: up to N TRID_B reads to slots N..2N-1.
+        uint32_t b_count = 0;
+        noc_async_read_set_trid(TRID_B);
+        while (b_count < N && next_page_id < end_page_id) {
+            noc_async_read_tile(next_page_id, src, cb_base + (N + b_count) * page_bytes);
+            ++next_page_id;
+            ++b_count;
         }
 
-        uint32_t next_page_id = start_page_id + initial_fill_pages;
-        uint32_t pages_pushed = 0;
-        uint32_t slot = 0;
+        // Push initial A, then initial B (consumer can start at full bandwidth).
+        if (a_count > 0) {
+            noc_async_read_barrier_with_trid(TRID_A);
+            DeviceTimestampedData("READ_AFTER_BARRIER", start_tile_id);
+            cb_push_back(cb_in, a_count * tiles_per_page);
+            pages_pushed += a_count;
+        } else {
+            DeviceTimestampedData("READ_AFTER_BARRIER", start_tile_id);
+        }
+        if (b_count > 0) {
+            noc_async_read_barrier_with_trid(TRID_B);
+            cb_push_back(cb_in, b_count * tiles_per_page);
+            pages_pushed += b_count;
+        }
 
+        // Steady-state: alternately refill A, push A, refill B, push B.
+        // Each refill issues up to N more reads on its TRID, overlapping with the
+        // other TRID's in-flight reads and the consumer's pop on the previous batch.
         while (pages_pushed < n_pages) {
-            const uint32_t trid = trids[slot];
-            noc_async_read_barrier_with_trid(trid);
-            if (pages_pushed == 0) {
-                DeviceTimestampedData("READ_AFTER_BARRIER", start_tile_id);
-            }
-            cb_push_back(cb_in, tiles_per_page);
-            ++pages_pushed;
-
-            if (next_page_id < end_page_id) {
-                cb_reserve_back(cb_in, tiles_per_page);
-                noc_async_read_set_trid(trid);
-                noc_async_read_tile(next_page_id, src, slot_addrs[slot]);
+            // Refill A. cb_reserve_back blocks until consumer has popped at least N
+            // tiles past the previous A push, freeing slots 0..N-1.
+            cb_reserve_back(cb_in, N * tiles_per_page);
+            uint32_t a_refill = 0;
+            noc_async_read_set_trid(TRID_A);
+            while (a_refill < N && next_page_id < end_page_id) {
+                noc_async_read_tile(next_page_id, src, cb_base + a_refill * page_bytes);
                 ++next_page_id;
+                ++a_refill;
             }
-            slot ^= 1;
+            if (a_refill > 0) {
+                noc_async_read_barrier_with_trid(TRID_A);
+                cb_push_back(cb_in, a_refill * tiles_per_page);
+                pages_pushed += a_refill;
+            }
+            if (pages_pushed >= n_pages) {
+                break;
+            }
+
+            // Refill B. Same idea on slots N..2N-1.
+            cb_reserve_back(cb_in, N * tiles_per_page);
+            uint32_t b_refill = 0;
+            noc_async_read_set_trid(TRID_B);
+            while (b_refill < N && next_page_id < end_page_id) {
+                noc_async_read_tile(next_page_id, src, cb_base + (N + b_refill) * page_bytes);
+                ++next_page_id;
+                ++b_refill;
+            }
+            if (b_refill > 0) {
+                noc_async_read_barrier_with_trid(TRID_B);
+                cb_push_back(cb_in, b_refill * tiles_per_page);
+                pages_pushed += b_refill;
+            }
         }
 
         DeviceTimestampedData("NCRISC_DONE", program_id);
         return;
     }
 
+    // Legacy reader modes (0 = incremental push-1; 1 = batch read+push).
     for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id;) {
         const uint32_t tiles_left = end_tile_id - tile_id;
         const uint32_t chunk = tiles_left < chunk_size ? tiles_left : chunk_size;
@@ -126,7 +187,7 @@ void kernel_main() {
         cb_reserve_back(cb_in, chunk);
         const uint32_t cb_base = get_write_ptr(cb_in);
 
-        if (reader_mode == 1) {
+        if constexpr (READER_MODE == 1) {
             for (uint32_t i = 0; i < chunk; ++i) {
                 const uint32_t tid = tile_id + i;
                 const uint32_t l1_write_addr = cb_base + i * tile_bytes;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -66,121 +66,105 @@ void kernel_main() {
     // src accessor is configured with the matching page_size at build time.
     const uint32_t start_page_id = effective_start_tile_id / tiles_per_page;
     const uint32_t n_pages = n_tiles / tiles_per_page;
-    const uint32_t end_page_id = start_page_id + n_pages;
 
     if constexpr (READER_MODE == 2) {
-        // Per-trid double-buffer with N = TRID_IN_FLIGHT reads in flight per TRID.
+        // Per-trid double buffer, N = TRID_IN_FLIGHT reads in flight per side.
         //
-        // Slot layout (depth = 2*N*tiles_per_page, asserted on host):
-        //   slots [0..N-1]     are owned by TRID_A
-        //   slots [N..2N-1]    are owned by TRID_B
+        // We are only measuring NoC read bandwidth: results are dummy and the compute
+        // side is a NOP. We STRIDE the source page_id across [start_page_id, +n_pages)
+        // (one increment per read) so consecutive transactions land on different DRAM
+        // banks -- the interleaved buffer maps page k to bank k % num_banks. Reading a
+        // single page pins every transaction to one bank and caps a single core at the
+        // single-bank ceiling (~22 GB/s on WH); striding across all banks reaches the
+        // ~30 GB/s all-bank ceiling (matches test_bw_and_latency -m 3 vs -m 1). Total
+        // reads already equal n_pages, so the stride sweeps the core's slice exactly
+        // once with no wrap. The L1 destination stays fixed at cb_base (dummy data; the
+        // single-bank reference shows distinct L1 is not what gates BW).
         //
-        // Why this works with the CB:
-        //   cb_reserve_back / cb_push_back only track a FIFO count (depth - filled);
-        //   they don't know which physical slot we're writing. But since we always
-        //   push in strict A, B, A, B, ... order, the consumer pops in that same
-        //   order. So when cb_reserve_back(N*tpp) unblocks we know the N "oldest"
-        //   slots have been freed - and those are exactly the slots of whichever
-        //   side we are about to refill.
+        // cb_reserve_back / cb_push_back are kept purely for flow control so the
+        // consumer pipeline advances; host guarantees depth >= 2*N*tiles_per_page.
         //
-        // Sequence:
-        //   1. cb_reserve_back(2*N*tpp), issue N TRID_A reads to slots 0..N-1,
-        //      issue N TRID_B reads to slots N..2N-1.
-        //   2. barrier(A), push N tiles_per_page pages.   <-- consumer starts eating A
-        //   3. barrier(B), push N tiles_per_page pages.   <-- consumer keeps eating
-        //   4. Steady loop:
-        //        cb_reserve_back(N*tpp)  // wait for consumer to free A's slots
-        //        refill N TRID_A reads to slots 0..N-1
-        //        barrier(A), push N
-        //        cb_reserve_back(N*tpp)  // wait for consumer to free B's slots
-        //        refill N TRID_B reads to slots N..2N-1
-        //        barrier(B), push N
-        constexpr uint32_t TRID_A = 1;
-        constexpr uint32_t TRID_B = 2;
+        // Pipeline (one batch always in flight while we stall on the other):
+        //   prologue: issue batch 0 on TRID_A.
+        //   head    : prefetch batch 1 on TRID_B, then barrier+push batch 0 (one-shot,
+        //             so the first-read profiler marker lives outside the hot loop).
+        //   hot loop: prefetch the NEXT batch on the other trid, then barrier+push the
+        //             oldest in-flight batch. The loop condition guarantees a next
+        //             batch exists, so there is no per-iteration have_next branch, and
+        //             the drained batch is always a full N (only the last batch can be
+        //             partial). Static branch prediction on this arch makes the
+        //             data-dependent branch worth eliminating.
+        //   tail    : drain the final lone in-flight batch (may be < N).
+        //
+        // TRID_A ^ 1 == TRID_B and vice versa, so a single xor toggles sides.
+        constexpr uint32_t TRID_A = 2;
+        constexpr uint32_t TRID_B = 3;
         constexpr uint32_t N = trid_in_flight;
+        const uint32_t batch_tiles = N * tiles_per_page;
 
-        const uint32_t page_bytes = tiles_per_page * tile_bytes;
-
-        // Initial reservation: up to 2N pages worth (clipped by what we'll actually fill).
-        const uint32_t initial_fill_pages = (n_pages < 2u * N) ? n_pages : (2u * N);
-        cb_reserve_back(cb_in, initial_fill_pages * tiles_per_page);
+        // Reserve room for both in-flight batches up front (covers prologue + head).
+        cb_reserve_back(cb_in, 2 * batch_tiles);
         const uint32_t cb_base = get_write_ptr(cb_in);
 
         DeviceTimestampedData("READ_BEFORE_BARRIER", effective_start_tile_id);
 
-        uint32_t next_page_id = start_page_id;
-        uint32_t pages_pushed = 0;
-
-        // Initial fill: up to N TRID_A reads to slots 0..N-1.
-        uint32_t a_count = 0;
-        noc_async_read_set_trid(TRID_A);
-        while (a_count < N && next_page_id < end_page_id) {
-            noc_async_read_tile(next_page_id, src, cb_base + a_count * page_bytes);
-            ++next_page_id;
-            ++a_count;
+        // Prologue: issue batch 0 on TRID_A.
+        uint32_t issue_trid = TRID_A;
+        uint32_t drain_trid = TRID_A;
+        uint32_t page_id = start_page_id;  // strides across banks, one bump per read
+        uint32_t issued = n_pages < N ? n_pages : N;
+        noc_async_read_set_trid(issue_trid);
+        for (uint32_t i = 0; i < issued; ++i) {
+            noc_async_read_tile(page_id++, src, cb_base);
         }
-        // Initial fill: up to N TRID_B reads to slots N..2N-1.
-        uint32_t b_count = 0;
-        noc_async_read_set_trid(TRID_B);
-        while (b_count < N && next_page_id < end_page_id) {
-            noc_async_read_tile(next_page_id, src, cb_base + (N + b_count) * page_bytes);
-            ++next_page_id;
-            ++b_count;
-        }
+        uint32_t pushed = 0;
 
-        // Push initial A, then initial B (consumer can start at full bandwidth).
-        if (a_count > 0) {
-            noc_async_read_barrier_with_trid(TRID_A);
+        // Head: if a second batch exists, prefetch it on the other trid (so two batches
+        // are in flight), then drain batch 0. The first-read marker is emitted here,
+        // once, so it never enters the hot loop.
+        if (issued < n_pages) {
+            issue_trid ^= 1u;
+            const uint32_t remaining = n_pages - issued;
+            const uint32_t nb = remaining < N ? remaining : N;
+            noc_async_read_set_trid(issue_trid);
+            for (uint32_t i = 0; i < nb; ++i) {
+                noc_async_read_tile(page_id++, src, cb_base);
+            }
+            issued += nb;
+
+            noc_async_read_barrier_with_trid(drain_trid);
             DeviceTimestampedData("READ_AFTER_BARRIER", effective_start_tile_id);
-            cb_push_back(cb_in, a_count * tiles_per_page);
-            pages_pushed += a_count;
-        } else {
+            cb_push_back(cb_in, batch_tiles);
+            pushed += N;
+            drain_trid ^= 1u;
+        }
+
+        // Hot loop: uniform prefetch-then-drain, no data-dependent branch. The reserve
+        // gates reuse of the region the oldest batch just vacated.
+        while (issued < n_pages) {
+            issue_trid ^= 1u;
+            const uint32_t remaining = n_pages - issued;
+            const uint32_t nb = remaining < N ? remaining : N;
+            cb_reserve_back(cb_in, batch_tiles);
+            noc_async_read_set_trid(issue_trid);
+            for (uint32_t i = 0; i < nb; ++i) {
+                noc_async_read_tile(page_id++, src, cb_base);
+            }
+            issued += nb;
+
+            noc_async_read_barrier_with_trid(drain_trid);
+            cb_push_back(cb_in, batch_tiles);
+            pushed += N;
+            drain_trid ^= 1u;
+        }
+
+        // Tail: drain the final in-flight batch (may be partial).
+        noc_async_read_barrier_with_trid(drain_trid);
+        if (pushed == 0) {
+            // n_pages <= N: head never ran, so emit the first-read marker here.
             DeviceTimestampedData("READ_AFTER_BARRIER", effective_start_tile_id);
         }
-        if (b_count > 0) {
-            noc_async_read_barrier_with_trid(TRID_B);
-            cb_push_back(cb_in, b_count * tiles_per_page);
-            pages_pushed += b_count;
-        }
-
-        // Steady-state: alternately refill A, push A, refill B, push B.
-        // Each refill issues up to N more reads on its TRID, overlapping with the
-        // other TRID's in-flight reads and the consumer's pop on the previous batch.
-        while (pages_pushed < n_pages) {
-            // Refill A. cb_reserve_back blocks until consumer has popped at least N
-            // tiles past the previous A push, freeing slots 0..N-1.
-            cb_reserve_back(cb_in, N * tiles_per_page);
-            uint32_t a_refill = 0;
-            noc_async_read_set_trid(TRID_A);
-            while (a_refill < N && next_page_id < end_page_id) {
-                noc_async_read_tile(next_page_id, src, cb_base + a_refill * page_bytes);
-                ++next_page_id;
-                ++a_refill;
-            }
-            if (a_refill > 0) {
-                noc_async_read_barrier_with_trid(TRID_A);
-                cb_push_back(cb_in, a_refill * tiles_per_page);
-                pages_pushed += a_refill;
-            }
-            if (pages_pushed >= n_pages) {
-                break;
-            }
-
-            // Refill B. Same idea on slots N..2N-1.
-            cb_reserve_back(cb_in, N * tiles_per_page);
-            uint32_t b_refill = 0;
-            noc_async_read_set_trid(TRID_B);
-            while (b_refill < N && next_page_id < end_page_id) {
-                noc_async_read_tile(next_page_id, src, cb_base + (N + b_refill) * page_bytes);
-                ++next_page_id;
-                ++b_refill;
-            }
-            if (b_refill > 0) {
-                noc_async_read_barrier_with_trid(TRID_B);
-                cb_push_back(cb_in, b_refill * tiles_per_page);
-                pages_pushed += b_refill;
-            }
-        }
+        cb_push_back(cb_in, (n_pages - pushed) * tiles_per_page);
 
         DeviceTimestampedData("NCRISC_DONE", program_id);
         return;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reads `n_tiles` tiles from an interleaved DRAM buffer starting at
+// `start_tile_id`, pushing them one-at-a-time into the input circular buffer
+// (CB_in). One instance of this kernel runs on every Tensix core; each core
+// gets its own [start_tile_id, start_tile_id + n_tiles) slice via runtime args.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
+
+    const uint32_t tile_size_bytes = get_tile_size(cb_in);
+    const auto src = TensorAccessor(src_args, src_addr);
+
+    const uint32_t end_tile_id = start_tile_id + n_tiles;
+    for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id; ++tile_id) {
+        cb_reserve_back(cb_in, 1);
+        const uint32_t l1_write_addr = get_write_ptr(cb_in);
+        noc_async_read_tile(tile_id, src, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_in, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -2,31 +2,81 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Reads `n_tiles` tiles from an interleaved DRAM buffer starting at
-// `start_tile_id`, pushing them one-at-a-time into the input circular buffer
-// (CB_in). One instance of this kernel runs on every Tensix core; each core
-// gets its own [start_tile_id, start_tile_id + n_tiles) slice via runtime args.
+// Reads `n_tiles` tiles from interleaved DRAM into CB_in.
+//
+// Runtime args:
+//   0: src_addr
+//   1: n_tiles
+//   2: start_tile_id
+//   3: program_id
+//   4: push_tile_count  (e.g. 2 — reserve/read/push this many tiles per chunk)
+//   5: reader_mode      (0 = reserve N, read+push one-by-one; 1 = reserve N, read all, push N)
+//
+// Profiler on first tile of the slice only: READ_BEFORE_BARRIER / READ_AFTER_BARRIER.
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "tools/profiler/kernel_profiler.hpp"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t n_tiles = get_arg_val<uint32_t>(1);
     const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t program_id = get_arg_val<uint32_t>(3);
+    const uint32_t push_tile_count = get_arg_val<uint32_t>(4);
+    const uint32_t reader_mode = get_arg_val<uint32_t>(5);
 
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
     constexpr auto src_args = TensorAccessorArgs<1>();
 
-    const uint32_t tile_size_bytes = get_tile_size(cb_in);
     const auto src = TensorAccessor(src_args, src_addr);
 
+    DeviceTimestampedData("PROG_ID", program_id);
+    DeviceTimestampedData("NCRISC_GO", program_id);
+
+    const uint32_t chunk_size = push_tile_count > 0 ? push_tile_count : 1;
     const uint32_t end_tile_id = start_tile_id + n_tiles;
-    for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id; ++tile_id) {
-        cb_reserve_back(cb_in, 1);
-        const uint32_t l1_write_addr = get_write_ptr(cb_in);
-        noc_async_read_tile(tile_id, src, l1_write_addr);
-        noc_async_read_barrier();
-        cb_push_back(cb_in, 1);
+    const uint32_t tile_bytes = get_local_cb_interface(cb_in).fifo_page_size;
+
+    for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id;) {
+        const uint32_t tiles_left = end_tile_id - tile_id;
+        const uint32_t chunk = tiles_left < chunk_size ? tiles_left : chunk_size;
+
+        cb_reserve_back(cb_in, chunk);
+        const uint32_t cb_base = get_write_ptr(cb_in);
+
+        if (reader_mode == 1) {
+            for (uint32_t i = 0; i < chunk; ++i) {
+                const uint32_t tid = tile_id + i;
+                const uint32_t l1_write_addr = cb_base + i * tile_bytes;
+                if (tid == start_tile_id) {
+                    DeviceTimestampedData("READ_BEFORE_BARRIER", tid);
+                }
+                noc_async_read_tile(tid, src, l1_write_addr);
+                noc_async_read_barrier();
+                if (tid == start_tile_id) {
+                    DeviceTimestampedData("READ_AFTER_BARRIER", tid);
+                }
+            }
+            cb_push_back(cb_in, chunk);
+        } else {
+            for (uint32_t i = 0; i < chunk; ++i) {
+                const uint32_t tid = tile_id + i;
+                const uint32_t l1_write_addr = get_write_ptr(cb_in);
+                if (tid == start_tile_id) {
+                    DeviceTimestampedData("READ_BEFORE_BARRIER", tid);
+                }
+                noc_async_read_tile(tid, src, l1_write_addr);
+                noc_async_read_barrier();
+                if (tid == start_tile_id) {
+                    DeviceTimestampedData("READ_AFTER_BARRIER", tid);
+                }
+                cb_push_back(cb_in, 1);
+            }
+        }
+
+        tile_id += chunk;
     }
+
+    DeviceTimestampedData("NCRISC_DONE", program_id);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -6,11 +6,17 @@
 //
 // Runtime args:
 //   0: src_addr
-//   1: n_tiles
-//   2: start_tile_id
+//   1: n_tiles                (logical tiles to read; must be a multiple of tiles_per_page)
+//   2: start_tile_id          (in tiles)
 //   3: program_id
-//   4: push_tile_count  (e.g. 2 — reserve/read/push this many tiles per chunk)
-//   5: reader_mode      (0 = reserve N, read+push one-by-one; 1 = reserve N, read all, push N)
+//   4: push_tile_count        (chunk size in tiles for modes 0/1; ignored for mode 2)
+//   5: reader_mode            (0 = reserve N, read+push one-by-one with a global barrier
+//                              1 = reserve N, read all, single barrier, push N
+//                              2 = per-trid double buffer: two slots, alternating trids 1 and 2,
+//                                  barrier on one trid while the other read is in flight)
+//   6: tiles_per_page         (DRAM page size in tiles; one noc_async_read_tile pulls a page
+//                              = this many tiles in one NoC transaction; CB still has 1 tile
+//                              per page, so we push this many CB pages per DRAM page read)
 //
 // Profiler on first tile of the slice only: READ_BEFORE_BARRIER / READ_AFTER_BARRIER.
 
@@ -25,6 +31,8 @@ void kernel_main() {
     const uint32_t program_id = get_arg_val<uint32_t>(3);
     const uint32_t push_tile_count = get_arg_val<uint32_t>(4);
     const uint32_t reader_mode = get_arg_val<uint32_t>(5);
+    const uint32_t tiles_per_page_rt = get_arg_val<uint32_t>(6);
+    const uint32_t tiles_per_page = tiles_per_page_rt > 0 ? tiles_per_page_rt : 1;
 
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
     constexpr auto src_args = TensorAccessorArgs<1>();
@@ -37,6 +45,79 @@ void kernel_main() {
     const uint32_t chunk_size = push_tile_count > 0 ? push_tile_count : 1;
     const uint32_t end_tile_id = start_tile_id + n_tiles;
     const uint32_t tile_bytes = get_local_cb_interface(cb_in).fifo_page_size;
+
+    // DRAM page = tiles_per_page tiles (one NoC transaction per page).
+    // src accessor is configured with the matching page_size at build time.
+    const uint32_t start_page_id = start_tile_id / tiles_per_page;
+    const uint32_t n_pages = n_tiles / tiles_per_page;
+    const uint32_t end_page_id = start_page_id + n_pages;
+
+    if (reader_mode == 2) {
+        // Per-trid double-buffer: exactly two slots in the CB (depth=2),
+        // alternating trids 1 and 2 (slot 0 always uses TRID_A, slot 1 always
+        // uses TRID_B). We track the two slot addresses explicitly because
+        // get_write_ptr cannot tell us where the in-flight read is going.
+        //
+        // Sequence:
+        //   issue read tile 0 -> slot 0 (TRID_A)
+        //   issue read tile 1 -> slot 1 (TRID_B)
+        //   loop:
+        //     barrier(TRID_A) -> push slot 0 -> compute consumes tile 0
+        //     wait for slot 0 to be free (cb_reserve_back gates on consumer)
+        //     issue next tile -> slot 0 (TRID_A) — overlaps with compute
+        //     barrier(TRID_B) -> push slot 1 -> compute consumes tile 1
+        //     wait for slot 1 to be free
+        //     issue next tile -> slot 1 (TRID_B)
+        constexpr uint32_t TRID_A = 1;
+        constexpr uint32_t TRID_B = 2;
+        const uint32_t trids[2] = {TRID_A, TRID_B};
+
+        if (n_pages == 0) {
+            DeviceTimestampedData("NCRISC_DONE", program_id);
+            return;
+        }
+
+        const uint32_t page_bytes = tiles_per_page * tile_bytes;
+        // Each slot holds one DRAM page (= tiles_per_page CB pages).
+        const uint32_t initial_fill_pages = n_pages >= 2 ? 2 : 1;
+        cb_reserve_back(cb_in, initial_fill_pages * tiles_per_page);
+        const uint32_t cb_base = get_write_ptr(cb_in);
+        const uint32_t slot_addrs[2] = {cb_base, cb_base + page_bytes};
+
+        DeviceTimestampedData("READ_BEFORE_BARRIER", start_tile_id);
+
+        noc_async_read_set_trid(TRID_A);
+        noc_async_read_tile(start_page_id, src, slot_addrs[0]);
+        if (initial_fill_pages == 2) {
+            noc_async_read_set_trid(TRID_B);
+            noc_async_read_tile(start_page_id + 1, src, slot_addrs[1]);
+        }
+
+        uint32_t next_page_id = start_page_id + initial_fill_pages;
+        uint32_t pages_pushed = 0;
+        uint32_t slot = 0;
+
+        while (pages_pushed < n_pages) {
+            const uint32_t trid = trids[slot];
+            noc_async_read_barrier_with_trid(trid);
+            if (pages_pushed == 0) {
+                DeviceTimestampedData("READ_AFTER_BARRIER", start_tile_id);
+            }
+            cb_push_back(cb_in, tiles_per_page);
+            ++pages_pushed;
+
+            if (next_page_id < end_page_id) {
+                cb_reserve_back(cb_in, tiles_per_page);
+                noc_async_read_set_trid(trid);
+                noc_async_read_tile(next_page_id, src, slot_addrs[slot]);
+                ++next_page_id;
+            }
+            slot ^= 1;
+        }
+
+        DeviceTimestampedData("NCRISC_DONE", program_id);
+        return;
+    }
 
     for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id;) {
         const uint32_t tiles_left = end_tile_id - tile_id;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -10,7 +10,7 @@
 //   2: start_tile_id          (in tiles)
 //   3: program_id
 //
-// Compile-time args (see TensorAccessorArgs<1> for src accessor):
+// Compile-time args (see TensorAccessorArgs<6> for src accessor):
 //   0: cb_in
 //   1: READER_MODE            (0 = reserve N, read+push one-by-one with a global barrier
 //                              1 = reserve N, read all, single barrier, push N
@@ -23,6 +23,9 @@
 //                              per page, so we push this many CB pages per DRAM page read)
 //   4: TRID_IN_FLIGHT         (reads in flight per TRID for mode 2; CB depth must be
 //                              >= 2 * TRID_IN_FLIGHT * TILES_PER_PAGE)
+//   5: CROSS_PROGRAM_OFFSET_TILES (0 = every program reads the same slice; >0 = program k
+//                              reads pages starting at start_tile_id + k*OFFSET. Host
+//                              must allocate a buffer big enough for all program slices.)
 //
 // Profiler on first tile of the slice only: READ_BEFORE_BARRIER / READ_AFTER_BARRIER.
 
@@ -41,7 +44,8 @@ void kernel_main() {
     constexpr uint32_t PUSH_TILE_COUNT = get_compile_time_arg_val(2);
     constexpr uint32_t TILES_PER_PAGE = get_compile_time_arg_val(3);
     constexpr uint32_t TRID_IN_FLIGHT = get_compile_time_arg_val(4);
-    constexpr auto src_args = TensorAccessorArgs<5>();
+    constexpr uint32_t CROSS_PROGRAM_OFFSET_TILES = get_compile_time_arg_val(5);
+    constexpr auto src_args = TensorAccessorArgs<6>();
 
     constexpr uint32_t chunk_size = PUSH_TILE_COUNT > 0 ? PUSH_TILE_COUNT : 1;
     constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
@@ -52,12 +56,15 @@ void kernel_main() {
     DeviceTimestampedData("PROG_ID", program_id);
     DeviceTimestampedData("NCRISC_GO", program_id);
 
-    const uint32_t end_tile_id = start_tile_id + n_tiles;
+    // When CROSS_PROGRAM_OFFSET_TILES > 0, each program reads a disjoint tile slice
+    // so the DRAM controller sees fresh row opens per program (more app-like).
+    const uint32_t effective_start_tile_id = start_tile_id + program_id * CROSS_PROGRAM_OFFSET_TILES;
+    const uint32_t end_tile_id = effective_start_tile_id + n_tiles;
     const uint32_t tile_bytes = get_local_cb_interface(cb_in).fifo_page_size;
 
     // DRAM page = tiles_per_page tiles (one NoC transaction per page).
     // src accessor is configured with the matching page_size at build time.
-    const uint32_t start_page_id = start_tile_id / tiles_per_page;
+    const uint32_t start_page_id = effective_start_tile_id / tiles_per_page;
     const uint32_t n_pages = n_tiles / tiles_per_page;
     const uint32_t end_page_id = start_page_id + n_pages;
 
@@ -99,7 +106,7 @@ void kernel_main() {
         cb_reserve_back(cb_in, initial_fill_pages * tiles_per_page);
         const uint32_t cb_base = get_write_ptr(cb_in);
 
-        DeviceTimestampedData("READ_BEFORE_BARRIER", start_tile_id);
+        DeviceTimestampedData("READ_BEFORE_BARRIER", effective_start_tile_id);
 
         uint32_t next_page_id = start_page_id;
         uint32_t pages_pushed = 0;
@@ -124,11 +131,11 @@ void kernel_main() {
         // Push initial A, then initial B (consumer can start at full bandwidth).
         if (a_count > 0) {
             noc_async_read_barrier_with_trid(TRID_A);
-            DeviceTimestampedData("READ_AFTER_BARRIER", start_tile_id);
+            DeviceTimestampedData("READ_AFTER_BARRIER", effective_start_tile_id);
             cb_push_back(cb_in, a_count * tiles_per_page);
             pages_pushed += a_count;
         } else {
-            DeviceTimestampedData("READ_AFTER_BARRIER", start_tile_id);
+            DeviceTimestampedData("READ_AFTER_BARRIER", effective_start_tile_id);
         }
         if (b_count > 0) {
             noc_async_read_barrier_with_trid(TRID_B);
@@ -180,7 +187,7 @@ void kernel_main() {
     }
 
     // Legacy reader modes (0 = incremental push-1; 1 = batch read+push).
-    for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id;) {
+    for (uint32_t tile_id = effective_start_tile_id; tile_id < end_tile_id;) {
         const uint32_t tiles_left = end_tile_id - tile_id;
         const uint32_t chunk = tiles_left < chunk_size ? tiles_left : chunk_size;
 
@@ -191,12 +198,12 @@ void kernel_main() {
             for (uint32_t i = 0; i < chunk; ++i) {
                 const uint32_t tid = tile_id + i;
                 const uint32_t l1_write_addr = cb_base + i * tile_bytes;
-                if (tid == start_tile_id) {
+                if (tid == effective_start_tile_id) {
                     DeviceTimestampedData("READ_BEFORE_BARRIER", tid);
                 }
                 noc_async_read_tile(tid, src, l1_write_addr);
                 noc_async_read_barrier();
-                if (tid == start_tile_id) {
+                if (tid == effective_start_tile_id) {
                     DeviceTimestampedData("READ_AFTER_BARRIER", tid);
                 }
             }
@@ -205,12 +212,12 @@ void kernel_main() {
             for (uint32_t i = 0; i < chunk; ++i) {
                 const uint32_t tid = tile_id + i;
                 const uint32_t l1_write_addr = get_write_ptr(cb_in);
-                if (tid == start_tile_id) {
+                if (tid == effective_start_tile_id) {
                     DeviceTimestampedData("READ_BEFORE_BARRIER", tid);
                 }
                 noc_async_read_tile(tid, src, l1_write_addr);
                 noc_async_read_barrier();
-                if (tid == start_tile_id) {
+                if (tid == effective_start_tile_id) {
                     DeviceTimestampedData("READ_AFTER_BARRIER", tid);
                 }
                 cb_push_back(cb_in, 1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
@@ -7,9 +7,21 @@
 // instance of this kernel runs on every Tensix core; each core gets its own
 // [start_tile_id, start_tile_id + n_tiles) slice via runtime args.
 //
-// The per-tile noc_async_write_barrier is intentional: it matches what real
-// ops do today (full barrier at op end before the next op can safely begin)
-// and is part of what the op-to-op latency benchmark is meant to measure.
+// Synchronization (per kernel review feedback):
+//   - noc_async_writes_flushed() after each tile so the source L1 slot is safe
+//     to recycle on the next cb_pop_front (write has at least left L1).
+//   - noc_async_write_barrier() ONCE at kernel exit so the next op sees fully
+//     committed DRAM writes (op-end safety).
+//
+// Runtime args:
+//   0: dst_addr
+//   1: n_tiles
+//   2: start_tile_id
+//   3: program_id
+//
+// Compile-time args (see TensorAccessorArgs<1> for dst accessor):
+//   0: cb_out
+//   1: TILES_PER_PAGE
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
@@ -20,19 +32,15 @@ void kernel_main() {
     const uint32_t n_tiles = get_arg_val<uint32_t>(1);
     const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
     const uint32_t program_id = get_arg_val<uint32_t>(3);
-    const uint32_t tiles_per_page_rt = get_arg_val<uint32_t>(4);
-    const uint32_t tiles_per_page = tiles_per_page_rt > 0 ? tiles_per_page_rt : 1;
-    // 0 = barrier after every write (default, mirrors current ops); 1 = single
-    // barrier after all writes (experiment: shrinks pack_finish -> brisc_done).
-    const uint32_t write_barrier_mode = get_arg_val<uint32_t>(5);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr uint32_t TILES_PER_PAGE = get_compile_time_arg_val(1);
+    constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
+    constexpr auto dst_args = TensorAccessorArgs<2>();
 
     const auto dst = TensorAccessor(dst_args, dst_addr);
 
     DeviceTimestampedData("PROG_ID", program_id);
-    // BRISC writer kernel entry (proxy for dataflow go on this RISC).
     DeviceTimestampedData("BRISC_GO", program_id);
 
     // DRAM page = tiles_per_page tiles. Compute pushes 1 CB page (1 tile) at
@@ -43,31 +51,22 @@ void kernel_main() {
     const uint32_t end_page_id = start_page_id + n_pages;
     const uint32_t last_page_id = (n_pages > 0) ? (end_page_id - 1) : start_page_id;
 
+    DeviceTimestampedData("WRITE_BEFORE_BARRIER", last_page_id);
+
     for (uint32_t page_id = start_page_id; page_id < end_page_id; ++page_id) {
         cb_wait_front(cb_out, tiles_per_page);
         const uint32_t l1_read_addr = get_read_ptr(cb_out);
-
-        if (page_id == last_page_id && write_barrier_mode == 0) {
-            DeviceTimestampedData("WRITE_BEFORE_BARRIER", page_id);
-        }
-
         noc_async_write_tile(page_id, dst, l1_read_addr);
-
-        if (write_barrier_mode == 0) {
-            noc_async_write_barrier();
-            if (page_id == last_page_id) {
-                DeviceTimestampedData("WRITE_AFTER_BARRIER", page_id);
-            }
-        }
-
+        // Cheap: ensures write left source L1, so the next cb_pop_front
+        // can safely recycle the slot without corrupting an in-flight write.
+        noc_async_writes_flushed();
         cb_pop_front(cb_out, tiles_per_page);
     }
 
-    if (write_barrier_mode == 1) {
-        DeviceTimestampedData("WRITE_BEFORE_BARRIER", last_page_id);
-        noc_async_write_barrier();
-        DeviceTimestampedData("WRITE_AFTER_BARRIER", last_page_id);
-    }
+    // Op-end safety: ONE barrier at kernel exit so the next op sees consistent
+    // DRAM (writes have not just left L1, they have landed at the destination).
+    noc_async_write_barrier();
+    DeviceTimestampedData("WRITE_AFTER_BARRIER", last_page_id);
 
     DeviceTimestampedData("BRISC_DONE", program_id);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Pops `n_tiles` tiles from the output circular buffer (CB_out) and writes
+// them to the corresponding tile slots in an interleaved DRAM buffer. One
+// instance of this kernel runs on every Tensix core; each core gets its own
+// [start_tile_id, start_tile_id + n_tiles) slice via runtime args.
+//
+// The per-tile noc_async_write_barrier is intentional: it matches what real
+// ops do today (full barrier at op end before the next op can safely begin)
+// and is part of what the op-to-op latency benchmark is meant to measure.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+
+    const auto dst = TensorAccessor(dst_args, dst_addr);
+
+    const uint32_t end_tile_id = start_tile_id + n_tiles;
+    for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id; ++tile_id) {
+        cb_wait_front(cb_out, 1);
+        const uint32_t l1_read_addr = get_read_ptr(cb_out);
+        noc_async_write_tile(tile_id, dst, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_out, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
@@ -13,23 +13,43 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "tools/profiler/kernel_profiler.hpp"
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t n_tiles = get_arg_val<uint32_t>(1);
     const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t program_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     constexpr auto dst_args = TensorAccessorArgs<1>();
 
     const auto dst = TensorAccessor(dst_args, dst_addr);
 
+    DeviceTimestampedData("PROG_ID", program_id);
+    // BRISC writer kernel entry (proxy for dataflow go on this RISC).
+    DeviceTimestampedData("BRISC_GO", program_id);
+
     const uint32_t end_tile_id = start_tile_id + n_tiles;
+    const uint32_t last_tile_id = (n_tiles > 0) ? (end_tile_id - 1) : start_tile_id;
+
     for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id; ++tile_id) {
         cb_wait_front(cb_out, 1);
         const uint32_t l1_read_addr = get_read_ptr(cb_out);
+
+        if (tile_id == last_tile_id) {
+            DeviceTimestampedData("WRITE_BEFORE_BARRIER", tile_id);
+        }
+
         noc_async_write_tile(tile_id, dst, l1_read_addr);
         noc_async_write_barrier();
+
+        if (tile_id == last_tile_id) {
+            DeviceTimestampedData("WRITE_AFTER_BARRIER", tile_id);
+        }
+
         cb_pop_front(cb_out, 1);
     }
+
+    DeviceTimestampedData("BRISC_DONE", program_id);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
@@ -20,6 +20,11 @@ void kernel_main() {
     const uint32_t n_tiles = get_arg_val<uint32_t>(1);
     const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
     const uint32_t program_id = get_arg_val<uint32_t>(3);
+    const uint32_t tiles_per_page_rt = get_arg_val<uint32_t>(4);
+    const uint32_t tiles_per_page = tiles_per_page_rt > 0 ? tiles_per_page_rt : 1;
+    // 0 = barrier after every write (default, mirrors current ops); 1 = single
+    // barrier after all writes (experiment: shrinks pack_finish -> brisc_done).
+    const uint32_t write_barrier_mode = get_arg_val<uint32_t>(5);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     constexpr auto dst_args = TensorAccessorArgs<1>();
@@ -30,25 +35,38 @@ void kernel_main() {
     // BRISC writer kernel entry (proxy for dataflow go on this RISC).
     DeviceTimestampedData("BRISC_GO", program_id);
 
-    const uint32_t end_tile_id = start_tile_id + n_tiles;
-    const uint32_t last_tile_id = (n_tiles > 0) ? (end_tile_id - 1) : start_tile_id;
+    // DRAM page = tiles_per_page tiles. Compute pushes 1 CB page (1 tile) at
+    // a time; we accumulate tiles_per_page in the CB then issue one
+    // noc_async_write_tile that pushes the whole page in a single NoC txn.
+    const uint32_t start_page_id = start_tile_id / tiles_per_page;
+    const uint32_t n_pages = n_tiles / tiles_per_page;
+    const uint32_t end_page_id = start_page_id + n_pages;
+    const uint32_t last_page_id = (n_pages > 0) ? (end_page_id - 1) : start_page_id;
 
-    for (uint32_t tile_id = start_tile_id; tile_id < end_tile_id; ++tile_id) {
-        cb_wait_front(cb_out, 1);
+    for (uint32_t page_id = start_page_id; page_id < end_page_id; ++page_id) {
+        cb_wait_front(cb_out, tiles_per_page);
         const uint32_t l1_read_addr = get_read_ptr(cb_out);
 
-        if (tile_id == last_tile_id) {
-            DeviceTimestampedData("WRITE_BEFORE_BARRIER", tile_id);
+        if (page_id == last_page_id && write_barrier_mode == 0) {
+            DeviceTimestampedData("WRITE_BEFORE_BARRIER", page_id);
         }
 
-        noc_async_write_tile(tile_id, dst, l1_read_addr);
+        noc_async_write_tile(page_id, dst, l1_read_addr);
+
+        if (write_barrier_mode == 0) {
+            noc_async_write_barrier();
+            if (page_id == last_page_id) {
+                DeviceTimestampedData("WRITE_AFTER_BARRIER", page_id);
+            }
+        }
+
+        cb_pop_front(cb_out, tiles_per_page);
+    }
+
+    if (write_barrier_mode == 1) {
+        DeviceTimestampedData("WRITE_BEFORE_BARRIER", last_page_id);
         noc_async_write_barrier();
-
-        if (tile_id == last_tile_id) {
-            DeviceTimestampedData("WRITE_AFTER_BARRIER", tile_id);
-        }
-
-        cb_pop_front(cb_out, 1);
+        DeviceTimestampedData("WRITE_AFTER_BARRIER", last_page_id);
     }
 
     DeviceTimestampedData("BRISC_DONE", program_id);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
@@ -8,8 +8,10 @@
 // [start_tile_id, start_tile_id + n_tiles) slice via runtime args.
 //
 // Synchronization (per kernel review feedback):
-//   - noc_async_writes_flushed() after each tile so the source L1 slot is safe
-//     to recycle on the next cb_pop_front (write has at least left L1).
+//   - noc_async_writes_flushed() so the source L1 slot is safe to recycle on
+//     cb_pop_front (write has at least left L1).  Mode 0: flush every page.
+//     Mode 1: flush only when output CB back-pressure requires it —
+//     batch up to (output_cb_depth / tiles_per_page - 1) writes before flush.
 //   - noc_async_write_barrier() ONCE at kernel exit so the next op sees fully
 //     committed DRAM writes (op-end safety).
 //
@@ -19,9 +21,20 @@
 //   2: start_tile_id
 //   3: program_id
 //
-// Compile-time args (see TensorAccessorArgs<1> for dst accessor):
+// Compile-time args (see TensorAccessorArgs<7> for dst accessor):
 //   0: cb_out
 //   1: TILES_PER_PAGE
+//   2: READ_ONLY        (1 = skip DRAM writes, just pop from output CB)
+//   3: WRITER_FLUSH_MODE (0 = flush every page; 1 = flush on CB back-pressure)
+//   4: OUTPUT_CB_DEPTH_TILES
+//   5: CROSS_PROGRAM_OFFSET_TILES (0 = every program writes same slice; >0 = program k
+//                                  writes pages starting at start_tile_id + k*OFFSET)
+//   6: END_BARRIER_MODE   (Batch-8 latency experiment — 's HW-barrier proposal)
+//                          0 = noc_async_write_barrier (DEFAULT; wait for DRAM ACK; current)
+//                          1 = noc_async_writes_flushed (just flush local L1; writes left
+//                              the source but next op may see in-flight committed-at-NoC)
+//                          2 = no barrier, no flush (UNSAFE for correctness in real
+//                              workloads; simulates "HW gives us this for free")
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
@@ -35,37 +48,65 @@ void kernel_main() {
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     constexpr uint32_t TILES_PER_PAGE = get_compile_time_arg_val(1);
+    constexpr uint32_t READ_ONLY = get_compile_time_arg_val(2);
+    constexpr uint32_t WRITER_FLUSH_MODE = get_compile_time_arg_val(3);
+    constexpr uint32_t OUTPUT_CB_DEPTH_TILES = get_compile_time_arg_val(4);
+    constexpr uint32_t CROSS_PROGRAM_OFFSET_TILES = get_compile_time_arg_val(5);
+    constexpr uint32_t END_BARRIER_MODE = get_compile_time_arg_val(6);
     constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr uint32_t output_cb_depth_tiles = OUTPUT_CB_DEPTH_TILES > 0 ? OUTPUT_CB_DEPTH_TILES : tiles_per_page;
+    constexpr uint32_t cb_page_slots = output_cb_depth_tiles / tiles_per_page;
+    constexpr uint32_t max_writes_before_flush = cb_page_slots > 1 ? cb_page_slots - 1 : 1;
+    constexpr auto dst_args = TensorAccessorArgs<7>();
 
     const auto dst = TensorAccessor(dst_args, dst_addr);
 
     DeviceTimestampedData("PROG_ID", program_id);
     DeviceTimestampedData("BRISC_GO", program_id);
 
+    // When CROSS_PROGRAM_OFFSET_TILES > 0, each program writes a disjoint slice
+    // (mirrors reader); host allocates a buffer large enough for all slices.
+    const uint32_t effective_start_tile_id = start_tile_id + program_id * CROSS_PROGRAM_OFFSET_TILES;
     // DRAM page = tiles_per_page tiles. Compute pushes 1 CB page (1 tile) at
     // a time; we accumulate tiles_per_page in the CB then issue one
     // noc_async_write_tile that pushes the whole page in a single NoC txn.
-    const uint32_t start_page_id = start_tile_id / tiles_per_page;
+    const uint32_t start_page_id = effective_start_tile_id / tiles_per_page;
     const uint32_t n_pages = n_tiles / tiles_per_page;
     const uint32_t end_page_id = start_page_id + n_pages;
     const uint32_t last_page_id = (n_pages > 0) ? (end_page_id - 1) : start_page_id;
 
     DeviceTimestampedData("WRITE_BEFORE_BARRIER", last_page_id);
 
+    uint32_t writes_since_flush = 0;
     for (uint32_t page_id = start_page_id; page_id < end_page_id; ++page_id) {
         cb_wait_front(cb_out, tiles_per_page);
-        const uint32_t l1_read_addr = get_read_ptr(cb_out);
-        noc_async_write_tile(page_id, dst, l1_read_addr);
-        // Cheap: ensures write left source L1, so the next cb_pop_front
-        // can safely recycle the slot without corrupting an in-flight write.
-        noc_async_writes_flushed();
+        if constexpr (READ_ONLY == 0) {
+            const uint32_t l1_read_addr = get_read_ptr(cb_out);
+            noc_async_write_tile(page_id, dst, l1_read_addr);
+            writes_since_flush++;
+            const bool flush_every_page = (WRITER_FLUSH_MODE == 0);
+            const bool flush_on_pressure = (WRITER_FLUSH_MODE != 0) && (writes_since_flush >= max_writes_before_flush);
+            if (flush_every_page || flush_on_pressure) {
+                noc_async_writes_flushed();
+                writes_since_flush = 0;
+            }
+        }
         cb_pop_front(cb_out, tiles_per_page);
     }
 
-    // Op-end safety: ONE barrier at kernel exit so the next op sees consistent
-    // DRAM (writes have not just left L1, they have landed at the destination).
-    noc_async_write_barrier();
+    if constexpr (READ_ONLY == 0) {
+        if ((WRITER_FLUSH_MODE != 0) && (writes_since_flush > 0)) {
+            noc_async_writes_flushed();
+        }
+    }
+
+    if constexpr (READ_ONLY == 0) {
+        if constexpr (END_BARRIER_MODE == 0) {
+            noc_async_write_barrier();
+        } else if constexpr (END_BARRIER_MODE == 1) {
+            noc_async_writes_flushed();
+        }
+    }
     DeviceTimestampedData("WRITE_AFTER_BARRIER", last_page_id);
 
     DeviceTimestampedData("BRISC_DONE", program_id);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/pick_grid_min_cb.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/pick_grid_min_cb.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Pick smallest CB at grid peak BW ('s shrink recipe).
+
+From cb_grid BUFFER_TUNE log lines:
+  1. Find peak dram_pipeline_gbps across all (input, output) pairs.
+  2. Keep pairs within tolerance_pct of peak.
+  3. Pick smallest input_cb_depth with any qualifying output.
+  4. For that input, pick smallest output_cb_depth still at peak.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GridRow:
+    input_cb: int
+    output_cb: int
+    gbps: float
+
+
+ROW_RE = re.compile(
+    r"BUFFER_TUNE,phase=cb_grid,input_cb_depth=(\d+),output_cb_depth=(\d+)," r".*dram_pipeline_gbps=([0-9.]+)"
+)
+
+
+def parse_grid_rows(text: str) -> list[GridRow]:
+    rows: list[GridRow] = []
+    for line in text.splitlines():
+        m = ROW_RE.search(line)
+        if m:
+            rows.append(GridRow(int(m.group(1)), int(m.group(2)), float(m.group(3))))
+    return rows
+
+
+def pick_min_cb_at_peak(rows: list[GridRow], tolerance_pct: float) -> tuple[float, int, int]:
+    if not rows:
+        raise ValueError("no cb_grid rows found")
+
+    peak = max(r.gbps for r in rows)
+    threshold = peak * (1.0 - tolerance_pct / 100.0)
+    qual = [r for r in rows if r.gbps >= threshold]
+    if not qual:
+        raise ValueError("no rows within tolerance of peak")
+
+    best_in = min(r.input_cb for r in qual)
+    outs = [r for r in qual if r.input_cb == best_in]
+    best_out = min(r.output_cb for r in outs)
+    return peak, best_in, best_out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("log_file", type=argparse.FileType("r"), help="grid_tune.log from buffer-tune grid")
+    p.add_argument("--tolerance-pct", type=float, default=2.0)
+    p.add_argument("--min-input-cb", type=int, default=0, help="floor for mode2 reader (e.g. 2*N)")
+    args = p.parse_args()
+
+    rows = parse_grid_rows(args.log_file.read())
+    peak, in_cb, out_cb = pick_min_cb_at_peak(rows, args.tolerance_pct)
+    if args.min_input_cb and in_cb < args.min_input_cb:
+        in_cb = args.min_input_cb
+
+    # peak,in,out — easy for bash
+    print(f"{peak:.4f} {in_cb} {out_cb}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/read_bw_from_profiler.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/read_bw_from_profiler.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compute reader DRAM read bandwidth from device-profiler kernel timestamps.
+
+The buffer-tune `dram_pipeline_gbps` number is host wall-clock (enqueue + Finish),
+so for short single-program runs it is dominated by ~60-125 us of fixed dispatch
+overhead and badly understates real NoC bandwidth. This script instead uses the
+on-device reader markers so we time *only the kernel's read phase*:
+
+    READ_BEFORE_BARRIER   emitted right before the first noc_async_read_tile
+    READ_LAST_BARRIER     emitted right after the final read barrier completes
+
+Per core, per program:
+    duration = READ_LAST_BARRIER - READ_BEFORE_BARRIER   (device cycles)
+    bytes    = --pages-per-core * --tile-bytes
+    BW       = bytes / duration
+
+This span still pays the pipeline fill latency at the start and the drain latency
+at the end (a fixed "tax" we accept); for a ~10 us read phase that tax is a small
+fraction. Reads and writes contend on the NoC/DRAM, so for an isolated read number
+run with --read-only; otherwise this reports read BW *under* that contention.
+
+The whole-kernel span (NCRISC_GO -> NCRISC_DONE) is available via --span go_to_done.
+
+Requires the run to have produced generated/profiler/.logs/profile_log_device.csv,
+i.e. TT_METAL_DEVICE_PROFILER=1 in the environment and the test invoked with
+--use-device-profiler.
+
+Example:
+  python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/read_bw_from_profiler.py \\
+    --pages-per-core 2048
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Reuse the canonical CSV header/freq parsing from the export script (same directory).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import (  # noqa: E402
+    DEFAULT_LOG,
+    READ_RISC_TYPES,
+    load_profiler_csv,
+    parse_chip_freq_mhz,
+)
+
+# Default DRAM page / CB tile size: Float16_b 32x32 tile = 2048 bytes (matches the
+# benchmark's kDataFormat). Override with --tile-bytes if the format changes.
+DEFAULT_TILE_BYTES = 2048
+
+START_ZONE = "READ_BEFORE_BARRIER"
+END_ZONES = {
+    "first_read_to_last_barrier": "READ_LAST_BARRIER",
+    "go_to_done": "NCRISC_DONE",
+}
+START_ZONES = {
+    "first_read_to_last_barrier": "READ_BEFORE_BARRIER",
+    "go_to_done": "NCRISC_GO",
+}
+
+
+def walk_read_spans(df: pd.DataFrame, start_zone: str, end_zone: str, min_prog_id: int) -> pd.DataFrame:
+    """Per (chip, core, prog_id) reader start/end cycle timestamps for the chosen span."""
+    zones = {"PROG_ID", start_zone, end_zone}
+    markers = df[(df["zone name"].isin(zones)) & (df["RISC processor type"].isin(READ_RISC_TYPES))].copy()
+    markers = markers.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
+
+    rows: list[dict] = []
+    group_cols = ["PCIe slot", "core_x", "core_y", "RISC processor type"]
+    for (chip, core_x, core_y, _risc), group in markers.groupby(group_cols, sort=False):
+        current_prog: int | None = None
+        start_cycles: int | None = None
+        for _, row in group.iterrows():
+            zone = row["zone name"]
+            time_cycles = int(row["time[cycles since reset]"])
+            if zone == "PROG_ID":
+                current_prog = int(row["data"])
+                start_cycles = None
+            elif current_prog is None:
+                continue
+            elif zone == start_zone:
+                start_cycles = time_cycles
+            elif zone == end_zone and start_cycles is not None:
+                if current_prog >= min_prog_id:
+                    rows.append(
+                        {
+                            "chip": chip,
+                            "core_x": core_x,
+                            "core_y": core_y,
+                            "prog_id": current_prog,
+                            "start_cycles": start_cycles,
+                            "end_cycles": time_cycles,
+                            "duration_cycles": time_cycles - start_cycles,
+                        }
+                    )
+                start_cycles = None
+    return pd.DataFrame(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Reader DRAM read bandwidth from device profiler markers.")
+    parser.add_argument("--input-file", type=Path, default=None, help=f"default: $TT_METAL_HOME/{DEFAULT_LOG}")
+    parser.add_argument("--output-csv", type=Path, default=None, help="write per-(prog,core) rows to this CSV")
+    parser.add_argument(
+        "--pages-per-core",
+        type=int,
+        required=True,
+        help="logical tiles read per core per program (= benchmark --num-pages-per-core / "
+        "--buffer-tune-pages-per-core)",
+    )
+    parser.add_argument("--tile-bytes", type=int, default=DEFAULT_TILE_BYTES, help="bytes per tile (default 2048)")
+    parser.add_argument(
+        "--span",
+        choices=sorted(END_ZONES.keys()),
+        default="first_read_to_last_barrier",
+        help="first_read_to_last_barrier (default; read phase) or go_to_done (whole kernel)",
+    )
+    parser.add_argument(
+        "--min-prog-id", type=int, default=1, help="skip programs below this id (default 1 skips warmup PROG_ID=0)"
+    )
+    args = parser.parse_args()
+
+    log_path = (args.input_file or Path(os.environ.get("TT_METAL_HOME", ".")) / DEFAULT_LOG).resolve()
+    if not log_path.is_file():
+        print(f"Input not found: {log_path}", file=sys.stderr)
+        return 1
+
+    freq_mhz = parse_chip_freq_mhz(log_path)
+    df = load_profiler_csv(log_path)
+
+    start_zone = START_ZONES[args.span]
+    end_zone = END_ZONES[args.span]
+    spans = walk_read_spans(df, start_zone, end_zone, args.min_prog_id)
+    if spans.empty:
+        print(
+            f"No reader spans found ({start_zone} -> {end_zone}). "
+            "Re-run the test with --use-device-profiler (and TT_METAL_DEVICE_PROFILER=1), "
+            "and ensure the kernel emits READ_LAST_BARRIER (reader_mode 2).",
+            file=sys.stderr,
+        )
+        return 1
+
+    bytes_per_core = args.pages_per_core * args.tile_bytes
+    # 1 byte / ns == 1 GB/s; duration_ns = cycles / freq_ghz; GB/s = bytes / duration_ns.
+    freq_ghz = freq_mhz / 1000.0
+    spans["duration_us"] = spans["duration_cycles"] / freq_mhz
+    spans["per_core_gbps"] = bytes_per_core / (spans["duration_cycles"] / freq_ghz)
+
+    if args.output_csv is not None:
+        args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+        spans.to_csv(args.output_csv, index=False)
+        print(f"Wrote {args.output_csv} ({len(spans)} per-(prog,core) rows)")
+
+    num_cores = spans.groupby(["chip", "core_x", "core_y"]).ngroups
+    progs = sorted(spans["prog_id"].unique())
+    pc = spans["per_core_gbps"]
+    dur = spans["duration_us"]
+
+    print(f"Chip frequency: {freq_mhz:.1f} MHz")
+    print(f"Span: {start_zone} -> {end_zone}")
+    print(f"Programs (>= id {args.min_prog_id}): {progs}   active reader cores: {num_cores}")
+    print(f"Bytes/core/program: {bytes_per_core} ({args.pages_per_core} tiles x {args.tile_bytes} B)")
+    print()
+    print("Per-core read BW (one value per core per program):")
+    print(
+        f"  per_core_gbps: median={pc.median():.2f}  mean={pc.mean():.2f}  "
+        f"min={pc.min():.2f}  max={pc.max():.2f}  n={len(pc)}"
+    )
+    print(f"  read-phase duration_us: median={dur.median():.2f}  min={dur.min():.2f}  max={dur.max():.2f}")
+    print()
+
+    # Aggregate device read BW: total bytes moved by all cores divided by the wall span
+    # from the first core starting to the last core finishing (captures cross-core skew;
+    # reads contend, so this is the realized shared BW). A single program id can appear
+    # in several execution *instances* (trace capture + timed replay run it ~ms apart),
+    # so split each prog id into instances by start-time gaps before aggregating.
+    gap_threshold = max(5.0 * float(spans["duration_cycles"].median()), 1.0)
+
+    spans = spans.sort_values(["prog_id", "start_cycles"]).reset_index(drop=True)
+    instance_ids: list[int] = []
+    inst = 0
+    prev_prog = None
+    prev_start = None
+    for _, row in spans.iterrows():
+        prog = int(row["prog_id"])
+        start = int(row["start_cycles"])
+        if prog != prev_prog:
+            inst = 0
+        elif prev_start is not None and (start - prev_start) > gap_threshold:
+            inst += 1
+        instance_ids.append(inst)
+        prev_prog, prev_start = prog, start
+    spans["instance"] = instance_ids
+
+    print("Aggregate device read BW per (program, execution instance) — all cores, union span:")
+    agg_gbps_vals = []
+    for (prog, inst), g in spans.groupby(["prog_id", "instance"]):
+        cores = g.groupby(["chip", "core_x", "core_y"]).ngroups
+        union_cycles = int(g["end_cycles"].max() - g["start_cycles"].min())
+        union_us = union_cycles / freq_mhz
+        total_bytes = cores * bytes_per_core
+        agg_gbps = total_bytes / (union_cycles / freq_ghz) if union_cycles > 0 else 0.0
+        agg_gbps_vals.append(agg_gbps)
+        print(
+            f"  prog {int(prog)} inst {int(inst)}: cores={cores}  union_span={union_us:.2f} us  "
+            f"aggregate={agg_gbps:.1f} GB/s"
+        )
+
+    if len(agg_gbps_vals) > 1:
+        print(f"  aggregate across instances: median={pd.Series(agg_gbps_vals).median():.1f} GB/s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch2_results.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch2_results.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Rebuild  batch-2 CSVs from existing sweep logs (no pandas, no re-benchmark)."""
+
+from __future__ import annotations
+
+import csv
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from export_op_to_op_gaps_csvlite import aggregate_runs
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TT_METAL_HOME = SCRIPT_DIR.parents[4]
+PYTHON = TT_METAL_HOME / "python_env" / "bin" / "python3"
+EXPORT_PY = SCRIPT_DIR / "export_op_to_op_profiler_csv.py"
+OUT_DIR = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch2"
+RUNS_ROOT = TT_METAL_HOME / "generated/profiler/op_to_op_runs"
+SWEEP_LOG = OUT_DIR / "zero_compute_sweep.log"
+READONLY_CSV = OUT_DIR / "read_only_bw.csv"
+ZERO_CHART = OUT_DIR / "zero_compute_chart_data.csv"
+SUMMARY = OUT_DIR / "batch2_summary.csv"
+
+ZERO_CORES = [1, 2, 4, 8, 10, 16, 20, 32, 40, 56, 64, 80, 96, 110]
+MIN_PROG_ID = 3
+NUM_RUNS = 3
+TRID_IN_FLIGHT = 2
+
+
+def parse_zero_compute_bw(log_text: str) -> dict[int, dict]:
+    """Parse 'picked: in_cb=.. out_cb=.. peak_in_gbps=..' blocks per core count."""
+    rows: dict[int, dict] = {}
+    current: int | None = None
+    for line in log_text.splitlines():
+        m = re.match(r"^=+\s*cores=(\d+)\s*=+", line)
+        if m:
+            current = int(m.group(1))
+            continue
+        if current is None:
+            continue
+        m = re.search(
+            r"picked: in_cb=(\d+) out_cb=(\d+) peak_in_gbps=([0-9.]+) peak_out_gbps=([0-9.]+)",
+            line,
+        )
+        if m:
+            rows[current] = {
+                "in_cb": int(m.group(1)),
+                "out_cb": int(m.group(2)),
+                "peak_in_gbps": float(m.group(3)),
+                "peak_out_gbps": float(m.group(4)),
+            }
+    return rows
+
+
+def reexport_runs(run_dirs: list[Path], in_cb: int, out_cb: int) -> None:
+    py = PYTHON if PYTHON.is_file() else Path(sys.executable)
+    for run_dir in run_dirs:
+        log = run_dir / "profile_log_device.csv"
+        if not log.is_file():
+            continue
+        rt = run_dir / "profile_log_device_rt.csv"
+        cmd = [
+            str(py),
+            str(EXPORT_PY),
+            "--input-file",
+            str(log),
+            "--min-prog-id",
+            str(MIN_PROG_ID),
+            "--tiles-per-core",
+            "16",
+            "--input-cb-depth-tiles",
+            str(in_cb),
+            "--reader-push-tiles",
+            "2",
+            "--output-dir",
+            str(run_dir),
+        ]
+        if rt.is_file():
+            cmd.extend(["--rt-input-file", str(rt)])
+        subprocess.run(cmd, check=True, capture_output=True)
+
+
+def load_readonly_summary() -> list[dict]:
+    rows: list[dict] = []
+    with READONLY_CSV.open(newline="") as f:
+        for row in csv.DictReader(f):
+            rows.append(row)
+    return rows
+
+
+def main() -> int:
+    if not SWEEP_LOG.is_file():
+        print(f"Missing {SWEEP_LOG}", file=sys.stderr)
+        return 1
+
+    bw_by_core = parse_zero_compute_bw(SWEEP_LOG.read_text())
+    zero_rows: list[dict] = []
+
+    for n in ZERO_CORES:
+        bw = bw_by_core.get(n)
+        if bw is None:
+            print(f"WARNING: no BW pick for cores={n}", file=sys.stderr)
+            continue
+
+        base = RUNS_ROOT / f"chart_cores{n}_n{TRID_IN_FLIGHT}"
+        run_dirs = sorted(base.glob("run_*"))[:NUM_RUNS]
+        if not run_dirs:
+            print(f"WARNING: no runs under {base}", file=sys.stderr)
+            continue
+
+        reexport_runs(run_dirs, bw["in_cb"], bw["out_cb"])
+        stats = aggregate_runs(run_dirs, MIN_PROG_ID)
+        cb_label = f"in={bw['in_cb']}/out={bw['out_cb']}"
+        zero_rows.append(
+            {
+                "num_cores": n,
+                "peak_input_gbps": f"{bw['peak_in_gbps']:.4f}",
+                "smallest_input_cb": bw["in_cb"],
+                "peak_output_gbps": f"{bw['peak_out_gbps']:.4f}",
+                "smallest_output_cb": bw["out_cb"],
+                "op2op_us_median": f"{stats['op2op_us_median']:.3f}",
+                "dg_first_ns": f"{stats['dg_first_ns']:.1f}",
+                "dg_median_ns": f"{stats['dg_median_ns']:.1f}",
+                "dg_last_ns": f"{stats['dg_last_ns']:.1f}",
+                "dg_issue_ns": f"{stats['dg_issue_ns']:.1f}",
+                "cb_label": cb_label,
+                "trid_in_flight": TRID_IN_FLIGHT,
+            }
+        )
+        print(
+            f"cores={n:3d}  peak={bw['peak_in_gbps']:.2f} GB/s  "
+            f"op2op={stats['op2op_us_median']:.3f}us  dg_median={stats['dg_median_ns']:.0f}ns  "
+            f"{cb_label}  runs={len(run_dirs)}"
+        )
+
+    zero_fields = [
+        "num_cores",
+        "peak_input_gbps",
+        "smallest_input_cb",
+        "peak_output_gbps",
+        "smallest_output_cb",
+        "op2op_us_median",
+        "dg_first_ns",
+        "dg_median_ns",
+        "dg_last_ns",
+        "dg_issue_ns",
+        "cb_label",
+        "trid_in_flight",
+    ]
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    with ZERO_CHART.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=zero_fields, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(zero_rows)
+
+    summary_fields = [
+        "section",
+        "cores",
+        "peak_bw_gbs",
+        "peak_bw_gbps",
+        "per_core_gbps",
+        "smallest_in_cb",
+        "smallest_out_cb",
+        "pack_to_unpack_us",
+        "dg_median_ns",
+        "dg_last_ns",
+        "cb_label",
+        "notes",
+    ]
+    with SUMMARY.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=summary_fields)
+        w.writeheader()
+        for row in load_readonly_summary():
+            nc = int(row["num_cores"])
+            peak = float(row["peak_bw_gbs"])
+            w.writerow(
+                {
+                    "section": "read_only_bw",
+                    "cores": nc,
+                    "peak_bw_gbs": f"{peak:.4f}",
+                    "peak_bw_gbps": row["peak_bw_gbps"],
+                    "per_core_gbps": row["per_core_gbps"],
+                    "smallest_in_cb": row["smallest_in_cb"],
+                    "smallest_out_cb": row["smallest_out_cb"],
+                    "cb_label": f"in={row['smallest_in_cb']}/out={row['smallest_out_cb']}",
+                    "notes": "read-only pipeline; BW=GB/s in logs x8=Gbps",
+                }
+            )
+        for row in zero_rows:
+            nc = int(row["num_cores"])
+            peak = float(row["peak_input_gbps"])
+            w.writerow(
+                {
+                    "section": "zero_compute",
+                    "cores": nc,
+                    "peak_bw_gbs": f"{peak:.4f}",
+                    "peak_bw_gbps": f"{peak * 8:.4f}",
+                    "per_core_gbps": f"{peak * 8 / nc:.4f}",
+                    "smallest_in_cb": row["smallest_input_cb"],
+                    "smallest_out_cb": row["smallest_output_cb"],
+                    "pack_to_unpack_us": row["op2op_us_median"],
+                    "dg_median_ns": row["dg_median_ns"],
+                    "dg_last_ns": row["dg_last_ns"],
+                    "cb_label": row["cb_label"],
+                    "notes": "compute_nops=0; gap=pack->unpack not math-to-math",
+                }
+            )
+
+    print(f"\nWrote {ZERO_CHART}")
+    print(f"Wrote {SUMMARY}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch3_results.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch3_results.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Aggregate batch-3 compute_nops sweep into batch3_compute_sweep.csv."""
+
+from __future__ import annotations
+
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TT_METAL_HOME = SCRIPT_DIR.parents[4]
+OUT_DIR = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch3"
+CSV_OUT = OUT_DIR / "batch3_compute_sweep.csv"
+
+PYTHON = TT_METAL_HOME / "python_env/bin/python3"
+EXPORT_PY = SCRIPT_DIR / "export_op_to_op_profiler_csv.py"
+
+CORE_COUNTS = [1, 10, 40, 80, 110]
+COMPUTE_NOPS_LIST = [0, 100, 500, 2000, 5000]
+MIN_PROG_ID = 3
+TRID_IN_FLIGHT = 2
+
+CB = {
+    1: (12, 2),
+    10: (12, 8),
+    40: (64, 64),
+    80: (64, 64),
+    110: (12, 64),
+}
+
+# batch 1 reference (2000 nops) for comparison column
+BATCH1_REF = {
+    1: (2.770, 1198),
+    10: (2.731, 639),
+    40: (5.981, 1070),
+    80: (6.699, 1025),
+    110: (5.644, 624),
+}
+
+
+def median(vals: list[float]) -> float:
+    vals = [v for v in vals if v == v]
+    if not vals:
+        return float("nan")
+    vals.sort()
+    n = len(vals)
+    mid = n // 2
+    return vals[mid] if n % 2 else (vals[mid - 1] + vals[mid]) / 2.0
+
+
+def reexport_run(run_dir: Path, in_cb: int) -> None:
+    py = PYTHON if PYTHON.is_file() else Path(sys.executable)
+    log = run_dir / "profile_log_device.csv"
+    if not log.is_file():
+        return
+    rt = run_dir / "profile_log_device_rt.csv"
+    cmd = [
+        str(py),
+        str(EXPORT_PY),
+        "--input-file",
+        str(log),
+        "--min-prog-id",
+        str(MIN_PROG_ID),
+        "--tiles-per-core",
+        "16",
+        "--input-cb-depth-tiles",
+        str(in_cb),
+        "--reader-push-tiles",
+        "2",
+        "--output-dir",
+        str(run_dir),
+    ]
+    if rt.is_file():
+        cmd.extend(["--rt-input-file", str(rt)])
+    subprocess.run(cmd, check=False, capture_output=True)
+
+
+def aggregate_label(label: str, in_cb: int) -> dict[str, float]:
+    base = TT_METAL_HOME / "generated/profiler/op_to_op_runs" / label
+    run_dirs = sorted(base.glob("run_*"))[:3]
+    op2op, dg_med, dg_first, dg_last = [], [], [], []
+    for run_dir in run_dirs:
+        reexport_run(run_dir, in_cb)
+        complete = run_dir / "profile_log_device_op_to_op_complete.csv"
+        if not complete.is_file():
+            continue
+        with complete.open(newline="") as f:
+            for row in csv.DictReader(f):
+                if int(float(row["from_prog_id"])) < MIN_PROG_ID:
+                    continue
+                op2op.append(float(row["gap_us"]))
+                for col, dst in (
+                    ("dg_median_ns", dg_med),
+                    ("_dg_median_ns", dg_med),
+                    ("dg_first_ns", dg_first),
+                    ("dg_last_ns", dg_last),
+                ):
+                    if col in row and row[col] not in ("", "nan"):
+                        try:
+                            dst.append(float(row[col]))
+                        except ValueError:
+                            pass
+    return {
+        "op2op_us_median": median(op2op),
+        "dg_median_ns": median(dg_med),
+        "dg_first_ns": median(dg_first),
+        "dg_last_ns": median(dg_last),
+    }
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "num_cores",
+        "compute_nops",
+        "input_cb",
+        "output_cb",
+        "op2op_us_median",
+        "dg_median_ns",
+        "dg_first_ns",
+        "dg_last_ns",
+        "batch1_op2op_us",
+        "batch1_dg_median_ns",
+        "cb_label",
+    ]
+    rows: list[dict] = []
+
+    for n in CORE_COUNTS:
+        in_cb, out_cb = CB[n]
+        b1_op2, b1_dg = BATCH1_REF.get(n, (float("nan"), float("nan")))
+        for nops in COMPUTE_NOPS_LIST:
+            label = f"batch3_cores{n}_nops{nops}_n2"
+            stats = aggregate_label(label, in_cb)
+            row = {
+                "num_cores": n,
+                "compute_nops": nops,
+                "input_cb": in_cb,
+                "output_cb": out_cb,
+                "op2op_us_median": f"{stats['op2op_us_median']:.3f}",
+                "dg_median_ns": f"{stats['dg_median_ns']:.1f}",
+                "dg_first_ns": f"{stats['dg_first_ns']:.1f}",
+                "dg_last_ns": f"{stats['dg_last_ns']:.1f}",
+                "batch1_op2op_us": f"{b1_op2:.3f}" if nops == 2000 else "",
+                "batch1_dg_median_ns": f"{b1_dg:.1f}" if nops == 2000 else "",
+                "cb_label": f"in={in_cb}/out={out_cb}",
+            }
+            rows.append(row)
+            print(
+                f"cores={n:3d} nops={nops:5d}  op2op={stats['op2op_us_median']:.3f}us  "
+                f"dg_median={stats['dg_median_ns']:.0f}ns  {row['cb_label']}"
+            )
+
+    with CSV_OUT.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+
+    print(f"\nWrote {CSV_OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch4_compare.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch4_compare.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Compare batch 4 (grid CB + writer flush-on-pressure) vs batch 1 (dg_v4)."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TT_METAL_HOME = SCRIPT_DIR.parents[4]
+BATCH1 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/chart_sweep/dg_v4/chart_data.csv"
+BATCH4 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch4/chart_data.csv"
+OUT = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch4/batch4_vs_batch1.csv"
+
+
+def load_chart(path: Path) -> dict[int, dict]:
+    if not path.is_file():
+        return {}
+    rows: dict[int, dict] = {}
+    with path.open() as f:
+        for row in csv.DictReader(f):
+            n = int(row["num_cores"])
+            rows[n] = row
+    return rows
+
+
+def f(row: dict, key: str, default: str = "") -> str:
+    for k in (key, key.replace("_gbs", "_gbps")):
+        if k in row and row[k] not in ("", "nan"):
+            return row[k]
+    return default
+
+
+def main() -> int:
+    b1 = load_chart(BATCH1)
+    b4 = load_chart(BATCH4)
+    if not b4:
+        print(f"No batch 4 data at {BATCH4}")
+        return 1
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "cores",
+        "b1_peak_gbs",
+        "b4_peak_gbs",
+        "peak_delta_pct",
+        "b1_cb",
+        "b4_cb",
+        "b1_op2op_us",
+        "b4_op2op_us",
+        "op2op_delta_us",
+        "b1_dg_median_ns",
+        "b4_dg_median_ns",
+        "dg_delta_ns",
+    ]
+    with OUT.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        for cores in sorted(b4.keys()):
+            r4 = b4[cores]
+            r1 = b1.get(cores, {})
+            p1 = float(f(r1, "peak_input_gbps", "0") or 0)
+            p4 = float(r4.get("peak_bw_gbs", 0) or 0)
+            o1 = float(f(r1, "op2op_us_median", "nan") or "nan")
+            o4 = float(r4.get("op2op_us_median", "nan") or "nan")
+            d1 = float(f(r1, "dg_median_ns", "nan") or "nan")
+            d4 = float(r4.get("dg_median_ns", "nan") or "nan")
+            peak_delta = ((p4 - p1) / p1 * 100.0) if p1 > 0 else float("nan")
+            w.writerow(
+                {
+                    "cores": cores,
+                    "b1_peak_gbs": f"{p1:.2f}" if p1 else "",
+                    "b4_peak_gbs": f"{p4:.2f}" if p4 else "",
+                    "peak_delta_pct": f"{peak_delta:+.1f}" if p1 > 0 else "",
+                    "b1_cb": r1.get("cb_label", ""),
+                    "b4_cb": r4.get("cb_label", ""),
+                    "b1_op2op_us": f"{o1:.3f}" if o1 == o1 else "",
+                    "b4_op2op_us": f"{o4:.3f}" if o4 == o4 else "",
+                    "op2op_delta_us": f"{o4 - o1:+.3f}" if o1 == o1 and o4 == o4 else "",
+                    "b1_dg_median_ns": f"{d1:.0f}" if d1 == d1 else "",
+                    "b4_dg_median_ns": f"{d4:.0f}" if d4 == d4 else "",
+                    "dg_delta_ns": f"{d4 - d1:+.0f}" if d1 == d1 and d4 == d4 else "",
+                }
+            )
+
+    print(f"Wrote {OUT}")
+    with OUT.open() as fh:
+        print(fh.read())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch5_compare.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch5_compare.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Compare batch 5 (grid peak + shrink CB) vs batch 1 and batch 4."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TT_METAL_HOME = SCRIPT_DIR.parents[4]
+
+BATCH1 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/chart_sweep/dg_v4/chart_data.csv"
+BATCH4 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch4/chart_data.csv"
+BATCH5 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch5/chart_data.csv"
+OUT = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch5/batch5_vs_batch1_batch4.csv"
+
+
+def load(path: Path) -> dict[int, dict]:
+    if not path.is_file():
+        return {}
+    out: dict[int, dict] = {}
+    with path.open() as f:
+        for row in csv.DictReader(f):
+            out[int(row["num_cores"])] = row
+    return out
+
+
+def gbs(row: dict) -> float:
+    for k in ("peak_bw_gbs", "peak_input_gbps"):
+        if k in row and row[k]:
+            return float(row[k])
+    return 0.0
+
+
+def gap(row: dict) -> float:
+    return float(row.get("op2op_us_median", "nan"))
+
+
+def dg(row: dict) -> float:
+    return float(row.get("dg_median_ns", "nan"))
+
+
+def cb(row: dict) -> str:
+    return row.get("cb_label", "")
+
+
+def main() -> int:
+    b1, b4, b5 = load(BATCH1), load(BATCH4), load(BATCH5)
+    if not b5:
+        print(f"No batch 5 data at {BATCH5}")
+        return 1
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "cores",
+        "b1_peak_gbs",
+        "b4_peak_gbs",
+        "b5_peak_gbs",
+        "b5_vs_b1_bw_pct",
+        "b1_cb",
+        "b4_cb",
+        "b5_cb",
+        "b1_op2op_us",
+        "b4_op2op_us",
+        "b5_op2op_us",
+        "b5_vs_b1_gap_us",
+        "b1_dg_ns",
+        "b5_dg_ns",
+    ]
+    with OUT.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        for cores in sorted(b5.keys()):
+            r1, r4, r5 = b1.get(cores, {}), b4.get(cores, {}), b5[cores]
+            p1, p4, p5 = gbs(r1), gbs(r4), gbs(r5)
+            o1, o4, o5 = gap(r1), gap(r4), gap(r5)
+            d1, d5 = dg(r1), dg(r5)
+            w.writerow(
+                {
+                    "cores": cores,
+                    "b1_peak_gbs": f"{p1:.2f}" if p1 else "",
+                    "b4_peak_gbs": f"{p4:.2f}" if p4 else "",
+                    "b5_peak_gbs": f"{p5:.2f}" if p5 else "",
+                    "b5_vs_b1_bw_pct": f"{(p5 - p1) / p1 * 100:+.1f}" if p1 > 0 and p5 else "",
+                    "b1_cb": cb(r1),
+                    "b4_cb": cb(r4),
+                    "b5_cb": cb(r5),
+                    "b1_op2op_us": f"{o1:.3f}" if o1 == o1 else "",
+                    "b4_op2op_us": f"{o4:.3f}" if o4 == o4 else "",
+                    "b5_op2op_us": f"{o5:.3f}" if o5 == o5 else "",
+                    "b5_vs_b1_gap_us": f"{o5 - o1:+.3f}" if o1 == o1 and o5 == o5 else "",
+                    "b1_dg_ns": f"{d1:.0f}" if d1 == d1 else "",
+                    "b5_dg_ns": f"{d5:.0f}" if d5 == d5 else "",
+                }
+            )
+
+    print(f"Wrote {OUT}\n")
+    print(OUT.read_text())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch7_compare.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/rebuild_batch7_compare.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Compare batch 7 (grid CB + flush-on-pressure + cross-program DRAM offset)
+against batch 4 (same, but every program touches the same DRAM slice) and
+batch 1 (sequential CB tune baseline).
+
+The batch7-vs-batch4 delta isolates the impact of forcing the DRAM controller
+to open new rows per program enqueue (i.e. how much of batch 4's apparent
+op-to-op gap was being optimistically helped by warm-row reuse)."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TT_METAL_HOME = SCRIPT_DIR.parents[4]
+
+BATCH1 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/chart_sweep/dg_v4/chart_data.csv"
+BATCH4 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch4/chart_data.csv"
+BATCH7 = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch7/chart_data.csv"
+OUT = TT_METAL_HOME / "generated/profiler/op_to_op_runs/batch7/batch7_vs_batch4.csv"
+
+
+def load(path: Path) -> dict[int, dict]:
+    if not path.is_file():
+        return {}
+    out: dict[int, dict] = {}
+    with path.open() as f:
+        for row in csv.DictReader(f):
+            out[int(row["num_cores"])] = row
+    return out
+
+
+def gbs(row: dict) -> float:
+    for k in ("peak_bw_gbs", "peak_input_gbps"):
+        if k in row and row[k]:
+            return float(row[k])
+    return 0.0
+
+
+def gap(row: dict) -> float:
+    return float(row.get("op2op_us_median", "nan") or "nan")
+
+
+def dg(row: dict) -> float:
+    return float(row.get("dg_median_ns", "nan") or "nan")
+
+
+def cb(row: dict) -> str:
+    return row.get("cb_label", "")
+
+
+def main() -> int:
+    b1, b4, b7 = load(BATCH1), load(BATCH4), load(BATCH7)
+    if not b7:
+        print(f"No batch 7 data at {BATCH7}")
+        return 1
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "cores",
+        "b1_peak_gbs",
+        "b4_peak_gbs",
+        "b7_peak_gbs",
+        "b7_vs_b4_bw_pct",
+        "b1_cb",
+        "b4_cb",
+        "b7_cb",
+        "b1_op2op_us",
+        "b4_op2op_us",
+        "b7_op2op_us",
+        "b7_vs_b4_gap_us",
+        "b7_vs_b4_gap_pct",
+        "b1_dg_ns",
+        "b4_dg_ns",
+        "b7_dg_ns",
+        "b7_vs_b4_dg_ns",
+    ]
+    with OUT.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        for cores in sorted(b7.keys()):
+            r1, r4, r7 = b1.get(cores, {}), b4.get(cores, {}), b7[cores]
+            p1, p4, p7 = gbs(r1), gbs(r4), gbs(r7)
+            o1, o4, o7 = gap(r1), gap(r4), gap(r7)
+            d1, d4, d7 = dg(r1), dg(r4), dg(r7)
+            w.writerow(
+                {
+                    "cores": cores,
+                    "b1_peak_gbs": f"{p1:.2f}" if p1 else "",
+                    "b4_peak_gbs": f"{p4:.2f}" if p4 else "",
+                    "b7_peak_gbs": f"{p7:.2f}" if p7 else "",
+                    "b7_vs_b4_bw_pct": f"{(p7 - p4) / p4 * 100:+.1f}" if p4 > 0 and p7 else "",
+                    "b1_cb": cb(r1),
+                    "b4_cb": cb(r4),
+                    "b7_cb": cb(r7),
+                    "b1_op2op_us": f"{o1:.3f}" if o1 == o1 else "",
+                    "b4_op2op_us": f"{o4:.3f}" if o4 == o4 else "",
+                    "b7_op2op_us": f"{o7:.3f}" if o7 == o7 else "",
+                    "b7_vs_b4_gap_us": f"{o7 - o4:+.3f}" if o4 == o4 and o7 == o7 else "",
+                    "b7_vs_b4_gap_pct": (f"{(o7 - o4) / o4 * 100:+.1f}" if o4 == o4 and o7 == o7 and o4 != 0 else ""),
+                    "b1_dg_ns": f"{d1:.0f}" if d1 == d1 else "",
+                    "b4_dg_ns": f"{d4:.0f}" if d4 == d4 else "",
+                    "b7_dg_ns": f"{d7:.0f}" if d7 == d7 else "",
+                    "b7_vs_b4_dg_ns": f"{d7 - d4:+.0f}" if d4 == d4 and d7 == d7 else "",
+                }
+            )
+
+    print(f"Wrote {OUT}\n")
+    print(OUT.read_text())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch2_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch2_sweep.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# batch-2 sweep (post-chart follow-ups):
+#   1. Read-only BW sanity vs NoC table (strip writer DRAM writes)
+#   2. Zero-compute chart (compute_nops=0) with denser core counts + larger CB sweep
+#   3. Aggregates into batch2_summary.csv for sharing
+#
+# Env overrides:
+#   READONLY_CORES   - default "1 10 20 40 80 110"
+#   ZERO_CORES       - default "1 2 4 8 10 16 20 32 40 56 64 80 96 110"
+#   INPUT_DEPTHS     - default "8,12,16,24,32,48,64" (mode2 min depth 8)
+#   OUTPUT_DEPTHS    - default "2,4,8,16,32,64"
+#   BW_PAGES         - default 256
+#   NUM_RUNS         - default 3
+#   RUN_READONLY     - default 1
+#   RUN_ZERO_CHART   - default 1
+#   BUILD            - default 1
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch2"
+SUMMARY="${OUT_DIR}/batch2_summary.csv"
+READONLY_CSV="${OUT_DIR}/read_only_bw.csv"
+ZERO_CHART="${OUT_DIR}/zero_compute_chart_data.csv"
+
+READONLY_CORES="${READONLY_CORES:-1 10 20 40 80 110}"
+ZERO_CORES="${ZERO_CORES:-1 2 4 8 10 16 20 32 40 56 64 80 96 110}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-8,12,16,24,32,48,64}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2,4,8,16,32,64}"
+BW_PAGES="${BW_PAGES:-256}"
+NUM_RUNS="${NUM_RUNS:-3}"
+RUN_READONLY="${RUN_READONLY:-1}"
+RUN_ZERO_CHART="${RUN_ZERO_CHART:-1}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD:-1}" != "0" ]]; then
+  if command -v cmake >/dev/null 2>&1; then
+    cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  else
+    /usr/local/bin/cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  fi
+fi
+
+echo "section,cores,peak_bw_gbs,peak_bw_gbps,per_core_gbps,smallest_in_cb,smallest_out_cb,pack_to_unpack_us,dg_median_ns,dg_last_ns,cb_label,notes" > "${SUMMARY}"
+
+# ---------------- Part 1: read-only BW ----------------
+if [[ "${RUN_READONLY}" == "1" ]]; then
+  echo "num_cores,peak_bw_gbs,peak_bw_gbps,per_core_gbps,smallest_in_cb,smallest_out_cb" > "${READONLY_CSV}"
+  for N in ${READONLY_CORES}; do
+    echo "======== read-only BW cores=${N} ========"
+    LOG="${OUT_DIR}/read_only_cores_${N}.log"
+    rm -f "${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+    "${TEST_BIN}" \
+      --read-only \
+      --buffer-tune \
+      --buffer-tune-input-depths "${INPUT_DEPTHS}" \
+      --buffer-tune-output-depths "${OUTPUT_DEPTHS}" \
+      --buffer-tune-pages-per-core "${BW_PAGES}" \
+      --buffer-tune-bw-tolerance-pct 2 \
+      --reader-dbuf-trid \
+      --reader-trid-in-flight "${TRID_IN_FLIGHT}" \
+      --reader-push-tiles 2 \
+      --compute-nops 0 \
+      --num-programs 1 \
+      --num-active-cores "${N}" \
+      2>&1 | tee "${LOG}"
+
+    PEAK=$(grep 'buffer_tune: peak_dram_pipeline_gbps=' "${LOG}" | tail -1 | sed -n 's/.*peak_dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+    IN_CB=$(grep 'smallest_input_cb_depth_at_peak=' "${LOG}" | tail -1 | sed -n 's/.*smallest_input_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+    OUT_CB=$(grep 'smallest_output_cb_depth_at_peak=' "${LOG}" | tail -1 | sed -n 's/.*smallest_output_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+    PEAK="${PEAK:-0}"
+    IN_CB="${IN_CB:-0}"
+    OUT_CB="${OUT_CB:-0}"
+
+    python3 - "${N}" "${PEAK}" "${IN_CB}" "${OUT_CB}" "${READONLY_CSV}" "${SUMMARY}" << 'PY'
+import sys
+ncores, peak, in_cb, out_cb, ro_csv, summary = sys.argv[1:]
+peak = float(peak)
+nc = int(ncores)
+per_core_gbps = (peak * 8.0 / nc) if nc > 0 else 0.0
+with open(ro_csv, "a") as f:
+    f.write(f"{ncores},{peak:.4f},{peak*8:.4f},{per_core_gbps:.4f},{in_cb},{out_cb}\n")
+with open(summary, "a") as f:
+    f.write(f"read_only_bw,{ncores},{peak:.4f},{peak*8:.4f},{per_core_gbps:.4f},"
+            f"{in_cb},{out_cb},,,,in={in_cb}/out={out_cb},"
+            f"read-only pipeline; BW=GB/s in logs x8=Gbps\n")
+print(f"  read-only cores={ncores}: {peak:.2f} GB/s = {peak*8:.2f} Gbps aggregate, "
+      f"{per_core_gbps:.2f} Gbps/core")
+PY
+  done
+fi
+
+# ---------------- Part 2: zero-compute chart sweep ----------------
+if [[ "${RUN_ZERO_CHART}" == "1" ]]; then
+  echo "======== zero-compute chart sweep ========"
+  CORE_COUNTS="${ZERO_CORES}" \
+  NUM_RUNS="${NUM_RUNS}" \
+  INPUT_DEPTHS="${INPUT_DEPTHS}" \
+  OUTPUT_DEPTHS="${OUTPUT_DEPTHS}" \
+  BW_PAGES="${BW_PAGES}" \
+  COMPUTE_NOPS=0 \
+  CHART_TAG=batch2_zero_compute \
+  TRID_IN_FLIGHT="${TRID_IN_FLIGHT}" \
+  USE_DBUF_TRID=1 \
+  BUILD=0 \
+  bash "${SCRIPT_DIR}/run_op_to_op_chart_sweep.sh" 2>&1 | tee "${OUT_DIR}/zero_compute_sweep.log"
+
+  ZERO_SRC="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_sweep/batch2_zero_compute/chart_data.csv"
+  if [[ -f "${ZERO_SRC}" ]]; then
+    cp "${ZERO_SRC}" "${ZERO_CHART}"
+    python3 - "${ZERO_SRC}" "${SUMMARY}" << 'PY'
+import sys
+import pandas as pd
+
+src, summary = sys.argv[1], sys.argv[2]
+df = pd.read_csv(src)
+for _, r in df.iterrows():
+    nc = int(r["num_cores"])
+    peak = float(r["peak_input_gbps"])
+    per_core = peak * 8.0 / nc if nc else 0.0
+    cb = r.get("cb_label", "")
+    with open(summary, "a") as f:
+        f.write(
+            f"zero_compute,{nc},{peak:.4f},{peak*8:.4f},{per_core:.4f},"
+            f"{r['smallest_input_cb']},{r['smallest_output_cb']},"
+            f"{r['op2op_us_median']:.3f},{r['dg_median_ns']:.1f},{r['dg_last_ns']:.1f},"
+            f"{cb},compute_nops=0; gap=pack->unpack not math-to-math\n"
+        )
+print(df.to_string(index=False))
+PY
+  fi
+fi
+
+echo
+echo "================ BATCH 2 DONE ================"
+echo "Summary:     ${SUMMARY}"
+echo "Read-only:   ${READONLY_CSV}"
+echo "Zero chart:  ${ZERO_CHART}"
+echo
+column -t -s, "${SUMMARY}" 2>/dev/null || cat "${SUMMARY}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch2_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch2_sweep.sh
@@ -21,7 +21,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
 TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch3_compute_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch3_compute_sweep.sh
@@ -25,7 +25,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 # Prefer project venv (system /opt/venv pandas is broken).
 if [[ -x "${TT_METAL_HOME}/python_env/bin/python3" ]]; then

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch3_compute_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch3_compute_sweep.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Batch 3: compute_nops sweep at fixed CB configs (isolate compute vs batch 1/2).
+#
+# Fixed CB per core count (from batch-2 zero-compute picks; held constant across all NOPs).
+#   cores=1   in=12  out=2
+#   cores=10  in=12  out=8
+#   cores=40  in=64  out=64
+#   cores=80  in=64  out=64
+#   cores=110 in=12  out=64
+#
+# Usage:
+#   source python_env/bin/activate
+#   export TT_METAL_DEVICE_PROFILER=1 TT_METAL_DEVICE_PROFILER_DISPATCH=1
+#   ./run_batch3_compute_sweep.sh
+#
+# Env:
+#   CORE_COUNTS        default "1 10 40 80 110"
+#   COMPUTE_NOPS_LIST  default "0 100 500 2000 5000"
+#   NUM_RUNS           default 3
+#   BUILD              default 1
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+# Prefer project venv (system /opt/venv pandas is broken).
+if [[ -x "${TT_METAL_HOME}/python_env/bin/python3" ]]; then
+  export PATH="${TT_METAL_HOME}/python_env/bin:${PATH}"
+fi
+
+CORE_COUNTS="${CORE_COUNTS:-1 10 40 80 110}"
+COMPUTE_NOPS_LIST="${COMPUTE_NOPS_LIST:-0 100 500 2000 5000}"
+NUM_RUNS="${NUM_RUNS:-3}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch3"
+mkdir -p "${OUT_DIR}"
+
+cb_in()  { case "$1" in 1) echo 12;; 10) echo 12;; 40) echo 64;; 80) echo 64;; 110) echo 12;; *) echo 12;; esac; }
+cb_out() { case "$1" in 1) echo 2;; 10) echo 8;; 40) echo 64;; 80) echo 64;; 110) echo 64;; *) echo 2;; esac; }
+
+echo "Batch 3 compute sweep: cores=[${CORE_COUNTS}] nops=[${COMPUTE_NOPS_LIST}] runs=${NUM_RUNS}"
+echo "Output: ${OUT_DIR}/batch3_compute_sweep.csv"
+echo | tee "${OUT_DIR}/batch3_sweep.log"
+
+for N in ${CORE_COUNTS}; do
+  IN_CB="$(cb_in "${N}")"
+  OUT_CB="$(cb_out "${N}")"
+  for NOPS in ${COMPUTE_NOPS_LIST}; do
+    echo "======== cores=${N} compute_nops=${NOPS} in=${IN_CB} out=${OUT_CB} ========" | tee -a "${OUT_DIR}/batch3_sweep.log"
+    CONFIG_LABEL="batch3_cores${N}_nops${NOPS}_n2" \
+    MIN_PROG_ID="${MIN_PROG_ID}" \
+    TILES_PER_CORE="${LATENCY_PAGES}" \
+    INPUT_CB_DEPTH="${IN_CB}" \
+    READER_PUSH=2 \
+    BUILD="${BUILD}" \
+    EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+                --compute-nops ${NOPS} --use-device-profiler --use-realtime-profiler \
+                --reader-push-tiles 2 --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+                --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+                --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+    bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tee -a "${OUT_DIR}/batch3_sweep.log" | tail -6
+    BUILD=0
+  done
+done
+
+python3 "${SCRIPT_DIR}/rebuild_batch3_results.py" 2>&1 | tee -a "${OUT_DIR}/batch3_sweep.log"
+
+echo
+echo "================ BATCH 3 DONE ================"
+echo "CSV: ${OUT_DIR}/batch3_compute_sweep.csv"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch4_chart_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch4_chart_sweep.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Batch 4: grid CB tune + writer flush-on-pressure (the remaining headroom).
+# Same chart methodology as batch 1 (dg_v4) but:
+#   - Phase 1: full input×output CB grid (not sequential tune)
+#   - Writer: --writer-flush-on-pressure (flush only on output CB back-pressure)
+#
+# Output:
+#   generated/profiler/op_to_op_runs/batch4/chart_data.csv
+#   generated/profiler/op_to_op_runs/batch4/batch4_vs_batch1.csv  (after rebuild script)
+#
+# Usage:
+#   source python_env/bin/activate   # recommended for export
+#   ./run_batch4_chart_sweep.sh
+#
+# Env: same as run_op_to_op_chart_sweep.sh; INPUT/OUTPUT depths default to batch-2 grid range.
+
+set -uo pipefail
+
+CORE_COUNTS="${CORE_COUNTS:-1 2 4 10 20 40 80 110}"
+NUM_RUNS="${NUM_RUNS:-5}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-8,12,16,24,32,48,64}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2,4,8,16,32,64}"
+BW_PAGES="${BW_PAGES:-256}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TOL_PCT="${TOL_PCT:-2}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch4"
+CHART_CSV="${OUT_DIR}/chart_data.csv"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  if command -v cmake >/dev/null 2>&1; then
+    cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  else
+    /usr/local/bin/cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  fi
+fi
+
+echo "num_cores,peak_bw_gbs,peak_bw_gbps,smallest_in_cb,smallest_out_cb,op2op_us_median,dg_median_ns,dg_issue_ns,cb_label,tune_method,writer_flush_mode" > "${CHART_CSV}"
+
+for N in ${CORE_COUNTS}; do
+  echo "================ batch4 cores=${N} ================"
+  RUN_DIR="${OUT_DIR}/cores_${N}"
+  mkdir -p "${RUN_DIR}"
+  TUNE_LOG="${RUN_DIR}/grid_tune.log"
+
+  rm -f "${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+
+  "${TEST_BIN}" \
+    --buffer-tune \
+    --buffer-tune-grid \
+    --buffer-tune-bw-only \
+    --buffer-tune-input-depths "${INPUT_DEPTHS}" \
+    --buffer-tune-output-depths "${OUTPUT_DEPTHS}" \
+    --buffer-tune-pages-per-core "${BW_PAGES}" \
+    --buffer-tune-bw-tolerance-pct "${TOL_PCT}" \
+    --writer-flush-on-pressure \
+    --reader-dbuf-trid \
+    --reader-trid-in-flight "${TRID_IN_FLIGHT}" \
+    --reader-push-tiles 2 \
+    --compute-nops 0 \
+    --num-programs 1 \
+    --num-active-cores "${N}" \
+    2>&1 | tee "${TUNE_LOG}" >/dev/null
+
+  PEAK=$(grep 'cb_grid peak_dram_pipeline_gbps=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*peak_dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+  IN_CB=$(grep 'smallest_input_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*smallest_input_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+  OUT_CB=$(grep 'smallest_output_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*smallest_output_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+
+  PEAK="${PEAK:-0}"
+  IN_CB="${IN_CB:-8}"
+  OUT_CB="${OUT_CB:-2}"
+  MIN_IN=$(( 2 * TRID_IN_FLIGHT ))
+  if (( IN_CB < MIN_IN )); then
+    echo "  bumping in_cb ${IN_CB} -> ${MIN_IN} (mode2 N=${TRID_IN_FLIGHT})"
+    IN_CB="${MIN_IN}"
+  fi
+  PEAK_GBPS=$(awk "BEGIN {printf \"%.1f\", ${PEAK} * 8}")
+  echo "  grid pick: peak=${PEAK} GB/s (${PEAK_GBPS} Gbps) in=${IN_CB} out=${OUT_CB}"
+
+  CONFIG_LABEL="batch4_cores${N}" \
+  MIN_PROG_ID="${MIN_PROG_ID}" \
+  TILES_PER_CORE="${LATENCY_PAGES}" \
+  INPUT_CB_DEPTH="${IN_CB}" \
+  READER_PUSH=2 \
+  BUILD=0 \
+  EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+              --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+              --writer-flush-on-pressure \
+              --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+              --reader-push-tiles 2 \
+              --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+              --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+  bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -8
+
+  PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+  if [[ ! -x "${PYTHON}" ]]; then
+    PYTHON="python3"
+  fi
+
+  "${PYTHON}" - "${N}" "${PEAK}" "${PEAK_GBPS}" "${IN_CB}" "${OUT_CB}" \
+    "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch4_cores${N}" \
+    "${CHART_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import sys, os, glob, statistics as st
+
+ncores, peak, peak_gbps, in_cb, out_cb, base, chart_csv, min_prog = sys.argv[1:9]
+runs = sorted(glob.glob(os.path.join(base, "run_*")))
+op2op, dg_med, dg_issue = [], [], []
+
+for r in runs:
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    import csv
+    with open(f) as fh:
+        rows = list(csv.DictReader(fh))
+    rows = [row for row in rows if int(float(row.get("from_prog_id", 0))) >= int(min_prog)]
+    if not rows:
+        continue
+    op2op.append(float(st.median([float(row["gap_us"]) for row in rows])))
+    dg_vals = [float(row["dg_median_ns"]) for row in rows if row.get("dg_median_ns") not in ("", "nan")]
+    if dg_vals:
+        dg_med.append(st.median(dg_vals))
+    iss = [float(row["dg_issue_ns"]) for row in rows if row.get("dg_issue_ns") not in ("", "nan")]
+    if iss:
+        dg_issue.append(st.median(iss))
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_m = med(op2op)
+dg_m = med(dg_med)
+dg_i = med(dg_issue)
+cb_label = f"in={in_cb}/out={out_cb}"
+with open(chart_csv, "a") as fh:
+    fh.write(
+        f"{ncores},{peak},{peak_gbps},{in_cb},{out_cb},"
+        f"{op2op_m:.3f},{dg_m:.1f},{dg_i:.1f},{cb_label},grid_cb,flush_on_pressure\n"
+    )
+print(f"  cores={ncores}  peak={peak} GB/s  op2op={op2op_m:.3f}us  dg_median={dg_m:.0f}ns")
+PYEOF
+done
+
+echo
+echo "Batch 4 chart: ${CHART_CSV}"
+"${PYTHON:-python3}" "${SCRIPT_DIR}/rebuild_batch4_compare.py" || true

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch4_chart_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch4_chart_sweep.sh
@@ -33,7 +33,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
 TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch5_chart_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch5_chart_sweep.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Batch 5: the full shrink-CB recipe with batch-4 kernel improvements.
+#   Phase 1: full input×output CB grid → find peak BW
+#   Phase 2: smallest input CB, then smallest output CB still within TOL_PCT of peak
+#             (sequential shrink — not min(in+out) sum like batch 4)
+#   Phase 3: latency at that CB with writer flush-on-pressure + trace
+#
+# Output:
+#   generated/profiler/op_to_op_runs/batch5/chart_data.csv
+#   generated/profiler/op_to_op_runs/batch5/batch5_vs_batch1_batch4.csv
+#
+# Usage:
+#   source python_env/bin/activate
+#   ./run_batch5_chart_sweep.sh
+
+set -uo pipefail
+
+CORE_COUNTS="${CORE_COUNTS:-1 2 4 10 20 40 80 110}"
+NUM_RUNS="${NUM_RUNS:-5}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-8,12,16,24,32,48,64}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2,4,8,16,32,64}"
+BW_PAGES="${BW_PAGES:-256}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TOL_PCT="${TOL_PCT:-2}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+if [[ ! -x "${PYTHON}" ]]; then
+  PYTHON="python3"
+fi
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PICK_PY="${SCRIPT_DIR}/pick_grid_min_cb.py"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch5"
+CHART_CSV="${OUT_DIR}/chart_data.csv"
+GRID_CSV="${OUT_DIR}/grid_picks.csv"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  if command -v cmake >/dev/null 2>&1; then
+    cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  else
+    /usr/local/bin/cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  fi
+fi
+
+echo "num_cores,peak_bw_gbs,peak_bw_gbps,smallest_in_cb,smallest_out_cb,op2op_us_median,dg_median_ns,dg_issue_ns,cb_label,tune_method,writer_flush_mode" > "${CHART_CSV}"
+echo "num_cores,peak_bw_gbs,smallest_in_cb,smallest_out_cb,batch4_in_cb,batch4_out_cb,pick_method" > "${GRID_CSV}"
+
+MIN_IN=$(( 2 * TRID_IN_FLIGHT ))
+
+for N in ${CORE_COUNTS}; do
+  echo "================ batch5 cores=${N} ================"
+  RUN_DIR="${OUT_DIR}/cores_${N}"
+  mkdir -p "${RUN_DIR}"
+  TUNE_LOG="${RUN_DIR}/grid_tune.log"
+
+  rm -f "${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+
+  "${TEST_BIN}" \
+    --buffer-tune \
+    --buffer-tune-grid \
+    --buffer-tune-bw-only \
+    --buffer-tune-input-depths "${INPUT_DEPTHS}" \
+    --buffer-tune-output-depths "${OUTPUT_DEPTHS}" \
+    --buffer-tune-pages-per-core "${BW_PAGES}" \
+    --buffer-tune-bw-tolerance-pct "${TOL_PCT}" \
+    --writer-flush-on-pressure \
+    --reader-dbuf-trid \
+    --reader-trid-in-flight "${TRID_IN_FLIGHT}" \
+    --reader-push-tiles 2 \
+    --compute-nops 0 \
+    --num-programs 1 \
+    --num-active-cores "${N}" \
+    2>&1 | tee "${TUNE_LOG}" >/dev/null
+
+  read -r PEAK IN_CB OUT_CB <<< "$("${PYTHON}" "${PICK_PY}" "${TUNE_LOG}" --tolerance-pct "${TOL_PCT}" --min-input-cb "${MIN_IN}")"
+
+  # Batch 4 pick (min in+out sum) for comparison in grid_picks.csv
+  B4_IN=$(grep 'smallest_input_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*smallest_input_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+  B4_OUT=$(grep 'smallest_output_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*smallest_output_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+
+  PEAK_GBPS=$(awk "BEGIN {printf \"%.1f\", ${PEAK} * 8}")
+  echo "  batch5 pick (shrink): peak=${PEAK} GB/s (${PEAK_GBPS} Gbps) in=${IN_CB} out=${OUT_CB}"
+  echo "  batch4 pick (sum):    in=${B4_IN:-?} out=${B4_OUT:-?}"
+  echo "${N},${PEAK},${IN_CB},${OUT_CB},${B4_IN:-},${B4_OUT:-},shrink_input_then_output" >> "${GRID_CSV}"
+
+  CONFIG_LABEL="batch5_cores${N}" \
+  MIN_PROG_ID="${MIN_PROG_ID}" \
+  TILES_PER_CORE="${LATENCY_PAGES}" \
+  INPUT_CB_DEPTH="${IN_CB}" \
+  READER_PUSH=2 \
+  BUILD=0 \
+  EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+              --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+              --writer-flush-on-pressure \
+              --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+              --reader-push-tiles 2 \
+              --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+              --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+  bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -8
+
+  "${PYTHON}" - "${N}" "${PEAK}" "${PEAK_GBPS}" "${IN_CB}" "${OUT_CB}" \
+    "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch5_cores${N}" \
+    "${CHART_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import csv
+import glob
+import os
+import statistics as st
+import sys
+
+ncores, peak, peak_gbps, in_cb, out_cb, base, chart_csv, min_prog = sys.argv[1:9]
+op2op, dg_med, dg_issue = [], [], []
+
+for r in sorted(glob.glob(os.path.join(base, "run_*"))):
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    with open(f) as fh:
+        rows = list(csv.DictReader(fh))
+    rows = [row for row in rows if int(float(row.get("from_prog_id", 0))) >= int(min_prog)]
+    if not rows:
+        continue
+    op2op.append(st.median([float(row["gap_us"]) for row in rows]))
+    dg_vals = [float(row["dg_median_ns"]) for row in rows if row.get("dg_median_ns") not in ("", "nan")]
+    if dg_vals:
+        dg_med.append(st.median(dg_vals))
+    iss = [float(row["dg_issue_ns"]) for row in rows if row.get("dg_issue_ns") not in ("", "nan")]
+    if iss:
+        dg_issue.append(st.median(iss))
+
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_m, dg_m, dg_i = med(op2op), med(dg_med), med(dg_issue)
+cb_label = f"in={in_cb}/out={out_cb}"
+with open(chart_csv, "a") as fh:
+    fh.write(
+        f"{ncores},{peak},{peak_gbps},{in_cb},{out_cb},"
+        f"{op2op_m:.3f},{dg_m:.1f},{dg_i:.1f},{cb_label},grid_shrink,flush_on_pressure\n"
+    )
+print(f"  cores={ncores}  peak={peak} GB/s  op2op={op2op_m:.3f}us  dg_median={dg_m:.0f}ns")
+PYEOF
+done
+
+echo
+echo "Batch 5 chart: ${CHART_CSV}"
+echo "Grid picks:    ${GRID_CSV}"
+"${PYTHON}" "${SCRIPT_DIR}/rebuild_batch5_compare.py" || true

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch5_chart_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch5_chart_sweep.sh
@@ -32,7 +32,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
 if [[ ! -x "${PYTHON}" ]]; then

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch6_pareto.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch6_pareto.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Batch 6: BW vs op-to-op-gap Pareto front at 80 and 110 cores.
+#
+# Goal: show the BW/latency tradeoff cares about — at the high-core counts
+# where batch 1 (small CB, low gap) and batch 4/5 (big CB, high BW) split apart.
+#
+# For each (cores, in_cb, out_cb) in CONFIGS:
+#   1. Measure peak BW (no profiler, multi-program) at that CB.
+#   2. Measure program-gap + dg_median (profiler) at that CB.
+#
+# Output:
+#   generated/profiler/op_to_op_runs/batch6/pareto.csv
+#   columns: cores, in_cb, out_cb, peak_gbs, op2op_us_median, dg_median_ns, cb_label
+#
+# Usage:
+#   source python_env/bin/activate
+#   ./run_batch6_pareto.sh
+
+set -uo pipefail
+
+NUM_RUNS="${NUM_RUNS:-3}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+# Pareto sweep — small -> big CBs, spanning batch-1 and batch-5 picks.
+# Format: "cores in_cb out_cb"
+CONFIGS_DEFAULT=(
+  "80 4 2"
+  "80 8 4"
+  "80 12 8"
+  "80 16 16"
+  "80 32 32"
+  "80 48 64"
+  "80 64 64"
+  "110 4 2"
+  "110 8 4"
+  "110 12 8"
+  "110 16 16"
+  "110 32 32"
+  "110 48 64"
+  "110 64 64"
+)
+# Comma-separated CONFIGS env var overrides default (e.g. CONFIGS="80 4 2,80 64 64").
+if [[ -n "${CONFIGS:-}" ]]; then
+  IFS=',' read -ra CONFIGS_ARR <<< "${CONFIGS}"
+else
+  CONFIGS_ARR=("${CONFIGS_DEFAULT[@]}")
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+if [[ ! -x "${PYTHON}" ]]; then
+  PYTHON="python3"
+fi
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch6"
+PARETO_CSV="${OUT_DIR}/pareto.csv"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  if command -v cmake >/dev/null 2>&1; then
+    cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  else
+    /usr/local/bin/cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  fi
+fi
+
+echo "cores,in_cb,out_cb,peak_bw_gbs,peak_bw_gbps,op2op_us_median,dg_median_ns,dg_issue_ns,cb_label" > "${PARETO_CSV}"
+
+MIN_IN=$(( 2 * TRID_IN_FLIGHT ))
+
+for cfg in "${CONFIGS_ARR[@]}"; do
+  read -r N IN_CB OUT_CB <<< "${cfg}"
+  if (( IN_CB < MIN_IN )); then
+    echo "  skip cores=${N} in=${IN_CB} (mode2 needs in >= ${MIN_IN}); bumping to ${MIN_IN}"
+    IN_CB="${MIN_IN}"
+  fi
+  echo "================ batch6 cores=${N} in=${IN_CB} out=${OUT_CB} ================"
+  RUN_DIR="${OUT_DIR}/cores_${N}_in${IN_CB}_out${OUT_CB}"
+  mkdir -p "${RUN_DIR}"
+  BW_LOG="${RUN_DIR}/bw.log"
+
+  # Phase 1: BW via buffer-tune-bw-only at this single CB pair
+  # (buffer-tune logs BUFFER_TUNE rows with dram_pipeline_gbps we can grep)
+  rm -f "${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+  "${TEST_BIN}" \
+    --buffer-tune \
+    --buffer-tune-grid \
+    --buffer-tune-bw-only \
+    --buffer-tune-input-depths "${IN_CB}" \
+    --buffer-tune-output-depths "${OUT_CB}" \
+    --buffer-tune-pages-per-core 256 \
+    --buffer-tune-bw-tolerance-pct 2 \
+    --writer-flush-on-pressure \
+    --reader-dbuf-trid --reader-trid-in-flight "${TRID_IN_FLIGHT}" \
+    --reader-push-tiles 2 \
+    --compute-nops 0 \
+    --num-programs 1 \
+    --num-active-cores "${N}" \
+    2>&1 | tee "${BW_LOG}" >/dev/null
+
+  PEAK=$(grep 'BUFFER_TUNE,phase=cb_grid' "${BW_LOG}" | tail -1 \
+    | sed -n 's/.*dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+  PEAK="${PEAK:-0}"
+  PEAK_GBPS=$(awk "BEGIN {printf \"%.1f\", ${PEAK} * 8}")
+
+  # Phase 2: latency at same CB
+  CONFIG_LABEL="batch6_c${N}_i${IN_CB}_o${OUT_CB}" \
+  MIN_PROG_ID="${MIN_PROG_ID}" \
+  TILES_PER_CORE="${LATENCY_PAGES}" \
+  INPUT_CB_DEPTH="${IN_CB}" \
+  READER_PUSH=2 \
+  BUILD=0 \
+  EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+              --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+              --writer-flush-on-pressure \
+              --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+              --reader-push-tiles 2 \
+              --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+              --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+  bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -4
+
+  "${PYTHON}" - "${N}" "${IN_CB}" "${OUT_CB}" "${PEAK}" "${PEAK_GBPS}" \
+    "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch6_c${N}_i${IN_CB}_o${OUT_CB}" \
+    "${PARETO_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import csv, glob, os, statistics as st, sys
+
+ncores, in_cb, out_cb, peak, peak_gbps, base, out_csv, min_prog = sys.argv[1:9]
+op2op, dg_med, dg_issue = [], [], []
+
+for r in sorted(glob.glob(os.path.join(base, "run_*"))):
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    with open(f) as fh:
+        rows = list(csv.DictReader(fh))
+    rows = [row for row in rows if int(float(row.get("from_prog_id", 0))) >= int(min_prog)]
+    if not rows:
+        continue
+    op2op.append(st.median([float(row["gap_us"]) for row in rows]))
+    dg_vals = [float(row["dg_median_ns"]) for row in rows if row.get("dg_median_ns") not in ("", "nan")]
+    if dg_vals:
+        dg_med.append(st.median(dg_vals))
+    iss = [float(row["dg_issue_ns"]) for row in rows if row.get("dg_issue_ns") not in ("", "nan")]
+    if iss:
+        dg_issue.append(st.median(iss))
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_m, dg_m, dg_i = med(op2op), med(dg_med), med(dg_issue)
+cb_label = f"in={in_cb}/out={out_cb}"
+with open(out_csv, "a") as fh:
+    fh.write(
+        f"{ncores},{in_cb},{out_cb},{peak},{peak_gbps},"
+        f"{op2op_m:.3f},{dg_m:.1f},{dg_i:.1f},{cb_label}\n"
+    )
+print(f"  cores={ncores} {cb_label}  peak={peak} GB/s  gap={op2op_m:.3f}us  dg={dg_m:.0f}ns")
+PYEOF
+done
+
+echo
+echo "Pareto CSV: ${PARETO_CSV}"
+"${PYTHON}" - "${PARETO_CSV}" << 'PYEOF'
+import csv, sys
+from collections import defaultdict
+
+with open(sys.argv[1]) as f:
+    rows = list(csv.DictReader(f))
+
+by_cores = defaultdict(list)
+for r in rows:
+    by_cores[int(r["cores"])].append(r)
+
+for cores in sorted(by_cores):
+    points = sorted(by_cores[cores], key=lambda r: float(r["peak_bw_gbs"]))
+    print(f"\n=== {cores} cores ===")
+    print(f"  {'CB':<14} {'BW GB/s':>10} {'gap us':>10} {'dg ns':>8}")
+    for r in points:
+        print(f"  {r['cb_label']:<14} {float(r['peak_bw_gbs']):>10.2f} {float(r['op2op_us_median']):>10.3f} {float(r['dg_median_ns']):>8.0f}")
+PYEOF

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch6_pareto.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch6_pareto.sh
@@ -55,7 +55,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
 if [[ ! -x "${PYTHON}" ]]; then

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_dram_offset.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_dram_offset.sh
@@ -38,7 +38,8 @@ TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
 TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_dram_offset.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_dram_offset.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Batch 7: same methodology as batch 4 (grid CB tune + writer flush-on-pressure)
+# but each program in the trace reads/writes a DISJOINT DRAM tile slice via
+# --cross-program-dram-offset. This forces the DRAM controller to open new rows
+# per program enqueue, isolating any optimistic "warm-row" cache effect that
+# could shrink op-to-op gap in batch 4 where every program touched the same
+# pages back-to-back.
+#
+# Output:
+#   generated/profiler/op_to_op_runs/batch7/chart_data.csv
+#   generated/profiler/op_to_op_runs/batch7/batch7_vs_batch4.csv  (rebuild script)
+#
+# Usage:
+#   source python_env/bin/activate   # recommended for export
+#   ./run_batch7_dram_offset.sh
+#
+# Env knobs match batch 4. Most relevant:
+#   NUM_PROGRAMS -> bigger N means bigger DRAM stride covered per replay
+#                   (host allocates (NUM_PROGRAMS+1) * per-program slice).
+
+set -uo pipefail
+
+CORE_COUNTS="${CORE_COUNTS:-1 2 4 10 20 40 80 110}"
+NUM_RUNS="${NUM_RUNS:-5}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-8,12,16,24,32,48,64}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2,4,8,16,32,64}"
+BW_PAGES="${BW_PAGES:-256}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TOL_PCT="${TOL_PCT:-2}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch7"
+CHART_CSV="${OUT_DIR}/chart_data.csv"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  if command -v cmake >/dev/null 2>&1; then
+    cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  else
+    /usr/local/bin/cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  fi
+fi
+
+echo "num_cores,peak_bw_gbs,peak_bw_gbps,smallest_in_cb,smallest_out_cb,op2op_us_median,dg_median_ns,dg_issue_ns,cb_label,tune_method,writer_flush_mode,dram_offset" > "${CHART_CSV}"
+
+for N in ${CORE_COUNTS}; do
+  echo "================ batch7 cores=${N} ================"
+  RUN_DIR="${OUT_DIR}/cores_${N}"
+  mkdir -p "${RUN_DIR}"
+  TUNE_LOG="${RUN_DIR}/grid_tune.log"
+
+  rm -f "${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+
+  # Phase 1: grid BW tune. Single-program so offset does not affect tune.
+  "${TEST_BIN}" \
+    --buffer-tune \
+    --buffer-tune-grid \
+    --buffer-tune-bw-only \
+    --buffer-tune-input-depths "${INPUT_DEPTHS}" \
+    --buffer-tune-output-depths "${OUTPUT_DEPTHS}" \
+    --buffer-tune-pages-per-core "${BW_PAGES}" \
+    --buffer-tune-bw-tolerance-pct "${TOL_PCT}" \
+    --writer-flush-on-pressure \
+    --reader-dbuf-trid \
+    --reader-trid-in-flight "${TRID_IN_FLIGHT}" \
+    --reader-push-tiles 2 \
+    --compute-nops 0 \
+    --num-programs 1 \
+    --num-active-cores "${N}" \
+    2>&1 | tee "${TUNE_LOG}" >/dev/null
+
+  PEAK=$(grep 'cb_grid peak_dram_pipeline_gbps=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*peak_dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+  IN_CB=$(grep 'smallest_input_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*smallest_input_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+  OUT_CB=$(grep 'smallest_output_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+    | sed -n 's/.*smallest_output_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+
+  PEAK="${PEAK:-0}"
+  IN_CB="${IN_CB:-8}"
+  OUT_CB="${OUT_CB:-2}"
+  MIN_IN=$(( 2 * TRID_IN_FLIGHT ))
+  if (( IN_CB < MIN_IN )); then
+    echo "  bumping in_cb ${IN_CB} -> ${MIN_IN} (mode2 N=${TRID_IN_FLIGHT})"
+    IN_CB="${MIN_IN}"
+  fi
+  PEAK_GBPS=$(awk "BEGIN {printf \"%.1f\", ${PEAK} * 8}")
+  echo "  grid pick: peak=${PEAK} GB/s (${PEAK_GBPS} Gbps) in=${IN_CB} out=${OUT_CB}"
+
+  # Phase 2: latency w/ cross-program DRAM offset.
+  CONFIG_LABEL="batch7_cores${N}" \
+  MIN_PROG_ID="${MIN_PROG_ID}" \
+  TILES_PER_CORE="${LATENCY_PAGES}" \
+  INPUT_CB_DEPTH="${IN_CB}" \
+  READER_PUSH=2 \
+  BUILD=0 \
+  EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+              --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+              --writer-flush-on-pressure \
+              --cross-program-dram-offset \
+              --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+              --reader-push-tiles 2 \
+              --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+              --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+  bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -8
+
+  PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+  if [[ ! -x "${PYTHON}" ]]; then
+    PYTHON="python3"
+  fi
+
+  "${PYTHON}" - "${N}" "${PEAK}" "${PEAK_GBPS}" "${IN_CB}" "${OUT_CB}" \
+    "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch7_cores${N}" \
+    "${CHART_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import sys, os, glob, statistics as st
+
+ncores, peak, peak_gbps, in_cb, out_cb, base, chart_csv, min_prog = sys.argv[1:9]
+runs = sorted(glob.glob(os.path.join(base, "run_*")))
+op2op, dg_med, dg_issue = [], [], []
+
+for r in runs:
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    import csv
+    with open(f) as fh:
+        rows = list(csv.DictReader(fh))
+    rows = [row for row in rows if int(float(row.get("from_prog_id", 0))) >= int(min_prog)]
+    if not rows:
+        continue
+    op2op.append(float(st.median([float(row["gap_us"]) for row in rows])))
+    dg_vals = [float(row["dg_median_ns"]) for row in rows if row.get("dg_median_ns") not in ("", "nan")]
+    if dg_vals:
+        dg_med.append(st.median(dg_vals))
+    iss = [float(row["dg_issue_ns"]) for row in rows if row.get("dg_issue_ns") not in ("", "nan")]
+    if iss:
+        dg_issue.append(st.median(iss))
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_m = med(op2op)
+dg_m = med(dg_med)
+dg_i = med(dg_issue)
+cb_label = f"in={in_cb}/out={out_cb}"
+with open(chart_csv, "a") as fh:
+    fh.write(
+        f"{ncores},{peak},{peak_gbps},{in_cb},{out_cb},"
+        f"{op2op_m:.3f},{dg_m:.1f},{dg_i:.1f},{cb_label},grid_cb,flush_on_pressure,cross_program\n"
+    )
+print(f"  cores={ncores}  peak={peak} GB/s  op2op={op2op_m:.3f}us  dg_median={dg_m:.0f}ns")
+PYEOF
+done
+
+echo
+echo "Batch 7 chart: ${CHART_CSV}"
+"${PYTHON:-python3}" "${SCRIPT_DIR}/rebuild_batch7_compare.py" || true

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_pareto.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_pareto.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Batch 7 Pareto: BW vs op-to-op-gap front at 80 and 110 cores, with each
+# program in the trace touching a disjoint DRAM tile slice
+# (--cross-program-dram-offset). Mirror of run_batch6_pareto.sh so we can
+# diff batch7-vs-batch6 per CB pair and see if the ±15% swings observed in the
+# batch7 main chart at 80c/110c are noise vs a real DRAM-pattern signal.
+#
+# For each (cores, in_cb, out_cb) in CONFIGS:
+#   1. Measure peak BW at that CB (--buffer-tune-grid --buffer-tune-bw-only,
+#      single-program so DRAM offset is moot for the tune phase).
+#   2. Measure program-gap + dg_median at that CB with --cross-program-dram-offset
+#      on, NUM_RUNS replays for variance reduction.
+#
+# Output:
+#   generated/profiler/op_to_op_runs/batch7_pareto/pareto.csv
+#   generated/profiler/op_to_op_runs/batch7_pareto/batch7_vs_batch6.csv
+#
+# Usage:
+#   source python_env/bin/activate
+#   ./run_batch7_pareto.sh
+
+set -uo pipefail
+
+NUM_RUNS="${NUM_RUNS:-5}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+# Same Pareto grid as batch 6 so we can do per-CB diff.
+CONFIGS_DEFAULT=(
+  "80 4 2"
+  "80 8 4"
+  "80 12 8"
+  "80 16 16"
+  "80 32 32"
+  "80 48 64"
+  "80 64 64"
+  "110 4 2"
+  "110 8 4"
+  "110 12 8"
+  "110 16 16"
+  "110 32 32"
+  "110 48 64"
+  "110 64 64"
+)
+if [[ -n "${CONFIGS:-}" ]]; then
+  IFS=',' read -ra CONFIGS_ARR <<< "${CONFIGS}"
+else
+  CONFIGS_ARR=("${CONFIGS_DEFAULT[@]}")
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+if [[ ! -x "${PYTHON}" ]]; then
+  PYTHON="python3"
+fi
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch7_pareto"
+PARETO_CSV="${OUT_DIR}/pareto.csv"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  if command -v cmake >/dev/null 2>&1; then
+    cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  else
+    /usr/local/bin/cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  fi
+fi
+
+echo "cores,in_cb,out_cb,peak_bw_gbs,peak_bw_gbps,op2op_us_median,dg_median_ns,dg_issue_ns,cb_label,dram_offset" > "${PARETO_CSV}"
+
+MIN_IN=$(( 2 * TRID_IN_FLIGHT ))
+
+for cfg in "${CONFIGS_ARR[@]}"; do
+  read -r N IN_CB OUT_CB <<< "${cfg}"
+  if (( IN_CB < MIN_IN )); then
+    echo "  bumping in_cb ${IN_CB} -> ${MIN_IN} (mode2 needs in >= ${MIN_IN})"
+    IN_CB="${MIN_IN}"
+  fi
+  echo "================ batch7_pareto cores=${N} in=${IN_CB} out=${OUT_CB} ================"
+  RUN_DIR="${OUT_DIR}/cores_${N}_in${IN_CB}_out${OUT_CB}"
+  mkdir -p "${RUN_DIR}"
+  BW_LOG="${RUN_DIR}/bw.log"
+
+  # Phase 1: BW at this CB pair (single-program tune; offset has no effect)
+  rm -f "${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+  "${TEST_BIN}" \
+    --buffer-tune \
+    --buffer-tune-grid \
+    --buffer-tune-bw-only \
+    --buffer-tune-input-depths "${IN_CB}" \
+    --buffer-tune-output-depths "${OUT_CB}" \
+    --buffer-tune-pages-per-core 256 \
+    --buffer-tune-bw-tolerance-pct 2 \
+    --writer-flush-on-pressure \
+    --reader-dbuf-trid --reader-trid-in-flight "${TRID_IN_FLIGHT}" \
+    --reader-push-tiles 2 \
+    --compute-nops 0 \
+    --num-programs 1 \
+    --num-active-cores "${N}" \
+    2>&1 | tee "${BW_LOG}" >/dev/null
+
+  PEAK=$(grep 'BUFFER_TUNE,phase=cb_grid' "${BW_LOG}" | tail -1 \
+    | sed -n 's/.*dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+  PEAK="${PEAK:-0}"
+  PEAK_GBPS=$(awk "BEGIN {printf \"%.1f\", ${PEAK} * 8}")
+
+  # Phase 2: latency at same CB, WITH cross-program DRAM offset
+  CONFIG_LABEL="batch7p_c${N}_i${IN_CB}_o${OUT_CB}" \
+  MIN_PROG_ID="${MIN_PROG_ID}" \
+  TILES_PER_CORE="${LATENCY_PAGES}" \
+  INPUT_CB_DEPTH="${IN_CB}" \
+  READER_PUSH=2 \
+  BUILD=0 \
+  EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+              --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+              --writer-flush-on-pressure \
+              --cross-program-dram-offset \
+              --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+              --reader-push-tiles 2 \
+              --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+              --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+  bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -4
+
+  "${PYTHON}" - "${N}" "${IN_CB}" "${OUT_CB}" "${PEAK}" "${PEAK_GBPS}" \
+    "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch7p_c${N}_i${IN_CB}_o${OUT_CB}" \
+    "${PARETO_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import csv, glob, os, statistics as st, sys
+
+ncores, in_cb, out_cb, peak, peak_gbps, base, out_csv, min_prog = sys.argv[1:9]
+op2op, dg_med, dg_issue = [], [], []
+
+for r in sorted(glob.glob(os.path.join(base, "run_*"))):
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    with open(f) as fh:
+        rows = list(csv.DictReader(fh))
+    rows = [row for row in rows if int(float(row.get("from_prog_id", 0))) >= int(min_prog)]
+    if not rows:
+        continue
+    op2op.append(st.median([float(row["gap_us"]) for row in rows]))
+    dg_vals = [float(row["dg_median_ns"]) for row in rows if row.get("dg_median_ns") not in ("", "nan")]
+    if dg_vals:
+        dg_med.append(st.median(dg_vals))
+    iss = [float(row["dg_issue_ns"]) for row in rows if row.get("dg_issue_ns") not in ("", "nan")]
+    if iss:
+        dg_issue.append(st.median(iss))
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_m, dg_m, dg_i = med(op2op), med(dg_med), med(dg_issue)
+cb_label = f"in={in_cb}/out={out_cb}"
+with open(out_csv, "a") as fh:
+    fh.write(
+        f"{ncores},{in_cb},{out_cb},{peak},{peak_gbps},"
+        f"{op2op_m:.3f},{dg_m:.1f},{dg_i:.1f},{cb_label},cross_program\n"
+    )
+print(f"  cores={ncores} {cb_label}  peak={peak} GB/s  gap={op2op_m:.3f}us  dg={dg_m:.0f}ns")
+PYEOF
+done
+
+echo
+echo "Pareto CSV: ${PARETO_CSV}"
+
+# Per-core summary
+"${PYTHON}" - "${PARETO_CSV}" << 'PYEOF'
+import csv, sys
+from collections import defaultdict
+
+with open(sys.argv[1]) as f:
+    rows = list(csv.DictReader(f))
+
+by_cores = defaultdict(list)
+for r in rows:
+    by_cores[int(r["cores"])].append(r)
+
+for cores in sorted(by_cores):
+    points = sorted(by_cores[cores], key=lambda r: float(r["peak_bw_gbs"]))
+    print(f"\n=== {cores} cores (cross-program DRAM offset) ===")
+    print(f"  {'CB':<14} {'BW GB/s':>10} {'gap us':>10} {'dg ns':>8}")
+    for r in points:
+        print(f"  {r['cb_label']:<14} {float(r['peak_bw_gbs']):>10.2f} {float(r['op2op_us_median']):>10.3f} {float(r['dg_median_ns']):>8.0f}")
+PYEOF
+
+# Batch7-vs-batch6 diff (per cores,in_cb,out_cb)
+BATCH6_CSV="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch6/pareto.csv"
+DIFF_CSV="${OUT_DIR}/batch7_vs_batch6.csv"
+"${PYTHON}" - "${BATCH6_CSV}" "${PARETO_CSV}" "${DIFF_CSV}" << 'PYEOF'
+import csv, os, sys
+
+b6_path, b7_path, out_path = sys.argv[1:4]
+
+def load(p):
+    if not os.path.isfile(p):
+        return {}
+    out = {}
+    with open(p) as f:
+        for r in csv.DictReader(f):
+            key = (int(r["cores"]), int(r["in_cb"]), int(r["out_cb"]))
+            out[key] = r
+    return out
+
+b6, b7 = load(b6_path), load(b7_path)
+if not b7:
+    print(f"No batch7 pareto data at {b7_path}")
+    raise SystemExit(0)
+
+def f(r, k, dflt="nan"):
+    v = r.get(k, dflt)
+    try:
+        return float(v) if v not in ("", "nan", None) else float("nan")
+    except (TypeError, ValueError):
+        return float("nan")
+
+fields = [
+    "cores", "in_cb", "out_cb", "cb_label",
+    "b6_peak_gbs", "b7_peak_gbs", "bw_delta_pct",
+    "b6_op2op_us", "b7_op2op_us", "gap_delta_us", "gap_delta_pct",
+    "b6_dg_ns", "b7_dg_ns", "dg_delta_ns",
+]
+with open(out_path, "w", newline="") as fh:
+    w = csv.DictWriter(fh, fieldnames=fields)
+    w.writeheader()
+    for key in sorted(b7):
+        r7 = b7[key]
+        r6 = b6.get(key, {})
+        p6, p7 = f(r6, "peak_bw_gbs"), f(r7, "peak_bw_gbs")
+        o6, o7 = f(r6, "op2op_us_median"), f(r7, "op2op_us_median")
+        d6, d7 = f(r6, "dg_median_ns"), f(r7, "dg_median_ns")
+        w.writerow({
+            "cores": key[0], "in_cb": key[1], "out_cb": key[2],
+            "cb_label": r7.get("cb_label", ""),
+            "b6_peak_gbs": f"{p6:.2f}" if p6 == p6 else "",
+            "b7_peak_gbs": f"{p7:.2f}" if p7 == p7 else "",
+            "bw_delta_pct": f"{(p7-p6)/p6*100:+.1f}" if p6 == p6 and p7 == p7 and p6 != 0 else "",
+            "b6_op2op_us": f"{o6:.3f}" if o6 == o6 else "",
+            "b7_op2op_us": f"{o7:.3f}" if o7 == o7 else "",
+            "gap_delta_us": f"{o7-o6:+.3f}" if o6 == o6 and o7 == o7 else "",
+            "gap_delta_pct": f"{(o7-o6)/o6*100:+.1f}" if o6 == o6 and o7 == o7 and o6 != 0 else "",
+            "b6_dg_ns": f"{d6:.0f}" if d6 == d6 else "",
+            "b7_dg_ns": f"{d7:.0f}" if d7 == d7 else "",
+            "dg_delta_ns": f"{d7-d6:+.0f}" if d6 == d6 and d7 == d7 else "",
+        })
+print(f"\nWrote {out_path}\n")
+with open(out_path) as fh:
+    print(fh.read())
+PYEOF

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_pareto.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch7_pareto.sh
@@ -57,7 +57,8 @@ TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
 if [[ ! -x "${PYTHON}" ]]; then

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8_barrier.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8_barrier.sh
@@ -48,7 +48,8 @@ TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
 if [[ ! -x "${PYTHON}" ]]; then

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8_barrier.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8_barrier.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Batch 8: writer end-of-kernel barrier sweep — directly tests how much HW
+# barrier-elimination would buy us ('s "optimizations around issuing
+# barriers" proposal).
+#
+# Three modes per core count (everything else identical to batch 4):
+#   end_barrier_mode=0: noc_async_write_barrier()  -- DEFAULT, wait for DRAM ACK
+#   end_barrier_mode=1: noc_async_writes_flushed() -- only flush local L1
+#   end_barrier_mode=2: nothing                    -- simulates HW giving it free
+#
+# CB sizes are taken from batch 4's grid pick per core count (apples-to-apples
+# vs batch 4); only the barrier knob changes.
+#
+# Output:
+#   generated/profiler/op_to_op_runs/batch8/chart_data.csv
+#   generated/profiler/op_to_op_runs/batch8/batch8_vs_batch4.csv
+#
+# Usage:
+#   source python_env/bin/activate
+#   ./run_batch8_barrier.sh
+
+set -uo pipefail
+
+CORE_COUNTS="${CORE_COUNTS:-1 2 4 10 20 40 80 110}"
+NUM_RUNS="${NUM_RUNS:-5}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+# CB sizes per core-count, taken from batch4 grid picks.
+# Format: cores in_cb out_cb
+declare -A CB_FOR_CORES=(
+  [1]="12 2"
+  [2]="12 2"
+  [4]="12 4"
+  [10]="16 8"
+  [20]="8 4"
+  [40]="64 64"
+  [80]="64 32"
+  [110]="64 16"
+)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+if [[ ! -x "${PYTHON}" ]]; then
+  PYTHON="python3"
+fi
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch8"
+CHART_CSV="${OUT_DIR}/chart_data.csv"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+fi
+
+echo "num_cores,end_barrier_mode,barrier_label,in_cb,out_cb,op2op_us_median,dg_median_ns,dg_issue_ns,cb_label" > "${CHART_CSV}"
+
+for N in ${CORE_COUNTS}; do
+  read -r IN_CB OUT_CB <<< "${CB_FOR_CORES[$N]:-16 8}"
+  for MODE in 0 1 2; do
+    case "${MODE}" in
+      0) LABEL="barrier";;
+      1) LABEL="flushed";;
+      2) LABEL="none";;
+    esac
+    echo "================ batch8 cores=${N} mode=${MODE}(${LABEL}) cb=${IN_CB}/${OUT_CB} ================"
+
+    CONFIG_LABEL="batch8_c${N}_m${MODE}" \
+    MIN_PROG_ID="${MIN_PROG_ID}" \
+    TILES_PER_CORE="${LATENCY_PAGES}" \
+    INPUT_CB_DEPTH="${IN_CB}" \
+    READER_PUSH=2 \
+    BUILD=0 \
+    EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+                --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+                --writer-flush-on-pressure \
+                --writer-end-barrier-mode ${MODE} \
+                --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+                --reader-push-tiles 2 \
+                --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+                --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+    bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -4
+
+    "${PYTHON}" - "${N}" "${MODE}" "${LABEL}" "${IN_CB}" "${OUT_CB}" \
+      "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch8_c${N}_m${MODE}" \
+      "${CHART_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import csv, glob, os, statistics as st, sys
+
+ncores, mode, label, in_cb, out_cb, base, out_csv, min_prog = sys.argv[1:9]
+op2op, dg_med, dg_issue = [], [], []
+
+for r in sorted(glob.glob(os.path.join(base, "run_*"))):
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    with open(f) as fh:
+        rows = list(csv.DictReader(fh))
+    rows = [row for row in rows if int(float(row.get("from_prog_id", 0))) >= int(min_prog)]
+    if not rows:
+        continue
+    op2op.append(st.median([float(row["gap_us"]) for row in rows]))
+    dg_vals = [float(row["dg_median_ns"]) for row in rows if row.get("dg_median_ns") not in ("", "nan")]
+    if dg_vals:
+        dg_med.append(st.median(dg_vals))
+    iss = [float(row["dg_issue_ns"]) for row in rows if row.get("dg_issue_ns") not in ("", "nan")]
+    if iss:
+        dg_issue.append(st.median(iss))
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_m, dg_m, dg_i = med(op2op), med(dg_med), med(dg_issue)
+cb_label = f"in={in_cb}/out={out_cb}"
+with open(out_csv, "a") as fh:
+    fh.write(
+        f"{ncores},{mode},{label},{in_cb},{out_cb},"
+        f"{op2op_m:.3f},{dg_m:.1f},{dg_i:.1f},{cb_label}\n"
+    )
+print(f"  cores={ncores} mode={mode}({label})  gap={op2op_m:.3f}us  dg={dg_m:.0f}ns")
+PYEOF
+  done
+done
+
+echo
+echo "Batch 8 chart: ${CHART_CSV}"
+
+# Build batch8_vs_batch4 delta table
+BATCH4_CSV="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch4/chart_data.csv"
+DIFF_CSV="${OUT_DIR}/batch8_vs_batch4.csv"
+"${PYTHON}" - "${BATCH4_CSV}" "${CHART_CSV}" "${DIFF_CSV}" << 'PYEOF'
+import csv, os, sys
+from collections import defaultdict
+
+b4_path, b8_path, out_path = sys.argv[1:4]
+
+def load_b4(p):
+    out = {}
+    if not os.path.isfile(p):
+        return out
+    with open(p) as f:
+        for r in csv.DictReader(f):
+            out[int(r["num_cores"])] = r
+    return out
+
+def load_b8(p):
+    out = defaultdict(dict)
+    if not os.path.isfile(p):
+        return out
+    with open(p) as f:
+        for r in csv.DictReader(f):
+            out[int(r["num_cores"])][int(r["end_barrier_mode"])] = r
+    return out
+
+def fl(r, k):
+    try:
+        v = r.get(k, "")
+        return float(v) if v not in ("", "nan", None) else float("nan")
+    except (TypeError, ValueError, AttributeError):
+        return float("nan")
+
+b4 = load_b4(b4_path)
+b8 = load_b8(b8_path)
+
+fields = [
+    "cores", "cb",
+    "b4_gap_us", "b4_dg_ns",
+    "b8m0_gap_us", "b8m0_dg_ns",
+    "b8m1_gap_us", "b8m1_dg_ns", "m1_vs_m0_gap_us", "m1_vs_m0_gap_pct",
+    "b8m2_gap_us", "b8m2_dg_ns", "m2_vs_m0_gap_us", "m2_vs_m0_gap_pct",
+]
+with open(out_path, "w", newline="") as fh:
+    w = csv.DictWriter(fh, fieldnames=fields)
+    w.writeheader()
+    for cores in sorted(b8):
+        modes = b8[cores]
+        r0 = modes.get(0, {}); r1 = modes.get(1, {}); r2 = modes.get(2, {})
+        rb4 = b4.get(cores, {})
+        g0 = fl(r0, "op2op_us_median"); g1 = fl(r1, "op2op_us_median"); g2 = fl(r2, "op2op_us_median")
+        d0 = fl(r0, "dg_median_ns"); d1 = fl(r1, "dg_median_ns"); d2 = fl(r2, "dg_median_ns")
+        gb4 = fl(rb4, "op2op_us_median"); db4 = fl(rb4, "dg_median_ns")
+        cb = r0.get("cb_label", "")
+        w.writerow({
+            "cores": cores, "cb": cb,
+            "b4_gap_us": f"{gb4:.3f}" if gb4 == gb4 else "",
+            "b4_dg_ns": f"{db4:.0f}" if db4 == db4 else "",
+            "b8m0_gap_us": f"{g0:.3f}" if g0 == g0 else "",
+            "b8m0_dg_ns": f"{d0:.0f}" if d0 == d0 else "",
+            "b8m1_gap_us": f"{g1:.3f}" if g1 == g1 else "",
+            "b8m1_dg_ns": f"{d1:.0f}" if d1 == d1 else "",
+            "m1_vs_m0_gap_us": f"{g1-g0:+.3f}" if g0 == g0 and g1 == g1 else "",
+            "m1_vs_m0_gap_pct": f"{(g1-g0)/g0*100:+.1f}" if g0 == g0 and g1 == g1 and g0 != 0 else "",
+            "b8m2_gap_us": f"{g2:.3f}" if g2 == g2 else "",
+            "b8m2_dg_ns": f"{d2:.0f}" if d2 == d2 else "",
+            "m2_vs_m0_gap_us": f"{g2-g0:+.3f}" if g0 == g0 and g2 == g2 else "",
+            "m2_vs_m0_gap_pct": f"{(g2-g0)/g0*100:+.1f}" if g0 == g0 and g2 == g2 and g0 != 0 else "",
+        })
+
+print(f"\nWrote {out_path}\n")
+with open(out_path) as fh:
+    print(fh.read())
+PYEOF

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8b_barrier_b1cb.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8b_barrier_b1cb.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Batch 8b: writer end-of-kernel barrier sweep, but pinned to BATCH 1 CBs
+# (the latency-optimal / baseline CBs) instead of batch 4's BW-optimal CBs.
+# Apples-to-apples vs batch 1, which is the right comparison for a pure
+# latency experiment.
+#
+# Three modes per core count (everything else identical to batch 4/8):
+#   end_barrier_mode=0: noc_async_write_barrier()  -- DEFAULT, wait for DRAM ACK
+#   end_barrier_mode=1: noc_async_writes_flushed() -- only flush local L1
+#   end_barrier_mode=2: nothing                    -- simulates HW giving it free
+#
+# Output:
+#   generated/profiler/op_to_op_runs/batch8b/chart_data.csv
+#   generated/profiler/op_to_op_runs/batch8b/batch8b_vs_batch1.csv
+
+set -uo pipefail
+
+CORE_COUNTS="${CORE_COUNTS:-1 2 4 10 20 40 80 110}"
+NUM_RUNS="${NUM_RUNS:-5}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-0}"
+
+# CB sizes per core-count, taken from batch 1 picks (latency-optimal).
+# Format: cores in_cb out_cb
+declare -A CB_FOR_CORES=(
+  [1]="4 2"
+  [2]="4 2"
+  [4]="6 2"
+  [10]="4 4"
+  [20]="4 2"
+  [40]="16 16"
+  [80]="12 16"
+  [110]="4 2"
+)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+if [[ ! -x "${PYTHON}" ]]; then
+  PYTHON="python3"
+fi
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch8b"
+CHART_CSV="${OUT_DIR}/chart_data.csv"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+fi
+
+echo "num_cores,end_barrier_mode,barrier_label,in_cb,out_cb,op2op_us_median,dg_median_ns,dg_issue_ns,cb_label" > "${CHART_CSV}"
+
+for N in ${CORE_COUNTS}; do
+  read -r IN_CB OUT_CB <<< "${CB_FOR_CORES[$N]:-4 2}"
+  for MODE in 0 1 2; do
+    case "${MODE}" in
+      0) LABEL="barrier";;
+      1) LABEL="flushed";;
+      2) LABEL="none";;
+    esac
+    echo "================ batch8b cores=${N} mode=${MODE}(${LABEL}) cb=${IN_CB}/${OUT_CB} ================"
+
+    CONFIG_LABEL="batch8b_c${N}_m${MODE}" \
+    MIN_PROG_ID="${MIN_PROG_ID}" \
+    TILES_PER_CORE="${LATENCY_PAGES}" \
+    INPUT_CB_DEPTH="${IN_CB}" \
+    READER_PUSH=2 \
+    BUILD=0 \
+    EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+                --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+                --writer-flush-on-pressure \
+                --writer-end-barrier-mode ${MODE} \
+                --reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT} \
+                --reader-push-tiles 2 \
+                --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+                --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+    bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -4
+
+    "${PYTHON}" - "${N}" "${MODE}" "${LABEL}" "${IN_CB}" "${OUT_CB}" \
+      "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch8b_c${N}_m${MODE}" \
+      "${CHART_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import csv, glob, os, statistics as st, sys
+
+ncores, mode, label, in_cb, out_cb, base, out_csv, min_prog = sys.argv[1:9]
+op2op, dg_med, dg_issue = [], [], []
+
+for r in sorted(glob.glob(os.path.join(base, "run_*"))):
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    with open(f) as fh:
+        rows = list(csv.DictReader(fh))
+    rows = [row for row in rows if int(float(row.get("from_prog_id", 0))) >= int(min_prog)]
+    if not rows:
+        continue
+    op2op.append(st.median([float(row["gap_us"]) for row in rows]))
+    dg_vals = [float(row["dg_median_ns"]) for row in rows if row.get("dg_median_ns") not in ("", "nan")]
+    if dg_vals:
+        dg_med.append(st.median(dg_vals))
+    iss = [float(row["dg_issue_ns"]) for row in rows if row.get("dg_issue_ns") not in ("", "nan")]
+    if iss:
+        dg_issue.append(st.median(iss))
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_m, dg_m, dg_i = med(op2op), med(dg_med), med(dg_issue)
+cb_label = f"in={in_cb}/out={out_cb}"
+with open(out_csv, "a") as fh:
+    fh.write(
+        f"{ncores},{mode},{label},{in_cb},{out_cb},"
+        f"{op2op_m:.3f},{dg_m:.1f},{dg_i:.1f},{cb_label}\n"
+    )
+print(f"  cores={ncores} mode={mode}({label})  gap={op2op_m:.3f}us  dg={dg_m:.0f}ns")
+PYEOF
+  done
+done
+
+echo
+echo "Batch 8b chart: ${CHART_CSV}"
+
+# Build batch8b_vs_batch1 delta table (apples-to-apples vs B1, the latency baseline)
+BATCH1_CANDIDATES=(
+  "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_sweep/dg_v4/chart_data.csv"
+  "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch1/chart_data.csv"
+  "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/paul_chart_sweep/chart_data.csv"
+)
+B1_REF=""
+for cand in "${BATCH1_CANDIDATES[@]}"; do
+  if [[ -f "${cand}" ]]; then B1_REF="${cand}"; break; fi
+done
+
+DIFF_CSV="${OUT_DIR}/batch8b_vs_batch1.csv"
+"${PYTHON}" - "${B1_REF}" "${CHART_CSV}" "${DIFF_CSV}" << 'PYEOF'
+import csv, os, sys
+from collections import defaultdict
+
+b1_path, b8b_path, out_path = sys.argv[1:4]
+
+def load_b1(p):
+    out = {}
+    if not p or not os.path.isfile(p):
+        return out
+    with open(p) as f:
+        for r in csv.DictReader(f):
+            # batch1 chart_data.csv uses "num_cores" / "op2op_us_median" / "dg_median_ns"
+            key = r.get("num_cores") or r.get("cores")
+            if key is None: continue
+            try:
+                out[int(float(key))] = r
+            except ValueError:
+                continue
+    return out
+
+def load_b8b(p):
+    out = defaultdict(dict)
+    if not os.path.isfile(p):
+        return out
+    with open(p) as f:
+        for r in csv.DictReader(f):
+            out[int(r["num_cores"])][int(r["end_barrier_mode"])] = r
+    return out
+
+def fl(r, *keys):
+    for k in keys:
+        v = r.get(k, "")
+        if v in ("", "nan", None): continue
+        try: return float(v)
+        except (TypeError, ValueError): continue
+    return float("nan")
+
+b1 = load_b1(b1_path)
+b8b = load_b8b(b8b_path)
+
+fields = [
+    "cores", "cb",
+    "b1_gap_us", "b1_dg_ns",
+    "b8bm0_gap_us", "b8bm0_dg_ns",
+    "b8bm1_gap_us", "b8bm1_dg_ns", "m1_vs_m0_gap_us", "m1_vs_m0_gap_pct",
+    "b8bm2_gap_us", "b8bm2_dg_ns", "m2_vs_m0_gap_us", "m2_vs_m0_gap_pct",
+]
+with open(out_path, "w", newline="") as fh:
+    w = csv.DictWriter(fh, fieldnames=fields)
+    w.writeheader()
+    for cores in sorted(b8b):
+        modes = b8b[cores]
+        r0 = modes.get(0, {}); r1 = modes.get(1, {}); r2 = modes.get(2, {})
+        rb1 = b1.get(cores, {})
+        g0 = fl(r0, "op2op_us_median"); g1 = fl(r1, "op2op_us_median"); g2 = fl(r2, "op2op_us_median")
+        d0 = fl(r0, "dg_median_ns"); d1 = fl(r1, "dg_median_ns"); d2 = fl(r2, "dg_median_ns")
+        gb1 = fl(rb1, "op2op_us_median", "gap_us")
+        db1 = fl(rb1, "dg_median_ns", "chip_done_to_go_ns_median")
+        cb = r0.get("cb_label", "")
+        w.writerow({
+            "cores": cores, "cb": cb,
+            "b1_gap_us": f"{gb1:.3f}" if gb1 == gb1 else "",
+            "b1_dg_ns": f"{db1:.0f}" if db1 == db1 else "",
+            "b8bm0_gap_us": f"{g0:.3f}" if g0 == g0 else "",
+            "b8bm0_dg_ns": f"{d0:.0f}" if d0 == d0 else "",
+            "b8bm1_gap_us": f"{g1:.3f}" if g1 == g1 else "",
+            "b8bm1_dg_ns": f"{d1:.0f}" if d1 == d1 else "",
+            "m1_vs_m0_gap_us": f"{g1-g0:+.3f}" if g0 == g0 and g1 == g1 else "",
+            "m1_vs_m0_gap_pct": f"{(g1-g0)/g0*100:+.1f}" if g0 == g0 and g1 == g1 and g0 != 0 else "",
+            "b8bm2_gap_us": f"{g2:.3f}" if g2 == g2 else "",
+            "b8bm2_dg_ns": f"{d2:.0f}" if d2 == d2 else "",
+            "m2_vs_m0_gap_us": f"{g2-g0:+.3f}" if g0 == g0 and g2 == g2 else "",
+            "m2_vs_m0_gap_pct": f"{(g2-g0)/g0*100:+.1f}" if g0 == g0 and g2 == g2 and g0 != 0 else "",
+        })
+
+print(f"\nWrote {out_path}\n")
+with open(out_path) as fh:
+    print(fh.read())
+PYEOF

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8b_barrier_b1cb.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_batch8b_barrier_b1cb.sh
@@ -42,7 +42,8 @@ TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_RUNTIME_ROOT="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
 if [[ ! -x "${PYTHON}" ]]; then

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_buffer_tune.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_buffer_tune.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Input CB depth vs DRAM bandwidth sweep, then op-to-op latency at smallest depth at peak BW.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+EXPORT_PY="${SCRIPT_DIR}/export_op_to_op_profiler_csv.py"
+LOG_DIR="${TT_METAL_HOME}/generated/profiler/.logs"
+
+INPUT_DEPTHS="${INPUT_DEPTHS:-2,4,6,8,12,16,24,32}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-}"
+BW_PAGES="${BW_PAGES:-32}"
+LATENCY_PAGES="${LATENCY_PAGES:-4}"
+LATENCY_NOPS="${LATENCY_NOPS:-1000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-2}"
+
+cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+rm -rf "${HOME}/.cache/tt-metal-cache" "${TT_METAL_CACHE:-}" 2>/dev/null || true
+mkdir -p "${LOG_DIR}"
+
+ARGS=(
+  --buffer-tune
+  --buffer-tune-input-depths "${INPUT_DEPTHS}"
+  --buffer-tune-pages-per-core "${BW_PAGES}"
+  --reader-push-tiles 2
+  --num-pages-per-core "${LATENCY_PAGES}"
+  --compute-nops "${LATENCY_NOPS}"
+  --num-programs "${NUM_PROGRAMS}"
+  --use-trace
+  --use-device-profiler
+  --use-realtime-profiler
+)
+if [[ -n "${OUTPUT_DEPTHS}" ]]; then
+  ARGS+=(--buffer-tune-output-depths "${OUTPUT_DEPTHS}")
+fi
+
+"${TEST_BIN}" "${ARGS[@]}" 2>&1 | tee "${LOG_DIR}/buffer_tune_run.log"
+
+INPUT_DEPTH=4
+if grep -q 'smallest_input_cb_depth_at_peak=' "${LOG_DIR}/buffer_tune_run.log"; then
+  INPUT_DEPTH="$(
+    grep 'smallest_input_cb_depth_at_peak=' "${LOG_DIR}/buffer_tune_run.log" | tail -1 \
+      | sed -n 's/.*smallest_input_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p'
+  )"
+fi
+
+python3 "${EXPORT_PY}" \
+  --input-file "${LOG_DIR}/profile_log_device.csv" \
+  --rt-input-file "${LOG_DIR}/profile_log_device_rt.csv" \
+  --tiles-per-core "${LATENCY_PAGES}" \
+  --input-cb-depth-tiles "${INPUT_DEPTH}" \
+  --reader-push-tiles 2
+
+echo "BUFFER_TUNE rows: grep BUFFER_TUNE ${LOG_DIR}/buffer_tune_run.log"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cb_grid_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cb_grid_sweep.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Full input×output CB grid BW sweep (try more in/out CB combinations).
+#
+# Uses --buffer-tune-grid --buffer-tune-bw-only: every (input_cb, output_cb) pair
+# is measured; logs BUFFER_TUNE rows with phase=cb_grid.
+#
+# Usage:
+#   source python_env/bin/activate
+#   ./run_cb_grid_sweep.sh
+#
+# Env:
+#   CORE_COUNTS     - default "64 70 80 90 96"
+#   INPUT_DEPTHS    - default "8,12,16,24,32,48,64"
+#   OUTPUT_DEPTHS   - default "2,4,8,16,32,64"
+#   BW_PAGES        - default 256
+#   NUM_ACTIVE_CORES per run (same as each CORE_COUNTS entry)
+#   BUILD           - default 1
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUT_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch2"
+CSV="${OUT_DIR}/cb_grid_sweep.csv"
+
+CORE_COUNTS="${CORE_COUNTS:-64 70 80 90 96}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-8,12,16,24,32,48,64}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2,4,8,16,32,64}"
+BW_PAGES="${BW_PAGES:-256}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+BUILD="${BUILD:-1}"
+
+mkdir -p "${OUT_DIR}"
+echo "num_cores,input_cb_depth,output_cb_depth,dram_pipeline_gbps,elapsed_us" > "${CSV}"
+
+if [[ "${BUILD}" != "0" ]]; then
+  cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+fi
+
+for N in ${CORE_COUNTS}; do
+  echo "======== CB grid cores=${N} ========"
+  LOG="${OUT_DIR}/cb_grid_cores_${N}.log"
+  "${TEST_BIN}" \
+    --buffer-tune \
+    --buffer-tune-grid \
+    --buffer-tune-bw-only \
+    --buffer-tune-input-depths "${INPUT_DEPTHS}" \
+    --buffer-tune-output-depths "${OUTPUT_DEPTHS}" \
+    --buffer-tune-pages-per-core "${BW_PAGES}" \
+    --buffer-tune-bw-tolerance-pct 2 \
+    --reader-dbuf-trid \
+    --reader-trid-in-flight "${TRID_IN_FLIGHT}" \
+    --reader-push-tiles 2 \
+    --compute-nops 0 \
+    --num-programs 1 \
+    --num-active-cores "${N}" \
+    2>&1 | tee "${LOG}"
+
+  grep 'BUFFER_TUNE,phase=cb_grid,' "${LOG}" | while IFS= read -r line; do
+    in_cb=$(echo "${line}" | sed -n 's/.*input_cb_depth=\([0-9][0-9]*\).*/\1/p')
+    out_cb=$(echo "${line}" | sed -n 's/.*output_cb_depth=\([0-9][0-9]*\).*/\1/p')
+    gbps=$(echo "${line}" | sed -n 's/.*dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+    elapsed=$(echo "${line}" | sed -n 's/.*elapsed_us=\([0-9][0-9]*\).*/\1/p')
+    echo "${N},${in_cb},${out_cb},${gbps},${elapsed}" >> "${CSV}"
+  done
+
+  peak=$(grep 'cb_grid peak_dram_pipeline_gbps=' "${LOG}" | tail -1 \
+    | sed -n 's/.*peak_dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+  in_pick=$(grep 'smallest_input_cb_depth_at_peak=' "${LOG}" | tail -1 \
+    | sed -n 's/.*smallest_input_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+  out_pick=$(grep 'smallest_output_cb_depth_at_peak=' "${LOG}" | tail -1 \
+    | sed -n 's/.*smallest_output_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+  echo "  peak=${peak} GB/s  picked in=${in_pick} out=${out_pick}"
+done
+
+echo
+echo "CB grid CSV: ${CSV}"
+echo "Peak per core (from grid summary lines in cb_grid_cores_*.log)"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cb_latency.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cb_latency.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# CB-depth -> latency tradeoff at a fixed (unsaturated) config. Deeper buffers buy a bit
+# of BW but cost drain latency. Two sweeps at cores=8, balanced nops, row, good NoC:
+#   cb_input_latency.csv  : sweep input CB depth (reader buffer), output fixed
+#   cb_output_latency.csv : sweep output CB depth (writer buffer), input fixed
+# Metrics per depth: agg_total BW, op-to-op, math-to-math, reader_to_writer, write_tail,
+# op_duration, writer_spread_pct.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+mkdir -p "${OUTDIR}"
+
+CORES="${CORES:-8}"
+NOPS="${NOPS:-64}"            # balanced knee for 8 cores
+N="${N:-8}"
+PAGES="${PAGES:-1024}"
+
+run() { # in_cb out_cb -> runs; leaves DEV_CSV
+  rm -f "${DEV_CSV}"
+  "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "$1" --output-cb-depth-tiles "$2" --writer-end-barrier-mode 0 \
+    --lean-compute --skip-output-validation \
+    --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops "${NOPS}" \
+    --use-trace --trace-warmup-replays 1 --num-active-cores "${CORES}" --use-device-profiler \
+    >/tmp/cbl_run.log 2>&1
+  grep -q PASSED /tmp/cbl_run.log
+}
+
+A="${OUTDIR}/cb_input_latency.csv"; rm -f "${A}"
+echo "==== input CB depth sweep (out_cb=8, cores=${CORES}, nops=${NOPS}) ===="
+for d in 16 32 64 128 256; do
+  if run "${d}" 8; then
+    "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${CORES}" --csv-out "${A}" \
+      --label "sweep=input;in_cb=${d};out_cb=8" 2>/dev/null \
+      | grep -E "agg_total_gbps|math_to_math_us|reader_to_writer_us|write_tail_us|op_duration_us"
+    echo "  in_cb=${d} done"
+  else echo "  in_cb=${d} FAILED"; fi
+done
+
+B="${OUTDIR}/cb_output_latency.csv"; rm -f "${B}"
+echo "==== output CB depth sweep (in_cb=64, cores=${CORES}, nops=${NOPS}) ===="
+for d in 2 4 8 16 32 64; do
+  if run 64 "${d}"; then
+    "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${CORES}" --csv-out "${B}" \
+      --label "sweep=output;in_cb=64;out_cb=${d}" 2>/dev/null \
+      | grep -E "agg_total_gbps|math_to_math_us|reader_to_writer_us|write_tail_us|op_duration_us"
+    echo "  out_cb=${d} done"
+  else echo "  out_cb=${d} FAILED"; fi
+done
+echo "CB_LATENCY_COMPLETE"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cb_latency.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cb_latency.sh
@@ -12,7 +12,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
@@ -42,7 +43,7 @@ for d in 16 32 64 128 256; do
   if run "${d}" 8; then
     "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${CORES}" --csv-out "${A}" \
       --label "sweep=input;in_cb=${d};out_cb=8" 2>/dev/null \
-      | grep -E "agg_total_gbps|math_to_math_us|reader_to_writer_us|write_tail_us|op_duration_us"
+      | grep -E "agg_total_gbps|official_op2op_min_us|m2m_bubble_us|reader_to_writer_us|write_tail_us|op_duration_us"
     echo "  in_cb=${d} done"
   else echo "  in_cb=${d} FAILED"; fi
 done
@@ -53,7 +54,7 @@ for d in 2 4 8 16 32 64; do
   if run 64 "${d}"; then
     "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${CORES}" --csv-out "${B}" \
       --label "sweep=output;in_cb=64;out_cb=${d}" 2>/dev/null \
-      | grep -E "agg_total_gbps|math_to_math_us|reader_to_writer_us|write_tail_us|op_duration_us"
+      | grep -E "agg_total_gbps|official_op2op_min_us|m2m_bubble_us|reader_to_writer_us|write_tail_us|op_duration_us"
     echo "  out_cb=${d} done"
   else echo "  out_cb=${d} FAILED"; fi
 done

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cores_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cores_sweep.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fewer-vs-more-cores: hold TOTAL work fixed (an "op" of TOTAL tiles), spread it across N
+# cores (pages/core = TOTAL/N), and see whether aggregate DRAM BW saturates (so adding
+# cores stops helping) while latency / starvation grow. Good NoC config is the default now
+# (reader=NOC0, writer=NOC1), row-major placement (saturates with the fewest cores).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+LAYOUT="${LAYOUT:-row}"                        # row | col core allocation order
+REVERSE="${REVERSE:-0}"                         # 1 = reverse fill order (last cores first)
+LF=""; [ "${LAYOUT}" = "col" ] && LF="--core-layout-col"
+tag="${LAYOUT}"; [ "${REVERSE}" = "1" ] && { LF="${LF} --core-reverse"; tag="${LAYOUT}_rev"; }
+OUT="${OUTDIR}/cores_sweep_fixed_total_${tag}.csv"
+mkdir -p "${OUTDIR}"
+
+TOTAL="${TOTAL:-16384}"                       # fixed total tiles (the op size)
+CORES="${CORES:-1 2 4 8 16 24 32 40 48 56}"
+IN_CB="${IN_CB:-32}"
+OUT_CB="${OUT_CB:-8}"
+N="${N:-8}"
+
+rm -f "${OUT}"
+for C in ${CORES}; do
+  pages=$(( (TOTAL + C / 2) / C ))            # round TOTAL/C
+  [ "${pages}" -lt 1 ] && pages=1
+  total=$(( pages * C ))
+  rm -f "${DEV_CSV}"
+  "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 ${LF} \
+    --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${OUT_CB}" --writer-end-barrier-mode 0 \
+    --lean-compute --skip-output-validation \
+    --num-pages-per-core "${pages}" --num-programs 2 --compute-nops 0 \
+    --use-trace --trace-warmup-replays 1 --num-active-cores "${C}" --use-device-profiler \
+    >/tmp/cs_run.log 2>&1
+  if ! grep -q PASSED /tmp/cs_run.log; then
+    echo "cores=${C} FAILED: $(grep -oE 'TT_FATAL: .*' /tmp/cs_run.log | head -1)"; continue
+  fi
+  "${PY}" "${DEC}" --pages-per-core "${pages}" --num-cores "${C}" --csv-out "${OUT}" \
+    --label "cores=${C};pages_per_core=${pages};total_tiles=${total}" 2>/dev/null \
+    | grep -E "agg_total_gbps|math_to_math_us|starvation_ratio"
+  echo "cores=${C} pages/core=${pages} total=${total} -> appended"
+done
+echo "CORES_SWEEP_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cores_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_cores_sweep.sh
@@ -10,7 +10,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
@@ -46,7 +47,7 @@ for C in ${CORES}; do
   fi
   "${PY}" "${DEC}" --pages-per-core "${pages}" --num-cores "${C}" --csv-out "${OUT}" \
     --label "cores=${C};pages_per_core=${pages};total_tiles=${total}" 2>/dev/null \
-    | grep -E "agg_total_gbps|math_to_math_us|starvation_ratio"
+    | grep -E "agg_total_gbps|official_op2op_min_us|m2m_bubble_us|starvation_ratio"
   echo "cores=${C} pages/core=${pages} total=${total} -> appended"
 done
 echo "CORES_SWEEP_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_extra_cores_chart.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_extra_cores_chart.sh
@@ -16,7 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 CORE_COUNTS="${CORE_COUNTS:-48 60 70 72 84 90 100}" \
 NUM_RUNS="${NUM_RUNS:-3}" \

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_extra_cores_chart.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_extra_cores_chart.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Zero-compute chart points for extra core counts (e.g. 70, 90) around the BW peak.
+#
+# Usage:
+#   source python_env/bin/activate
+#   export TT_METAL_DEVICE_PROFILER=1 TT_METAL_DEVICE_PROFILER_DISPATCH=1
+#   ./run_extra_cores_chart.sh
+#
+# Env:
+#   CORE_COUNTS  - default "48 60 70 72 84 90 100"
+#   Then run rebuild_batch2_results.py with EXTRA_CORES merged (see script footer).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+CORE_COUNTS="${CORE_COUNTS:-48 60 70 72 84 90 100}" \
+NUM_RUNS="${NUM_RUNS:-3}" \
+INPUT_DEPTHS="${INPUT_DEPTHS:-8,12,16,24,32,48,64}" \
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2,4,8,16,32,64}" \
+BW_PAGES="${BW_PAGES:-256}" \
+COMPUTE_NOPS=0 \
+CHART_TAG=batch2_extra \
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}" \
+USE_DBUF_TRID=1 \
+BUILD="${BUILD:-1}" \
+bash "${SCRIPT_DIR}/run_op_to_op_chart_sweep.sh" \
+  2>&1 | tee "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/batch2/extra_cores_sweep.log"
+
+echo
+echo "Extra chart CSV: ${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_sweep/batch2_extra/chart_data.csv"
+echo "Re-merge: python_env/bin/python3 ${SCRIPT_DIR}/rebuild_batch2_results.py"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_n_vs_cores.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_n_vs_cores.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Read-N latency-hiding vs core count. Isolates N (reader trid_in_flight = outstanding NoC
+# read txns) as the ONLY latency-hiding knob: input CB held FIXED+DEEP (in_cb=128) so the
+# cb_reserve_back run-ahead/stall axis is constant across N, and READ-ONLY so there is no
+# writer DRAM contention. Headline metric is per-core read BW; knee N = smallest N reaching
+# ~peak per-core BW. Question: does knee N depend on core count (BW unsaturated vs saturated)?
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUT:-${OUTDIR}/n_vs_cores.csv}"
+mkdir -p "${OUTDIR}"
+
+IN_CB="${IN_CB:-128}"          # fixed + deep: never the limiter, holds reserve-stall axis constant
+OUT_CB="${OUT_CB:-8}"          # just needs to drain (writer pops even in read-only)
+PAGES="${PAGES:-2048}"         # long read span -> stable per-core BW
+CORES_LIST="${CORES_LIST:-1 2 4 8 16 32 56}"
+N_LIST="${N_LIST:-1 2 3 4 6 8 12 16 24 32}"
+
+# decompose drops per_core_* / agg_read from its CSV and agg_total is NaN in read-only, so
+# we capture the read fields from its stdout and write our own CSV here.
+field() { awk -v f="$1" '$1==f{print $2}' <<<"$2"; }
+
+echo "cores,N,in_cb,agg_read_gbps,per_core_read_med,per_core_read_min,starvation_ratio" > "${OUT}"
+for C in ${CORES_LIST}; do
+  for N in ${N_LIST}; do
+    rm -f "${DEV_CSV}"
+    "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+      --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${OUT_CB}" \
+      --read-only --skip-output-validation --lean-compute \
+      --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
+      --use-trace --trace-warmup-replays 1 --num-active-cores "${C}" --use-device-profiler \
+      >/tmp/nvc_run.log 2>&1
+    if grep -q PASSED /tmp/nvc_run.log; then
+      out=$("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" 2>/dev/null)
+      ar=$(field agg_read_gbps "${out}"); pcm=$(field per_core_gbps_median "${out}")
+      pcmin=$(field per_core_gbps_min "${out}"); st=$(field starvation_ratio "${out}")
+      echo "${C},${N},${IN_CB},${ar},${pcm},${pcmin},${st}" >> "${OUT}"
+      echo "  cores=${C} N=${N}: agg_read=${ar} per_core_med=${pcm} starv=${st}"
+    else echo "  cores=${C} N=${N} FAILED: $(grep -oE 'TT_FATAL: .*' /tmp/nvc_run.log | head -1)"; fi
+  done
+done
+echo "N_VS_CORES_COMPLETE"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_n_vs_cores.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_n_vs_cores.sh
@@ -11,7 +11,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_all_configs.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_all_configs.sh
@@ -6,7 +6,7 @@
 #   1) baseline_push1_cb2     -- original: push-1, CB depth 2, 2 tiles/core
 #   2) push2_cb4_incremental  -- push-2, CB depth 4 (2x push), incremental
 #   3) push2_cb4_batch        -- push-2, CB depth 4, --reader-batch-push
-#   4) push2_cb6_bufftuned    -- push-2, CB depth 6 (Paul's buffer-tune pick)
+#   4) push2_cb6_bufftuned    -- push-2, CB depth 6 (buffer-tune pick)
 #
 # Override NUM_RUNS by passing as arg 1 (default 5).
 set -euo pipefail

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_all_configs.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_all_configs.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run the op-to-op latency benchmark NUM_RUNS times across multiple reader
+# configurations, then print a side-by-side comparison summary.
+#
+# Configs:
+#   1) baseline_push1_cb2     -- original: push-1, CB depth 2, 2 tiles/core
+#   2) push2_cb4_incremental  -- push-2, CB depth 4 (2x push), incremental
+#   3) push2_cb4_batch        -- push-2, CB depth 4, --reader-batch-push
+#   4) push2_cb6_bufftuned    -- push-2, CB depth 6 (Paul's buffer-tune pick)
+#
+# Override NUM_RUNS by passing as arg 1 (default 5).
+set -euo pipefail
+
+NUM_RUNS="${1:-5}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+MULTI_SH="${SCRIPT_DIR}/run_op_to_op_multi.sh"
+RUNS_PARENT="${TT_METAL_HOME}/generated/profiler/op_to_op_runs"
+COMMON_ARGS="--use-trace --num-programs 2 --compute-nops 1000 --use-device-profiler --use-realtime-profiler"
+
+cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+
+run_config() {
+  local label="$1"
+  local extra="$2"
+  local tiles="$3"
+  local cb="$4"
+  local push="$5"
+  echo "########################################"
+  echo "### Config: ${label}"
+  echo "### Args : ${extra}"
+  echo "########################################"
+  CONFIG_LABEL="${label}" \
+  EXTRA_ARGS="${COMMON_ARGS} ${extra}" \
+  TILES_PER_CORE="${tiles}" \
+  INPUT_CB_DEPTH="${cb}" \
+  READER_PUSH="${push}" \
+  BUILD=0 \
+    bash "${MULTI_SH}" "${NUM_RUNS}"
+}
+
+run_config "baseline_push1_cb2"    "--reader-push-tiles 1 --input-cb-depth-tiles 2 --num-pages-per-core 2" 2 2 1
+run_config "push2_cb4_incremental" "--reader-push-tiles 2 --input-cb-depth-tiles 4 --num-pages-per-core 4" 4 4 2
+run_config "push2_cb4_batch"       "--reader-push-tiles 2 --input-cb-depth-tiles 4 --num-pages-per-core 4 --reader-batch-push" 4 4 2
+run_config "push2_cb6_bufftuned"   "--reader-push-tiles 2 --input-cb-depth-tiles 6 --num-pages-per-core 4" 4 6 2
+
+# Side-by-side comparison summary: device op-to-op + dispatch done->go,
+# aggregated across NUM_RUNS for each config.
+python3 - "${RUNS_PARENT}" <<'PY'
+import sys
+from pathlib import Path
+import pandas as pd
+
+runs_parent = Path(sys.argv[1])
+configs = ["baseline_push1_cb2", "push2_cb4_incremental", "push2_cb4_batch", "push2_cb6_bufftuned"]
+
+device_rows, dispatch_rows = [], []
+for cfg in configs:
+    dev_csv = runs_parent / cfg / "multi_run_device_op_to_op_gap.csv"
+    disp_csv = runs_parent / cfg / "multi_run_dispatch_done_to_go.csv"
+    if dev_csv.is_file():
+        df = pd.read_csv(dev_csv)
+        for col in ("mean_gap_us", "median_gap_us", "min_gap_us", "max_gap_us"):
+            if col not in df.columns:
+                df[col] = float("nan")
+        device_rows.append({
+            "config": cfg,
+            "runs": len(df),
+            "median_us_mean":  df["median_gap_us"].mean(),
+            "median_us_std":   df["median_gap_us"].std(),
+            "median_us_min":   df["median_gap_us"].min(),
+            "median_us_max":   df["median_gap_us"].max(),
+            "mean_us_mean":    df["mean_gap_us"].mean(),
+            "mean_us_std":     df["mean_gap_us"].std(),
+            "overall_min_us":  df["min_gap_us"].min() if df["min_gap_us"].notna().any() else float("nan"),
+            "overall_max_us":  df["max_gap_us"].max() if df["max_gap_us"].notna().any() else float("nan"),
+        })
+    if disp_csv.is_file():
+        df = pd.read_csv(disp_csv)
+        if "dispatch_gap_us" in df.columns:
+            s = df["dispatch_gap_us"]
+            dispatch_rows.append({
+                "config": cfg,
+                "transitions": len(df),
+                "dispatch_us_mean":   s.mean(),
+                "dispatch_us_std":    s.std(),
+                "dispatch_us_min":    s.min(),
+                "dispatch_us_max":    s.max(),
+                "dispatch_us_median": s.median(),
+            })
+
+if device_rows:
+    device_df = pd.DataFrame(device_rows)
+    out = runs_parent / "config_comparison_device_gap.csv"
+    device_df.to_csv(out, index=False)
+    print(f"\nWrote {out}")
+    print(device_df.to_string(index=False, float_format=lambda x: f"{x:.3f}"))
+
+if dispatch_rows:
+    disp_df = pd.DataFrame(dispatch_rows)
+    out = runs_parent / "config_comparison_dispatch_gap.csv"
+    disp_df.to_csv(out, index=False)
+    print(f"\nWrote {out}")
+    print(disp_df.to_string(index=False, float_format=lambda x: f"{x:.3f}"))
+PY
+
+echo
+echo "All configs done. Per-config runs under: ${RUNS_PARENT}/<config>/run_*/"
+echo "Per-config aggregates : ${RUNS_PARENT}/<config>/multi_run_*.csv"
+echo "Side-by-side summary  : ${RUNS_PARENT}/config_comparison_*.csv"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_chart_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_chart_sweep.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# BW-vs-latency chart sweep across core counts.
+#
+# For each core count N in CORE_COUNTS:
+#   1. Buffer-tune (sweep input & output CB depths) to find peak DRAM BW
+#      and the smallest CB depths still within TOL_PCT of peak.
+#   2. Steady-state validation run (trace warmup + later prog transitions)
+#      at those CB depths to get clean op2op latency and chip dispatch done/go.
+#
+# Produces a single chart-ready CSV:
+#   chart_data.csv
+#   columns: num_cores, peak_input_gbps, smallest_input_cb,
+#            peak_output_gbps, smallest_output_cb,
+#            op2op_us_median, chip_done_to_go_ns_median,
+#            brisc_done_to_go_us_median
+#
+# Usage:
+#   ./run_op_to_op_chart_sweep.sh
+#
+# Env overrides:
+#   CORE_COUNTS     - space-separated list (default: "1 2 4 10 20 40 80 110")
+#   NUM_RUNS        - latency runs per core count (default: 3)
+#   INPUT_DEPTHS    - comma list for input sweep (default: "2,4,6,8,12,16,24,32")
+#   OUTPUT_DEPTHS   - comma list for output sweep (default: "2,4,8,16")
+#   BW_PAGES        - pages/core during BW sweep (default: 32)
+#   LATENCY_PAGES   - pages/core during latency phase (default: 16)
+#   COMPUTE_NOPS    - compute NOPs/tile during latency phase (default: 2000)
+#   NUM_PROGRAMS    - programs in trace (default: 8)
+#   MIN_PROG_ID     - earliest from_prog_id to keep (default: 3)
+#   TOL_PCT         - BW tolerance %% (default: 2)
+#   BUILD           - "0" to skip cmake build (default: build once)
+
+set -euo pipefail
+
+CORE_COUNTS="${CORE_COUNTS:-1 2 4 10 20 40 80 110}"
+NUM_RUNS="${NUM_RUNS:-5}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-2,4,6,8,12,16,24,32}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2,4,8,16}"
+BW_PAGES="${BW_PAGES:-256}"
+LATENCY_PAGES="${LATENCY_PAGES:-16}"
+COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
+NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
+MIN_PROG_ID="${MIN_PROG_ID:-3}"
+TOL_PCT="${TOL_PCT:-2}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+LOG_DIR="${TT_METAL_HOME}/generated/profiler/.logs"
+CHART_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_sweep"
+CHART_CSV="${CHART_DIR}/chart_data.csv"
+
+mkdir -p "${CHART_DIR}"
+
+if [[ "${BUILD:-1}" != "0" ]]; then
+  cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+fi
+
+echo "num_cores,peak_input_gbps,smallest_input_cb,peak_output_gbps,smallest_output_cb,op2op_us_median,chip_done_to_go_ns_median,brisc_done_to_go_us_median" > "${CHART_CSV}"
+
+for N in ${CORE_COUNTS}; do
+  echo "================ cores=${N} ================"
+
+  RUN_DIR="${CHART_DIR}/cores_${N}"
+  mkdir -p "${RUN_DIR}"
+  TUNE_LOG="${RUN_DIR}/buffer_tune.log"
+
+  # ---------------- Phase 1: buffer-tune sweep ----------------
+  rm -f "${LOG_DIR}/profile_log_device.csv" "${LOG_DIR}/profile_log_device_rt.csv"
+  "${TEST_BIN}" \
+    --buffer-tune \
+    --buffer-tune-input-depths "${INPUT_DEPTHS}" \
+    --buffer-tune-output-depths "${OUTPUT_DEPTHS}" \
+    --buffer-tune-pages-per-core "${BW_PAGES}" \
+    --buffer-tune-bw-tolerance-pct "${TOL_PCT}" \
+    --reader-push-tiles 2 \
+    --num-pages-per-core "${LATENCY_PAGES}" \
+    --compute-nops 0 \
+    --num-programs 1 \
+    --num-active-cores "${N}" \
+    --use-device-profiler 2>&1 | tee "${TUNE_LOG}" >/dev/null
+
+  IN_CB=$(grep 'smallest_input_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+            | sed -n 's/.*smallest_input_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+  OUT_CB=$(grep 'smallest_output_cb_depth_at_peak=' "${TUNE_LOG}" | tail -1 \
+            | sed -n 's/.*smallest_output_cb_depth_at_peak=\([0-9][0-9]*\).*/\1/p')
+  PEAK_IN_BW=$(grep 'buffer_tune: peak_dram_pipeline_gbps=' "${TUNE_LOG}" | tail -1 \
+            | sed -n 's/.*peak_dram_pipeline_gbps=\([0-9.]*\).*/\1/p')
+  PEAK_OUT_BW=$(grep 'output sweep peak_gbps=' "${TUNE_LOG}" | tail -1 \
+            | sed -n 's/.*peak_gbps=\([0-9.]*\).*/\1/p')
+
+  IN_CB="${IN_CB:-2}"
+  OUT_CB="${OUT_CB:-2}"
+  PEAK_IN_BW="${PEAK_IN_BW:-0}"
+  PEAK_OUT_BW="${PEAK_OUT_BW:-0}"
+  echo "  picked: in_cb=${IN_CB} out_cb=${OUT_CB} peak_in_gbps=${PEAK_IN_BW} peak_out_gbps=${PEAK_OUT_BW}"
+
+  # ---------------- Phase 2: latency at picked CBs ----------------
+  CONFIG_LABEL="chart_cores${N}" \
+  MIN_PROG_ID="${MIN_PROG_ID}" \
+  TILES_PER_CORE="${LATENCY_PAGES}" \
+  INPUT_CB_DEPTH="${IN_CB}" \
+  READER_PUSH=2 \
+  BUILD=0 \
+  EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
+              --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
+              --reader-push-tiles 2 \
+              --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
+              --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
+  bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -8
+
+  # ---------------- Phase 3: aggregate this row ----------------
+  python3 - "${N}" "${IN_CB}" "${OUT_CB}" "${PEAK_IN_BW}" "${PEAK_OUT_BW}" \
+          "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_cores${N}" \
+          "${CHART_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+import sys, os, glob, statistics as st
+import pandas as pd
+
+ncores, in_cb, out_cb, peak_in, peak_out, base, chart_csv, min_prog = sys.argv[1:]
+runs = sorted(glob.glob(os.path.join(base, "run_*")))
+op2op_meds, brisc_meds, chip_ns_meds = [], [], []
+for r in runs:
+    f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
+    if not os.path.exists(f):
+        continue
+    df = pd.read_csv(f)
+    if "from_prog_id" in df.columns:
+        df = df[df["from_prog_id"] >= int(min_prog)]
+    if df.empty:
+        continue
+    op2op_meds.append(df["gap_us"].median())
+    brisc_meds.append(df["brisc_done_to_go_us"].median())
+    chip_ns_meds.append(df["chip_dispatch_gap_ns"].median())
+
+def med(xs):
+    return st.median(xs) if xs else float("nan")
+
+op2op_med = med(op2op_meds)
+brisc_med = med(brisc_meds)
+chip_med = med(chip_ns_meds)
+
+with open(chart_csv, "a") as fh:
+    fh.write(f"{ncores},{peak_in},{in_cb},{peak_out},{out_cb},"
+             f"{op2op_med:.3f},{chip_med:.1f},{brisc_med:.3f}\n")
+print(f"  cores={ncores}  op2op={op2op_med:.3f}us  brisc_dg={brisc_med:.3f}us  chip_dg={chip_med:.1f}ns")
+PYEOF
+done
+
+echo
+echo "================ DONE ================"
+echo "Chart CSV: ${CHART_CSV}"
+python3 -c "
+import pandas as pd
+df = pd.read_csv('${CHART_CSV}')
+print(df.to_string(index=False))
+"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_chart_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_chart_sweep.sh
@@ -11,8 +11,19 @@
 #   chart_data.csv
 #   columns: num_cores, peak_input_gbps, smallest_input_cb,
 #            peak_output_gbps, smallest_output_cb,
-#            op2op_us_median, chip_done_to_go_ns_median,
-#            brisc_done_to_go_us_median
+#            op2op_us_median,
+#            dg_first_ns / dg_median_ns / dg_last_ns,
+#                                       <-- "true" done/go: nearest/median/
+#                                       farthest worker observes new GO after
+#                                       dispatch_s sees workers done (includes
+#                                       MCAST propagation; bounded above by NoC
+#                                       MCAST MANY L1 latency from the table).
+#            dg_issue_ns                <-- dispatch-only MCAST issue cost
+#                                       (single NoC register write, ~30 ns BH)
+#            chip_dispatch_loop_ns_median  <-- legacy metric: dispatch_s
+#                                              internal state-machine overhead
+#                                              only (excludes propagation +
+#                                              worker FW launch path)
 #
 # Usage:
 #   ./run_op_to_op_chart_sweep.sh
@@ -29,8 +40,14 @@
 #   MIN_PROG_ID     - earliest from_prog_id to keep (default: 3)
 #   TOL_PCT         - BW tolerance %% (default: 2)
 #   BUILD           - "0" to skip cmake build (default: build once)
+#   TRID_IN_FLIGHT  - N reads in flight per TRID for mode 2 (default: 2).
+#                     The script enforces input_cb_depth >= 2*N for the latency phase.
+#   USE_DBUF_TRID   - "1" enables --reader-dbuf-trid in the latency phase (default: 1).
 
-set -euo pipefail
+set -uo pipefail
+# Intentionally NOT -e: if one core count fails (e.g. asserts on min CB depth),
+# we still want subsequent core counts to run. Each row in chart_data.csv is
+# independent; a missing row is better than aborting the whole sweep.
 
 CORE_COUNTS="${CORE_COUNTS:-1 2 4 10 20 40 80 110}"
 NUM_RUNS="${NUM_RUNS:-5}"
@@ -42,25 +59,38 @@ COMPUTE_NOPS="${COMPUTE_NOPS:-2000}"
 NUM_PROGRAMS="${NUM_PROGRAMS:-8}"
 MIN_PROG_ID="${MIN_PROG_ID:-3}"
 TOL_PCT="${TOL_PCT:-2}"
+TRID_IN_FLIGHT="${TRID_IN_FLIGHT:-2}"
+USE_DBUF_TRID="${USE_DBUF_TRID:-1}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
+# Enable dispatch-core profiling so DISP_DONE_OBSERVED / DISP_GO_ISSUED markers
+# show up in profile_log_device.csv (required for the dg_* columns).
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
 TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 LOG_DIR="${TT_METAL_HOME}/generated/profiler/.logs"
-CHART_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_sweep"
+# Sweep results land under chart_sweep/<tag>/ so multiple TRID_IN_FLIGHT runs
+# don't clobber each other. CHART_TAG can be set explicitly; otherwise it's
+# derived from TRID_IN_FLIGHT (e.g. "n2_dbuf").
+CHART_TAG="${CHART_TAG:-n${TRID_IN_FLIGHT}_dbuf${USE_DBUF_TRID}}"
+CHART_DIR="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_sweep/${CHART_TAG}"
 CHART_CSV="${CHART_DIR}/chart_data.csv"
 
 mkdir -p "${CHART_DIR}"
 
 if [[ "${BUILD:-1}" != "0" ]]; then
-  cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  if command -v cmake >/dev/null 2>&1; then
+    cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  else
+    /usr/local/bin/cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+  fi
 fi
 
-echo "num_cores,peak_input_gbps,smallest_input_cb,peak_output_gbps,smallest_output_cb,op2op_us_median,chip_done_to_go_ns_median,brisc_done_to_go_us_median" > "${CHART_CSV}"
+echo "num_cores,peak_input_gbps,smallest_input_cb,peak_output_gbps,smallest_output_cb,op2op_us_median,dg_first_ns,dg_median_ns,dg_last_ns,dg_issue_ns,fw_done_to_go_us_median,user_done_to_go_us_median,chip_dispatch_loop_ns_median,cb_label,trid_in_flight" > "${CHART_CSV}"
 
 for N in ${CORE_COUNTS}; do
   echo "================ cores=${N} ================"
@@ -97,10 +127,21 @@ for N in ${CORE_COUNTS}; do
   OUT_CB="${OUT_CB:-2}"
   PEAK_IN_BW="${PEAK_IN_BW:-0}"
   PEAK_OUT_BW="${PEAK_OUT_BW:-0}"
-  echo "  picked: in_cb=${IN_CB} out_cb=${OUT_CB} peak_in_gbps=${PEAK_IN_BW} peak_out_gbps=${PEAK_OUT_BW}"
+
+  # Mode 2 needs input_cb_depth >= 2 * TRID_IN_FLIGHT. Floor the picked depth.
+  DBUF_FLAG=""
+  if [[ "${USE_DBUF_TRID}" == "1" ]]; then
+    MIN_IN_CB=$(( 2 * TRID_IN_FLIGHT ))
+    if (( IN_CB < MIN_IN_CB )); then
+      echo "  bumping in_cb from ${IN_CB} to ${MIN_IN_CB} (required for mode 2 with N=${TRID_IN_FLIGHT})"
+      IN_CB="${MIN_IN_CB}"
+    fi
+    DBUF_FLAG="--reader-dbuf-trid --reader-trid-in-flight ${TRID_IN_FLIGHT}"
+  fi
+  echo "  picked: in_cb=${IN_CB} out_cb=${OUT_CB} peak_in_gbps=${PEAK_IN_BW} peak_out_gbps=${PEAK_OUT_BW} (mode2_n=${TRID_IN_FLIGHT})"
 
   # ---------------- Phase 2: latency at picked CBs ----------------
-  CONFIG_LABEL="chart_cores${N}" \
+  CONFIG_LABEL="chart_cores${N}_n${TRID_IN_FLIGHT}" \
   MIN_PROG_ID="${MIN_PROG_ID}" \
   TILES_PER_CORE="${LATENCY_PAGES}" \
   INPUT_CB_DEPTH="${IN_CB}" \
@@ -108,21 +149,22 @@ for N in ${CORE_COUNTS}; do
   BUILD=0 \
   EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs ${NUM_PROGRAMS} \
               --compute-nops ${COMPUTE_NOPS} --use-device-profiler --use-realtime-profiler \
-              --reader-push-tiles 2 \
+              --reader-push-tiles 2 ${DBUF_FLAG} \
               --input-cb-depth-tiles ${IN_CB} --output-cb-depth-tiles ${OUT_CB} \
               --num-pages-per-core ${LATENCY_PAGES} --num-active-cores ${N}" \
   bash "${SCRIPT_DIR}/run_op_to_op_multi.sh" "${NUM_RUNS}" 2>&1 | tail -8
 
   # ---------------- Phase 3: aggregate this row ----------------
   python3 - "${N}" "${IN_CB}" "${OUT_CB}" "${PEAK_IN_BW}" "${PEAK_OUT_BW}" \
-          "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_cores${N}" \
-          "${CHART_CSV}" "${MIN_PROG_ID}" << 'PYEOF'
+          "${TT_METAL_HOME}/generated/profiler/op_to_op_runs/chart_cores${N}_n${TRID_IN_FLIGHT}" \
+          "${CHART_CSV}" "${MIN_PROG_ID}" "${TRID_IN_FLIGHT}" << 'PYEOF'
 import sys, os, glob, statistics as st
 import pandas as pd
 
-ncores, in_cb, out_cb, peak_in, peak_out, base, chart_csv, min_prog = sys.argv[1:]
+ncores, in_cb, out_cb, peak_in, peak_out, base, chart_csv, min_prog, n_inflight = sys.argv[1:]
 runs = sorted(glob.glob(os.path.join(base, "run_*")))
-op2op_meds, brisc_meds, chip_ns_meds = [], [], []
+op2op_meds, brisc_meds, fw_meds, chip_ns_meds = [], [], [], []
+dg_first_meds, dg_median_meds, dg_last_meds, dg_issue_meds = [], [], [], []
 for r in runs:
     f = os.path.join(r, "profile_log_device_op_to_op_complete.csv")
     if not os.path.exists(f):
@@ -134,19 +176,37 @@ for r in runs:
         continue
     op2op_meds.append(df["gap_us"].median())
     brisc_meds.append(df["brisc_done_to_go_us"].median())
+    if "brisc_fw_done_to_go_us" in df.columns:
+        fw_meds.append(df["brisc_fw_done_to_go_us"].dropna().median())
     chip_ns_meds.append(df["chip_dispatch_gap_ns"].median())
+    if "dg_first_ns" in df.columns:
+        dg_first_meds.append(df["dg_first_ns"].dropna().median())
+    if "dg_median_ns" in df.columns:
+        dg_median_meds.append(df["dg_median_ns"].dropna().median())
+    if "dg_last_ns" in df.columns:
+        dg_last_meds.append(df["dg_last_ns"].dropna().median())
+    if "dg_issue_ns" in df.columns:
+        dg_issue_meds.append(df["dg_issue_ns"].dropna().median())
 
 def med(xs):
+    xs = [x for x in xs if x == x]
     return st.median(xs) if xs else float("nan")
 
 op2op_med = med(op2op_meds)
 brisc_med = med(brisc_meds)
+fw_med = med(fw_meds)
 chip_med = med(chip_ns_meds)
+dg_first = med(dg_first_meds)
+dg_median = med(dg_median_meds)
+dg_last = med(dg_last_meds)
+dg_issue = med(dg_issue_meds)
 
+cb_label = f"in={in_cb}/out={out_cb}"
 with open(chart_csv, "a") as fh:
     fh.write(f"{ncores},{peak_in},{in_cb},{peak_out},{out_cb},"
-             f"{op2op_med:.3f},{chip_med:.1f},{brisc_med:.3f}\n")
-print(f"  cores={ncores}  op2op={op2op_med:.3f}us  brisc_dg={brisc_med:.3f}us  chip_dg={chip_med:.1f}ns")
+             f"{op2op_med:.3f},{dg_first:.1f},{dg_median:.1f},{dg_last:.1f},{dg_issue:.1f},"
+             f"{fw_med:.3f},{brisc_med:.3f},{chip_med:.1f},{cb_label},{n_inflight}\n")
+print(f"  cores={ncores} N={n_inflight}  op2op={op2op_med:.3f}us  done_to_go(first/med/last)={dg_first:.0f}/{dg_median:.0f}/{dg_last:.0f}ns  dg_issue={dg_issue:.0f}ns")
 PYEOF
 done
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_chart_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_chart_sweep.sh
@@ -68,7 +68,8 @@ export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
 # Enable dispatch-core profiling so DISP_DONE_OBSERVED / DISP_GO_ISSUED markers
 # show up in profile_log_device.csv (required for the dg_* columns).
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
 TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
@@ -13,7 +13,8 @@
 #   TILES_PER_CORE - tiles/core for export buffering breakdown (default: 2)
 #   INPUT_CB_DEPTH - input CB depth for export buffering breakdown (default: 2)
 #   READER_PUSH    - reader push tiles for export (default: 1)
-set -euo pipefail
+set -uo pipefail
+# Intentionally NOT -e: a failing run shouldn't kill all subsequent runs.
 
 NUM_RUNS="${1:-5}"
 CONFIG_LABEL="${CONFIG_LABEL:-default}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
@@ -21,6 +21,7 @@ EXTRA_ARGS="${EXTRA_ARGS:---use-trace --num-programs 2 --compute-nops 1000 --use
 TILES_PER_CORE="${TILES_PER_CORE:-2}"
 INPUT_CB_DEPTH="${INPUT_CB_DEPTH:-2}"
 READER_PUSH="${READER_PUSH:-1}"
+MIN_PROG_ID="${MIN_PROG_ID:-1}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
@@ -62,6 +63,7 @@ for i in $(seq 1 "${NUM_RUNS}"); do
     --tiles-per-core "${TILES_PER_CORE}" \
     --input-cb-depth-tiles "${INPUT_CB_DEPTH}" \
     --reader-push-tiles "${READER_PUSH}" \
+    --min-prog-id "${MIN_PROG_ID}" \
     --output-dir "${run_dir}"
 done
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Run op-to-op latency benchmark N times, export each run, then aggregate.
+#
+# Usage:
+#   ./run_op_to_op_multi.sh [NUM_RUNS]
+#
+# Env overrides:
+#   CONFIG_LABEL  - subdirectory name under op_to_op_runs/ (default: "default")
+#   EXTRA_ARGS    - extra CLI args to pass to the test binary
+#                   (default: --use-trace --num-programs 2 --compute-nops 1000
+#                             --use-device-profiler --use-realtime-profiler)
+#   BUILD         - set to "0" to skip cmake build (default: build once)
+#   TILES_PER_CORE - tiles/core for export buffering breakdown (default: 2)
+#   INPUT_CB_DEPTH - input CB depth for export buffering breakdown (default: 2)
+#   READER_PUSH    - reader push tiles for export (default: 1)
+set -euo pipefail
+
+NUM_RUNS="${1:-5}"
+CONFIG_LABEL="${CONFIG_LABEL:-default}"
+EXTRA_ARGS="${EXTRA_ARGS:---use-trace --num-programs 2 --compute-nops 1000 --use-device-profiler --use-realtime-profiler}"
+TILES_PER_CORE="${TILES_PER_CORE:-2}"
+INPUT_CB_DEPTH="${INPUT_CB_DEPTH:-2}"
+READER_PUSH="${READER_PUSH:-1}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_HOME
+export TT_METAL_DEVICE_PROFILER=1
+
+BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
+TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+EXPORT_PY="${SCRIPT_DIR}/export_op_to_op_profiler_csv.py"
+LOG_DIR="${TT_METAL_HOME}/generated/profiler/.logs"
+RUNS_PARENT="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/${CONFIG_LABEL}"
+
+echo "TT_METAL_HOME=${TT_METAL_HOME}"
+echo "CONFIG_LABEL=${CONFIG_LABEL}"
+echo "EXTRA_ARGS=${EXTRA_ARGS}"
+echo "Runs: ${NUM_RUNS} -> ${RUNS_PARENT}/run_*"
+
+if [[ "${BUILD:-1}" != "0" ]]; then
+  cmake --build "${BUILD_DIR}" --target test_op_to_op_latency -j
+fi
+
+mkdir -p "${RUNS_PARENT}"
+
+# shellcheck disable=SC2086
+EXTRA_ARGS_ARR=(${EXTRA_ARGS})
+
+for i in $(seq 1 "${NUM_RUNS}"); do
+  run_dir="${RUNS_PARENT}/run_${i}"
+  mkdir -p "${run_dir}"
+  echo "=== ${CONFIG_LABEL} Run ${i}/${NUM_RUNS} ==="
+  rm -f "${LOG_DIR}/profile_log_device.csv" "${LOG_DIR}/profile_log_device_rt.csv"
+  "${TEST_BIN}" "${EXTRA_ARGS_ARR[@]}"
+  cp "${LOG_DIR}/profile_log_device.csv" "${run_dir}/profile_log_device.csv"
+  if [[ -f "${LOG_DIR}/profile_log_device_rt.csv" ]]; then
+    cp "${LOG_DIR}/profile_log_device_rt.csv" "${run_dir}/profile_log_device_rt.csv"
+  fi
+  python3 "${EXPORT_PY}" \
+    --input-file "${run_dir}/profile_log_device.csv" \
+    --rt-input-file "${run_dir}/profile_log_device_rt.csv" \
+    --tiles-per-core "${TILES_PER_CORE}" \
+    --input-cb-depth-tiles "${INPUT_CB_DEPTH}" \
+    --reader-push-tiles "${READER_PUSH}" \
+    --output-dir "${run_dir}"
+done
+
+python3 "${EXPORT_PY}" --aggregate-runs-dir "${RUNS_PARENT}" --output-dir "${RUNS_PARENT}"
+echo "Done. Per-run CSVs under ${RUNS_PARENT}/run_*/"
+echo "Multi-run summary: ${RUNS_PARENT}/multi_run_*.csv"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
@@ -27,10 +27,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
 TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 EXPORT_PY="${SCRIPT_DIR}/export_op_to_op_profiler_csv.py"
+EXPORT_PY_LITE="${SCRIPT_DIR}/export_op_to_op_gaps_csvlite.py"
+PYTHON="${TT_METAL_HOME}/python_env/bin/python3"
+if [[ ! -x "${PYTHON}" ]]; then
+  PYTHON="python3"
+fi
 LOG_DIR="${TT_METAL_HOME}/generated/profiler/.logs"
 RUNS_PARENT="${TT_METAL_HOME}/generated/profiler/op_to_op_runs/${CONFIG_LABEL}"
 
@@ -58,16 +64,24 @@ for i in $(seq 1 "${NUM_RUNS}"); do
   if [[ -f "${LOG_DIR}/profile_log_device_rt.csv" ]]; then
     cp "${LOG_DIR}/profile_log_device_rt.csv" "${run_dir}/profile_log_device_rt.csv"
   fi
-  python3 "${EXPORT_PY}" \
+  if ! "${PYTHON}" "${EXPORT_PY}" \
     --input-file "${run_dir}/profile_log_device.csv" \
     --rt-input-file "${run_dir}/profile_log_device_rt.csv" \
     --tiles-per-core "${TILES_PER_CORE}" \
     --input-cb-depth-tiles "${INPUT_CB_DEPTH}" \
     --reader-push-tiles "${READER_PUSH}" \
     --min-prog-id "${MIN_PROG_ID}" \
-    --output-dir "${run_dir}"
+    --output-dir "${run_dir}" 2>/dev/null; then
+    echo "  pandas export failed; using csvlite fallback"
+    "${PYTHON}" "${EXPORT_PY_LITE}" \
+      --input-file "${run_dir}/profile_log_device.csv" \
+      --output-file "${run_dir}/profile_log_device_op_to_op_complete.csv" \
+      --min-prog-id "${MIN_PROG_ID}"
+  fi
 done
 
-python3 "${EXPORT_PY}" --aggregate-runs-dir "${RUNS_PARENT}" --output-dir "${RUNS_PARENT}"
+"${PYTHON}" "${EXPORT_PY}" --aggregate-runs-dir "${RUNS_PARENT}" --output-dir "${RUNS_PARENT}" 2>/dev/null \
+  || "${PYTHON}" "${EXPORT_PY_LITE}" --aggregate-runs-dir "${RUNS_PARENT}" --min-prog-id "${MIN_PROG_ID}" 2>/dev/null \
+  || true
 echo "Done. Per-run CSVs under ${RUNS_PARENT}/run_*/"
 echo "Multi-run summary: ${RUNS_PARENT}/multi_run_*.csv"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_multi.sh
@@ -27,7 +27,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_HOME
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BUILD_DIR="${BUILD_DIR:-${TT_METAL_HOME}/build_Release}"
 TEST_BIN="${BUILD_DIR}/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_validation.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_validation.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Steady-state op-to-op validation: trace warmup + later program transitions.
+#
+# - trace warmup replays (2 untimed) then 1 measured replay
+# - num_programs=8 so we can analyze transitions >= 3→4
+# - longer kernel (~10-20us): 16 tiles/core + compute nops
+# - export with --min-prog-id 3 (skip early transitions)
+#
+# Usage:
+#   ./run_op_to_op_validation.sh [NUM_RUNS] [NUM_ACTIVE_CORES]
+#
+set -euo pipefail
+
+NUM_RUNS="${1:-5}"
+NUM_CORES="${2:-110}"
+
+CONFIG_LABEL="validation_cores${NUM_CORES}" \
+MIN_PROG_ID=3 \
+TILES_PER_CORE=16 \
+INPUT_CB_DEPTH=2 \
+READER_PUSH=2 \
+EXTRA_ARGS="--use-trace --trace-warmup-replays 2 --num-programs 8 --compute-nops 2000 --use-device-profiler --use-realtime-profiler --reader-dbuf-trid --input-cb-depth-tiles 2 --output-cb-depth-tiles 4 --num-pages-per-core 16 --num-active-cores ${NUM_CORES}" \
+bash "$(dirname "$0")/run_op_to_op_multi.sh" "${NUM_RUNS}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_outcb_balanced.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_outcb_balanced.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Output-CB depth -> math-to-math, evaluated at the BALANCED knee NOPs (not nops=0), since
+# the out_cb drain-tail effect depends on compute pacing. Per core count: find the knee NOPs
+# (largest where read BW still >= 95% of peak), then sweep out_cb at that NOPs. N=4, in_cb=64.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUTDIR}/m2m_vs_outcb_balanced.csv"
+mkdir -p "${OUTDIR}"
+
+N="${N:-4}"
+READER_NOC="${READER_NOC:-0}"   # good: reader=0/writer=1 ; swapped (write-contended): reader=1/writer=0
+WRITER_NOC="${WRITER_NOC:-1}"
+IN_CB="${IN_CB:-64}"
+PAGES="${PAGES:-1024}"
+CORES_LIST="${CORES_LIST:-8 16 56}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2 4 8 16 32 64}"
+NOP_SWEEP="${NOP_SWEEP:-0 32 64 128 256 512 1024 2048}"
+KNEE_TOL="${KNEE_TOL:-0.95}"
+
+run() { # cores out_cb nops
+  rm -f "${DEV_CSV}"
+  "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "$2" --writer-end-barrier-mode 0 \
+    --reader-noc "${READER_NOC}" --writer-noc "${WRITER_NOC}" \
+    --lean-compute --skip-output-validation \
+    --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops "$3" \
+    --use-trace --trace-warmup-replays 1 --num-active-cores "$1" --use-device-profiler >/tmp/ocb_run.log 2>&1
+  grep -q PASSED /tmp/ocb_run.log
+}
+field() { "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "$1" 2>/dev/null | awk -v f="$2" '$1==f{print $2}'; }
+
+rm -f "${OUT}"
+for C in ${CORES_LIST}; do
+  echo "==== cores=${C}: knee search (N=${N}, out_cb=8) ===="
+  run "${C}" 8 0 || { echo "  nops=0 FAILED"; continue; }
+  peak=$(field "${C}" agg_read_gbps); knee=0
+  for nq in ${NOP_SWEEP}; do
+    run "${C}" 8 "${nq}" || continue
+    bw=$(field "${C}" agg_read_gbps)
+    echo "  nops=${nq}: agg_read=${bw}"
+    if awk -v a="${bw:-0}" -v p="${peak}" -v t="${KNEE_TOL}" 'BEGIN{exit !(a>=p*t)}'; then knee="${nq}"; else break; fi
+  done
+  echo "  -> balanced knee nops=${knee} (peak_read=${peak})"
+  echo "==== cores=${C}: output-CB sweep at balanced nops=${knee} ===="
+  for o in ${OUTPUT_DEPTHS}; do
+    if run "${C}" "${o}" "${knee}"; then
+      "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
+        --label "cores=${C};nops=${knee};out_cb=${o}" 2>/dev/null \
+        | grep -E "agg_total_gbps|math_to_math_us|reader_to_writer_us"
+      echo "  cores=${C} out_cb=${o} done"
+    else echo "  cores=${C} out_cb=${o} FAILED"; fi
+  done
+done
+echo "OUTCB_BALANCED_COMPLETE"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_outcb_balanced.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_outcb_balanced.sh
@@ -9,7 +9,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
@@ -57,7 +58,7 @@ for C in ${CORES_LIST}; do
     if run "${C}" "${o}" "${knee}"; then
       "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
         --label "cores=${C};nops=${knee};out_cb=${o}" 2>/dev/null \
-        | grep -E "agg_total_gbps|math_to_math_us|reader_to_writer_us"
+        | grep -E "agg_total_gbps|official_op2op_min_us|m2m_bubble_us|reader_to_writer_us"
       echo "  cores=${C} out_cb=${o} done"
     else echo "  cores=${C} out_cb=${o} FAILED"; fi
   done

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_read_bw_noc_table.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_read_bw_noc_table.sh
@@ -11,7 +11,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_read_bw_noc_table.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_read_bw_noc_table.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Read-BW vs spatial-extent x NoC table (read-only, isolates the read NoC path).
+# 4 series: {rows, cols} x {default reader NoC (NOC1), swapped (NOC0)}.
+#   rows: N full rows of cores (N*WIDTH), grown row-major.
+#   cols: N full columns (N*HEIGHT), grown column-major.
+# Per point, picks the best input-CB depth. Emits one CSV: orientation,noc,units,cores,in_cb,read_gbps.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUTDIR}/read_bw_noc_table.csv"
+mkdir -p "${OUTDIR}"
+
+WIDTH="${WIDTH:-8}"          # usable grid width (cores per row)
+HEIGHT="${HEIGHT:-7}"        # usable grid height (cores per column)
+INPUT_DEPTHS="${INPUT_DEPTHS:-16 32}"
+N="${N:-8}"                  # trid_in_flight
+PAGES="${PAGES:-1024}"
+
+echo "orientation,noc,units,cores,in_cb,read_gbps" > "${OUT}"
+
+# best read BW over input depths -> echoes "bw in_cb"
+measure() { # layout_flag swap_flag cores
+  local lf="$1" sw="$2" cores="$3" best=0 bestd=0
+  for d in ${INPUT_DEPTHS}; do
+    rm -f "${DEV_CSV}"
+    "${BIN}" --read-only --lean-compute ${lf} ${sw} \
+      --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+      --input-cb-depth-tiles "${d}" --output-cb-depth-tiles 2 \
+      --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
+      --use-trace --trace-warmup-replays 1 --num-active-cores "${cores}" --use-device-profiler \
+      >/tmp/rbnoc_run.log 2>&1
+    grep -q PASSED /tmp/rbnoc_run.log || continue
+    local bw
+    bw=$("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${cores}" 2>/dev/null | awk '/agg_read_gbps/{print $2}')
+    awk -v a="${bw:-0}" -v b="${best}" 'BEGIN{exit !(a>b)}' && { best="${bw}"; bestd="${d}"; }
+  done
+  echo "${best} ${bestd}"
+}
+
+for noc in default swapped; do
+  sw=""; [ "${noc}" = "swapped" ] && sw="--swap-nocs"
+  for u in $(seq 1 "${HEIGHT}"); do          # rows: 1..HEIGHT rows of WIDTH cores
+    cores=$((u * WIDTH))
+    read -r bw d < <(measure "" "${sw}" "${cores}")
+    echo "rows,${noc},${u},${cores},${d},${bw}" >> "${OUT}"
+    echo "rows noc=${noc} ${u} row(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
+  done
+  for u in $(seq 1 "${WIDTH}"); do            # cols: 1..WIDTH columns of HEIGHT cores
+    cores=$((u * HEIGHT))
+    read -r bw d < <(measure "--core-layout-col" "${sw}" "${cores}")
+    echo "cols,${noc},${u},${cores},${d},${bw}" >> "${OUT}"
+    echo "cols noc=${noc} ${u} col(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
+  done
+done
+echo "READ_BW_NOC_TABLE_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_read_bw_noc_table.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_read_bw_noc_table.sh
@@ -29,11 +29,11 @@ PAGES="${PAGES:-1024}"
 echo "orientation,noc,units,cores,in_cb,read_gbps" > "${OUT}"
 
 # best read BW over input depths -> echoes "bw in_cb"
-measure() { # layout_flag swap_flag cores
-  local lf="$1" sw="$2" cores="$3" best=0 bestd=0
+measure() { # layout_flag extra_flags cores
+  local lf="$1" extra="$2" cores="$3" best=0 bestd=0
   for d in ${INPUT_DEPTHS}; do
     rm -f "${DEV_CSV}"
-    "${BIN}" --read-only --lean-compute ${lf} ${sw} \
+    "${BIN}" --read-only --lean-compute ${lf} ${extra} \
       --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
       --input-cb-depth-tiles "${d}" --output-cb-depth-tiles 2 \
       --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
@@ -47,19 +47,19 @@ measure() { # layout_flag swap_flag cores
   echo "${best} ${bestd}"
 }
 
-for noc in default swapped; do
-  sw=""; [ "${noc}" = "swapped" ] && sw="--swap-nocs"
+for rnoc in 0 1; do
+  noc="noc${rnoc}"; extra="--reader-noc ${rnoc}"
   for u in $(seq 1 "${HEIGHT}"); do          # rows: 1..HEIGHT rows of WIDTH cores
     cores=$((u * WIDTH))
-    read -r bw d < <(measure "" "${sw}" "${cores}")
+    read -r bw d < <(measure "" "${extra}" "${cores}")
     echo "rows,${noc},${u},${cores},${d},${bw}" >> "${OUT}"
-    echo "rows noc=${noc} ${u} row(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
+    echo "rows reader=${noc} ${u} row(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
   done
   for u in $(seq 1 "${WIDTH}"); do            # cols: 1..WIDTH columns of HEIGHT cores
     cores=$((u * HEIGHT))
-    read -r bw d < <(measure "--core-layout-col" "${sw}" "${cores}")
+    read -r bw d < <(measure "--core-layout-col" "${extra}" "${cores}")
     echo "cols,${noc},${u},${cores},${d},${bw}" >> "${OUT}"
-    echo "cols noc=${noc} ${u} col(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
+    echo "cols reader=${noc} ${u} col(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
   done
 done
 echo "READ_BW_NOC_TABLE_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_spread_tables.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_spread_tables.sh
@@ -11,7 +11,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_spread_tables.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_spread_tables.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Two matched-parameter tables for one spreadsheet tab (good NoC config, row layout):
+#   Table 1 spread_vs_cores.csv : BW + done-spread vs core count (nops=0). Spread grows.
+#   Table 2 spread_vs_nops.csv  : writer spread vs NOPs at fixed cores. Spread drops back.
+# Identical pages/core, input/output CB across both so they agree at (cores=FIX, nops=0).
+# writer_spread_pct = spread / per-core op duration (work-size independent).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+mkdir -p "${OUTDIR}"
+
+PAGES="${PAGES:-512}"          # fixed per-core work (so spread is comparable across runs)
+IN_CB="${IN_CB:-32}"
+OUT_CB="${OUT_CB:-16}"         # held deep+fixed so output buffering isn't a confound
+N="${N:-8}"
+CORES_LIST="${CORES_LIST:-1 2 4 8 16 24 32 40 48 56}"
+NOPS_LIST="${NOPS_LIST:-0 64 128 256 512 1024 2048 4096}"
+FIX_CORES="${FIX_CORES:-56}"
+
+run() { # cores nops
+  rm -f "${DEV_CSV}"
+  "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${OUT_CB}" --writer-end-barrier-mode 0 \
+    --lean-compute --skip-output-validation \
+    --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops "$2" \
+    --use-trace --trace-warmup-replays 1 --num-active-cores "$1" --use-device-profiler >/tmp/st_run.log 2>&1
+  grep -q PASSED /tmp/st_run.log
+}
+
+T1="${OUTDIR}/spread_vs_cores.csv"; rm -f "${T1}"
+echo "==== Table 1: BW + done-spread vs cores (nops=0, row) ===="
+for C in ${CORES_LIST}; do
+  if run "${C}" 0; then
+    "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${T1}" \
+      --label "cores=${C};nops=0" 2>/dev/null \
+      | grep -E "agg_total_gbps|writer_done_spread_us|writer_spread_pct|starvation_ratio"
+    echo "  T1 cores=${C} done"
+  else echo "  T1 cores=${C} FAILED: $(grep -oE 'TT_FATAL: .*' /tmp/st_run.log | head -1)"; fi
+done
+
+T2="${OUTDIR}/spread_vs_nops.csv"; rm -f "${T2}"
+echo "==== Table 2: writer spread vs NOPs (cores=${FIX_CORES}, row) ===="
+for NQ in ${NOPS_LIST}; do
+  if run "${FIX_CORES}" "${NQ}"; then
+    "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${FIX_CORES}" --csv-out "${T2}" \
+      --label "cores=${FIX_CORES};nops=${NQ}" 2>/dev/null \
+      | grep -E "agg_total_gbps|writer_done_spread_us|writer_spread_pct|starvation_ratio"
+    echo "  T2 nops=${NQ} done"
+  else echo "  T2 nops=${NQ} FAILED"; fi
+done
+echo "SPREAD_TABLES_COMPLETE"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_stage_a_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_stage_a_sweep.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stage A of the op-to-op latency/BW campaign: balanced-compute decomposition sweep.
+# For each layout (row, column) x core count:
+#   1. tune input CB depth for peak aggregate read BW (nops=0, read-bound),
+#   2. derive balanced compute: nops so per-tile compute (~COPY_NS + nops) ~= per-tile
+#      read time at the measured per-core BW,
+#   3. final full-pipeline run, decompose into BW + latency + starvation columns.
+# Emits one CSV per layout (chart-ready). Resumable: rows already present are skipped.
+# Reader trid_in_flight is locked at 8 (re-tune showed it flat 4..32).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+mkdir -p "${OUTDIR}"
+
+CORES="${CORES:-1 2 4 8 16 32 56}"          # coarse first; densify (e.g. add 48) later
+LAYOUTS="${LAYOUTS:-row col}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-16 32 64}"     # input CB depth candidates (>= 2*trid_in_flight)
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2 4 8 16 32}"  # output CB candidates (tuned in balanced regime)
+OUT_CB_BASE="${OUT_CB_BASE:-4}"              # output CB used during the input-depth tune
+N="${N:-8}"                                  # trid_in_flight, locked
+PAGES="${PAGES:-1024}"                       # tiles/core
+TUNE_PROGS="${TUNE_PROGS:-2}"
+FINAL_PROGS="${FINAL_PROGS:-4}"
+BW_TOL="${BW_TOL:-0.98}"                     # smallest depth within this frac of peak BW
+# Balance = NOP knee: largest NOPs/tile where read BW still sits at its read-bound peak.
+# Beyond the knee compute gates reads (BW drops). Early-exit once BW falls below KNEE_TOL*peak.
+NOP_SWEEP="${NOP_SWEEP:-0 32 64 128 256 512 1024 1536}"
+KNEE_TOL="${KNEE_TOL:-0.95}"
+
+run_test() { # layout_flag cores in_cb out_cb nops nprogs
+  local lf="$1" cores="$2" in_cb="$3" out_cb="$4" nops="$5" nprogs="$6"
+  rm -f "${DEV_CSV}"
+  "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "${in_cb}" --output-cb-depth-tiles "${out_cb}" \
+    --writer-end-barrier-mode 0 --lean-compute --skip-output-validation ${lf} \
+    --num-pages-per-core "${PAGES}" --num-programs "${nprogs}" \
+    --use-trace --trace-warmup-replays 1 --compute-nops "${nops}" \
+    --num-active-cores "${cores}" --use-device-profiler >/tmp/stage_a_run.log 2>&1
+  grep -q "PASSED" /tmp/stage_a_run.log
+}
+
+decomp_field() { # field-name cores  (reads current DEV_CSV, prints value)
+  "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "$2" 2>/dev/null \
+    | awk -v f="$1" '$1==f{print $2}'
+}
+
+for layout in ${LAYOUTS}; do
+  lf=""; [ "${layout}" = "col" ] && lf="--core-layout-col"
+  OUT="${OUTDIR}/stage_a_${layout}.csv"
+  for C in ${CORES}; do
+    if [ -f "${OUT}" ] && grep -q "^${layout},${C}," "${OUT}"; then
+      echo "[skip] ${layout} cores=${C} (already in ${OUT})"; continue
+    fi
+    # --- Stage 1: tune input CB depth at nops=0 (read-bound), max agg_read ---
+    echo "==== ${layout} cores=${C}: tuning input CB depth (nops=0) ===="
+    best_bw=0; declare -A BW_AT; declare -A PCMED_AT
+    for d in ${INPUT_DEPTHS}; do
+      if ! run_test "${lf}" "${C}" "${d}" "${OUT_CB_BASE}" 0 "${TUNE_PROGS}"; then
+        echo "  in_cb=${d}: FAILED ($(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1))"; continue
+      fi
+      bw=$(decomp_field agg_read_gbps "${C}"); pcm=$(decomp_field per_core_gbps_median "${C}")
+      BW_AT[$d]="${bw:-0}"; PCMED_AT[$d]="${pcm:-0}"
+      echo "  in_cb=${d}: agg_read=${bw} GB/s  per_core_med=${pcm}"
+      awk -v a="${bw:-0}" -v b="${best_bw}" 'BEGIN{exit !(a>b)}' && best_bw="${bw}"
+    done
+    [ "${best_bw}" = "0" ] && { echo "  no successful input tune; skipping"; unset BW_AT PCMED_AT; continue; }
+    best_in=""
+    for d in ${INPUT_DEPTHS}; do
+      [ -z "${BW_AT[$d]:-}" ] && continue
+      if awk -v a="${BW_AT[$d]}" -v p="${best_bw}" -v t="${BW_TOL}" 'BEGIN{exit !(a>=p*t)}'; then best_in="${d}"; break; fi
+    done
+    peak_read="${BW_AT[$best_in]}"
+    echo "  -> in_cb=${best_in} (read-bound peak agg_read=${peak_read})"
+
+    # --- Balance via NOP knee: largest NOPs where agg_read still >= KNEE_TOL*peak ---
+    echo "==== ${layout} cores=${C}: NOP-knee search (peak_read=${peak_read}) ===="
+    nops=0
+    for nq in ${NOP_SWEEP}; do
+      if ! run_test "${lf}" "${C}" "${best_in}" "${OUT_CB_BASE}" "${nq}" "${TUNE_PROGS}"; then
+        echo "  nops=${nq}: FAILED"; continue
+      fi
+      bw=$(decomp_field agg_read_gbps "${C}")
+      echo "  nops=${nq}: agg_read=${bw}"
+      if awk -v a="${bw:-0}" -v p="${peak_read}" -v t="${KNEE_TOL}" 'BEGIN{exit !(a>=p*t)}'; then
+        nops="${nq}"
+      else
+        break  # past the knee: compute is gating reads
+      fi
+    done
+    echo "  -> balanced (knee) nops=${nops}"
+
+    # --- Stage 2: tune output CB depth in the BALANCED regime, max agg_total ---
+    # (Output starvation only appears once compute is real; at high cores partial read
+    #  starvation backs up the output CB and stalls compute, so deeper output can help.)
+    echo "==== ${layout} cores=${C}: tuning output CB depth (balanced nops=${nops}) ===="
+    best_tot=0; declare -A TOT_AT
+    for o in ${OUTPUT_DEPTHS}; do
+      if ! run_test "${lf}" "${C}" "${best_in}" "${o}" "${nops}" "${TUNE_PROGS}"; then
+        echo "  out_cb=${o}: FAILED ($(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1))"; continue
+      fi
+      tot=$(decomp_field agg_total_gbps "${C}")
+      TOT_AT[$o]="${tot:-0}"
+      echo "  out_cb=${o}: agg_total=${tot} GB/s"
+      awk -v a="${tot:-0}" -v b="${best_tot}" 'BEGIN{exit !(a>b)}' && best_tot="${tot}"
+    done
+    best_out="${OUT_CB_BASE}"
+    if [ "${best_tot}" != "0" ]; then
+      for o in ${OUTPUT_DEPTHS}; do
+        [ -z "${TOT_AT[$o]:-}" ] && continue
+        if awk -v a="${TOT_AT[$o]}" -v p="${best_tot}" -v t="${BW_TOL}" 'BEGIN{exit !(a>=p*t)}'; then best_out="${o}"; break; fi
+      done
+    fi
+    echo "  -> out_cb=${best_out} (agg_total peak=${best_tot})"
+
+    echo "==== ${layout} cores=${C}: final balanced run (in=${best_in} out=${best_out} nops=${nops}) ===="
+    if run_test "${lf}" "${C}" "${best_in}" "${best_out}" "${nops}" "${FINAL_PROGS}"; then
+      "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
+        --label "layout=${layout};cores=${C};in_cb=${best_in};out_cb=${best_out};nops=${nops};peak_read_gbps=${peak_read}" \
+        2>/dev/null | grep -E "agg_total_gbps|agg_read_gbps|math_to_math_us|starvation_ratio|writer_done_spread"
+      echo "  appended ${layout} cores=${C} -> ${OUT}"
+    else
+      echo "  FINAL FAILED for ${layout} cores=${C}: $(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1)"
+    fi
+    unset BW_AT PCMED_AT TOT_AT
+  done
+  echo; echo "==== ${layout} done: ${OUT} ===="; column -t -s, "${OUT}" 2>/dev/null || cat "${OUT}"
+done
+echo "STAGE_A_SWEEP_COMPLETE"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_stage_a_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_stage_a_sweep.sh
@@ -29,7 +29,12 @@ LAYOUTS="${LAYOUTS:-row col}"
 INPUT_DEPTHS="${INPUT_DEPTHS:-16 32 64}"     # input CB depth candidates (>= 2*trid_in_flight)
 OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2 4 8 16 32}"  # output CB candidates (tuned in balanced regime)
 OUT_CB_BASE="${OUT_CB_BASE:-4}"              # output CB used during the input-depth tune
-N="${N:-8}"                                  # trid_in_flight, locked
+N="${N:-4}"                                  # trid_in_flight (4 saturates BW at all core counts)
+# Final run is repeated per end-barrier mode so the writer-drain/barrier term of math-to-math
+# can be attributed: 0=noc_async_write_barrier (full ack), 1=writes_flushed, 2=none (relaxed).
+# writer-CB/barrier contribution = m2m(mode 0) - m2m(mode 2). Tuning runs at TUNE_BARRIER.
+BARRIER_MODES="${BARRIER_MODES:-0 1 2}"
+TUNE_BARRIER="${TUNE_BARRIER:-0}"
 PAGES="${PAGES:-1024}"                       # tiles/core
 TUNE_PROGS="${TUNE_PROGS:-2}"
 FINAL_PROGS="${FINAL_PROGS:-4}"
@@ -39,12 +44,12 @@ BW_TOL="${BW_TOL:-0.98}"                     # smallest depth within this frac o
 NOP_SWEEP="${NOP_SWEEP:-0 32 64 128 256 512 1024 1536}"
 KNEE_TOL="${KNEE_TOL:-0.95}"
 
-run_test() { # layout_flag cores in_cb out_cb nops nprogs
-  local lf="$1" cores="$2" in_cb="$3" out_cb="$4" nops="$5" nprogs="$6"
+run_test() { # layout_flag cores in_cb out_cb nops nprogs [barrier_mode=0]
+  local lf="$1" cores="$2" in_cb="$3" out_cb="$4" nops="$5" nprogs="$6" barrier="${7:-0}"
   rm -f "${DEV_CSV}"
   "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
     --input-cb-depth-tiles "${in_cb}" --output-cb-depth-tiles "${out_cb}" \
-    --writer-end-barrier-mode 0 --lean-compute --skip-output-validation ${lf} \
+    --writer-end-barrier-mode "${barrier}" --lean-compute --skip-output-validation ${lf} \
     --num-pages-per-core "${PAGES}" --num-programs "${nprogs}" \
     --use-trace --trace-warmup-replays 1 --compute-nops "${nops}" \
     --num-active-cores "${cores}" --use-device-profiler >/tmp/stage_a_run.log 2>&1
@@ -60,8 +65,11 @@ for layout in ${LAYOUTS}; do
   lf=""; [ "${layout}" = "col" ] && lf="--core-layout-col"
   OUT="${OUTDIR}/stage_a_${layout}.csv"
   for C in ${CORES}; do
-    if [ -f "${OUT}" ] && grep -q "^${layout},${C}," "${OUT}"; then
-      echo "[skip] ${layout} cores=${C} (already in ${OUT})"; continue
+    # Skip this (layout,cores) only if every barrier-mode row is already present.
+    if [ -f "${OUT}" ]; then
+      have_all=1
+      for m in ${BARRIER_MODES}; do grep -q "^${layout},${C},${m}," "${OUT}" || have_all=0; done
+      if [ "${have_all}" = "1" ]; then echo "[skip] ${layout} cores=${C} (all modes present)"; continue; fi
     fi
     # --- Stage 1: tune input CB depth at nops=0 (read-bound), max agg_read ---
     echo "==== ${layout} cores=${C}: tuning input CB depth (nops=0) ===="
@@ -124,15 +132,18 @@ for layout in ${LAYOUTS}; do
     fi
     echo "  -> out_cb=${best_out} (agg_total peak=${best_tot})"
 
-    echo "==== ${layout} cores=${C}: final balanced run (in=${best_in} out=${best_out} nops=${nops}) ===="
-    if run_test "${lf}" "${C}" "${best_in}" "${best_out}" "${nops}" "${FINAL_PROGS}"; then
-      "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
-        --label "layout=${layout};cores=${C};in_cb=${best_in};out_cb=${best_out};nops=${nops};peak_read_gbps=${peak_read}" \
-        2>/dev/null | grep -E "agg_total_gbps|agg_read_gbps|math_to_math_us|starvation_ratio|writer_done_spread"
-      echo "  appended ${layout} cores=${C} -> ${OUT}"
-    else
-      echo "  FINAL FAILED for ${layout} cores=${C}: $(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1)"
-    fi
+    echo "==== ${layout} cores=${C}: final balanced runs (in=${best_in} out=${best_out} nops=${nops}) barriers=[${BARRIER_MODES}] ===="
+    for m in ${BARRIER_MODES}; do
+      if [ -f "${OUT}" ] && grep -q "^${layout},${C},${m}," "${OUT}"; then echo "  [skip] barrier=${m}"; continue; fi
+      if run_test "${lf}" "${C}" "${best_in}" "${best_out}" "${nops}" "${FINAL_PROGS}" "${m}"; then
+        "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
+          --label "layout=${layout};cores=${C};barrier=${m};in_cb=${best_in};out_cb=${best_out};nops=${nops};peak_read_gbps=${peak_read}" \
+          2>/dev/null | grep -E "agg_total_gbps|m2m_bubble_us|m2m_skew_env_us|finish_skew_us|start_skew_us|read_fill_head_us"
+        echo "  appended ${layout} cores=${C} barrier=${m} -> ${OUT}"
+      else
+        echo "  FINAL FAILED ${layout} cores=${C} barrier=${m}: $(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1)"
+      fi
+    done
     unset BW_AT PCMED_AT TOT_AT
   done
   echo; echo "==== ${layout} done: ${OUT} ===="; column -t -s, "${OUT}" 2>/dev/null || cat "${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_stage_a_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_stage_a_sweep.sh
@@ -15,7 +15,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_trid_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_trid_sweep.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sweep trid_in_flight (reads per per-trid batch = N) with CB DEPTH HELD FIXED (in_cb=64),
+# to isolate N from CB depth. Tests: (a) does larger N raise per-core BW (-> fewer cores to
+# saturate)?  (b) does larger N defer math start (bigger first batch -> later first push)?
+# good NoC config (default), row, nops=0 (read+write bound). in_cb=64 stays >= 2*N for N<=32.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUTDIR}/trid_sweep.csv"
+mkdir -p "${OUTDIR}"
+
+IN_CB="${IN_CB:-64}"          # fixed CB depth (>= 2*max N) to decouple from N
+OUT_CB="${OUT_CB:-8}"
+PAGES="${PAGES:-1024}"
+CORES_LIST="${CORES_LIST:-1 8 32}"
+TRID_LIST="${TRID_LIST:-2 4 8 16 32}"
+
+rm -f "${OUT}"
+for C in ${CORES_LIST}; do
+  for NF in ${TRID_LIST}; do
+    rm -f "${DEV_CSV}"
+    "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${NF}" --reader-push-tiles 2 \
+      --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${OUT_CB}" --writer-end-barrier-mode 0 \
+      --lean-compute --skip-output-validation \
+      --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
+      --use-trace --trace-warmup-replays 1 --num-active-cores "${C}" --use-device-profiler \
+      >/tmp/trid_run.log 2>&1
+    if grep -q PASSED /tmp/trid_run.log; then
+      "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
+        --label "cores=${C};trid=${NF};in_cb=${IN_CB}" 2>/dev/null \
+        | grep -E "agg_total_gbps|read_fill_head_us|math_to_math_us"
+      echo "  cores=${C} trid=${NF} done"
+    else echo "  cores=${C} trid=${NF} FAILED: $(grep -oE 'TT_FATAL: .*' /tmp/trid_run.log | head -1)"; fi
+  done
+done
+echo "TRID_SWEEP_COMPLETE"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_trid_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_trid_sweep.sh
@@ -10,7 +10,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
@@ -38,7 +39,7 @@ for C in ${CORES_LIST}; do
     if grep -q PASSED /tmp/trid_run.log; then
       "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
         --label "cores=${C};trid=${NF};in_cb=${IN_CB}" 2>/dev/null \
-        | grep -E "agg_total_gbps|read_fill_head_us|math_to_math_us"
+        | grep -E "agg_total_gbps|read_fill_head_us|official_op2op_min_us|m2m_bubble_us"
       echo "  cores=${C} trid=${NF} done"
     else echo "  cores=${C} trid=${NF} FAILED: $(grep -oE 'TT_FATAL: .*' /tmp/trid_run.log | head -1)"; fi
   done

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_write_bw_noc_table.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_write_bw_noc_table.sh
@@ -10,7 +10,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 export TT_METAL_DEVICE_PROFILER=1
-export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
 BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
 PY="${TT_METAL_HOME}/python_env/bin/python3"
 DEC="${SCRIPT_DIR}/decompose_latency_bw.py"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_write_bw_noc_table.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_write_bw_noc_table.sh
@@ -25,15 +25,17 @@ OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2 8 16}"
 IN_CB="${IN_CB:-32}"        # reads on NOC0 aren't the bottleneck; fixed input depth
 N="${N:-8}"
 PAGES="${PAGES:-1024}"
-READER_NOC="${READER_NOC:-0}"   # pin reader to its best NoC
 
 # best write BW over output depths -> echoes "bw out_cb"
+# CONSTRAINT: reader and writer must be on DIFFERENT NoCs, so reader = the other NoC.
+# This means the two writer-NoC series are the two valid pipeline configs:
+#   writer=NOC1 (reader=NOC0, fast reads) and writer=NOC0 (reader=NOC1, read-capped).
 measure() { # layout_flag wnoc cores
-  local lf="$1" wnoc="$2" cores="$3" best=0 besto=0
+  local lf="$1" wnoc="$2" cores="$3" rnoc=$((1 - wnoc)) best=0 besto=0
   for o in ${OUTPUT_DEPTHS}; do
     rm -f "${DEV_CSV}"
     "${BIN}" --lean-compute --skip-output-validation ${lf} \
-      --reader-noc "${READER_NOC}" --writer-noc "${wnoc}" \
+      --reader-noc "${rnoc}" --writer-noc "${wnoc}" \
       --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
       --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${o}" --writer-end-barrier-mode 0 \
       --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_write_bw_noc_table.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_write_bw_noc_table.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Write-BW vs spatial-extent x writer-NoC table (full pipeline, reader pinned to its best
+# NoC = NOC0 so reads don't bottleneck; isolates the writer NoC's effect on write BW).
+# 4 series: {rows, cols} x {writer NOC0, writer NOC1}.
+# Per point, picks the best output-CB depth (writer pipelining). Emits one CSV.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUTDIR}/write_bw_noc_table.csv"
+mkdir -p "${OUTDIR}"
+
+WIDTH="${WIDTH:-8}"
+HEIGHT="${HEIGHT:-7}"
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2 8 16}"
+IN_CB="${IN_CB:-32}"        # reads on NOC0 aren't the bottleneck; fixed input depth
+N="${N:-8}"
+PAGES="${PAGES:-1024}"
+READER_NOC="${READER_NOC:-0}"   # pin reader to its best NoC
+
+# best write BW over output depths -> echoes "bw out_cb"
+measure() { # layout_flag wnoc cores
+  local lf="$1" wnoc="$2" cores="$3" best=0 besto=0
+  for o in ${OUTPUT_DEPTHS}; do
+    rm -f "${DEV_CSV}"
+    "${BIN}" --lean-compute --skip-output-validation ${lf} \
+      --reader-noc "${READER_NOC}" --writer-noc "${wnoc}" \
+      --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+      --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${o}" --writer-end-barrier-mode 0 \
+      --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
+      --use-trace --trace-warmup-replays 1 --num-active-cores "${cores}" --use-device-profiler \
+      >/tmp/wbnoc_run.log 2>&1
+    grep -q PASSED /tmp/wbnoc_run.log || continue
+    local bw
+    bw=$("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${cores}" 2>/dev/null | awk '/agg_write_gbps/{print $2}')
+    awk -v a="${bw:-0}" -v b="${best}" 'BEGIN{exit !(a>b)}' && { best="${bw}"; besto="${o}"; }
+  done
+  echo "${best} ${besto}"
+}
+
+echo "orientation,writer_noc,units,cores,out_cb,write_gbps" > "${OUT}"
+for wnoc in 0 1; do
+  for u in $(seq 1 "${HEIGHT}"); do
+    cores=$((u * WIDTH))
+    read -r bw o < <(measure "" "${wnoc}" "${cores}")
+    echo "rows,noc${wnoc},${u},${cores},${o},${bw}" >> "${OUT}"
+    echo "rows writer=noc${wnoc} ${u} row(s) cores=${cores} -> ${bw} GB/s (out_cb=${o})"
+  done
+  for u in $(seq 1 "${WIDTH}"); do
+    cores=$((u * HEIGHT))
+    read -r bw o < <(measure "--core-layout-col" "${wnoc}" "${cores}")
+    echo "cols,noc${wnoc},${u},${cores},${o},${bw}" >> "${OUT}"
+    echo "cols writer=noc${wnoc} ${u} col(s) cores=${cores} -> ${bw} GB/s (out_cb=${o})"
+  done
+done
+echo "WRITE_BW_NOC_TABLE_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -156,6 +156,10 @@ struct BenchmarkConfig {
     // Read-only mode: writer pops from output CB but skips DRAM writes.
     // Isolates pure DRAM read BW through the reader pipeline.
     bool read_only = false;
+    // Lean compute: drop per-tile TILE_IDX / MATH profiler markers (keep tile 0) so the
+    // consumer drains at full speed and does not back-pressure the reader. Use when
+    // measuring read bandwidth; compute cost is then copy + NOPs only.
+    bool lean_compute = false;
     // Writer: 0 = noc_async_writes_flushed every page; 1 = flush only when output
     // CB back-pressure requires it (recommended back-pressure write path).
     bool writer_flush_on_pressure = false;
@@ -233,6 +237,9 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     }
     if (test_args::has_command_option(args, "--read-only")) {
         cfg.read_only = true;
+    }
+    if (test_args::has_command_option(args, "--lean-compute")) {
+        cfg.lean_compute = true;
     }
     if (test_args::has_command_option(args, "--writer-flush-on-pressure")) {
         cfg.writer_flush_on_pressure = true;
@@ -669,7 +676,8 @@ BuiltProgram build_program(
             .compile_args = writer_compile_time_args});
 
     // Compute: copy_tile + tunable NOP spin.
-    std::vector<uint32_t> compute_compile_time_args = {kInputCbId, kOutputCbId, cfg.num_nops_per_tile};
+    std::vector<uint32_t> compute_compile_time_args = {
+        kInputCbId, kOutputCbId, cfg.num_nops_per_tile, cfg.lean_compute ? 0u : 1u};
     auto compute_kernel = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp",

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -124,14 +124,15 @@ struct BenchmarkConfig {
     uint32_t input_cb_depth_tiles = 0;
     // 0 = default 2 tiles (compute->writer still pops 1 at a time).
     uint32_t output_cb_depth_tiles = 0;
-    // 0 = reserve N then read+push one tile at a time; 1 = reserve N, read all, push N.
+    // 0 = reserve N then read+push one tile at a time; 1 = reserve N, read all, push N;
+    // 2 = per-trid double-buffer (N reads in flight per TRID).
     uint32_t reader_mode = 0;
+    // Reads in flight per TRID for reader_mode 2. CB depth must be
+    // >= 2 * reader_trid_in_flight * page_size_tiles.
+    uint32_t reader_trid_in_flight = 2;
     // DRAM page size in tiles. Larger pages = fewer, larger NoC transactions
     // per program. CB pages stay 1 tile each so compute kernel is unchanged.
     uint32_t page_size_tiles = 1;
-    // Writer barrier mode: 0 = per-tile barrier (default, mirrors current ops);
-    //                     1 = single barrier at end of all writes.
-    uint32_t write_barrier_mode = 0;
     // Cap active core count. 0 = use full grid (default). Used to test whether
     // brisc_done_to_go scales with core count.
     uint32_t num_active_cores = 0;
@@ -166,9 +167,8 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
         cfg.reader_mode = 2;
     }
     cfg.page_size_tiles = test_args::get_command_option_uint32(args, "--page-size-tiles", cfg.page_size_tiles);
-    if (test_args::has_command_option(args, "--writer-barrier-at-end")) {
-        cfg.write_barrier_mode = 1;
-    }
+    cfg.reader_trid_in_flight =
+        test_args::get_command_option_uint32(args, "--reader-trid-in-flight", cfg.reader_trid_in_flight);
     cfg.num_active_cores = test_args::get_command_option_uint32(args, "--num-active-cores", cfg.num_active_cores);
     if (test_args::has_command_option(args, "--buffer-tune")) {
         cfg.buffer_tune = true;
@@ -418,21 +418,21 @@ struct BuiltProgram {
     uint32_t tiles_per_core_group_2 = 0;
     uint32_t reader_push_tile_count = 2;
     uint32_t reader_mode = 0;
+    uint32_t reader_trid_in_flight = 2;
     uint32_t input_cb_depth_tiles = 0;
     uint32_t output_cb_depth_tiles = 2;
     uint32_t page_size_tiles = 1;
-    uint32_t write_barrier_mode = 0;
 };
 
-// Set reader/writer/compute runtime args (including program_id) on every active core.
+// Set reader/writer/compute runtime args (only the truly per-launch ones; kernel knobs
+// like reader_mode / push_tile_count / tiles_per_page / trid_in_flight are compile-time
+// args on the kernel so they fold into constants and dead code gets eliminated).
 void set_program_launch_args(
     Program& program,
     const BuiltProgram& built,
     uint32_t input_buffer_addr,
     uint32_t output_buffer_addr,
-    uint32_t program_id,
-    uint32_t reader_push_tile_count,
-    uint32_t reader_mode) {
+    uint32_t program_id) {
     const auto work_groups = {
         std::make_pair(built.core_group_1, built.tiles_per_core_group_1),
         std::make_pair(built.core_group_2, built.tiles_per_core_group_2)};
@@ -444,26 +444,12 @@ void set_program_launch_args(
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
                 SetRuntimeArgs(
-                    program,
-                    built.reader_kernel,
-                    core,
-                    {input_buffer_addr,
-                     tiles_per_core,
-                     start_tile_id,
-                     program_id,
-                     reader_push_tile_count,
-                     reader_mode,
-                     built.page_size_tiles});
+                    program, built.reader_kernel, core, {input_buffer_addr, tiles_per_core, start_tile_id, program_id});
                 SetRuntimeArgs(
                     program,
                     built.writer_kernel,
                     core,
-                    {output_buffer_addr,
-                     tiles_per_core,
-                     start_tile_id,
-                     program_id,
-                     built.page_size_tiles,
-                     built.write_barrier_mode});
+                    {output_buffer_addr, tiles_per_core, start_tile_id, program_id});
                 SetRuntimeArgs(program, built.compute_kernel, core, {tiles_per_core, program_id});
                 start_tile_id += tiles_per_core;
             }
@@ -479,14 +465,7 @@ void configure_program_launch(
     uint32_t output_buffer_addr,
     uint32_t profiler_program_id,
     uint32_t host_runtime_id) {
-    set_program_launch_args(
-        program,
-        built,
-        input_buffer_addr,
-        output_buffer_addr,
-        profiler_program_id,
-        built.reader_push_tile_count,
-        built.reader_mode);
+    set_program_launch_args(program, built, input_buffer_addr, output_buffer_addr, profiler_program_id);
     program.set_runtime_id(host_runtime_id);
 }
 
@@ -560,12 +539,23 @@ BuiltProgram build_program(
         "output CB depth ({}) must be >= --page-size-tiles ({}) so the writer can accumulate a full page",
         output_cb_depth,
         page_size_tiles);
+    const uint32_t trid_in_flight = cfg.reader_trid_in_flight > 0 ? cfg.reader_trid_in_flight : 2;
     if (cfg.reader_mode == 2) {
         TT_FATAL(
-            input_cb_depth >= 2 * page_size_tiles,
-            "per-trid DB needs input CB depth ({}) >= 2 * --page-size-tiles ({})",
+            trid_in_flight >= 2,
+            "--reader-trid-in-flight ({}) must be >= 2 for mode 2 (per-trid double-buffer needs both sides active)",
+            trid_in_flight);
+        TT_FATAL(
+            input_cb_depth >= 2 * trid_in_flight * page_size_tiles,
+            "per-trid DB needs input CB depth ({}) >= 2 * --reader-trid-in-flight ({}) * --page-size-tiles ({})",
             input_cb_depth,
-            2 * page_size_tiles);
+            trid_in_flight,
+            page_size_tiles);
+        TT_FATAL(
+            cfg.num_pages_per_core / page_size_tiles >= 1,
+            "--num-pages-per-core ({}) / --page-size-tiles ({}) must be >= 1 for reader_mode 2",
+            cfg.num_pages_per_core,
+            page_size_tiles);
     } else if (page_size_tiles > 1) {
         TT_FATAL(
             false,
@@ -575,12 +565,13 @@ BuiltProgram build_program(
 
     log_info(
         LogTest,
-        "Reader: push_tiles={}, input_cb_depth={}, output_cb_depth={}, page_size_tiles={} (compute->writer still 1 "
-        "tile at a time), reader_mode={} (0=incremental read+push, 1=batch read then push, 2=per-trid double-buffer)",
+        "Reader: push_tiles={}, input_cb_depth={}, output_cb_depth={}, page_size_tiles={}, trid_in_flight={} "
+        "(reader_mode={}: 0=incremental, 1=batch, 2=per-trid DB with N reads in flight per TRID)",
         push_tiles,
         input_cb_depth,
         output_cb_depth,
         page_size_tiles,
+        trid_in_flight,
         cfg.reader_mode);
 
     CircularBufferConfig cb_in_config =
@@ -594,7 +585,11 @@ BuiltProgram build_program(
     CreateCircularBuffer(program, all_cores, cb_out_config);
 
     // Reader: NOC1 / RISCV1, pulls from interleaved DRAM via TensorAccessor.
-    std::vector<uint32_t> reader_compile_time_args = {kInputCbId};
+    // Compile-time args order MUST match reader_interleaved.cpp:
+    //   [0]=cb_in, [1]=READER_MODE, [2]=PUSH_TILE_COUNT, [3]=TILES_PER_PAGE,
+    //   [4]=TRID_IN_FLIGHT, then TensorAccessorArgs starting at index 5.
+    std::vector<uint32_t> reader_compile_time_args = {
+        kInputCbId, cfg.reader_mode, push_tiles, page_size_tiles, trid_in_flight};
     TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
     auto reader_kernel = CreateKernel(
         program,
@@ -606,7 +601,9 @@ BuiltProgram build_program(
             .compile_args = reader_compile_time_args});
 
     // Writer: NOC0 / RISCV0, pushes to interleaved DRAM.
-    std::vector<uint32_t> writer_compile_time_args = {kOutputCbId};
+    // Compile-time args order MUST match writer_interleaved.cpp:
+    //   [0]=cb_out, [1]=TILES_PER_PAGE, then TensorAccessorArgs starting at index 2.
+    std::vector<uint32_t> writer_compile_time_args = {kOutputCbId, page_size_tiles};
     TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
     auto writer_kernel = CreateKernel(
         program,
@@ -637,26 +634,9 @@ BuiltProgram build_program(
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
                 SetRuntimeArgs(
-                    program,
-                    reader_kernel,
-                    core,
-                    {input_buffer->address(),
-                     tiles_per_core,
-                     start_tile_id,
-                     0,
-                     push_tiles,
-                     cfg.reader_mode,
-                     page_size_tiles});
+                    program, reader_kernel, core, {input_buffer->address(), tiles_per_core, start_tile_id, 0});
                 SetRuntimeArgs(
-                    program,
-                    writer_kernel,
-                    core,
-                    {output_buffer->address(),
-                     tiles_per_core,
-                     start_tile_id,
-                     0,
-                     page_size_tiles,
-                     cfg.write_barrier_mode});
+                    program, writer_kernel, core, {output_buffer->address(), tiles_per_core, start_tile_id, 0});
                 SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, 0});
                 start_tile_id += tiles_per_core;
             }
@@ -679,10 +659,10 @@ BuiltProgram build_program(
     built.tiles_per_core_group_2 = num_tiles_per_core_group_2;
     built.reader_push_tile_count = push_tiles;
     built.reader_mode = cfg.reader_mode;
+    built.reader_trid_in_flight = trid_in_flight;
     built.input_cb_depth_tiles = input_cb_depth;
     built.output_cb_depth_tiles = output_cb_depth;
     built.page_size_tiles = page_size_tiles;
-    built.write_barrier_mode = cfg.write_barrier_mode;
     return built;
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -41,7 +41,7 @@
 //                           (next start - previous end, ns). Inactive on some
 //                           dispatch setups; see
 //                           tech_reports/real_time_profiler/getting-started.md
-//   --no-warmup             skip the warmup enqueue
+//   --trace-warmup-replays N  untimed trace replays before the measured replay (default 0)
 //   --trace-region-size N   trace buffer size, bytes (default 1 MiB)
 //   --device-id N           device under test (default 0)
 //   --output-cb-depth-tiles N  output CB depth in tiles (default 2)
@@ -145,6 +145,8 @@ struct BenchmarkConfig {
     bool use_device_profiler = false;
     bool use_realtime_profiler = false;
     size_t trace_region_size = 1ull << 20;  // 1 MiB
+    // Untimed trace replays before the measured replay (steady-state trace path).
+    uint32_t trace_warmup_replays = 0;
 };
 
 BenchmarkConfig parse_args(const std::vector<std::string>& args) {
@@ -186,6 +188,8 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     cfg.device_id = test_args::get_command_option_uint32(args, "--device-id", cfg.device_id);
     cfg.trace_region_size =
         test_args::get_command_option_uint32(args, "--trace-region-size", static_cast<uint32_t>(cfg.trace_region_size));
+    cfg.trace_warmup_replays =
+        test_args::get_command_option_uint32(args, "--trace-warmup-replays", cfg.trace_warmup_replays);
     if (test_args::has_command_option(args, "--no-warmup")) {
         cfg.warmup = false;
     }
@@ -1159,7 +1163,8 @@ int main(int argc, char** argv) {
             LogTest,
             "op_to_op_latency: device_id={}, pages_per_core={}, reader_push_tiles={}, input_cb_depth_tiles={}, "
             "output_cb_depth_tiles={}, reader_mode={}, compute_nops={}, num_programs={}, warmup={}, use_trace={}, "
-            "use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}, buffer_tune={}",
+            "use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}, trace_warmup_replays={}, "
+            "buffer_tune={}",
             cfg.device_id,
             cfg.num_pages_per_core,
             cfg.reader_push_tile_count,
@@ -1173,6 +1178,7 @@ int main(int argc, char** argv) {
             cfg.use_device_profiler,
             cfg.use_realtime_profiler,
             cfg.trace_region_size,
+            cfg.trace_warmup_replays,
             cfg.buffer_tune);
         TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
         TT_FATAL(cfg.num_pages_per_core >= 1, "--num-pages-per-core must be >= 1");
@@ -1314,6 +1320,20 @@ int main(int argc, char** argv) {
             mesh_device->end_mesh_trace(kCqId, tid);
             distributed::Finish(cq);  // make sure capture is fully committed before timing
 
+            // Untimed replays warm up the trace path; we measure the steady-state replay.
+            for (uint32_t replay = 0; replay < cfg.trace_warmup_replays; ++replay) {
+                mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+                distributed::Finish(cq);
+                if (cfg.use_device_profiler) {
+                    // Flush device profiler so warmup markers do not pollute the timed replay.
+                    tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+                }
+            }
+            if (cfg.trace_warmup_replays > 0) {
+                log_info(
+                    LogTest, "Trace: {} untimed warmup replay(s) before measured replay", cfg.trace_warmup_replays);
+            }
+
             {
                 RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);
                 const auto t_begin = std::chrono::steady_clock::now();
@@ -1324,7 +1344,7 @@ int main(int argc, char** argv) {
             }
 
             mesh_device->release_mesh_trace(tid);
-            mode_label = "Trace replay";
+            mode_label = cfg.trace_warmup_replays > 0 ? "Trace replay (after warmup)" : "Trace replay";
         } else {
             {
                 RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Op-to-op latency benchmark.
+//
+// Background: HW team wants to measure the time between when one op's math
+// finishes and the next op's math starts (op-to-op latency). That gap is
+// firmware tear-down + dispatch + barrier overhead, and is what they need to
+// shrink (e.g. by virtualising init registers so program N+1 can preload
+// while N is still finishing, or by relaxing end-of-op barriers).
+//
+// This benchmark does the textbook reader -> CB -> compute -> CB -> writer
+// pipeline on every Tensix core, with interleaved DRAM in/out, then runs the
+// same MeshWorkload back-to-back N times in either Fast-Dispatch or Trace
+// mode. The compute kernel wraps its per-tile body in
+// DeviceZoneScopedMainN("MATH"), so a profiler-enabled build dumps
+// MATH_begin/MATH_end timestamps per TRISC per program-run per core into
+// generated/profiler/.logs/profile_log_device.csv.
+//
+// To get op-to-op latency:
+//   op_to_op_latency_per_core = MATH_begin[program N+1] - MATH_end[program N]
+//
+// CLI:
+//   --num-pages-per-core N  pages of interleaved DRAM per core (default 2)
+//   --compute-nops N        TTI_NOPs in the per-tile body (default 0;
+//                           tune up so the math zone is comfortably > 10us)
+//   --num-programs N        back-to-back enqueues per measurement (default 8)
+//   --use-trace             capture once + replay (default: FD mode)
+//   --use-device-profiler   call ReadMeshDeviceProfilerResults after Finish
+//                           (requires --enable-profiler build + env var
+//                            TT_METAL_DEVICE_PROFILER=1)
+//   --no-warmup             skip the warmup enqueue
+//   --trace-region-size N   trace buffer size, bytes (default 1 MiB)
+//   --device-id N           device under test (default 0)
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <hostdevcommon/common_values.hpp>
+#include "impl/context/metal_context.hpp"
+
+#include "test_common.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Defaults:
+//   num_pages_per_core = 2 matches Almeet's "each core gets 2 pages" suggestion
+//   num_nops_per_tile  = 0 keeps the math zone short for now; Step 4 will tune
+//                        this up to ~10us once we have profiler markers
+//                        in place to actually measure the kernel runtime.
+//   num_programs       = 8 enqueues back-to-back per measurement run; gives
+//                        seven (N-1) op-to-op gaps to look at later.
+//   warmup             = true runs one untimed enqueue first to absorb
+//                        dispatcher / kernel-setup transients.
+//   use_trace          = false keeps step-2 FD behaviour as default. Pass
+//                        --use-trace to capture-once / replay-once.
+//   trace_region_size  = 1 MiB. Plenty for tens of small back-to-back
+//                        programs; tunable via --trace-region-size if
+//                        --num-programs is bumped a lot.
+struct BenchmarkConfig {
+    uint32_t num_pages_per_core = 2;
+    uint32_t num_nops_per_tile = 0;
+    uint32_t num_programs = 8;
+    uint32_t device_id = 0;
+    bool warmup = true;
+    bool use_trace = false;
+    bool use_device_profiler = false;
+    size_t trace_region_size = 1ull << 20;  // 1 MiB
+};
+
+BenchmarkConfig parse_args(const std::vector<std::string>& args) {
+    BenchmarkConfig cfg;
+    cfg.num_pages_per_core = test_args::get_command_option_uint32(args, "--num-pages-per-core", cfg.num_pages_per_core);
+    cfg.num_nops_per_tile = test_args::get_command_option_uint32(args, "--compute-nops", cfg.num_nops_per_tile);
+    cfg.num_programs = test_args::get_command_option_uint32(args, "--num-programs", cfg.num_programs);
+    cfg.device_id = test_args::get_command_option_uint32(args, "--device-id", cfg.device_id);
+    cfg.trace_region_size =
+        test_args::get_command_option_uint32(args, "--trace-region-size", static_cast<uint32_t>(cfg.trace_region_size));
+    if (test_args::has_command_option(args, "--no-warmup")) {
+        cfg.warmup = false;
+    }
+    if (test_args::has_command_option(args, "--use-trace")) {
+        cfg.use_trace = true;
+    }
+    if (test_args::has_command_option(args, "--use-device-profiler")) {
+        cfg.use_device_profiler = true;
+    }
+    return cfg;
+}
+
+// Build the reader -> compute -> writer program covering every Tensix core,
+// with the per-core tile slice assigned via runtime args.
+Program build_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const BenchmarkConfig& cfg,
+    const std::shared_ptr<distributed::MeshBuffer>& input_buffer,
+    const std::shared_ptr<distributed::MeshBuffer>& output_buffer,
+    uint32_t total_num_tiles,
+    uint32_t single_tile_size_bytes) {
+    Program program = CreateProgram();
+
+    const auto grid = mesh_device->compute_with_storage_grid_size();
+    constexpr bool kRowMajor = true;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(grid, total_num_tiles, kRowMajor);
+
+    log_info(
+        LogTest,
+        "Grid {}x{}, {} cores active, total_num_tiles={} ({} tiles/core in group_1, {} in group_2)",
+        grid.x,
+        grid.y,
+        num_cores,
+        total_num_tiles,
+        num_tiles_per_core_group_1,
+        num_tiles_per_core_group_2);
+
+    // CBs: c_0 is reader -> compute, c_16 is compute -> writer. Sized at 2
+    // tiles each (double-buffered) so the reader/compute/writer can overlap.
+    constexpr uint32_t kInputCbId = tt::CBIndex::c_0;
+    constexpr uint32_t kOutputCbId = tt::CBIndex::c_16;
+    constexpr uint32_t kCbDepthInTiles = 2;
+    constexpr auto kDataFormat = tt::DataFormat::Float16_b;
+
+    CircularBufferConfig cb_in_config =
+        CircularBufferConfig(kCbDepthInTiles * single_tile_size_bytes, {{kInputCbId, kDataFormat}})
+            .set_page_size(kInputCbId, single_tile_size_bytes);
+    CreateCircularBuffer(program, all_cores, cb_in_config);
+
+    CircularBufferConfig cb_out_config =
+        CircularBufferConfig(kCbDepthInTiles * single_tile_size_bytes, {{kOutputCbId, kDataFormat}})
+            .set_page_size(kOutputCbId, single_tile_size_bytes);
+    CreateCircularBuffer(program, all_cores, cb_out_config);
+
+    // Reader: NOC1 / RISCV1, pulls from interleaved DRAM via TensorAccessor.
+    std::vector<uint32_t> reader_compile_time_args = {kInputCbId};
+    TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
+    auto reader_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_compile_time_args});
+
+    // Writer: NOC0 / RISCV0, pushes to interleaved DRAM.
+    std::vector<uint32_t> writer_compile_time_args = {kOutputCbId};
+    TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
+    auto writer_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_compile_time_args});
+
+    // Compute: copy_tile + tunable NOP spin.
+    std::vector<uint32_t> compute_compile_time_args = {kInputCbId, kOutputCbId, cfg.num_nops_per_tile};
+    auto compute_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp",
+        all_cores,
+        ComputeConfig{.compile_args = compute_compile_time_args});
+
+    // Per-core runtime args: each core gets [start_tile_id, start_tile_id + n_tiles).
+    const auto work_groups = {
+        std::make_pair(core_group_1, num_tiles_per_core_group_1),
+        std::make_pair(core_group_2, num_tiles_per_core_group_2)};
+    uint32_t start_tile_id = 0;
+    for (const auto& [group, tiles_per_core] : work_groups) {
+        if (tiles_per_core == 0) {
+            continue;
+        }
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                SetRuntimeArgs(program, reader_kernel, core, {input_buffer->address(), tiles_per_core, start_tile_id});
+                SetRuntimeArgs(program, writer_kernel, core, {output_buffer->address(), tiles_per_core, start_tile_id});
+                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core});
+                start_tile_id += tiles_per_core;
+            }
+        }
+    }
+    TT_FATAL(
+        start_tile_id == total_num_tiles,
+        "Tile distribution mismatch: assigned {} but expected {}",
+        start_tile_id,
+        total_num_tiles);
+
+    return program;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    bool pass = true;
+    try {
+        const std::vector<std::string> args(argv, argv + argc);
+        const BenchmarkConfig cfg = parse_args(args);
+
+        log_info(
+            LogTest,
+            "op_to_op_latency: device_id={}, pages_per_core={}, compute_nops={}, num_programs={}, warmup={}, "
+            "use_trace={}, use_device_profiler={}, trace_region_size={}",
+            cfg.device_id,
+            cfg.num_pages_per_core,
+            cfg.num_nops_per_tile,
+            cfg.num_programs,
+            cfg.warmup,
+            cfg.use_trace,
+            cfg.use_device_profiler,
+            cfg.trace_region_size);
+        TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
+
+        // If the user asked for a CSV dump, make sure the runtime profiler is
+        // actually enabled (--enable-profiler build + TT_METAL_DEVICE_PROFILER=1
+        // env var). Without this check, the CSV would just be empty and the
+        // failure mode would be silent. Pattern mirrors test_dram_offchip.cpp.
+        if (cfg.use_device_profiler) {
+            const bool profiler_runtime_enabled =
+                tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled();
+            TT_FATAL(
+                profiler_runtime_enabled,
+                "--use-device-profiler requires the device profiler to be enabled at runtime. "
+                "Build with `./build_metal.sh --enable-profiler` and set TT_METAL_DEVICE_PROFILER=1 "
+                "(e.g. `TT_METAL_DEVICE_PROFILER=1 ./test_op_to_op_latency --use-device-profiler ...`).");
+        }
+
+        // trace_region_size = 0 would disable trace capture entirely (legacy
+        // path) -- in trace mode we always want a non-zero value. The default
+        // is 1 MiB which covers tens of small programs comfortably.
+        const size_t trace_region_size = cfg.use_trace ? cfg.trace_region_size : 0;
+        auto mesh_device =
+            distributed::MeshDevice::create_unit_mesh(cfg.device_id, DEFAULT_L1_SMALL_SIZE, trace_region_size);
+
+        const auto grid = mesh_device->compute_with_storage_grid_size();
+        const uint32_t num_cores = grid.x * grid.y;
+        const uint32_t total_num_tiles = num_cores * cfg.num_pages_per_core;
+
+        constexpr auto kDataFormat = tt::DataFormat::Float16_b;
+        const uint32_t single_tile_size_bytes = tile_size(kDataFormat);
+        const uint32_t buffer_size_bytes = total_num_tiles * single_tile_size_bytes;
+
+        // Interleaved DRAM buffer: page_size == one tile, so pages are spread
+        // across DRAM banks round-robin. This is what makes the read/write
+        // pattern look like a real op.
+        distributed::DeviceLocalBufferConfig dram_local_config{
+            .page_size = single_tile_size_bytes,
+            .buffer_type = BufferType::DRAM,
+        };
+        distributed::ReplicatedBufferConfig dram_buf_config{.size = buffer_size_bytes};
+
+        auto input_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+        auto output_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+
+        // Random bf16 input data, packed two values per uint32_t.
+        const auto seed = static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
+        std::vector<uint32_t> input_data = create_random_vector_of_bfloat16(buffer_size_bytes, /*rand_max=*/100, seed);
+
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/false);
+
+        Program program =
+            build_program(mesh_device, cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
+
+        distributed::MeshWorkload workload;
+        const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+        workload.add_program(device_range, std::move(program));
+
+        // Warmup (untimed): one eager enqueue absorbs the JIT-load /
+        // dispatcher prefetch cost so they do not pollute either the FD timing
+        // loop or the trace-capture step.
+        if (cfg.warmup) {
+            distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            distributed::Finish(cq);
+        }
+
+        constexpr uint8_t kCqId = 0;
+        long long elapsed_us = 0;
+        const char* mode_label = nullptr;
+
+        if (cfg.use_trace) {
+            // Step 3: capture one trace containing all N back-to-back enqueues,
+            // then time a single replay + Finish. Capture itself is untimed --
+            // it's a one-time setup cost that is amortised when the same
+            // trace is replayed many times in real workloads.
+            //
+            // Note: BeginTraceCapture is the only trace API exposed as a free
+            // distributed:: function; end / replay / release are MeshDevice
+            // member methods.
+            const distributed::MeshTraceId tid = distributed::BeginTraceCapture(mesh_device.get(), kCqId);
+            for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            }
+            mesh_device->end_mesh_trace(kCqId, tid);
+            distributed::Finish(cq);  // make sure capture is fully committed before timing
+
+            const auto t_begin = std::chrono::steady_clock::now();
+            mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+            distributed::Finish(cq);
+            const auto t_end = std::chrono::steady_clock::now();
+            elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+
+            mesh_device->release_mesh_trace(tid);
+            mode_label = "Trace replay";
+        } else {
+            // Step 2: enqueue the same MeshWorkload back-to-back num_programs
+            // times under one Finish.
+            const auto t_begin = std::chrono::steady_clock::now();
+            for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            }
+            distributed::Finish(cq);
+            const auto t_end = std::chrono::steady_clock::now();
+            elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+            mode_label = "FD back-to-back";
+        }
+
+        const double avg_us_per_program = static_cast<double>(elapsed_us) / cfg.num_programs;
+        log_info(
+            LogTest,
+            "{}: {} programs in {} us (avg {:.2f} us/program)",
+            mode_label,
+            cfg.num_programs,
+            elapsed_us,
+            avg_us_per_program);
+
+        // Step 4: flush device profiler buffers to
+        // generated/profiler/.logs/profile_log_device.csv. Filter the rows
+        // for zone "MATH" and compute MATH_begin[N+1] - MATH_end[N] per core
+        // to get the on-chip op-to-op latency. tools/tracy/process_device_log.py
+        // can post-process the CSV.
+        if (cfg.use_device_profiler) {
+            tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+            log_info(
+                LogTest,
+                "Device profiler results dumped. Inspect "
+                "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv "
+                "and look for the 'MATH' zone to compute op-to-op latency.");
+        }
+
+        std::vector<uint32_t> output_data;
+        distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
+
+        if (output_data.size() != input_data.size()) {
+            log_error(
+                LogTest, "Output size mismatch: got {} elems, expected {}", output_data.size(), input_data.size());
+            pass = false;
+        } else {
+            const bool match = std::equal(input_data.begin(), input_data.end(), output_data.begin());
+            if (!match) {
+                size_t mismatch_count = 0;
+                size_t first_mismatch = 0;
+                for (size_t i = 0; i < input_data.size(); ++i) {
+                    if (input_data[i] != output_data[i]) {
+                        if (mismatch_count == 0) {
+                            first_mismatch = i;
+                        }
+                        ++mismatch_count;
+                    }
+                }
+                log_error(
+                    LogTest,
+                    "Output mismatch: {}/{} elements differ; first mismatch at index {} "
+                    "(in=0x{:08x}, out=0x{:08x})",
+                    mismatch_count,
+                    input_data.size(),
+                    first_mismatch,
+                    input_data[first_mismatch],
+                    output_data[first_mismatch]);
+                pass = false;
+            }
+        }
+
+        mesh_device->close();
+    } catch (const std::exception& e) {
+        log_error(LogTest, "Caught exception: {}", e.what());
+        pass = false;
+    }
+
+    if (pass) {
+        log_info(LogTest, "op_to_op_latency: PASSED");
+        return 0;
+    }
+    log_error(LogTest, "op_to_op_latency: FAILED");
+    return 1;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -68,10 +68,15 @@ using namespace tt::tt_metal;
 namespace {
 
 // Defaults:
-//   num_pages_per_core = 2 matches Almeet's "each core gets 2 pages" suggestion
-//   num_nops_per_tile  = 0 keeps the math zone short for now; Step 4 will tune
-//                        this up to ~10us once we have profiler markers
-//                        in place to actually measure the kernel runtime.
+//   num_pages_per_core = 2 (each core processes 2 interleaved DRAM pages, so
+//                        every Tensix sees ≥ 2 per-tile MATH-zone entries
+//                        and we still touch every DRAM bank in a chip-wide
+//                        interleaved layout).
+//   num_nops_per_tile  = 0 keeps the math zone short by default; tune this
+//                        up via --compute-nops until the per-tile MATH zone
+//                        in profile_log_device.csv is comfortably > 10us
+//                        (the target program runtime for op-to-op latency
+//                        measurement to be meaningful vs dispatch noise).
 //   num_programs       = 8 enqueues back-to-back per measurement run; gives
 //                        seven (N-1) op-to-op gaps to look at later.
 //   warmup             = true runs one untimed enqueue first to absorb

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -75,6 +75,7 @@
 #include <tt-metalium/experimental/realtime_profiler.hpp>
 #include <hostdevcommon/common_values.hpp>
 #include "impl/context/metal_context.hpp"
+#include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 
 #include "test_common.hpp"
 
@@ -263,9 +264,53 @@ struct RealtimeProfilerDrainGuard {
     }
 };
 
+struct BuiltProgram {
+    Program program;
+    KernelHandle compute_kernel = 0;
+};
+
+// Set compute runtime arg 1 (program_id) on every core. program_id 0 marks
+// pre-compile / warmup rows in the device CSV; timed launches use 1..N.
+void set_compute_program_id(
+    Program& program,
+    KernelHandle compute_kernel,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t total_num_tiles,
+    uint32_t program_id) {
+    const auto grid = mesh_device->compute_with_storage_grid_size();
+    constexpr bool kRowMajor = true;
+    auto [_num_cores, _all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(grid, total_num_tiles, kRowMajor);
+    const auto work_groups = {
+        std::make_pair(core_group_1, num_tiles_per_core_group_1),
+        std::make_pair(core_group_2, num_tiles_per_core_group_2)};
+    for (const auto& [group, tiles_per_core] : work_groups) {
+        if (tiles_per_core == 0) {
+            continue;
+        }
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, program_id});
+            }
+        }
+    }
+}
+
+// Configure host runtime id (RT profiler) and device CSV program_id before each launch.
+void configure_program_launch(
+    Program& program,
+    KernelHandle compute_kernel,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t total_num_tiles,
+    uint32_t profiler_program_id,
+    uint32_t host_runtime_id) {
+    set_compute_program_id(program, compute_kernel, mesh_device, total_num_tiles, profiler_program_id);
+    program.set_runtime_id(host_runtime_id);
+}
+
 // Build the reader -> compute -> writer program covering every Tensix core,
 // with the per-core tile slice assigned via runtime args.
-Program build_program(
+BuiltProgram build_program(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const BenchmarkConfig& cfg,
     const std::shared_ptr<distributed::MeshBuffer>& input_buffer,
@@ -351,7 +396,7 @@ Program build_program(
             for (const auto& core : range) {
                 SetRuntimeArgs(program, reader_kernel, core, {input_buffer->address(), tiles_per_core, start_tile_id});
                 SetRuntimeArgs(program, writer_kernel, core, {output_buffer->address(), tiles_per_core, start_tile_id});
-                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core});
+                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, /*program_id=*/0});
                 start_tile_id += tiles_per_core;
             }
         }
@@ -362,7 +407,7 @@ Program build_program(
         start_tile_id,
         total_num_tiles);
 
-    return program;
+    return BuiltProgram{std::move(program), compute_kernel};
 }
 
 }  // namespace
@@ -387,6 +432,7 @@ int main(int argc, char** argv) {
             cfg.use_realtime_profiler,
             cfg.trace_region_size);
         TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
+        TT_FATAL(cfg.num_pages_per_core >= 1, "--num-pages-per-core must be >= 1");
 
         // If the user asked for a CSV dump, make sure the runtime profiler is
         // actually enabled (Tracy-enabled build + TT_METAL_DEVICE_PROFILER=1
@@ -411,6 +457,8 @@ int main(int argc, char** argv) {
         auto mesh_device =
             distributed::MeshDevice::create_unit_mesh(cfg.device_id, DEFAULT_L1_SMALL_SIZE, trace_region_size);
 
+        log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->get_devices()[0]));
+
         const auto grid = mesh_device->compute_with_storage_grid_size();
         const uint32_t num_cores = grid.x * grid.y;
         const uint32_t total_num_tiles = num_cores * cfg.num_pages_per_core;
@@ -433,28 +481,38 @@ int main(int argc, char** argv) {
 
         // Random bf16 input data, packed two values per uint32_t.
         const auto seed = static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
-        std::vector<uint32_t> input_data = create_random_vector_of_bfloat16(buffer_size_bytes, /*rand_max=*/100, seed);
+        std::vector<uint32_t> input_data =
+            create_random_vector_of_bfloat16(buffer_size_bytes, /*rand_max_float=*/100, seed);
 
         auto& cq = mesh_device->mesh_command_queue();
         distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/false);
+        // Drain the input upload before trace capture: host writes are not allowed while
+        // a trace is being recorded (see FDMeshCommandQueue "Writes are not supported
+        // during trace capture"). Warmup's Finish used to hide this; --no-warmup needs
+        // an explicit Finish here.
+        distributed::Finish(cq);
 
-        Program program =
+        BuiltProgram built =
             build_program(mesh_device, cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
-
-        // Real-time profiler: D2H pages use the program's host runtime id as start_id.
-        // The receiver drops id==0 (non-GO housekeeping); Program defaults runtime_id to 0
-        // (program_impl.hpp), so without this line every record is filtered and callbacks
-        // never fire (RealtimeProfilerManager::process_one_page).
-        program.set_runtime_id(1);
 
         distributed::MeshWorkload workload;
         const distributed::MeshCoordinateRange device_range(mesh_device->shape());
-        workload.add_program(device_range, std::move(program));
+        workload.add_program(device_range, std::move(built.program));
+        Program& program = workload.get_programs().begin()->second;
+
+        // Real-time profiler drops id==0; timed launches use host_runtime_id 1..N.
+        constexpr uint32_t kPrecompileProfilerProgramId = 0;
+
+        auto launch = [&](uint32_t profiler_program_id, uint32_t host_runtime_id) {
+            configure_program_launch(
+                program, built.compute_kernel, mesh_device, total_num_tiles, profiler_program_id, host_runtime_id);
+        };
 
         // Warmup (untimed): one eager enqueue absorbs the JIT-load /
         // dispatcher prefetch cost so they do not pollute either the FD timing
         // loop or the trace-capture step.
         if (cfg.warmup) {
+            launch(kPrecompileProfilerProgramId, 1);
             distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
             distributed::Finish(cq);
         }
@@ -466,6 +524,16 @@ int main(int argc, char** argv) {
         const char* mode_label = nullptr;
 
         if (cfg.use_trace) {
+            // First enqueue inside trace capture triggers JIT / host-side setup, which
+            // is not allowed while recording ("Writes are not supported during trace
+            // capture"). Warmup already pre-compiles; with --no-warmup do it here.
+            if (!cfg.warmup) {
+                log_info(LogTest, "Trace mode: pre-compiling kernels before capture (PROG_ID=0).");
+                launch(kPrecompileProfilerProgramId, 1);
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                distributed::Finish(cq);
+            }
+
             // Step 3: capture one trace containing all N back-to-back enqueues,
             // then time a single replay + Finish. Capture itself is untimed --
             // it's a one-time setup cost that is amortised when the same
@@ -476,6 +544,8 @@ int main(int argc, char** argv) {
             // member methods.
             const distributed::MeshTraceId tid = distributed::BeginTraceCapture(mesh_device.get(), kCqId);
             for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                const uint32_t program_index = i + 1;
+                launch(program_index, program_index);
                 distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
             }
             mesh_device->end_mesh_trace(kCqId, tid);
@@ -499,6 +569,8 @@ int main(int argc, char** argv) {
                 // times under one Finish.
                 const auto t_begin = std::chrono::steady_clock::now();
                 for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                    const uint32_t program_index = i + 1;
+                    launch(program_index, program_index);
                     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
                 }
                 distributed::Finish(cq);
@@ -530,7 +602,7 @@ int main(int argc, char** argv) {
                 LogTest,
                 "Device profiler results dumped. Inspect "
                 "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv "
-                "(per-tile MATH / TRISC-KERNEL zones; program gaps: --use-realtime-profiler).");
+                "(PROG_ID, TRISC_0 TILE_IDX, TRISC_2 FINISH_LAST_PUSH; chip gaps: --use-realtime-profiler).");
         }
 
         std::vector<uint32_t> output_data;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -13,13 +13,17 @@
 // This benchmark does the textbook reader -> CB -> compute -> CB -> writer
 // pipeline on every Tensix core, with interleaved DRAM in/out, then runs the
 // same MeshWorkload back-to-back N times in either Fast-Dispatch or Trace
-// mode. The compute kernel wraps its per-tile body in
-// DeviceZoneScopedMainN("MATH"), so a profiler-enabled build dumps
-// MATH_begin/MATH_end timestamps per TRISC per program-run per core into
+// mode. The compute kernel emits per-tile DeviceZoneScopedN("MATH") zones
+// (plus TILE_IDX data) so a profiler-enabled build dumps timestamps into
 // generated/profiler/.logs/profile_log_device.csv.
 //
-// To get op-to-op latency:
-//   op_to_op_latency_per_core = MATH_begin[program N+1] - MATH_end[program N]
+// For **program-level** op-to-op (between host enqueues), use
+// `--use-realtime-profiler` (ProgramRealtimeRecord gaps), not nested
+// DeviceZoneScopedMainN in user TRISC code (see compute kernel comments).
+//
+// CSV / in-kernel timing: use per-tile MATH zones on the MATH TRISC row,
+// or TRISC-KERNEL zones emitted by firmware (trisck.cc) for whole-kernel
+// envelope on each TRISC.
 //
 // CLI:
 //   --num-pages-per-core N  pages of interleaved DRAM per core (default 2)
@@ -28,8 +32,15 @@
 //   --num-programs N        back-to-back enqueues per measurement (default 8)
 //   --use-trace             capture once + replay (default: FD mode)
 //   --use-device-profiler   call ReadMeshDeviceProfilerResults after Finish
-//                           (requires --enable-profiler build + env var
-//                            TT_METAL_DEVICE_PROFILER=1)
+//                           (requires Tracy-enabled build — default unless
+//                            build_metal.sh --disable-profiler; plus env var
+//                            TT_METAL_DEVICE_PROFILER=1 before process start)
+//   --use-realtime-profiler register ProgramRealtimeProfilerCallback for the
+//                           timed portion only (FD: N enqueues + Finish; trace:
+//                           replay + Finish). Logs per-chip op-to-op gaps
+//                           (next start - previous end, ns). Inactive on some
+//                           dispatch setups; see
+//                           tech_reports/real_time_profiler/getting-started.md
 //   --no-warmup             skip the warmup enqueue
 //   --trace-region-size N   trace buffer size, bytes (default 1 MiB)
 //   --device-id N           device under test (default 0)
@@ -39,8 +50,12 @@
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <tt-logger/tt-logger.hpp>
@@ -57,6 +72,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/experimental/realtime_profiler.hpp>
 #include <hostdevcommon/common_values.hpp>
 #include "impl/context/metal_context.hpp"
 
@@ -94,6 +110,7 @@ struct BenchmarkConfig {
     bool warmup = true;
     bool use_trace = false;
     bool use_device_profiler = false;
+    bool use_realtime_profiler = false;
     size_t trace_region_size = 1ull << 20;  // 1 MiB
 };
 
@@ -114,8 +131,137 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     if (test_args::has_command_option(args, "--use-device-profiler")) {
         cfg.use_device_profiler = true;
     }
+    if (test_args::has_command_option(args, "--use-realtime-profiler")) {
+        cfg.use_realtime_profiler = true;
+    }
     return cfg;
 }
+
+// Real-time profiler callbacks run on a worker thread; collect records here
+// and analyse after UnregisterProgramRealtimeProfilerCallback.
+void log_realtime_op_to_op_gaps(const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records) {
+    if (records.size() < 2) {
+        log_info(LogTest, "Real-time profiler: got {} record(s); need >= 2 to compute op-to-op gaps.", records.size());
+        return;
+    }
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        double sum_gap_ns = 0.0;
+        uint32_t gap_count = 0;
+        double min_gap_ns = 0.0;
+        double max_gap_ns = 0.0;
+        for (size_t i = 1; i < chip_records.size(); ++i) {
+            const auto& prev = chip_records[i - 1];
+            const auto& cur = chip_records[i];
+            if (cur.start_timestamp < prev.end_timestamp) {
+                log_warning(
+                    LogTest,
+                    "Real-time profiler chip {}: record {} start {} < prev end {} (skip gap)",
+                    chip_id,
+                    i,
+                    cur.start_timestamp,
+                    prev.end_timestamp);
+                continue;
+            }
+            const uint64_t gap_cycles = cur.start_timestamp - prev.end_timestamp;
+            const double freq = (cur.frequency > 0.0) ? cur.frequency : prev.frequency;
+            if (freq <= 0.0) {
+                continue;
+            }
+            const double gap_ns = static_cast<double>(gap_cycles) / freq;
+            if (gap_count == 0) {
+                min_gap_ns = max_gap_ns = gap_ns;
+            } else {
+                min_gap_ns = std::min(min_gap_ns, gap_ns);
+                max_gap_ns = std::max(max_gap_ns, gap_ns);
+            }
+            sum_gap_ns += gap_ns;
+            ++gap_count;
+        }
+        if (gap_count > 0) {
+            log_info(
+                LogTest,
+                "Real-time profiler chip {}: {} op-to-op gap(s) — min {:.2f} ns, max {:.2f} ns, mean {:.2f} ns "
+                "(next program start − previous program end)",
+                chip_id,
+                gap_count,
+                min_gap_ns,
+                max_gap_ns,
+                sum_gap_ns / gap_count);
+        }
+    }
+}
+
+struct RealtimeProfilerSession {
+    std::mutex mutex;
+    std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord> records;
+    std::optional<tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle> handle;
+
+    void register_callback() {
+        handle = tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(
+            [this](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
+                std::lock_guard<std::mutex> lock(mutex);
+                records.push_back(record);
+            });
+    }
+
+    void unregister_and_drain() {
+        if (handle.has_value()) {
+            tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback(*handle);
+            handle.reset();
+        }
+    }
+
+    std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord> copy_records() {
+        std::lock_guard<std::mutex> lock(mutex);
+        return records;
+    }
+};
+
+// Registers RT profiler callback after warmup; on destruction quiesces, waits for
+// D2H records, unregisters, then logs per-chip op-to-op gaps (Mo's metric:
+// next start - previous end). Must outlive the timed enqueue burst only.
+struct RealtimeProfilerDrainGuard {
+    distributed::MeshDevice* mesh = nullptr;
+    std::unique_ptr<RealtimeProfilerSession> session;
+
+    RealtimeProfilerDrainGuard(distributed::MeshDevice* mesh_in, bool use_realtime_profiler, bool profiler_active) :
+        mesh(mesh_in) {
+        if (!use_realtime_profiler) {
+            return;
+        }
+        if (!profiler_active) {
+            log_warning(
+                LogTest,
+                "Real-time profiler: --use-realtime-profiler set but IsProgramRealtimeProfilerActive() is false; "
+                "skipping (ETH dispatch / remote chip / resources — see "
+                "tech_reports/real_time_profiler/getting-started.md).");
+            return;
+        }
+        session = std::make_unique<RealtimeProfilerSession>();
+        session->register_callback();
+        log_info(LogTest, "Real-time profiler: callback registered for timed section.");
+    }
+
+    RealtimeProfilerDrainGuard(const RealtimeProfilerDrainGuard&) = delete;
+    RealtimeProfilerDrainGuard& operator=(const RealtimeProfilerDrainGuard&) = delete;
+
+    ~RealtimeProfilerDrainGuard() {
+        if (!session) {
+            return;
+        }
+        mesh->quiesce_devices();
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        session->unregister_and_drain();
+        log_realtime_op_to_op_gaps(session->copy_records());
+    }
+};
 
 // Build the reader -> compute -> writer program covering every Tensix core,
 // with the per-core tile slice assigned via runtime args.
@@ -230,7 +376,7 @@ int main(int argc, char** argv) {
         log_info(
             LogTest,
             "op_to_op_latency: device_id={}, pages_per_core={}, compute_nops={}, num_programs={}, warmup={}, "
-            "use_trace={}, use_device_profiler={}, trace_region_size={}",
+            "use_trace={}, use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}",
             cfg.device_id,
             cfg.num_pages_per_core,
             cfg.num_nops_per_tile,
@@ -238,12 +384,13 @@ int main(int argc, char** argv) {
             cfg.warmup,
             cfg.use_trace,
             cfg.use_device_profiler,
+            cfg.use_realtime_profiler,
             cfg.trace_region_size);
         TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
 
         // If the user asked for a CSV dump, make sure the runtime profiler is
-        // actually enabled (--enable-profiler build + TT_METAL_DEVICE_PROFILER=1
-        // env var). Without this check, the CSV would just be empty and the
+        // actually enabled (Tracy-enabled build + TT_METAL_DEVICE_PROFILER=1
+        // env var before process start). Without this check, the CSV would just be empty and the
         // failure mode would be silent. Pattern mirrors test_dram_offchip.cpp.
         if (cfg.use_device_profiler) {
             const bool profiler_runtime_enabled =
@@ -251,8 +398,10 @@ int main(int argc, char** argv) {
             TT_FATAL(
                 profiler_runtime_enabled,
                 "--use-device-profiler requires the device profiler to be enabled at runtime. "
-                "Build with `./build_metal.sh --enable-profiler` and set TT_METAL_DEVICE_PROFILER=1 "
-                "(e.g. `TT_METAL_DEVICE_PROFILER=1 ./test_op_to_op_latency --use-device-profiler ...`).");
+                "Use a Tracy-enabled build (default: omit `build_metal.sh --disable-profiler`) and "
+                "export TT_METAL_DEVICE_PROFILER=1 before starting the process "
+                "(e.g. `TT_METAL_DEVICE_PROFILER=1 ./test_op_to_op_latency --use-device-profiler ...`). "
+                "If kernels were JIT-cached without profiler, clear ~/.cache/tt-metal-cache and re-run.");
         }
 
         // trace_region_size = 0 would disable trace capture entirely (legacy
@@ -292,6 +441,12 @@ int main(int argc, char** argv) {
         Program program =
             build_program(mesh_device, cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
 
+        // Real-time profiler: D2H pages use the program's host runtime id as start_id.
+        // The receiver drops id==0 (non-GO housekeeping); Program defaults runtime_id to 0
+        // (program_impl.hpp), so without this line every record is filtered and callbacks
+        // never fire (RealtimeProfilerManager::process_one_page).
+        program.set_runtime_id(1);
+
         distributed::MeshWorkload workload;
         const distributed::MeshCoordinateRange device_range(mesh_device->shape());
         workload.add_program(device_range, std::move(program));
@@ -303,6 +458,8 @@ int main(int argc, char** argv) {
             distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
             distributed::Finish(cq);
         }
+
+        const bool rt_profiler_active = tt::tt_metal::experimental::IsProgramRealtimeProfilerActive();
 
         constexpr uint8_t kCqId = 0;
         long long elapsed_us = 0;
@@ -324,24 +481,30 @@ int main(int argc, char** argv) {
             mesh_device->end_mesh_trace(kCqId, tid);
             distributed::Finish(cq);  // make sure capture is fully committed before timing
 
-            const auto t_begin = std::chrono::steady_clock::now();
-            mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
-            distributed::Finish(cq);
-            const auto t_end = std::chrono::steady_clock::now();
-            elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+            {
+                RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);
+                const auto t_begin = std::chrono::steady_clock::now();
+                mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+                distributed::Finish(cq);
+                const auto t_end = std::chrono::steady_clock::now();
+                elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+            }
 
             mesh_device->release_mesh_trace(tid);
             mode_label = "Trace replay";
         } else {
-            // Step 2: enqueue the same MeshWorkload back-to-back num_programs
-            // times under one Finish.
-            const auto t_begin = std::chrono::steady_clock::now();
-            for (uint32_t i = 0; i < cfg.num_programs; ++i) {
-                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            {
+                RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);
+                // Step 2: enqueue the same MeshWorkload back-to-back num_programs
+                // times under one Finish.
+                const auto t_begin = std::chrono::steady_clock::now();
+                for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                }
+                distributed::Finish(cq);
+                const auto t_end = std::chrono::steady_clock::now();
+                elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
             }
-            distributed::Finish(cq);
-            const auto t_end = std::chrono::steady_clock::now();
-            elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
             mode_label = "FD back-to-back";
         }
 
@@ -355,17 +518,19 @@ int main(int argc, char** argv) {
             avg_us_per_program);
 
         // Step 4: flush device profiler buffers to
-        // generated/profiler/.logs/profile_log_device.csv. Filter the rows
-        // for zone "MATH" and compute MATH_begin[N+1] - MATH_end[N] per core
-        // to get the on-chip op-to-op latency. tools/tracy/process_device_log.py
-        // can post-process the CSV.
+        // generated/profiler/.logs/profile_log_device.csv. For in-kernel timing,
+        // filter per-tile `MATH` rows (MATH TRISC) or firmware `TRISC-KERNEL`
+        // rows. Program-level op-to-op between host enqueues is from
+        // `--use-realtime-profiler`, not from nesting DeviceZoneScopedMainN in
+        // user TRISC kernels. tools/tracy/process_device_log.py can post-process
+        // the CSV.
         if (cfg.use_device_profiler) {
             tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
             log_info(
                 LogTest,
                 "Device profiler results dumped. Inspect "
                 "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv "
-                "and look for the 'MATH' zone to compute op-to-op latency.");
+                "(per-tile MATH / TRISC-KERNEL zones; program gaps: --use-realtime-profiler).");
         }
 
         std::vector<uint32_t> output_data;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -44,13 +44,24 @@
 //   --no-warmup             skip the warmup enqueue
 //   --trace-region-size N   trace buffer size, bytes (default 1 MiB)
 //   --device-id N           device under test (default 0)
+//   --output-cb-depth-tiles N  output CB depth in tiles (default 2)
+//   --buffer-tune           Buffer sizing study: reader push-2 (double buffer),
+//                           sweep --buffer-tune-input-depths for DRAM BW, pick smallest
+//                           depth at peak BW, then run --num-programs with profiler flags
+//   --buffer-tune-input-depths LIST  comma-separated input CB depths (default 2,4,6,8,12,16,24,32)
+//   --buffer-tune-output-depths LIST optional output CB depth sweep after input tune
+//   --buffer-tune-pages-per-core N   tiles/core for BW phase (default 32; NOP compute → DRAM bound)
+//   --buffer-tune-bw-tolerance PCT   depths within PCT%% of peak BW count as peak (default 2)
 
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
+#include <fstream>
+#include <iomanip>
 #include <map>
+#include <sstream>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -104,10 +115,22 @@ namespace {
 //                        programs; tunable via --trace-region-size if
 //                        --num-programs is bumped a lot.
 struct BenchmarkConfig {
-    uint32_t num_pages_per_core = 2;
+    uint32_t num_pages_per_core = 4;
     uint32_t num_nops_per_tile = 0;
     uint32_t num_programs = 8;
     uint32_t device_id = 0;
+    uint32_t reader_push_tile_count = 2;
+    // 0 = auto (2 * reader_push_tile_count) for input CB depth.
+    uint32_t input_cb_depth_tiles = 0;
+    // 0 = default 2 tiles (compute->writer still pops 1 at a time).
+    uint32_t output_cb_depth_tiles = 0;
+    // 0 = reserve N then read+push one tile at a time; 1 = reserve N, read all, push N.
+    uint32_t reader_mode = 0;
+    bool buffer_tune = false;
+    std::string buffer_tune_input_depths = "2,4,6,8,12,16,24,32";
+    std::string buffer_tune_output_depths;
+    uint32_t buffer_tune_pages_per_core = 32;
+    double buffer_tune_bw_tolerance_pct = 2.0;
     bool warmup = true;
     bool use_trace = false;
     bool use_device_profiler = false;
@@ -118,6 +141,28 @@ struct BenchmarkConfig {
 BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     BenchmarkConfig cfg;
     cfg.num_pages_per_core = test_args::get_command_option_uint32(args, "--num-pages-per-core", cfg.num_pages_per_core);
+    cfg.reader_push_tile_count =
+        test_args::get_command_option_uint32(args, "--reader-push-tiles", cfg.reader_push_tile_count);
+    cfg.input_cb_depth_tiles =
+        test_args::get_command_option_uint32(args, "--input-cb-depth-tiles", cfg.input_cb_depth_tiles);
+    cfg.output_cb_depth_tiles =
+        test_args::get_command_option_uint32(args, "--output-cb-depth-tiles", cfg.output_cb_depth_tiles);
+    if (test_args::has_command_option(args, "--reader-batch-push")) {
+        cfg.reader_mode = 1;
+    }
+    if (test_args::has_command_option(args, "--buffer-tune")) {
+        cfg.buffer_tune = true;
+    }
+    if (test_args::has_command_option(args, "--buffer-tune-input-depths")) {
+        cfg.buffer_tune_input_depths = test_args::get_command_option(args, "--buffer-tune-input-depths");
+    }
+    if (test_args::has_command_option(args, "--buffer-tune-output-depths")) {
+        cfg.buffer_tune_output_depths = test_args::get_command_option(args, "--buffer-tune-output-depths");
+    }
+    cfg.buffer_tune_pages_per_core =
+        test_args::get_command_option_uint32(args, "--buffer-tune-pages-per-core", cfg.buffer_tune_pages_per_core);
+    cfg.buffer_tune_bw_tolerance_pct =
+        test_args::get_command_option_double(args, "--buffer-tune-bw-tolerance", cfg.buffer_tune_bw_tolerance_pct);
     cfg.num_nops_per_tile = test_args::get_command_option_uint32(args, "--compute-nops", cfg.num_nops_per_tile);
     cfg.num_programs = test_args::get_command_option_uint32(args, "--num-programs", cfg.num_programs);
     cfg.device_id = test_args::get_command_option_uint32(args, "--device-id", cfg.device_id);
@@ -140,6 +185,31 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
 
 // Real-time profiler callbacks run on a worker thread; collect records here
 // and analyse after UnregisterProgramRealtimeProfilerCallback.
+void log_realtime_program_go_done(const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records) {
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        for (const auto& r : chip_records) {
+            const uint64_t duration_cycles =
+                (r.end_timestamp >= r.start_timestamp) ? (r.end_timestamp - r.start_timestamp) : 0;
+            const double duration_ns = (r.frequency > 0.0) ? static_cast<double>(duration_cycles) / r.frequency : 0.0;
+            log_info(
+                LogTest,
+                "Real-time profiler chip {} program {}: go_cycles={} done_cycles={} duration={:.2f} ns",
+                chip_id,
+                r.program_id,
+                r.start_timestamp,
+                r.end_timestamp,
+                duration_ns);
+        }
+    }
+}
+
 void log_realtime_op_to_op_gaps(const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records) {
     if (records.size() < 2) {
         log_info(LogTest, "Real-time profiler: got {} record(s); need >= 2 to compute op-to-op gaps.", records.size());
@@ -160,6 +230,15 @@ void log_realtime_op_to_op_gaps(const std::vector<tt::tt_metal::experimental::Pr
         for (size_t i = 1; i < chip_records.size(); ++i) {
             const auto& prev = chip_records[i - 1];
             const auto& cur = chip_records[i];
+            if (cur.program_id == prev.program_id) {
+                log_warning(
+                    LogTest,
+                    "Real-time profiler chip {}: skipping dispatch gap between duplicate program_id {} "
+                    "(trace replay may report the same host runtime id twice)",
+                    chip_id,
+                    cur.program_id);
+                continue;
+            }
             if (cur.start_timestamp < prev.end_timestamp) {
                 log_warning(
                     LogTest,
@@ -225,6 +304,41 @@ struct RealtimeProfilerSession {
     }
 };
 
+void write_realtime_profiler_csv(
+    const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records, const std::string& path) {
+    std::ofstream out(path);
+    if (!out) {
+        log_warning(LogTest, "Real-time profiler: could not open {} for write", path);
+        return;
+    }
+    out << "program_id,chip_id,go_cycles,done_cycles,gap_to_next_go_cycles,duration_cycles,duration_ns,frequency_ghz\n";
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        for (size_t i = 0; i < chip_records.size(); ++i) {
+            const auto& r = chip_records[i];
+            const uint64_t duration_cycles =
+                (r.end_timestamp >= r.start_timestamp) ? (r.end_timestamp - r.start_timestamp) : 0;
+            const double duration_ns = (r.frequency > 0.0) ? static_cast<double>(duration_cycles) / r.frequency : 0.0;
+            uint64_t gap_to_next_go = 0;
+            if (i + 1 < chip_records.size()) {
+                const auto& next = chip_records[i + 1];
+                if (next.program_id != r.program_id && next.start_timestamp >= r.end_timestamp) {
+                    gap_to_next_go = next.start_timestamp - r.end_timestamp;
+                }
+            }
+            out << r.program_id << "," << chip_id << "," << r.start_timestamp << "," << r.end_timestamp << ","
+                << gap_to_next_go << "," << duration_cycles << "," << duration_ns << "," << r.frequency << "\n";
+        }
+    }
+    log_info(LogTest, "Real-time profiler: wrote {} record(s) to {}", records.size(), path);
+}
+
 // Registers RT profiler callback after warmup; on destruction quiesces, waits for
 // D2H records, unregisters, then logs per-chip op-to-op gaps (Mo's metric:
 // next start - previous end). Must outlive the timed enqueue burst only.
@@ -260,37 +374,68 @@ struct RealtimeProfilerDrainGuard {
         mesh->quiesce_devices();
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         session->unregister_and_drain();
-        log_realtime_op_to_op_gaps(session->copy_records());
+        const auto records = session->copy_records();
+        log_realtime_program_go_done(records);
+        log_realtime_op_to_op_gaps(records);
+        const char* metal_home = std::getenv("TT_METAL_HOME");
+        if (metal_home != nullptr) {
+            write_realtime_profiler_csv(
+                records, std::string(metal_home) + "/generated/profiler/.logs/profile_log_device_rt.csv");
+        }
     }
 };
 
 struct BuiltProgram {
     Program program;
+    KernelHandle reader_kernel = 0;
+    KernelHandle writer_kernel = 0;
     KernelHandle compute_kernel = 0;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t tiles_per_core_group_1 = 0;
+    uint32_t tiles_per_core_group_2 = 0;
+    uint32_t reader_push_tile_count = 2;
+    uint32_t reader_mode = 0;
+    uint32_t input_cb_depth_tiles = 0;
+    uint32_t output_cb_depth_tiles = 2;
 };
 
-// Set compute runtime arg 1 (program_id) on every core. program_id 0 marks
-// pre-compile / warmup rows in the device CSV; timed launches use 1..N.
-void set_compute_program_id(
+// Set reader/writer/compute runtime args (including program_id) on every active core.
+void set_program_launch_args(
     Program& program,
-    KernelHandle compute_kernel,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    uint32_t total_num_tiles,
-    uint32_t program_id) {
-    const auto grid = mesh_device->compute_with_storage_grid_size();
-    constexpr bool kRowMajor = true;
-    auto [_num_cores, _all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        split_work_to_cores(grid, total_num_tiles, kRowMajor);
+    const BuiltProgram& built,
+    uint32_t input_buffer_addr,
+    uint32_t output_buffer_addr,
+    uint32_t program_id,
+    uint32_t reader_push_tile_count,
+    uint32_t reader_mode) {
     const auto work_groups = {
-        std::make_pair(core_group_1, num_tiles_per_core_group_1),
-        std::make_pair(core_group_2, num_tiles_per_core_group_2)};
+        std::make_pair(built.core_group_1, built.tiles_per_core_group_1),
+        std::make_pair(built.core_group_2, built.tiles_per_core_group_2)};
+    uint32_t start_tile_id = 0;
     for (const auto& [group, tiles_per_core] : work_groups) {
         if (tiles_per_core == 0) {
             continue;
         }
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
-                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, program_id});
+                SetRuntimeArgs(
+                    program,
+                    built.reader_kernel,
+                    core,
+                    {input_buffer_addr,
+                     tiles_per_core,
+                     start_tile_id,
+                     program_id,
+                     reader_push_tile_count,
+                     reader_mode});
+                SetRuntimeArgs(
+                    program,
+                    built.writer_kernel,
+                    core,
+                    {output_buffer_addr, tiles_per_core, start_tile_id, program_id});
+                SetRuntimeArgs(program, built.compute_kernel, core, {tiles_per_core, program_id});
+                start_tile_id += tiles_per_core;
             }
         }
     }
@@ -299,12 +444,19 @@ void set_compute_program_id(
 // Configure host runtime id (RT profiler) and device CSV program_id before each launch.
 void configure_program_launch(
     Program& program,
-    KernelHandle compute_kernel,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    uint32_t total_num_tiles,
+    const BuiltProgram& built,
+    uint32_t input_buffer_addr,
+    uint32_t output_buffer_addr,
     uint32_t profiler_program_id,
     uint32_t host_runtime_id) {
-    set_compute_program_id(program, compute_kernel, mesh_device, total_num_tiles, profiler_program_id);
+    set_program_launch_args(
+        program,
+        built,
+        input_buffer_addr,
+        output_buffer_addr,
+        profiler_program_id,
+        built.reader_push_tile_count,
+        built.reader_mode);
     program.set_runtime_id(host_runtime_id);
 }
 
@@ -334,20 +486,43 @@ BuiltProgram build_program(
         num_tiles_per_core_group_1,
         num_tiles_per_core_group_2);
 
-    // CBs: c_0 is reader -> compute, c_16 is compute -> writer. Sized at 2
-    // tiles each (double-buffered) so the reader/compute/writer can overlap.
+    // Input CB depth defaults to 2x reader push chunk (e.g. push 2 -> depth 4).
     constexpr uint32_t kInputCbId = tt::CBIndex::c_0;
     constexpr uint32_t kOutputCbId = tt::CBIndex::c_16;
-    constexpr uint32_t kCbDepthInTiles = 2;
     constexpr auto kDataFormat = tt::DataFormat::Float16_b;
 
+    const uint32_t push_tiles = cfg.reader_push_tile_count > 0 ? cfg.reader_push_tile_count : 1;
+    const uint32_t input_cb_depth = cfg.input_cb_depth_tiles > 0 ? cfg.input_cb_depth_tiles : (2 * push_tiles);
+    // Compute -> writer unchanged: still wait_front(1) / pack one tile at a time.
+    const uint32_t output_cb_depth = cfg.output_cb_depth_tiles > 0 ? cfg.output_cb_depth_tiles : 2;
+
+    TT_FATAL(
+        input_cb_depth >= push_tiles,
+        "input CB depth ({}) must be >= --reader-push-tiles ({})",
+        input_cb_depth,
+        push_tiles);
+    TT_FATAL(
+        cfg.num_pages_per_core >= push_tiles,
+        "--num-pages-per-core ({}) must be >= --reader-push-tiles ({})",
+        cfg.num_pages_per_core,
+        push_tiles);
+
+    log_info(
+        LogTest,
+        "Reader: push_tiles={}, input_cb_depth={}, output_cb_depth={} (compute->writer still 1 tile at a time), "
+        "reader_mode={} (0=incremental read+push, 1=batch read then push)",
+        push_tiles,
+        input_cb_depth,
+        output_cb_depth,
+        cfg.reader_mode);
+
     CircularBufferConfig cb_in_config =
-        CircularBufferConfig(kCbDepthInTiles * single_tile_size_bytes, {{kInputCbId, kDataFormat}})
+        CircularBufferConfig(input_cb_depth * single_tile_size_bytes, {{kInputCbId, kDataFormat}})
             .set_page_size(kInputCbId, single_tile_size_bytes);
     CreateCircularBuffer(program, all_cores, cb_in_config);
 
     CircularBufferConfig cb_out_config =
-        CircularBufferConfig(kCbDepthInTiles * single_tile_size_bytes, {{kOutputCbId, kDataFormat}})
+        CircularBufferConfig(output_cb_depth * single_tile_size_bytes, {{kOutputCbId, kDataFormat}})
             .set_page_size(kOutputCbId, single_tile_size_bytes);
     CreateCircularBuffer(program, all_cores, cb_out_config);
 
@@ -394,9 +569,14 @@ BuiltProgram build_program(
         }
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
-                SetRuntimeArgs(program, reader_kernel, core, {input_buffer->address(), tiles_per_core, start_tile_id});
-                SetRuntimeArgs(program, writer_kernel, core, {output_buffer->address(), tiles_per_core, start_tile_id});
-                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, /*program_id=*/0});
+                SetRuntimeArgs(
+                    program,
+                    reader_kernel,
+                    core,
+                    {input_buffer->address(), tiles_per_core, start_tile_id, 0, push_tiles, cfg.reader_mode});
+                SetRuntimeArgs(
+                    program, writer_kernel, core, {output_buffer->address(), tiles_per_core, start_tile_id, 0});
+                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, 0});
                 start_tile_id += tiles_per_core;
             }
         }
@@ -407,7 +587,465 @@ BuiltProgram build_program(
         start_tile_id,
         total_num_tiles);
 
-    return BuiltProgram{std::move(program), compute_kernel};
+    BuiltProgram built;
+    built.program = std::move(program);
+    built.reader_kernel = reader_kernel;
+    built.writer_kernel = writer_kernel;
+    built.compute_kernel = compute_kernel;
+    built.core_group_1 = core_group_1;
+    built.core_group_2 = core_group_2;
+    built.tiles_per_core_group_1 = num_tiles_per_core_group_1;
+    built.tiles_per_core_group_2 = num_tiles_per_core_group_2;
+    built.reader_push_tile_count = push_tiles;
+    built.reader_mode = cfg.reader_mode;
+    built.input_cb_depth_tiles = input_cb_depth;
+    built.output_cb_depth_tiles = output_cb_depth;
+    return built;
+}
+
+struct BufferTuneBwRow {
+    uint32_t input_cb_depth = 0;
+    uint32_t output_cb_depth = 0;
+    long long elapsed_us = 0;
+    double gbps = 0.0;
+};
+
+std::vector<uint32_t> parse_uint32_list(const std::string& list_str, const std::vector<uint32_t>& fallback) {
+    if (list_str.empty()) {
+        return fallback;
+    }
+    std::vector<uint32_t> out;
+    std::stringstream ss(list_str);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        if (item.empty()) {
+            continue;
+        }
+        out.push_back(static_cast<uint32_t>(std::stoul(item)));
+    }
+    if (out.empty()) {
+        return fallback;
+    }
+    std::sort(out.begin(), out.end());
+    out.erase(std::unique(out.begin(), out.end()), out.end());
+    return out;
+}
+
+double pipeline_dram_gbps(uint64_t bytes_moved, long long elapsed_us) {
+    if (elapsed_us <= 0) {
+        return 0.0;
+    }
+    const double seconds = static_cast<double>(elapsed_us) * 1e-6;
+    return static_cast<double>(bytes_moved) / seconds / 1e9;
+}
+
+void log_buffer_tune_row(
+    const char* phase,
+    const BenchmarkConfig& cfg,
+    uint32_t input_cb_depth,
+    uint32_t output_cb_depth,
+    uint32_t pages_per_core,
+    long long elapsed_us,
+    uint64_t bytes_moved,
+    double gbps) {
+    log_info(
+        LogTest,
+        "BUFFER_TUNE,phase={},input_cb_depth={},output_cb_depth={},reader_push={},reader_mode={},"
+        "pages_per_core={},compute_nops={},num_programs={},elapsed_us={},bytes_moved={},dram_pipeline_gbps={:.4f}",
+        phase,
+        input_cb_depth,
+        output_cb_depth,
+        cfg.reader_push_tile_count,
+        cfg.reader_mode,
+        pages_per_core,
+        cfg.num_nops_per_tile,
+        cfg.num_programs,
+        elapsed_us,
+        bytes_moved,
+        gbps);
+}
+
+long long execute_timed_workload(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshCommandQueue& cq,
+    distributed::MeshWorkload& workload,
+    Program& program,
+    const BuiltProgram& built,
+    const BenchmarkConfig& cfg,
+    uint32_t input_buffer_addr,
+    uint32_t output_buffer_addr,
+    uint32_t num_programs,
+    bool use_realtime_profiler,
+    bool rt_profiler_active) {
+    constexpr uint32_t kPrecompileProfilerProgramId = 0;
+    auto launch = [&](uint32_t profiler_program_id, uint32_t host_runtime_id) {
+        configure_program_launch(
+            program, built, input_buffer_addr, output_buffer_addr, profiler_program_id, host_runtime_id);
+    };
+
+    constexpr uint8_t kCqId = 0;
+    long long elapsed_us = 0;
+
+    if (cfg.use_trace) {
+        if (!cfg.warmup) {
+            launch(kPrecompileProfilerProgramId, 1);
+            distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            distributed::Finish(cq);
+        }
+        const distributed::MeshTraceId tid = distributed::BeginTraceCapture(mesh_device.get(), kCqId);
+        for (uint32_t i = 0; i < num_programs; ++i) {
+            const uint32_t program_index = i + 1;
+            launch(program_index, program_index);
+            distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+        }
+        mesh_device->end_mesh_trace(kCqId, tid);
+        distributed::Finish(cq);
+
+        {
+            RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), use_realtime_profiler, rt_profiler_active);
+            const auto t_begin = std::chrono::steady_clock::now();
+            mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+            distributed::Finish(cq);
+            const auto t_end = std::chrono::steady_clock::now();
+            elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+        }
+        mesh_device->release_mesh_trace(tid);
+    } else {
+        RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), use_realtime_profiler, rt_profiler_active);
+        const auto t_begin = std::chrono::steady_clock::now();
+        for (uint32_t i = 0; i < num_programs; ++i) {
+            const uint32_t program_index = i + 1;
+            launch(program_index, program_index);
+            distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+        }
+        distributed::Finish(cq);
+        const auto t_end = std::chrono::steady_clock::now();
+        elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+    }
+    return elapsed_us;
+}
+
+uint32_t pick_smallest_depth_at_peak_bw(
+    const std::vector<BufferTuneBwRow>& rows, double tolerance_fraction, double* peak_gbps_out) {
+    double peak_gbps = 0.0;
+    for (const auto& row : rows) {
+        peak_gbps = std::max(peak_gbps, row.gbps);
+    }
+    if (peak_gbps_out != nullptr) {
+        *peak_gbps_out = peak_gbps;
+    }
+    const double threshold = peak_gbps * (1.0 - tolerance_fraction);
+
+    bool found = false;
+    uint32_t best_depth = 0;
+    for (const auto& row : rows) {
+        if (row.gbps >= threshold) {
+            if (!found || row.input_cb_depth < best_depth) {
+                best_depth = row.input_cb_depth;
+                found = true;
+            }
+        }
+    }
+    if (!found) {
+        // No depth met tolerance; use shallowest depth that hit peak BW.
+        uint32_t fallback = rows.front().input_cb_depth;
+        for (const auto& row : rows) {
+            if (row.gbps >= peak_gbps - 1e-6 && row.input_cb_depth < fallback) {
+                fallback = row.input_cb_depth;
+            }
+        }
+        return fallback;
+    }
+    return best_depth;
+}
+
+bool verify_output_matches_input(
+    distributed::MeshCommandQueue& cq,
+    std::shared_ptr<distributed::MeshBuffer>& output_buffer,
+    const std::vector<uint32_t>& input_data) {
+    std::vector<uint32_t> output_data;
+    distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
+    if (output_data.size() != input_data.size()) {
+        log_error(LogTest, "Output size mismatch: got {} elems, expected {}", output_data.size(), input_data.size());
+        return false;
+    }
+    if (!std::equal(input_data.begin(), input_data.end(), output_data.begin())) {
+        log_error(LogTest, "Output data mismatch after pipeline run");
+        return false;
+    }
+    return true;
+}
+
+// Buffer-tune mode: double-buffer reader, NOP compute (DRAM bound), sweep input CB depth for
+// peak DRAM pipeline BW, then measure op-to-op latency at the smallest depth that reaches peak BW.
+bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
+    bool pass = true;
+    BenchmarkConfig tune_cfg = cfg;
+    tune_cfg.reader_push_tile_count = std::max<uint32_t>(2u, tune_cfg.reader_push_tile_count);
+    tune_cfg.num_pages_per_core = tune_cfg.buffer_tune_pages_per_core;
+    tune_cfg.num_nops_per_tile = 0;
+    tune_cfg.warmup = true;
+
+    const std::vector<uint32_t> default_input_depths = {2, 4, 6, 8, 12, 16, 24, 32};
+    const std::vector<uint32_t> input_depths =
+        parse_uint32_list(tune_cfg.buffer_tune_input_depths, default_input_depths);
+
+    log_info(
+        LogTest,
+        "buffer_tune: pages_per_core={}, reader_push={}, compute_nops=0, input_depths=[{}], "
+        "output_depth_sweep={}, bw_tolerance={:.1f}%",
+        tune_cfg.num_pages_per_core,
+        tune_cfg.reader_push_tile_count,
+        tune_cfg.buffer_tune_input_depths,
+        tune_cfg.buffer_tune_output_depths.empty() ? "none" : tune_cfg.buffer_tune_output_depths.c_str(),
+        tune_cfg.buffer_tune_bw_tolerance_pct);
+
+    if (tune_cfg.use_device_profiler) {
+        const bool profiler_runtime_enabled = tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled();
+        TT_FATAL(
+            profiler_runtime_enabled,
+            "--buffer-tune latency phase needs TT_METAL_DEVICE_PROFILER=1 when --use-device-profiler is set");
+    }
+
+    const size_t trace_region_size = tune_cfg.use_trace ? tune_cfg.trace_region_size : 0;
+    auto mesh_device =
+        distributed::MeshDevice::create_unit_mesh(tune_cfg.device_id, DEFAULT_L1_SMALL_SIZE, trace_region_size);
+
+    log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->get_devices()[0]));
+
+    const auto grid = mesh_device->compute_with_storage_grid_size();
+    const uint32_t num_cores = grid.x * grid.y;
+    const uint32_t total_num_tiles = num_cores * tune_cfg.num_pages_per_core;
+
+    constexpr auto kDataFormat = tt::DataFormat::Float16_b;
+    const uint32_t single_tile_size_bytes = tile_size(kDataFormat);
+    const uint32_t buffer_size_bytes = total_num_tiles * single_tile_size_bytes;
+    const uint64_t bytes_per_program = 2ull * total_num_tiles * single_tile_size_bytes;
+
+    distributed::DeviceLocalBufferConfig dram_local_config{
+        .page_size = single_tile_size_bytes,
+        .buffer_type = BufferType::DRAM,
+    };
+    distributed::ReplicatedBufferConfig dram_buf_config{.size = buffer_size_bytes};
+
+    auto input_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+    auto output_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+
+    const auto seed = static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::vector<uint32_t> input_data =
+        create_random_vector_of_bfloat16(buffer_size_bytes, /*rand_max_float=*/100, seed);
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/false);
+    distributed::Finish(cq);
+
+    const uint32_t input_buffer_addr = input_buffer->address();
+    const uint32_t output_buffer_addr = output_buffer->address();
+    const bool rt_profiler_active = tt::tt_metal::experimental::IsProgramRealtimeProfilerActive();
+
+    std::vector<BufferTuneBwRow> input_bw_rows;
+    for (const uint32_t depth : input_depths) {
+        TT_FATAL(
+            depth >= tune_cfg.reader_push_tile_count,
+            "buffer_tune input_cb_depth {} must be >= reader_push {}",
+            depth,
+            tune_cfg.reader_push_tile_count);
+
+        BenchmarkConfig sweep_cfg = tune_cfg;
+        sweep_cfg.input_cb_depth_tiles = depth;
+        sweep_cfg.num_programs = 1;
+
+        BuiltProgram built =
+            build_program(mesh_device, sweep_cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
+
+        distributed::MeshWorkload workload;
+        const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+        workload.add_program(device_range, std::move(built.program));
+        Program& program = workload.get_programs().begin()->second;
+
+        configure_program_launch(program, built, input_buffer_addr, output_buffer_addr, 0, 0);
+        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+        distributed::Finish(cq);
+
+        const long long elapsed_us = execute_timed_workload(
+            mesh_device,
+            cq,
+            workload,
+            program,
+            built,
+            sweep_cfg,
+            input_buffer_addr,
+            output_buffer_addr,
+            /*num_programs=*/1,
+            /*use_realtime_profiler=*/false,
+            rt_profiler_active);
+
+        const double gbps = pipeline_dram_gbps(bytes_per_program, elapsed_us);
+        input_bw_rows.push_back({depth, built.output_cb_depth_tiles, elapsed_us, gbps});
+        log_buffer_tune_row(
+            "input_bw_sweep",
+            sweep_cfg,
+            depth,
+            built.output_cb_depth_tiles,
+            tune_cfg.num_pages_per_core,
+            elapsed_us,
+            bytes_per_program,
+            gbps);
+    }
+
+    double peak_gbps = 0.0;
+    const double tolerance_fraction = tune_cfg.buffer_tune_bw_tolerance_pct / 100.0;
+    const uint32_t best_input_depth = pick_smallest_depth_at_peak_bw(input_bw_rows, tolerance_fraction, &peak_gbps);
+
+    const double threshold_gbps = peak_gbps * (1.0 - tolerance_fraction);
+    log_info(
+        LogTest,
+        "buffer_tune: peak_dram_pipeline_gbps={:.4f}, threshold_gbps={:.4f} (within {:.1f}% of peak), "
+        "smallest_input_cb_depth_at_peak={}",
+        peak_gbps,
+        threshold_gbps,
+        tune_cfg.buffer_tune_bw_tolerance_pct,
+        best_input_depth);
+
+    uint32_t best_output_depth = tune_cfg.output_cb_depth_tiles > 0 ? tune_cfg.output_cb_depth_tiles : 2;
+
+    if (!tune_cfg.buffer_tune_output_depths.empty()) {
+        const std::vector<uint32_t> default_output_depths = {2, 4, 8, 16};
+        const std::vector<uint32_t> output_depths =
+            parse_uint32_list(tune_cfg.buffer_tune_output_depths, default_output_depths);
+
+        std::vector<BufferTuneBwRow> output_bw_rows;
+        for (const uint32_t out_depth : output_depths) {
+            BenchmarkConfig sweep_cfg = tune_cfg;
+            sweep_cfg.input_cb_depth_tiles = best_input_depth;
+            sweep_cfg.output_cb_depth_tiles = out_depth;
+            sweep_cfg.num_programs = 1;
+
+            BuiltProgram built = build_program(
+                mesh_device, sweep_cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
+
+            distributed::MeshWorkload workload;
+            const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+            workload.add_program(device_range, std::move(built.program));
+            Program& program = workload.get_programs().begin()->second;
+
+            configure_program_launch(program, built, input_buffer_addr, output_buffer_addr, 0, 0);
+            distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            distributed::Finish(cq);
+
+            const long long elapsed_us = execute_timed_workload(
+                mesh_device,
+                cq,
+                workload,
+                program,
+                built,
+                sweep_cfg,
+                input_buffer_addr,
+                output_buffer_addr,
+                /*num_programs=*/1,
+                /*use_realtime_profiler=*/false,
+                rt_profiler_active);
+
+            const double gbps = pipeline_dram_gbps(bytes_per_program, elapsed_us);
+            output_bw_rows.push_back({best_input_depth, out_depth, elapsed_us, gbps});
+            log_buffer_tune_row(
+                "output_bw_sweep",
+                sweep_cfg,
+                best_input_depth,
+                out_depth,
+                tune_cfg.num_pages_per_core,
+                elapsed_us,
+                bytes_per_program,
+                gbps);
+        }
+
+        double output_peak_gbps = 0.0;
+        for (const auto& row : output_bw_rows) {
+            output_peak_gbps = std::max(output_peak_gbps, row.gbps);
+        }
+        const double out_thresh = output_peak_gbps * (1.0 - tolerance_fraction);
+        best_output_depth = output_bw_rows.front().output_cb_depth;
+        for (const auto& row : output_bw_rows) {
+            if (row.gbps >= out_thresh && row.output_cb_depth < best_output_depth) {
+                best_output_depth = row.output_cb_depth;
+            }
+        }
+        log_info(
+            LogTest,
+            "buffer_tune: output sweep peak_gbps={:.4f}, smallest_output_cb_depth_at_peak={}",
+            output_peak_gbps,
+            best_output_depth);
+    }
+
+    // Op-to-op latency at the smallest input (and output) buffer sizes that reach peak BW.
+    BenchmarkConfig latency_cfg = tune_cfg;
+    latency_cfg.input_cb_depth_tiles = best_input_depth;
+    latency_cfg.output_cb_depth_tiles = best_output_depth;
+    latency_cfg.num_programs = std::max<uint32_t>(2u, cfg.num_programs);
+    latency_cfg.num_pages_per_core = cfg.num_pages_per_core;
+    latency_cfg.num_nops_per_tile = cfg.num_nops_per_tile;
+
+    log_info(
+        LogTest,
+        "buffer_tune: latency_phase input_cb_depth={}, output_cb_depth={}, pages_per_core={}, "
+        "num_programs={}, compute_nops={}",
+        latency_cfg.input_cb_depth_tiles,
+        latency_cfg.output_cb_depth_tiles,
+        latency_cfg.num_pages_per_core,
+        latency_cfg.num_programs,
+        latency_cfg.num_nops_per_tile);
+
+    TT_FATAL(
+        latency_cfg.num_pages_per_core <= tune_cfg.num_pages_per_core,
+        "buffer_tune latency --num-pages-per-core ({}) must be <= --buffer-tune-pages-per-core ({})",
+        latency_cfg.num_pages_per_core,
+        tune_cfg.num_pages_per_core);
+
+    const uint32_t latency_total_tiles = num_cores * latency_cfg.num_pages_per_core;
+    BuiltProgram latency_built = build_program(
+        mesh_device, latency_cfg, input_buffer, output_buffer, latency_total_tiles, single_tile_size_bytes);
+
+    distributed::MeshWorkload latency_workload;
+    const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    latency_workload.add_program(device_range, std::move(latency_built.program));
+    Program& latency_program = latency_workload.get_programs().begin()->second;
+
+    configure_program_launch(latency_program, latency_built, input_buffer_addr, output_buffer_addr, 0, 0);
+    distributed::EnqueueMeshWorkload(cq, latency_workload, /*blocking=*/false);
+    distributed::Finish(cq);
+
+    const long long latency_elapsed_us = execute_timed_workload(
+        mesh_device,
+        cq,
+        latency_workload,
+        latency_program,
+        latency_built,
+        latency_cfg,
+        input_buffer_addr,
+        output_buffer_addr,
+        latency_cfg.num_programs,
+        latency_cfg.use_realtime_profiler,
+        rt_profiler_active);
+
+    log_info(
+        LogTest,
+        "buffer_tune: latency_phase {} program(s) in {} us (avg {:.2f} us/program)",
+        latency_cfg.num_programs,
+        latency_elapsed_us,
+        static_cast<double>(latency_elapsed_us) / latency_cfg.num_programs);
+
+    if (latency_cfg.use_device_profiler) {
+        tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+        log_info(
+            LogTest,
+            "buffer_tune: device profiler CSV at $TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv "
+            "(export with export_op_to_op_profiler_csv.py)");
+    }
+
+    pass = verify_output_matches_input(cq, output_buffer, input_data) && pass;
+
+    mesh_device->close();
+    return pass;
 }
 
 }  // namespace
@@ -420,19 +1058,36 @@ int main(int argc, char** argv) {
 
         log_info(
             LogTest,
-            "op_to_op_latency: device_id={}, pages_per_core={}, compute_nops={}, num_programs={}, warmup={}, "
-            "use_trace={}, use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}",
+            "op_to_op_latency: device_id={}, pages_per_core={}, reader_push_tiles={}, input_cb_depth_tiles={}, "
+            "output_cb_depth_tiles={}, reader_mode={}, compute_nops={}, num_programs={}, warmup={}, use_trace={}, "
+            "use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}, buffer_tune={}",
             cfg.device_id,
             cfg.num_pages_per_core,
+            cfg.reader_push_tile_count,
+            cfg.input_cb_depth_tiles,
+            cfg.output_cb_depth_tiles,
+            cfg.reader_mode,
             cfg.num_nops_per_tile,
             cfg.num_programs,
             cfg.warmup,
             cfg.use_trace,
             cfg.use_device_profiler,
             cfg.use_realtime_profiler,
-            cfg.trace_region_size);
+            cfg.trace_region_size,
+            cfg.buffer_tune);
         TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
         TT_FATAL(cfg.num_pages_per_core >= 1, "--num-pages-per-core must be >= 1");
+        TT_FATAL(cfg.reader_push_tile_count >= 1, "--reader-push-tiles must be >= 1");
+
+        if (cfg.buffer_tune) {
+            const bool tune_pass = run_buffer_tune_mode(cfg);
+            if (tune_pass) {
+                log_info(LogTest, "op_to_op_latency: PASSED (buffer_tune)");
+                return 0;
+            }
+            log_error(LogTest, "op_to_op_latency: FAILED (buffer_tune)");
+            return 1;
+        }
 
         // If the user asked for a CSV dump, make sure the runtime profiler is
         // actually enabled (Tracy-enabled build + TT_METAL_DEVICE_PROFILER=1
@@ -500,19 +1155,22 @@ int main(int argc, char** argv) {
         workload.add_program(device_range, std::move(built.program));
         Program& program = workload.get_programs().begin()->second;
 
-        // Real-time profiler drops id==0; timed launches use host_runtime_id 1..N.
+        // Device CSV uses PROG_ID=0 for warmup/pre-compile; export skips id < 1.
+        // Host runtime_id=0 is not reported by the real-time profiler (dropped by Metal).
         constexpr uint32_t kPrecompileProfilerProgramId = 0;
 
+        const uint32_t input_buffer_addr = input_buffer->address();
+        const uint32_t output_buffer_addr = output_buffer->address();
         auto launch = [&](uint32_t profiler_program_id, uint32_t host_runtime_id) {
             configure_program_launch(
-                program, built.compute_kernel, mesh_device, total_num_tiles, profiler_program_id, host_runtime_id);
+                program, built, input_buffer_addr, output_buffer_addr, profiler_program_id, host_runtime_id);
         };
 
         // Warmup (untimed): one eager enqueue absorbs the JIT-load /
         // dispatcher prefetch cost so they do not pollute either the FD timing
         // loop or the trace-capture step.
         if (cfg.warmup) {
-            launch(kPrecompileProfilerProgramId, 1);
+            launch(kPrecompileProfilerProgramId, kPrecompileProfilerProgramId);
             distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
             distributed::Finish(cq);
         }
@@ -602,7 +1260,8 @@ int main(int argc, char** argv) {
                 LogTest,
                 "Device profiler results dumped. Inspect "
                 "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv "
-                "(PROG_ID, TRISC_0 TILE_IDX, TRISC_2 FINISH_LAST_PUSH; chip gaps: --use-realtime-profiler).");
+                "(PROG_ID, read/write barriers, TRISC_0 TILE_IDX, TRISC_2 FINISH_LAST_PUSH; "
+                "dispatch done/go: --use-realtime-profiler -> profile_log_device_rt.csv).");
         }
 
         std::vector<uint32_t> output_data;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -964,16 +964,30 @@ bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
             output_peak_gbps = std::max(output_peak_gbps, row.gbps);
         }
         const double out_thresh = output_peak_gbps * (1.0 - tolerance_fraction);
-        best_output_depth = output_bw_rows.front().output_cb_depth;
+        bool out_found = false;
         for (const auto& row : output_bw_rows) {
-            if (row.gbps >= out_thresh && row.output_cb_depth < best_output_depth) {
-                best_output_depth = row.output_cb_depth;
+            if (row.gbps >= out_thresh) {
+                if (!out_found || row.output_cb_depth < best_output_depth) {
+                    best_output_depth = row.output_cb_depth;
+                    out_found = true;
+                }
+            }
+        }
+        if (!out_found) {
+            best_output_depth = output_bw_rows.front().output_cb_depth;
+            for (const auto& row : output_bw_rows) {
+                if (row.gbps >= output_peak_gbps - 1e-6 && row.output_cb_depth < best_output_depth) {
+                    best_output_depth = row.output_cb_depth;
+                }
             }
         }
         log_info(
             LogTest,
-            "buffer_tune: output sweep peak_gbps={:.4f}, smallest_output_cb_depth_at_peak={}",
+            "buffer_tune: output sweep peak_gbps={:.4f}, threshold_gbps={:.4f} (within {:.1f}% of peak), "
+            "smallest_output_cb_depth_at_peak={}",
             output_peak_gbps,
+            out_thresh,
+            tune_cfg.buffer_tune_bw_tolerance_pct,
             best_output_depth);
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -126,6 +126,15 @@ struct BenchmarkConfig {
     uint32_t output_cb_depth_tiles = 0;
     // 0 = reserve N then read+push one tile at a time; 1 = reserve N, read all, push N.
     uint32_t reader_mode = 0;
+    // DRAM page size in tiles. Larger pages = fewer, larger NoC transactions
+    // per program. CB pages stay 1 tile each so compute kernel is unchanged.
+    uint32_t page_size_tiles = 1;
+    // Writer barrier mode: 0 = per-tile barrier (default, mirrors current ops);
+    //                     1 = single barrier at end of all writes.
+    uint32_t write_barrier_mode = 0;
+    // Cap active core count. 0 = use full grid (default). Used to test whether
+    // brisc_done_to_go scales with core count.
+    uint32_t num_active_cores = 0;
     bool buffer_tune = false;
     std::string buffer_tune_input_depths = "2,4,6,8,12,16,24,32";
     std::string buffer_tune_output_depths;
@@ -150,6 +159,15 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     if (test_args::has_command_option(args, "--reader-batch-push")) {
         cfg.reader_mode = 1;
     }
+    if (test_args::has_command_option(args, "--reader-dbuf-trid")) {
+        // Per-trid double-buffer reader (Almeet's pipelined design).
+        cfg.reader_mode = 2;
+    }
+    cfg.page_size_tiles = test_args::get_command_option_uint32(args, "--page-size-tiles", cfg.page_size_tiles);
+    if (test_args::has_command_option(args, "--writer-barrier-at-end")) {
+        cfg.write_barrier_mode = 1;
+    }
+    cfg.num_active_cores = test_args::get_command_option_uint32(args, "--num-active-cores", cfg.num_active_cores);
     if (test_args::has_command_option(args, "--buffer-tune")) {
         cfg.buffer_tune = true;
     }
@@ -398,6 +416,8 @@ struct BuiltProgram {
     uint32_t reader_mode = 0;
     uint32_t input_cb_depth_tiles = 0;
     uint32_t output_cb_depth_tiles = 2;
+    uint32_t page_size_tiles = 1;
+    uint32_t write_barrier_mode = 0;
 };
 
 // Set reader/writer/compute runtime args (including program_id) on every active core.
@@ -428,12 +448,18 @@ void set_program_launch_args(
                      start_tile_id,
                      program_id,
                      reader_push_tile_count,
-                     reader_mode});
+                     reader_mode,
+                     built.page_size_tiles});
                 SetRuntimeArgs(
                     program,
                     built.writer_kernel,
                     core,
-                    {output_buffer_addr, tiles_per_core, start_tile_id, program_id});
+                    {output_buffer_addr,
+                     tiles_per_core,
+                     start_tile_id,
+                     program_id,
+                     built.page_size_tiles,
+                     built.write_barrier_mode});
                 SetRuntimeArgs(program, built.compute_kernel, core, {tiles_per_core, program_id});
                 start_tile_id += tiles_per_core;
             }
@@ -471,7 +497,14 @@ BuiltProgram build_program(
     uint32_t single_tile_size_bytes) {
     Program program = CreateProgram();
 
-    const auto grid = mesh_device->compute_with_storage_grid_size();
+    const auto full_grid = mesh_device->compute_with_storage_grid_size();
+    CoreCoord grid = full_grid;
+    if (cfg.num_active_cores > 0 && cfg.num_active_cores < full_grid.x * full_grid.y) {
+        const uint32_t want = cfg.num_active_cores;
+        const uint32_t gx = std::min<uint32_t>(full_grid.x, want);
+        const uint32_t gy = (want + gx - 1) / gx;
+        grid = CoreCoord{gx, std::min<uint32_t>(full_grid.y, gy)};
+    }
     constexpr bool kRowMajor = true;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(grid, total_num_tiles, kRowMajor);
@@ -507,13 +540,43 @@ BuiltProgram build_program(
         cfg.num_pages_per_core,
         push_tiles);
 
+    const uint32_t page_size_tiles = cfg.page_size_tiles > 0 ? cfg.page_size_tiles : 1;
+    TT_FATAL(
+        cfg.num_pages_per_core % page_size_tiles == 0,
+        "--num-pages-per-core ({}) must be a multiple of --page-size-tiles ({})",
+        cfg.num_pages_per_core,
+        page_size_tiles);
+    TT_FATAL(
+        input_cb_depth >= page_size_tiles,
+        "input CB depth ({}) must be >= --page-size-tiles ({})",
+        input_cb_depth,
+        page_size_tiles);
+    TT_FATAL(
+        output_cb_depth >= page_size_tiles,
+        "output CB depth ({}) must be >= --page-size-tiles ({}) so the writer can accumulate a full page",
+        output_cb_depth,
+        page_size_tiles);
+    if (cfg.reader_mode == 2) {
+        TT_FATAL(
+            input_cb_depth >= 2 * page_size_tiles,
+            "per-trid DB needs input CB depth ({}) >= 2 * --page-size-tiles ({})",
+            input_cb_depth,
+            2 * page_size_tiles);
+    } else if (page_size_tiles > 1) {
+        TT_FATAL(
+            false,
+            "--page-size-tiles > 1 currently requires --reader-dbuf-trid (reader_mode 2); "
+            "legacy modes 0/1 use tile_id as page_id and would read wrong data.");
+    }
+
     log_info(
         LogTest,
-        "Reader: push_tiles={}, input_cb_depth={}, output_cb_depth={} (compute->writer still 1 tile at a time), "
-        "reader_mode={} (0=incremental read+push, 1=batch read then push)",
+        "Reader: push_tiles={}, input_cb_depth={}, output_cb_depth={}, page_size_tiles={} (compute->writer still 1 "
+        "tile at a time), reader_mode={} (0=incremental read+push, 1=batch read then push, 2=per-trid double-buffer)",
         push_tiles,
         input_cb_depth,
         output_cb_depth,
+        page_size_tiles,
         cfg.reader_mode);
 
     CircularBufferConfig cb_in_config =
@@ -573,9 +636,23 @@ BuiltProgram build_program(
                     program,
                     reader_kernel,
                     core,
-                    {input_buffer->address(), tiles_per_core, start_tile_id, 0, push_tiles, cfg.reader_mode});
+                    {input_buffer->address(),
+                     tiles_per_core,
+                     start_tile_id,
+                     0,
+                     push_tiles,
+                     cfg.reader_mode,
+                     page_size_tiles});
                 SetRuntimeArgs(
-                    program, writer_kernel, core, {output_buffer->address(), tiles_per_core, start_tile_id, 0});
+                    program,
+                    writer_kernel,
+                    core,
+                    {output_buffer->address(),
+                     tiles_per_core,
+                     start_tile_id,
+                     0,
+                     page_size_tiles,
+                     cfg.write_barrier_mode});
                 SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, 0});
                 start_tile_id += tiles_per_core;
             }
@@ -600,6 +677,8 @@ BuiltProgram build_program(
     built.reader_mode = cfg.reader_mode;
     built.input_cb_depth_tiles = input_cb_depth;
     built.output_cb_depth_tiles = output_cb_depth;
+    built.page_size_tiles = page_size_tiles;
+    built.write_barrier_mode = cfg.write_barrier_mode;
     return built;
 }
 
@@ -814,7 +893,11 @@ bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
     log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->get_devices()[0]));
 
     const auto grid = mesh_device->compute_with_storage_grid_size();
-    const uint32_t num_cores = grid.x * grid.y;
+    uint32_t effective_cores = grid.x * grid.y;
+    if (tune_cfg.num_active_cores > 0 && tune_cfg.num_active_cores < effective_cores) {
+        effective_cores = tune_cfg.num_active_cores;
+    }
+    const uint32_t num_cores = effective_cores;
     const uint32_t total_num_tiles = num_cores * tune_cfg.num_pages_per_core;
 
     constexpr auto kDataFormat = tt::DataFormat::Float16_b;
@@ -822,8 +905,10 @@ bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
     const uint32_t buffer_size_bytes = total_num_tiles * single_tile_size_bytes;
     const uint64_t bytes_per_program = 2ull * total_num_tiles * single_tile_size_bytes;
 
+    const uint32_t dram_page_size_bytes =
+        (tune_cfg.page_size_tiles > 0 ? tune_cfg.page_size_tiles : 1) * single_tile_size_bytes;
     distributed::DeviceLocalBufferConfig dram_local_config{
-        .page_size = single_tile_size_bytes,
+        .page_size = dram_page_size_bytes,
         .buffer_type = BufferType::DRAM,
     };
     distributed::ReplicatedBufferConfig dram_buf_config{.size = buffer_size_bytes};
@@ -1129,18 +1214,24 @@ int main(int argc, char** argv) {
         log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->get_devices()[0]));
 
         const auto grid = mesh_device->compute_with_storage_grid_size();
-        const uint32_t num_cores = grid.x * grid.y;
+        uint32_t effective_cores = grid.x * grid.y;
+        if (cfg.num_active_cores > 0 && cfg.num_active_cores < effective_cores) {
+            effective_cores = cfg.num_active_cores;
+        }
+        const uint32_t num_cores = effective_cores;
         const uint32_t total_num_tiles = num_cores * cfg.num_pages_per_core;
 
         constexpr auto kDataFormat = tt::DataFormat::Float16_b;
         const uint32_t single_tile_size_bytes = tile_size(kDataFormat);
         const uint32_t buffer_size_bytes = total_num_tiles * single_tile_size_bytes;
 
-        // Interleaved DRAM buffer: page_size == one tile, so pages are spread
-        // across DRAM banks round-robin. This is what makes the read/write
-        // pattern look like a real op.
+        // Interleaved DRAM buffer: page_size = page_size_tiles * tile_bytes
+        // (default 1 tile per page), so each NoC transaction transfers one
+        // page from one DRAM bank; pages are spread across banks round-robin.
+        const uint32_t dram_page_size_bytes =
+            (cfg.page_size_tiles > 0 ? cfg.page_size_tiles : 1) * single_tile_size_bytes;
         distributed::DeviceLocalBufferConfig dram_local_config{
-            .page_size = single_tile_size_bytes,
+            .page_size = dram_page_size_bytes,
             .buffer_type = BufferType::DRAM,
         };
         distributed::ReplicatedBufferConfig dram_buf_config{.size = buffer_size_bytes};

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -140,10 +140,12 @@ struct BenchmarkConfig {
     // true = column-major (fix x, vary y first). Lets us probe NoC-direction asymmetry
     // (a row of cores contends differently on the torus than a column).
     bool core_layout_col = false;
-    // Swap which NoC reader/writer use. Default: reader=NOC1, writer=NOC0. The two NoCs
-    // route opposite directions on the torus, so one favors the read path and the other
-    // the write path (more so with many cores). Spot-check which assignment is better.
-    bool swap_nocs = false;
+    // NoC assignment for reader / writer (0 = NOC0, 1 = NOC1). The two NoCs route opposite
+    // directions on the torus; measured read-BW table shows reads scale to ~206 GB/s on
+    // NOC0 but cap at ~67 on NOC1, so the defaults are reader=NOC0, writer=NOC1 (the
+    // opposite of the framework default reader=NOC1/writer=NOC0). Override per kernel.
+    uint32_t reader_noc = 0;
+    uint32_t writer_noc = 1;
     bool buffer_tune = false;
     std::string buffer_tune_input_depths = "2,4,6,8,12,16,24,32";
     std::string buffer_tune_output_depths;
@@ -212,8 +214,12 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     if (test_args::has_command_option(args, "--core-layout-col")) {
         cfg.core_layout_col = true;
     }
+    cfg.reader_noc = test_args::get_command_option_uint32(args, "--reader-noc", cfg.reader_noc);
+    cfg.writer_noc = test_args::get_command_option_uint32(args, "--writer-noc", cfg.writer_noc);
     if (test_args::has_command_option(args, "--swap-nocs")) {
-        cfg.swap_nocs = true;
+        // Back-compat: legacy framework assignment (reader=NOC1, writer=NOC0).
+        cfg.reader_noc = 1;
+        cfg.writer_noc = 0;
     }
     if (test_args::has_command_option(args, "--buffer-tune")) {
         cfg.buffer_tune = true;
@@ -687,9 +693,10 @@ BuiltProgram build_program(
     const uint32_t cross_program_offset_tiles = cfg.cross_program_dram_offset ? total_num_tiles : 0u;
     std::vector<uint32_t> reader_compile_time_args = {
         kInputCbId, cfg.reader_mode, push_tiles, page_size_tiles, trid_in_flight, cross_program_offset_tiles};
-    // Default reader=NOC1, writer=NOC0; --swap-nocs flips them.
-    const NOC reader_noc = cfg.swap_nocs ? NOC::NOC_0 : NOC::NOC_1;
-    const NOC writer_noc = cfg.swap_nocs ? NOC::NOC_1 : NOC::NOC_0;
+    // Defaults: reader=NOC0, writer=NOC1 (measured best). --reader-noc/--writer-noc override.
+    const NOC reader_noc = (cfg.reader_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
+    const NOC writer_noc = (cfg.writer_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
+    log_info(LogTest, "NoC assignment: reader=NOC{}, writer=NOC{}", cfg.reader_noc, cfg.writer_noc);
     TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
     auto reader_kernel = CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -136,6 +136,14 @@ struct BenchmarkConfig {
     // Cap active core count. 0 = use full grid (default). Used to test whether
     // brisc_done_to_go scales with core count.
     uint32_t num_active_cores = 0;
+    // Core placement for the active set: false = row-major (fill a row then next row),
+    // true = column-major (fix x, vary y first). Lets us probe NoC-direction asymmetry
+    // (a row of cores contends differently on the torus than a column).
+    bool core_layout_col = false;
+    // Swap which NoC reader/writer use. Default: reader=NOC1, writer=NOC0. The two NoCs
+    // route opposite directions on the torus, so one favors the read path and the other
+    // the write path (more so with many cores). Spot-check which assignment is better.
+    bool swap_nocs = false;
     bool buffer_tune = false;
     std::string buffer_tune_input_depths = "2,4,6,8,12,16,24,32";
     std::string buffer_tune_output_depths;
@@ -160,6 +168,10 @@ struct BenchmarkConfig {
     // consumer drains at full speed and does not back-pressure the reader. Use when
     // measuring read bandwidth; compute cost is then copy + NOPs only.
     bool lean_compute = false;
+    // Skip the host output-data check. The BW reader writes dummy data to a fixed L1
+    // address, so the written DRAM won't match the input; for latency/BW measurement
+    // (which needs real DRAM writes, i.e. not --read-only) we don't care about data.
+    bool skip_output_validation = false;
     // Writer: 0 = noc_async_writes_flushed every page; 1 = flush only when output
     // CB back-pressure requires it (recommended back-pressure write path).
     bool writer_flush_on_pressure = false;
@@ -197,6 +209,12 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     cfg.reader_trid_in_flight =
         test_args::get_command_option_uint32(args, "--reader-trid-in-flight", cfg.reader_trid_in_flight);
     cfg.num_active_cores = test_args::get_command_option_uint32(args, "--num-active-cores", cfg.num_active_cores);
+    if (test_args::has_command_option(args, "--core-layout-col")) {
+        cfg.core_layout_col = true;
+    }
+    if (test_args::has_command_option(args, "--swap-nocs")) {
+        cfg.swap_nocs = true;
+    }
     if (test_args::has_command_option(args, "--buffer-tune")) {
         cfg.buffer_tune = true;
     }
@@ -237,6 +255,9 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     }
     if (test_args::has_command_option(args, "--read-only")) {
         cfg.read_only = true;
+    }
+    if (test_args::has_command_option(args, "--skip-output-validation")) {
+        cfg.skip_output_validation = true;
     }
     if (test_args::has_command_option(args, "--lean-compute")) {
         cfg.lean_compute = true;
@@ -532,26 +553,50 @@ BuiltProgram build_program(
     Program program = CreateProgram();
 
     const auto full_grid = mesh_device->compute_with_storage_grid_size();
-    CoreCoord grid = full_grid;
-    if (cfg.num_active_cores > 0 && cfg.num_active_cores < full_grid.x * full_grid.y) {
-        const uint32_t want = cfg.num_active_cores;
-        const uint32_t gx = std::min<uint32_t>(full_grid.x, want);
-        const uint32_t gy = (want + gx - 1) / gx;
-        grid = CoreCoord{gx, std::min<uint32_t>(full_grid.y, gy)};
+    uint32_t want = full_grid.x * full_grid.y;
+    if (cfg.num_active_cores > 0 && cfg.num_active_cores < want) {
+        want = cfg.num_active_cores;
     }
-    constexpr bool kRowMajor = true;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        split_work_to_cores(grid, total_num_tiles, kRowMajor);
+    // Build exactly `want` worker cores. Row-major fills a row before stepping y;
+    // column-major (--core-layout-col) fixes x and varies y first, so e.g. 8 cores
+    // land in a column at x=0 (physical x=1) instead of a single NoC row.
+    std::vector<CoreCoord> core_list;
+    if (cfg.core_layout_col) {
+        for (uint32_t x = 0; x < full_grid.x && core_list.size() < want; ++x) {
+            for (uint32_t y = 0; y < full_grid.y && core_list.size() < want; ++y) {
+                core_list.push_back(CoreCoord{x, y});
+            }
+        }
+    } else {
+        for (uint32_t y = 0; y < full_grid.y && core_list.size() < want; ++y) {
+            for (uint32_t x = 0; x < full_grid.x && core_list.size() < want; ++x) {
+                core_list.push_back(CoreCoord{x, y});
+            }
+        }
+    }
+    const uint32_t num_cores = static_cast<uint32_t>(core_list.size());
+    std::vector<CoreRange> ranges;
+    ranges.reserve(num_cores);
+    for (const auto& c : core_list) {
+        ranges.emplace_back(c, c);
+    }
+    CoreRangeSet all_cores(ranges);
+    CoreRangeSet core_group_1 = all_cores;
+    CoreRangeSet core_group_2;
+    const uint32_t num_tiles_per_core_group_1 = num_cores > 0 ? total_num_tiles / num_cores : 0;
+    const uint32_t num_tiles_per_core_group_2 = 0;
 
     log_info(
         LogTest,
-        "Grid {}x{}, {} cores active, total_num_tiles={} ({} tiles/core in group_1, {} in group_2)",
-        grid.x,
-        grid.y,
+        "Active cores: {} ({}-major), full_grid {}x{}, total_num_tiles={} ({} tiles/core); first={} last={}",
         num_cores,
+        cfg.core_layout_col ? "column" : "row",
+        full_grid.x,
+        full_grid.y,
         total_num_tiles,
         num_tiles_per_core_group_1,
-        num_tiles_per_core_group_2);
+        num_cores ? core_list.front().str() : "none",
+        num_cores ? core_list.back().str() : "none");
 
     // Input CB depth defaults to 2x reader push chunk (e.g. push 2 -> depth 4).
     constexpr uint32_t kInputCbId = tt::CBIndex::c_0;
@@ -642,15 +687,16 @@ BuiltProgram build_program(
     const uint32_t cross_program_offset_tiles = cfg.cross_program_dram_offset ? total_num_tiles : 0u;
     std::vector<uint32_t> reader_compile_time_args = {
         kInputCbId, cfg.reader_mode, push_tiles, page_size_tiles, trid_in_flight, cross_program_offset_tiles};
+    // Default reader=NOC1, writer=NOC0; --swap-nocs flips them.
+    const NOC reader_noc = cfg.swap_nocs ? NOC::NOC_0 : NOC::NOC_1;
+    const NOC writer_noc = cfg.swap_nocs ? NOC::NOC_1 : NOC::NOC_0;
     TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
     auto reader_kernel = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp",
         all_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = reader_compile_time_args});
+            .processor = DataMovementProcessor::RISCV_1, .noc = reader_noc, .compile_args = reader_compile_time_args});
 
     // Writer: NOC0 / RISCV0, pushes to interleaved DRAM.
     // Compile-time args order MUST match writer_interleaved.cpp:
@@ -671,9 +717,7 @@ BuiltProgram build_program(
         "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp",
         all_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = writer_compile_time_args});
+            .processor = DataMovementProcessor::RISCV_0, .noc = writer_noc, .compile_args = writer_compile_time_args});
 
     // Compute: copy_tile + tunable NOP spin.
     std::vector<uint32_t> compute_compile_time_args = {
@@ -1576,7 +1620,7 @@ int main(int argc, char** argv) {
                 "dispatch done/go: --use-realtime-profiler -> profile_log_device_rt.csv).");
         }
 
-        if (!cfg.read_only) {
+        if (!cfg.read_only && !cfg.skip_output_validation) {
             std::vector<uint32_t> output_data;
             distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -333,6 +333,7 @@ void log_realtime_op_to_op_gaps(const std::vector<tt::tt_metal::experimental::Pr
         uint32_t gap_count = 0;
         double min_gap_ns = 0.0;
         double max_gap_ns = 0.0;
+        std::vector<double> gaps_ns;
         for (size_t i = 1; i < chip_records.size(); ++i) {
             const auto& prev = chip_records[i - 1];
             const auto& cur = chip_records[i];
@@ -369,17 +370,26 @@ void log_realtime_op_to_op_gaps(const std::vector<tt::tt_metal::experimental::Pr
             }
             sum_gap_ns += gap_ns;
             ++gap_count;
+            gaps_ns.push_back(gap_ns);
         }
         if (gap_count > 0) {
+            std::sort(gaps_ns.begin(), gaps_ns.end());
+            const double median_ns = gaps_ns[gaps_ns.size() / 2];
             log_info(
                 LogTest,
-                "Real-time profiler chip {}: {} op-to-op gap(s) — min {:.2f} ns, max {:.2f} ns, mean {:.2f} ns "
-                "(next program start − previous program end)",
+                "Real-time profiler chip {}: {} op-to-op gap(s) — min {:.2f} ns, median {:.2f} ns, max {:.2f} ns, "
+                "mean {:.2f} ns (next program start − previous program end)",
                 chip_id,
                 gap_count,
                 min_gap_ns,
+                median_ns,
                 max_gap_ns,
                 sum_gap_ns / gap_count);
+            std::string all = "Real-time profiler chip " + std::to_string(chip_id) + " sorted gaps (ns):";
+            for (double g : gaps_ns) {
+                all += fmt::format(" {:.0f}", g);
+            }
+            log_info(LogTest, "{}", all);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -694,6 +694,17 @@ BuiltProgram build_program(
     std::vector<uint32_t> reader_compile_time_args = {
         kInputCbId, cfg.reader_mode, push_tiles, page_size_tiles, trid_in_flight, cross_program_offset_tiles};
     // Defaults: reader=NOC0, writer=NOC1 (measured best). --reader-noc/--writer-noc override.
+    // HARD CONSTRAINT: the two data-movement kernels on a core must be on DIFFERENT NoCs.
+    // Putting both on the same NoC hangs the device (requires a chip reset), so fail fast.
+    TT_FATAL(
+        cfg.reader_noc <= 1 && cfg.writer_noc <= 1,
+        "--reader-noc/--writer-noc must be 0 or 1 (got reader={}, writer={})",
+        cfg.reader_noc,
+        cfg.writer_noc);
+    TT_FATAL(
+        cfg.reader_noc != cfg.writer_noc,
+        "reader and writer must use DIFFERENT NoCs (both NOC{} requested) -- same NoC hangs the device",
+        cfg.reader_noc);
     const NOC reader_noc = (cfg.reader_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
     const NOC writer_noc = (cfg.writer_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
     log_info(LogTest, "NoC assignment: reader=NOC{}, writer=NOC{}", cfg.reader_noc, cfg.writer_noc);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -140,6 +140,9 @@ struct BenchmarkConfig {
     // true = column-major (fix x, vary y first). Lets us probe NoC-direction asymmetry
     // (a row of cores contends differently on the torus than a column).
     bool core_layout_col = false;
+    // Reverse the core fill order (take the LAST `want` cores instead of the first) -- the
+    // mirror-image core set, to test whether which specific cores are used drives results.
+    bool core_reverse = false;
     // NoC assignment for reader / writer (0 = NOC0, 1 = NOC1). The two NoCs route opposite
     // directions on the torus; measured read-BW table shows reads scale to ~206 GB/s on
     // NOC0 but cap at ~67 on NOC1, so the defaults are reader=NOC0, writer=NOC1 (the
@@ -213,6 +216,9 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     cfg.num_active_cores = test_args::get_command_option_uint32(args, "--num-active-cores", cfg.num_active_cores);
     if (test_args::has_command_option(args, "--core-layout-col")) {
         cfg.core_layout_col = true;
+    }
+    if (test_args::has_command_option(args, "--core-reverse")) {
+        cfg.core_reverse = true;
     }
     cfg.reader_noc = test_args::get_command_option_uint32(args, "--reader-noc", cfg.reader_noc);
     cfg.writer_noc = test_args::get_command_option_uint32(args, "--writer-noc", cfg.writer_noc);
@@ -563,23 +569,29 @@ BuiltProgram build_program(
     if (cfg.num_active_cores > 0 && cfg.num_active_cores < want) {
         want = cfg.num_active_cores;
     }
-    // Build exactly `want` worker cores. Row-major fills a row before stepping y;
-    // column-major (--core-layout-col) fixes x and varies y first, so e.g. 8 cores
-    // land in a column at x=0 (physical x=1) instead of a single NoC row.
-    std::vector<CoreCoord> core_list;
+    // Build the full grid order (row-major, or column-major with --core-layout-col), then
+    // take the first `want`. --core-reverse takes the LAST `want` instead (reversed fill
+    // order) so we can use the mirror-image core set and rule out which specific cores /
+    // direction drive the curve.
+    std::vector<CoreCoord> full_order;
     if (cfg.core_layout_col) {
-        for (uint32_t x = 0; x < full_grid.x && core_list.size() < want; ++x) {
-            for (uint32_t y = 0; y < full_grid.y && core_list.size() < want; ++y) {
-                core_list.push_back(CoreCoord{x, y});
+        for (uint32_t x = 0; x < full_grid.x; ++x) {
+            for (uint32_t y = 0; y < full_grid.y; ++y) {
+                full_order.push_back(CoreCoord{x, y});
             }
         }
     } else {
-        for (uint32_t y = 0; y < full_grid.y && core_list.size() < want; ++y) {
-            for (uint32_t x = 0; x < full_grid.x && core_list.size() < want; ++x) {
-                core_list.push_back(CoreCoord{x, y});
+        for (uint32_t y = 0; y < full_grid.y; ++y) {
+            for (uint32_t x = 0; x < full_grid.x; ++x) {
+                full_order.push_back(CoreCoord{x, y});
             }
         }
     }
+    if (cfg.core_reverse) {
+        std::reverse(full_order.begin(), full_order.end());
+    }
+    std::vector<CoreCoord> core_list(
+        full_order.begin(), full_order.begin() + std::min<size_t>(want, full_order.size()));
     const uint32_t num_cores = static_cast<uint32_t>(core_list.size());
     std::vector<CoreRange> ranges;
     ranges.reserve(num_cores);
@@ -594,9 +606,10 @@ BuiltProgram build_program(
 
     log_info(
         LogTest,
-        "Active cores: {} ({}-major), full_grid {}x{}, total_num_tiles={} ({} tiles/core); first={} last={}",
+        "Active cores: {} ({}-major{}), full_grid {}x{}, total_num_tiles={} ({} tiles/core); first={} last={}",
         num_cores,
         cfg.core_layout_col ? "column" : "row",
+        cfg.core_reverse ? " reversed" : "",
         full_grid.x,
         full_grid.y,
         total_num_tiles,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -141,6 +141,11 @@ struct BenchmarkConfig {
     std::string buffer_tune_output_depths;
     uint32_t buffer_tune_pages_per_core = 32;
     double buffer_tune_bw_tolerance_pct = 2.0;
+    // Full input×output CB grid (requires --buffer-tune-output-depths). Skips
+    // sequential pick; logs BUFFER_TUNE rows with phase=cb_grid.
+    bool buffer_tune_grid = false;
+    // Skip latency/profiler phase after BW sweep (for grid sweeps).
+    bool buffer_tune_bw_only = false;
     bool warmup = true;
     bool use_trace = false;
     bool use_device_profiler = false;
@@ -148,6 +153,24 @@ struct BenchmarkConfig {
     size_t trace_region_size = 1ull << 20;  // 1 MiB
     // Untimed trace replays before the measured replay (steady-state trace path).
     uint32_t trace_warmup_replays = 0;
+    // Read-only mode: writer pops from output CB but skips DRAM writes.
+    // Isolates pure DRAM read BW through the reader pipeline.
+    bool read_only = false;
+    // Writer: 0 = noc_async_writes_flushed every page; 1 = flush only when output
+    // CB back-pressure requires it (recommended back-pressure write path).
+    bool writer_flush_on_pressure = false;
+    // Each program reads/writes a disjoint per-program tile slice rather than the
+    // same tiles every program. Forces DRAM controller to open new rows per
+    // program (more app-like streaming pattern); allocates a buffer big enough
+    // for (num_programs + 1) slices.
+    bool cross_program_dram_offset = false;
+    // Writer end-of-kernel barrier (Batch-8 latency experiment for 's HW
+    // barrier-elimination proposal):
+    //   0 = noc_async_write_barrier()  (DEFAULT; wait for DRAM ACK; safe)
+    //   1 = noc_async_writes_flushed() (cheaper; writes left source but not yet ACKed)
+    //   2 = no end barrier             (UNSAFE for real workloads; simulates HW
+    //                                   giving us this guarantee for free)
+    uint32_t writer_end_barrier_mode = 0;
 };
 
 BenchmarkConfig parse_args(const std::vector<std::string>& args) {
@@ -183,6 +206,12 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
         test_args::get_command_option_uint32(args, "--buffer-tune-pages-per-core", cfg.buffer_tune_pages_per_core);
     cfg.buffer_tune_bw_tolerance_pct =
         test_args::get_command_option_double(args, "--buffer-tune-bw-tolerance", cfg.buffer_tune_bw_tolerance_pct);
+    if (test_args::has_command_option(args, "--buffer-tune-grid")) {
+        cfg.buffer_tune_grid = true;
+    }
+    if (test_args::has_command_option(args, "--buffer-tune-bw-only")) {
+        cfg.buffer_tune_bw_only = true;
+    }
     cfg.num_nops_per_tile = test_args::get_command_option_uint32(args, "--compute-nops", cfg.num_nops_per_tile);
     cfg.num_programs = test_args::get_command_option_uint32(args, "--num-programs", cfg.num_programs);
     cfg.device_id = test_args::get_command_option_uint32(args, "--device-id", cfg.device_id);
@@ -201,6 +230,21 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     }
     if (test_args::has_command_option(args, "--use-realtime-profiler")) {
         cfg.use_realtime_profiler = true;
+    }
+    if (test_args::has_command_option(args, "--read-only")) {
+        cfg.read_only = true;
+    }
+    if (test_args::has_command_option(args, "--writer-flush-on-pressure")) {
+        cfg.writer_flush_on_pressure = true;
+    }
+    if (test_args::has_command_option(args, "--cross-program-dram-offset")) {
+        cfg.cross_program_dram_offset = true;
+    }
+    cfg.writer_end_barrier_mode =
+        test_args::get_command_option_uint32(args, "--writer-end-barrier-mode", cfg.writer_end_barrier_mode);
+    if (cfg.writer_end_barrier_mode > 2) {
+        log_fatal(LogTest, "--writer-end-barrier-mode must be 0 (barrier), 1 (flushed), or 2 (none)");
+        cfg.writer_end_barrier_mode = 0;
     }
     return cfg;
 }
@@ -587,9 +631,10 @@ BuiltProgram build_program(
     // Reader: NOC1 / RISCV1, pulls from interleaved DRAM via TensorAccessor.
     // Compile-time args order MUST match reader_interleaved.cpp:
     //   [0]=cb_in, [1]=READER_MODE, [2]=PUSH_TILE_COUNT, [3]=TILES_PER_PAGE,
-    //   [4]=TRID_IN_FLIGHT, then TensorAccessorArgs starting at index 5.
+    //   [4]=TRID_IN_FLIGHT, [5]=CROSS_PROGRAM_OFFSET_TILES, then TensorAccessorArgs starting at index 6.
+    const uint32_t cross_program_offset_tiles = cfg.cross_program_dram_offset ? total_num_tiles : 0u;
     std::vector<uint32_t> reader_compile_time_args = {
-        kInputCbId, cfg.reader_mode, push_tiles, page_size_tiles, trid_in_flight};
+        kInputCbId, cfg.reader_mode, push_tiles, page_size_tiles, trid_in_flight, cross_program_offset_tiles};
     TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
     auto reader_kernel = CreateKernel(
         program,
@@ -602,8 +647,17 @@ BuiltProgram build_program(
 
     // Writer: NOC0 / RISCV0, pushes to interleaved DRAM.
     // Compile-time args order MUST match writer_interleaved.cpp:
-    //   [0]=cb_out, [1]=TILES_PER_PAGE, then TensorAccessorArgs starting at index 2.
-    std::vector<uint32_t> writer_compile_time_args = {kOutputCbId, page_size_tiles};
+    //   [0]=cb_out, [1]=TILES_PER_PAGE, [2]=READ_ONLY, [3]=WRITER_FLUSH_MODE,
+    //   [4]=OUTPUT_CB_DEPTH_TILES, [5]=CROSS_PROGRAM_OFFSET_TILES,
+    //   [6]=END_BARRIER_MODE, then TensorAccessorArgs starting at index 7.
+    std::vector<uint32_t> writer_compile_time_args = {
+        kOutputCbId,
+        page_size_tiles,
+        cfg.read_only ? 1u : 0u,
+        cfg.writer_flush_on_pressure ? 1u : 0u,
+        output_cb_depth,
+        cross_program_offset_tiles,
+        cfg.writer_end_barrier_mode};
     TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
     auto writer_kernel = CreateKernel(
         program,
@@ -887,7 +941,7 @@ bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
     constexpr auto kDataFormat = tt::DataFormat::Float16_b;
     const uint32_t single_tile_size_bytes = tile_size(kDataFormat);
     const uint32_t buffer_size_bytes = total_num_tiles * single_tile_size_bytes;
-    const uint64_t bytes_per_program = 2ull * total_num_tiles * single_tile_size_bytes;
+    const uint64_t bytes_per_program = (tune_cfg.read_only ? 1ull : 2ull) * total_num_tiles * single_tile_size_bytes;
 
     const uint32_t dram_page_size_bytes =
         (tune_cfg.page_size_tiles > 0 ? tune_cfg.page_size_tiles : 1) * single_tile_size_bytes;
@@ -912,82 +966,141 @@ bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
     const uint32_t output_buffer_addr = output_buffer->address();
     const bool rt_profiler_active = tt::tt_metal::experimental::IsProgramRealtimeProfilerActive();
 
-    std::vector<BufferTuneBwRow> input_bw_rows;
-    for (const uint32_t depth : input_depths) {
-        TT_FATAL(
-            depth >= tune_cfg.reader_push_tile_count,
-            "buffer_tune input_cb_depth {} must be >= reader_push {}",
-            depth,
-            tune_cfg.reader_push_tile_count);
+    const uint32_t page_size_tiles = tune_cfg.page_size_tiles > 0 ? tune_cfg.page_size_tiles : 1;
+    const uint32_t min_input_cb_for_reader = (tune_cfg.reader_mode == 2)
+                                                 ? (2u * tune_cfg.reader_trid_in_flight * page_size_tiles)
+                                                 : tune_cfg.reader_push_tile_count;
 
-        BenchmarkConfig sweep_cfg = tune_cfg;
-        sweep_cfg.input_cb_depth_tiles = depth;
-        sweep_cfg.num_programs = 1;
-
-        BuiltProgram built =
-            build_program(mesh_device, sweep_cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
-
-        distributed::MeshWorkload workload;
-        const distributed::MeshCoordinateRange device_range(mesh_device->shape());
-        workload.add_program(device_range, std::move(built.program));
-        Program& program = workload.get_programs().begin()->second;
-
-        configure_program_launch(program, built, input_buffer_addr, output_buffer_addr, 0, 0);
-        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
-        distributed::Finish(cq);
-
-        const long long elapsed_us = execute_timed_workload(
-            mesh_device,
-            cq,
-            workload,
-            program,
-            built,
-            sweep_cfg,
-            input_buffer_addr,
-            output_buffer_addr,
-            /*num_programs=*/1,
-            /*use_realtime_profiler=*/false,
-            rt_profiler_active);
-
-        const double gbps = pipeline_dram_gbps(bytes_per_program, elapsed_us);
-        input_bw_rows.push_back({depth, built.output_cb_depth_tiles, elapsed_us, gbps});
-        log_buffer_tune_row(
-            "input_bw_sweep",
-            sweep_cfg,
-            depth,
-            built.output_cb_depth_tiles,
-            tune_cfg.num_pages_per_core,
-            elapsed_us,
-            bytes_per_program,
-            gbps);
-    }
-
-    double peak_gbps = 0.0;
     const double tolerance_fraction = tune_cfg.buffer_tune_bw_tolerance_pct / 100.0;
-    const uint32_t best_input_depth = pick_smallest_depth_at_peak_bw(input_bw_rows, tolerance_fraction, &peak_gbps);
 
-    const double threshold_gbps = peak_gbps * (1.0 - tolerance_fraction);
-    log_info(
-        LogTest,
-        "buffer_tune: peak_dram_pipeline_gbps={:.4f}, threshold_gbps={:.4f} (within {:.1f}% of peak), "
-        "smallest_input_cb_depth_at_peak={}",
-        peak_gbps,
-        threshold_gbps,
-        tune_cfg.buffer_tune_bw_tolerance_pct,
-        best_input_depth);
-
+    uint32_t best_input_depth = 0;
     uint32_t best_output_depth = tune_cfg.output_cb_depth_tiles > 0 ? tune_cfg.output_cb_depth_tiles : 2;
+    double peak_gbps = 0.0;
+    bool skip_sequential_tune = false;
 
-    if (!tune_cfg.buffer_tune_output_depths.empty()) {
+    // Full input×output grid: every (in_cb, out_cb) pair at fixed core count.
+    if (tune_cfg.buffer_tune_grid) {
+        TT_FATAL(
+            !tune_cfg.buffer_tune_output_depths.empty(), "--buffer-tune-grid requires --buffer-tune-output-depths");
         const std::vector<uint32_t> default_output_depths = {2, 4, 8, 16};
         const std::vector<uint32_t> output_depths =
             parse_uint32_list(tune_cfg.buffer_tune_output_depths, default_output_depths);
 
-        std::vector<BufferTuneBwRow> output_bw_rows;
-        for (const uint32_t out_depth : output_depths) {
+        std::vector<BufferTuneBwRow> grid_rows;
+        for (const uint32_t in_depth : input_depths) {
+            if (in_depth < min_input_cb_for_reader) {
+                continue;
+            }
+            TT_FATAL(
+                in_depth >= tune_cfg.reader_push_tile_count,
+                "buffer_tune input_cb_depth {} must be >= reader_push {}",
+                in_depth,
+                tune_cfg.reader_push_tile_count);
+            for (const uint32_t out_depth : output_depths) {
+                BenchmarkConfig sweep_cfg = tune_cfg;
+                sweep_cfg.input_cb_depth_tiles = in_depth;
+                sweep_cfg.output_cb_depth_tiles = out_depth;
+                sweep_cfg.num_programs = 1;
+
+                BuiltProgram built = build_program(
+                    mesh_device, sweep_cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
+
+                distributed::MeshWorkload workload;
+                const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+                workload.add_program(device_range, std::move(built.program));
+                Program& program = workload.get_programs().begin()->second;
+
+                configure_program_launch(program, built, input_buffer_addr, output_buffer_addr, 0, 0);
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                distributed::Finish(cq);
+
+                const long long elapsed_us = execute_timed_workload(
+                    mesh_device,
+                    cq,
+                    workload,
+                    program,
+                    built,
+                    sweep_cfg,
+                    input_buffer_addr,
+                    output_buffer_addr,
+                    /*num_programs=*/1,
+                    /*use_realtime_profiler=*/false,
+                    rt_profiler_active);
+
+                const double gbps = pipeline_dram_gbps(bytes_per_program, elapsed_us);
+                grid_rows.push_back({in_depth, out_depth, elapsed_us, gbps});
+                log_buffer_tune_row(
+                    "cb_grid",
+                    sweep_cfg,
+                    in_depth,
+                    out_depth,
+                    tune_cfg.num_pages_per_core,
+                    elapsed_us,
+                    bytes_per_program,
+                    gbps);
+            }
+        }
+
+        double grid_peak_gbps = 0.0;
+        for (const auto& row : grid_rows) {
+            grid_peak_gbps = std::max(grid_peak_gbps, row.gbps);
+        }
+        const double grid_thresh = grid_peak_gbps * (1.0 - tolerance_fraction);
+        uint32_t grid_best_in = 0;
+        uint32_t grid_best_out = 0;
+        bool grid_found = false;
+        for (const auto& row : grid_rows) {
+            if (row.gbps >= grid_thresh) {
+                if (!grid_found || row.input_cb_depth + row.output_cb_depth < grid_best_in + grid_best_out) {
+                    grid_best_in = row.input_cb_depth;
+                    grid_best_out = row.output_cb_depth;
+                    grid_found = true;
+                }
+            }
+        }
+        log_info(
+            LogTest,
+            "buffer_tune: cb_grid peak_dram_pipeline_gbps={:.4f}, threshold_gbps={:.4f} (within {:.1f}% of peak), "
+            "smallest_input_cb_depth_at_peak={}, smallest_output_cb_depth_at_peak={}, grid_points={}",
+            grid_peak_gbps,
+            grid_thresh,
+            tune_cfg.buffer_tune_bw_tolerance_pct,
+            grid_best_in,
+            grid_best_out,
+            grid_rows.size());
+
+        if (tune_cfg.buffer_tune_bw_only) {
+            mesh_device->close();
+            return pass;
+        }
+        best_input_depth = grid_best_in;
+        best_output_depth = grid_best_out;
+        peak_gbps = grid_peak_gbps;
+        skip_sequential_tune = grid_found;
+        TT_FATAL(skip_sequential_tune, "buffer_tune grid found no CB pair within tolerance of peak BW");
+    }
+
+    if (!skip_sequential_tune) {
+        std::vector<BufferTuneBwRow> input_bw_rows;
+        for (const uint32_t depth : input_depths) {
+            if (depth < min_input_cb_for_reader) {
+                log_info(
+                    LogTest,
+                    "buffer_tune: skipping input_cb_depth={} (min {} for reader_mode={} trid_in_flight={})",
+                    depth,
+                    min_input_cb_for_reader,
+                    tune_cfg.reader_mode,
+                    tune_cfg.reader_trid_in_flight);
+                continue;
+            }
+            TT_FATAL(
+                depth >= tune_cfg.reader_push_tile_count,
+                "buffer_tune input_cb_depth {} must be >= reader_push {}",
+                depth,
+                tune_cfg.reader_push_tile_count);
+
             BenchmarkConfig sweep_cfg = tune_cfg;
-            sweep_cfg.input_cb_depth_tiles = best_input_depth;
-            sweep_cfg.output_cb_depth_tiles = out_depth;
+            sweep_cfg.input_cb_depth_tiles = depth;
             sweep_cfg.num_programs = 1;
 
             BuiltProgram built = build_program(
@@ -1016,49 +1129,118 @@ bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
                 rt_profiler_active);
 
             const double gbps = pipeline_dram_gbps(bytes_per_program, elapsed_us);
-            output_bw_rows.push_back({best_input_depth, out_depth, elapsed_us, gbps});
+            input_bw_rows.push_back({depth, built.output_cb_depth_tiles, elapsed_us, gbps});
             log_buffer_tune_row(
-                "output_bw_sweep",
+                "input_bw_sweep",
                 sweep_cfg,
-                best_input_depth,
-                out_depth,
+                depth,
+                built.output_cb_depth_tiles,
                 tune_cfg.num_pages_per_core,
                 elapsed_us,
                 bytes_per_program,
                 gbps);
         }
 
-        double output_peak_gbps = 0.0;
-        for (const auto& row : output_bw_rows) {
-            output_peak_gbps = std::max(output_peak_gbps, row.gbps);
-        }
-        const double out_thresh = output_peak_gbps * (1.0 - tolerance_fraction);
-        bool out_found = false;
-        for (const auto& row : output_bw_rows) {
-            if (row.gbps >= out_thresh) {
-                if (!out_found || row.output_cb_depth < best_output_depth) {
-                    best_output_depth = row.output_cb_depth;
-                    out_found = true;
-                }
-            }
-        }
-        if (!out_found) {
-            best_output_depth = output_bw_rows.front().output_cb_depth;
-            for (const auto& row : output_bw_rows) {
-                if (row.gbps >= output_peak_gbps - 1e-6 && row.output_cb_depth < best_output_depth) {
-                    best_output_depth = row.output_cb_depth;
-                }
-            }
-        }
+        double peak_gbps_seq = 0.0;
+        const uint32_t best_input_depth_seq =
+            pick_smallest_depth_at_peak_bw(input_bw_rows, tolerance_fraction, &peak_gbps_seq);
+        best_input_depth = best_input_depth_seq;
+        peak_gbps = peak_gbps_seq;
+
+        const double threshold_gbps = peak_gbps * (1.0 - tolerance_fraction);
         log_info(
             LogTest,
-            "buffer_tune: output sweep peak_gbps={:.4f}, threshold_gbps={:.4f} (within {:.1f}% of peak), "
-            "smallest_output_cb_depth_at_peak={}",
-            output_peak_gbps,
-            out_thresh,
+            "buffer_tune: peak_dram_pipeline_gbps={:.4f}, threshold_gbps={:.4f} (within {:.1f}% of peak), "
+            "smallest_input_cb_depth_at_peak={}",
+            peak_gbps,
+            threshold_gbps,
             tune_cfg.buffer_tune_bw_tolerance_pct,
-            best_output_depth);
-    }
+            best_input_depth);
+
+        best_output_depth = tune_cfg.output_cb_depth_tiles > 0 ? tune_cfg.output_cb_depth_tiles : 2;
+
+        if (!tune_cfg.buffer_tune_output_depths.empty()) {
+            const std::vector<uint32_t> default_output_depths = {2, 4, 8, 16};
+            const std::vector<uint32_t> output_depths =
+                parse_uint32_list(tune_cfg.buffer_tune_output_depths, default_output_depths);
+
+            std::vector<BufferTuneBwRow> output_bw_rows;
+            for (const uint32_t out_depth : output_depths) {
+                BenchmarkConfig sweep_cfg = tune_cfg;
+                sweep_cfg.input_cb_depth_tiles = best_input_depth;
+                sweep_cfg.output_cb_depth_tiles = out_depth;
+                sweep_cfg.num_programs = 1;
+
+                BuiltProgram built = build_program(
+                    mesh_device, sweep_cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
+
+                distributed::MeshWorkload workload;
+                const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+                workload.add_program(device_range, std::move(built.program));
+                Program& program = workload.get_programs().begin()->second;
+
+                configure_program_launch(program, built, input_buffer_addr, output_buffer_addr, 0, 0);
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                distributed::Finish(cq);
+
+                const long long elapsed_us = execute_timed_workload(
+                    mesh_device,
+                    cq,
+                    workload,
+                    program,
+                    built,
+                    sweep_cfg,
+                    input_buffer_addr,
+                    output_buffer_addr,
+                    /*num_programs=*/1,
+                    /*use_realtime_profiler=*/false,
+                    rt_profiler_active);
+
+                const double gbps = pipeline_dram_gbps(bytes_per_program, elapsed_us);
+                output_bw_rows.push_back({best_input_depth, out_depth, elapsed_us, gbps});
+                log_buffer_tune_row(
+                    "output_bw_sweep",
+                    sweep_cfg,
+                    best_input_depth,
+                    out_depth,
+                    tune_cfg.num_pages_per_core,
+                    elapsed_us,
+                    bytes_per_program,
+                    gbps);
+            }
+
+            double output_peak_gbps = 0.0;
+            for (const auto& row : output_bw_rows) {
+                output_peak_gbps = std::max(output_peak_gbps, row.gbps);
+            }
+            const double out_thresh = output_peak_gbps * (1.0 - tolerance_fraction);
+            bool out_found = false;
+            for (const auto& row : output_bw_rows) {
+                if (row.gbps >= out_thresh) {
+                    if (!out_found || row.output_cb_depth < best_output_depth) {
+                        best_output_depth = row.output_cb_depth;
+                        out_found = true;
+                    }
+                }
+            }
+            if (!out_found) {
+                best_output_depth = output_bw_rows.front().output_cb_depth;
+                for (const auto& row : output_bw_rows) {
+                    if (row.gbps >= output_peak_gbps - 1e-6 && row.output_cb_depth < best_output_depth) {
+                        best_output_depth = row.output_cb_depth;
+                    }
+                }
+            }
+            log_info(
+                LogTest,
+                "buffer_tune: output sweep peak_gbps={:.4f}, threshold_gbps={:.4f} (within {:.1f}% of peak), "
+                "smallest_output_cb_depth_at_peak={}",
+                output_peak_gbps,
+                out_thresh,
+                tune_cfg.buffer_tune_bw_tolerance_pct,
+                best_output_depth);
+        }
+    }  // !skip_sequential_tune
 
     // Op-to-op latency at the smallest input (and output) buffer sizes that reach peak BW.
     BenchmarkConfig latency_cfg = tune_cfg;
@@ -1125,7 +1307,9 @@ bool run_buffer_tune_mode(const BenchmarkConfig& cfg) {
             "(export with export_op_to_op_profiler_csv.py)");
     }
 
-    pass = verify_output_matches_input(cq, output_buffer, input_data) && pass;
+    if (!tune_cfg.read_only) {
+        pass = verify_output_matches_input(cq, output_buffer, input_data) && pass;
+    }
 
     mesh_device->close();
     return pass;
@@ -1144,7 +1328,7 @@ int main(int argc, char** argv) {
             "op_to_op_latency: device_id={}, pages_per_core={}, reader_push_tiles={}, input_cb_depth_tiles={}, "
             "output_cb_depth_tiles={}, reader_mode={}, compute_nops={}, num_programs={}, warmup={}, use_trace={}, "
             "use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}, trace_warmup_replays={}, "
-            "buffer_tune={}",
+            "buffer_tune={}, read_only={}",
             cfg.device_id,
             cfg.num_pages_per_core,
             cfg.reader_push_tile_count,
@@ -1159,7 +1343,8 @@ int main(int argc, char** argv) {
             cfg.use_realtime_profiler,
             cfg.trace_region_size,
             cfg.trace_warmup_replays,
-            cfg.buffer_tune);
+            cfg.buffer_tune,
+            cfg.read_only);
         TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
         TT_FATAL(cfg.num_pages_per_core >= 1, "--num-pages-per-core must be >= 1");
         TT_FATAL(cfg.reader_push_tile_count >= 1, "--reader-push-tiles must be >= 1");
@@ -1209,7 +1394,21 @@ int main(int argc, char** argv) {
 
         constexpr auto kDataFormat = tt::DataFormat::Float16_b;
         const uint32_t single_tile_size_bytes = tile_size(kDataFormat);
-        const uint32_t buffer_size_bytes = total_num_tiles * single_tile_size_bytes;
+        // When cross-program DRAM offset is on, allocate enough room for warmup
+        // (pid=0) + num_programs disjoint slices so each timed program touches
+        // fresh DRAM pages.
+        const uint32_t buffer_num_tiles =
+            cfg.cross_program_dram_offset ? (cfg.num_programs + 1u) * total_num_tiles : total_num_tiles;
+        const uint32_t buffer_size_bytes = buffer_num_tiles * single_tile_size_bytes;
+        if (cfg.cross_program_dram_offset) {
+            log_info(
+                LogTest,
+                "cross_program_dram_offset: enabled; buffer={} tiles ({} per-program slice x {} = {} MB)",
+                buffer_num_tiles,
+                total_num_tiles,
+                cfg.num_programs + 1u,
+                buffer_size_bytes / (1024 * 1024));
+        }
 
         // Interleaved DRAM buffer: page_size = page_size_tiles * tile_bytes
         // (default 1 tile per page), so each NoC transaction transfers one
@@ -1369,38 +1568,40 @@ int main(int argc, char** argv) {
                 "dispatch done/go: --use-realtime-profiler -> profile_log_device_rt.csv).");
         }
 
-        std::vector<uint32_t> output_data;
-        distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
+        if (!cfg.read_only) {
+            std::vector<uint32_t> output_data;
+            distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
 
-        if (output_data.size() != input_data.size()) {
-            log_error(
-                LogTest, "Output size mismatch: got {} elems, expected {}", output_data.size(), input_data.size());
-            pass = false;
-        } else {
-            const bool match = std::equal(input_data.begin(), input_data.end(), output_data.begin());
-            if (!match) {
-                size_t mismatch_count = 0;
-                size_t first_mismatch = 0;
-                for (size_t i = 0; i < input_data.size(); ++i) {
-                    if (input_data[i] != output_data[i]) {
-                        if (mismatch_count == 0) {
-                            first_mismatch = i;
-                        }
-                        ++mismatch_count;
-                    }
-                }
+            if (output_data.size() != input_data.size()) {
                 log_error(
-                    LogTest,
-                    "Output mismatch: {}/{} elements differ; first mismatch at index {} "
-                    "(in=0x{:08x}, out=0x{:08x})",
-                    mismatch_count,
-                    input_data.size(),
-                    first_mismatch,
-                    input_data[first_mismatch],
-                    output_data[first_mismatch]);
+                    LogTest, "Output size mismatch: got {} elems, expected {}", output_data.size(), input_data.size());
                 pass = false;
+            } else {
+                const bool match = std::equal(input_data.begin(), input_data.end(), output_data.begin());
+                if (!match) {
+                    size_t mismatch_count = 0;
+                    size_t first_mismatch = 0;
+                    for (size_t i = 0; i < input_data.size(); ++i) {
+                        if (input_data[i] != output_data[i]) {
+                            if (mismatch_count == 0) {
+                                first_mismatch = i;
+                            }
+                            ++mismatch_count;
+                        }
+                    }
+                    log_error(
+                        LogTest,
+                        "Output mismatch: {}/{} elements differ; first mismatch at index {} "
+                        "(in=0x{:08x}, out=0x{:08x})",
+                        mismatch_count,
+                        input_data.size(),
+                        first_mismatch,
+                        input_data[first_mismatch],
+                        output_data[first_mismatch]);
+                    pass = false;
+                }
             }
-        }
+        }  // !read_only validation
 
         mesh_device->close();
     } catch (const std::exception& e) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
@@ -31,6 +31,7 @@ set(PERF_MICROBENCH_TESTS_SRCS
     9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
     10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
     11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+    op_to_op_latency/test_op_to_op_latency.cpp
 )
 
 set(X86_64_ONLY_TESTS

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -435,6 +435,13 @@ int main() {
             launch_msg_t* launch_msg_address = &(mailboxes->launch[launch_msg_rd_ptr]);
             DeviceValidateProfiler(launch_msg_address->kernel_config.enables);
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
+            // Done/go worker-side marker. Fires right after the GO spin exits
+            // (the worker has observed the new GO multicast). Pair with
+            // DISP_DONE_OBSERVED on dispatch_s (same chip clock domain) to
+            // compute the full done/go interval:
+            //   "dispatch sees all workers done -> worker observes new GO"
+            // which on BH is dominated by NoC MCAST MANY L1 latency (~561 ns).
+            DeviceTimestampedData("WORKER_GO_OBSERVED", launch_msg_address->kernel_config.host_assigned_id);
 
             uint32_t enables = launch_msg_address->kernel_config.enables;
             // Trigger the NCRISC to start loading CBs and IRAM as soon as possible.

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -435,13 +435,6 @@ int main() {
             launch_msg_t* launch_msg_address = &(mailboxes->launch[launch_msg_rd_ptr]);
             DeviceValidateProfiler(launch_msg_address->kernel_config.enables);
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
-            // Done/go worker-side marker. Fires right after the GO spin exits
-            // (the worker has observed the new GO multicast). Pair with
-            // DISP_DONE_OBSERVED on dispatch_s (same chip clock domain) to
-            // compute the full done/go interval:
-            //   "dispatch sees all workers done -> worker observes new GO"
-            // which on BH is dominated by NoC MCAST MANY L1 latency (~561 ns).
-            DeviceTimestampedData("WORKER_GO_OBSERVED", launch_msg_address->kernel_config.host_assigned_id);
 
             uint32_t enables = launch_msg_address->kernel_config.enables;
             // Trigger the NCRISC to start loading CBs and IRAM as soon as possible.

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -229,7 +229,7 @@ FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 }
 
 FORCE_INLINE
-void process_go_signal_mcast_cmd() {
+void process_go_signal_mcast_cmd(uint32_t profiler_program_id = 0) {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t sync_index = cmd->mcast.wait_stream - first_stream_used;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
@@ -276,10 +276,18 @@ void process_go_signal_mcast_cmd() {
         noc_increment_nonposted_writes_acked(noc_index, num_dests);
 
         wait_for_workers(wait_count, wait_stream);
+        // Done/go window START: wait_for_workers just observed all workers done.
+        DeviceTimestampedData("DISP_DONE_OBSERVED", profiler_program_id);
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
         noc_increment_nonposted_writes_issued(noc_index, 1);
+        // Done/go window END: MCAST GO write has been issued to NOC.
+        // Delta(END - START) = dispatch-side "MCAST GO issue cost"; pair with
+        // WORKER_GO_OBSERVED on a worker to also include MCAST propagation.
+        DeviceTimestampedData("DISP_GO_ISSUED", profiler_program_id);
     } else {
         wait_for_workers(wait_count, wait_stream);
+        DeviceTimestampedData("DISP_DONE_OBSERVED", profiler_program_id);
+        DeviceTimestampedData("DISP_GO_ISSUED", profiler_program_id);
     }
 
     *aligned_go_signal_storage = go_signal_value;
@@ -447,7 +455,7 @@ void kernel_main() {
             write_buffer_id(rt_profiler_msg, buffer_id);
         }
         switch (cmd->base.cmd_id) {
-            case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: process_go_signal_mcast_cmd(); break;
+            case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: process_go_signal_mcast_cmd(popped_pid); break;
             case CQ_DISPATCH_SET_NUM_WORKER_SEMS: set_num_worker_sems(); break;
             case CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA: set_go_signal_noc_data(); break;
             case CQ_DISPATCH_CMD_WAIT: process_dispatch_s_wait_cmd(); break;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -229,7 +229,7 @@ FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 }
 
 FORCE_INLINE
-void process_go_signal_mcast_cmd(uint32_t profiler_program_id = 0) {
+void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t sync_index = cmd->mcast.wait_stream - first_stream_used;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
@@ -276,18 +276,10 @@ void process_go_signal_mcast_cmd(uint32_t profiler_program_id = 0) {
         noc_increment_nonposted_writes_acked(noc_index, num_dests);
 
         wait_for_workers(wait_count, wait_stream);
-        // Done/go window START: wait_for_workers just observed all workers done.
-        DeviceTimestampedData("DISP_DONE_OBSERVED", profiler_program_id);
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
         noc_increment_nonposted_writes_issued(noc_index, 1);
-        // Done/go window END: MCAST GO write has been issued to NOC.
-        // Delta(END - START) = dispatch-side "MCAST GO issue cost"; pair with
-        // WORKER_GO_OBSERVED on a worker to also include MCAST propagation.
-        DeviceTimestampedData("DISP_GO_ISSUED", profiler_program_id);
     } else {
         wait_for_workers(wait_count, wait_stream);
-        DeviceTimestampedData("DISP_DONE_OBSERVED", profiler_program_id);
-        DeviceTimestampedData("DISP_GO_ISSUED", profiler_program_id);
     }
 
     *aligned_go_signal_storage = go_signal_value;
@@ -455,7 +447,7 @@ void kernel_main() {
             write_buffer_id(rt_profiler_msg, buffer_id);
         }
         switch (cmd->base.cmd_id) {
-            case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: process_go_signal_mcast_cmd(popped_pid); break;
+            case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: process_go_signal_mcast_cmd(); break;
             case CQ_DISPATCH_SET_NUM_WORKER_SEMS: set_num_worker_sems(); break;
             case CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA: set_go_signal_noc_data(); break;
             case CQ_DISPATCH_CMD_WAIT: process_dispatch_s_wait_cmd(); break;


### PR DESCRIPTION
## Summary

Adds a perf microbenchmark under `tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/` that measures **per-core** op-to-op latency from when one program **finishes pack** to when the next program **starts unpack** (tile 0). This is the on-chip gap HW cares about for dispatch / barrier / firmware overhead (virtualised init registers, relaxed end-of-op barriers, etc.).

Includes a post-run Python export that turns `profile_log_device.csv` into per-transition gap tables plus chip-wide and per-core summary CSVs, an optimization knob surface (CB depth tuning, per-trid double-buffer reader, page size, writer barrier mode, core-count cap, trace warmup replays), and end-to-end sweep wrappers for the BW-vs-latency-vs-cores chart used in the HW review.

## Pipeline

On every Tensix core:

```
reader (NOC1) ──CB_in──▶ compute (3 TRISCs) ──CB_out──▶ writer (NOC0)
   interleaved DRAM       UNPACK / MATH / PACK         write + barrier
```

- Pages are interleaved across DRAM banks; work is split via `split_work_to_cores`.
- The same `MeshWorkload` is enqueued back-to-back `--num-programs N` times in **FD mode** (host loop) or **Trace mode** (capture once, optional untimed warmup replays, then timed replay).
- Warmup / pre-compile launch uses `PROG_ID=0`; timed launches use `PROG_ID` 1..N.

## Device profiler markers

| RISC / TRISC | Marker | When |
|---|---|---|
| TRISC_0 (unpack) | `TILE_IDX` | Start of tile *i* compute (`UNPACK(...)`) |
| TRISC_2 (pack) | `FINISH_LAST_PUSH` | Once at kernel exit, **outside** the tile loop (`PACK(...)`) |
| NCRISC (reader) | `NCRISC_GO` / `NCRISC_DONE` | Reader kernel entry / exit |
| NCRISC (reader) | `READ_BEFORE_BARRIER` / `READ_AFTER_BARRIER` | First DRAM read of slice — measures tile-0 DRAM round-trip |
| BRISC (writer) | `BRISC_GO` / `BRISC_DONE` | Writer kernel entry / exit (per-core BRISC FW transition window) |
| BRISC (writer) | `WRITE_BEFORE_BARRIER` / `WRITE_AFTER_BARRIER` | Last DRAM write of slice (or end of writes in `--writer-barrier-at-end` mode) |
| All RISCs | `PROG_ID` | Once per launch (`data` = program id) |

Plus chip-level dispatcher stamps from the realtime profiler (`profile_log_device_rt.csv`) when `--use-realtime-profiler` is enabled.

**Op-to-op gap (device CSV):**
`TRISC_0` `TILE_IDX` (`data`=0) of program *k+1* − `TRISC_2` `FINISH_LAST_PUSH` of program *k* (per core, per transition).

Do **not** use `DeviceZoneScopedMainN` in compute `kernel_main` (breaks `TRISC-KERNEL` marker pairing).

## CLI

| flag | default | meaning |
|---|---:|---|
| `--num-pages-per-core N` | 2 | interleaved DRAM pages per core |
| `--compute-nops N` | 0 | `TTI_NOP`s per tile (tune so math work ≫ dispatch gap, or set to 0 to expose the FW transition) |
| `--num-programs N` | 8 | back-to-back enqueues per measurement |
| `--use-trace` | off | capture-once / replay-once instead of FD loop |
| `--trace-warmup-replays N` | 0 | untimed trace replays before the measured replay (reach steady-state trace path) |
| `--use-device-profiler` | off | dump `profile_log_device.csv` after `Finish` |
| `--use-realtime-profiler` | off | log per-chip dispatcher done/go gaps (timed section only) |
| `--no-warmup` | off | skip untimed warmup enqueue |
| `--trace-region-size N` | 1 MiB | trace buffer (bytes) |
| `--device-id N` | 0 | physical device |
| `--num-active-cores N` | full grid | cap active cores (rounded up to smallest rectangle that fits); used for core-count sweeps |
| `--reader-push-tiles N` | 1 | reader chunk size (tiles reserved per `cb_reserve_back`) |
| `--reader-batch-push` | off | reader mode 1: reserve N, read all, single barrier, push N |
| `--reader-dbuf-trid` | off | reader mode 2: per-trid double-buffer using TRID A/B alternating across two CB slots (requires `input_cb_depth = 2 × page_size_tiles`) |
| `--input-cb-depth-tiles N` | 2 × push | input CB depth in tiles |
| `--output-cb-depth-tiles N` | 2 | output CB depth in tiles |
| `--page-size-tiles N` | 1 | DRAM page size in tiles (requires `--reader-dbuf-trid` when > 1) |
| `--writer-barrier-at-end` | off | defer `noc_async_write_barrier` to end of all writes (experiment — per-tile barrier turned out faster) |
| `--buffer-tune` | off | sweep CB depths, find smallest within tolerance of peak BW, then run latency phase |
| `--buffer-tune-input-depths LIST` | `2,4,6,8,12,16,24,32` | comma-separated input CB depths to sweep |
| `--buffer-tune-output-depths LIST` | (none = skip output sweep) | comma-separated output CB depths to sweep |
| `--buffer-tune-pages-per-core N` | 32 | pages/core during BW sweep (use 256+ for stable steady-state) |
| `--buffer-tune-bw-tolerance-pct PCT` | 2.0 | tolerance for "still at peak BW" pick |

`--use-device-profiler` **TT_FATAL**s if `TT_METAL_DEVICE_PROFILER=1` was not set before process start.

## Export script (`export_op_to_op_profiler_csv.py`)

Parses `profile_log_device.csv` (+ optional `profile_log_device_rt.csv`) and writes:

| File | Contents |
|---|---|
| `profile_log_device_op_to_op_gaps.csv` | Per core, per transition *k*→*k+1*: `gap_us` (pack_finish → unpack_tile_0) |
| `profile_log_device_op_to_op_complete.csv` | Full per-transition timeline: gap + barriers + `brisc_done_to_go_us` + `chip_dispatch_gap_us` + tile-0 DRAM breakdown |
| `profile_log_device_op_to_op_summary_chip.csv` | All-cores stats (mean/median/min/max gap) |
| `profile_log_device_op_to_op_summary_per_core.csv` | Per-core averages |
| `profile_log_device_op_to_op_tiles.csv` | TRISC_0 per-tile unpack starts |
| `profile_log_device_op_to_op_prog_ids.csv` | `PROG_ID` rows |
| `profile_log_device_op_to_op_dispatch_gaps.csv` | Chip-level dispatcher done→go (RT profiler) |
| `profile_log_device_op_to_op_rt_programs.csv` | RT profiler per-program durations |
| `profile_log_device_op_to_op_timeline.csv` | Timeline view used for the breakdown |

Notable flags:
- `--min-prog-id N` — drop transitions where `from_prog_id < N`. Use `--min-prog-id 3` (with `--num-programs 8` and `--trace-warmup-replays 2`) to count only steady-state transitions.
- `--aggregate-runs-dir DIR` — aggregate across run subdirectories produced by `run_op_to_op_multi.sh`.

Dispatcher-gap calculation explicitly filters out trace wrap-around transitions (e.g., `8 → 3` at the end of a replay), counting only consecutive `pid[i+1] == pid[i] + 1`.

The script also prints a `done/go validation summary` block with `chip_dispatch_gap_us`, `brisc_done_to_go_us`, and `op2op_us` side-by-side, so the two "done/go" metrics (chip dispatcher vs per-core BRISC FW) are never conflated.

## Helper scripts

| Script | Purpose |
|---|---|
| `run_op_to_op_multi.sh` | Run benchmark `N` times for one config (env-driven: `CONFIG_LABEL`, `EXTRA_ARGS`, `TILES_PER_CORE`, `INPUT_CB_DEPTH`, `READER_PUSH`, `MIN_PROG_ID`); aggregates per-run CSVs |
| `run_op_to_op_all_configs.sh` | Compare baseline push-1 vs push-2 (incremental & batch) vs push-2 BW-tuned, side-by-side |
| `run_buffer_tune.sh` | End-to-end BW-then-latency recipe (input depth sweep → smallest depth at peak → latency at that depth) |
| `run_op_to_op_validation.sh` | Steady-state validation wrapper: 2 trace warmup replays + 8 programs + `--min-prog-id 3` + ~12-25 µs kernel runtime; reports clean chip dispatch done/go |
| `run_op_to_op_chart_sweep.sh` | Full sweep across `{1, 2, 4, 10, 20, 40, 80, 110}` cores: for each, buffer-tune to find smallest CB at peak BW, then steady-state latency at that CB. Produces a single `chart_data.csv` ready to plot for the BW vs latency vs cores chart |

## Quick start (steady-state validation)

```bash
export TT_METAL_HOME=$(pwd)
export TT_METAL_DEVICE_PROFILER=1

cmake --build build_Release --target test_op_to_op_latency -j

# Validate done/go at 1 and 110 cores, 5 runs each
bash tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_validation.sh 5 1
bash tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_validation.sh 5 110

# Full BW vs latency vs cores chart sweep (~3 min)
bash tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/run_op_to_op_chart_sweep.sh
```

Chart data lands at `generated/profiler/op_to_op_runs/chart_sweep/chart_data.csv`.

## Sample results (Blackhole, 110 cores, steady-state methodology, 5 runs)

Median across runs, transitions from program 3 onward:

| metric | value |
|---|---:|
| op2op gap (pack_finish → unpack_tile_0) | 3.79 µs |
| BRISC per-core done→go (FW transition) | 2.18 µs |
| **Chip dispatcher done→go** | **119 ns** |
| Tile-0 DRAM read + barrier | 0.78 µs |
| Read_after_barrier → unpack_tile_0 | 0.05 µs |

**Done/go validation:** chip dispatcher done→go is **86–131 ns across all 8 core counts** in the sweep (1, 2, 4, 10, 20, 40, 80, 110), well under the WH ~500–800 ns reference, flat across CB depths, and only ±45 ns across the core sweep.

## Optimization study summary

| Knob | Result |
|---|---|
| Input CB depth (2 → 32 tiles) | Helps at high cores (need depth 24–32 to saturate DRAM); flat at low cores |
| Output CB depth (2 → 16 tiles) | Helped ~0.6 µs in early sweeps |
| Per-trid double-buffer reader (`--reader-dbuf-trid`) | Helped ~0.25 µs — overlaps next-tile read with current-tile compute |
| DRAM page size 1→4 tiles (`--page-size-tiles`) | Hurts — first-tile DRAM grows because barrier waits for whole page |
| End-only writer barrier (`--writer-barrier-at-end`) | Slightly worse — per-tile barrier lets writes drain during compute |
| Tiles/core (1, 2, 4) | 2 tiles/core was sweet spot; 1 too small to amortize FW |
| Core count (1 → 110) | Op2op floor ~2.7 µs at low cores; per-core BRISC FW transition is dominant component at all core counts |
| **80-core anomaly** | At `--num-active-cores 80` (= 11×8 grid) per-core BRISC done→go jumps to 4.17 µs vs 2.18 µs at 110 cores — chip dispatcher is fine in both cases, suggests GO-multicast path through the 11×8 rectangle is slower |

## Files

```
tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/
├── README.md
├── test_op_to_op_latency.cpp
├── export_op_to_op_profiler_csv.py
├── run_op_to_op_multi.sh
├── run_op_to_op_all_configs.sh
├── run_buffer_tune.sh
├── run_op_to_op_validation.sh
├── run_op_to_op_chart_sweep.sh
└── kernels/
    ├── reader_interleaved.cpp
    ├── writer_interleaved.cpp
    └── compute_copy_with_nops.cpp
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/op-to-op-latency-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/op-to-op-latency-benchmark)