### PR TITLE
[ttnn] Allow per-layer block_size on paged_{update,fill}_cache

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -17,8 +17,9 @@ The tests cover:
 * legacy behavior (no override, matching head_dim): byte-identical to
   the pre-change path.
 * "flips view" cases in both directions: cache allocated as one shape,
-  written through the override as the other shape; verified via a
-  torch ``view`` reshape of the round-tripped buffer.
+  written through the override as the other shape; verified by
+  reinterpreting the round-tripped buffer with ``_permute_tile_grid``
+  rather than a torch ``view`` reshape.
 * shared buffer with both views interleaved: one physical cache, writes
   from each view land at disjoint block IDs without trampling.
 * negative cases: byte-count mismatch and override without page_table
@@ -27,7 +28,6 @@ The tests cover:
 
 import pytest
 import torch
-from loguru import logger
 
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal

--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -4,26 +4,13 @@
 """Tests for the ``block_size`` override on ``paged_update_cache`` and
 ``paged_fill_cache``.
 
-These ops gained an optional ``block_size`` kwarg so that callers (e.g.
-vLLM's hybrid kv-cache-groups manager) can write into a single physical
-cache buffer with different ``(block_size, head_dim)`` views per layer
-type, as long as ``num_kv_heads * block_size * head_dim`` (the per-block
-element count) is preserved across views. The kernel now derives
-``head_dim`` from the input tensor (CUDA-style) and ``block_size`` from
-the override or the cache shape.
+These ops accept an optional ``block_size`` kwarg so callers (e.g. vLLM's hybrid
+kv-cache-groups manager) can write into one physical cache with different
+``(block_size, head_dim)`` views per layer, as long as
+``num_kv_heads * block_size * head_dim`` is preserved across views.
 
-The tests cover:
-
-* legacy behavior (no override, matching head_dim): byte-identical to
-  the pre-change path.
-* "flips view" cases in both directions: cache allocated as one shape,
-  written through the override as the other shape; verified by
-  reinterpreting the round-tripped buffer with ``_permute_tile_grid``
-  rather than a torch ``view`` reshape.
-* shared buffer with both views interleaved: one physical cache, writes
-  from each view land at disjoint block IDs without trampling.
-* negative cases: byte-count mismatch and override without page_table
-  must both raise ``RuntimeError`` from validation.
+Coverage: legacy (no override), override in both directions, shared buffer with
+interleaved views, and negative cases (byte-count mismatch, override without page_table).
 """
 
 import pytest
@@ -37,12 +24,8 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 
 
 def _sharded_input(device, x_padded):
-    """Convert a torch input ``(1, B, padded_heads, head_dim)`` to a height-
-    sharded ttnn tensor on ``device``, one shard per batch user.
-
-    Matches the layout that ``run_test_paged_update_cache_decode`` uses in
-    ``tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py``.
-    """
+    """Convert ``(1, B, padded_heads, head_dim)`` to a height-sharded ttnn tensor,
+    matching the layout in ``test_paged_update_cache.py::run_test_paged_update_cache_decode``."""
     num_users = x_padded.shape[1]
     xt = ttnn.Tensor(x_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -76,29 +59,11 @@ def _read_paged_cache(cache_tt):
 def _permute_tile_grid(t, view_block_size, view_head_dim):
     """Reinterpret ``t``'s last two dims under a different tile-grid.
 
-    Why this is needed:
-    The op's ``block_size`` override lets a single physical buffer be
-    accessed with different ``(block_size, head_dim)`` views per call —
-    the kernel addresses DRAM tiles by their *linear* position within a
-    block, computed from the view's tile-grid. ttnn's tilize/untilize,
-    on the other hand, is bound to the cache's *declared* shape and
-    interprets the same DRAM bytes through the cache's tile-grid.
-
-    Concretely: a write to view tile ``(br, hc)`` (linear position
-    ``br * view_Wt + hc``) lands at the same DRAM bytes as the cache
-    tile ``(BR_alloc, HC_alloc) == (linear // alloc_Wt, linear % alloc_Wt)``.
-    Inside the tile, the kernel's 32x32-element layout is preserved.
-    The element-level permutation that takes the cache-shape torch
-    tensor (after ttnn's untilize) to the view-shape torch tensor
-    therefore has to respect the linear-tile correspondence, not the
-    naive element-row-major flat offset that ``torch.view`` would use.
-
-    Implementation: split the last two dims into ``(tile_rows, 32,
-    tile_cols, 32)``, group ``(tile_rows, tile_cols)`` into a linear
-    tile index, re-split that linear index under the view's
-    ``(view_tile_rows, view_tile_cols)`` shape, then put the inner
-    32x32 dims back. No data copy beyond the standard non-contiguous
-    permutes ``.contiguous()`` forces.
+    The kernel writes by linear tile position within a block; ttnn's untilize is bound
+    to the cache's *declared* shape. So when alloc-shape differs from call-view, a plain
+    ``torch.view`` reshape of the untilized tensor would mis-place data — the tile
+    boundaries are in different places. This permutation re-groups tiles by their linear
+    index into the view's tile-grid, keeping each 32×32 tile intact.
     """
     N, KV, alloc_block_size, alloc_head_dim = t.shape
     TILE = 32
@@ -111,17 +76,12 @@ def _permute_tile_grid(t, view_block_size, view_head_dim):
     total_tiles = alloc_BR_t * alloc_Wt
     assert total_tiles == view_BR_t * view_Wt, "per-block tile count must match"
 
-    # (N, KV, BS, HD) -> split into tile-grid + intra-tile.
+    # Split into (tile-grid, intra-tile), flatten tile-grid, re-split under view, repack.
     t = t.view(N, KV, alloc_BR_t, TILE, alloc_Wt, TILE)
-    # Move tile-grid dims together: (N, KV, alloc_BR_t, alloc_Wt, TILE, TILE).
     t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
-    # Flatten tile-grid into linear tile index.
     t = t.view(N, KV, total_tiles, TILE, TILE)
-    # Re-split under view's tile-grid.
     t = t.view(N, KV, view_BR_t, view_Wt, TILE, TILE)
-    # Put intra-tile rows next to tile-row dim, intra-tile cols next to tile-col dim.
     t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
-    # Collapse back to (N, KV, view_BS, view_HD).
     return t.view(N, KV, view_block_size, view_head_dim)
 
 
@@ -130,11 +90,7 @@ def _permute_tile_grid(t, view_block_size, view_head_dim):
 
 @pytest.mark.parametrize("block_size, head_dim", [(64, 256), (128, 256), (64, 512)])
 def test_paged_update_cache_legacy_no_override(block_size, head_dim, device):
-    """No ``block_size`` kwarg → behavior identical to the pre-change op.
-
-    This guards backward compatibility: every existing caller that doesn't
-    pass ``block_size`` must keep working unchanged.
-    """
+    """No ``block_size`` kwarg → behavior identical to the pre-change op. Backward-compat guard."""
     torch.manual_seed(0)
     num_users = 4
     num_kv_heads = 1
@@ -157,10 +113,8 @@ def test_paged_update_cache_legacy_no_override(block_size, head_dim, device):
     x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
     xt = _sharded_input(device, x_padded)
 
-    # Update reference: in cache_ref, each user maps virtual block →
-    # physical via page_table; for user i, position cache_idxs[i] lands
-    # in block page_table[i, cache_idxs[i] // block_size] at row
-    # cache_idxs[i] % block_size.
+    # Reference: walk page_table to find each user's physical block, then write at
+    # ``cache_idxs[u] % block_size`` within it.
     for u in range(num_users):
         pos = cache_idxs[u]
         physical_block = page_table[u, pos // block_size].item()
@@ -180,44 +134,26 @@ def test_paged_update_cache_legacy_no_override(block_size, head_dim, device):
 
 @pytest.mark.parametrize("num_kv_heads", [1, 8])
 def test_paged_update_cache_override_view_full_into_sliding_buffer(num_kv_heads, device):
-    """Buffer allocated for sliding (block=128, head=256); call writes
-    with the full-attention view (block=64, head=512) via the override.
+    """Buffer allocated as sliding (block=128, head=256); writes use the full-attention
+    view (block=64, head=512) via the override. Canonical Gemma4-E2B scenario after
+    vLLM's page-size unifier matches sliding's block_size to full's.
 
-    Verifies the kernel addresses the right block boundary, and after
-    reading back + ``view``-reshaping to ``(N, 1, 64, 512)`` the written
-    data appears at the expected (view-relative) position.
-
-    This is the canonical Gemma4-E2B scenario: the page-size unifier in
-    vLLM doubles sliding's block_size from 64 to 128 to match full's
-    65,536-byte page; the shared DRAM buffer then needs to support both
-    views.
-
-    Parametrized on ``num_kv_heads`` so the multi-head per-block stride
-    (``num_kv_heads * block_size * head_dim`` elements) gets exercised:
-    single-head values can't catch a regression where the wrong
-    dimension is used in the stride math.
+    Parametrized on ``num_kv_heads`` to exercise the multi-head per-block stride.
     """
     torch.manual_seed(1)
 
     num_users = 4
-    # Allocation view: sliding shape.
+    # Alloc view: sliding. Call view: full.
     alloc_block_size = 128
     alloc_head_dim = 256
-    # Call view: full shape.
     view_block_size = 64
     view_head_dim = 512
-    # Both views have ``num_kv_heads * 32768`` elements/block, same per-block bytes.
     assert num_kv_heads * alloc_block_size * alloc_head_dim == num_kv_heads * view_block_size * view_head_dim
 
-    # Max logical sequence length under the *view*; the page table indexes
-    # the view's block count.
     max_seq_len_view = 512
     max_num_blocks_per_seq = max_seq_len_view // view_block_size
     max_num_blocks = num_users * max_num_blocks_per_seq
 
-    # Cache is allocated under the legacy/alloc view. The number of
-    # cache-blocks must also match (per-block-byte-count is identical, so
-    # the block count is identical too).
     assert max_seq_len_view % alloc_block_size == 0
     cache_tt, cache_ref_alloc = _make_paged_cache(
         max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device
@@ -226,12 +162,10 @@ def test_paged_update_cache_override_view_full_into_sliding_buffer(num_kv_heads,
     page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
     page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
-    # Decode update positions, expressed in the *view* coordinate system
-    # (block_size=64 here).
-    cache_idxs = [10 + u * 17 for u in range(num_users)]  # spread across blocks
+    # cache_idxs are in view coordinates.
+    cache_idxs = [10 + u * 17 for u in range(num_users)]
     cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
 
-    # Input with the view's head_dim.
     x = torch.randn([1, num_users, num_kv_heads, view_head_dim]).bfloat16().float()
     x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
     xt = _sharded_input(device, x_padded)
@@ -244,23 +178,15 @@ def test_paged_update_cache_override_view_full_into_sliding_buffer(num_kv_heads,
         block_size=view_block_size,
     )
 
-    # Read cache back as allocated, then re-interpret under the view's
-    # tile-grid via ``_permute_tile_grid`` (NOT torch.view — see that
-    # helper's docstring).
     got_alloc = _read_paged_cache(cache_tt)
     assert got_alloc.shape == (max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim)
     got_view = _permute_tile_grid(got_alloc, view_block_size, view_head_dim)
 
-    # Build the reference in the view's coordinate system: take the
-    # initial cache, translate to view coords via the same tile-grid
-    # permutation, then apply the writes in view coords.
     cache_ref_view = _permute_tile_grid(cache_ref_alloc, view_block_size, view_head_dim).clone()
     for u in range(num_users):
         pos = cache_idxs[u]
         physical_block = page_table[u, pos // view_block_size].item()
-        # ``x[0, u]`` is ``[KV, head_dim]``; target slot is ``[KV, 1, head_dim]``.
-        # ``unsqueeze(1)`` makes the kv-head dim broadcast-compatible with the
-        # 1-token slot — both single-head and multi-head land at the right slot.
+        # unsqueeze(1) broadcasts [KV, head_dim] into the [KV, 1, head_dim] slot.
         cache_ref_view[physical_block, 0:num_kv_heads, pos % view_block_size : pos % view_block_size + 1, :] = x[
             0, u
         ].unsqueeze(1)
@@ -366,9 +292,7 @@ def test_paged_update_cache_shared_buffer_both_views_disjoint_blocks(device):
         xt_sliding,
         update_idxs_tensor=sliding_idxs_tt,
         page_table=sliding_pt_tt,
-        # No override here — call view matches the allocation view; this
-        # also exercises that legacy callers on a shared buffer keep
-        # working when other layers later use the override path.
+        # No override: call view matches alloc view.
     )
 
     # Full write: block IDs num_users..2*num_users-1.
@@ -386,10 +310,7 @@ def test_paged_update_cache_shared_buffer_both_views_disjoint_blocks(device):
         block_size=full_block_size,
     )
 
-    # Reference: apply sliding write directly in alloc/sliding coords
-    # (alloc shape == sliding view), then transition into full view via
-    # the tile-grid-aware permutation for the full write — same as the
-    # kernel does on device.
+    # Reference: write sliding in alloc coords, permute to full coords, then write full.
     cache_ref_sliding = cache_ref_alloc.clone()
     for u in range(num_users):
         pos = sliding_idxs[u]
@@ -413,15 +334,13 @@ def test_paged_update_cache_shared_buffer_both_views_disjoint_blocks(device):
 
 
 def test_paged_update_cache_negative_byte_count_mismatch(device):
-    """An override that breaks the per-block byte invariant must be
-    rejected at validation time, not silently corrupt memory."""
+    """Override that breaks the per-block byte invariant must be rejected at validation."""
     torch.manual_seed(4)
     num_users = 4
     num_kv_heads = 1
-    # Allocate (1, 64, 512) — 32768 elem/block.
+    # Alloc: 32768 elem/block. View: 65536 (mismatched).
     alloc_block_size = 64
     alloc_head_dim = 512
-    # Call with mismatched view: 256 * 256 = 65536 (double the bytes).
     view_block_size = 256
     view_head_dim = 256
     max_num_blocks = 4
@@ -447,10 +366,7 @@ def test_paged_update_cache_negative_byte_count_mismatch(device):
 
 
 def test_paged_update_cache_negative_override_without_page_table(device):
-    """``block_size`` only makes sense in paged mode. The validator
-    explicitly rejects it when no ``page_table`` is supplied to surface
-    the misconfiguration instead of letting the kernel use it silently
-    in non-paged mode."""
+    """``block_size`` is paged-mode only; validator must reject it without a page_table."""
     torch.manual_seed(5)
     num_users = 4
     num_kv_heads = 1
@@ -492,22 +408,14 @@ def _run_fill_cache_round_trip(
     input_seq_len,
     block_size_kwarg,
 ):
-    """Shared fill-cache test body.
-
-    Allocates a paged cache with ``(alloc_block_size, alloc_head_dim)``,
-    fills it user-by-user with an input shaped under the view's
-    ``(view_block_size, view_head_dim)``, and verifies the round trip
-    matches the reference torch fill (viewed in the same coordinate
-    system as the write).
-
-    ``block_size_kwarg`` is what we pass to ``paged_fill_cache``; when
-    None, we expect alloc-view == call-view (no override).
+    """Shared fill-cache test body. Allocates a paged cache under the alloc view, fills
+    user-by-user with input shaped under the call view, and checks the round-trip in
+    view coordinates. ``block_size_kwarg=None`` means no override (alloc == call view).
     """
     max_num_blocks_per_seq = input_seq_len // view_block_size
     assert max_num_blocks_per_seq * view_block_size == input_seq_len
     max_num_blocks = num_users * max_num_blocks_per_seq
 
-    # Allocate as alloc view.
     cache_shape = [max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim]
     cache_torch_alloc = torch.randn(cache_shape).bfloat16().float()
     cache_tt = ttnn.Tensor(cache_torch_alloc, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
@@ -515,9 +423,6 @@ def _run_fill_cache_round_trip(
     page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
     page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
-    # One paged_fill_cache call per user. Reference is built in the view
-    # coordinate system, mapping alloc-shape bytes to view-shape via the
-    # tile-grid-aware permutation (see ``_permute_tile_grid``).
     cache_ref_view = _permute_tile_grid(cache_torch_alloc, view_block_size, view_head_dim).clone()
     for u in range(num_users):
         x = torch.randn([1, num_kv_heads, input_seq_len, view_head_dim]).bfloat16().float()
@@ -528,8 +433,6 @@ def _run_fill_cache_round_trip(
             kwargs["block_size"] = block_size_kwarg
         ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, **kwargs)
 
-        # Apply equivalent torch fill: distribute tokens 0..input_seq_len-1
-        # to the user's virtual blocks per the page table.
         for t in range(input_seq_len):
             vb = t // view_block_size
             slot = t % view_block_size
@@ -561,15 +464,9 @@ def test_paged_fill_cache_legacy_no_override(device):
 
 @pytest.mark.parametrize("num_kv_heads", [1, 8])
 def test_paged_fill_cache_override_view_full_into_sliding_buffer(num_kv_heads, device):
-    """Cache allocated as sliding ``(128, 256)``, filled via override
-    with full ``(64, 512)``.
-
-    Parametrized on ``num_kv_heads`` so the kernel's per-block stride
-    (``num_kv_heads * block_size * head_dim``) is exercised on a
-    realistic multi-head case as well. ``paged_fill_cache``'s program
-    factory derives ``num_heads`` from ``input.padded_shape()[1]``, so
-    the multi-head case also catches regressions in the
-    ``input_num_heads == cache_num_heads`` validator.
+    """Cache allocated as sliding ``(128, 256)``, filled via override with full
+    ``(64, 512)``. Parametrized on ``num_kv_heads`` to exercise the multi-head per-block
+    stride and the ``input_num_heads == cache_num_heads`` validator.
     """
     torch.manual_seed(11)
     _run_fill_cache_round_trip(
@@ -607,9 +504,9 @@ def test_paged_fill_cache_negative_byte_count_mismatch(device):
     torch.manual_seed(13)
     num_users = 2
     num_kv_heads = 1
+    # Alloc: 32768 elem/block. View: 65536 (mismatched).
     alloc_block_size = 64
     alloc_head_dim = 512
-    # 256 * 256 = 65536 elem/block, doubled from alloc's 32768.
     view_block_size = 256
     view_head_dim = 256
     input_seq_len = 128

--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -1,0 +1,611 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``block_size`` override on ``paged_update_cache`` and
+``paged_fill_cache``.
+
+These ops gained an optional ``block_size`` kwarg so that callers (e.g.
+vLLM's hybrid kv-cache-groups manager) can write into a single physical
+cache buffer with different ``(block_size, head_dim)`` views per layer
+type, as long as ``num_kv_heads * block_size * head_dim`` (the per-block
+element count) is preserved across views. The kernel now derives
+``head_dim`` from the input tensor (CUDA-style) and ``block_size`` from
+the override or the cache shape.
+
+The tests cover:
+
+* legacy behavior (no override, matching head_dim): byte-identical to
+  the pre-change path.
+* "flips view" cases in both directions: cache allocated as one shape,
+  written through the override as the other shape; verified via a
+  torch ``view`` reshape of the round-tripped buffer.
+* shared buffer with both views interleaved: one physical cache, writes
+  from each view land at disjoint block IDs without trampling.
+* negative cases: byte-count mismatch and override without page_table
+  must both raise ``RuntimeError`` from validation.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
+
+
+# ── Test harness helpers ───────────────────────────────────────────────────
+
+
+def _sharded_input(device, x_padded):
+    """Convert a torch input ``(1, B, padded_heads, head_dim)`` to a height-
+    sharded ttnn tensor on ``device``, one shard per batch user.
+
+    Matches the layout that ``run_test_paged_update_cache_decode`` uses in
+    ``tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py``.
+    """
+    num_users = x_padded.shape[1]
+    xt = ttnn.Tensor(x_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    shard_grid = ttnn.num_cores_to_corerangeset(num_users, compute_grid_size, True)
+    input_shard_spec = ttnn.ShardSpec(
+        shard_grid,
+        [
+            xt.volume() // xt.padded_shape[-1] // num_users,
+            xt.padded_shape[-1],
+        ],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    return xt.to(device, input_mem_config)
+
+
+def _make_paged_cache(num_blocks, num_kv_heads, block_size, head_dim, device):
+    """Allocate a ttnn paged cache tensor filled with deterministic random
+    data, plus its torch reference."""
+    cache_shape = [num_blocks, num_kv_heads, block_size, head_dim]
+    cache_torch = torch.randn(cache_shape).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    return cache_tt, cache_torch
+
+
+def _read_paged_cache(cache_tt):
+    """Read a ttnn paged cache back to torch in its declared shape."""
+    return cache_tt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+
+
+def _permute_tile_grid(t, view_block_size, view_head_dim):
+    """Reinterpret ``t``'s last two dims under a different tile-grid.
+
+    Why this is needed:
+    The op's ``block_size`` override lets a single physical buffer be
+    accessed with different ``(block_size, head_dim)`` views per call —
+    the kernel addresses DRAM tiles by their *linear* position within a
+    block, computed from the view's tile-grid. ttnn's tilize/untilize,
+    on the other hand, is bound to the cache's *declared* shape and
+    interprets the same DRAM bytes through the cache's tile-grid.
+
+    Concretely: a write to view tile ``(br, hc)`` (linear position
+    ``br * view_Wt + hc``) lands at the same DRAM bytes as the cache
+    tile ``(BR_alloc, HC_alloc) == (linear // alloc_Wt, linear % alloc_Wt)``.
+    Inside the tile, the kernel's 32x32-element layout is preserved.
+    The element-level permutation that takes the cache-shape torch
+    tensor (after ttnn's untilize) to the view-shape torch tensor
+    therefore has to respect the linear-tile correspondence, not the
+    naive element-row-major flat offset that ``torch.view`` would use.
+
+    Implementation: split the last two dims into ``(tile_rows, 32,
+    tile_cols, 32)``, group ``(tile_rows, tile_cols)`` into a linear
+    tile index, re-split that linear index under the view's
+    ``(view_tile_rows, view_tile_cols)`` shape, then put the inner
+    32x32 dims back. No data copy beyond the standard non-contiguous
+    permutes ``.contiguous()`` forces.
+    """
+    N, KV, alloc_block_size, alloc_head_dim = t.shape
+    TILE = 32
+    assert alloc_block_size % TILE == 0 and alloc_head_dim % TILE == 0, "alloc dims must be tile-aligned"
+    assert view_block_size % TILE == 0 and view_head_dim % TILE == 0, "view dims must be tile-aligned"
+    alloc_BR_t = alloc_block_size // TILE
+    alloc_Wt = alloc_head_dim // TILE
+    view_BR_t = view_block_size // TILE
+    view_Wt = view_head_dim // TILE
+    total_tiles = alloc_BR_t * alloc_Wt
+    assert total_tiles == view_BR_t * view_Wt, "per-block tile count must match"
+
+    # (N, KV, BS, HD) -> split into tile-grid + intra-tile.
+    t = t.view(N, KV, alloc_BR_t, TILE, alloc_Wt, TILE)
+    # Move tile-grid dims together: (N, KV, alloc_BR_t, alloc_Wt, TILE, TILE).
+    t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
+    # Flatten tile-grid into linear tile index.
+    t = t.view(N, KV, total_tiles, TILE, TILE)
+    # Re-split under view's tile-grid.
+    t = t.view(N, KV, view_BR_t, view_Wt, TILE, TILE)
+    # Put intra-tile rows next to tile-row dim, intra-tile cols next to tile-col dim.
+    t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
+    # Collapse back to (N, KV, view_BS, view_HD).
+    return t.view(N, KV, view_block_size, view_head_dim)
+
+
+# ── paged_update_cache tests ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("block_size, head_dim", [(64, 256), (128, 256), (64, 512)])
+def test_paged_update_cache_legacy_no_override(block_size, head_dim, device):
+    """No ``block_size`` kwarg → behavior identical to the pre-change op.
+
+    This guards backward compatibility: every existing caller that doesn't
+    pass ``block_size`` must keep working unchanged.
+    """
+    torch.manual_seed(0)
+    num_users = 4
+    num_kv_heads = 1
+    max_seq_len = 256
+    max_num_blocks_per_seq = max_seq_len // block_size
+    max_num_blocks = num_users * max_num_blocks_per_seq
+
+    cache_tt, cache_ref = _make_paged_cache(max_num_blocks, num_kv_heads, block_size, head_dim, device)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    # One decode token per user.
+    cache_idx = block_size + 5  # straddles a block boundary
+    cache_idxs = [cache_idx + i * 3 for i in range(num_users)]
+    cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
+
+    # Input shape: [1, B, num_kv_heads_padded_to_32, head_dim]
+    x = torch.randn([1, num_users, num_kv_heads, head_dim]).bfloat16().float()
+    x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
+    xt = _sharded_input(device, x_padded)
+
+    # Update reference: in cache_ref, each user maps virtual block →
+    # physical via page_table; for user i, position cache_idxs[i] lands
+    # in block page_table[i, cache_idxs[i] // block_size] at row
+    # cache_idxs[i] % block_size.
+    for u in range(num_users):
+        pos = cache_idxs[u]
+        physical_block = page_table[u, pos // block_size].item()
+        cache_ref[physical_block, 0:num_kv_heads, pos % block_size : pos % block_size + 1, :] = x[:, u, :, :]
+
+    ttnn.experimental.paged_update_cache(
+        cache_tt,
+        xt,
+        update_idxs_tensor=cache_idxs_tt,
+        page_table=page_table_tt,
+    )
+
+    got = _read_paged_cache(cache_tt)
+    eq, msg = comp_equal(cache_ref, got)
+    assert eq, f"legacy path diverged from reference: {msg}"
+
+
+def test_paged_update_cache_override_view_full_into_sliding_buffer(device):
+    """Buffer allocated for sliding (block=128, head=256); call writes
+    with the full-attention view (block=64, head=512) via the override.
+
+    Verifies the kernel addresses the right block boundary, and after
+    reading back + ``view``-reshaping to ``(N, 1, 64, 512)`` the written
+    data appears at the expected (view-relative) position.
+
+    This is the canonical Gemma4-E2B scenario: the page-size unifier in
+    vLLM doubles sliding's block_size from 64 to 128 to match full's
+    65,536-byte page; the shared DRAM buffer then needs to support both
+    views.
+    """
+    torch.manual_seed(1)
+
+    num_users = 4
+    num_kv_heads = 1
+    # Allocation view: sliding shape.
+    alloc_block_size = 128
+    alloc_head_dim = 256
+    # Call view: full shape.
+    view_block_size = 64
+    view_head_dim = 512
+    # Both views have 32768 elements/block, same per-block bytes.
+    assert num_kv_heads * alloc_block_size * alloc_head_dim == num_kv_heads * view_block_size * view_head_dim
+
+    # Max logical sequence length under the *view*; the page table indexes
+    # the view's block count.
+    max_seq_len_view = 512
+    max_num_blocks_per_seq = max_seq_len_view // view_block_size
+    max_num_blocks = num_users * max_num_blocks_per_seq
+
+    # Cache is allocated under the legacy/alloc view. The number of
+    # cache-blocks must also match (per-block-byte-count is identical, so
+    # the block count is identical too).
+    assert max_seq_len_view % alloc_block_size == 0
+    cache_tt, cache_ref_alloc = _make_paged_cache(
+        max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device
+    )
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    # Decode update positions, expressed in the *view* coordinate system
+    # (block_size=64 here).
+    cache_idxs = [10 + u * 17 for u in range(num_users)]  # spread across blocks
+    cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
+
+    # Input with the view's head_dim.
+    x = torch.randn([1, num_users, num_kv_heads, view_head_dim]).bfloat16().float()
+    x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
+    xt = _sharded_input(device, x_padded)
+
+    ttnn.experimental.paged_update_cache(
+        cache_tt,
+        xt,
+        update_idxs_tensor=cache_idxs_tt,
+        page_table=page_table_tt,
+        block_size=view_block_size,
+    )
+
+    # Read cache back as allocated, then re-interpret under the view's
+    # tile-grid via ``_permute_tile_grid`` (NOT torch.view — see that
+    # helper's docstring).
+    got_alloc = _read_paged_cache(cache_tt)
+    assert got_alloc.shape == (max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim)
+    got_view = _permute_tile_grid(got_alloc, view_block_size, view_head_dim)
+
+    # Build the reference in the view's coordinate system: take the
+    # initial cache, translate to view coords via the same tile-grid
+    # permutation, then apply the writes in view coords.
+    cache_ref_view = _permute_tile_grid(cache_ref_alloc, view_block_size, view_head_dim).clone()
+    for u in range(num_users):
+        pos = cache_idxs[u]
+        physical_block = page_table[u, pos // view_block_size].item()
+        cache_ref_view[physical_block, 0:num_kv_heads, pos % view_block_size : pos % view_block_size + 1, :] = x[
+            :, u, :, :
+        ]
+
+    eq, msg = comp_equal(cache_ref_view, got_view)
+    assert eq, f"override view mismatch: {msg}"
+
+
+def test_paged_update_cache_override_view_sliding_into_full_buffer(device):
+    """Symmetric: buffer allocated for full (block=64, head=512); call
+    writes with the sliding view (block=128, head=256)."""
+    torch.manual_seed(2)
+
+    num_users = 4
+    num_kv_heads = 1
+    alloc_block_size = 64
+    alloc_head_dim = 512
+    view_block_size = 128
+    view_head_dim = 256
+    assert num_kv_heads * alloc_block_size * alloc_head_dim == num_kv_heads * view_block_size * view_head_dim
+
+    max_seq_len_view = 512
+    max_num_blocks_per_seq = max_seq_len_view // view_block_size
+    max_num_blocks = num_users * max_num_blocks_per_seq
+
+    cache_tt, cache_ref_alloc = _make_paged_cache(
+        max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device
+    )
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    cache_idxs = [40 + u * 33 for u in range(num_users)]
+    cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
+
+    x = torch.randn([1, num_users, num_kv_heads, view_head_dim]).bfloat16().float()
+    x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
+    xt = _sharded_input(device, x_padded)
+
+    ttnn.experimental.paged_update_cache(
+        cache_tt,
+        xt,
+        update_idxs_tensor=cache_idxs_tt,
+        page_table=page_table_tt,
+        block_size=view_block_size,
+    )
+
+    got_alloc = _read_paged_cache(cache_tt)
+    got_view = _permute_tile_grid(got_alloc, view_block_size, view_head_dim)
+    cache_ref_view = _permute_tile_grid(cache_ref_alloc, view_block_size, view_head_dim).clone()
+    for u in range(num_users):
+        pos = cache_idxs[u]
+        physical_block = page_table[u, pos // view_block_size].item()
+        cache_ref_view[physical_block, 0:num_kv_heads, pos % view_block_size : pos % view_block_size + 1, :] = x[
+            :, u, :, :
+        ]
+
+    eq, msg = comp_equal(cache_ref_view, got_view)
+    assert eq, f"symmetric override view mismatch: {msg}"
+
+
+def test_paged_update_cache_shared_buffer_both_views_disjoint_blocks(device):
+    """One physical buffer, two consecutive writes from different views.
+
+    Writes block IDs ``0..num_users-1`` with the sliding view, then block
+    IDs ``num_users..2*num_users-1`` with the full view, and verifies
+    both writes land correctly without disturbing each other. This is the
+    interleaved access pattern that vLLM's hybrid kv-cache-groups manager
+    produces when sliding and full layers share one ``KVCacheTensor``.
+    """
+    torch.manual_seed(3)
+
+    num_users = 4
+    num_kv_heads = 1
+    sliding_block_size = 128
+    sliding_head_dim = 256
+    full_block_size = 64
+    full_head_dim = 512
+    assert num_kv_heads * sliding_block_size * sliding_head_dim == num_kv_heads * full_block_size * full_head_dim
+
+    # Each view uses its own block-count slice. The cache is allocated as
+    # sliding-shape and has 2 * num_users blocks total — first half for
+    # sliding writes, second half for full writes.
+    max_num_blocks = 2 * num_users
+    sliding_blocks_per_user = 1
+    full_blocks_per_user = 1
+
+    # Allocate as sliding view. Per-block bytes are identical between
+    # views, so the byte capacity supports either view's block layout.
+    cache_tt, cache_ref_alloc = _make_paged_cache(
+        max_num_blocks, num_kv_heads, sliding_block_size, sliding_head_dim, device
+    )
+
+    # Sliding write: block IDs 0..num_users-1, one block per user.
+    sliding_pt = torch.arange(0, num_users, dtype=torch.int32).reshape(num_users, sliding_blocks_per_user)
+    sliding_pt_tt = ttnn.Tensor(sliding_pt, ttnn.int32).to(device)
+    sliding_idxs = [10 + u for u in range(num_users)]
+    sliding_idxs_tt = ttnn.Tensor(torch.tensor(sliding_idxs), ttnn.int32).to(device)
+    x_sliding = torch.randn([1, num_users, num_kv_heads, sliding_head_dim]).bfloat16().float()
+    xt_sliding = _sharded_input(device, torch.nn.functional.pad(x_sliding, (0, 0, 0, 32 - num_kv_heads), "constant", 0))
+    ttnn.experimental.paged_update_cache(
+        cache_tt,
+        xt_sliding,
+        update_idxs_tensor=sliding_idxs_tt,
+        page_table=sliding_pt_tt,
+        # No override here — call view matches the allocation view; this
+        # also exercises that legacy callers on a shared buffer keep
+        # working when other layers later use the override path.
+    )
+
+    # Full write: block IDs num_users..2*num_users-1.
+    full_pt = torch.arange(num_users, 2 * num_users, dtype=torch.int32).reshape(num_users, full_blocks_per_user)
+    full_pt_tt = ttnn.Tensor(full_pt, ttnn.int32).to(device)
+    full_idxs = [20 + u for u in range(num_users)]
+    full_idxs_tt = ttnn.Tensor(torch.tensor(full_idxs), ttnn.int32).to(device)
+    x_full = torch.randn([1, num_users, num_kv_heads, full_head_dim]).bfloat16().float()
+    xt_full = _sharded_input(device, torch.nn.functional.pad(x_full, (0, 0, 0, 32 - num_kv_heads), "constant", 0))
+    ttnn.experimental.paged_update_cache(
+        cache_tt,
+        xt_full,
+        update_idxs_tensor=full_idxs_tt,
+        page_table=full_pt_tt,
+        block_size=full_block_size,
+    )
+
+    # Reference: apply sliding write directly in alloc/sliding coords
+    # (alloc shape == sliding view), then transition into full view via
+    # the tile-grid-aware permutation for the full write — same as the
+    # kernel does on device.
+    cache_ref_sliding = cache_ref_alloc.clone()
+    for u in range(num_users):
+        pos = sliding_idxs[u]
+        physical_block = sliding_pt[u, 0].item()
+        cache_ref_sliding[
+            physical_block, 0:num_kv_heads, pos % sliding_block_size : pos % sliding_block_size + 1, :
+        ] = x_sliding[:, u, :, :]
+
+    cache_ref_full = _permute_tile_grid(cache_ref_sliding, full_block_size, full_head_dim).clone()
+    for u in range(num_users):
+        pos = full_idxs[u]
+        physical_block = full_pt[u, 0].item()
+        cache_ref_full[physical_block, 0:num_kv_heads, pos % full_block_size : pos % full_block_size + 1, :] = x_full[
+            :, u, :, :
+        ]
+
+    got_alloc = _read_paged_cache(cache_tt)
+    got_view = _permute_tile_grid(got_alloc, full_block_size, full_head_dim)
+    eq, msg = comp_equal(cache_ref_full, got_view)
+    assert eq, f"shared-buffer interleaved writes diverged: {msg}"
+
+
+def test_paged_update_cache_negative_byte_count_mismatch(device):
+    """An override that breaks the per-block byte invariant must be
+    rejected at validation time, not silently corrupt memory."""
+    torch.manual_seed(4)
+    num_users = 4
+    num_kv_heads = 1
+    # Allocate (1, 64, 512) — 32768 elem/block.
+    alloc_block_size = 64
+    alloc_head_dim = 512
+    # Call with mismatched view: 256 * 256 = 65536 (double the bytes).
+    view_block_size = 256
+    view_head_dim = 256
+    max_num_blocks = 4
+
+    cache_tt, _ = _make_paged_cache(max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, 1)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+    cache_idxs_tt = ttnn.Tensor(torch.zeros(num_users, dtype=torch.int32), ttnn.int32).to(device)
+
+    x = torch.randn([1, num_users, num_kv_heads, view_head_dim]).bfloat16().float()
+    x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
+    xt = _sharded_input(device, x_padded)
+
+    with pytest.raises(RuntimeError, match="geometry mismatch"):
+        ttnn.experimental.paged_update_cache(
+            cache_tt,
+            xt,
+            update_idxs_tensor=cache_idxs_tt,
+            page_table=page_table_tt,
+            block_size=view_block_size,
+        )
+
+
+def test_paged_update_cache_negative_override_without_page_table(device):
+    """``block_size`` only makes sense in paged mode. The validator
+    explicitly rejects it when no ``page_table`` is supplied to surface
+    the misconfiguration instead of letting the kernel use it silently
+    in non-paged mode."""
+    torch.manual_seed(5)
+    num_users = 4
+    num_kv_heads = 1
+    max_seq_len = 256
+    head_dim = 256
+
+    cache_shape = [num_users, num_kv_heads, max_seq_len, head_dim]
+    cache_torch = torch.randn(cache_shape).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    cache_idxs = [0 + i for i in range(num_users)]
+    cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
+
+    x = torch.randn([1, num_users, num_kv_heads, head_dim]).bfloat16().float()
+    x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
+    xt = _sharded_input(device, x_padded)
+
+    with pytest.raises(RuntimeError, match="block_size_override is only supported in paged mode"):
+        ttnn.experimental.paged_update_cache(
+            cache_tt,
+            xt,
+            update_idxs_tensor=cache_idxs_tt,
+            # No page_table.
+            block_size=64,
+        )
+
+
+# ── paged_fill_cache tests ────────────────────────────────────────────────
+
+
+def _run_fill_cache_round_trip(
+    device,
+    num_kv_heads,
+    alloc_block_size,
+    alloc_head_dim,
+    view_block_size,
+    view_head_dim,
+    num_users,
+    input_seq_len,
+    block_size_kwarg,
+):
+    """Shared fill-cache test body.
+
+    Allocates a paged cache with ``(alloc_block_size, alloc_head_dim)``,
+    fills it user-by-user with an input shaped under the view's
+    ``(view_block_size, view_head_dim)``, and verifies the round trip
+    matches the reference torch fill (viewed in the same coordinate
+    system as the write).
+
+    ``block_size_kwarg`` is what we pass to ``paged_fill_cache``; when
+    None, we expect alloc-view == call-view (no override).
+    """
+    max_num_blocks_per_seq = input_seq_len // view_block_size
+    assert max_num_blocks_per_seq * view_block_size == input_seq_len
+    max_num_blocks = num_users * max_num_blocks_per_seq
+
+    # Allocate as alloc view.
+    cache_shape = [max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim]
+    cache_torch_alloc = torch.randn(cache_shape).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch_alloc, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    # One paged_fill_cache call per user. Reference is built in the view
+    # coordinate system, mapping alloc-shape bytes to view-shape via the
+    # tile-grid-aware permutation (see ``_permute_tile_grid``).
+    cache_ref_view = _permute_tile_grid(cache_torch_alloc, view_block_size, view_head_dim).clone()
+    for u in range(num_users):
+        x = torch.randn([1, num_kv_heads, input_seq_len, view_head_dim]).bfloat16().float()
+        xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+        kwargs = dict(batch_idx=u)
+        if block_size_kwarg is not None:
+            kwargs["block_size"] = block_size_kwarg
+        ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, **kwargs)
+
+        # Apply equivalent torch fill: distribute tokens 0..input_seq_len-1
+        # to the user's virtual blocks per the page table.
+        for t in range(input_seq_len):
+            vb = t // view_block_size
+            slot = t % view_block_size
+            physical_block = page_table[u, vb].item()
+            cache_ref_view[physical_block, 0:num_kv_heads, slot : slot + 1, :] = x[0, :, t : t + 1, :]
+
+    got_alloc = _read_paged_cache(cache_tt)
+    got_view = _permute_tile_grid(got_alloc, view_block_size, view_head_dim)
+
+    eq, msg = comp_equal(cache_ref_view, got_view)
+    assert eq, f"fill cache round trip mismatch: {msg}"
+
+
+def test_paged_fill_cache_legacy_no_override(device):
+    """Legacy path: matched views, no override. Backward-compat guard."""
+    torch.manual_seed(10)
+    _run_fill_cache_round_trip(
+        device,
+        num_kv_heads=1,
+        alloc_block_size=64,
+        alloc_head_dim=256,
+        view_block_size=64,
+        view_head_dim=256,
+        num_users=2,
+        input_seq_len=128,
+        block_size_kwarg=None,
+    )
+
+
+def test_paged_fill_cache_override_view_full_into_sliding_buffer(device):
+    """Cache allocated as sliding ``(128, 256)``, filled via override
+    with full ``(64, 512)``."""
+    torch.manual_seed(11)
+    _run_fill_cache_round_trip(
+        device,
+        num_kv_heads=1,
+        alloc_block_size=128,
+        alloc_head_dim=256,
+        view_block_size=64,
+        view_head_dim=512,
+        num_users=2,
+        input_seq_len=128,
+        block_size_kwarg=64,
+    )
+
+
+def test_paged_fill_cache_override_view_sliding_into_full_buffer(device):
+    """Symmetric: cache allocated as full ``(64, 512)``, filled via
+    override with sliding ``(128, 256)``."""
+    torch.manual_seed(12)
+    _run_fill_cache_round_trip(
+        device,
+        num_kv_heads=1,
+        alloc_block_size=64,
+        alloc_head_dim=512,
+        view_block_size=128,
+        view_head_dim=256,
+        num_users=2,
+        input_seq_len=128,
+        block_size_kwarg=128,
+    )
+
+
+def test_paged_fill_cache_negative_byte_count_mismatch(device):
+    """Same as ``paged_update_cache`` byte-count mismatch but for fill."""
+    torch.manual_seed(13)
+    num_users = 2
+    num_kv_heads = 1
+    alloc_block_size = 64
+    alloc_head_dim = 512
+    # 256 * 256 = 65536 elem/block, doubled from alloc's 32768.
+    view_block_size = 256
+    view_head_dim = 256
+    input_seq_len = 128
+    max_num_blocks = 4
+
+    cache_torch = torch.randn([max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim]).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, 2)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    x = torch.randn([1, num_kv_heads, input_seq_len, view_head_dim]).bfloat16().float()
+    xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    with pytest.raises(RuntimeError, match="geometry mismatch"):
+        ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, batch_idx=0, block_size=view_block_size)

--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -178,7 +178,8 @@ def test_paged_update_cache_legacy_no_override(block_size, head_dim, device):
     assert eq, f"legacy path diverged from reference: {msg}"
 
 
-def test_paged_update_cache_override_view_full_into_sliding_buffer(device):
+@pytest.mark.parametrize("num_kv_heads", [1, 8])
+def test_paged_update_cache_override_view_full_into_sliding_buffer(num_kv_heads, device):
     """Buffer allocated for sliding (block=128, head=256); call writes
     with the full-attention view (block=64, head=512) via the override.
 
@@ -190,18 +191,22 @@ def test_paged_update_cache_override_view_full_into_sliding_buffer(device):
     vLLM doubles sliding's block_size from 64 to 128 to match full's
     65,536-byte page; the shared DRAM buffer then needs to support both
     views.
+
+    Parametrized on ``num_kv_heads`` so the multi-head per-block stride
+    (``num_kv_heads * block_size * head_dim`` elements) gets exercised:
+    single-head values can't catch a regression where the wrong
+    dimension is used in the stride math.
     """
     torch.manual_seed(1)
 
     num_users = 4
-    num_kv_heads = 1
     # Allocation view: sliding shape.
     alloc_block_size = 128
     alloc_head_dim = 256
     # Call view: full shape.
     view_block_size = 64
     view_head_dim = 512
-    # Both views have 32768 elements/block, same per-block bytes.
+    # Both views have ``num_kv_heads * 32768`` elements/block, same per-block bytes.
     assert num_kv_heads * alloc_block_size * alloc_head_dim == num_kv_heads * view_block_size * view_head_dim
 
     # Max logical sequence length under the *view*; the page table indexes
@@ -253,9 +258,12 @@ def test_paged_update_cache_override_view_full_into_sliding_buffer(device):
     for u in range(num_users):
         pos = cache_idxs[u]
         physical_block = page_table[u, pos // view_block_size].item()
+        # ``x[0, u]`` is ``[KV, head_dim]``; target slot is ``[KV, 1, head_dim]``.
+        # ``unsqueeze(1)`` makes the kv-head dim broadcast-compatible with the
+        # 1-token slot — both single-head and multi-head land at the right slot.
         cache_ref_view[physical_block, 0:num_kv_heads, pos % view_block_size : pos % view_block_size + 1, :] = x[
-            :, u, :, :
-        ]
+            0, u
+        ].unsqueeze(1)
 
     eq, msg = comp_equal(cache_ref_view, got_view)
     assert eq, f"override view mismatch: {msg}"
@@ -551,13 +559,22 @@ def test_paged_fill_cache_legacy_no_override(device):
     )
 
 
-def test_paged_fill_cache_override_view_full_into_sliding_buffer(device):
+@pytest.mark.parametrize("num_kv_heads", [1, 8])
+def test_paged_fill_cache_override_view_full_into_sliding_buffer(num_kv_heads, device):
     """Cache allocated as sliding ``(128, 256)``, filled via override
-    with full ``(64, 512)``."""
+    with full ``(64, 512)``.
+
+    Parametrized on ``num_kv_heads`` so the kernel's per-block stride
+    (``num_kv_heads * block_size * head_dim``) is exercised on a
+    realistic multi-head case as well. ``paged_fill_cache``'s program
+    factory derives ``num_heads`` from ``input.padded_shape()[1]``, so
+    the multi-head case also catches regressions in the
+    ``input_num_heads == cache_num_heads`` validator.
+    """
     torch.manual_seed(11)
     _run_fill_cache_round_trip(
         device,
-        num_kv_heads=1,
+        num_kv_heads=num_kv_heads,
         alloc_block_size=128,
         alloc_head_dim=256,
         view_block_size=64,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -4,6 +4,8 @@
 
 #include "paged_fill_cache_device_operation.hpp"
 
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::tt_metal;
@@ -44,8 +46,56 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
     auto page_table_shape = page_table_tensor.padded_shape();
 
     TT_FATAL(args.batch_idx_fallback <= cache_shape[0], "Batch idx must fit in cache batch size");
+
+    // Per-block byte-count consistency check. ``paged_fill_cache``'s
+    // kernel addresses cache pages at a stride of
+    // ``cache_block_size * cache_num_kv_heads * cache_head_dim`` elements
+    // (1 per cache page). When the caller reinterprets the same buffer
+    // with a different ``(block_size, head_dim)`` view — see
+    // ``PagedFillCacheParams::block_size_override`` — that product must
+    // be preserved. Trivially holds when no override is set and head
+    // dims match.
+    const uint32_t cache_num_heads = cache_shape[1];
+    const uint32_t cache_block_size = cache_shape[2];
+    const uint32_t cache_head_dim = cache_shape[3];
+    const uint32_t input_head_dim = input_shape[3];
+    const uint32_t effective_block_size = args.block_size_override.value_or(cache_block_size);
+    const uint64_t cache_elems_per_block = static_cast<uint64_t>(cache_num_heads) * cache_block_size * cache_head_dim;
+    const uint64_t view_elems_per_block =
+        static_cast<uint64_t>(cache_num_heads) * effective_block_size * input_head_dim;
     TT_FATAL(
-        input_shape[2] <= cache_shape[2] * page_table_shape[1], "Input seq_len must fit in max_num_blocks_per_seq");
+        view_elems_per_block == cache_elems_per_block,
+        "paged_fill_cache geometry mismatch: cache holds {} elements per block "
+        "(num_kv_heads={}, block_size={}, head_dim={}) but the call's view is {} "
+        "elements per block (num_kv_heads={}, block_size={}, head_dim={}). The "
+        "kernel addresses cache pages at a stride of num_kv_heads * block_size "
+        "* head_dim, so this product must be preserved across views of the same "
+        "physical buffer.",
+        cache_elems_per_block,
+        cache_num_heads,
+        cache_block_size,
+        cache_head_dim,
+        view_elems_per_block,
+        cache_num_heads,
+        effective_block_size,
+        input_head_dim);
+    TT_FATAL(
+        input_head_dim % tt::constants::TILE_WIDTH == 0,
+        "input_tensor last dim ({}) must be a multiple of TILE_WIDTH ({})",
+        input_head_dim,
+        tt::constants::TILE_WIDTH);
+    TT_FATAL(
+        effective_block_size % tt::constants::TILE_HEIGHT == 0,
+        "effective block_size ({}) must be a multiple of TILE_HEIGHT ({})",
+        effective_block_size,
+        tt::constants::TILE_HEIGHT);
+
+    TT_FATAL(
+        input_shape[2] <= effective_block_size * page_table_shape[1],
+        "Input seq_len ({}) must fit in max_num_blocks_per_seq ({}) * block_size ({})",
+        input_shape[2],
+        page_table_shape[1],
+        effective_block_size);
 
     if (tensor_args.batch_idx_tensor_opt.has_value()) {
         const auto& tensor = tensor_args.batch_idx_tensor_opt.value();
@@ -74,8 +124,9 @@ ttsl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
 
     // Exclude batch_idx_fallback and noop from hash since they're runtime-only parameters (used only in runtime args)
     // Include mesh_coords since it affects program factory selection
+    // Include block_size_override since it enters compile-time args.
     return operation::hash_operation<PagedFillCacheDeviceOperation>(
-        args.mesh_coords, tensor_args, program_factory.index());
+        args.mesh_coords, args.block_size_override, tensor_args, program_factory.index());
 }
 
 }  // namespace ttnn::experimental::prim
@@ -88,12 +139,15 @@ Tensor paged_fill_cache(
     const Tensor& page_table,
     const std::optional<Tensor>& batch_idx_tensor,
     uint32_t batch_idx_fallback,
-    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords) {
+    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords,
+    std::optional<uint32_t> block_size_override) {
     using OperationType = ttnn::experimental::prim::PagedFillCacheDeviceOperation;
 
     auto operation_attributes = OperationType::operation_attributes_t{
         .batch_idx_fallback = batch_idx_fallback,
         .mesh_coords = mesh_coords,
+        .noop = false,
+        .block_size_override = block_size_override,
     };
     auto tensor_args = OperationType::tensor_args_t{
         .cache_tensor = cache_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -52,15 +52,32 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
         args.batch_idx_fallback < page_table_shape[0],
         "Batch idx must be within the page_table batch size");
 
+    // The program factory derives ``num_heads`` from
+    // ``input_tensor.padded_shape()[1]`` (CUDA-style: per-token write
+    // geometry comes from the input) and uses it as a compile-time arg
+    // for the kernel's per-block stride. If input and cache disagree
+    // on ``num_heads`` the kernel addresses would be wrong on either
+    // side: too-large strides walk off the end of the cache page,
+    // too-small ones skip tiles. The byte-count check below only
+    // guards against mismatched ``(block_size, head_dim)`` views;
+    // assert ``num_heads`` separately so the failure mode is explicit.
+    const uint32_t cache_num_heads = cache_shape[1];
+    const uint32_t input_num_heads = input_shape[1];
+    TT_FATAL(
+        input_num_heads == cache_num_heads,
+        "paged_fill_cache num_heads mismatch: input has {} heads but cache has {}. "
+        "The kernel uses input's num_heads as the per-block stride; they must agree.",
+        input_num_heads,
+        cache_num_heads);
+
     // Per-block byte-count consistency check. ``paged_fill_cache``'s
     // kernel addresses cache pages at a stride of
-    // ``cache_block_size * cache_num_kv_heads * cache_head_dim`` elements
+    // ``cache_block_size * num_heads * cache_head_dim`` elements
     // (1 per cache page). When the caller reinterprets the same buffer
     // with a different ``(block_size, head_dim)`` view — see
     // ``PagedFillCacheParams::block_size_override`` — that product must
     // be preserved. Trivially holds when no override is set and head
     // dims match.
-    const uint32_t cache_num_heads = cache_shape[1];
     const uint32_t cache_block_size = cache_shape[2];
     const uint32_t cache_head_dim = cache_shape[3];
     const uint32_t input_head_dim = input_shape[3];

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -45,39 +45,26 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
     auto input_shape = input_tensor.padded_shape();
     auto page_table_shape = page_table_tensor.padded_shape();
 
-    // The kernel uses the batch index to select a row from the page table,
-    // so validate against the page-table batch dimension, not the cache's
-    // block dimension.
+    // batch_idx indexes the page table, not the cache's block dimension.
     TT_FATAL(
         args.batch_idx_fallback < page_table_shape[0],
         "Batch idx must be within the page_table batch size");
 
-    // The program factory derives ``num_heads`` from
-    // ``input_tensor.padded_shape()[1]`` (CUDA-style: per-token write
-    // geometry comes from the input) and uses it as a compile-time arg
-    // for the kernel's per-block stride. If input and cache disagree
-    // on ``num_heads`` the kernel addresses would be wrong on either
-    // side: too-large strides walk off the end of the cache page,
-    // too-small ones skip tiles. The byte-count check below only
-    // guards against mismatched ``(block_size, head_dim)`` views;
-    // assert ``num_heads`` separately so the failure mode is explicit.
+    // The program factory reads num_heads from input.padded_shape[1] and bakes it into
+    // the kernel's per-block stride, so input and cache must agree on num_heads
+    // independently of the per-block byte-count check below.
     const uint32_t cache_num_heads = cache_shape[1];
     const uint32_t input_num_heads = input_shape[1];
     TT_FATAL(
         input_num_heads == cache_num_heads,
-        "paged_fill_cache num_heads mismatch: input has {} heads but cache has {}. "
-        "The kernel uses input's num_heads as the per-block stride; they must agree.",
+        "paged_fill_cache num_heads mismatch: input has {} heads but cache has {}.",
         input_num_heads,
         cache_num_heads);
 
-    // Per-block byte-count consistency check. ``paged_fill_cache``'s
-    // kernel addresses cache pages at a stride of
-    // ``cache_block_size * num_heads * cache_head_dim`` elements
-    // (1 per cache page). When the caller reinterprets the same buffer
-    // with a different ``(block_size, head_dim)`` view — see
-    // ``PagedFillCacheParams::block_size_override`` — that product must
-    // be preserved. Trivially holds when no override is set and head
-    // dims match.
+    // Per-block byte-count consistency. When the caller reinterprets the cache with a
+    // different (block_size, head_dim) view via block_size_override, the kernel's
+    // per-block element stride (num_kv_heads * block_size * head_dim) must be preserved.
+    // Trivially holds for legacy callers (no override, matching head dims).
     const uint32_t cache_block_size = cache_shape[2];
     const uint32_t cache_head_dim = cache_shape[3];
     const uint32_t input_head_dim = input_shape[3];
@@ -87,12 +74,9 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
         static_cast<uint64_t>(cache_num_heads) * effective_block_size * input_head_dim;
     TT_FATAL(
         view_elems_per_block == cache_elems_per_block,
-        "paged_fill_cache geometry mismatch: cache holds {} elements per block "
-        "(num_kv_heads={}, block_size={}, head_dim={}) but the call's view is {} "
-        "elements per block (num_kv_heads={}, block_size={}, head_dim={}). The "
-        "kernel addresses cache pages at a stride of num_kv_heads * block_size "
-        "* head_dim, so this product must be preserved across views of the same "
-        "physical buffer.",
+        "paged_fill_cache geometry mismatch: cache has {} elems/block "
+        "(kv_heads={}, block_size={}, head_dim={}) but call view is {} "
+        "(kv_heads={}, block_size={}, head_dim={}).",
         cache_elems_per_block,
         cache_num_heads,
         cache_block_size,
@@ -144,9 +128,9 @@ ttsl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(args, tensor_args);
 
-    // Exclude batch_idx_fallback and noop from hash since they're runtime-only parameters (used only in runtime args)
-    // Include mesh_coords since it affects program factory selection
-    // Include block_size_override since it enters compile-time args.
+    // Exclude batch_idx_fallback and noop (runtime-only).
+    // Include mesh_coords (affects program factory selection).
+    // Include block_size_override (enters compile-time args).
     return operation::hash_operation<PagedFillCacheDeviceOperation>(
         args.mesh_coords, args.block_size_override, tensor_args, program_factory.index());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -45,7 +45,12 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
     auto input_shape = input_tensor.padded_shape();
     auto page_table_shape = page_table_tensor.padded_shape();
 
-    TT_FATAL(args.batch_idx_fallback <= cache_shape[0], "Batch idx must fit in cache batch size");
+    // The kernel uses the batch index to select a row from the page table,
+    // so validate against the page-table batch dimension, not the cache's
+    // block dimension.
+    TT_FATAL(
+        args.batch_idx_fallback < page_table_shape[0],
+        "Batch idx must be within the page_table batch size");
 
     // Per-block byte-count consistency check. ``paged_fill_cache``'s
     // kernel addresses cache pages at a stride of

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
@@ -44,6 +44,7 @@ Tensor paged_fill_cache(
     const Tensor& page_table,
     const std::optional<Tensor>& batch_idx_tensor,
     uint32_t batch_idx_fallback,
-    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords = std::nullopt);
+    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords = std::nullopt,
+    std::optional<uint32_t> block_size_override = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
@@ -14,9 +14,7 @@ struct PagedFillCacheParams {
     const uint32_t batch_idx_fallback;
     const std::optional<std::set<ttnn::MeshCoordinate>> mesh_coords;
     const bool noop = false;  // When true, kernels early exit
-    // Optional override of the per-block token capacity. See
-    // ``PagedUpdateCacheParams::block_size_override`` for the full story;
-    // same rationale here for prefill fills under hybrid kv-cache-groups.
+    // Optional per-call block_size override; see PagedUpdateCacheParams::block_size_override.
     const std::optional<uint32_t> block_size_override = std::nullopt;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
@@ -14,6 +14,10 @@ struct PagedFillCacheParams {
     const uint32_t batch_idx_fallback;
     const std::optional<std::set<ttnn::MeshCoordinate>> mesh_coords;
     const bool noop = false;  // When true, kernels early exit
+    // Optional override of the per-block token capacity. See
+    // ``PagedUpdateCacheParams::block_size_override`` for the full story;
+    // same rationale here for prefill fills under hybrid kv-cache-groups.
+    const std::optional<uint32_t> block_size_override = std::nullopt;
 };
 
 struct PagedFillCacheInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -34,15 +34,11 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
     // input_tensor: [1, num_heads, input_seq_len, head_dim]
-    // cache_tensor: [max_num_blocks, num_heads_or_num_kv_heads, block_size, head_dim]
+    // cache_tensor: [max_num_blocks, num_kv_heads, block_size, head_dim]
     // page_table_tensor: [b, max_num_blocks_per_seq]
     //
-    // ``head_dim`` (and therefore ``Wt``) is read from the input —
-    // CUDA-style — so callers can write into a cache that was physically
-    // allocated with a different ``head_dim`` per their HMA tensor-sharing
-    // view, as long as the per-block byte count is preserved (enforced
-    // in validate_on_program_cache_miss). ``block_size`` honors the
-    // optional override for the same reason.
+    // head_dim comes from the input and block_size honors the override; the cache shape
+    // is only a byte budget (per-block byte count enforced in validate).
     const uint32_t num_heads = input_tensor.padded_shape()[1];
     const uint32_t input_seq_len = input_tensor.padded_shape()[2];
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -34,7 +34,7 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
     // input_tensor: [1, num_heads, input_seq_len, head_dim]
-    // cache_tensor: [max_num_blocks, 1, block_size, head_dim]
+    // cache_tensor: [max_num_blocks, num_heads_or_num_kv_heads, block_size, head_dim]
     // page_table_tensor: [b, max_num_blocks_per_seq]
     //
     // ``head_dim`` (and therefore ``Wt``) is read from the input —

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -36,11 +36,18 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     // input_tensor: [1, num_heads, input_seq_len, head_dim]
     // cache_tensor: [max_num_blocks, 1, block_size, head_dim]
     // page_table_tensor: [b, max_num_blocks_per_seq]
+    //
+    // ``head_dim`` (and therefore ``Wt``) is read from the input —
+    // CUDA-style — so callers can write into a cache that was physically
+    // allocated with a different ``head_dim`` per their HMA tensor-sharing
+    // view, as long as the per-block byte count is preserved (enforced
+    // in validate_on_program_cache_miss). ``block_size`` honors the
+    // optional override for the same reason.
     const uint32_t num_heads = input_tensor.padded_shape()[1];
     const uint32_t input_seq_len = input_tensor.padded_shape()[2];
 
-    const uint32_t block_size = cache_tensor.padded_shape()[2];
-    const uint32_t head_dim = cache_tensor.padded_shape()[3];
+    const uint32_t block_size = operation_attributes.block_size_override.value_or(cache_tensor.padded_shape()[2]);
+    const uint32_t head_dim = input_tensor.padded_shape()[3];
 
     const uint32_t input_seq_len_t = input_seq_len / TILE_HEIGHT;
     const uint32_t Wt = head_dim / TILE_WIDTH;
@@ -300,7 +307,8 @@ PagedFillCacheMeshWorkloadFactory::cached_mesh_workload_t PagedFillCacheMeshWork
                 PagedFillCacheParams dummy_attrs{
                     .batch_idx_fallback = operation_attributes.batch_idx_fallback,
                     .mesh_coords = operation_attributes.mesh_coords,
-                    .noop = true};
+                    .noop = true,
+                    .block_size_override = operation_attributes.block_size_override};
                 auto cached_program =
                     PagedFillCacheProgramFactory::create(dummy_attrs, tensor_args, tensor_return_value);
                 shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
@@ -348,7 +356,8 @@ void PagedFillCacheMeshWorkloadFactory::override_runtime_arguments(
         PagedFillCacheParams coord_attrs{
             .batch_idx_fallback = operation_attributes.batch_idx_fallback,
             .mesh_coords = operation_attributes.mesh_coords,
-            .noop = is_dummy};
+            .noop = is_dummy,
+            .block_size_override = operation_attributes.block_size_override};
 
         ttnn::device_operation::mesh_device_operation_utils::apply_override_runtime_arguments(
             program_factory, program, shared_variables, coord_attrs, coord, tensor_args, tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -52,36 +52,20 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
         cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Only interleaved cache is supported");
 
-    // ``block_size_override`` only makes sense in paged mode (it overrides
-    // the cache's block dimension, which exists only when the cache is
-    // organised into pages indexed by ``page_table``). Reject early —
-    // before the byte-count check below — so the user sees the actual
-    // misconfiguration rather than an unrelated geometry-mismatch error
-    // computed against the non-paged ``cache.shape[2]`` (which is the
-    // sequence length, not a block size).
+    // block_size_override is paged-mode only: in non-paged mode cache.shape[2] is the
+    // sequence length, and a "geometry mismatch" error there would be misleading.
     if (operation_attributes.block_size_override.has_value()) {
         TT_FATAL(
             page_table.has_value(),
             "block_size_override is only supported in paged mode (when page_table is provided)");
     }
 
-    // Per-block byte-count consistency. The kernel derives its write
-    // geometry from ``num_heads`` (cache.padded_shape[1]),
-    // ``input.padded_shape[-1]`` (per-token head_dim — CUDA-style: read
-    // from input, not cache) and ``block_size`` (``block_size_override``
-    // when provided, else cache.padded_shape[2]). For the kernel's
-    // ``block_start_id = physical_block_id * num_heads * block_size_t * Wt``
-    // arithmetic to address the right block boundary in DRAM, the
-    // product ``num_heads * block_size * head_dim`` (elements per block,
-    // pre-dtype) must equal what the cache was physically allocated for.
-    // When the override is not provided and head_dims match, this check
-    // is trivially satisfied — behavior is byte-identical to the
-    // pre-override path for legacy callers.
-    //
-    // Only checked in paged mode: non-paged callers never set the
-    // override and the legacy assertion (input.last_dim ==
-    // cache.last_dim) below still applies to keep their sharding /
-    // stride assumptions intact.
+    // Per-block byte-count consistency. When the caller reinterprets the cache with a
+    // different (block_size, head_dim) view via block_size_override, the kernel's
+    // per-block element stride (num_kv_heads * block_size * head_dim) must be preserved
+    // or block_start_id math will land in the wrong place. Trivially holds for legacy
+    // callers (no override, matching head dims). Non-paged callers keep the stricter
+    // legacy last-dim equality below (sharding/stride assumptions upstream).
     const uint32_t input_head_dim = input_tensor.padded_shape()[-1];
     if (page_table.has_value()) {
         const uint32_t cache_num_heads = cache_tensor.padded_shape()[1];
@@ -94,12 +78,9 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
             static_cast<uint64_t>(cache_num_heads) * effective_block_size * input_head_dim;
         TT_FATAL(
             view_elems_per_block == cache_elems_per_block,
-            "paged_update_cache geometry mismatch: cache holds {} elements per block "
-            "(num_kv_heads={}, block_size={}, head_dim={}) but the call's view is {} "
-            "elements per block (num_kv_heads={}, block_size={}, head_dim={}). The "
-            "kernel addresses cache blocks at a stride of num_kv_heads * block_size "
-            "* head_dim, so this product must be preserved across views of the same "
-            "physical buffer.",
+            "paged_update_cache geometry mismatch: cache has {} elems/block "
+            "(kv_heads={}, block_size={}, head_dim={}) but call view is {} "
+            "(kv_heads={}, block_size={}, head_dim={}).",
             cache_elems_per_block,
             cache_num_heads,
             cache_block_size,
@@ -114,18 +95,14 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
             effective_block_size,
             tt::constants::TILE_HEIGHT);
     } else {
-        // Non-paged path: keep the legacy invariant that input and cache
-        // share the same last dim (sharding / stride assumption upstream
-        // of the program factory).
         TT_FATAL(
             input_head_dim == cache_tensor.padded_shape()[-1],
             "Last dim of input tensor ({}) must match last dim of cache tensor ({}) in non-paged mode",
             input_head_dim,
             cache_tensor.padded_shape()[-1]);
     }
-    // Sharded inputs assume the kernel's compile-time Wt matches the
-    // shard width. Wt is now derived from ``input.padded_shape[-1]``, so
-    // input must be tile-aligned on the last dim regardless of cache shape.
+    // Wt is derived from input.padded_shape[-1], so the last dim must be tile-aligned
+    // regardless of cache shape.
     TT_FATAL(
         input_head_dim % tt::constants::TILE_WIDTH == 0,
         "input_tensor last dim ({}) must be a multiple of TILE_WIDTH ({})",
@@ -291,9 +268,7 @@ ttsl::hash::hash_t PagedUpdateCacheDeviceOperation::compute_program_hash(
     // - compute_kernel_config: affects compile-time args (fp32_dest_acc_en)
     // - share_cache: affects program structure (semaphore setup)
     // - mesh_coords: affects program factory selection
-    // - block_size_override: enters compile-time args as block_size /
-    //   block_size_t; two calls with different overrides must compile
-    //   to different programs even on the same cache + input shapes.
+    // - block_size_override: enters compile-time args
     return operation::hash_operation<PagedUpdateCacheDeviceOperation>(
         args.compute_kernel_config,
         args.share_cache,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "paged_update_cache_device_operation_types.hpp"
 #include "paged_update_cache_program_factory.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/constants.hpp>
 
 using namespace tt::tt_metal;
 
@@ -50,9 +51,86 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Only interleaved cache is supported");
+
+    // ``block_size_override`` only makes sense in paged mode (it overrides
+    // the cache's block dimension, which exists only when the cache is
+    // organised into pages indexed by ``page_table``). Reject early —
+    // before the byte-count check below — so the user sees the actual
+    // misconfiguration rather than an unrelated geometry-mismatch error
+    // computed against the non-paged ``cache.shape[2]`` (which is the
+    // sequence length, not a block size).
+    if (operation_attributes.block_size_override.has_value()) {
+        TT_FATAL(
+            page_table.has_value(),
+            "block_size_override is only supported in paged mode (when page_table is provided)");
+    }
+
+    // Per-block byte-count consistency. The kernel derives its write
+    // geometry from ``num_heads`` (cache.padded_shape[1]),
+    // ``input.padded_shape[-1]`` (per-token head_dim — CUDA-style: read
+    // from input, not cache) and ``block_size`` (``block_size_override``
+    // when provided, else cache.padded_shape[2]). For the kernel's
+    // ``block_start_id = physical_block_id * num_heads * block_size_t * Wt``
+    // arithmetic to address the right block boundary in DRAM, the
+    // product ``num_heads * block_size * head_dim`` (elements per block,
+    // pre-dtype) must equal what the cache was physically allocated for.
+    // When the override is not provided and head_dims match, this check
+    // is trivially satisfied — behavior is byte-identical to the
+    // pre-override path for legacy callers.
+    //
+    // Only checked in paged mode: non-paged callers never set the
+    // override and the legacy assertion (input.last_dim ==
+    // cache.last_dim) below still applies to keep their sharding /
+    // stride assumptions intact.
+    const uint32_t input_head_dim = input_tensor.padded_shape()[-1];
+    if (page_table.has_value()) {
+        const uint32_t cache_num_heads = cache_tensor.padded_shape()[1];
+        const uint32_t cache_block_size = cache_tensor.padded_shape()[2];
+        const uint32_t cache_head_dim = cache_tensor.padded_shape()[-1];
+        const uint32_t effective_block_size = operation_attributes.block_size_override.value_or(cache_block_size);
+        const uint64_t cache_elems_per_block =
+            static_cast<uint64_t>(cache_num_heads) * cache_block_size * cache_head_dim;
+        const uint64_t view_elems_per_block =
+            static_cast<uint64_t>(cache_num_heads) * effective_block_size * input_head_dim;
+        TT_FATAL(
+            view_elems_per_block == cache_elems_per_block,
+            "paged_update_cache geometry mismatch: cache holds {} elements per block "
+            "(num_kv_heads={}, block_size={}, head_dim={}) but the call's view is {} "
+            "elements per block (num_kv_heads={}, block_size={}, head_dim={}). The "
+            "kernel addresses cache blocks at a stride of num_kv_heads * block_size "
+            "* head_dim, so this product must be preserved across views of the same "
+            "physical buffer.",
+            cache_elems_per_block,
+            cache_num_heads,
+            cache_block_size,
+            cache_head_dim,
+            view_elems_per_block,
+            cache_num_heads,
+            effective_block_size,
+            input_head_dim);
+        TT_FATAL(
+            effective_block_size % tt::constants::TILE_HEIGHT == 0,
+            "effective block_size ({}) must be a multiple of TILE_HEIGHT ({})",
+            effective_block_size,
+            tt::constants::TILE_HEIGHT);
+    } else {
+        // Non-paged path: keep the legacy invariant that input and cache
+        // share the same last dim (sharding / stride assumption upstream
+        // of the program factory).
+        TT_FATAL(
+            input_head_dim == cache_tensor.padded_shape()[-1],
+            "Last dim of input tensor ({}) must match last dim of cache tensor ({}) in non-paged mode",
+            input_head_dim,
+            cache_tensor.padded_shape()[-1]);
+    }
+    // Sharded inputs assume the kernel's compile-time Wt matches the
+    // shard width. Wt is now derived from ``input.padded_shape[-1]``, so
+    // input must be tile-aligned on the last dim regardless of cache shape.
     TT_FATAL(
-        input_tensor.padded_shape()[-1] == cache_tensor.padded_shape()[-1],
-        "Last dim of input tensor must match last dim of cache tensor");
+        input_head_dim % tt::constants::TILE_WIDTH == 0,
+        "input_tensor last dim ({}) must be a multiple of TILE_WIDTH ({})",
+        input_head_dim,
+        tt::constants::TILE_WIDTH);
 
     // Paged cache validation
     const bool paged_cache = page_table.has_value();
@@ -213,8 +291,16 @@ ttsl::hash::hash_t PagedUpdateCacheDeviceOperation::compute_program_hash(
     // - compute_kernel_config: affects compile-time args (fp32_dest_acc_en)
     // - share_cache: affects program structure (semaphore setup)
     // - mesh_coords: affects program factory selection
+    // - block_size_override: enters compile-time args as block_size /
+    //   block_size_t; two calls with different overrides must compile
+    //   to different programs even on the same cache + input shapes.
     return operation::hash_operation<PagedUpdateCacheDeviceOperation>(
-        args.compute_kernel_config, args.share_cache, args.mesh_coords, tensor_args, program_factory.index());
+        args.compute_kernel_config,
+        args.share_cache,
+        args.mesh_coords,
+        args.block_size_override,
+        tensor_args,
+        program_factory.index());
 }
 
 }  // namespace ttnn::experimental::prim
@@ -230,7 +316,8 @@ ttnn::experimental::prim::PagedUpdateCacheDeviceOperation::tensor_return_value_t
     const std::optional<const Tensor>& page_table,
     uint32_t batch_offset,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords) {
+    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
+    std::optional<uint32_t> block_size_override) {
     using OperationType = ttnn::experimental::prim::PagedUpdateCacheDeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
@@ -241,7 +328,8 @@ ttnn::experimental::prim::PagedUpdateCacheDeviceOperation::tensor_return_value_t
         .batch_offset = batch_offset,
         .compute_kernel_config = kernel_config_val,
         .share_cache = share_cache_arg,
-        .mesh_coords = mesh_coords};
+        .mesh_coords = mesh_coords,
+        .block_size_override = block_size_override};
 
     auto tensor_args = OperationType::tensor_args_t{
         .cache_tensor = cache_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
@@ -49,6 +49,7 @@ ttnn::experimental::prim::PagedUpdateCacheDeviceOperation::tensor_return_value_t
     const std::optional<const Tensor>& page_table,
     uint32_t batch_offset,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords);
+    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
+    std::optional<uint32_t> block_size_override = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
@@ -20,16 +20,10 @@ struct PagedUpdateCacheParams {
     const ttnn::DeviceComputeKernelConfig compute_kernel_config;
     const bool share_cache;
     const std::optional<std::set<ttnn::MeshCoordinate>> mesh_coords;
-    // Optional override of the per-block token capacity. When unset, the
-    // kernel derives ``block_size`` from ``cache_tensor.padded_shape()[2]``
-    // (the legacy CUDA-style "block_size from cache" path). When set,
-    // every call may interpret the same physical buffer as having a
-    // different ``(block_size, head_dim)`` tile arrangement, as long as
-    // the total bytes per cache block are preserved — this is what
-    // upstream vLLM's hybrid kv-cache-groups manager assumes after its
-    // page-size unifier doubles smaller-page-size groups' ``block_size``
-    // to equalise per-block memory. See validate_on_program_cache_miss
-    // for the byte-count consistency check.
+    // Optional per-call block_size, overriding cache.padded_shape[2]. Lets a single
+    // physical buffer be addressed with different (block_size, head_dim) views as long
+    // as num_kv_heads * block_size * head_dim is preserved (checked in
+    // validate_on_program_cache_miss). Used by vLLM's hybrid kv-cache-groups path.
     const std::optional<uint32_t> block_size_override;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
@@ -20,6 +20,17 @@ struct PagedUpdateCacheParams {
     const ttnn::DeviceComputeKernelConfig compute_kernel_config;
     const bool share_cache;
     const std::optional<std::set<ttnn::MeshCoordinate>> mesh_coords;
+    // Optional override of the per-block token capacity. When unset, the
+    // kernel derives ``block_size`` from ``cache_tensor.padded_shape()[2]``
+    // (the legacy CUDA-style "block_size from cache" path). When set,
+    // every call may interpret the same physical buffer as having a
+    // different ``(block_size, head_dim)`` tile arrangement, as long as
+    // the total bytes per cache block are preserved — this is what
+    // upstream vLLM's hybrid kv-cache-groups manager assumes after its
+    // page-size unifier doubles smaller-page-size groups' ``block_size``
+    // to equalise per-block memory. See validate_on_program_cache_miss
+    // for the byte-count consistency check.
+    const std::optional<uint32_t> block_size_override;
 };
 
 struct PagedUpdateCacheInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -65,7 +65,16 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
         index_stick_size = update_idxs_tensor.value().buffer()->aligned_page_size();
     }
 
-    // Pagetable-specific parameters
+    // Pagetable-specific parameters.
+    //
+    // ``block_size`` selects how many tile-rows live in one cache block.
+    // In the legacy path we always read it from ``cache_tensor.padded_shape()[2]``;
+    // when ``block_size_override`` is set, the caller is reinterpreting
+    // the same physical buffer with a different ``(block_size, head_dim)``
+    // tile arrangement, so we use the override instead. Validation in
+    // ``validate_on_program_cache_miss`` already ensured the per-block
+    // byte count is preserved across views, so ``block_start_id`` math
+    // still addresses the right block boundary.
     bool is_paged_cache = page_table.has_value();
     uint32_t block_size = 0;
     uint32_t block_size_t = 0;
@@ -76,7 +85,7 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
     if (is_paged_cache) {
         const auto& page_table_tensor = page_table.value();
 
-        block_size = cache_tensor.padded_shape()[2];
+        block_size = operation_attributes.block_size_override.value_or(cache_tensor.padded_shape()[2]);
         block_size_t = block_size / TILE_HEIGHT;
         max_blocks_per_seq = page_table_tensor.padded_shape()[1];
         page_table_stick_size = page_table_tensor.padded_shape()[-1] * page_table_tensor.element_size();
@@ -84,10 +93,18 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.dtype());
     }
 
-    uint32_t Wt = cache_tensor.padded_shape()[-1] / TILE_WIDTH;
-    uint32_t St = cache_tensor.padded_shape()[-2] / TILE_HEIGHT;
-    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor.padded_shape()[-1] * sizeof(float)
-                                       : cache_tensor.padded_shape()[-1] * 2;  // 2 bytes for bfloat16
+    // CUDA-style: per-call write geometry (``head_dim`` and therefore
+    // ``Wt`` / ``Wbytes``) comes from the input tensor — the cache shape
+    // is just a byte-budget hint. The kernel still uses ``num_heads``
+    // from the cache because ``num_heads`` is per-block (a property of
+    // how the cache is laid out), not per-token. ``St`` is the cache's
+    // block-size in tiles — for paged mode it equals ``block_size_t``
+    // (overridden), for non-paged it's the cache's sequence length in
+    // tiles (no override).
+    uint32_t Wt = input_tensor.padded_shape()[-1] / TILE_WIDTH;
+    uint32_t St = is_paged_cache ? block_size_t : cache_tensor.padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t Wbytes = fp32_dest_acc_en ? input_tensor.padded_shape()[-1] * sizeof(float)
+                                       : input_tensor.padded_shape()[-1] * 2;  // 2 bytes for bfloat16
     uint32_t cache_total_num_tiles = cache_tensor.physical_volume() / TILE_HW;
     uint32_t cache_batch_num_tiles =
         operation_attributes.share_cache

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -66,15 +66,6 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
     }
 
     // Pagetable-specific parameters.
-    //
-    // ``block_size`` selects how many tile-rows live in one cache block.
-    // In the legacy path we always read it from ``cache_tensor.padded_shape()[2]``;
-    // when ``block_size_override`` is set, the caller is reinterpreting
-    // the same physical buffer with a different ``(block_size, head_dim)``
-    // tile arrangement, so we use the override instead. Validation in
-    // ``validate_on_program_cache_miss`` already ensured the per-block
-    // byte count is preserved across views, so ``block_start_id`` math
-    // still addresses the right block boundary.
     bool is_paged_cache = page_table.has_value();
     uint32_t block_size = 0;
     uint32_t block_size_t = 0;
@@ -93,14 +84,9 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.dtype());
     }
 
-    // CUDA-style: per-call write geometry (``head_dim`` and therefore
-    // ``Wt`` / ``Wbytes``) comes from the input tensor — the cache shape
-    // is just a byte-budget hint. The kernel still uses ``num_heads``
-    // from the cache because ``num_heads`` is per-block (a property of
-    // how the cache is laid out), not per-token. ``St`` is the cache's
-    // block-size in tiles — for paged mode it equals ``block_size_t``
-    // (overridden), for non-paged it's the cache's sequence length in
-    // tiles (no override).
+    // Per-call write geometry (head_dim, Wt, Wbytes) comes from the input tensor; the
+    // cache shape is only a byte budget. num_heads is per-block, so it still comes from
+    // the cache. St is block_size_t in paged mode, cache seq-len-in-tiles otherwise.
     uint32_t Wt = input_tensor.padded_shape()[-1] / TILE_WIDTH;
     uint32_t St = is_paged_cache ? block_size_t : cache_tensor.padded_shape()[-2] / TILE_HEIGHT;
     uint32_t Wbytes = fp32_dest_acc_en ? input_tensor.padded_shape()[-1] * sizeof(float)

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
@@ -21,7 +21,8 @@ ttnn::Tensor paged_update_cache(
     const std::optional<const Tensor>& page_table,
     uint32_t batch_offset,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords) {
+    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
+    std::optional<uint32_t> block_size_override) {
     return ttnn::prim::paged_update_cache(
         cache_tensor,
         input_tensor,
@@ -31,7 +32,8 @@ ttnn::Tensor paged_update_cache(
         page_table,
         batch_offset,
         compute_kernel_config,
-        mesh_coords);
+        mesh_coords,
+        block_size_override);
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> paged_fused_update_cache(
@@ -67,12 +69,13 @@ ttnn::Tensor paged_fill_cache(
     const std::optional<const Tensor>& batch_idx_tensor,
     uint32_t batch_idx,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords) {
+    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
+    std::optional<uint32_t> block_size_override) {
     // Note: compute_kernel_config is not used by fill_cache operation
     (void)compute_kernel_config;
 
     return ttnn::prim::paged_fill_cache(
-        cache_tensor, input_tensor, page_table, batch_idx_tensor, batch_idx, mesh_coords);
+        cache_tensor, input_tensor, page_table, batch_idx_tensor, batch_idx, mesh_coords, block_size_override);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
@@ -18,7 +18,8 @@ ttnn::Tensor paged_update_cache(
     const std::optional<const Tensor>& page_table,
     uint32_t batch_offset,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords);
+    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
+    std::optional<uint32_t> block_size_override = std::nullopt);
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> paged_fused_update_cache(
     const Tensor& cache_tensor1,
@@ -40,6 +41,7 @@ ttnn::Tensor paged_fill_cache(
     const std::optional<const Tensor>& batch_idx_tensor,
     uint32_t batch_idx,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords);
+    const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
+    std::optional<uint32_t> block_size_override = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -52,7 +52,7 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         nb::arg("batch_offset") = 0,
         nb::arg("compute_kernel_config").noconvert() = nb::none(),
         nb::arg("mesh_coords").noconvert() = nb::none(),
-        nb::arg("block_size").noconvert() = nb::none());
+        nb::arg("block_size") = nb::none());
 
     const auto* paged_fused_update_cache_doc =
         R"doc(

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -24,6 +24,18 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
     const auto* paged_update_cache_doc =
         R"doc(
          Paged update cache operation. This operation expects the following inputs: cache_tensor of shape [B, 1, kv_len, head_dim] and input_tensor of shape [1, B, 1[32], head_dim] where input_tensor is height sharded on B cores. update_idxs will specify for each batch element which token to update in the cache.
+
+         The per-token write geometry (``head_dim``) is taken from
+         ``input_tensor.padded_shape[-1]``. The cache's block dimension
+         comes from ``cache_tensor.padded_shape[2]`` by default; pass
+         ``block_size`` to override it for callers (e.g. vLLM's hybrid
+         kv-cache-groups path) that reinterpret one physical cache buffer
+         as having a different ``(block_size, head_dim)`` tile arrangement
+         per layer type. The total bytes per cache block must be
+         preserved: ``num_kv_heads * block_size * head_dim`` (taking
+         num_kv_heads from cache.padded_shape[1], block_size from the
+         override or cache.padded_shape[2], head_dim from input) must
+         equal the cache's physical per-block element count.
         )doc";
 
     ttnn::bind_function<"paged_update_cache", "ttnn.experimental.">(
@@ -39,7 +51,8 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         nb::arg("page_table").noconvert() = nb::none(),
         nb::arg("batch_offset") = 0,
         nb::arg("compute_kernel_config").noconvert() = nb::none(),
-        nb::arg("mesh_coords").noconvert() = nb::none());
+        nb::arg("mesh_coords").noconvert() = nb::none(),
+        nb::arg("block_size").noconvert() = nb::none());
 
     const auto* paged_fused_update_cache_doc =
         R"doc(
@@ -91,6 +104,15 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         batch_idx_tensor (optional) shape: [1] (scalar uint32 tensor)
         batch_idx (scalar, defaults to 0) is used if batch_idx_tensor is not provided.
         mesh_coords (optional) is a set of MeshCoordinate objects that specify the mesh coordinates to execute on.
+
+        The per-token write geometry (``head_dim``) is taken from
+        ``input_tensor.padded_shape[-1]``. The cache's block dimension
+        comes from ``cache_tensor.padded_shape[2]`` by default; pass
+        ``block_size`` to override it for callers that reinterpret one
+        physical cache buffer as having a different
+        ``(block_size, head_dim)`` tile arrangement (see the equivalent
+        kwarg on ``paged_update_cache``). Per-block byte count must be
+        preserved across views.
         )doc";
 
     ttnn::bind_function<"paged_fill_cache", "ttnn.experimental.">(
@@ -104,7 +126,8 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         nb::arg("batch_idx_tensor").noconvert() = nb::none(),
         nb::arg("batch_idx") = 0,
         nb::arg("compute_kernel_config").noconvert() = nb::none(),
-        nb::arg("mesh_coords").noconvert() = nb::none());
+        nb::arg("mesh_coords").noconvert() = nb::none(),
+        nb::arg("block_size").noconvert() = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::paged_cache::detail

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -25,17 +25,11 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         R"doc(
          Paged update cache operation. This operation expects the following inputs: cache_tensor of shape [B, 1, kv_len, head_dim] and input_tensor of shape [1, B, 1[32], head_dim] where input_tensor is height sharded on B cores. update_idxs will specify for each batch element which token to update in the cache.
 
-         The per-token write geometry (``head_dim``) is taken from
-         ``input_tensor.padded_shape[-1]``. The cache's block dimension
-         comes from ``cache_tensor.padded_shape[2]`` by default; pass
-         ``block_size`` to override it for callers (e.g. vLLM's hybrid
-         kv-cache-groups path) that reinterpret one physical cache buffer
-         as having a different ``(block_size, head_dim)`` tile arrangement
-         per layer type. The total bytes per cache block must be
-         preserved: ``num_kv_heads * block_size * head_dim`` (taking
-         num_kv_heads from cache.padded_shape[1], block_size from the
-         override or cache.padded_shape[2], head_dim from input) must
-         equal the cache's physical per-block element count.
+         ``head_dim`` is read from ``input_tensor.padded_shape[-1]``. ``block_size``
+         defaults to ``cache_tensor.padded_shape[2]``; pass the kwarg to override it for
+         callers that reinterpret one physical buffer with different
+         ``(block_size, head_dim)`` tile layouts (e.g. vLLM's hybrid kv-cache-groups
+         path). ``num_kv_heads * block_size * head_dim`` must be preserved across views.
         )doc";
 
     ttnn::bind_function<"paged_update_cache", "ttnn.experimental.">(
@@ -105,14 +99,9 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         batch_idx (scalar, defaults to 0) is used if batch_idx_tensor is not provided.
         mesh_coords (optional) is a set of MeshCoordinate objects that specify the mesh coordinates to execute on.
 
-        The per-token write geometry (``head_dim``) is taken from
-        ``input_tensor.padded_shape[-1]``. The cache's block dimension
-        comes from ``cache_tensor.padded_shape[2]`` by default; pass
-        ``block_size`` to override it for callers that reinterpret one
-        physical cache buffer as having a different
-        ``(block_size, head_dim)`` tile arrangement (see the equivalent
-        kwarg on ``paged_update_cache``). Per-block byte count must be
-        preserved across views.
+        ``head_dim`` is read from ``input_tensor.padded_shape[-1]``. ``block_size``
+        defaults to ``cache_tensor.padded_shape[2]``; pass the kwarg to override it (see
+        ``paged_update_cache`` for details). Per-block byte count must be preserved.
         )doc";
 
     ttnn::bind_function<"paged_fill_cache", "ttnn.experimental.">(
@@ -127,7 +116,7 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         nb::arg("batch_idx") = 0,
         nb::arg("compute_kernel_config").noconvert() = nb::none(),
         nb::arg("mesh_coords").noconvert() = nb::none(),
-        nb::arg("block_size").noconvert() = nb::none());
+        nb::arg("block_size") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::paged_cache::detail


### PR DESCRIPTION
## Summary

Adds an optional `block_size` kwarg to `ttnn.experimental.paged_update_cache` and `ttnn.experimental.paged_fill_cache` so callers can write into a single physical cache buffer using different `(block_size, head_dim)` views per layer — as long as `num_kv_heads * block_size * head_dim` (per-block element count) is preserved across views.

## Why

vLLM's hybrid kv-cache-groups manager unifies *page sizes* across attention groups by adjusting `block_size` per group. For models like Gemma4 with per-spec `head_dim` (sliding=256 vs full=512), one DRAM buffer ends up shared by layers that want to interpret its bytes through different `(block_size, head_dim)` shapes. Without the override, the kernel derived everything from the cache shape, so the second layer's writes mismatched the cache's declared last-dim and hit:

> `TT_FATAL: Last dim of input tensor must match last dim of cache tensor`

This was the blocking issue when wiring Gemma4 into vLLM's hybrid kv-cache-groups path.

## Design (CUDA-style minimal API)

The change mirrors how vLLM's CUDA `triton_reshape_and_cache_flash` works — the kernel reads per-token geometry from the *input* tensor rather than the cache's declared shape. Specifically, in the program factories:

- `head_dim` (`Wt`, `Wbytes`) now comes from `input.padded_shape[-1]` (was `cache.padded_shape[-1]`) for **both** ops.
- `block_size` comes from the new `block_size` kwarg if set, else `cache.padded_shape[2]` — for **both** ops.
- `num_heads` derivation differs between the two ops (preserved from each op's pre-change behaviour to keep legacy callers byte-identical):
  - `paged_update_cache` continues to read `num_heads` from `cache.padded_shape[1]`.
  - `paged_fill_cache` continues to read `num_heads` from `input.padded_shape[1]`.
  - The per-block element-count invariant requires `input.padded_shape[1] == cache.padded_shape[1]` in either case. `paged_update_cache` enforces this via the existing equality checks in `validate_on_program_cache_miss`; `paged_fill_cache` now asserts it explicitly (see Copilot review fix below).

Validation replaces the strict `input.last_dim == cache.last_dim` equality (paged path) with a per-block-byte-count consistency check. Trivially holds when no override is set and head dims match, so **legacy callers are unaffected**. Non-paged callers keep the original equality assertion.

**Compute and reader/writer kernels are unchanged** — they already consumed `Wt` / `block_size_t` / `num_heads` as compile-time args; only the program factory's source of those values changed.

## Public API

One new optional kwarg on each op:

```
python
ttnn.experimental.paged_update_cache(
    cache, input,
    update_idxs_tensor=..., page_table=...,
    block_size=None,   # NEW: optional, defaults to cache.padded_shape[2]
)

ttnn.experimental.paged_fill_cache(
    cache, input, page_table,
    batch_idx=0,
    block_size=None,   # NEW: optional, defaults to cache.padded_shape[2]
)
```

## Files touched

C++ op (11 files, ~80 lines of plumbing + comments):

```
ttnn/cpp/ttnn/operations/experimental/paged_cache/
├── paged_cache.{hpp,cpp}                                       public API
├── paged_cache_nanobind.cpp                                    Python kwarg
├── device/update_cache/
│   ├── paged_update_cache_device_operation_types.hpp           attr field
│   ├── paged_update_cache_device_operation.{hpp,cpp}           prim signature, validation
│   └── paged_update_cache_program_factory.cpp                  read from input
└── device/fill_cache/                                          same pattern
    ├── paged_fill_cache_device_operation_types.hpp
    ├── paged_fill_cache_device_operation.{hpp,cpp}
    └── paged_fill_cache_program_factory.cpp
```

New test file: `tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py` (14 tests).

## Copilot review follow-ups

Addressed in commit `13ca350fb6a`:

1. **`paged_fill_cache` `num_heads` validator.** The program factory derives `num_heads` from `input.padded_shape[1]` and uses it as a compile-time arg for the per-block stride. Pre-change validation only enforced the per-block-byte invariant — never that `input.padded_shape[1] == cache.padded_shape[1]`. If they differ the kernel addresses are wrong on either side (too-large strides walk off the page, too-small ones skip tiles). Added an explicit `TT_FATAL` so the failure mode is named.
2. **Multi-head test coverage.** The override-path tests hard-coded `num_kv_heads=1`, so the multi-head per-block stride (`num_kv_heads * block_size * head_dim` elements) wasn't exercised. Parametrized `test_paged_update_cache_override_view_full_into_sliding_buffer` and `test_paged_fill_cache_override_view_full_into_sliding_buffer` on `num_kv_heads in [1, 8]`; the multi-head case also catches the new validator above.

Addressed earlier via Copilot Autofix (commit `2d8d8d9ee36`):

3. **`batch_idx_fallback` bound.** Fix-up to `paged_fill_cache_device_operation.cpp`: the validator now compares `args.batch_idx_fallback < page_table_shape[0]` rather than `<= cache_shape[0]`, since the kernel uses the batch index to select a row from the page table.

## Test plan

- [x] All 14 new tests in `test_paged_cache_flexible_geometry.py` pass on Wormhole (12 original + 2 added from `num_kv_heads` parametrization).
  - Legacy-no-override (×3 shape combos) for `paged_update_cache`
  - `paged_update_cache` override flipping full into sliding-shape buffer (×2 `num_kv_heads ∈ {1, 8}`)
  - `paged_update_cache` override flipping sliding into full-shape buffer
  - `paged_update_cache` shared-buffer with both views writing disjoint blocks
  - `paged_update_cache` negative: byte-count mismatch → raises
  - `paged_update_cache` negative: override without page_table → raises
  - `paged_fill_cache` legacy-no-override
  - `paged_fill_cache` override flipping full into sliding-shape buffer (×2 `num_kv_heads ∈ {1, 8}`)
  - `paged_fill_cache` override flipping sliding into full-shape buffer
  - `paged_fill_cache` negative: byte-count mismatch → raises
- [x] Regression: 72 existing `test_paged_update_cache_decode` cases pass
- [x] Regression: 17 existing non-paged `test_update_cache_decode` cases pass
- [x] Regression: 16 existing `test_paged_fill_cache_program_cache` cases pass

## Notable subtlety (in the test, not the op)

ttnn's TILE layout is *tile-grid-shape-specific*: the byte arrangement of a cache that was tilized as `(128, 256)` differs from the same total-byte cache tilized as `(64, 512)`. The kernel still writes the right DRAM bytes for each view — but to *verify* the round trip when alloc shape differs from the call's view, the test reference applies a tile-grid-aware permutation (`_permute_tile_grid`) instead of a plain `torch.view`. See the helper's docstring.

The op contract remains clean: a layer that writes and later reads with the *same* view sees consistent data; layers in a shared buffer with disjoint block IDs don't interfere with each other.

## Follow-on work (not in this PR)

Gemma4's vLLM bridge (separate branch) needs to pass `block_size=` at each `paged_update_cache` / `paged_fill_cache` call in its attention layers, and revert the no-share allocator workaround (which OOM'd due to lost HMA sharing). Same recipe applies to any other hybrid-attention model with per-spec `head_dim` heterogeneity.

### Manually-dispatched verification runs

Triggered to exercise the new tests directly on this branch:

- [Sanity tests nightly debug run (#25805489315)](https://github.com/tenstorrent/tt-metal/actions/runs/25805489315) — calls `sanity-tests.yaml` and `blackhole-post-commit.yaml`, each of which calls `ttnn-post-commit.yaml`. _(Exercises the 14 new tests in `tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py` via the "ttnn misc ops group" matrix entry on both Wormhole and Blackhole.)_
- [Nightly tt-metal L2 tests (#25805491495)](https://github.com/tenstorrent/tt-metal/actions/runs/25805491495) — `additional_test_categories=sdpa,transformers,misc`. _(Regression coverage: existing paged-cache test suites — `test_paged_update_cache_decode`, `test_update_cache_decode`, `test_paged_fill_cache_program_cache` — in `tests/ttnn/nightly/unit_tests/operations/transformers/` to confirm the new optional `block_size` kwarg does not break legacy callers.)_

Earlier runs against the pre-review commit (kept for reference): [sanity-tests-debug #25799061672](https://github.com/tenstorrent/tt-metal/actions/runs/25799061672), [L2 nightly #25799086365](https://github.com/tenstorrent/tt-metal/actions/runs/25799086365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/paged-cache-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/paged-cache-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/paged-cache-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/paged-cache-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/paged-cache-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/paged-cache-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/paged-cache-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/paged-cache-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/paged-cache-flexible-geometry)
