### PR TITLE
Ign/reduce sum int32

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum_int.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum_int.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""ttnn.sum vs torch.sum for int32 (SFPU reduce path, issue #26726)."""
+"""ttnn.sum vs torch.sum for int32 (SFPU reduce path)."""
 
 import pytest
 import torch
@@ -78,7 +78,7 @@ def test_sum_int32_overflow_wraps(device):
 
 
 def test_sum_int32_all_zeros_regression(device):
-    """Guards the original silent all-zeros int32 sum bug (issue #26726)."""
+    """Guards the original silent all-zeros int32 sum bug."""
     torch.manual_seed(0)
     x = torch.randint(-_INT32_VALUE_BOUND, _INT32_VALUE_BOUND + 1, (1, 3, 17, 19), dtype=torch.int32)
     x_ttnn = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum_sfpu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum_sfpu.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ttnn.sum vs torch.sum for int32 (SFPU reduce path, issue #26726)."""
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal
+
+pytestmark = pytest.mark.use_module_device
+
+# Single tile, partial tiles, multi-batch, multi-chunk, and large multi-core shapes.
+_SHAPES = [
+    (1, 1, 32, 32),
+    (1, 1, 64, 60),
+    (1, 1, 100, 120),
+    (1, 1, 30, 96),
+    (1, 1, 90, 32),
+    (2, 3, 64, 64),
+    (1, 3, 17, 19),
+    (2, 4, 64, 60),
+    (1, 1, 64, 512),
+    (1, 1, 512, 64),
+    (2, 1, 256, 2048),
+    (2, 1, 2048, 256),
+]
+
+_DIMS = [-1, -2, 0, 1, (-1, -2), None]
+
+# Bound keeps the largest sum (2*2048*256 elems) well within int32 range.
+_INT32_VALUE_BOUND = 1000
+
+
+@pytest.mark.parametrize("input_shape", _SHAPES)
+@pytest.mark.parametrize("dim", _DIMS)
+def test_sum_int32(device, input_shape, dim):
+    """ttnn.sum on int32 must match torch.sum exactly."""
+    torch.manual_seed(0)
+    torch_input = torch.randint(-_INT32_VALUE_BOUND, _INT32_VALUE_BOUND + 1, input_shape, dtype=torch.int32)
+    torch_output = torch.sum(torch_input, dim=dim)  # torch promotes int32 -> int64
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
+    ttnn_output = ttnn.to_torch(ttnn.sum(ttnn_input, dim=dim))
+
+    assert ttnn_output.dtype == torch.int32
+    assert_equal(ttnn_output.to(torch.int64).reshape(torch_output.shape), torch_output)
+
+
+@pytest.mark.parametrize("dim", [-1, -2, (-1, -2), None])
+def test_sum_int32_keepdim(device, dim):
+    """keepdim=True keeps the reduced axis as size 1."""
+    torch.manual_seed(0)
+    shape = (2, 3, 64, 64)
+    torch_input = torch.randint(-_INT32_VALUE_BOUND, _INT32_VALUE_BOUND + 1, shape, dtype=torch.int32)
+    torch_output = torch.sum(torch_input, dim=dim, keepdim=True) if dim is not None else torch.sum(torch_input)
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
+    ttnn_output = ttnn.to_torch(ttnn.sum(ttnn_input, dim=dim, keepdim=True))
+
+    assert ttnn_output.dtype == torch.int32
+    assert_equal(ttnn_output.to(torch.int64).reshape(torch_output.shape), torch_output)
+
+
+def test_sum_int32_overflow_wraps(device):
+    """int32 sum wraps in 2's-complement like torch (proves integer add, not float promotion)."""
+    torch.manual_seed(0)
+    torch_input = torch.full((1, 1, 64, 64), 2_000_000, dtype=torch.int32)  # sum > 2^31 -> wraps
+    expected_wrapped = torch.sum(torch_input.to(torch.int64)).to(torch.int32)
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
+    ttnn_output = ttnn.to_torch(ttnn.sum(ttnn_input))
+
+    assert ttnn_output.dtype == torch.int32
+    assert_equal(ttnn_output.reshape(expected_wrapped.shape), expected_wrapped)
+
+
+def test_sum_int32_all_zeros_regression(device):
+    """Guards the original silent all-zeros int32 sum bug (issue #26726)."""
+    torch.manual_seed(0)
+    x = torch.randint(-_INT32_VALUE_BOUND, _INT32_VALUE_BOUND + 1, (1, 3, 17, 19), dtype=torch.int32)
+    x_ttnn = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
+
+    torch_sum_all = torch.sum(x)
+    ttnn_sum_all = ttnn.to_torch(ttnn.sum(x_ttnn))
+    assert ttnn_sum_all.dtype == torch.int32
+    assert_equal(ttnn_sum_all.to(torch.int64).reshape(torch_sum_all.shape), torch_sum_all)
+
+    torch_sum_dim = torch.sum(x, dim=2)
+    ttnn_sum_dim = ttnn.to_torch(ttnn.sum(x_ttnn, dim=2))
+    assert ttnn_sum_dim.dtype == torch.int32
+    assert_equal(ttnn_sum_dim.to(torch.int64).reshape(torch_sum_dim.shape), torch_sum_dim)
+
+
+@pytest.mark.parametrize("scale", [2.0, 0.5, -3.0])
+@pytest.mark.parametrize("input_shape, dim", [((1, 2, 64, 64), -1), ((1, 1, 96, 64), -2), ((1, 1, 64, 64), (-1, -2))])
+def test_sum_int32_with_scaling(device, input_shape, dim, scale):
+    """scalar= is a post-reduce fp32 multiply: result == trunc(scale * int_sum)."""
+    torch.manual_seed(0)
+    torch_input = torch.randint(-100, 100, input_shape, dtype=torch.int32)  # small so int_sum stays < 2^24
+    torch_expected = (torch.sum(torch_input, dim=dim).to(torch.float32) * scale).to(torch.int32)
+
+    input_tensor = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
+    output_tensor = ttnn.to_torch(ttnn.sum(input_tensor, dim=dim, scalar=scale))
+
+    assert output_tensor.dtype == torch.int32
+    assert_equal(output_tensor.reshape(torch_expected.shape), torch_expected)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -19,13 +19,16 @@ constexpr bool reduce_uses_matmul() {
 }
 
 /**
- * @brief Determines whether a reduce operation should use the SFPU max path.
+ * @brief Determines whether a reduce operation should use the SFPU path.
  *
- * Int32 MAX on REDUCE_ROW/COL uses SFPU. Int32 MAX REDUCE_SCALAR is unsupported.
+ * Int32 MAX and SUM on REDUCE_ROW/COL use SFPU (GMPOOL/matmul have no Int32 support).
+ * Int32 REDUCE_SCALAR is unsupported (no SFPU scalar primitive); the host decomposes an
+ * Int32 HW reduce into a W-then-H two-step (see reduce_op.cpp use_two_step_hw_sfpu_reduce).
+ * MIN is pre-lowered to MAX + negate and dispatched via reduce_{h,w}_neg.
  */
 template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim, DataFormat data_format>
 constexpr bool is_sfpu_reduce_path() {
-    if constexpr (pool_type != ckernel::PoolType::MAX) {
+    if constexpr (pool_type != ckernel::PoolType::MAX && pool_type != ckernel::PoolType::SUM) {
         return false;
     }
     if constexpr (data_format != DataFormat::Int32) {

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -292,10 +292,10 @@ struct NoOp {
  * @tparam scaler_dfb_id DataflowBuffer ID containing scaler tile (compile-time CB id)
  * @tparam output_dfb_id Output DataflowBuffer ID for reduced tiles (compile-time CB id)
  *                       The input/output formats are deduced from these CB ids
- *                       (unpack_src_format / pack_dst_format), so Int32 MAX is routed to the
- *                       SFPU path automatically (Int32 has no FPU support).
- *                       Other formats use FPU/GMPOOL. Only REDUCE_ROW/REDUCE_COL MAX on SFPU; MIN
- *                       dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
+ *                       (unpack_src_format / pack_dst_format), so Int32 MAX and SUM are routed to
+ *                       the SFPU path automatically (Int32 has no FPU support).
+ *                       Other formats use FPU/GMPOOL. Only REDUCE_ROW/REDUCE_COL Int32 MAX/SUM on
+ *                       SFPU; MIN dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
  * @tparam input_policy Input handling policy (default: WaitAndPopPerTile - streaming mode)
  * @tparam reconfig_mode Data format reconfiguration mode (default: INPUT_AND_OUTPUT)
  *

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -5,6 +5,7 @@
 // Implementation file for reduce_helpers_compute.hpp
 // Do not include directly - include reduce_helpers_compute.hpp instead
 
+#include "api/compute/add_int_sfpu.h"
 #include "api/compute/binary_max_min.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
@@ -37,15 +38,45 @@ ALWI void sfpu_reduce_max_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
     binary_max_int32_tile(a, b, out);
 }
 
-// Copy one input tile into DST and fold into running MAX (first tile seeds dst_idx directly).
+// SFPU SUM fold (Int32 cross-tile add). add_int_tile is exact 2's-complement and wraps on
+// overflow, matching torch's Int32 sum semantics.
 template <DataFormat format>
-ALWI void sfpu_copy_and_fold_max(
+ALWI void sfpu_reduce_sum_fold_init() {
+    static_assert(format == DataFormat::Int32, "SFPU reduce SUM fold: Int32 only");
+    add_int_tile_init();
+}
+
+template <DataFormat format>
+ALWI void sfpu_reduce_sum_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
+    static_assert(format == DataFormat::Int32, "SFPU reduce SUM fold: Int32 only");
+    add_int_tile<format>(a, b, out);
+}
+
+// Pool-type dispatched cross-tile fold init (MAX -> binary_max, SUM -> add_int).
+// Used only by compute_kernel_lib::reduce(); the _neg kernels call the MAX fold directly.
+template <PoolType pool_type, DataFormat format>
+ALWI void sfpu_reduce_fold_init() {
+    if constexpr (pool_type == PoolType::SUM) {
+        sfpu_reduce_sum_fold_init<format>();
+    } else {
+        sfpu_reduce_max_fold_init<format>();
+    }
+}
+
+// Copy one input tile into DST and fold into the running accumulator (first tile seeds dst_idx
+// directly). Fold op is selected by pool_type: MAX -> running max, SUM -> running sum.
+template <PoolType pool_type, DataFormat format>
+ALWI void sfpu_copy_and_fold(
     uint32_t input_cb_id, uint32_t tile_idx, uint32_t dst_idx, uint32_t work_dst, bool is_first_tile) {
     if (is_first_tile) {
         copy_tile(input_cb_id, tile_idx, dst_idx);
     } else {
         copy_tile(input_cb_id, tile_idx, work_dst);
-        sfpu_reduce_max_fold_tile<format>(dst_idx, work_dst, dst_idx);
+        if constexpr (pool_type == PoolType::SUM) {
+            sfpu_reduce_sum_fold_tile<format>(dst_idx, work_dst, dst_idx);
+        } else {
+            sfpu_reduce_max_fold_tile<format>(dst_idx, work_dst, dst_idx);
+        }
     }
 }
 
@@ -193,7 +224,7 @@ ALWI void reload_accumulator_if_needed(
             // Use short version since packer config is still valid from initial init
             // Pass accumulator DFB as old_dfb_id to reconfigure data format from accumulator to input DFB
             if constexpr (is_sfpu) {
-                detail::sfpu_reduce_max_fold_init<reduce_format>();
+                detail::sfpu_reduce_fold_init<reduce_type, reduce_format>();
             } else if constexpr (use_matmul) {
                 reduce_with_matmul_init_with_dt(input_dfb_id, scaler_dfb_id, accumulate.config.cb_accumulator);
             } else {
@@ -252,8 +283,9 @@ ALWI void reduce(
     // Static Assertions (compile-time validation)
     // =============================================================================
     static_assert(
-        reduce_type != PoolType::MAX || reduce_dim != ReduceDim::REDUCE_SCALAR || reduce_format != DataFormat::Int32,
-        "Int32 MAX REDUCE_SCALAR is not supported");
+        (reduce_type != PoolType::MAX && reduce_type != PoolType::SUM) ||
+            reduce_dim != ReduceDim::REDUCE_SCALAR || reduce_format != DataFormat::Int32,
+        "Int32 MAX/SUM REDUCE_SCALAR is not supported (host decomposes Int32 HW reduce into W-then-H)");
     static_assert(
         is_accumulation_type_v<AccumulateT>,
         "AccumulateT must be a valid accumulation type (NoAccumulation or Accumulate)");
@@ -302,8 +334,10 @@ ALWI void reduce(
     const uint32_t Wt = input_block_shape.cols;
     const uint32_t num_batches = input_block_shape.batches;
 
-    constexpr bool use_matmul = reduce_uses_matmul<reduce_type, reduce_dim>();
+    // is_sfpu wins over use_matmul: SUM/AVG on REDUCE_ROW would normally use matmul, but Int32 SUM
+    // has no FPU/matmul support, so it takes the SFPU path instead (matmul would force a float accumulate).
     constexpr bool is_sfpu = is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format>();
+    constexpr bool use_matmul = reduce_uses_matmul<reduce_type, reduce_dim>() && !is_sfpu;
 
     DataflowBuffer input_dfb(input_dfb_id);
     DataflowBuffer scaler_dfb(scaler_dfb_id);
@@ -462,7 +496,7 @@ ALWI void reduce(
                     accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
                 if constexpr (is_sfpu) {
                     if (Wt > 1) {
-                        detail::sfpu_reduce_max_fold_init<reduce_format>();
+                        detail::sfpu_reduce_fold_init<reduce_type, reduce_format>();
                     }
                 }
 
@@ -473,14 +507,14 @@ ALWI void reduce(
                         const bool is_first_tile = detail::sfpu_is_first_tile(wt, accumulate);
                         if constexpr (waits_per_tile(input_policy)) {
                             input_dfb.wait_front(onetile);
-                            detail::sfpu_copy_and_fold_max<reduce_format>(
+                            detail::sfpu_copy_and_fold<reduce_type, reduce_format>(
                                 input_dfb_id, 0, dst_idx, sfpu_work_dst, is_first_tile);
                             input_dfb.pop_front(onetile);
                         } else if constexpr (waits_bulk(input_policy)) {
-                            detail::sfpu_copy_and_fold_max<reduce_format>(
+                            detail::sfpu_copy_and_fold<reduce_type, reduce_format>(
                                 input_dfb_id, wt, dst_idx, sfpu_work_dst, is_first_tile);
                         } else {
-                            detail::sfpu_copy_and_fold_max<reduce_format>(
+                            detail::sfpu_copy_and_fold<reduce_type, reduce_format>(
                                 input_dfb_id, wt + index_offset, dst_idx, sfpu_work_dst, is_first_tile);
                         }
                     } else if constexpr (waits_per_tile(input_policy)) {
@@ -595,7 +629,7 @@ ALWI void reduce(
                     accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
                 if constexpr (is_sfpu) {
                     if (Ht > 1) {
-                        detail::sfpu_reduce_max_fold_init<reduce_format>();
+                        detail::sfpu_reduce_fold_init<reduce_type, reduce_format>();
                     }
                 }
 
@@ -608,16 +642,16 @@ ALWI void reduce(
                             constexpr uint32_t sfpu_work_dst = chunk_size;
                             if constexpr (waits_per_tile(input_policy)) {
                                 input_dfb.wait_front(onetile);
-                                detail::sfpu_copy_and_fold_max<reduce_format>(
+                                detail::sfpu_copy_and_fold<reduce_type, reduce_format>(
                                     input_dfb_id, 0, dst_idx, sfpu_work_dst, is_first_tile);
                                 input_dfb.pop_front(onetile);
                             } else if constexpr (waits_bulk(input_policy)) {
                                 const uint32_t tile_idx = ht * current_chunk + (i - wt);
-                                detail::sfpu_copy_and_fold_max<reduce_format>(
+                                detail::sfpu_copy_and_fold<reduce_type, reduce_format>(
                                     input_dfb_id, tile_idx, dst_idx, sfpu_work_dst, is_first_tile);
                             } else {
                                 const uint32_t tile_idx = batch_offset + ht * stride + i;
-                                detail::sfpu_copy_and_fold_max<reduce_format>(
+                                detail::sfpu_copy_and_fold<reduce_type, reduce_format>(
                                     input_dfb_id, tile_idx, dst_idx, sfpu_work_dst, is_first_tile);
                             }
                         } else if constexpr (waits_per_tile(input_policy)) {

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -287,6 +287,9 @@ ALWI void reduce(
             reduce_dim != ReduceDim::REDUCE_SCALAR || reduce_format != DataFormat::Int32,
         "Int32 MAX/SUM REDUCE_SCALAR is not supported (host decomposes Int32 HW reduce into W-then-H)");
     static_assert(
+        reduce_type != PoolType::AVG || reduce_format != DataFormat::Int32,
+        "Int32 AVG (mean) is not supported");
+    static_assert(
         is_accumulation_type_v<AccumulateT>,
         "AccumulateT must be a valid accumulation type (NoAccumulation or Accumulate)");
     static_assert(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -51,6 +51,21 @@ inline uint32_t dense_rm_padding_identity_bits(tt::DataFormat df, tt::tt_metal::
     return static_cast<uint32_t>(bf16);
 }
 
+// True when the reduce uses the Int32 SFPU path (FPU GMPOOL/matmul have no Int32 support).
+// Int32 MAX/SUM only; MIN is lowered to MAX + negate on the host before reaching the factories.
+inline bool use_sfpu_reduce_path(tt::tt_metal::DataType dtype, tt::tt_metal::ReduceOpMath math_op) {
+    using tt::tt_metal::ReduceOpMath;
+    return dtype == tt::tt_metal::DataType::INT32 && (math_op == ReduceOpMath::MAX || math_op == ReduceOpMath::SUM);
+}
+
+// True when a non-unity scalar must be applied as a post-reduce multiply instead of via the scaler
+// CB (MAX/MIN keep only its exponent; the Int32 SFPU path ignores the CB). Float/bf16 SUM use the CB.
+inline bool requires_post_mul(tt::tt_metal::ReduceOpMath math_op, tt::tt_metal::DataType dtype, float scaler) {
+    using tt::tt_metal::ReduceOpMath;
+    return scaler != 1.0f &&
+           (math_op == ReduceOpMath::MAX || (math_op == ReduceOpMath::SUM && dtype == tt::tt_metal::DataType::INT32));
+}
+
 // All RM-path locals derived from the input shape, tile geometry, and math op.
 // One instance is populated at the top of the RM branch in each factory and consumed
 // by the build_rm_*_ct_args helpers; both factories see the same field layout.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Thin wrapper around compute_kernel_lib::reduce<>. The input data format is deduced from the input
-// CB id inside the helper, so Int32 MAX is routed to the SFPU path automatically; otherwise
+// CB id inside the helper, so Int32 MAX and SUM are routed to the SFPU path automatically; otherwise
 // FPU/GMPOOL. MIN on Int32 is dispatched separately via reduce_{h,w}_neg.
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -158,7 +158,15 @@ Tensor reduce(
     // scalar after reduction via post-multiplication. See issue #40498. The flag also
     // covers reduce_min (math_op=MAX with negate=true) since high-level dispatch lowers
     // min through reduce_min before reaching here.
-    const bool use_post_mul = (reduce_math == tt::tt_metal::ReduceOpMath::MAX) && (scaler != 1.0f);
+    //
+    // Int32 SUM additionally needs post-mul: it runs on the SFPU reduce path, which ignores the
+    // scaler CB entirely (like MAX). Float/bf16 SUM keep using the scaler CB on the FPU/matmul
+    // path, so they are excluded here. (Int32 post-mul is a typecast-bracketed fp32 multiply, so a
+    // non-unity scalar on Int32 SUM is lossy for |result| > 2^24 — fine for the default scaler=1.0.)
+    const bool use_post_mul =
+        (scaler != 1.0f) &&
+        (reduce_math == tt::tt_metal::ReduceOpMath::MAX ||
+         (reduce_math == tt::tt_metal::ReduceOpMath::SUM && tilized_input.dtype() == tt::tt_metal::DataType::INT32));
     const float reduce_scaler = use_post_mul ? 1.0f : scaler;
     const float post_mul = use_post_mul ? scaler : 1.0f;
 
@@ -193,12 +201,12 @@ Tensor reduce(
     // However, sqrt of a negative number is NaN, so negative scalers
     // must take the two-step W-then-H path where the scaler is applied once.
     //
-    // INT32 SFPU max/min has no REDUCE_SCALAR primitive (ROW/COL only), so Int32 HW always uses
+    // INT32 SFPU reduce has no REDUCE_SCALAR primitive (ROW/COL only), so Int32 HW always uses
     // W-then-H. Float32 max HW can use single-core REDUCE_SCALAR (FPU) when num_tiles == 1;
-    // multi-tile HW still uses W-then-H via is_multicore_hw. Applies to MAX and MIN (MIN via negate).
-    const bool use_two_step_hw_sfpu_reduce = (reduce_dim == tt::tt_metal::ReduceOpDim::HW) &&
-                                             (tilized_input.dtype() == tt::tt_metal::DataType::INT32) &&
-                                             (reduce_math == tt::tt_metal::ReduceOpMath::MAX);
+    // multi-tile HW still uses W-then-H via is_multicore_hw. Applies to MAX/SUM and MIN (MIN via negate).
+    const bool use_two_step_hw_sfpu_reduce =
+        (reduce_dim == tt::tt_metal::ReduceOpDim::HW) && (tilized_input.dtype() == tt::tt_metal::DataType::INT32) &&
+        (reduce_math == tt::tt_metal::ReduceOpMath::MAX || reduce_math == tt::tt_metal::ReduceOpMath::SUM);
 
     if (is_multicore_hw || use_two_step_hw_sfpu_reduce ||
         (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -153,20 +153,10 @@ Tensor reduce(
             input_tensor, padded_shape, pad_value, input_tensor.memory_config(), std::nullopt, true, sub_core_grids);
     }
 
-    // GMPOOL applies exp2(floor(log2(|s|))) of the scalar (only the exponent), so for
-    // MAX/MIN with non-unity scalar we instead reduce with scaler=1.0 and apply the user
-    // scalar after reduction via post-multiplication. See issue #40498. The flag also
-    // covers reduce_min (math_op=MAX with negate=true) since high-level dispatch lowers
-    // min through reduce_min before reaching here.
-    //
-    // Int32 SUM additionally needs post-mul: it runs on the SFPU reduce path, which ignores the
-    // scaler CB entirely (like MAX). Float/bf16 SUM keep using the scaler CB on the FPU/matmul
-    // path, so they are excluded here. (Int32 post-mul is a typecast-bracketed fp32 multiply, so a
-    // non-unity scalar on Int32 SUM is lossy for |result| > 2^24 — fine for the default scaler=1.0.)
-    const bool use_post_mul =
-        (scaler != 1.0f) &&
-        (reduce_math == tt::tt_metal::ReduceOpMath::MAX ||
-         (reduce_math == tt::tt_metal::ReduceOpMath::SUM && tilized_input.dtype() == tt::tt_metal::DataType::INT32));
+    // A non-unity scalar is applied after the reduction (see requires_post_mul() in common.hpp):
+    // GMPOOL keeps only the scaler's exponent for MAX/MIN, and the Int32 SFPU path ignores the
+    // scaler CB. Int32 post-mul rounds through fp32, so it is lossy for |result| > 2^24.
+    const bool use_post_mul = ttnn::prim::requires_post_mul(reduce_math, tilized_input.dtype(), scaler);
     const float reduce_scaler = use_post_mul ? 1.0f : scaler;
     const float post_mul = use_post_mul ? scaler : 1.0f;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -79,16 +79,18 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
             static_cast<int>(operation_attributes.output_mem_config.memory_layout()));
     } else {
         TT_FATAL((tensor_args.layout() == Layout::TILE), "Inputs to reduce must be tilized");
-        // INT32 MIN/MAX is supported via the SFPU reduce path (format deduced from input CB in
-        // compute_kernel_lib::reduce and reduce_{h,w}_neg; MIN uses the dedicated reduce_{h,w}_neg kernels).
-        const bool is_int32_max_reduce =
-            tensor_args.dtype() == DataType::INT32 && operation_attributes.math_op == ReduceOpMath::MAX;
+        // INT32 MIN/MAX/SUM is supported via the SFPU reduce path (format deduced from input CB in
+        // compute_kernel_lib::reduce; MIN uses the dedicated reduce_{h,w}_neg kernels). MIN is lowered
+        // to MAX + negate on the host, so only MAX and SUM appear here.
+        const bool is_int32_sfpu_reduce =
+            tensor_args.dtype() == DataType::INT32 &&
+            (operation_attributes.math_op == ReduceOpMath::MAX || operation_attributes.math_op == ReduceOpMath::SUM);
         TT_FATAL(
             tensor_args.dtype() == DataType::BFLOAT16 || tensor_args.dtype() == DataType::FLOAT32 ||
                 tensor_args.dtype() == DataType::BFLOAT8_B || tensor_args.dtype() == DataType::UINT32 ||
-                is_int32_max_reduce,
+                is_int32_sfpu_reduce,
             "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction "
-            "(INT32 is supported for MAX/MIN) - got {}.",
+            "(INT32 is supported for MAX/MIN/SUM) - got {}.",
             tensor_args.dtype());
     }
     validate_reduce_sharded_buffer_types(tensor_args.memory_config(), operation_attributes.output_mem_config, "reduce");

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -81,10 +81,8 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL((tensor_args.layout() == Layout::TILE), "Inputs to reduce must be tilized");
         // INT32 MIN/MAX/SUM is supported via the SFPU reduce path (format deduced from input CB in
         // compute_kernel_lib::reduce; MIN uses the dedicated reduce_{h,w}_neg kernels). MIN is lowered
-        // to MAX + negate on the host, so only MAX and SUM appear here.
-        const bool is_int32_sfpu_reduce =
-            tensor_args.dtype() == DataType::INT32 &&
-            (operation_attributes.math_op == ReduceOpMath::MAX || operation_attributes.math_op == ReduceOpMath::SUM);
+        // to MAX + negate on the host, so only MAX and SUM appear here. See common.hpp.
+        const bool is_int32_sfpu_reduce = use_sfpu_reduce_path(tensor_args.dtype(), operation_attributes.math_op);
         TT_FATAL(
             tensor_args.dtype() == DataType::BFLOAT16 || tensor_args.dtype() == DataType::FLOAT32 ||
                 tensor_args.dtype() == DataType::BFLOAT8_B || tensor_args.dtype() == DataType::UINT32 ||

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -83,10 +83,12 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     // reduction via SFPU mul_unary_tile inside the compute kernel.
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
 
-    // Int32 max/min use the SFPU reduce path (GMPOOL has no Int32 support).
+    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support).
     // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
-    // so this single check covers both MAX and MIN.
-    const bool use_sfpu_reduce_path = a.dtype() == DataType::INT32 && operation_attributes.math_op == ReduceOpMath::MAX;
+    // so this check covers MAX, MIN and SUM. SUM never negates, so use_fpu_negate is unaffected.
+    const bool use_sfpu_reduce_path =
+        a.dtype() == DataType::INT32 &&
+        (operation_attributes.math_op == ReduceOpMath::MAX || operation_attributes.math_op == ReduceOpMath::SUM);
     const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -83,13 +83,10 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     // reduction via SFPU mul_unary_tile inside the compute kernel.
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
 
-    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support).
-    // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
-    // so this check covers MAX, MIN and SUM. SUM never negates, so use_fpu_negate is unaffected.
-    const bool use_sfpu_reduce_path =
-        a.dtype() == DataType::INT32 &&
-        (operation_attributes.math_op == ReduceOpMath::MAX || operation_attributes.math_op == ReduceOpMath::SUM);
-    const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
+    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support); see
+    // use_sfpu_reduce_path() in common.hpp. SUM never negates, so use_fpu_negate is unaffected.
+    const bool is_sfpu_reduce = use_sfpu_reduce_path(a.dtype(), operation_attributes.math_op);
+    const bool use_fpu_negate = operation_attributes.negate && !is_sfpu_reduce;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto num_cols = NC * Wt;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -176,10 +176,12 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
-    // Int32 max/min use the SFPU reduce path (GMPOOL has no Int32 support).
+    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support).
     // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
-    // so this single check covers both MAX and MIN.
-    const bool use_sfpu_reduce_path = a.dtype() == DataType::INT32 && operation_attributes.math_op == ReduceOpMath::MAX;
+    // so this check covers MAX, MIN and SUM. SUM never negates, so use_fpu_negate is unaffected.
+    const bool use_sfpu_reduce_path =
+        a.dtype() == DataType::INT32 &&
+        (operation_attributes.math_op == ReduceOpMath::MAX || operation_attributes.math_op == ReduceOpMath::SUM);
     const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
 
     std::vector<uint32_t> reader_compile_time_args;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -176,13 +176,10 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
-    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support).
-    // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
-    // so this check covers MAX, MIN and SUM. SUM never negates, so use_fpu_negate is unaffected.
-    const bool use_sfpu_reduce_path =
-        a.dtype() == DataType::INT32 &&
-        (operation_attributes.math_op == ReduceOpMath::MAX || operation_attributes.math_op == ReduceOpMath::SUM);
-    const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
+    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support); see
+    // use_sfpu_reduce_path() in common.hpp. SUM never negates, so use_fpu_negate is unaffected.
+    const bool is_sfpu_reduce = use_sfpu_reduce_path(a.dtype(), operation_attributes.math_op);
+    const bool use_fpu_negate = operation_attributes.negate && !is_sfpu_reduce;
 
     std::vector<uint32_t> reader_compile_time_args;
     if (rm_path) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -499,6 +499,12 @@ Tensor reduce(
     float scalar,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    // ttnn.mean does not support integer inputs. Remove once integer AVG is implemented.
+    if constexpr (reduce_type == reduction_common::ReduceType::Mean) {
+        const auto dt = input_tensor_arg.dtype();
+        TT_FATAL(
+            dt != DataType::INT32 && dt != DataType::UINT32, "ttnn.mean does not support integer inputs - got {}.", dt);
+    }
     ttnn::SmallVector<int> dim = reduction_common::generate_reduce_dim(input_tensor_arg, dim_arg);
     float pad_value = get_pad_value(reduce_type, input_tensor_arg.dtype());
     // TODO: generalize to support all types, parameters, and formats. Issue #18566

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -19,7 +19,13 @@ namespace ttnn::operations::reduction::detail {
 
 namespace nb = nanobind;
 
-inline std::string get_generic_reduction_doc(const char* op_name, const char* qualified_name) {
+inline std::string get_generic_reduction_doc(const char* op_name, const char* qualified_name, bool int32_supported) {
+    // INT32 (TILE only) is supported for sum/min/max via the SFPU reduce path, but not for mean:
+    // the average (sum / N) is usually fractional, so there is no canonical INT32 result to return.
+    const char* int32_row = int32_supported ? R"doc(
+                * - INT32
+                  - TILE)doc"
+                                            : "";
     return fmt::format(
         R"doc(
         Computes the {0} of the input tensor :attr:`input_tensor` along the specified dimension(s) :attr:`dim`.
@@ -53,7 +59,7 @@ inline std::string get_generic_reduction_doc(const char* op_name, const char* qu
                 * - BFLOAT16
                   - ROW_MAJOR, TILE
                 * - BFLOAT8_B
-                  - TILE
+                  - TILE{2}
 
             The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`.
             Exception: for sum and mean, 4D ROW_MAJOR BFLOAT16/FLOAT32 inputs with INTERLEAVED memory
@@ -65,7 +71,8 @@ inline std::string get_generic_reduction_doc(const char* op_name, const char* qu
             - Output sharding will mirror the input
         )doc",
         op_name,
-        qualified_name);
+        qualified_name,
+        int32_row);
 }
 
 // Wrapper that detects explicit use of the deprecated 'correction' parameter and
@@ -106,7 +113,7 @@ Tensor generic_reduction_with_deprecated_correction(
 }
 
 inline void bind_generic_reductions(nb::module_& mod) {
-    const auto sum_doc = get_generic_reduction_doc("sum", "ttnn.sum");
+    const auto sum_doc = get_generic_reduction_doc("sum", "ttnn.sum", /*int32_supported=*/true);
     ttnn::bind_function<"sum">(
         mod,
         sum_doc.c_str(),
@@ -121,7 +128,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("correction") = nb::none(),
         nb::arg("sub_core_grids") = nb::none());
 
-    const auto mean_doc = get_generic_reduction_doc("mean", "ttnn.mean");
+    const auto mean_doc = get_generic_reduction_doc("mean", "ttnn.mean", /*int32_supported=*/false);
     ttnn::bind_function<"mean">(
         mod,
         mean_doc.c_str(),
@@ -136,7 +143,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("correction") = nb::none(),
         nb::arg("sub_core_grids") = nb::none());
 
-    const auto max_doc = get_generic_reduction_doc("max", "ttnn.max");
+    const auto max_doc = get_generic_reduction_doc("max", "ttnn.max", /*int32_supported=*/true);
     ttnn::bind_function<"max">(
         mod,
         max_doc.c_str(),
@@ -151,7 +158,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("correction") = nb::none(),
         nb::arg("sub_core_grids") = nb::none());
 
-    const auto min_doc = get_generic_reduction_doc("min", "ttnn.min");
+    const auto min_doc = get_generic_reduction_doc("min", "ttnn.min", /*int32_supported=*/true);
     ttnn::bind_function<"min">(
         mod,
         min_doc.c_str(),


### PR DESCRIPTION
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

**[Feature]** Int32 support for ttnn.sum using SFPU
Ticket : [#26724](https://github.com/tenstorrent/tt-metal/issues/26724)

### Summary

<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

This PR implements INT32 `ttnn.sum` reductions using an SFPU compute path, because the existing GMPOOL/FPU reduce path does not support this combination reliably and can produce incorrect results.

The implementation extends the SFPU reduction infrastructure introduced for INT32/FP32 MIN/MAX support and adds INT32 SUM support for:

* H reductions
* W reductions
* Full HxW reductions through W → H decomposition
* Multi-batch inputs
* Partial-tile shapes

### Perf Comparision

The following table below shows perf numbers from DRAM + INTERLEAVED tests on Wormhole. `bfloat16` continues to use the legacy FPU path on both branches and therefore shows no meaningful change. `int32` SUM now runs through the SFPU path, which introduces a small regression versus the legacy FPU reduce path due to the additional INT32 fold/add operations performed entirely on SFPU. `float32` SUM is also routed through the SFPU path for consistency with the reduction framework updates.

**Note :** Diff % represent perf calculation with (current branch - main branch)

| S. No | Shape           | Dtype    | Dim | Ops | Diff % (+ve : degradation) |
| ----- | --------------- | -------- | --- | --- | -------------------------- |
| 1     | (1_1_32_128)    | bfloat16 | -2  | sum | 0.17%                      |
| 2     | (1_1_32_128)    | bfloat16 | -1  | sum | -0.49%                     |
| 3     | (1_1_32_128)    | int32    | -2  | sum | -4.14%                     |
| 4     | (1_1_32_128)    | int32    | -1  | sum | -10.24%                    |
| 5     | (1_1_32_128)    | float32  | -2  | sum | -4.06%                     |
| 6     | (1_1_32_128)    | float32  | -1  | sum | -8.91%                     |
| 7     | (1_1_128_32)    | bfloat16 | -2  | sum | 0.42%                      |
| 8     | (1_1_128_32)    | bfloat16 | -1  | sum | 0.88%                      |
| 9     | (1_1_128_32)    | int32    | -2  | sum | -7.01%                     |
| 10    | (1_1_128_32)    | int32    | -1  | sum | -6.16%                     |
| 11    | (1_1_128_32)    | float32  | -2  | sum | -7.47%                     |
| 12    | (1_1_128_32)    | float32  | -1  | sum | -7.59%                     |
| 13    | (1_1_1024_1024) | bfloat16 | -2  | sum | -0.32%                     |
| 14    | (1_1_1024_1024) | bfloat16 | -1  | sum | 0.29%                      |
| 15    | (1_1_1024_1024) | int32    | -2  | sum | -1.15%                     |
| 16    | (1_1_1024_1024) | int32    | -1  | sum | -1.11%                     |
| 17    | (1_1_1024_1024) | float32  | -2  | sum | -1.50%                     |
| 18    | (1_1_1024_1024) | float32  | -1  | sum | 0.13%                      |
| 19    | (1_1_4096_256)  | bfloat16 | -2  | sum | -0.13%                     |
| 20    | (1_1_4096_256)  | bfloat16 | -1  | sum | 0.08%                      |
| 21    | (1_1_4096_256)  | int32    | -2  | sum | -0.18%                     |
| 22    | (1_1_4096_256)  | int32    | -1  | sum | 0.38%                      |
| 23    | (1_1_4096_256)  | float32  | -2  | sum | 0.29%                      |
| 24    | (1_1_4096_256)  | float32  | -1  | sum | 1.08%                      |
| 25    | (1_1_256_4096)  | bfloat16 | -2  | sum | 0.81%                      |
| 26    | (1_1_256_4096)  | bfloat16 | -1  | sum | 0.38%                      |
| 27    | (1_1_256_4096)  | int32    | -2  | sum | -3.70%                     |
| 28    | (1_1_256_4096)  | int32    | -1  | sum | -0.39%                     |
| 29    | (1_1_256_4096)  | float32  | -2  | sum | -0.40%                     |
| 30    | (1_1_256_4096)  | float32  | -1  | sum | -0.40%                     |

### Notes for reviewers

<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Implemented on top of **Int32 support for ttnn.min and ttnn.max using SFPU #43989**

Primary review areas:

* `reduce_sfpu_helpers_compute.hpp / .inl`
* `reduce_op_multi_core_{h,w}_program_factory.cpp`
* `reduce_op_device_operation.cpp`
* `reduce_op.cpp`
* `tests/ttnn/nightly/unit_tests/operations/reduction/test_sum_int32.py`

**NOTE** : This PR must be reviewed only after [#26726](https://github.com/tenstorrent/tt-metal/issues/26726)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/reduce_sum_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/reduce_sum_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/reduce_sum_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/reduce_sum_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/reduce_sum_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/reduce_sum_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/reduce_sum_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/reduce_sum_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/reduce_sum_int32)