### PR TITLE
[Bug fix]: Read updated pending interrupts on txn ids before clearing the ones that were processed

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -324,7 +324,7 @@ extern "C" uint32_t _start1() {
                 bool subordinates_run_kernel = start_subordinate_kernel_run_early(enables);
 
                 int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
-                if (subordinates_run_kernel) {
+                if (subordinates_run_kernel || (enables & (1u << index))) {
                     // If subordinates run kernel they could be using DFBs. DM0 needs to setup DFBs to program implicit synchronization.
                     uint32_t num_local_dfbs = launch_msg_address->kernel_config.local_cb_mask;
                     setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -168,15 +168,12 @@ inline void run_triscs(uint32_t enables) {
     }
 }
 
-inline bool start_subordinate_kernel_run_early(uint32_t enables) {
-    bool subordinates_run_kernel = false;
+inline void start_subordinate_kernel_run_early(uint32_t enables) {
     for (int i = 1; i < NUM_DM_CORES; i++) {  // start from 1 to skip DM0
         if (enables & (1u << i)) {
-            subordinates_run_kernel = true;
             *((volatile uint8_t*)&(subordinate_sync->dm1) + i - 1) = RUN_SYNC_MSG_GO;
         }
     }
-    return subordinates_run_kernel;
 }
 
 inline void wait_subordinates() {
@@ -321,15 +318,14 @@ extern "C" uint32_t _start1() {
                 for (uint32_t i = 0; i < MaxDMProcessorsPerCoreType; i++) {
                     mailboxes->shared_globals_ready[i] = SHARED_GLOBALS_READY_WAIT;
                 }
-                bool subordinates_run_kernel = start_subordinate_kernel_run_early(enables);
+                start_subordinate_kernel_run_early(enables);
 
-                int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
-                if (subordinates_run_kernel || (enables & (1u << index))) {
-                    // If subordinates run kernel they could be using DFBs. DM0 needs to setup DFBs to program implicit synchronization.
-                    uint32_t num_local_dfbs = launch_msg_address->kernel_config.local_cb_mask;
-                    setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
-                }
+                // DM0 needs to setup DFBs to program implicit synchronization regardless of whether it runs a kernel or not.
+                uint32_t num_local_dfbs = launch_msg_address->kernel_config.local_cb_mask;
+                setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+
                 // Run the kernel
+                int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
                 WAYPOINT("R");
                 if (enables & (1u << index)) {
                     uint32_t kernel_lma =

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h
@@ -32,9 +32,9 @@ inline __attribute__((always_inline)) void dfb_tile_poster_irq_handler() {
         pending &= (pending - 1);
     }
     if ((fired_trids >> 32) != 0) {
-        uint64_t to_clear = (fired_trids >> 32) & 0xFFFFFFFFULL;
-        uint64_t clear_val = fired_trids & ~(to_clear << 32);
-        CMDBUF_WR_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_1_REG_OFFSET, clear_val);
+        // W0C: write 0 to clear a bit, write 1 to leave it unchanged
+        uint64_t to_clear = (fired_trids >> 32) << 32;
+        CMDBUF_WR_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_1_REG_OFFSET, ~to_clear);
     }
 #endif
 }
@@ -61,9 +61,9 @@ inline __attribute__((always_inline)) void dfb_tile_acker_irq_handler() {
         pending &= (pending - 1);
     }
     if ((fired_trids & 0xFFFFFFFFULL) != 0) {
+        // W0C: write 0 to clear a bit, write 1 to leave it unchanged
         uint64_t to_clear = fired_trids & 0xFFFFFFFFULL;
-        uint64_t clear_val = fired_trids & ~to_clear;
-        CMDBUF_WR_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_2_REG_OFFSET, clear_val);
+        CMDBUF_WR_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_2_REG_OFFSET, ~to_clear);
     }
 #endif
 }


### PR DESCRIPTION
### Summary
When clearing the interrupt pending bits any interrupts on txn ids that met their isr thresholds while servicing the isr would get clobbered. 

Also DM0 needs to unconditionally setup the DFB interfaces - not just when DM subordinates run because we could have tensix only cases. 

Found from tests in [shengxiangji/host-api-43440](https://github.com/tenstorrent/tt-metal/tree/shengxiangji/host-api-43440)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/ip-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/ip-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/ip-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/ip-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/ip-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/ip-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/ip-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/ip-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/ip-race)