### PR TITLE
Pool: restore actual-page sizing for DRAM reader indices CB

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -457,10 +457,14 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
 
     if (config_tensor_in_dram) {
         // DRAM-backed reader indices buffer: the CB is purely local scratch; the kernel
-        // reads from DRAM via TensorAccessor and the CB is sized to the worst-case
-        // payload that fits a single page.
+        // reads from DRAM via TensorAccessor and the CB is sized to the actual buffer
+        // page size (see PR #43193) to keep the L1 footprint tight. The worst-case
+        // value above is only used as an upper-bound check.
         add_local_cb(
-            in_reader_indices_cb_id, max_reader_indices_size, in_reader_indices_cb_npages, tt::DataFormat::UInt16);
+            in_reader_indices_cb_id,
+            actual_reader_indices_buffer_page_size,
+            in_reader_indices_cb_npages,
+            tt::DataFormat::UInt16);
     } else {
         add_sharded_cb(
             in_reader_indices_cb_id,


### PR DESCRIPTION
## Summary

PR #43305 (pool migration to `ProgramDescriptor`) reverted the sizing fix from PR #43193 for the DRAM-backed `in_reader_indices` CB. The factory switched back to allocating the worst-case payload (`max_out_nhw_per_core * 3 * sizeof(uint16_t) + 2`), but `calculate_pool_cb_sizes` (and the factory call site at `pool_multi_core_program_factory.cpp:358`) still pass the **actual** buffer page size as the prediction. The descriptor-level self-consistency check at `pool_multi_core_program_factory.cpp:920` then fires:

```
TT_FATAL @ pool_multi_core_program_factory.cpp:920:
  actual_local_cb_size == cb_sizes.local_cb_total() || is_graph_capture_no_dispatch_mode
info: Local CB size mismatch: actual 18458 != expected 18452
```

Failing test (regression first seen in run [25695898779](https://github.com/tenstorrent/tt-metal/actions/runs/25695898779)):
`test_avg_pool2d_post_commit[in_dtype=DataType.BFLOAT16-shard_scheme=None-divisor_override=None-count_include_pad=False-ceil_mode=False-padding=(1, 1)-stride=(2, 2)-kernel_size=(3, 3)-input_shape=[2, 32, 16, 16]]`

The 6-byte mismatch equals `worst_case − actual_page_size` for this geometry (`max_out_nhw_per_core = 2` → worst = 14, actual = 8).

Fix: size the local CB to `actual_reader_indices_buffer_page_size`, matching the pre-migration behavior (PR #43193) and the prediction in `pool_utils.cpp`. The existing `TT_FATAL` upper-bound guard against `max_reader_indices_size` is retained.

## Test plan

- [x] `test_avg_pool2d_post_commit[…]` (the originally failing parametrization) — PASS
- [x] Full `tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py` — 248 passed, 144 skipped
- [x] Full `tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py` — 104 passed, 13 skipped
- [ ] [Nightly L2 (pool only)](https://github.com/tenstorrent/tt-metal/actions/runs/25722448418)
- [ ] [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/25722450050)
- [ ] [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/25722452602)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-pool-reader-indices-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-pool-reader-indices-cb-size)