### PR TITLE
Add Multi-Turn HostIoDecoderStage Sweep Harness + CLI

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -19,6 +19,7 @@ from models.demos.deepseek_v3_b1.demo.stage import (
     ACTIVATION_W_TOKEN_META_PAGE_SIZE_BYTES,
     DEFAULT_ACTIVATION_FIFO_PAGES,
     PIPELINE_CORE_COORD,
+    TOKEN_FIFO_NUM_PAGES,
     StageContext,
     StageKind,
     activation_fifo_size_bytes,
@@ -37,9 +38,11 @@ from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert, SharedExp
 from models.demos.deepseek_v3_b1.utils import (
     deinterleave_kv_cache,
     get_pinned_optimal_dram_bank_to_logical_worker_assignment,
+    interleave_kv_cache,
 )
 from models.demos.deepseek_v3_b1.weights.prepare import (
     DeepSeekV3DenseLayerWeights,
+    DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3MoELayerWeights,
     create_gate_indices_tensor,
 )
@@ -929,6 +932,11 @@ class DecoderStage(StageKind):
             "reduce_root_coord": reduce_root_coord,
             "recv_socket": recv_socket,
             "downstream_sockets": downstream_sockets,
+            # Captured for get_kv_cache_host: ConcatMesh2dToTensor needs the mesh handle,
+            # interleave_kv_cache needs (device_chunk_size, num_sp).
+            "mesh_device": mesh_device,
+            "dcs": d["device_chunk_size"],
+            "num_sp": mesh_device.shape[0],
         }
 
         if self._persistent_mode:
@@ -944,6 +952,196 @@ class DecoderStage(StageKind):
 
     def terminate(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
         self._persistent_loop.terminate()
+
+    def get_kv_cache_host(self) -> torch.Tensor | None:
+        """Pull this stage's on-device KV cache to host as a single torch tensor.
+
+        Caller must invoke this under a fast-dispatch context (e.g.
+        ``with ttnn.device.setup_fast_dispatch(mesh_device): ...``) since slow-dispatch
+        does not support arbitrary on-device reads. Persisting the result to disk
+        (filename, layout, suffixing, etc.) is the caller's responsibility — this
+        method only composes the sharded on-device KV cache into a host tensor
+        and returns it.
+
+        Returns:
+            The composed host KV-cache tensor of shape
+            ``(num_slots, 1, max_seq_len, kvpe_dim)`` dtype bfloat16, or ``None``
+            if invoked before ``setup`` (no KV cache to compose).
+        """
+        if not self._state or "d" not in self._state:
+            logger.warning("get_kv_cache_host called before setup; returning None")
+            return None
+        ttnn_kv_cache = self._state["d"]["ttnn_kv_cache"]
+        mesh_device = self._state["mesh_device"]
+        dcs = self._state["dcs"]
+        num_sp = self._state["num_sp"]
+        mesh_rows, mesh_cols = mesh_device.shape
+
+        ttnn.synchronize_device(mesh_device)
+
+        # KV cache mapper is ShardTensor2dMesh(dims=(2, None)): sharded along seq (dim 2)
+        # over rows, replicated over cols. ConcatMesh2dToTensor(dims=(2, 0)) concats seq
+        # along rows and stacks the replicated col copies along dim 0; slice to dedupe.
+        composed = ttnn.to_torch(
+            ttnn_kv_cache,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=(mesh_rows, mesh_cols), dims=(2, 0)),
+        )
+
+        # TP-axis (cols) is replicated, so each `num_slots` block along dim 0 should be
+        # byte-identical. Mismatches mean a write landed on one TP replica but not all.
+        for col_idx in range(1, mesh_cols):
+            col0 = composed[: self._num_slots]
+            col_n = composed[col_idx * self._num_slots : (col_idx + 1) * self._num_slots]
+            if not torch.equal(col0, col_n):
+                n_diff = (col0 != col_n).any(dim=tuple(range(1, col0.dim()))).sum().item()
+                logger.warning(f"TP col mismatch: col 0 vs col {col_idx} differ on {n_diff}/{self._num_slots} slots")
+
+        composed = composed[: self._num_slots]
+        kv_cache_torch = interleave_kv_cache(composed, dcs, num_sp)
+        logger.info(f"composed KV cache shape={tuple(kv_cache_torch.shape)} dtype={kv_cache_torch.dtype}")
+        return kv_cache_torch
+
+
+class HostIoDecoderStage(DecoderStage):
+    """Decoder stage that runs as a single-stage pipeline talking directly to host I/O.
+
+    Compute layout is identical to :class:`DecoderStage` (broadcast → fused decoder
+    block → reduce-to-one), but the entry/exit D2D sockets are replaced by host I/O:
+
+      - H2D socket on the stage's entry node feeds ``MOE_SENDER_CORE`` via the fused
+        H2D + embedding kernel: each token id is looked up in the DRAM-resident
+        embedding table, and the ``embedding row + DeepseekMetadata`` payload is
+        pushed into the local socket pair that the decoder broadcast consumes.
+      - Multi-upstream D2H socket on the stage's exit node: ``len(gate_proj_cores)``
+        upstream feeders (one per allreduce shard) deliver one ``ACTIVATION_PAGE //
+        N`` slice each, the last shard appends the metadata tail, and the BRISC D2H
+        sender kernel assembles a single ``ACTIVATION_W_TOKEN_META`` page back to
+        host over PCIe.
+
+    Selecting ``LoopbackConfig.no_loopback(...)`` with this stage as the only stage
+    in the pipeline (``num_procs == 1``) trips ``PipelineBlock``'s combined H2D+D2H
+    branch (``_init_combined_h2d_d2h_stage``); no D2D socket interfaces are
+    constructed.
+    """
+
+    def __init__(
+        self,
+        *,
+        weights: DeepSeekV3MoELayerWeights | DeepSeekV3DenseLayerWeights,
+        embedding_weights: DeepSeekV3EmbeddingLayerWeights | None = None,
+        layer_idx: int,
+        metadata: DeepseekMetadata,
+        max_seq_len: int,
+        num_slots: int,
+        persistent_mode: bool,
+        is_torus: bool,
+        is_moe: bool,
+        num_routed_experts: int,
+        use_hardcoded_expert_index: bool,
+        enable_routing: bool,
+        inject_hidden_states: bool = False,
+    ) -> None:
+        # Two mutually-exclusive H2D modes:
+        #   - default (embedding lookup): host pushes a 256-byte token page; the fused
+        #     H2D+embedding kernel resolves token_id -> embedding row from DRAM.
+        #   - inject_hidden_states: host pushes a full
+        #     `activation (HIDDEN_SIZE bf16) || DeepseekMetadata` page; the simple
+        #     h2d_receiver kernel forwards verbatim. Used by tests that drive the
+        #     decoder with reference hidden-state traces.
+        if inject_hidden_states:
+            assert embedding_weights is None, (
+                "embedding_weights cannot be set when inject_hidden_states=True (the embedding "
+                "lookup is bypassed in this mode)"
+            )
+        else:
+            assert embedding_weights is not None, "embedding_weights is required unless inject_hidden_states=True"
+        super().__init__(
+            weights=weights,
+            layer_idx=layer_idx,
+            metadata=metadata,
+            max_seq_len=max_seq_len,
+            num_slots=num_slots,
+            persistent_mode=persistent_mode,
+            is_torus=is_torus,
+            is_moe=is_moe,
+            num_routed_experts=num_routed_experts,
+            use_hardcoded_expert_index=use_hardcoded_expert_index,
+            enable_routing=enable_routing,
+            host_loopback=False,
+        )
+        self._embedding_weights = embedding_weights
+        self._inject_hidden_states = inject_hidden_states
+
+    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
+        mesh_device = ctx.mesh_device
+        pipeline_config = ctx.pipeline_config
+        my_stage_idx = ctx.my_stage_idx
+
+        # Multi-upstream feeders: same dram-bank-pinned worker cores DecoderStage uses for
+        # the gate_proj allreduce shards. They live on the stage's exit node alongside the
+        # D2H sender kernel.
+        gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(mesh_device, ttnn.NOC.NOC_0)
+        gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in gate_proj_worker_cores])
+        shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
+
+        stage_entry_device = pipeline_config[my_stage_idx].entry_node_coord
+        reduce_root_coord = pipeline_config[my_stage_idx].exit_node_coord
+
+        exit_upstream_cores = [ttnn.MeshCoreCoord(reduce_root_coord, c) for c in shard_cores_list]
+        assert (
+            ACTIVATION_PAGE_SIZE_BYTES % len(shard_cores_list) == 0
+        ), "ACTIVATION_PAGE_SIZE_BYTES must be divisible by len(shard_cores_list)"
+        exit_upstream_page_size = ACTIVATION_PAGE_SIZE_BYTES // len(shard_cores_list)
+
+        # Combined D2H page = activation + DeepseekMetadata; matches the assertion in
+        # PipelineBlock._init_combined_h2d_d2h_stage:
+        #   d2h_page_size == N * exit_upstream_page_size + DeepseekMetadata.aligned_size_bytes()
+        page_size = ACTIVATION_W_TOKEN_META_PAGE_SIZE_BYTES
+
+        # Two H2D modes:
+        #   - default: 256-byte token page + DRAM embedding lookup (production).
+        #   - inject_hidden_states: full `activation || metadata` page direct from host;
+        #     embedding kernel bypassed. Smaller H2D FIFO depth since pages are 57x larger.
+        if self._inject_hidden_states:
+            h2d_socket_page_size = page_size
+            h2d_socket_fifo_size = h2d_socket_page_size * DEFAULT_ACTIVATION_FIFO_PAGES
+            embedding_tensor = None
+        else:
+            h2d_socket_page_size = DeepseekMetadata.aligned_size_bytes()
+            # H2D socket depth matches every other stage that pulls tokens from host
+            # (see EmbeddingStage / TOKEN_META_FIFO_SIZE).
+            h2d_socket_fifo_size = h2d_socket_page_size * TOKEN_FIFO_NUM_PAGES
+            embedding_tensor = self._embedding_weights.embedding
+
+        d2h_socket_page_size = page_size
+        d2h_socket_fifo_size = d2h_socket_page_size * DEFAULT_ACTIVATION_FIFO_PAGES
+        # Local socket pair between the H2D core and MOE_SENDER_CORE on the entry node.
+        h2d_to_compute_fifo_size = activation_fifo_size_bytes(page_size, DEFAULT_ACTIVATION_FIFO_PAGES)
+
+        return PipelineBlock(
+            mesh_device,
+            PIPELINE_CORE_COORD,
+            # The upstream/downstream D2D socket sizes are unused by the combined H2D+D2H
+            # branch but PipelineBlock's __init__ asserts FIFO >= page on them. Reuse the
+            # H2D-to-compute FIFO size + page size so the asserts pass with sensible values.
+            upstream_d2d_socket_fifo_size=h2d_to_compute_fifo_size,
+            downstream_d2d_socket_fifo_size=h2d_to_compute_fifo_size,
+            upstream_d2d_socket_page_size=page_size,
+            downstream_d2d_socket_page_size=page_size,
+            h2d_socket_fifo_size=h2d_socket_fifo_size,
+            h2d_socket_page_size=h2d_socket_page_size,
+            d2h_socket_fifo_size=d2h_socket_fifo_size,
+            d2h_socket_page_size=d2h_socket_page_size,
+            embedding_tensor=embedding_tensor,
+            entry_node_downstream=ttnn.MeshCoreCoord(stage_entry_device, self.MOE_SENDER_CORE),
+            exit_node_upstream=exit_upstream_cores,
+            exit_upstream_page_size=exit_upstream_page_size,
+            forward_metadata=True,
+            my_stage_idx=my_stage_idx,
+            stages_metadata=ctx.stages_metadata,
+            pipeline_config=pipeline_config,
+            loopback=LoopbackConfig.no_loopback(HostIoPlacement.default(PIPELINE_CORE_COORD)),
+        )
 
 
 class MoEDecoderStage(DecoderStage):

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -3041,6 +3041,15 @@ void kernel_main() {
             unified_kernels::reconfig_cb_interfaces(mla_cb_config);
             setup_mla_sharded_buffers();
         }
+        {
+            volatile tt_l1_ptr uint32_t* risc_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("risc_sync_semaphore_addr"));
+            unified_kernels::sync_riscs_enter(risc_sync_sem);
+            unified_kernels::sync_riscs_exit(risc_sync_sem);
+        }
+#if defined(COMPILE_FOR_TRISC)
+        deepseek_compute_kernel_init();
+#endif
 #ifdef ENABLE_REDUCE_TO_ONE
 #if defined(COMPILE_FOR_NCRISC)
         if constexpr (Core::is_sender_core) {

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender_multiple_upstreams.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender_multiple_upstreams.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Multi-upstream D2H sender (BRISC-only).
+//
+// Per iteration, this kernel assembles a single D2H page from N upstream
+// receiver sockets (read sequentially in order 0..N-1), writes the assembled
+// payload directly to PCIe via the D2H sender socket, then advances the D2H
+// FIFO. There is no NCRISC half and no inter-RISC handshake — a single BRISC
+// kernel owns the D2H sender socket and all N upstream receiver sockets.
+//
+// Layout of one D2H page in PCIe:
+//   bytes [i * upstream_page_size, (i+1) * upstream_page_size)
+//     for i in [0, N-1)
+//   bytes [(N-1) * upstream_page_size,
+//          N * upstream_page_size + forward_metadata_size_bytes)
+//     for the last upstream (extra metadata bytes appended).
+//
+// Host-side preconditions:
+//   - All upstream sender cores must share a device with this kernel
+//     (no fabric on the receiver side).
+//   - d2h_page_size == N * upstream_page_size + forward_metadata_size_bytes.
+//
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+#include "api/socket_api.h"
+#include "pcie_noc_utils.h"
+#include "../../../unified_kernels/termination.hpp"
+
+constexpr uint32_t send_socket_config_addr = get_compile_time_arg_val(0);
+constexpr uint32_t termination_semaphore_addr = get_compile_time_arg_val(1);
+constexpr uint32_t d2h_page_size = get_compile_time_arg_val(2);
+constexpr uint32_t upstream_page_size = get_compile_time_arg_val(3);
+constexpr uint32_t num_upstream_sockets = get_compile_time_arg_val(4);
+constexpr uint32_t forward_metadata_size_bytes = get_compile_time_arg_val(5);
+
+constexpr uint32_t upstream_socket_addrs_start_idx = 6;
+
+template <size_t START_IDX, size_t COUNT, size_t I = 0>
+struct CTAArrayFiller {
+    static constexpr void fill(std::array<uint32_t, COUNT>& arr) {
+        arr[I] = get_compile_time_arg_val(START_IDX + I);
+        if constexpr (I + 1 < COUNT) {
+            CTAArrayFiller<START_IDX, COUNT, I + 1>::fill(arr);
+        }
+    }
+};
+
+template <size_t START_IDX, size_t COUNT>
+constexpr std::array<uint32_t, COUNT> fill_ct_args_array() {
+    std::array<uint32_t, COUNT> arr{};
+    if constexpr (COUNT > 0) {
+        CTAArrayFiller<START_IDX, COUNT>::fill(arr);
+    }
+    return arr;
+}
+
+constexpr auto receiver_socket_config_addrs =
+    fill_ct_args_array<upstream_socket_addrs_start_idx, num_upstream_sockets>();
+
+void kernel_main() {
+    DPRINT << "Starting d2h multi-upstream sender kernel" << ENDL();
+    DEVICE_PRINT("Starting d2h multi-upstream sender kernel\n");
+
+    SocketSenderInterface sender_socket = create_sender_socket_interface(send_socket_config_addr);
+    set_sender_socket_page_size(sender_socket, d2h_page_size);
+
+    SocketReceiverInterface receiver_sockets[num_upstream_sockets];
+    for (uint32_t i = 0; i < num_upstream_sockets; ++i) {
+        receiver_sockets[i] = create_receiver_socket_interface(receiver_socket_config_addrs[i]);
+        const uint32_t rx_page_size =
+            (i == num_upstream_sockets - 1) ? upstream_page_size + forward_metadata_size_bytes : upstream_page_size;
+        set_receiver_socket_page_size(receiver_sockets[i], rx_page_size);
+    }
+
+    const uint32_t write_addr_hi = sender_socket.d2h.data_addr_hi;
+    const uint32_t pcie_xy_enc = sender_socket.d2h.pcie_xy_enc;
+
+    noc_write_init_state<write_cmd_buf>(NOC_INDEX, NOC_UNICAST_WRITE_VC);
+
+    volatile tt_l1_ptr uint32_t* termination_semaphore =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_semaphore_addr);
+
+    bool terminated = false;
+    while (!terminated) {
+        socket_reserve_pages(sender_socket, 1);
+
+        const uint64_t d2h_base_addr =
+            ((static_cast<uint64_t>(write_addr_hi) << 32) | sender_socket.downstream_fifo_addr) +
+            sender_socket.write_ptr;
+
+        for (uint32_t i = 0; i < num_upstream_sockets; ++i) {
+            if (!deepseek_b1_ops::socket_wait_for_pages_with_termination(
+                    receiver_sockets[i], 1, termination_semaphore)) {
+                terminated = true;
+                break;
+            }
+            noc_async_wide_write_any_len_with_state(
+                NOC_INDEX,
+                receiver_sockets[i].read_ptr,
+                pcie_xy_enc,
+                d2h_base_addr + i * upstream_page_size,
+                receiver_sockets[i].page_size);
+            socket_pop_pages(receiver_sockets[i], 1);
+            noc_async_writes_flushed();
+            socket_notify_sender(receiver_sockets[i]);
+        }
+
+        if (terminated) {
+            break;
+        }
+
+        socket_push_pages(sender_socket, 1);
+        socket_notify_receiver(sender_socket);
+        invalidate_l1_cache();
+    }
+
+    update_socket_config(sender_socket);
+    socket_barrier(sender_socket);
+    for (uint32_t i = 0; i < num_upstream_sockets; ++i) {
+        update_socket_config(receiver_sockets[i]);
+    }
+
+    noc_async_write_barrier();
+    noc_async_read_barrier();
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
@@ -116,7 +116,8 @@ FORCE_INLINE void send_pages_over_socket(
         }
         socket_push_pages(sender_socket, 1);
     } else {
-        write_data_to_local_core_with_ack(sender_socket, l1_read_addr, dst_addr, embedding_page_size);
+        write_data_to_local_core_with_ack(
+            sender_socket, l1_read_addr, dst_addr, embedding_page_size + metadata_size_bytes);
     }
 }
 

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -9,19 +9,25 @@ Provides bidirectional communication between host and device using H2D (Host-to-
 and D2H (Device-to-Host) sockets with termination support.
 
 Current Limitations:
-- Only supports communication with a single core on a single chip
-- H2D and D2H sockets must be on the same core
-- No multi-chip or multi-core host communication support
+- H2D side talks to a single downstream core on the same device.
+- D2H side talks to either a single upstream core (single-upstream mode) or N upstream
+  cores on the same device (multi-upstream mode). Cross-device upstreams are not
+  supported on the D2H side.
+- Loopback mode requires H2D and D2H sockets to share a core.
 
 Modes:
 - Loopback mode: H2D receiver and D2H sender communicate via circular buffers (CBs)
   for testing purposes
-- Socket mode: H2D receiver and D2H sender forward data to/from downstream/upstream cores
-  via D2D (Device-to-Device) sockets
+- Socket mode (single-upstream D2H): H2D receiver forwards downstream and D2H sender
+  reads from a single upstream socket pair via D2D (Device-to-Device) sockets
+- Socket mode (multi-upstream D2H): D2H sender (BRISC-only kernel) reads one page from
+  each of N same-device upstream cores and assembles them into a single D2H page in
+  PCIe order. Selected by passing ``d2h_upstream_cores`` (list) instead of
+  ``d2h_upstream_core``.
 
 Components:
 - H2D receiver: Pulls data from host (or receives via PCIe push), forwards to downstream
-- D2H sender: Receives data from upstream, pushes to host via PCIe
+- D2H sender: Receives data from upstream(s), pushes to host via PCIe
 
 Termination:
 - Controlled via global semaphore that both kernels poll during blocking operations
@@ -54,6 +60,12 @@ class HostInterface:
         sender_mesh=None,
         receiver_mesh=None,
         metadata_size_bytes=0,
+        # Multi-upstream D2H: pass a list of upstream cores (mutually exclusive with
+        # d2h_upstream_core). All cores must live on the same device as the D2H kernel.
+        d2h_upstream_cores=None,
+        d2h_upstream_page_size=None,
+        d2h_socket_fifo_size=None,
+        d2h_forward_metadata_size_bytes=0,
     ):
         assert h2d_socket is not None or d2h_socket is not None, "Either h2d_socket or d2h_socket must be provided"
 
@@ -61,6 +73,32 @@ class HostInterface:
             assert (
                 h2d_socket.get_mesh_device() == d2h_socket.get_mesh_device()
             ), "Expected Host <-> Device Communication for Blitz Decode to be on the same mesh device."
+
+        # Multi-upstream D2H configuration: validate up front so later code can branch on a single flag.
+        self.multi_upstream_d2h = d2h_upstream_cores is not None
+        if self.multi_upstream_d2h:
+            assert d2h_socket is not None, "d2h_upstream_cores requires a d2h_socket"
+            assert not loopback_mode, "Multi-upstream D2H is not supported in loopback_mode"
+            assert (
+                d2h_upstream_core is None
+            ), "Pass either d2h_upstream_core (single) or d2h_upstream_cores (list), not both"
+            assert (
+                isinstance(d2h_upstream_cores, list) and len(d2h_upstream_cores) >= 1
+            ), "d2h_upstream_cores must be a non-empty list"
+            assert d2h_upstream_page_size is not None, "d2h_upstream_page_size is required for multi-upstream D2H"
+            assert d2h_socket_fifo_size is not None, "d2h_socket_fifo_size is required for multi-upstream D2H"
+            assert d2h_socket_fifo_size % d2h_page_size == 0, (
+                f"d2h_socket_fifo_size ({d2h_socket_fifo_size}) must be a multiple of d2h_page_size "
+                f"({d2h_page_size}) so per-upstream FIFO depth matches the D2H FIFO depth"
+            )
+            assert (
+                d2h_page_size == len(d2h_upstream_cores) * d2h_upstream_page_size + d2h_forward_metadata_size_bytes
+            ), (
+                f"d2h_page_size ({d2h_page_size}) must equal "
+                f"len(d2h_upstream_cores) ({len(d2h_upstream_cores)}) * d2h_upstream_page_size "
+                f"({d2h_upstream_page_size}) + d2h_forward_metadata_size_bytes "
+                f"({d2h_forward_metadata_size_bytes})"
+            )
 
         self.h2d_socket = h2d_socket
         self.d2h_socket = d2h_socket
@@ -75,6 +113,10 @@ class HostInterface:
         self.embedding_tensor = embedding_tensor
         self.h2d_downstream_core = h2d_downstream_core
         self.d2h_upstream_core = d2h_upstream_core
+        self.d2h_upstream_cores = d2h_upstream_cores
+        self.d2h_upstream_page_size = d2h_upstream_page_size
+        self.d2h_socket_fifo_size = d2h_socket_fifo_size
+        self.d2h_forward_metadata_size_bytes = d2h_forward_metadata_size_bytes
         self.metadata_size_bytes = metadata_size_bytes
 
         if self.h2d_socket:
@@ -92,7 +134,9 @@ class HostInterface:
             if self.h2d_socket:
                 assert self.h2d_downstream_core is not None
             if self.d2h_socket:
-                assert self.d2h_upstream_core is not None
+                assert (
+                    self.d2h_upstream_core is not None or self.multi_upstream_d2h
+                ), "D2H socket requires either d2h_upstream_core (single) or d2h_upstream_cores (multi)"
 
         self.mesh_device = self.h2d_socket.get_mesh_device() if self.h2d_socket else self.d2h_socket.get_mesh_device()
 
@@ -121,6 +165,7 @@ class HostInterface:
         self.downstream_socket_pair = None
         self.downstream_mesh_socket = None
         self.upstream_socket_pair = None
+        self.upstream_socket_pairs = None  # populated only in multi-upstream D2H mode
         self.sender_mesh = sender_mesh
         self.receiver_mesh = receiver_mesh
         self.inter_mesh_downstream = (
@@ -156,7 +201,30 @@ class HostInterface:
                         self.mesh_device, self.mesh_device, downstream_socket_config
                     )
 
-            if self.d2h_socket and self.d2h_upstream_core is not None:
+            if self.d2h_socket and self.multi_upstream_d2h:
+                # Per-upstream FIFO depth matches the D2H FIFO depth, mirroring the
+                # SocketInterface multi-upstream sizing in d2d_exchange/op.py.
+                buffer_depth = self.d2h_socket_fifo_size // self.d2h_page_size
+                upstream_fifo_size = self.d2h_upstream_page_size * buffer_depth
+                last_upstream_fifo_size = (
+                    self.d2h_upstream_page_size + self.d2h_forward_metadata_size_bytes
+                ) * buffer_depth
+                num_upstreams = len(self.d2h_upstream_cores)
+                self.upstream_socket_pairs = []
+                for idx, uc in enumerate(self.d2h_upstream_cores):
+                    assert uc.device_coord == self.d2h_mesh_core_coord.device_coord, (
+                        f"d2h_upstream_cores[{idx}] is on device {uc.device_coord}, expected "
+                        f"{self.d2h_mesh_core_coord.device_coord} (same device as the D2H kernel)"
+                    )
+                    is_last = idx == num_upstreams - 1
+                    fifo_size = last_upstream_fifo_size if is_last else upstream_fifo_size
+                    pair_memory_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, fifo_size)
+                    pair_connection = ttnn.SocketConnection(uc, self.d2h_mesh_core_coord)
+                    pair_config = ttnn.SocketConfig([pair_connection], pair_memory_config)
+                    self.upstream_socket_pairs.append(
+                        ttnn.create_socket_pair(self.mesh_device, self.mesh_device, pair_config)
+                    )
+            elif self.d2h_socket and self.d2h_upstream_core is not None:
                 upstream_socket_connection = ttnn.SocketConnection(
                     self.d2h_upstream_core,
                     self.d2h_mesh_core_coord,
@@ -262,6 +330,11 @@ class HostInterface:
         return h2d_kernel
 
     def _create_d2h_kernel(self):
+        if self.multi_upstream_d2h:
+            return self._create_d2h_kernel_multi()
+        return self._create_d2h_kernel_single()
+
+    def _create_d2h_kernel_single(self):
         # D2H Sender Core will forward data to upstream core via fabric if:
         # 1. Not in loopback mode (i.e. real workload)
         # 2. Upstream core is not on the same device as the D2H sender core
@@ -289,7 +362,37 @@ class HostInterface:
         )
         return d2h_kernel
 
-    def _create_cb_descriptors(self, mesh_core_coord, use_fabric):
+    def _create_d2h_kernel_multi(self):
+        # CT-arg layout matches d2h_sender_multiple_upstreams.cpp:
+        #   0 send_socket_config_addr
+        #   1 termination_semaphore_addr
+        #   2 d2h_page_size
+        #   3 upstream_page_size
+        #   4 num_upstream_sockets
+        #   5 forward_metadata_size_bytes
+        #   6..6+N-1  upstream receiver socket config addrs
+        receiver_socket_config_addrs = [pair[1].get_config_buffer_address() for pair in self.upstream_socket_pairs]
+        d2h_socket_kernel_ct_args = [
+            self.d2h_socket.get_config_buffer_address(),
+            ttnn.get_global_semaphore_address(self.termination_semaphore),
+            self.d2h_page_size,
+            self.d2h_upstream_page_size,
+            len(self.upstream_socket_pairs),
+            self.d2h_forward_metadata_size_bytes,
+        ]
+        d2h_socket_kernel_ct_args.extend(receiver_socket_config_addrs)
+        d2h_kernel = ttnn.KernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender_multiple_upstreams.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=ttnn.CoreRangeSet(
+                [ttnn.CoreRange(self.d2h_mesh_core_coord.core_coord, self.d2h_mesh_core_coord.core_coord)]
+            ),
+            compile_time_args=d2h_socket_kernel_ct_args,
+            config=ttnn.ReaderConfigDescriptor(),
+        )
+        return d2h_kernel
+
+    def _create_cb_descriptors(self, mesh_core_coord, use_fabric, *, include_embedding=False):
         cb_descriptors = []
         if self.loopback_mode:
             intermed_cb_desc = ttnn.CBDescriptor(
@@ -306,8 +409,10 @@ class HostInterface:
             )
             cb_descriptors.append(intermed_cb_desc)
 
-        # CB for embedding DRAM reads
-        if self.has_embedding:
+        # CB for embedding DRAM reads — only the H2D-side fused embedding kernel uses this CB.
+        # The D2H sender kernels (single- or multi-upstream) never reference it, so we skip
+        # allocating it on the D2H core to avoid wasted L1 there.
+        if self.has_embedding and include_embedding:
             embedding_cb_desc = ttnn.CBDescriptor(
                 total_size=self.embedding_page_size + self.metadata_size_bytes,
                 core_ranges=ttnn.CoreRangeSet([ttnn.CoreRange(mesh_core_coord.core_coord, mesh_core_coord.core_coord)]),
@@ -384,7 +489,9 @@ class HostInterface:
                 and my_downstream_fabric_node_id is not None
                 and h2d_fabric_node_id != my_downstream_fabric_node_id
             )
-            h2d_cb_descriptors = self._create_cb_descriptors(self.h2d_mesh_core_coord, h2d_uses_fabric)
+            h2d_cb_descriptors = self._create_cb_descriptors(
+                self.h2d_mesh_core_coord, h2d_uses_fabric, include_embedding=True
+            )
 
         if self.d2h_socket:
             d2h_kernel = self._create_d2h_kernel()
@@ -505,10 +612,29 @@ class HostInterface:
             raise ValueError("Downstream sender socket not available")
 
     def get_upstream_socket(self):
+        if self.multi_upstream_d2h:
+            raise RuntimeError(
+                "HostInterface is in multi-upstream D2H mode; use get_upstream_sockets() to retrieve all "
+                "per-upstream sender sockets"
+            )
         if self.upstream_socket_pair is not None:
             return self.upstream_socket_pair[0]
         else:
             raise ValueError("Upstream socket not available")
+
+    def get_upstream_sockets(self):
+        """Return a list of upstream sender sockets, one per upstream core.
+
+        In single-upstream mode this is a length-1 list; in multi-upstream D2H mode it
+        is length N. Each returned socket is the sender side of a local socket pair
+        whose receiver is the D2H kernel core, so producers can push pages to the D2H
+        sender by writing into these sockets.
+        """
+        if self.multi_upstream_d2h:
+            return [pair[0] for pair in self.upstream_socket_pairs]
+        if self.upstream_socket_pair is not None:
+            return [self.upstream_socket_pair[0]]
+        raise ValueError("Upstream socket not available")
 
     def terminate(self, sync_devices):
         if self.h2d_socket:

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
@@ -12,9 +12,9 @@ interfaces for forwarding data between pipeline stages across hosts.
 Pipeline topology is determined by generate_blitz_decode_pipeline(), which
 maps physical ASIC locations to logical mesh coordinates for each stage.
 
-There are four distinct stage configurations:
+There are five distinct stage configurations:
 
-  1. First stage (mesh_id == 0):
+  1. First stage (mesh_id == 0, num_procs > 1):
      H2D socket receives tokens from host, looks up embedding in DRAM,
      forwards embedding rows downstream via exit D2D socket.
      If loopback is enabled, also receives results from the last stage
@@ -33,6 +33,15 @@ There are four distinct stage configurations:
      directly to the host on this process. The entry D2D's downstream
      socket is wired to the D2H kernel's upstream socket so data flows
      through a single shared socket pair.
+
+  5. Combined H2D + D2H stage (num_procs == 1, no loopback):
+     Single-process pipeline that owns both host sockets on the same stage.
+     H2D delivers each token + metadata to ``entry_node_downstream`` (compute
+     input core); compute produces N output shards on ``exit_node_upstream``
+     cores; the multi-upstream D2H sender (BRISC kernel) reads one page from
+     each upstream and assembles them into a single D2H page back to host.
+     No D2D socket interfaces are constructed — all I/O is through ``host_io``.
+     Intended for plumbing a ``DecoderStage``-shaped compute directly to host.
 
 Per-device parallel mode (pipeline_device_coords):
   When a list of MeshCoordinate device coordinates is provided, each channel
@@ -186,6 +195,7 @@ class PipelineBlock:
         upstream_d2d_socket_page_size,
         downstream_d2d_socket_page_size,
         h2d_socket_fifo_size=None,
+        h2d_socket_page_size=None,
         d2h_socket_fifo_size=None,
         d2h_socket_page_size=None,
         entry_node_downstream=None,
@@ -248,8 +258,34 @@ class PipelineBlock:
         self._h2d_page_size_bytes = None
         self._d2h_page_size_bytes = None
 
-        token_size_bytes = DeepseekMetadata.aligned_size_bytes()
-        if self.is_pipeline_start:
+        # Default H2D page = DeepseekMetadata struct (256 B). Callers like the combined
+        # H2D+D2H stage in inject-hidden-states mode override this to fit a full
+        # (activation || metadata) payload directly on the H2D wire.
+        token_size_bytes = (
+            h2d_socket_page_size if h2d_socket_page_size is not None else DeepseekMetadata.aligned_size_bytes()
+        )
+        if self.is_pipeline_start and self.is_last_stage and not self.initialize_loopback:
+            # Single-process pipeline (one stage spanning the mesh) with both H2D and D2H on
+            # the same stage. Plugs a decoder-shaped compute (entry_node_downstream /
+            # exit_node_upstream-list) directly into host I/O, with the D2H sender pulling
+            # from N upstream cores. None of the upstream/downstream D2D parameters apply
+            # here — only the H2D / D2H sizes and the H2D-to-compute local socket size do.
+            self._init_combined_h2d_d2h_stage(
+                mesh_device,
+                pipeline_config,
+                token_size_bytes,
+                h2d_socket_fifo_size,
+                d2h_socket_fifo_size,
+                d2h_socket_page_size,
+                h2d_to_compute_socket_buffer_size=downstream_d2d_socket_fifo_size,
+                embedding_tensor=embedding_tensor,
+                forward_metadata=forward_metadata,
+                entry_node_downstream=entry_node_downstream,
+                exit_node_upstream=exit_node_upstream,
+                exit_upstream_page_size=exit_upstream_page_size,
+                host_io_placement=loopback.host_io_placement,
+            )
+        elif self.is_pipeline_start:
             self._init_first_stage(
                 mesh_device,
                 pipeline_config,
@@ -411,6 +447,95 @@ class PipelineBlock:
                 sender_mesh=MeshWrapper(rank=ls.rank, mesh_id=ls.mesh_id),
                 receiver_mesh=MeshWrapper(mesh_device),
             )
+
+    def _init_combined_h2d_d2h_stage(
+        self,
+        mesh_device,
+        pipeline_config,
+        token_size_bytes,
+        h2d_socket_fifo_size,
+        d2h_socket_fifo_size,
+        d2h_socket_page_size,
+        h2d_to_compute_socket_buffer_size,
+        embedding_tensor,
+        forward_metadata,
+        entry_node_downstream,
+        exit_node_upstream,
+        exit_upstream_page_size,
+        host_io_placement,
+    ):
+        """Combined H2D + multi-upstream D2H stage for a single-process pipeline.
+
+        The stage spans the mesh: H2D lives on the stage's entry node and D2H lives on its
+        exit node. H2D delivers each token + metadata to ``entry_node_downstream`` (the
+        compute input core, on the entry node); the compute produces N output shards on
+        ``exit_node_upstream`` cores (on the exit node); the multi-upstream D2H sender
+        (BRISC kernel) reads one page from each upstream and assembles them into a single
+        D2H page sent back to host. No D2D socket interfaces are constructed — all I/O
+        flows through ``self.host_io``.
+
+        ``h2d_to_compute_socket_buffer_size`` sizes the local FIFO of the H2D→compute
+        socket pair on the entry node.
+        """
+        assert h2d_socket_fifo_size is not None, "h2d_socket_fifo_size must be provided"
+        assert d2h_socket_fifo_size is not None, "d2h_socket_fifo_size must be provided"
+        assert d2h_socket_page_size is not None, "d2h_socket_page_size must be provided"
+        assert d2h_socket_fifo_size >= d2h_socket_page_size
+        assert h2d_socket_fifo_size >= token_size_bytes
+        # embedding_tensor is optional: when None, HostInterface skips the fused embedding
+        # kernel and uses h2d_receiver.cpp to forward the host-supplied page verbatim
+        # (used by inject-hidden-states mode where the host pushes a full
+        # `activation || metadata` page instead of just a token id).
+        assert (
+            entry_node_downstream is not None
+        ), "entry_node_downstream is required for the combined H2D+D2H stage (the compute input core)"
+        assert (
+            isinstance(exit_node_upstream, list) and len(exit_node_upstream) >= 1
+        ), "exit_node_upstream must be a non-empty list of MeshCoreCoord (compute output cores feeding D2H)"
+        assert exit_upstream_page_size is not None, "exit_upstream_page_size is required for the combined H2D+D2H stage"
+
+        metadata_size_bytes = DeepseekMetadata.aligned_size_bytes() if forward_metadata else 0
+        assert d2h_socket_page_size == len(exit_node_upstream) * exit_upstream_page_size + metadata_size_bytes, (
+            f"d2h_socket_page_size ({d2h_socket_page_size}) must equal len(exit_node_upstream) "
+            f"({len(exit_node_upstream)}) * exit_upstream_page_size ({exit_upstream_page_size}) "
+            f"+ metadata_size_bytes ({metadata_size_bytes})"
+        )
+
+        # H2D on the entry node, D2H on the exit node. HostInterface's same_device check
+        # falls through to two separate per-device programs in this layout.
+        h2d_device_coord = pipeline_config[self.my_stage_idx].entry_node_coord
+        d2h_device_coord = pipeline_config[self.my_stage_idx].exit_node_coord
+
+        self.h2d_socket = ttnn.H2DSocket(
+            mesh_device,
+            ttnn.MeshCoreCoord(h2d_device_coord, host_io_placement.h2d_core),
+            ttnn.BufferType.L1,
+            h2d_socket_fifo_size,
+            ttnn.H2DMode.HOST_PUSH,
+        )
+        self._h2d_page_size_bytes = token_size_bytes
+
+        self.d2h_socket = ttnn.D2HSocket(
+            mesh_device,
+            ttnn.MeshCoreCoord(d2h_device_coord, host_io_placement.d2h_core),
+            d2h_socket_fifo_size,
+        )
+        self._d2h_page_size_bytes = d2h_socket_page_size
+
+        self.host_io = HostInterface(
+            self.h2d_socket,
+            self.d2h_socket,
+            token_size_bytes,
+            d2h_socket_page_size,
+            core_to_core_socket_buffer_size=h2d_to_compute_socket_buffer_size,
+            h2d_downstream_core=entry_node_downstream,
+            embedding_tensor=embedding_tensor,
+            metadata_size_bytes=metadata_size_bytes,
+            d2h_upstream_cores=exit_node_upstream,
+            d2h_upstream_page_size=exit_upstream_page_size,
+            d2h_socket_fifo_size=d2h_socket_fifo_size,
+            d2h_forward_metadata_size_bytes=metadata_size_bytes,
+        )
 
     def _init_last_stage_with_d2h(
         self,
@@ -678,9 +803,16 @@ class PipelineBlock:
             mesh_program_descriptor[ttnn.MeshCoordinateRange(device_coord, device_coord)] = merged
         return ttnn.generic_op([dummy_tensor, dummy_tensor], mesh_program_descriptor)
 
+    def _is_combined_h2d_d2h_stage(self):
+        return (
+            self.is_pipeline_start and self.is_last_stage and not self.initialize_loopback and not self.parallel_devices
+        )
+
     def run(self):
         if self.parallel_devices:
             self._dispatch_parallel_device_programs()
+        elif self._is_combined_h2d_d2h_stage():
+            self.host_io.run()
         elif self.is_pipeline_start:
             self.host_io.run()
             self.exit_socket_interface.run()
@@ -701,6 +833,8 @@ class PipelineBlock:
             for i, si in enumerate(self.exit_socket_interface):
                 last = i == len(self.exit_socket_interface) - 1
                 si.terminate(last)
+        elif self._is_combined_h2d_d2h_stage():
+            self.host_io.terminate(True)
         elif self.is_pipeline_start:
             self.host_io.terminate(False)
             if self.initialize_loopback:
@@ -789,12 +923,18 @@ class PipelineBlock:
     def get_downstream_socket(self):
         """Return a single downstream socket (non-parallel mode only)."""
         assert not self.parallel_devices, "Use get_downstream_sockets() for parallel mode"
+        if self.entry_socket_interface is None:
+            # Combined H2D+D2H stage: compute reads from the H2D's downstream socket directly.
+            return self.host_io.get_downstream_socket()
         return self.entry_socket_interface.get_downstream_socket()
 
     def get_upstream_sockets(self):
         """Return list of upstream sockets (per-device parallel or multi-upstream modes)."""
         if self.parallel_devices:
             return [si.get_upstream_sockets() for si in self.exit_socket_interface]
+        if self.exit_socket_interface is None:
+            # Combined H2D+D2H stage: compute writes into the multi-upstream D2H feeders.
+            return self.host_io.get_upstream_sockets()
         return self.exit_socket_interface.get_upstream_sockets()
 
     def get_downstream_sockets(self):

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
@@ -1,0 +1,983 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable harness for the HostIoDecoderStage multi-turn sweep.
+
+This module provides the configuration, schedule, result, and entry-point types
+used by the CLI driver (`run_host_io_decoder_sweep.py`). It deliberately knows
+nothing about argparse — all CLI ergonomics live in the driver.
+
+Multi-turn semantics (the only scheduling policy in this harness)
+-----------------------------------------------------------------
+Every prompt is run through the SAME set of replicated slots
+(``[0, num_replication_slots)``) in sequence. Position ids accumulate across
+prompts: prompt ``i`` occupies positions
+``[sum(L_0..L_{i-1}), sum(L_0..L_{i}))`` in every slot's KV cache. Conceptually
+this models a single user (slot) continuing a multi-turn conversation, fanned
+out across ``num_replication_slots`` identical-state replicas for cross-slot
+determinism validation.
+
+The persistent decoder + H2D/D2H sockets are launched ONCE before the first
+prompt and torn down ONCE after the last prompt. The on-device KV cache thus
+holds the concatenated state of every prompt at the end of the sweep, and can
+be sliced by prompt for downstream consumption.
+
+Validation gates (every gate is independently toggleable in the config)
+-----------------------------------------------------------------------
+1. ``validate_metadata_roundtrip`` — per-iteration assertions that the H2D
+   page's slot_id / position_id / token_id / token_0_type are preserved on the
+   D2H tail (catches socket / multi-upstream-D2H corruption).
+2. ``validate_hidden_states_cross_slot`` — per-prompt ``torch.equal`` of every
+   replicated slot's collected output against slot 0 (catches slot-dependent
+   decoder nondeterminism; no-op in Mode A).
+3. ``validate_kv_cache_cross_slot`` — post-teardown per-prompt ``torch.equal``
+   on the KV cache slice (slot s, prompt p's position range) against slot 0
+   (same property, checked through the KV-cache path; no-op in Mode A).
+4. ``validate_hidden_states_cross_trace`` — per-(prompt, slot) PCC of the
+   collected output against the prompt's reference ``trace["output"]``
+   (numerical-correctness check; threshold from ``pcc_threshold``).
+
+Dumps (independently toggleable, both off by default suppresses all disk I/O)
+----------------------------------------------------------------------------
+- ``dump_hidden_states`` — one file per (slot, prompt):
+  ``output_hidden_states_slot_<id:02d>_<prompt>.pt`` containing
+  ``(L_p, HIDDEN_SIZE)`` bf16.
+- ``dump_kv_cache`` — one file per (slot, prompt):
+  ``kv_cache_slot_<id:02d>_<prompt>.pt`` containing
+  ``(1, L_p, kvpe_dim)`` bf16. Sliced from the global on-device KV cache by
+  the prompt's position range.
+
+Public API surface
+------------------
+- :class:`HostIoDecoderSweepConfig` — frozen dataclass with every knob.
+- :class:`MultiTurnSchedule` — derived position-id schedule (returned in
+  :class:`SweepResult`; built internally by the harness).
+- :class:`SweepResult` — outputs (collected hidden states + KV cache +
+  schedule + loaded traces).
+- :func:`run_sweep` — main entry point; takes config + parent MeshDevice.
+- :func:`open_mesh_device` — context manager that opens / closes the parent
+  MeshDevice and applies fabric configuration. Replaces the
+  ``bh_2d_mesh_device`` pytest fixture.
+
+Stubs / not yet implemented
+---------------------------
+The helpers, preflight, and ``run_sweep`` body are scoped to subsequent
+checkpoints of the migration plan. See ``host_io_decoder_stage_context.txt``
+(or the per-PR notes) for which checkpoint lands what.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc, is_slow_dispatch
+from models.demos.deepseek_v3_b1.demo.decoder_stage import HostIoDecoderStage
+from models.demos.deepseek_v3_b1.demo.stage import ACTIVATION_W_TOKEN_META_PAGE_SIZE_BYTES, StageContext
+from models.demos.deepseek_v3_b1.demo.weight_provider import CacheWeightProvider
+from models.demos.deepseek_v3_b1.metadata.metadata import DeepseekMetadata
+from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
+from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import StageMetadata
+from models.demos.deepseek_v3_b1.model import InputField, TokenType, parse_output_page
+from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
+from models.demos.deepseek_v3_b1.utils import float_to_uint32
+from models.demos.deepseek_v3_b1.weights.prepare import NUM_ROUTED_EXPERTS
+
+# Env var names — referenced by both the harness (preflight) and the CLI driver
+# (for argparse defaults). Single source of truth so we don't drift.
+HIDDEN_STATES_DIR_ENV = "DEEPSEEK_V3_HIDDEN_STATES_DIR"
+KV_CACHE_DUMP_DIR_ENV = "DEEPSEEK_V3_KV_CACHE_DUMP_DIR"
+
+# Default paths for weight loading. Either can be overridden through
+# ``HostIoDecoderSweepConfig.hf_model_path`` / ``cache_path`` (or, transitively,
+# via CLI flags).
+DEFAULT_HF_MODEL_PATH = Path("/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized")
+DEFAULT_CACHE_PATH = Path.home() / ".cache"
+
+# DeepSeek V3 architecture: layer indices [0, NUM_DENSE_LAYERS) are dense
+# (attention + dense MLP), and indices [NUM_DENSE_LAYERS, num_layers) are MoE
+# (attention + routed-experts MLP). Matches ``demo/pipeline.py`` which maps
+# pipeline stages 1/2/3 -> dense layer ids and stages 4+ -> MoE layer ids.
+# The b1 demo does not re-export a configuration constant for this, so it's
+# inlined here. (See ``DeepSeekV3Config.NUM_DENSE_LAYERS`` in deepseek_v3_d_p
+# for the same constant in the other code path.)
+NUM_DENSE_LAYERS = 3
+
+
+def _is_moe_layer(layer_idx: int) -> bool:
+    """Return True iff ``layer_idx`` is a MoE (routed-experts) layer.
+
+    Used by :func:`run_sweep` to auto-select between dense / MoE weight loaders
+    and the matching ``HostIoDecoderStage`` kwargs without forcing the caller
+    to pass a redundant stage-type flag.
+    """
+    return layer_idx >= NUM_DENSE_LAYERS
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MultiTurnSchedule:
+    """Position-id schedule for a multi-turn sweep.
+
+    Each prompt occupies a disjoint, contiguous, monotonically-incrementing
+    block of positions in every replicated slot's KV cache. Built by the
+    harness's preflight step from the reference traces' ``"input"`` shapes.
+
+    Attributes:
+        prompt_lengths: Per-prompt sequence length L_i, parallel to
+            ``HostIoDecoderSweepConfig.prompt_names`` (same order, same length).
+    """
+
+    prompt_lengths: tuple[int, ...]
+
+    def offset_for(self, prompt_idx: int) -> int:
+        """Position offset where prompt ``prompt_idx`` starts."""
+        return sum(self.prompt_lengths[:prompt_idx])
+
+    def range_for(self, prompt_idx: int) -> tuple[int, int]:
+        """Half-open ``(start, end)`` position range for prompt ``prompt_idx``."""
+        start = self.offset_for(prompt_idx)
+        return (start, start + self.prompt_lengths[prompt_idx])
+
+    def total_length(self) -> int:
+        """Total positions consumed across all prompts (= ``sum(prompt_lengths)``)."""
+        return sum(self.prompt_lengths)
+
+
+@dataclass(frozen=True)
+class HostIoDecoderSweepConfig:
+    """All knobs for one ``run_sweep`` invocation.
+
+    Field validation in ``__post_init__`` covers STATIC config invariants only.
+    Trace-shape-dependent invariants (e.g. ``total_length() + 1 < max_seq_len``)
+    and filesystem-existence checks are validated by the harness's preflight
+    step once the traces are loaded.
+    """
+
+    # --- required: prompt source + identifying knobs ---
+    # Positions are disjoint and incrementing in ``prompt_names`` order. Single
+    # prompt is allowed; multi-prompt fans out into a multi-turn conversation
+    # across the shared slot range.
+    decoder_layer_idx: int
+    hidden_states_dir: Path
+    prompt_names: tuple[str, ...]
+
+    # --- model shape ---
+    max_seq_len: int = 128 * 1024
+    num_slots: int = 64
+    mesh_rows: int = 4
+    mesh_cols: int = 2
+
+    # --- replication / mode ---
+    num_replication_slots: int = 8  # 1 = Mode A (single slot); >1 = Mode B (replicated)
+
+    # --- validation knobs ---
+    validate_metadata_roundtrip: bool = True
+    validate_hidden_states_cross_slot: bool = True
+    validate_kv_cache_cross_slot: bool = True
+    validate_hidden_states_cross_trace: bool = False
+    pcc_threshold: float = 0.97  # only consulted when validate_hidden_states_cross_trace is True
+
+    # --- dump knobs ---
+    # Disk dumps are OPT-IN: defaults are False so a validation-only run (or a
+    # pure sweep) does not require ``--dump-dir`` and does not pay the cost of
+    # the device-to-host KV cache pull. Set explicitly when you want artifacts.
+    dump_hidden_states: bool = False
+    dump_kv_cache: bool = False
+    dump_dir: Path | None = None  # required if any dump knob is True
+
+    # --- weights ---
+    hf_model_path: Path = DEFAULT_HF_MODEL_PATH
+    cache_path: Path = DEFAULT_CACHE_PATH
+
+    # --- misc ---
+    seed: int = 0
+    log_per_iteration: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate static invariants. Trace-dependent checks live in preflight."""
+        if self.decoder_layer_idx < 0:
+            raise ValueError(f"decoder_layer_idx must be >= 0, got {self.decoder_layer_idx}")
+        if not self.prompt_names:
+            raise ValueError("prompt_names must contain at least one entry")
+        for name in self.prompt_names:
+            if not isinstance(name, str) or not name:
+                raise ValueError(f"prompt_names must be non-empty strings; got {self.prompt_names!r}")
+        if self.num_replication_slots < 1:
+            raise ValueError(f"num_replication_slots must be >= 1, got {self.num_replication_slots}")
+        # num_slots must leave room for the termination dummy at slot=num_slots-1,
+        # so num_replication_slots is strictly less than num_slots.
+        if self.num_slots <= self.num_replication_slots:
+            raise ValueError(
+                f"num_slots ({self.num_slots}) must be > num_replication_slots "
+                f"({self.num_replication_slots}) to reserve slot={self.num_slots - 1} "
+                f"for the termination dummy"
+            )
+        if self.max_seq_len <= 1:
+            raise ValueError(f"max_seq_len must be > 1, got {self.max_seq_len}")
+        # mesh_rows and mesh_cols must each be >= 2 because run_sweep's pipeline_config
+        # hard-codes entry_node_coord=MeshCoordinate(1, 0) and exit_node_coord=
+        # MeshCoordinate(1, 1) (matching test_decoder_block.test_decoder's broadcast
+        # source / reduce-to-one root layout). Smaller submeshes would trip out-of-bounds
+        # coord errors at submesh construction.
+        if self.mesh_rows < 2 or self.mesh_cols < 2:
+            raise ValueError(
+                f"mesh_rows and mesh_cols must each be >= 2 (the harness's single-stage "
+                f"pipeline uses fixed entry=(1,0) / exit=(1,1) coordinates); got "
+                f"({self.mesh_rows}, {self.mesh_cols})"
+            )
+        if not (0.0 < self.pcc_threshold <= 1.0):
+            raise ValueError(f"pcc_threshold must be in (0, 1]; got {self.pcc_threshold}")
+        if (self.dump_hidden_states or self.dump_kv_cache) and self.dump_dir is None:
+            raise ValueError("dump_dir is required when dump_hidden_states or dump_kv_cache is True")
+
+
+@dataclass
+class SweepResult:
+    """Outputs of one ``run_sweep`` invocation.
+
+    Attributes:
+        collected: Nested dict keyed by ``prompt_name`` -> ``slot_id`` ->
+            ``(L_p, HIDDEN_SIZE)`` bf16 tensor of collected decoder outputs.
+        kv_cache: Composed host KV cache tensor of shape
+            ``(num_slots, 1, max_seq_len, kvpe_dim)`` dtype bfloat16, or
+            ``None`` when the device-to-host pull was skipped because neither
+            KV-cache validation nor KV-cache dump was requested.
+        schedule: The :class:`MultiTurnSchedule` actually used.
+        traces: Reference traces as loaded from disk; outer key is
+            ``prompt_name``, inner keys are ``"input"`` / ``"output"`` -> bf16
+            tensor of shape ``(L_p, HIDDEN_SIZE)``.
+    """
+
+    collected: dict[str, dict[int, torch.Tensor]]
+    kv_cache: torch.Tensor | None
+    schedule: MultiTurnSchedule
+    traces: dict[str, dict[str, torch.Tensor]]
+
+
+# ---------------------------------------------------------------------------
+# Internal types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SinglePipelineStage:
+    """Duck-typed stand-in for ``ttnn.experimental.BlitzDecodePipelineStage``.
+
+    ``generate_blitz_decode_pipeline`` does not handle ``num_meshes == 1`` (it
+    OOBs on ``hops[0]`` for the no-loopback path) and the C++
+    ``BlitzDecodePipelineStage`` binding is read-only, so we construct the
+    1-stage descriptor in Python. ``HostIoDecoderStage`` and
+    ``PipelineBlock._init_combined_h2d_d2h_stage`` only read
+    ``entry_node_coord`` and ``exit_node_coord`` from this object.
+    """
+
+    entry_node_coord: ttnn.MeshCoordinate
+    exit_node_coord: ttnn.MeshCoordinate
+
+
+# ---------------------------------------------------------------------------
+# Trace I/O + H2D page construction + D2H page parsing (ported from the
+# original pytest test_host_io_decoder_stage.py; semantics unchanged except
+# for ``_build_per_iteration_input`` which now plumbs a single ``global_pos``).
+# ---------------------------------------------------------------------------
+
+
+def _load_reference_trace(trace_dir: Path, prompt_name: str) -> dict[str, torch.Tensor]:
+    """Load and validate one prompt's reference trace.
+
+    Expected on-disk format (per prompt):
+        torch.save(
+            {"input":  (L, HIDDEN_SIZE) bf16,
+             "output": (L, HIDDEN_SIZE) bf16},
+            f"{trace_dir}/{prompt_name}.pt",
+        )
+
+    Returns the dict unchanged. Raises ``FileNotFoundError`` / ``ValueError`` if
+    the file's structure / shapes / dtypes don't match the contract.
+    """
+    path = trace_dir / f"{prompt_name}.pt"
+    if not path.exists():
+        raise FileNotFoundError(f"Reference trace not found: {path}")
+    # map_location="cpu" so traces saved on a CUDA host still load on a CPU host
+    # (the harness only consumes the tensors on host before pushing to ttnn).
+    trace = torch.load(path, map_location="cpu")
+    if not isinstance(trace, dict):
+        raise ValueError(f"{path}: expected dict, got {type(trace).__name__}")
+    if not set(trace.keys()) >= {"input", "output"}:
+        raise ValueError(f"{path}: missing required keys 'input'/'output'; got {sorted(trace.keys())}")
+    inp, out = trace["input"], trace["output"]
+    if not (isinstance(inp, torch.Tensor) and isinstance(out, torch.Tensor)):
+        raise ValueError(f"{path}: 'input' and 'output' must be torch.Tensor")
+    if inp.dtype != torch.bfloat16 or out.dtype != torch.bfloat16:
+        raise ValueError(f"{path}: expected bfloat16 tensors, got input={inp.dtype}, output={out.dtype}")
+    if inp.ndim != 2 or out.ndim != 2:
+        raise ValueError(
+            f"{path}: expected 2D (seq_len, HIDDEN_SIZE) tensors, got input.shape={tuple(inp.shape)}, "
+            f"output.shape={tuple(out.shape)}"
+        )
+    if inp.shape[-1] != D.HIDDEN_SIZE or out.shape[-1] != D.HIDDEN_SIZE:
+        raise ValueError(
+            f"{path}: last dim must equal D.HIDDEN_SIZE ({D.HIDDEN_SIZE}), got "
+            f"input.shape={tuple(inp.shape)}, output.shape={tuple(out.shape)}"
+        )
+    if inp.shape[0] != out.shape[0]:
+        raise ValueError(f"{path}: input and output seq_len mismatch: input={inp.shape[0]}, output={out.shape[0]}")
+    return trace
+
+
+def _to_hidden_state_input(
+    hidden_state: torch.Tensor,
+    *,
+    token_id: int,
+    prefill_token_id: int,
+    user_id: int,
+    position_id: int,
+    token_type: int,
+    temperature: float,
+    top_k: int,
+    probability_mass_threshold: float,
+) -> ttnn.Tensor:
+    """Build an H2D passthrough page = ``hidden_state || DeepseekMetadata`` (uint32-typed).
+
+    Used with ``HostIoDecoderStage(inject_hidden_states=True)``. The activation
+    half is the bf16 hidden state reinterpreted as int32 words; the metadata
+    half mirrors ``model.to_spec_input``'s field placement so the decoder +
+    multi-upstream D2H tail round-trip the input metadata fields the same way
+    as the embedding-driven path.
+    """
+    assert hidden_state.dtype == torch.bfloat16, f"hidden_state must be bf16, got {hidden_state.dtype}"
+    assert (
+        hidden_state.numel() == D.HIDDEN_SIZE
+    ), f"hidden_state must have {D.HIDDEN_SIZE} elements, got {hidden_state.numel()}"
+
+    hidden_int32 = hidden_state.contiguous().view(torch.int32)  # (HIDDEN_SIZE / 2,) int32
+
+    metadata_words = torch.zeros(DeepseekMetadata.aligned_size_bytes() // 4, dtype=torch.int32)
+    metadata_words[InputField.TOKEN_ID] = token_id
+    metadata_words[InputField.PREFILL_TOKEN_ID] = prefill_token_id
+    metadata_words[InputField.TOKEN_TYPE] = token_type
+    metadata_words[InputField.USER_ID] = user_id
+    metadata_words[InputField.POSITION_ID] = position_id
+    metadata_words[InputField.TOKEN0_POSITION_ID] = position_id
+    metadata_words[InputField.TEMPERATURE] = float_to_uint32(temperature)
+    metadata_words[InputField.TOP_K] = top_k
+    metadata_words[InputField.PROBABILITY_MASS_THRESHOLD] = float_to_uint32(probability_mass_threshold)
+
+    combined = torch.cat([hidden_int32, metadata_words]).reshape(1, -1)
+    return ttnn.from_torch(combined, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+
+def _build_per_iteration_input(
+    hidden_state: torch.Tensor,
+    *,
+    slot_id: int,
+    global_pos: int,
+) -> ttnn.Tensor:
+    """Build a single H2D inject-mode page for one (slot, global_pos) sweep iteration.
+
+    Thin wrapper over :func:`_to_hidden_state_input` that fixes the canonical
+    decode-step defaults (matching ``demo/model_pipeline.py:_write_spec_pair``):
+    ``prefill_token_id=-1``, ``token_type=TokenType.BASE``, ``temperature=0.6``,
+    ``top_k=1``, ``probability_mass_threshold=1.0``.
+
+    In multi-turn mode the same ``global_pos`` is written to ``token_id``,
+    ``position_id`` (which also propagates to ``token0_pos``). This keeps the
+    metadata round-trip assertions a single source of truth: the global
+    position is the only "address" the decoder sees, no trace-local indices.
+    """
+    return _to_hidden_state_input(
+        hidden_state,
+        token_id=global_pos,
+        prefill_token_id=-1,
+        user_id=slot_id,
+        position_id=global_pos,
+        token_type=TokenType.BASE,
+        temperature=0.6,
+        top_k=1,
+        probability_mass_threshold=1.0,
+    )
+
+
+def _extract_activation_from_d2h(output_tensor: ttnn.Tensor) -> torch.Tensor:
+    """Return the activation half (first HIDDEN_SIZE bf16 elements) of a D2H page.
+
+    The D2H page layout is ``activation (HIDDEN_SIZE bf16) || DeepseekMetadata
+    (256 bytes)``. The leading slice IS the decoder's output hidden state for
+    the corresponding ``(slot, global_pos)``.
+    """
+    return ttnn.to_torch(output_tensor).flatten()[: D.HIDDEN_SIZE]
+
+
+def _extract_metadata_from_d2h(output_tensor: ttnn.Tensor):
+    """Extract and parse the trailing DeepseekMetadata tail of a D2H page.
+
+    Slices the last ``DeepseekMetadata.aligned_size_bytes()`` bytes off the
+    bf16 receive buffer, reinterprets them bitwise as ``(64,) int32`` words,
+    and parses via ``model.parse_output_page``.
+
+    Returns:
+        metadata_flat: torch.Tensor of shape ``(64,)`` int32 — raw idx reads
+            (e.g. ``metadata_flat[InputField.POSITION_ID]`` for the input-side
+            position_id field, which ``parse_output_page`` does not expose).
+        parsed: ``DecodeResult`` — convenience accessors for ``slot_id`` and
+            the ``token_0_*`` output fields.
+    """
+    metadata_bytes = DeepseekMetadata.aligned_size_bytes()  # 256
+    metadata_uint32_count = metadata_bytes // 4  # 64
+    metadata_bf16_count = metadata_bytes // dtype_size(ttnn.bfloat16)  # 128
+
+    torch_full = ttnn.to_torch(output_tensor).flatten()
+    metadata_words = torch_full[-metadata_bf16_count:].contiguous().view(torch.int32).reshape(1, metadata_uint32_count)
+    metadata_tensor = ttnn.from_torch(metadata_words, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    parsed = parse_output_page(metadata_tensor)
+    return metadata_words.flatten(), parsed
+
+
+# ---------------------------------------------------------------------------
+# Preflight: trace loading + trace-dependent invariant validation
+# ---------------------------------------------------------------------------
+
+
+def _preflight(
+    config: HostIoDecoderSweepConfig,
+) -> tuple[MultiTurnSchedule, dict[str, dict[str, torch.Tensor]]]:
+    """Load all reference traces and build the multi-turn schedule.
+
+    Validates trace-dependent invariants that ``HostIoDecoderSweepConfig.__post_init__``
+    can't catch: filesystem existence of ``hidden_states_dir`` and each prompt
+    file, per-trace shape/dtype conformance (delegated to
+    :func:`_load_reference_trace`), and the cumulative-position constraint
+    ``total_length() + 1 < max_seq_len`` (the ``+1`` reserves the
+    ``(slot=num_slots-1, pos=max_seq_len-1)`` corner for the termination
+    dummy in :func:`run_sweep`'s phase 1).
+
+    Returns:
+        ``(schedule, traces)`` where ``traces`` is keyed by prompt_name and
+        each value is the dict returned by :func:`_load_reference_trace`.
+
+    Raises:
+        ValueError: any trace-dependent invariant violated.
+        AssertionError: per-trace shape/dtype contract violated (from
+            :func:`_load_reference_trace`).
+    """
+    if not config.hidden_states_dir.is_dir():
+        raise ValueError(f"hidden_states_dir does not exist or is not a directory: {config.hidden_states_dir}")
+
+    traces: dict[str, dict[str, torch.Tensor]] = {}
+    prompt_lengths: list[int] = []
+    for prompt_name in config.prompt_names:
+        trace = _load_reference_trace(config.hidden_states_dir, prompt_name)
+        traces[prompt_name] = trace
+        prompt_lengths.append(int(trace["input"].shape[0]))
+
+    schedule = MultiTurnSchedule(prompt_lengths=tuple(prompt_lengths))
+
+    total = schedule.total_length()
+    if total + 1 >= config.max_seq_len:
+        raise ValueError(
+            f"Total positions consumed across all prompts ({total}) + 1 (termination dummy) "
+            f">= max_seq_len ({config.max_seq_len}). Reduce prompt seq_lens or increase max_seq_len."
+        )
+
+    return schedule, traces
+
+
+# ---------------------------------------------------------------------------
+# Per-prompt inner sweep (used by run_sweep's prompt loop)
+# ---------------------------------------------------------------------------
+
+
+def _run_prompt_sweep(
+    *,
+    config: HostIoDecoderSweepConfig,
+    pipeline_block,
+    prompt_name: str,
+    prompt_idx: int,
+    schedule: MultiTurnSchedule,
+    trace: dict[str, torch.Tensor],
+    collected_for_prompt: dict[int, torch.Tensor],
+    output_tensor: ttnn.Tensor,
+) -> None:
+    """Run one prompt's H2D / decoder / D2H sweep, writing into the supplied collector.
+
+    Each ``(p_local, slot_id)`` iteration writes
+    ``hidden_state || DeepseekMetadata`` to H2D, reads the D2H reply, optionally
+    asserts the input metadata round-trips, and stashes the activation half in
+    ``collected_for_prompt[slot_id][p_local, :]``. ``global_pos`` is the
+    schedule offset plus ``p_local`` and is the only "position" the decoder
+    sees.
+
+    Both the collector and the ``output_tensor`` D2H receive buffer are
+    allocated by the caller (in ``run_sweep``'s phase 0.5) so the sweep loop
+    only writes/reads/stores, with no allocation work mixed in. ``output_tensor``
+    is overwritten every iteration by ``read_output``; the per-iter activation /
+    metadata extractors copy the bytes out to fresh CPU tensors so reuse is safe.
+
+    Heartbeat logging is every ``log_every`` iterations of the outer p_local
+    loop (1 if ``config.log_per_iteration`` is True, else 1000).
+    """
+    L_p = schedule.prompt_lengths[prompt_idx]
+    offset = schedule.offset_for(prompt_idx)
+    assert set(collected_for_prompt.keys()) == set(range(config.num_replication_slots)), (
+        f"collected_for_prompt keys mismatch: expected {set(range(config.num_replication_slots))}, "
+        f"got {set(collected_for_prompt.keys())}"
+    )
+    for slot, tensor in collected_for_prompt.items():
+        assert tensor.shape == (L_p, D.HIDDEN_SIZE) and tensor.dtype == torch.bfloat16, (
+            f"collected_for_prompt[{slot}] must be ({L_p}, {D.HIDDEN_SIZE}) bf16; "
+            f"got shape={tuple(tensor.shape)} dtype={tensor.dtype}"
+        )
+    log_every = 1 if config.log_per_iteration else 1000
+    logger.info(
+        f"sweep prompt={prompt_name!r} (idx={prompt_idx}): L_p={L_p} "
+        f"global_pos_range=[{offset}, {offset + L_p}) "
+        f"replication_slots={config.num_replication_slots}"
+    )
+    for p_local in range(L_p):
+        global_pos = offset + p_local
+        hidden_state = trace["input"][p_local]
+        for slot_id in range(config.num_replication_slots):
+            input_tensor = _build_per_iteration_input(hidden_state, slot_id=slot_id, global_pos=global_pos)
+            pipeline_block.write_token(input_tensor)
+
+            pipeline_block.read_output(output_tensor)
+
+            if config.validate_metadata_roundtrip:
+                metadata_flat, parsed = _extract_metadata_from_d2h(output_tensor)
+                actual_position_id = int(metadata_flat[InputField.POSITION_ID].item())
+                actual_token_id = int(metadata_flat[InputField.TOKEN_ID].item())
+                assert parsed.slot_id == slot_id, (
+                    f"prompt={prompt_name!r} slot={slot_id} global_pos={global_pos}: "
+                    f"slot_id round-trip mismatch (got {parsed.slot_id})"
+                )
+                assert actual_position_id == global_pos, (
+                    f"prompt={prompt_name!r} slot={slot_id} global_pos={global_pos}: "
+                    f"position_id round-trip mismatch (got {actual_position_id})"
+                )
+                assert actual_token_id == global_pos, (
+                    f"prompt={prompt_name!r} slot={slot_id} global_pos={global_pos}: "
+                    f"token_id round-trip mismatch (got {actual_token_id})"
+                )
+                assert parsed.token_0_type == TokenType.BASE, (
+                    f"prompt={prompt_name!r} slot={slot_id} global_pos={global_pos}: "
+                    f"token_0_type round-trip mismatch (got {parsed.token_0_type})"
+                )
+
+            collected_for_prompt[slot_id][p_local, :] = _extract_activation_from_d2h(output_tensor)
+
+        if (p_local + 1) % log_every == 0 or p_local + 1 == L_p:
+            logger.info(f"sweep prompt={prompt_name!r}: {p_local + 1}/{L_p} positions complete")
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def open_mesh_device(device_params: dict) -> Iterator[ttnn.MeshDevice]:
+    """Open the parent ``MeshDevice`` and yield it; close on exit.
+
+    Thin wrapper around :func:`conftest.bh_2d_mesh_device_context` so the
+    fabric configuration / open / close lifecycle matches the production
+    pytest path exactly. The parent mesh shape is determined by the system
+    topology (1, 2, 4, 8, or 32 visible devices); the submesh of the shape
+    requested by ``HostIoDecoderSweepConfig.mesh_rows / mesh_cols`` is
+    created inside :func:`run_sweep`.
+
+    Args:
+        device_params: Fabric / worker-l1 / fabric-router config dict; same
+            shape as the indirect ``device_params`` pytest fixture today (i.e.
+            ``{"fabric_config": ..., "fabric_router_config": ...,
+            "worker_l1_size": ...}``).
+
+    Yields:
+        The parent ``MeshDevice`` handle.
+
+    Raises:
+        ImportError: ``conftest.bh_2d_mesh_device_context`` is not importable
+            (workspace root not on ``sys.path`` and/or ``pytest`` not installed).
+            The harness module's other public types (dataclasses, ``run_sweep``,
+            helpers) are importable independently of pytest; only this context
+            manager pulls pytest in transitively.
+    """
+    # Imported lazily so the harness MODULE is importable without pytest on
+    # PYTHONPATH (e.g. for tooling that only consumes the dataclasses). Calling
+    # this context manager DOES require pytest to be installed and the
+    # workspace root to be on sys.path, because conftest.py itself imports
+    # pytest at module load. Raise an actionable error if either is missing.
+    try:
+        from conftest import bh_2d_mesh_device_context
+    except ImportError as e:
+        raise ImportError(
+            "open_mesh_device requires conftest.bh_2d_mesh_device_context, which lives "
+            "at the tt-metal repo root and imports pytest at module load. Run from the "
+            "repo root (so conftest.py is on sys.path) and ensure pytest is installed."
+        ) from e
+
+    with bh_2d_mesh_device_context(device_params) as parent_mesh:
+        yield parent_mesh
+
+
+def run_sweep(
+    config: HostIoDecoderSweepConfig,
+    parent_mesh: ttnn.MeshDevice,
+) -> SweepResult:
+    """Run one multi-turn HostIoDecoderStage sweep end-to-end.
+
+    Phases (see module docstring for full semantics):
+        0.  Preflight: load traces, build :class:`MultiTurnSchedule`, validate
+            trace-dependent invariants. Pre-allocate every prompt's per-slot
+            ``collected`` tensors so the sweep loop has zero allocation work.
+        0.5 Submesh + slow-dispatch + weights + HostIoDecoderStage + persistent
+            kernels launch (runs ONCE for the whole multi-turn run).
+        1.  Multi-turn prompt loop: per-prompt sweep into pre-allocated
+            collectors. No validation in this phase — keeps the hot path
+            (write/read/round-trip/store) free of any per-prompt host work
+            other than the per-iter metadata round-trip asserts.
+        2.  Termination (single teardown).
+        3.  Hidden state validation (post-teardown):
+            3a. Per-prompt cross-slot ``torch.equal`` across replicated slots.
+            3b. Optional per-(prompt, slot) cross-trace PCC vs reference.
+        4.  KV cache validation: conditional pull (fast-dispatch) + per-prompt
+            KV cross-slot equality.
+        5.  Per-(prompt, slot) dumps for hidden states and KV cache.
+
+    Args:
+        config: Frozen configuration. Validate-only and dump-only invocations
+            are supported by toggling the relevant knobs.
+        parent_mesh: Parent ``MeshDevice`` owned by the caller (e.g. by
+            :func:`open_mesh_device`); not closed by ``run_sweep``.
+
+    Returns:
+        :class:`SweepResult` with collected outputs, full KV cache, schedule,
+        and loaded reference traces.
+
+    Raises:
+        AssertionError: any enabled validation gate that fires.
+        ValueError: preflight invariants violated (trace shape, sum of seq lens
+            vs max_seq_len, missing dump_dir while a dump knob is set, etc.).
+        RuntimeError: not invoked under slow dispatch (sets the env var
+            ``TT_METAL_SLOW_DISPATCH_MODE=1`` upstream).
+    """
+    # =========================================================================
+    # Phase 0: Preflight + environment checks
+    # =========================================================================
+    if not is_slow_dispatch():
+        raise RuntimeError(
+            "run_sweep requires slow dispatch (the H2D / D2H sockets do not work under fast "
+            "dispatch). Set TT_METAL_SLOW_DISPATCH_MODE=1 before launching."
+        )
+    if not config.hf_model_path.exists():
+        raise FileNotFoundError(f"HF model path does not exist: {config.hf_model_path}")
+
+    torch.manual_seed(config.seed)
+    schedule, traces = _preflight(config)
+    logger.info(
+        f"preflight: prompts={list(config.prompt_names)} "
+        f"prompt_lengths={schedule.prompt_lengths} total_length={schedule.total_length()} "
+        f"max_seq_len={config.max_seq_len}"
+    )
+
+    num_devices = config.mesh_rows * config.mesh_cols
+    if parent_mesh.shape[0] * parent_mesh.shape[1] < num_devices:
+        raise RuntimeError(
+            f"parent_mesh has {parent_mesh.shape[0] * parent_mesh.shape[1]} devices but "
+            f"config requires {num_devices} ({config.mesh_rows}x{config.mesh_cols})"
+        )
+
+    if config.dump_dir is not None:
+        config.dump_dir.mkdir(parents=True, exist_ok=True)
+
+    # =========================================================================
+    # Phase 0.5: One-time setup (submesh, weights, persistent kernels)
+    # =========================================================================
+    logger.info(f"Creating {config.mesh_rows}x{config.mesh_cols} submesh ({num_devices} devices)")
+    submesh = parent_mesh.create_submesh(ttnn.MeshShape((config.mesh_rows, config.mesh_cols)))
+    ttnn.enable_asynchronous_slow_dispatch(submesh)
+
+    logger.info(f"Using HF model path: {config.hf_model_path}")
+    logger.info(f"Using cache path:    {config.cache_path}")
+    provider = CacheWeightProvider(cache_path=config.cache_path, model_path=config.hf_model_path)
+
+    # Auto-detect dense vs MoE from layer_idx (see NUM_DENSE_LAYERS comment at the
+    # top of this module). Dense layers use a different weight loader and pass
+    # different MoE-related kwargs into HostIoDecoderStage; everything else about
+    # the harness (broadcast / reduce / sockets / KV cache) is layer-type agnostic.
+    is_moe_layer = _is_moe_layer(config.decoder_layer_idx)
+    layer_type = "MoE" if is_moe_layer else "dense"
+    logger.info(
+        f"Layer type auto-detected: layer_idx={config.decoder_layer_idx} -> {layer_type} "
+        f"(NUM_DENSE_LAYERS={NUM_DENSE_LAYERS})"
+    )
+    if is_moe_layer:
+        layer_weights = provider.load_moe_layer(layer_id=config.decoder_layer_idx, device=submesh)
+    else:
+        layer_weights = provider.load_dense_layer(layer_id=config.decoder_layer_idx, device=submesh)
+    logger.info(f"{layer_type} layer weights ready")
+
+    # Single-stage pipeline (num_procs == 1, no loopback). Coords match
+    # the original test_decoder_block.test_decoder layout:
+    # broadcast source = (1, 0), reduce-to-one root = (1, 1).
+    pipeline_config = [
+        _SinglePipelineStage(
+            entry_node_coord=ttnn.MeshCoordinate(1, 0),
+            exit_node_coord=ttnn.MeshCoordinate(1, 1),
+        )
+    ]
+    stages_metadata = {0: StageMetadata(rank=0, mesh_id=0)}
+    ctx = StageContext(
+        mesh_device=submesh,
+        pipeline_config=pipeline_config,
+        my_stage_idx=0,
+        stages_metadata=stages_metadata,
+    )
+
+    # Production-shape decoder: is_torus=True, persistent_mode=True,
+    # use_hardcoded_expert_index=False. MoE layers also set is_moe=True with
+    # num_routed_experts=NUM_ROUTED_EXPERTS (256) and enable_routing=True; dense
+    # layers set those to False/0/False. position_id=0 seeds the initial KV cache
+    # state; runtime per-token positions come from each H2D page (global_pos in
+    # multi-turn).
+    if is_moe_layer:
+        layer_type_kwargs = dict(
+            is_moe=True,
+            num_routed_experts=NUM_ROUTED_EXPERTS,
+            enable_routing=True,
+        )
+    else:
+        layer_type_kwargs = dict(
+            is_moe=False,
+            num_routed_experts=0,
+            enable_routing=False,
+        )
+    logger.info(
+        f"Instantiating HostIoDecoderStage (layer_idx={config.decoder_layer_idx}, "
+        f"layer_type={layer_type}, layer_type_kwargs={layer_type_kwargs})"
+    )
+    stage = HostIoDecoderStage(
+        weights=layer_weights,
+        layer_idx=config.decoder_layer_idx,
+        metadata=DeepseekMetadata(position_id=0),
+        max_seq_len=config.max_seq_len,
+        num_slots=config.num_slots,
+        persistent_mode=True,
+        is_torus=True,
+        use_hardcoded_expert_index=False,
+        inject_hidden_states=True,
+        **layer_type_kwargs,
+    )
+
+    logger.info("Building PipelineBlock + persistent kernels")
+    pipeline_block = stage.create_pipeline_block(ctx)
+    stage.setup(ctx, pipeline_block)
+    pipeline_block.run()
+    stage.launch_compute(ctx, pipeline_block)
+    logger.info("All persistent kernels dispatched")
+
+    out_words = ACTIVATION_W_TOKEN_META_PAGE_SIZE_BYTES // dtype_size(ttnn.bfloat16)
+
+    # Pre-allocate ALL per-prompt collectors AND the shared D2H receive buffer
+    # before any H2D write. Keeps the multi-turn sweep loop tight: only
+    # writes/reads/stores live in the hot path, no allocation work between
+    # iterations.
+    #
+    # output_tensor is reused across every (prompt, position, slot) iteration:
+    # read_output overwrites it in place, and the activation/metadata extractors
+    # copy the bytes out to fresh CPU tensors before the next read_output runs.
+    collected: dict[str, dict[int, torch.Tensor]] = {
+        prompt_name: {
+            slot: torch.zeros(schedule.prompt_lengths[prompt_idx], D.HIDDEN_SIZE, dtype=torch.bfloat16)
+            for slot in range(config.num_replication_slots)
+        }
+        for prompt_idx, prompt_name in enumerate(config.prompt_names)
+    }
+    output_tensor = ttnn.from_torch(
+        torch.zeros(1, out_words, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+    logger.info(
+        f"Pre-allocated collected hidden states for {len(config.prompt_names)} prompt(s) x "
+        f"{config.num_replication_slots} slot(s); reusing one D2H receive buffer "
+        f"(out_words={out_words}) across all iterations"
+    )
+
+    # =========================================================================
+    # Phase 1: Multi-turn prompt loop (sweep only — no validation here)
+    # =========================================================================
+    for prompt_idx, prompt_name in enumerate(config.prompt_names):
+        _run_prompt_sweep(
+            config=config,
+            pipeline_block=pipeline_block,
+            prompt_name=prompt_name,
+            prompt_idx=prompt_idx,
+            schedule=schedule,
+            trace=traces[prompt_name],
+            collected_for_prompt=collected[prompt_name],
+            output_tensor=output_tensor,
+        )
+
+    # =========================================================================
+    # Phase 2: Termination (single teardown for the entire multi-turn run)
+    # =========================================================================
+    logger.info("Phase 2: signalling persistent decoder termination")
+    stage.terminate(ctx, pipeline_block)
+
+    # Termination dummy targets (slot=num_slots-1, position=max_seq_len-1).
+    # Preflight asserts schedule.total_length() + 1 < max_seq_len, so the dummy
+    # never lands on a used position. __post_init__ asserts num_slots >
+    # num_replication_slots, so it never lands on a used slot.
+    zero_hidden_state = torch.zeros(D.HIDDEN_SIZE, dtype=torch.bfloat16)
+    termination_dummy = _to_hidden_state_input(
+        zero_hidden_state,
+        token_id=0,
+        prefill_token_id=-1,
+        user_id=config.num_slots - 1,
+        position_id=config.max_seq_len - 1,
+        token_type=TokenType.BASE,
+        temperature=0.6,
+        top_k=1,
+        probability_mass_threshold=1.0,
+    )
+    logger.info(f"Pushing termination dummy at slot={config.num_slots - 1} pos={config.max_seq_len - 1}")
+    pipeline_block.write_token(termination_dummy)
+    pipeline_block.drain_dummy_output()
+    pipeline_block.terminate()
+    ttnn.synchronize_device(submesh)
+    logger.info("Phase 2 complete: HostIoDecoderStage teardown done")
+
+    # =========================================================================
+    # Phase 3: Hidden state validation (cross-slot equality + cross-trace PCC)
+    # =========================================================================
+    # Per-prompt cross-slot equality. The same hidden state is pushed through
+    # every replicated slot at each position, so each slot's collected output
+    # must be byte-identical for every prompt. (No-op for Mode A.)
+    if config.validate_hidden_states_cross_slot and config.num_replication_slots > 1:
+        logger.info(
+            f"Phase 3a: hidden-state cross-slot equality across "
+            f"{config.num_replication_slots} slots for {len(config.prompt_names)} prompt(s)"
+        )
+        for prompt_name in config.prompt_names:
+            ref = collected[prompt_name][0]
+            for s in range(1, config.num_replication_slots):
+                assert torch.equal(collected[prompt_name][s], ref), (
+                    f"Hidden-state cross-slot equality failed: prompt={prompt_name!r} " f"slot {s} diverged from slot 0"
+                )
+            logger.info(f"prompt={prompt_name!r}: hidden-state cross-slot equality OK")
+    else:
+        logger.info("Phase 3a skipped: validate_hidden_states_cross_slot=False or num_replication_slots == 1")
+
+    # Cross-trace per-(prompt, slot) PCC against the reference output trace.
+    # If 3a already proved cross-slot equality (i.e. all slots byte-identical to
+    # slot 0), PCC of slot 0 is a sound proxy for every slot — skip the redundant
+    # PCC computations for slots 1..N-1. Otherwise (Mode A, or 3a disabled) we
+    # have no proof of cross-slot equality and must PCC each slot independently.
+    if config.validate_hidden_states_cross_trace:
+        cross_slot_proven = config.validate_hidden_states_cross_slot and config.num_replication_slots > 1
+        slots_to_pcc: list[int] = [0] if cross_slot_proven else list(range(config.num_replication_slots))
+        logger.info(
+            f"Phase 3b: cross-trace PCC validation (threshold={config.pcc_threshold}) "
+            f"for {len(config.prompt_names)} prompt(s); slots_to_pcc={slots_to_pcc} "
+            f"(cross_slot_proven_in_3a={cross_slot_proven})"
+        )
+        for prompt_name in config.prompt_names:
+            expected = traces[prompt_name]["output"]
+            for slot in slots_to_pcc:
+                passing, pcc = comp_pcc(
+                    expected.flatten(),
+                    collected[prompt_name][slot].flatten(),
+                    config.pcc_threshold,
+                )
+                slot_label = (
+                    f"slot={slot} (proxy for all {config.num_replication_slots} slots)"
+                    if cross_slot_proven
+                    else f"slot={slot}"
+                )
+                logger.info(
+                    f"PCC: prompt={prompt_name!r} {slot_label} pcc={float(pcc):.6f} "
+                    f"threshold={config.pcc_threshold} pass={passing}"
+                )
+                assert passing, (
+                    f"Cross-trace validation FAILED: prompt={prompt_name!r} slot={slot} "
+                    f"pcc={float(pcc):.6f} < threshold {config.pcc_threshold}"
+                )
+        logger.info("Phase 3b complete: cross-trace PCC OK for all prompts")
+    else:
+        logger.info("Phase 3b skipped: validate_hidden_states_cross_trace=False")
+
+    # =========================================================================
+    # Phase 4: KV cache pull (fast-dispatch) + per-prompt cross-slot validation
+    # =========================================================================
+    # Skip the device-to-host KV pull entirely if neither validation nor dump
+    # needs it. The pull composes a ~9.6 GB host tensor (production shape) so
+    # this is a meaningful win for validation-only or pure-sweep invocations.
+    # Note: cross-slot validation is itself a no-op in Mode A (single slot), so
+    # it can't justify pulling on its own when num_replication_slots == 1.
+    kv_cache_torch: torch.Tensor | None = None
+    need_kv_cache = config.dump_kv_cache or (config.validate_kv_cache_cross_slot and config.num_replication_slots > 1)
+    if need_kv_cache:
+        logger.info("Phase 4: pulling on-device KV cache to host (fast-dispatch context)")
+        with ttnn.device.setup_fast_dispatch(submesh):
+            kv_cache_torch = stage.get_kv_cache_host()
+        assert kv_cache_torch is not None, "get_kv_cache_host returned None (setup not completed?)"
+        logger.info(f"KV cache shape={tuple(kv_cache_torch.shape)} dtype={kv_cache_torch.dtype}")
+    else:
+        logger.info("Phase 4: KV cache pull skipped (no KV-cache validation, no KV-cache dump)")
+
+    if config.validate_kv_cache_cross_slot and config.num_replication_slots > 1:
+        assert kv_cache_torch is not None  # guaranteed by need_kv_cache above
+        logger.info(f"Phase 4: per-prompt KV-cache cross-slot equality " f"({config.num_replication_slots} slots)")
+        for prompt_idx, prompt_name in enumerate(config.prompt_names):
+            start, end = schedule.range_for(prompt_idx)
+            ref_kv = kv_cache_torch[0, :, start:end, :]
+            for s in range(1, config.num_replication_slots):
+                assert torch.equal(kv_cache_torch[s, :, start:end, :], ref_kv), (
+                    f"KV-cache cross-slot equality failed: prompt={prompt_name!r} "
+                    f"position_range=[{start}, {end}) slot {s} diverged from slot 0"
+                )
+            logger.info(f"prompt={prompt_name!r} KV cross-slot OK for positions [{start}, {end})")
+
+    # =========================================================================
+    # Phase 5: Per-(prompt, slot) dumps
+    # =========================================================================
+    if config.dump_hidden_states or config.dump_kv_cache:
+        assert config.dump_dir is not None  # __post_init__ guarantees this
+        logger.info(f"Phase 5: per-(prompt, slot) dumps to {config.dump_dir}")
+
+    if config.dump_hidden_states:
+        for prompt_name in config.prompt_names:
+            for slot in range(config.num_replication_slots):
+                out_path = config.dump_dir / f"output_hidden_states_slot_{slot:02d}_{prompt_name}.pt"
+                torch.save(collected[prompt_name][slot], out_path)
+                logger.info(f"Wrote {out_path}")
+
+    if config.dump_kv_cache:
+        assert kv_cache_torch is not None  # guaranteed by need_kv_cache above
+        for prompt_idx, prompt_name in enumerate(config.prompt_names):
+            start, end = schedule.range_for(prompt_idx)
+            for slot in range(config.num_replication_slots):
+                kv_slice = kv_cache_torch[slot, :, start:end, :]
+                out_path = config.dump_dir / f"kv_cache_slot_{slot:02d}_{prompt_name}.pt"
+                torch.save(kv_slice, out_path)
+                logger.info(f"Wrote {out_path} shape={tuple(kv_slice.shape)}")
+
+    logger.info("run_sweep complete")
+    return SweepResult(
+        collected=collected,
+        kv_cache=kv_cache_torch,
+        schedule=schedule,
+        traces=traces,
+    )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/run_host_io_decoder_sweep.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/run_host_io_decoder_sweep.py
@@ -1,0 +1,379 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI entrypoint for the HostIoDecoderStage multi-turn sweep harness.
+
+Thin argparse wrapper around :func:`host_io_decoder_harness.run_sweep`. Every
+knob in :class:`HostIoDecoderSweepConfig` is exposed as a flag; boolean knobs
+use ``argparse.BooleanOptionalAction`` so each is toggleable with
+``--knob`` / ``--no-knob``.
+
+Environment variables (read only as fallback defaults; flags always win):
+    DEEPSEEK_V3_HIDDEN_STATES_DIR   -> --hidden-states-dir
+    DEEPSEEK_V3_KV_CACHE_DUMP_DIR   -> --dump-dir
+
+Slow dispatch is required for this sweep to function. Set this in
+the calling environment before invoking::
+
+    TT_METAL_SLOW_DISPATCH_MODE=1 python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep ...
+
+Usage examples
+--------------
+
+Mode A (single slot), one prompt, dump everything to ``./dumps``::
+
+    TT_METAL_SLOW_DISPATCH_MODE=1 \\
+    python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \\
+        --decoder-layer-idx 4 \\
+        --hidden-states-dir /data/asaigal/pipeclean_traces \\
+        --prompt pipeclean_seq_8192 \\
+        --num-replication-slots 1 \\
+        --dump-dir ./dumps
+
+Mode B (8 replication slots), two-prompt multi-turn, validate everything,
+no dumps, use real GPU reference traces for cross-trace PCC::
+
+    TT_METAL_SLOW_DISPATCH_MODE=1 \\
+    DEEPSEEK_V3_HIDDEN_STATES_DIR=/data/gpu_reference \\
+    python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \\
+        --decoder-layer-idx 4 \\
+        --prompt q_what_is_python q_quick_brown_fox \\
+        --num-replication-slots 8 \\
+        --validate-hidden-states-cross-trace \\
+        --no-dump-hidden-states --no-dump-kv-cache
+
+Dry-run (print resolved config and exit, no device opened)::
+
+    python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \\
+        --decoder-layer-idx 4 \\
+        --hidden-states-dir /tmp/x --prompt foo --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
+from models.demos.deepseek_v3_b1.tests.unit_tests.host_io_decoder_harness import (
+    DEFAULT_CACHE_PATH,
+    DEFAULT_HF_MODEL_PATH,
+    HIDDEN_STATES_DIR_ENV,
+    KV_CACHE_DUMP_DIR_ENV,
+    HostIoDecoderSweepConfig,
+    open_mesh_device,
+    run_sweep,
+)
+
+# Production device_params constants ported from the original pytest's indirect
+# ``device_params`` fixture. The fabric config, max packet payload, and worker
+# L1 size are not currently exposed as CLI knobs because no caller has needed
+# to vary them; promote any of these to flags later if that changes.
+_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_2D_TORUS_X
+_FABRIC_ROUTER_MAX_PAYLOAD_BYTES = 15232
+_WORKER_L1_SIZE = 1431568
+
+
+# ---------------------------------------------------------------------------
+# Argparse setup
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a multi-turn HostIoDecoderStage sweep against one or more reference "
+            "hidden-state traces. Validates metadata round-trip, cross-slot determinism "
+            "for hidden states and KV cache, and (optionally) cross-trace PCC; dumps "
+            "per-(slot, prompt) hidden states and KV-cache slices to disk."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # --- required: prompt source + identifying knobs ---
+    required = parser.add_argument_group("required")
+    required.add_argument(
+        "--decoder-layer-idx",
+        type=int,
+        required=True,
+        help="DeepSeek V3 decoder layer index to instantiate (e.g. 4 for the first MoE layer).",
+    )
+    required.add_argument(
+        "--hidden-states-dir",
+        type=Path,
+        default=None,
+        help=(
+            f"Directory containing per-prompt reference traces (*.pt files with bf16 "
+            f"{{'input', 'output'}} tensors). Falls back to ${HIDDEN_STATES_DIR_ENV} if omitted; "
+            f"required if neither flag nor env is set."
+        ),
+    )
+    required.add_argument(
+        "--prompt",
+        dest="prompt_names",
+        nargs="+",
+        required=True,
+        metavar="NAME",
+        help=(
+            "One or more prompt names (file stems under --hidden-states-dir). Multiple "
+            "prompts are run back-to-back in a single decoder launch; positions are "
+            "disjoint and accumulating across prompts (multi-turn semantics)."
+        ),
+    )
+
+    # --- model shape ---
+    model = parser.add_argument_group("model shape")
+    model.add_argument("--max-seq-len", type=int, default=128 * 1024)
+    model.add_argument("--num-slots", type=int, default=64)
+    model.add_argument("--mesh-rows", type=int, default=4)
+    model.add_argument("--mesh-cols", type=int, default=2)
+
+    # --- replication / mode ---
+    parser.add_argument(
+        "--num-replication-slots",
+        type=int,
+        default=8,
+        help="Replication slots (1 = Mode A; >1 = Mode B); must be < --num-slots.",
+    )
+
+    # --- validation knobs ---
+    val = parser.add_argument_group("validation")
+    val.add_argument(
+        "--validate-metadata-roundtrip",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Assert per-iteration that slot_id / position_id / token_id / token_0_type round-trip through D2H.",
+    )
+    val.add_argument(
+        "--validate-hidden-states-cross-slot",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Mode B only: per-prompt torch.equal of every replicated slot's collected output against slot 0.",
+    )
+    val.add_argument(
+        "--validate-kv-cache-cross-slot",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Mode B only: per-prompt torch.equal of every replicated slot's KV-cache slice against slot 0.",
+    )
+    val.add_argument(
+        "--validate-hidden-states-cross-trace",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Per-(prompt, slot) PCC of collected output against the prompt's reference 'output' trace.",
+    )
+    val.add_argument(
+        "--pcc-threshold",
+        type=float,
+        default=0.97,
+        help="PCC threshold used only when --validate-hidden-states-cross-trace is set.",
+    )
+
+    # --- dump knobs ---
+    dump = parser.add_argument_group("dumps")
+    dump.add_argument(
+        "--dump-hidden-states",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Write one (seq_len, HIDDEN_SIZE) bf16 file per (slot, prompt) to --dump-dir. "
+            "Opt-in (default off) so validation-only runs don't require --dump-dir."
+        ),
+    )
+    dump.add_argument(
+        "--dump-kv-cache",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Write one (1, seq_len, kvpe_dim) bf16 file per (slot, prompt) to --dump-dir. "
+            "Opt-in (default off) so the harness can skip the ~9.6 GB device-to-host KV "
+            "cache pull entirely on validation-only / pure-sweep runs."
+        ),
+    )
+    dump.add_argument(
+        "--dump-dir",
+        type=Path,
+        default=None,
+        help=(
+            f"Output directory for dumps. Falls back to ${KV_CACHE_DUMP_DIR_ENV} if omitted; "
+            f"required if any dump knob is on."
+        ),
+    )
+
+    # --- weights ---
+    weights = parser.add_argument_group("weights")
+    weights.add_argument(
+        "--hf-model-path",
+        type=Path,
+        default=DEFAULT_HF_MODEL_PATH,
+        help="HuggingFace model checkpoint root (must contain config.json + safetensors).",
+    )
+    weights.add_argument(
+        "--cache-path",
+        type=Path,
+        default=DEFAULT_CACHE_PATH,
+        help="CacheWeightProvider persistent cache directory.",
+    )
+
+    # --- misc ---
+    misc = parser.add_argument_group("misc")
+    misc.add_argument("--seed", type=int, default=0)
+    misc.add_argument(
+        "--log-per-iteration",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="If set, log every inner sweep iteration; otherwise log every 1000 outer positions per prompt.",
+    )
+    misc.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print resolved config and exit before opening any device.",
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Config + device_params resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_hidden_states_dir(args: argparse.Namespace) -> Path:
+    """Flag wins; env is fallback; error if neither set."""
+    if args.hidden_states_dir is not None:
+        return args.hidden_states_dir
+    raw = os.environ.get(HIDDEN_STATES_DIR_ENV)
+    if raw:
+        return Path(raw)
+    raise ValueError(f"--hidden-states-dir is required (or set ${HIDDEN_STATES_DIR_ENV})")
+
+
+def _resolve_dump_dir(args: argparse.Namespace) -> Path | None:
+    """Flag wins; env is fallback; None permitted iff both dump knobs are off."""
+    if args.dump_dir is not None:
+        return args.dump_dir
+    raw = os.environ.get(KV_CACHE_DUMP_DIR_ENV)
+    if raw:
+        return Path(raw)
+    return None
+
+
+def _config_from_args(args: argparse.Namespace) -> HostIoDecoderSweepConfig:
+    """Build a frozen :class:`HostIoDecoderSweepConfig` from parsed argparse args."""
+    hidden_states_dir = _resolve_hidden_states_dir(args)
+    dump_dir = _resolve_dump_dir(args)
+    return HostIoDecoderSweepConfig(
+        decoder_layer_idx=args.decoder_layer_idx,
+        hidden_states_dir=hidden_states_dir,
+        prompt_names=tuple(args.prompt_names),
+        max_seq_len=args.max_seq_len,
+        num_slots=args.num_slots,
+        mesh_rows=args.mesh_rows,
+        mesh_cols=args.mesh_cols,
+        num_replication_slots=args.num_replication_slots,
+        validate_metadata_roundtrip=args.validate_metadata_roundtrip,
+        validate_hidden_states_cross_slot=args.validate_hidden_states_cross_slot,
+        validate_kv_cache_cross_slot=args.validate_kv_cache_cross_slot,
+        validate_hidden_states_cross_trace=args.validate_hidden_states_cross_trace,
+        pcc_threshold=args.pcc_threshold,
+        dump_hidden_states=args.dump_hidden_states,
+        dump_kv_cache=args.dump_kv_cache,
+        dump_dir=dump_dir,
+        hf_model_path=args.hf_model_path,
+        cache_path=args.cache_path,
+        seed=args.seed,
+        log_per_iteration=args.log_per_iteration,
+    )
+
+
+def _build_device_params(config: HostIoDecoderSweepConfig) -> dict:
+    """Return the device_params dict consumed by :func:`open_mesh_device`.
+
+    Production fabric / worker-l1 constants ported from the original pytest's
+    indirect ``device_params`` fixture. These are intentionally not CLI flags
+    today; promote if a caller needs to vary them.
+    """
+    return {
+        "fabric_config": _FABRIC_CONFIG,
+        "fabric_router_config": create_fabric_router_config(_FABRIC_ROUTER_MAX_PAYLOAD_BYTES),
+        "worker_l1_size": _WORKER_L1_SIZE,
+    }
+
+
+def _log_resolved_config(config: HostIoDecoderSweepConfig) -> None:
+    """Render the resolved config in a human-readable block, before the run."""
+    logger.info("Resolved HostIoDecoderSweepConfig:")
+    for field, value in (
+        ("decoder_layer_idx", config.decoder_layer_idx),
+        ("hidden_states_dir", config.hidden_states_dir),
+        ("prompt_names", list(config.prompt_names)),
+        ("max_seq_len", config.max_seq_len),
+        ("num_slots", config.num_slots),
+        ("mesh_rows x mesh_cols", f"{config.mesh_rows} x {config.mesh_cols}"),
+        ("num_replication_slots", config.num_replication_slots),
+        ("validate_metadata_roundtrip", config.validate_metadata_roundtrip),
+        ("validate_hidden_states_cross_slot", config.validate_hidden_states_cross_slot),
+        ("validate_kv_cache_cross_slot", config.validate_kv_cache_cross_slot),
+        ("validate_hidden_states_cross_trace", config.validate_hidden_states_cross_trace),
+        ("pcc_threshold", config.pcc_threshold),
+        ("dump_hidden_states", config.dump_hidden_states),
+        ("dump_kv_cache", config.dump_kv_cache),
+        ("dump_dir", config.dump_dir),
+        ("hf_model_path", config.hf_model_path),
+        ("cache_path", config.cache_path),
+        ("seed", config.seed),
+        ("log_per_iteration", config.log_per_iteration),
+    ):
+        logger.info(f"  {field:38s} = {value}")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        config = _config_from_args(args)
+    except (ValueError, FileNotFoundError) as e:
+        parser.error(str(e))
+        return 2  # pragma: no cover (parser.error sys.exits 2)
+
+    _log_resolved_config(config)
+
+    if args.dry_run:
+        logger.info("--dry-run set; exiting before opening device")
+        return 0
+
+    device_params = _build_device_params(config)
+    with open_mesh_device(device_params) as parent_mesh:
+        result = run_sweep(config, parent_mesh)
+
+    # Result summary so the CLI ends with an audit-friendly digest of what ran.
+    logger.info("=" * 80)
+    logger.info("SUMMARY")
+    logger.info("=" * 80)
+    logger.info(f"prompts run: {list(result.collected.keys())}")
+    logger.info(f"prompt_lengths: {result.schedule.prompt_lengths}")
+    logger.info(f"total positions: {result.schedule.total_length()}")
+    if result.kv_cache is not None:
+        logger.info(f"kv_cache shape: {tuple(result.kv_cache.shape)} dtype={result.kv_cache.dtype}")
+    else:
+        logger.info("kv_cache: not pulled (no KV-cache validation, no KV-cache dump)")
+    if config.dump_dir is not None and (config.dump_hidden_states or config.dump_kv_cache):
+        logger.info(f"dumps written under: {config.dump_dir}")
+    logger.info("=" * 80)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/demos/deepseek_v3_b1/utils.py
+++ b/models/demos/deepseek_v3_b1/utils.py
@@ -25,6 +25,14 @@ def deinterleave_kv_cache(kv: torch.Tensor, device_chunk_size: int, num_devices:
     return kv.reshape(b, h, chunks_per_device, num_devices, device_chunk_size, d).transpose(2, 3).reshape(b, h, seq, d)
 
 
+def interleave_kv_cache(kv: torch.Tensor, device_chunk_size: int, num_devices: int) -> torch.Tensor:
+    """Inverse of deinterleave_kv_cache: device-major back to round-robin chunk-major."""
+    b, h, seq, d = kv.shape
+    num_chunks = seq // device_chunk_size
+    chunks_per_device = num_chunks // num_devices
+    return kv.reshape(b, h, num_devices, chunks_per_device, device_chunk_size, d).transpose(2, 3).reshape(b, h, seq, d)
+
+
 def float_to_bfloat16_packed(value):
     """Convert float to packed bfloat16 (two copies in uint32)"""
     # Convert float32 to bytes


### PR DESCRIPTION
### PR Category
Feature

### Summary
- New end-to-end harness for the single-stage `HostIoDecoderStage` with real DeepSeek V3 weights.
- Multi-turn/Multi-user schedule: shared replication slots across all prompts; disjoint; monotonically-incrementing global position ids per prompt (models a single user continuing a conversation across turns).
- Inject-hidden-states mode: H2D passes a full (activation || metadata) page into the decoder, bypassing the embedding lookup so reference hidden-state traces from disk can drive the decoder verbatim.
- New CLI `run_host_io_decoder_sweep.py` exposes every knob via argparse. Auto-detects dense vs MoE from layer_idx (`NUM_DENSE_LAYERS=3`).
- Independent validation gates: per-iter metadata round-trip; per-prompt hidden-state cross-slot torch.equal; per-prompt KV-cache slice cross-slot torch.equal; per-(prompt, slot) PCC vs reference output (with slot-0-only short-circuit when cross-slot equality is already proven).
- Independent dump gates: per-(slot, prompt) hidden states and KV-cache slices written to disk.
- `DecoderStage.get_kv_cache_host()`: returns the composed (`num_slots, 1, max_seq_len, kvpe_dim`) `bf16` KV cache to host. Added `utils.interleave_kv_cache` helper.
- `PipelineBlock` accepts `h2d_socket_page_size` to size H2D for full-activation pages; `embedding_tensor` is optional on the combined H2D+D2H stage.
- KV-cache device-to-host pull is conditional on at least one validation or dump knob being on; pure-sweep invocations skip the ~9.6 GB transfer.

### Notes for reviewers
- This PR is useful for stress testing decoder changes in a production setup, without running the full pipeline
- Multi-User + Multi-Turn testing is supported out of the box
- Follow up PRs will include additional configurations with more decoders & non-decoder stages

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:assaigal/decoder_testing_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:assaigal/decoder_testing_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:assaigal/decoder_testing_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:assaigal/decoder_testing_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:assaigal/decoder_testing_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:assaigal/decoder_testing_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:assaigal/decoder_testing_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=assaigal/decoder_testing_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:assaigal/decoder_testing_rebased)