### PR TITLE
[Bug fix] rotary_embedding validation to use logical seq dim 

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
@@ -362,3 +362,48 @@ def test_rotary_embedding_row_major(W, Z, Y, X, cache_size, device):
     p, o = comp_pcc(pt_out, tt_got_back)
     logger.info(o)
     assert p
+
+
+# Regression for issue #43910.
+@pytest.mark.parametrize(
+    "input_seq, head_dim",
+    [
+        (32, 32),
+        (32, 64),
+        (128, 32),
+        (128, 64),
+    ],
+)
+def test_rotary_embedding_rejects_cos_seq_smaller_than_input_seq(input_seq, head_dim, device):
+    torch.manual_seed(0)
+    batch, n_heads = 1, 32
+    x = torch.randn([batch, n_heads, input_seq, head_dim]).bfloat16().float()
+    cos = torch.randn([1, 1, 1, head_dim]).bfloat16().float()
+    sin = torch.randn([1, 1, 1, head_dim]).bfloat16().float()
+
+    xt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    cost = ttnn.Tensor(cos, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    sint = ttnn.Tensor(sin, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    with pytest.raises(RuntimeError, match="Cosine cache must cover the input sequence length"):
+        ttnn.experimental.rotary_embedding(xt, cost, sint)
+
+
+@pytest.mark.parametrize("token_idx", [0, 5, 31])
+@pytest.mark.parametrize("head_dim", [32, 64])
+def test_rotary_embedding_rejects_cos_seq_not_covering_token_index(token_idx, head_dim, device):
+    torch.manual_seed(0)
+    batch, n_heads = 1, 32
+    x = torch.randn([1, batch, n_heads, head_dim]).bfloat16().float()
+    cos = torch.randn([1, 1, 1, head_dim]).bfloat16().float()
+    sin = torch.randn([1, 1, 1, head_dim]).bfloat16().float()
+
+    xt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    cost = ttnn.Tensor(cos, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    sint = ttnn.Tensor(sin, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    if token_idx == 0:
+        ttnn.experimental.rotary_embedding(xt, cost, sint, token_idx)
+    else:
+        with pytest.raises(RuntimeError, match="Cosine cache must cover the token index"):
+            ttnn.experimental.rotary_embedding(xt, cost, sint, token_idx)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_hf.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_hf.py
@@ -697,3 +697,33 @@ def test_rotary_embedding_hf_decode_fp32(
 def test_rotary_embedding_hf_row_major(W, Z, Y, X, cache_size, device):
     """``rotary_embedding_hf`` validates TILE layout; row-major inputs are unsupported."""
     pytest.skip("rotary_embedding_hf requires TILE layout inputs (see device op validate)")
+
+
+@pytest.mark.parametrize(
+    "input_seq, head_dim",
+    [
+        (32, 64),
+        (64, 64),
+        (128, 64),
+    ],
+)
+def test_rotary_embedding_hf_prefill_rejects_cos_seq_smaller_than_input_seq(input_seq, head_dim, device):
+    torch.manual_seed(0)
+    num_heads = 8
+    x = torch.randn([1, num_heads, input_seq, head_dim]).bfloat16().float()
+    cos = torch.randn([1, 1, 1, head_dim]).bfloat16().float()
+    sin = torch.randn([1, 1, 1, head_dim]).bfloat16().float()
+
+    xt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    cost = ttnn.Tensor(cos, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    sint = ttnn.Tensor(sin, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    rope_cfg = _hf_rope_compute_kernel_config()
+    with pytest.raises(RuntimeError, match="Cos seq_len must be >= input seq_len"):
+        ttnn.experimental.rotary_embedding_hf(
+            xt,
+            cost,
+            sint,
+            is_decode_mode=False,
+            compute_kernel_config=rope_cfg,
+        )

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
@@ -33,7 +33,7 @@ ttnn::Tensor rotary_embedding(
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device");
     TT_FATAL(
-        cos_cache.padded_shape() == sin_cache.padded_shape(),
+        cos_cache.logical_shape() == sin_cache.logical_shape(),
         "Cosine and Sine cache dimensions must match. Cos cache dimensions: {}, Sin cache dimensions: {}.",
         cos_cache.padded_shape(),
         sin_cache.padded_shape());

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
@@ -44,6 +44,7 @@ ttnn::Tensor rotary_embedding(
         X,
         cos_cache.padded_shape());
 
+    uint32_t cos_seq_len = cos_cache.logical_shape()[-2];
     if (token_index.has_value()) {
         seq_len = input_tensor.padded_shape()[0];
         TT_FATAL(
@@ -52,16 +53,18 @@ ttnn::Tensor rotary_embedding(
             seq_len);
 
         TT_FATAL(
-            cos_cache.padded_shape()[-2] >= token_index,
-            "Cosine cache dimensions must cover the token index. Token index: {}, Cos cache dimension: {}.",
+            cos_seq_len > token_index.value(),
+            "Cosine cache must cover the token index. Token index: {}, Cos cache sequence length: {}.",
             token_index.value(),
-            cos_cache.padded_shape()[-2]);
+            cos_seq_len);
     } else {
+        uint32_t input_seq_len = input_tensor.logical_shape()[-2];
         TT_FATAL(
-            cos_cache.padded_shape()[-2] >= seq_len,
-            "Cosine cache dimensions must cover the sequence length. Sequence length: {}, Cos cache dimension: {}.",
-            seq_len,
-            cos_cache.padded_shape()[-2]);
+            cos_seq_len >= input_seq_len,
+            "Cosine cache must cover the input sequence length. Input sequence length: {}, "
+            "Cos cache sequence length: {}.",
+            input_seq_len,
+            cos_seq_len);
     }
 
     auto arch = input_tensor.device()->arch();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
@@ -62,11 +62,21 @@ void RotaryEmbeddingHfDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(sin.padded_shape()[0] == 1, "Sin seq_len must be 1 in decode mode");
     } else {
         // Prefill mode: input [1, num_heads, seq_len, head_dim], cos/sin [1, 1, seq_len, head_dim]
-        uint32_t seq_len = input_tensor.padded_shape()[-2];
+        uint32_t seq_len = input_tensor.logical_shape()[-2];
+        uint32_t cos_seq_len = cos.logical_shape()[-2];
+        uint32_t sin_seq_len = sin.logical_shape()[-2];
         TT_FATAL(cos.padded_shape()[1] == 1, "Cos must have batch dim = 1 in prefill mode");
         TT_FATAL(sin.padded_shape()[1] == 1, "Sin must have batch dim = 1 in prefill mode");
-        TT_FATAL(cos.padded_shape()[-2] >= seq_len, "Cos seq_len must be >= input seq_len");
-        TT_FATAL(sin.padded_shape()[-2] >= seq_len, "Sin seq_len must be >= input seq_len");
+        TT_FATAL(
+            cos_seq_len >= seq_len,
+            "Cos seq_len must be >= input seq_len. Input seq_len: {}, Cos seq_len: {}.",
+            seq_len,
+            cos_seq_len);
+        TT_FATAL(
+            sin_seq_len >= seq_len,
+            "Sin seq_len must be >= input seq_len. Input seq_len: {}, Sin seq_len: {}.",
+            seq_len,
+            sin_seq_len);
 
         if (input_tensor.is_sharded()) {
             TT_FATAL(


### PR DESCRIPTION
Closes [#43910](https://github.com/tenstorrent/tt-metal/issues/43910)


### PR Category

Bug fix

### Summary

The cos/sin seq check used padded_shape(), so a cos with logical seq=1 passed validation when its tile-padded seq (32) covered the input — the kernel then read padding zeros for rows beyond logical extent, producing silently wrong output (Phi-1.5/Phi-2 first-decode PCC ~0.82).

Switch to logical_shape() and tighten the token_index check to strict greater-than to cover a new identified bug in the decode path validation (using greater-equal was not consistent with zero indexing used in token_index). Add regression tests covering both prefill and decode paths.

Summary of code changes:

ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp:47-68 — switched the cos cache seq check from padded_shape()[-2] to logical_shape()[-2]. A cos with logical seq=1 tile-pads up to 32, so the old check passed for input seq ≤ 32 and silently let the kernel read tile-padding zeros (issue #43910). Now the case is rejected up front. Also tightened the token_index check from >= to > since token_index is 0-indexed.

tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py:367-412 — two new tests:

test_rotary_embedding_rejects_cos_seq_smaller_than_input_seq — prefill path with cos logical seq=1 vs input seq ∈ {32,128}, head_dim ∈ {32,64}; expects validation error.
test_rotary_embedding_rejects_cos_seq_not_covering_token_index — decode path with cos logical seq=1, token_idx ∈ {0, 5, 31}; passes at token_idx=0 (boundary), errors otherwise.

ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp#L63-L82 - switched prefill seq checks to logical_shape()[-2]

tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_hf.py#L702-L733 - a new regression test.

### Tests

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation) Relevant cases passing in [this](https://github.com/tenstorrent/tt-metal/actions/runs/25743952779/job/75604999459) and [this](https://github.com/tenstorrent/tt-metal/actions/runs/25743952779/job/75604999465) job, failing cases are also failing in main

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apascual/43910-fix-rotary-embedding-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/43910-fix-rotary-embedding-validation)