### PR TITLE
Fix conv3d WH pack destination race

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -708,6 +708,7 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         tt::tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
             .math_approx_mode = math_approx_mode,
             .compile_args = compute_compile_time_args});
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/compute/compute_kernel_api.h"
+#include <algorithm>
 #include <tt-metalium/constants.hpp>
 
 #include "api/compute/untilize.h"
@@ -65,97 +66,72 @@ void matmul_blocks(
             for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                 pack_tile(i, out_cb);
             }
-            tile_regs_release();
             cb_push_back(out_cb, out_subblock_num_tiles);
+            tile_regs_release();
             in1_index_offset += subblock_w;
         }
         in0_index_offset += subblock_h * in0_block_w;
     }
 }
 
-template <uint32_t rows, uint32_t cols>
-void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
-    // Math-side broadcast add (`add_tiles_bcast_rows`): used when inout_cb is not
-    // physically full, so we cannot rely on pop+reserve returning the same L1 slots
-    // and the pack-side L1-acc path in `add_inplace_l1_acc` is unsafe.
+ALWI void pack_tile_with_wh_destination_wait(uint32_t tile, uint32_t out_cb, uint32_t pack_sequence_idx) {
+#if defined(ARCH_WORMHOLE)
+    if (pack_sequence_idx != 0) {
+        // Workaround for https://github.com/tenstorrent/tt-metal/issues/44077:
+        // WH pack_tile reprograms the packer L1 destination. Wait before the
+        // next tile rewrites that address while the previous pack is in flight.
+        PACK(TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK));
+    }
+#endif
+    pack_tile(tile, out_cb);
+}
 
+template <uint32_t rows, uint32_t cols, uint32_t add_dst_tiles>
+void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
     constexpr uint32_t num_tiles = rows * cols;
-    constexpr uint32_t max_dst_tiles = compute_kernel_lib::DEST_AUTO_LIMIT;
 
     add_bcast_rows_init_short(inout_cb, bias_cb);
     cb_wait_front(inout_cb, num_tiles);
     cb_wait_front(bias_cb, cols);
     for (uint32_t i = 0; i < rows; ++i) {
-        for (uint32_t col_start = 0; col_start < cols; col_start += max_dst_tiles) {
-            const uint32_t cols_cur = (cols - col_start) < max_dst_tiles ? (cols - col_start) : max_dst_tiles;
-
+        for (uint32_t col_start = 0; col_start < cols; col_start += add_dst_tiles) {
+            const uint32_t cols_cur = std::min(add_dst_tiles, cols - col_start);
             tile_regs_acquire();
             for (uint32_t j = 0; j < cols_cur; ++j) {
                 add_tiles_bcast_rows(inout_cb, bias_cb, j, col_start + j, j);
             }
             tile_regs_commit();
+            tile_regs_wait();
             cb_pop_front(inout_cb, cols_cur);
             cb_reserve_back(inout_cb, cols_cur);
-            tile_regs_wait();
-            pack_tile_block(0, inout_cb, cols_cur);
+            for (uint32_t j = 0; j < cols_cur; ++j) {
+                pack_tile_with_wh_destination_wait(j, inout_cb, i * cols + col_start + j);
+            }
             cb_push_back(inout_cb, cols_cur);
             tile_regs_release();
         }
     }
 }
 
-template <uint32_t rows, uint32_t cols, bool consume_add_cb>
-void add_inplace_l1_acc(uint32_t inout_cb, uint32_t add_cb) {
-    // Pack-side L1 accumulation (`pack_reconfig_l1_acc(1)` + indexed pack): cheaper
-    // than the math add in `add_bias_inplace` because the add fuses into the pack,
-    // but requires inout_cb to be physically full — pop+reserve must return the
-    // same L1 slots so the indexed pack lands on top of the existing tiles.
-    // consume_add_cb=false: add_cb is a single bias row reused for every output row.
-    // consume_add_cb=true:  add_cb is a full block consumed tile-for-tile (reduction).
-    constexpr uint32_t num_tiles = rows * cols;
-    constexpr uint32_t add_tiles = consume_add_cb ? num_tiles : cols;
-    constexpr uint32_t max_dst_tiles = compute_kernel_lib::DEST_AUTO_LIMIT;
-    static_assert(rows > 0 && cols > 0);
-
-    cb_wait_front(inout_cb, num_tiles);
-    cb_wait_front(add_cb, add_tiles);
-
-    copy_tile_to_dst_init_short_with_dt(inout_cb, add_cb);
-    pack_reconfig_data_format(inout_cb);
-    pack_reconfig_l1_acc(1);
-    for (uint32_t i = 0; i < rows; ++i) {
-        for (uint32_t col_start = 0; col_start < cols; col_start += max_dst_tiles) {
-            const uint32_t cols_cur = (cols - col_start) < max_dst_tiles ? (cols - col_start) : max_dst_tiles;
-            const uint32_t add_offset = consume_add_cb ? 0 : col_start;
-
-            tile_regs_acquire();
-            for (uint32_t j = 0; j < cols_cur; ++j) {
-                copy_tile(add_cb, add_offset + j, j);
-            }
-            tile_regs_commit();
-            cb_pop_front(inout_cb, cols_cur);
-            if constexpr (consume_add_cb) {
-                cb_pop_front(add_cb, cols_cur);
-            }
-            cb_reserve_back(inout_cb, cols_cur);
-            tile_regs_wait();
-            for (uint32_t j = 0; j < cols_cur; ++j) {
-                pack_tile<true>(j, inout_cb, j);
-            }
-            cb_push_back(inout_cb, cols_cur);
-            tile_regs_release();
+template <uint32_t num_tiles, uint32_t add_dst_tiles>
+void add_block_inplace_math(uint32_t inout_cb, uint32_t add_cb) {
+    add_tiles_init(inout_cb, add_cb);
+    for (uint32_t i = 0; i < num_tiles; i += add_dst_tiles) {
+        const uint32_t tiles_cur = std::min(add_dst_tiles, num_tiles - i);
+        tile_regs_acquire();
+        for (uint32_t tile = 0; tile < tiles_cur; ++tile) {
+            add_tiles(inout_cb, add_cb, tile, tile, tile);
         }
-    }
-    pack_reconfig_l1_acc(0);
-}
-
-template <uint32_t rows, uint32_t cols, bool use_fp32_partials, bool use_bias, uint32_t inout_cb, uint32_t bias_cb>
-void add_bias_inplace_l1_acc_if_needed() {
-    if constexpr (use_bias) {
-        if constexpr (use_fp32_partials) {
-            reconfig_data_format(inout_cb, bias_cb);
+        tile_regs_commit();
+        tile_regs_wait();
+        cb_pop_front(inout_cb, tiles_cur);
+        cb_pop_front(add_cb, tiles_cur);
+        cb_reserve_back(inout_cb, tiles_cur);
+        for (uint32_t tile = 0; tile < tiles_cur; ++tile) {
+            pack_tile_with_wh_destination_wait(tile, inout_cb, i + tile);
         }
-        add_inplace_l1_acc<rows, cols, false>(inout_cb, bias_cb);
+        cb_push_back(inout_cb, tiles_cur);
+        tile_regs_release();
     }
 }
 
@@ -181,35 +157,30 @@ template <
     uint32_t inout_cb,
     uint32_t bias_cb,
     uint32_t out_cb>
-void bias_untilize_fullblock() {
+void bias_untilize_fullblock_math() {
     cb_wait_front(inout_cb, rows * cols);
-    if constexpr (rows == 1 && cols == 1) {
-        if constexpr (use_bias) {
-            if constexpr (use_fp32_partials) {
-                reconfig_data_format(inout_cb, bias_cb);
-            }
-            add_bias_inplace<rows, cols>(inout_cb, bias_cb);
+    if constexpr (use_bias) {
+        if constexpr (use_fp32_partials) {
+            reconfig_data_format(inout_cb, bias_cb);
         }
-    } else {
-        add_bias_inplace_l1_acc_if_needed<rows, cols, use_fp32_partials, use_bias, inout_cb, bias_cb>();
+        add_bias_inplace<rows, cols, compute_kernel_lib::DEST_AUTO_LIMIT>(inout_cb, bias_cb);
     }
     untilize_block<rows, cols, use_fp32_partials, inout_cb, out_cb>();
 }
 
 template <uint32_t rows, uint32_t cols, bool use_fp32_partials, uint32_t local_cb, uint32_t remote_cb>
-void reduce_fullblock_inplace(uint32_t num_workers) {
+void reduce_fullblock_inplace_math(uint32_t num_workers) {
     constexpr uint32_t num_tiles = rows * cols;
 
     cb_wait_front(local_cb, num_tiles);
 
     if constexpr (use_fp32_partials) {
-        reconfig_data_format_srca(local_cb);
+        reconfig_data_format(local_cb, remote_cb);
+        pack_reconfig_data_format(local_cb);
     }
     for (uint32_t i = 0; i < num_workers; i++) {
         cb_wait_front(remote_cb, num_tiles);
-        // Flatten rows x cols into one logical row so the full remote partial block is
-        // consumed tile-for-tile while preserving the physical-full inout_cb invariant.
-        add_inplace_l1_acc<1, num_tiles, true>(local_cb, remote_cb);
+        add_block_inplace_math<num_tiles, compute_kernel_lib::DEST_AUTO_LIMIT>(local_cb, remote_cb);
     }
 }
 
@@ -223,8 +194,10 @@ template <
     uint32_t bias_cb,
     uint32_t out_cb>
 void reduce_bias_untilize_fullblock(uint32_t num_workers) {
-    reduce_fullblock_inplace<rows, cols, use_fp32_partials, local_cb, remote_cb>(num_workers);
-    bias_untilize_fullblock<rows, cols, use_fp32_partials, use_bias, local_cb, bias_cb, out_cb>();
+    if (num_workers > 0) {
+        reduce_fullblock_inplace_math<rows, cols, use_fp32_partials, local_cb, remote_cb>(num_workers);
+    }
+    bias_untilize_fullblock_math<rows, cols, use_fp32_partials, use_bias, local_cb, bias_cb, out_cb>();
 }
 
 void kernel_main() {
@@ -356,15 +329,17 @@ void kernel_main() {
 
                                     if constexpr (enable_streaming_output) {
                                         // Streaming emits subblocks before cb_matmul_interm_tiled is physically full,
-                                        // so bias uses math add and untilizes immediately.  The full-block path below
-                                        // waits for the whole block and can use L1 pack accumulation instead.
+                                        // so bias uses math add and untilizes immediately.
                                         cb_wait_front(cb_matmul_interm_tiled, subblock_tiles);
 
                                         if constexpr (use_bias) {
                                             if constexpr (use_fp32_partials) {
                                                 reconfig_data_format(cb_matmul_interm_tiled, cb_bias_tiled);
                                             }
-                                            add_bias_inplace<subblock_h, matmul_N_t>(
+                                            add_bias_inplace<
+                                                subblock_h,
+                                                matmul_N_t,
+                                                compute_kernel_lib::DEST_AUTO_LIMIT>(
                                                 cb_matmul_interm_tiled, cb_bias_tiled);
                                         }
 


### PR DESCRIPTION
## Summary

Fixes a conv3d accuracy regression on Wormhole introduced by `bccae69c` (`Optimize conv3d data movement paths`, PR #43541).

This regression is currently making the following pipelines red:

- `(T3K) T3000 unit tests` -> `t3000-unit-tests / t3k_dits_tests [wh_llmbox]`
  - Failing test: `test_wan_decoder[..., 2x4_h1_w0, fake_weights, 480p]`
  - Observed PCC: `97.8842%`, target `99.9%`
  - Failing run: https://github.com/tenstorrent/tt-metal/actions/runs/25561707155/job/75038424598
- `(Galaxy) integration tests` -> `galaxy-integration-tests / Galaxy Wan2.2 integration tests [wh_galaxy]`
  - Failing tests: Wan decoder real-weight `wh_4x8` / `bh_4x8`, `480p` and `720p`
  - Observed PCC: about `96.72%`, target `99.9%`
  - Failing run: https://github.com/tenstorrent/tt-metal/actions/runs/25650195794/job/75287458134

The fix avoids unsafe pack-side L1 accumulation in the conv3d reduction/bias path. The replacement path performs the add in math and repacks the result. On Wormhole only, repeated repacks use a narrow PACK wait before the next `pack_tile()` reprograms the packer L1 destination.

The WH workaround is tracked as an LLK/API issue here:

- https://github.com/tenstorrent/tt-metal/issues/44077

Also propagates `dst_full_sync_en` from the conv3d compute kernel config into `ComputeConfig`.

## Why

The failure is consistent with a WH packer destination reprogramming race when tightly issuing repeated `pack_tile()` calls to different L1 destination addresses. CB synchronization is not enough for this because the hazard is packer configuration reuse, not CB producer/consumer visibility.

This PR keeps the workaround local to conv3d and WH while the LLK-level contract is tracked separately.

## CI

Triggered CI on this branch:

- `(T3K) T3000 unit tests`, `model=dits`: https://github.com/tenstorrent/tt-metal/actions/runs/25728980781
- `(Galaxy) integration tests`, `model=wan22`: https://github.com/tenstorrent/tt-metal/actions/runs/25728980798
- `Nightly tt-metal L2 tests`, conv only: https://github.com/tenstorrent/tt-metal/actions/runs/25729021898
- `Sanity tests`: https://github.com/tenstorrent/tt-metal/actions/runs/25729021708
- `Blackhole post-commit tests`: https://github.com/tenstorrent/tt-metal/actions/runs/25729021731

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/conv3d-wh-pack-dest-wait)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/conv3d-wh-pack-dest-wait)
## Dependency

Blocked by #44417. Without #44417, some conv3d cases hang on BH.