### PR TITLE
[tt-train] Lazy init

### DIFF
--- a/tt-train/configs/training_configs/training_shakespeare_nanogpt_char.yaml
+++ b/tt-train/configs/training_configs/training_shakespeare_nanogpt_char.yaml
@@ -15,9 +15,10 @@ training_config:
     beta1: 0.9
     beta2: 0.999
     epsilon: 1.0e-8
-    weight_decay: 0.01
-    amsgrad: false
-    stochastic_rounding: false
+  weight_decay: 0.01
+  amsgrad: false
+  stochastic_rounding: false
+  # lazy_parameter_init: false  # if true: defer Python Parameter alloc (train_nanogpt.py); default eager
 
 device_config:
   enable_ddp: false

--- a/tt-train/sources/examples/nano_gpt/train_nanogpt.py
+++ b/tt-train/sources/examples/nano_gpt/train_nanogpt.py
@@ -145,6 +145,10 @@ class TrainingConfig(BaseTrainingConfig):
         self.num_epochs = self.epochs
         self.model_save_interval = self.save_every
 
+        # Deferred Python Parameter init: build with `ttml.lazy_init()` then
+        # `ttml.materialize_module()` immediately (same init ops / order as eager).
+        self.lazy_parameter_init = bool(tc.get("lazy_parameter_init", False))
+
 
 @dataclass
 class ModelExperimentalConfig:
@@ -1028,6 +1032,35 @@ def create_model_from_config(model_config: ModelConfig, use_tp: bool = False) ->
         raise ValueError(f"Unsupported model type: {model_config.model_type}")
 
 
+def instantiate_model_from_config(
+    model_config: ModelConfig,
+    lazy_init: bool,
+    *,
+    use_tp: bool = False,
+    track_memory: bool = False,
+) -> Model:
+    """Create model; optionally defer Python :class:`~ttml.modules.parameter.Parameter` allocation.
+
+    When ``lazy_init`` is True, uses ``with ttml.lazy_init():`` then
+    :func:`ttml.materialize_module` so the same ``ttml.init.*`` factories run
+    after device open and ``set_seed`` (same numerical init as eager construction).
+
+    When ``track_memory`` is True and ``lazy_init`` is True, records device memory
+    snapshots after the lazy context (metadata-only, minimal weight DRAM) and after
+    materialization (weights allocated). Requires an active capture (e.g. ``--track-memory``).
+    """
+    if lazy_init:
+        with ttml.lazy_init():
+            model = create_model_from_config(model_config, use_tp=use_tp)
+        if track_memory:
+            MemoryUsageTracker.snapshot("LAZY_INIT_AFTER_CONTEXT")
+        ttml.materialize_module(model)
+        if track_memory:
+            MemoryUsageTracker.snapshot("LAZY_INIT_AFTER_MATERIALIZE")
+        return model
+    return create_model_from_config(model_config, use_tp=use_tp)
+
+
 def save_checkpoint(
     checkpoint_path: str,
     step: int,
@@ -1307,7 +1340,14 @@ def main():
             "step thereafter. Columns: step,layer,expert,prob."
         ),
     )
-
+    parser.add_argument(
+        "--lazy-parameter-init",
+        action="store_true",
+        help=(
+            "Defer Python Parameter allocation (lazy metadata + materialize). "
+            "Same init as eager when device and seed are unchanged before model build."
+        ),
+    )
     args = parser.parse_args()
 
     print("=" * 70)
@@ -1358,6 +1398,8 @@ def main():
         training_config.clip_grad_norm_max_norm = args.clip_grad_norm
     if args.sequence_length is not None:
         model_config.max_sequence_length = args.sequence_length
+    if args.lazy_parameter_init:
+        training_config.lazy_parameter_init = True
 
     # Only checkpoint when explicitly requested via --model_save_path.
     # No model_path in YAML -> no checkpointing.
@@ -1554,11 +1596,18 @@ def main():
             print(f"    Max sequence length: {model_config.max_sequence_length}")
             print(f"    Runner type: {runner_type_str}")
             print(f"    Weight tying: {weight_tying_str}")
+            if training_config.lazy_parameter_init:
+                print("    lazy_parameter_init: True (ttml.lazy_init + materialize_module)")
 
             # Create model. Pass use_tp so Llama configures ColumnParallelLinear
             # against the "tp" axis of the active mesh (no-op for non-Llama and
             # an error for non-Llama with TP).
-            model = create_model_from_config(model_config, use_tp=device_config.enable_tp)
+            model = instantiate_model_from_config(
+                model_config,
+                lazy_init=training_config.lazy_parameter_init,
+                use_tp=device_config.enable_tp,
+                track_memory=args.track_memory,
+            )
             if args.print_summary:
                 summary(model)
 

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -143,6 +143,12 @@ void py_module(nb::module_& m) {
             nb::arg("dim"),
             nb::arg("cluster_axis") = nb::none());
 
+        py_distributed.def(
+            "replicate_tensor_to_mesh_mapper",
+            static_cast<std::unique_ptr<ttnn::distributed::TensorToMesh> (*)(ttnn::distributed::MeshDevice&)>(
+                &ttnn::distributed::replicate_tensor_to_mesh_mapper),
+            nb::arg("device"));
+
         // Returns std::unique_ptr<MeshToTensor> - composer for combining distributed tensors
         py_distributed.def(
             "concat_mesh_to_tensor_composer",

--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -33,7 +33,7 @@ from . import models
 from . import modules
 
 # Lazy / deferred parameter initialization (Python-side)
-from .lazy import is_lazy_init_enabled, lazy_init, materialize_module, replicate_mesh_mapper_config
+from .lazy import is_lazy_init_enabled, lazy_init, materialize_module
 
 # --- Re-export _ttml submodules that have no Python package counterpart ---
 # These are pure C++ nanobind submodules; making them attributes of ttml

--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -27,9 +27,13 @@ from ._ttml import NamedParameters
 
 # --- Python subpackages ---
 from . import autograd
+from . import lazy
 from . import init
 from . import models
 from . import modules
+
+# Lazy / deferred parameter initialization (Python-side)
+from .lazy import is_lazy_init_enabled, lazy_init, materialize_module, replicate_mesh_mapper_config
 
 # --- Re-export _ttml submodules that have no Python package counterpart ---
 # These are pure C++ nanobind submodules; making them attributes of ttml

--- a/tt-train/sources/ttml/ttml/init.py
+++ b/tt-train/sources/ttml/ttml/init.py
@@ -40,6 +40,7 @@ from typing import Literal
 import numpy as np
 import ttnn
 import ttml
+from .lazy import is_lazy_init_enabled
 
 
 _NonlinearityType = Literal[
@@ -147,82 +148,136 @@ def calculate_gain(nonlinearity: _NonlinearityType, param: int | float | None = 
 # ---------------------------------------------------------------------------
 
 
+def _maybe_lazy(shape, init_fn, mapper=None):
+    """If lazy init is active, return TensorMetadata holding ``init_fn``; else allocate."""
+    shape_tuple = tuple(shape)
+    if is_lazy_init_enabled():
+        from ttml.modules.parameter import TensorMetadata
+
+        return TensorMetadata(shape=shape_tuple, init_fn=init_fn, mapper=mapper)
+    return init_fn(shape_tuple, mapper)
+
+
+def _uniform_materialize(shape, a, b, mapper=None):
+    """Host NumPy uniform then device tensor (matches eager path on main)."""
+    data = np.random.uniform(low=a, high=b, size=tuple(shape)).astype(np.float32)
+    return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
+
+
 def uniform(a: float = 0.0, b: float = 1.0):
     """Uniform distribution over [a, b)."""
 
     def uniform_init(shape, mapper=None):
-        data = np.random.uniform(low=a, high=b, size=tuple(shape)).astype(np.float32)
-        return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
+        def init_fn(s, m=None):
+            return _uniform_materialize(s, a, b, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return uniform_init
+
+
+def _normal_materialize(shape, mean, std, mapper=None):
+    """Host NumPy normal then device tensor (matches eager path on main)."""
+    data = np.random.normal(loc=mean, scale=std, size=tuple(shape)).astype(np.float32)
+    return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
 
 
 def normal(mean: float = 0.0, std: float = 1.0):
     """Normal (Gaussian) distribution."""
 
     def normal_init(shape, mapper=None):
-        data = np.random.normal(loc=mean, scale=std, size=tuple(shape)).astype(np.float32)
-        return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
+        def init_fn(s, m=None):
+            return _normal_materialize(s, mean, std, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return normal_init
+
+
+def _constant_materialize(shape, val, mapper=None):
+    if mapper is not None:
+        data = np.full(shape, val, dtype=np.float32)
+        return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
+    device = _get_device()
+    t = ttnn.full(
+        shape,
+        fill_value=val,
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.Layout.TILE,
+    )
+    return ttml.autograd.create_tensor(t)
 
 
 def constant(val: float):
     """All elements set to val."""
 
     def constant_init(shape, mapper=None):
-        if mapper is not None:
-            data = np.full(shape, val, dtype=np.float32)
-            return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
-        device = _get_device()
-        t = ttnn.full(
-            shape,
-            fill_value=val,
-            device=device,
-            dtype=ttnn.DataType.BFLOAT16,
-            layout=ttnn.Layout.TILE,
-        )
-        return ttml.autograd.create_tensor(t)
+        def init_fn(s, m=None):
+            return _constant_materialize(s, val, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return constant_init
+
+
+def _zeros_materialize(shape, mapper=None):
+    if mapper is not None:
+        data = np.zeros(shape, dtype=np.float32)
+        return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
+    device = _get_device()
+    t = ttnn.zeros(
+        shape,
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.Layout.TILE,
+    )
+    return ttml.autograd.create_tensor(t)
 
 
 def zeros():
     """All zeros."""
 
     def zeros_init(shape, mapper=None):
-        if mapper is not None:
-            data = np.zeros(shape, dtype=np.float32)
-            return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
-        device = _get_device()
-        t = ttnn.zeros(
-            shape,
-            device=device,
-            dtype=ttnn.DataType.BFLOAT16,
-            layout=ttnn.Layout.TILE,
-        )
-        return ttml.autograd.create_tensor(t)
+        def init_fn(s, m=None):
+            return _zeros_materialize(s, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return zeros_init
+
+
+def _ones_materialize(shape, mapper=None):
+    if mapper is not None:
+        data = np.ones(shape, dtype=np.float32)
+        return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
+    device = _get_device()
+    t = ttnn.ones(
+        shape,
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.Layout.TILE,
+    )
+    return ttml.autograd.create_tensor(t)
 
 
 def ones():
     """All ones."""
 
     def ones_init(shape, mapper=None):
-        if mapper is not None:
-            data = np.ones(shape, dtype=np.float32)
-            return ttml.autograd.Tensor.from_numpy(data, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, mapper)
-        device = _get_device()
-        t = ttnn.ones(
-            shape,
-            device=device,
-            dtype=ttnn.DataType.BFLOAT16,
-            layout=ttnn.Layout.TILE,
-        )
-        return ttml.autograd.create_tensor(t)
+        def init_fn(s, m=None):
+            return _ones_materialize(s, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return ones_init
+
+
+def _xavier_uniform_materialize(shape, gain, mapper=None):
+    fan_in, fan_out = _calculate_fan_in_and_fan_out(list(shape))
+    std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
+    a = math.sqrt(3.0) * std
+    return _uniform_materialize(shape, -a, a, mapper)
 
 
 def xavier_uniform(gain: float = 1.0):
@@ -232,13 +287,19 @@ def xavier_uniform(gain: float = 1.0):
     Use ``calculate_gain`` to compute gain for a specific nonlinearity.
     """
 
-    def xavier_uniform_init(shape):
-        fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
-        std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
-        a = math.sqrt(3.0) * std
-        return uniform(-a, a)(shape)
+    def xavier_uniform_init(shape, mapper=None):
+        def init_fn(s, m=None):
+            return _xavier_uniform_materialize(s, gain, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return xavier_uniform_init
+
+
+def _xavier_normal_materialize(shape, gain, mapper=None):
+    fan_in, fan_out = _calculate_fan_in_and_fan_out(list(shape))
+    std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
+    return _normal_materialize(shape, 0.0, std, mapper)
 
 
 def xavier_normal(gain: float = 1.0):
@@ -248,12 +309,21 @@ def xavier_normal(gain: float = 1.0):
     Use ``calculate_gain`` to compute gain for a specific nonlinearity.
     """
 
-    def xavier_normal_init(shape):
-        fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
-        std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
-        return normal(0.0, std)(shape)
+    def xavier_normal_init(shape, mapper=None):
+        def init_fn(s, m=None):
+            return _xavier_normal_materialize(s, gain, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return xavier_normal_init
+
+
+def _kaiming_uniform_materialize(shape, a, mode, nonlinearity, mapper=None):
+    fan = _calculate_correct_fan(list(shape), mode)
+    g = calculate_gain(nonlinearity, a)
+    std = g / math.sqrt(fan)
+    bound = math.sqrt(3.0) * std
+    return _uniform_materialize(shape, -bound, bound, mapper)
 
 
 def kaiming_uniform(
@@ -273,14 +343,20 @@ def kaiming_uniform(
             "leaky_relu".
     """
 
-    def kaiming_uniform_init(shape):
-        fan = _calculate_correct_fan(shape, mode)
-        gain = calculate_gain(nonlinearity, a)
-        std = gain / math.sqrt(fan)
-        bound = math.sqrt(3.0) * std
-        return uniform(-bound, bound)(shape)
+    def kaiming_uniform_init(shape, mapper=None):
+        def init_fn(s, m=None):
+            return _kaiming_uniform_materialize(s, a, mode, nonlinearity, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return kaiming_uniform_init
+
+
+def _kaiming_normal_materialize(shape, a, mode, nonlinearity, mapper=None):
+    fan = _calculate_correct_fan(list(shape), mode)
+    g = calculate_gain(nonlinearity, a)
+    std = g / math.sqrt(fan)
+    return _normal_materialize(shape, 0.0, std, mapper)
 
 
 def kaiming_normal(
@@ -300,11 +376,11 @@ def kaiming_normal(
             "leaky_relu".
     """
 
-    def kaiming_normal_init(shape):
-        fan = _calculate_correct_fan(shape, mode)
-        gain = calculate_gain(nonlinearity, a)
-        std = gain / math.sqrt(fan)
-        return normal(0.0, std)(shape)
+    def kaiming_normal_init(shape, mapper=None):
+        def init_fn(s, m=None):
+            return _kaiming_normal_materialize(s, a, mode, nonlinearity, m)
+
+        return _maybe_lazy(shape, init_fn, mapper)
 
     return kaiming_normal_init
 
@@ -320,9 +396,16 @@ def kaiming_normal(
 
 def _unwrap_tensor(tensor_or_param):
     """Return the underlying autograd tensor, unwrapping Parameter/Buffer if needed."""
-    from ttml.modules.parameter import Buffer, Parameter
+    from ttml.modules.parameter import Buffer, Parameter, TensorMetadata
 
-    if isinstance(tensor_or_param, (Parameter, Buffer)):
+    if isinstance(tensor_or_param, Parameter):
+        inner = tensor_or_param.peek_tensor()
+        if isinstance(inner, TensorMetadata):
+            raise RuntimeError(
+                "In-place initializer cannot run on a lazy Parameter. " "Call ttml.materialize_module(...) first."
+            )
+        return inner
+    if isinstance(tensor_or_param, Buffer):
         return tensor_or_param.tensor
     return tensor_or_param
 

--- a/tt-train/sources/ttml/ttml/lazy.py
+++ b/tt-train/sources/ttml/ttml/lazy.py
@@ -10,8 +10,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Callable, Optional
 
-import ttnn
-
 from ttml.modules.parameter import Parameter, TensorMetadata
 
 _lazy_init_enabled: ContextVar[bool] = ContextVar("ttml_lazy_init_enabled", default=False)
@@ -36,9 +34,12 @@ def lazy_init():
         _lazy_init_enabled.reset(token)
 
 
-def replicate_mesh_mapper_config(mesh: Any) -> ttnn.MeshMapperConfig:
-    """All-replicate placement on the given mesh (for non-sharded weights)."""
-    return ttnn.MeshMapperConfig([ttnn.PlacementReplicate() for _ in mesh.shape])
+def _replicate_tensor_to_mesh_mapper() -> Any | None:
+    """Return a TensorToMesh replicate mapper for non-sharded mesh parameters."""
+    import ttml
+
+    device = ttml.autograd.AutoContext.get_instance().get_device()
+    return ttml.core.distributed.replicate_tensor_to_mesh_mapper(device)
 
 
 def _collect_lazy_parameter_slots(root: Any) -> list[tuple[Any, str]]:
@@ -66,8 +67,8 @@ def materialize_module(
     Args:
         root: Model root (subclass of :class:`~ttml.modules.module_base.AbstractModuleBase`).
         mesh_device: Optional mesh; when ``None``, uses :func:`ttml.maybe_mesh`. When the
-            mesh has multiple devices and a parameter has no mapper, a full replicate
-            :class:`ttnn.MeshMapperConfig` is applied so weights are not left single-device.
+            mesh has multiple devices and a parameter has no mapper, a TensorToMesh replicate
+            mapper is applied so weights are not left single-device.
         layout_plan: Optional ``(full_param_path, metadata) -> mapper | None``. A non-``None``
             return overrides the metadata's mapper for that parameter.
         on_device_init: Reserved for future on-device random init parity with host path.
@@ -100,7 +101,7 @@ def materialize_module(
             if override is not None:
                 mapper = override
         if mapper is None and mesh is not None and mesh.num_devices() > 1:
-            return replicate_mesh_mapper_config(mesh)
+            return _replicate_tensor_to_mesh_mapper()
         return mapper
 
     tensor_by_metadata_id: dict[int, Any] = {}

--- a/tt-train/sources/ttml/ttml/lazy.py
+++ b/tt-train/sources/ttml/ttml/lazy.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lazy (deferred) parameter initialization for Python TTML modules."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Callable, Optional
+
+import ttnn
+
+from ttml.modules.parameter import Parameter, TensorMetadata
+
+_lazy_init_enabled: ContextVar[bool] = ContextVar("ttml_lazy_init_enabled", default=False)
+
+
+def is_lazy_init_enabled() -> bool:
+    return _lazy_init_enabled.get()
+
+
+@contextmanager
+def lazy_init():
+    """Context: `ttml.init.*` factories return :class:`TensorMetadata` instead of allocating.
+
+    :class:`~ttml.modules.parameter.Parameter` then holds metadata until
+    :func:`materialize_module` runs. C++ parameter registration is deferred until
+    materialization.
+    """
+    token = _lazy_init_enabled.set(True)
+    try:
+        yield
+    finally:
+        _lazy_init_enabled.reset(token)
+
+
+def replicate_mesh_mapper_config(mesh: Any) -> ttnn.MeshMapperConfig:
+    """All-replicate placement on the given mesh (for non-sharded weights)."""
+    return ttnn.MeshMapperConfig([ttnn.PlacementReplicate() for _ in mesh.shape])
+
+
+def _collect_lazy_parameter_slots(root: Any) -> list[tuple[Any, str]]:
+    from ttml.modules.module_base import AbstractModuleBase
+
+    slots: list[tuple[Any, str]] = []
+    for _prefix, mod in root.named_modules():
+        if not isinstance(mod, AbstractModuleBase):
+            continue
+        for attr_name in list(mod.__dict__.keys()):
+            val = mod.__dict__.get(attr_name)
+            if isinstance(val, Parameter) and isinstance(val.peek_tensor(), TensorMetadata):
+                slots.append((mod, attr_name))
+    return slots
+
+
+def materialize_module(
+    root: Any,
+    mesh_device: Optional[Any] = None,
+    layout_plan: Optional[Callable[[str, TensorMetadata], Any]] = None,
+    on_device_init: bool = False,
+) -> Any:
+    """Replace lazy :class:`TensorMetadata` with real tensors and register parameters.
+
+    Args:
+        root: Model root (subclass of :class:`~ttml.modules.module_base.AbstractModuleBase`).
+        mesh_device: Optional mesh; when ``None``, uses :func:`ttml.maybe_mesh`. When the
+            mesh has multiple devices and a parameter has no mapper, a full replicate
+            :class:`ttnn.MeshMapperConfig` is applied so weights are not left single-device.
+        layout_plan: Optional ``(full_param_path, metadata) -> mapper | None``. A non-``None``
+            return overrides the metadata's mapper for that parameter.
+        on_device_init: Reserved for future on-device random init parity with host path.
+
+    Returns:
+        ``root`` for chaining.
+    """
+    from ttml._mesh import maybe_mesh
+    from ttml.modules.module_base import AbstractModuleBase
+
+    if not isinstance(root, AbstractModuleBase):
+        raise TypeError(f"materialize_module expects AbstractModuleBase, got {type(root)!r}")
+
+    mesh = mesh_device if mesh_device is not None else maybe_mesh()
+
+    lazy_slots = _collect_lazy_parameter_slots(root)
+    if not lazy_slots:
+        return root
+
+    def _full_path(mod: AbstractModuleBase, attr_name: str) -> str:
+        for prefix, m in root.named_modules():
+            if m is mod:
+                return f"{prefix}.{attr_name}" if prefix else attr_name
+        return attr_name
+
+    def _resolve_mapper(full_path: str, meta: TensorMetadata) -> Any | None:
+        mapper = meta.mapper
+        if layout_plan is not None:
+            override = layout_plan(full_path, meta)
+            if override is not None:
+                mapper = override
+        if mapper is None and mesh is not None and mesh.num_devices() > 1:
+            return replicate_mesh_mapper_config(mesh)
+        return mapper
+
+    tensor_by_metadata_id: dict[int, Any] = {}
+
+    for mod, attr_name in lazy_slots:
+        param = getattr(mod, attr_name)
+        meta = param.peek_tensor()
+        if not isinstance(meta, TensorMetadata):
+            continue
+        mid = id(meta)
+        if mid in tensor_by_metadata_id:
+            tensor = tensor_by_metadata_id[mid]
+        else:
+            full_path = _full_path(mod, attr_name)
+            mapper = _resolve_mapper(full_path, meta)
+            tensor = meta.materialize(mapper_override=mapper)
+            tensor_by_metadata_id[mid] = tensor
+        object.__setattr__(param, "tensor", tensor)
+
+    for mod, attr_name in lazy_slots:
+        param = getattr(mod, attr_name)
+        inner = param.peek_tensor()
+        if isinstance(inner, TensorMetadata):
+            raise RuntimeError(
+                f"Parameter {attr_name!r} on {mod.get_name() if hasattr(mod, 'get_name') else mod!r} "
+                "is still lazy after materialize_module; check init_fn or layout_plan."
+            )
+        mod._bind_parameter(inner, attr_name)
+
+    if on_device_init:
+        # Placeholder: host NumPy init remains default; on-device rand path can be wired here.
+        pass
+
+    return root

--- a/tt-train/sources/ttml/ttml/modules/__init__.py
+++ b/tt-train/sources/ttml/ttml/modules/__init__.py
@@ -13,7 +13,7 @@ from .embedding import Embedding
 from .linear import LinearLayer, ColumnParallelLinear, RowParallelLinear
 from .lora import LoraConfig, LoraLinear, LoraColumnParallelLinear, LoraRowParallelLinear, LoraModel
 from .module_base import AbstractModuleBase, ModuleDict, ModuleList
-from .parameter import Buffer, Parameter
+from .parameter import Buffer, Parameter, TensorMetadata
 
 __all__ = [
     # C++ bindings
@@ -35,4 +35,5 @@ __all__ = [
     "ModuleDict",
     "ModuleList",
     "Parameter",
+    "TensorMetadata",
 ]

--- a/tt-train/sources/ttml/ttml/modules/module_base.py
+++ b/tt-train/sources/ttml/ttml/modules/module_base.py
@@ -6,7 +6,7 @@
 
 from typing import Any, Iterable, Iterator, Optional, Union, overload
 from _ttml.modules import ModuleBase as CppModuleBase
-from .parameter import Buffer, Parameter
+from .parameter import Buffer, Parameter, TensorMetadata
 
 
 class AbstractModuleBase(CppModuleBase):
@@ -30,7 +30,10 @@ class AbstractModuleBase(CppModuleBase):
             return
 
         if isinstance(value, Parameter):
-            self._bind_parameter(value.tensor, name)
+            inner = value.peek_tensor()
+            if isinstance(inner, TensorMetadata):
+                return
+            self._bind_parameter(inner, name)
             return
 
         if isinstance(value, Buffer):

--- a/tt-train/sources/ttml/ttml/modules/parameter.py
+++ b/tt-train/sources/ttml/ttml/modules/parameter.py
@@ -4,17 +4,67 @@
 
 """Parameter and Buffer wrappers for tensor registration."""
 
-from typing import Any
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+LAZY_PARAMETER_ACCESS_MSG = (
+    "This parameter has not been materialized yet. "
+    "Build the model inside `with ttml.lazy_init():` and then call "
+    "`ttml.materialize_module(model)` before accessing `.tensor` or running forward. "
+    "In-place initializers (`ttml.init.uniform_`, etc.) also require a materialized tensor."
+)
+
+
+@dataclass(frozen=True)
+class TensorMetadata:
+    """Deferred parameter: shape + factory; no device storage until materialization.
+
+    Do not use empty `ttml.autograd.Tensor` as a stand-in; keep allocation in
+    `init_fn` until `materialize()` runs.
+    """
+
+    shape: tuple[int, ...]
+    init_fn: Callable[..., Any]
+    mapper: Any | None = None
+    requires_grad: bool = True
+
+    def materialize(self, mapper_override: Any | None = None) -> Any:
+        """Allocate the autograd tensor using optional mapper override."""
+        mapper = self.mapper if mapper_override is None else mapper_override
+        return self.init_fn(self.shape, mapper)
 
 
 class Parameter:
     """Wrapper marking a tensor as a trainable parameter."""
 
     def __init__(self, tensor: Any) -> None:
-        self.tensor = tensor
+        object.__setattr__(self, "tensor", tensor)
+
+    def __getattribute__(self, name: str) -> Any:
+        if name == "tensor":
+            t = object.__getattribute__(self, "tensor")
+            if isinstance(t, TensorMetadata):
+                raise RuntimeError(LAZY_PARAMETER_ACCESS_MSG)
+            return t
+        return object.__getattribute__(self, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        object.__setattr__(self, name, value)
+
+    def peek_tensor(self) -> Any:
+        """Return stored tensor or :class:`TensorMetadata` without raising."""
+        return object.__getattribute__(self, "tensor")
+
+    @property
+    def is_lazy(self) -> bool:
+        return isinstance(self.peek_tensor(), TensorMetadata)
 
     def __repr__(self) -> str:
-        return f"Parameter({self.tensor})"
+        inner = self.peek_tensor()
+        return f"Parameter({inner})"
 
 
 class Buffer:

--- a/tt-train/tests/python/test_lazy_metadata_init.py
+++ b/tt-train/tests/python/test_lazy_metadata_init.py
@@ -11,6 +11,17 @@ from ttml.modules import AbstractModuleBase, LinearLayer, Parameter, TensorMetad
 from ttml.modules.parameter import LAZY_PARAMETER_ACCESS_MSG
 
 
+@pytest.fixture(autouse=True)
+def _close_device_between_lazy_init_tests():
+    """Eager ``LinearLayer`` / ``ops.rand`` opens the global mesh via ``get_device()``; without a reset,
+    ``open_device()`` in device tests raises *open_device was called after the device was created*.
+    """
+    ctx = ttml.autograd.AutoContext.get_instance()
+    ctx.close_device()
+    yield
+    ctx.close_device()
+
+
 class _TieModel(AbstractModuleBase):
     """Two linear layers sharing one Parameter (weight tying)."""
 
@@ -58,6 +69,17 @@ def test_inplace_init_on_lazy_parameter_raises():
         ttml.init.uniform_(layer.weight, -0.1, 0.1)
 
 
+def test_lazy_parameter_keeps_explicit_mapper():
+    mapper = object()
+
+    with ttml.lazy_init():
+        param = Parameter(ttml.init.uniform()(shape=(1, 1, 32, 32), mapper=mapper))
+
+    meta = param.peek_tensor()
+    assert isinstance(meta, TensorMetadata)
+    assert meta.mapper is mapper
+
+
 def test_eager_linear_unchanged():
     layer = LinearLayer(64, 32, has_bias=False)
     assert not isinstance(layer.weight.peek_tensor(), TensorMetadata)
@@ -66,43 +88,41 @@ def test_eager_linear_unchanged():
 
 @pytest.mark.requires_device
 def test_materialize_then_parameters_and_forward():
-    ttml.autograd.AutoContext.get_instance().open_device()
-    try:
-        with ttml.lazy_init():
-            layer = LinearLayer(64, 32, has_bias=True)
+    ttml.autograd.AutoContext.get_instance().get_device()
 
-        assert len(dict(layer.parameters())) == 0
-        ttml.materialize_module(layer)
-        params = dict(layer.parameters())
-        assert len(params) >= 2
+    with ttml.lazy_init():
+        layer = LinearLayer(64, 32, has_bias=True)
 
-        import numpy as np
-        import ttnn
+    assert len(dict(layer.parameters())) == 0
+    ttml.materialize_module(layer)
+    params = dict(layer.parameters())
+    assert len(params) >= 2
 
-        x = ttml.autograd.Tensor.from_numpy(
-            np.random.randn(1, 1, 4, 64).astype("float32"),
-            layout=ttnn.Layout.TILE,
-            new_type=ttnn.DataType.BFLOAT16,
-        )
-        y = layer(x)
-        assert y is not None
-    finally:
-        ttml.autograd.AutoContext.get_instance().close_device()
+    import numpy as np
+    import ttnn
+
+    x = ttml.autograd.Tensor.from_numpy(
+        np.random.randn(1, 1, 4, 64).astype("float32"),
+        layout=ttnn.Layout.TILE,
+        new_type=ttnn.DataType.BFLOAT16,
+    )
+    y = layer(x)
+    assert y is not None
 
 
 @pytest.mark.requires_device
 def test_lazy_weight_tying_same_storage():
-    ttml.autograd.AutoContext.get_instance().open_device()
-    try:
-        with ttml.lazy_init():
-            m = _TieModel()
+    ttml.autograd.AutoContext.get_instance().get_device()
 
-        ttml.materialize_module(m)
-        w_a = m.a.weight.tensor
-        w_b = m.b.weight.tensor
-        assert w_a.get_value() is w_b.get_value()
-    finally:
-        ttml.autograd.AutoContext.get_instance().close_device()
+    with ttml.lazy_init():
+        m = _TieModel()
+
+    ttml.materialize_module(m)
+    assert m.a.weight is m.b.weight
+    w_a = m.a.weight.tensor
+    w_b = m.b.weight.tensor
+    # Same underlying weights; ``get_value()`` may still return distinct ttnn.Tensor handles.
+    assert w_a is w_b
 
 
 def test_is_lazy_init_enabled_only_inside_context():

--- a/tt-train/tests/python/test_lazy_metadata_init.py
+++ b/tt-train/tests/python/test_lazy_metadata_init.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for lazy TensorMetadata parameter initialization."""
+
+import pytest
+
+import ttml
+from ttml.modules import AbstractModuleBase, LinearLayer, Parameter, TensorMetadata
+from ttml.modules.parameter import LAZY_PARAMETER_ACCESS_MSG
+
+
+class _TieModel(AbstractModuleBase):
+    """Two linear layers sharing one Parameter (weight tying)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = LinearLayer(32, 32, has_bias=False)
+        self.b = LinearLayer(32, 32, has_bias=False)
+        self.b.weight = self.a.weight
+
+    def forward(self, x):
+        return self.b(self.a(x))
+
+
+def test_lazy_linear_stores_metadata_no_cpp_params():
+    with ttml.lazy_init():
+        layer = LinearLayer(64, 32, has_bias=True)
+
+    assert isinstance(layer.weight.peek_tensor(), TensorMetadata)
+    assert isinstance(layer.bias.peek_tensor(), TensorMetadata)
+    assert len(dict(layer.parameters())) == 0
+
+
+def test_lazy_access_tensor_raises():
+    with ttml.lazy_init():
+        layer = LinearLayer(64, 32, has_bias=False)
+
+    with pytest.raises(RuntimeError, match="materialized"):
+        _ = layer.weight.tensor
+
+
+def test_lazy_access_tensor_message_contains_hint():
+    with ttml.lazy_init():
+        layer = LinearLayer(64, 32, has_bias=False)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _ = layer.weight.tensor
+    assert "materialize_module" in str(exc_info.value) or LAZY_PARAMETER_ACCESS_MSG in str(exc_info.value)
+
+
+def test_inplace_init_on_lazy_parameter_raises():
+    with ttml.lazy_init():
+        layer = LinearLayer(64, 32, has_bias=False)
+
+    with pytest.raises(RuntimeError, match="materialize_module"):
+        ttml.init.uniform_(layer.weight, -0.1, 0.1)
+
+
+def test_eager_linear_unchanged():
+    layer = LinearLayer(64, 32, has_bias=False)
+    assert not isinstance(layer.weight.peek_tensor(), TensorMetadata)
+    assert len(dict(layer.parameters())) >= 1
+
+
+@pytest.mark.requires_device
+def test_materialize_then_parameters_and_forward():
+    ttml.autograd.AutoContext.get_instance().open_device()
+    try:
+        with ttml.lazy_init():
+            layer = LinearLayer(64, 32, has_bias=True)
+
+        assert len(dict(layer.parameters())) == 0
+        ttml.materialize_module(layer)
+        params = dict(layer.parameters())
+        assert len(params) >= 2
+
+        import numpy as np
+        import ttnn
+
+        x = ttml.autograd.Tensor.from_numpy(
+            np.random.randn(1, 1, 4, 64).astype("float32"),
+            layout=ttnn.Layout.TILE,
+            new_type=ttnn.DataType.BFLOAT16,
+        )
+        y = layer(x)
+        assert y is not None
+    finally:
+        ttml.autograd.AutoContext.get_instance().close_device()
+
+
+@pytest.mark.requires_device
+def test_lazy_weight_tying_same_storage():
+    ttml.autograd.AutoContext.get_instance().open_device()
+    try:
+        with ttml.lazy_init():
+            m = _TieModel()
+
+        ttml.materialize_module(m)
+        w_a = m.a.weight.tensor
+        w_b = m.b.weight.tensor
+        assert w_a.get_value() is w_b.get_value()
+    finally:
+        ttml.autograd.AutoContext.get_instance().close_device()
+
+
+def test_is_lazy_init_enabled_only_inside_context():
+    assert not ttml.is_lazy_init_enabled()
+    with ttml.lazy_init():
+        assert ttml.is_lazy_init_enabled()
+    assert not ttml.is_lazy_init_enabled()


### PR DESCRIPTION
### Summary

Closes https://github.com/tenstorrent/tt-metal/issues/39804

Adds **deferred Python-side parameter initialization** for TTML models using `AbstractModuleBase` / `Parameter`, without empty autograd tensors as placeholders ([issue #39804](https://github.com/tenstorrent/tt-metal/issues/39804#issue-4071739670)).
### Implementation 

**Goal:** Build the Python module tree without allocating device weights or registering parameters in C++. One explicit step runs the same `ttml.init` logic and registers tensors so behavior matches eager construction (same seed / device / mappers).

**Phase 1 — declare (`with ttml.lazy_init():`)**

- A `ContextVar` flips lazy mode so `ttml.init.*` inner factories return **`TensorMetadata`** (shape + `init_fn` + optional `mapper`) instead of calling `ops.rand` / `from_numpy` / etc.
- **`Parameter(TensorMetadata(...))`** is stored on modules; **`AbstractModuleBase.__setattr__`** skips **`register_tensor`** until materialization.
- Accessing **`parameter.tensor`** (or in-place `ttml.init.*_` on a lazy parameter) raises with a clear message so forwards cannot run on placeholders.

**Phase 2 — realize (`ttml.materialize_module(model)`)**

- Walk the tree for **`Parameter`** slots still holding **`TensorMetadata`**.
- Materialize each distinct metadata object once (`id(metadata)`), assign the resulting autograd tensor into every **`Parameter`** that shared it.
- Resolve mapper: metadata mapper → optional **`layout_plan(full_path, meta)`** override → if multi-device mesh and still no mapper, use **all-replicate** `MeshMapperConfig` so non-sharded weights are not left single-device.
- **`_bind_parameter`** every `(module, attr)` that was lazy so **weight tying** registers the same tensor under each name (e.g. two modules, one shared **`Parameter`**).

**Init parity:** `init.py` uses **`_maybe_lazy`** plus shared **`_*_materialize`** helpers so eager and lazy call the same allocation code paths.

**Training:** `train_nanogpt.py` keeps order **open device → set seed → build**; with lazy enabled, build is **`lazy_init` + construct + `materialize_module` immediately after** so numerics align with eager.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lazy-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lazy-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lazy-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lazy-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lazy-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lazy-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lazy-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lazy-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lazy-init)