### PR TITLE
test(sdpa): run ring SDPA perf off QB2 only, tighten margin

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1166,13 +1166,13 @@ def test_ring_joint_attention_create_perf_table(model_name):
 
 # === TEST 5: PERFORMANCE CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
 # Symmetric +/- band — catches both regressions and unexpected speedups.
-RING_JOINT_PERF_MARGIN = 0.007
+RING_JOINT_PERF_MARGIN = 0.005
 
 RING_JOINT_PERF_CHECK_CONFIGS = [
     # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
     # 4-device ring (QuietBox)
     ("wan2_2_1xGLX", 288, 512, 4, 68.9),
-    ("mla_100k", 160, 320, 4, 61.4),
+    ("mla_100k", 160, 320, 4, 61.7),
 ]
 
 


### PR DESCRIPTION
## Summary

Tighten the ring SDPA perf-check band now that the leg is pinned to QB2-class boxes.

The CI mechanism (skip QB1 / 4xP150 for the `bh-ring-sdpa-perf` job) already landed on `main` via the Blackhole pipeline reorg (#44022) — that job in `tests/pipeline_reorg/blackhole_e2e_tests.yaml` excludes `bh_llmbox` and runs on DeskBox / LoudBox / P300 / QB2 only. This PR is the follow-up that takes advantage of the lower variance:

- `RING_JOINT_PERF_MARGIN` 0.007 → 0.005.
- `mla_100k-q160-k320` expected 61.4 → 61.7, matching the QB2 measurement after the K-mcast change (#43787).
- Other thresholds (`wan2_2_1xGLX`, `ring4-4k`, `ring4-8k`) and `EXP_RING_JOINT_PERF_MARGIN` (already 0.005) left untouched.

## Test plan

- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/ring-sdpa-perf-qb2-only)](https://github.com/tenstorrent/tt-metal/actions/runs/25726034176)