### PR TITLE
Cleanup: Update BGE vLLM generators after VLLM split to plugin

### DIFF
--- a/models/demos/wormhole/bge_large_en/demo/generator_vllm.py
+++ b/models/demos/wormhole/bge_large_en/demo/generator_vllm.py
@@ -126,17 +126,7 @@ class BGEForEmbedding:
             f"Initializing BGE-Large-EN-v1.5 for vLLM: " f"max_batch_size={max_batch_size}, max_seq_len={max_seq_len}"
         )
 
-        # When vLLM wraps the class, it requires vllm_config to be passed
         if vllm_config is not None:
-            # Mark this as an embedding model in override_tt_config for KV cache allocation
-            # This flag is used by get_num_available_blocks_tt to allocate sufficient blocks
-            if (
-                not hasattr(vllm_config.model_config, "override_tt_config")
-                or vllm_config.model_config.override_tt_config is None
-            ):
-                vllm_config.model_config.override_tt_config = {}
-            vllm_config.model_config.override_tt_config["is_embedding_model"] = True
-
             return cls(
                 device=mesh_device,
                 model_location_generator=model_location_generator,

--- a/models/demos/wormhole/bge_m3/demo/generator_vllm.py
+++ b/models/demos/wormhole/bge_m3/demo/generator_vllm.py
@@ -91,13 +91,6 @@ class BgeM3ForEmbedding:
             raise ValueError("Optimizations are not supported for BGE-M3")
 
         if vllm_config is not None:
-            if (
-                not hasattr(vllm_config.model_config, "override_tt_config")
-                or vllm_config.model_config.override_tt_config is None
-            ):
-                vllm_config.model_config.override_tt_config = {}
-            vllm_config.model_config.override_tt_config["is_embedding_model"] = True
-
             return cls(
                 device=mesh_device,
                 model_location_generator=model_location_generator,


### PR DESCRIPTION
### Summary

Add the missing updates to BGE generators after vLLM split to OoT plugin. Followup after https://github.com/tenstorrent/tt-metal/pull/43603 to reduce code review wait time.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/oot-ph2-bge-vllm-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/oot-ph2-bge-vllm-followup)