### PR TITLE
[ttnn] Allow per-layer block_size on paged_scaled_dot_product_attention_decode

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/test_paged_sdpa_decode_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_paged_sdpa_decode_flexible_geometry.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``block_size`` override on
+``ttnn.transformer.paged_scaled_dot_product_attention_decode``.
+
+vLLM's shared kv-cache groups let multiple attention layers share one physical K/V
+buffer. When those layers disagree on ``(block_size, head_dim)`` — e.g. Gemma4's
+sliding (block=128, head=256) and full (block=64, head=512) layers — the buffer is
+allocated for one layer's shape and the others must read it through their own view.
+The ``block_size`` kwarg lets a call do that: ``head_dim`` comes from Q's last dim,
+``block_size`` from the kwarg, and ``num_kv_heads * block_size * head_dim`` must be
+preserved across views of the same buffer.
+
+Coverage: legacy (no kwarg), no-op override (kwarg matches cache shape), override in
+both directions, and a negative case (byte-count mismatch).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _permute_tile_grid(t, view_block_size, view_head_dim):
+    """Reinterpret a paged-cache torch tensor's last two dims under a different
+    tile-grid. ttnn's TILE layout stores tiles row-major in the cache's *declared*
+    tile-grid, so viewing the same bytes under a different ``(block_size, head_dim)``
+    needs a linear-tile-index-preserving permutation, not a ``torch.view``. See
+    ``test_paged_cache_flexible_geometry.py`` for the long version.
+    """
+    N, KV, alloc_block_size, alloc_head_dim = t.shape
+    TILE = 32
+    assert alloc_block_size % TILE == 0 and alloc_head_dim % TILE == 0
+    assert view_block_size % TILE == 0 and view_head_dim % TILE == 0
+    alloc_BR_t = alloc_block_size // TILE
+    alloc_Wt = alloc_head_dim // TILE
+    view_BR_t = view_block_size // TILE
+    view_Wt = view_head_dim // TILE
+    total_tiles = alloc_BR_t * alloc_Wt
+    assert total_tiles == view_BR_t * view_Wt, "per-block tile count must match"
+    t = t.view(N, KV, alloc_BR_t, TILE, alloc_Wt, TILE)
+    t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
+    t = t.view(N, KV, total_tiles, TILE, TILE)
+    t = t.view(N, KV, view_BR_t, view_Wt, TILE, TILE)
+    t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
+    return t.view(N, KV, view_block_size, view_head_dim)
+
+
+def _torch_sdpa_reference(q, k, v, cur_pos, scale):
+    """Causal SDPA reference in fp32. q is ``(1, B, num_q_heads, head_dim)``, k/v are
+    ``(B, num_kv_heads, max_seq_len, head_dim)``, ``cur_pos[b]`` is the most-recent
+    token index for user b (inclusive). Output: ``(1, B, num_q_heads, head_dim_v)``.
+    """
+    B = q.shape[1]
+    num_q_heads = q.shape[2]
+    num_kv_heads = k.shape[1]
+    head_dim_v = v.shape[3]
+    repeat = num_q_heads // num_kv_heads
+    out = torch.zeros(1, B, num_q_heads, head_dim_v, dtype=torch.float32)
+    for b in range(B):
+        pos = int(cur_pos[b].item() if torch.is_tensor(cur_pos) else cur_pos[b])
+        k_b = k[b, :, : pos + 1, :].float()  # (kv_heads, S, head_dim)
+        v_b = v[b, :, : pos + 1, :].float()  # (kv_heads, S, head_dim_v)
+        q_b = q[0, b, :, :].float()  # (num_q_heads, head_dim)
+        k_b_rep = k_b.repeat_interleave(repeat, dim=0)  # (num_q_heads, S, head_dim)
+        v_b_rep = v_b.repeat_interleave(repeat, dim=0)  # (num_q_heads, S, head_dim_v)
+        scores = torch.einsum("hd,hsd->hs", q_b, k_b_rep) * scale
+        weights = torch.softmax(scores, dim=-1)
+        out[0, b, :, :] = torch.einsum("hs,hsd->hd", weights, v_b_rep)
+    return out
+
+
+def _paged_layout(unshuffled_per_user, page_table, num_kv_heads, block_size, head_dim):
+    """Lay out per-user K/V into a paged buffer keyed by physical block id, following
+    ``page_table[user, virtual_block] -> physical_block``.
+    """
+    B = unshuffled_per_user.shape[0]
+    max_num_blocks_per_seq = unshuffled_per_user.shape[2] // block_size
+    max_num_blocks = int(page_table.max().item() + 1)
+    paged = torch.zeros(max_num_blocks, num_kv_heads, block_size, head_dim, dtype=unshuffled_per_user.dtype)
+    for b in range(B):
+        for vb in range(max_num_blocks_per_seq):
+            pb = int(page_table[b, vb].item())
+            paged[pb, :, :, :] = unshuffled_per_user[b, :, vb * block_size : (vb + 1) * block_size, :]
+    return paged
+
+
+def _alloc_paged_cache_on_device(num_blocks, num_kv_heads, block_size, head_dim, device, fill=None):
+    """Allocate a paged cache on device, optionally seeded from ``fill``."""
+    if fill is None:
+        fill = torch.randn(num_blocks, num_kv_heads, block_size, head_dim).bfloat16().float()
+    cache_tt = ttnn.Tensor(fill, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    return cache_tt, fill
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "block_size, head_dim",
+    [(64, 256), (128, 256), (64, 512), (128, 128)],
+    ids=["b64_d256", "b128_d256", "b64_d512", "b128_d128"],
+)
+def test_legacy_no_override(block_size, head_dim, device):
+    """No ``block_size`` kwarg → identical to the pre-change op. Backward-compat guard."""
+    torch.manual_seed(0)
+    B = 4
+    num_kv_heads = 1
+    num_q_heads = num_kv_heads  # MHA for simplicity
+    max_seq_len = 256
+    max_num_blocks_per_seq = max_seq_len // block_size
+    max_num_blocks = B * max_num_blocks_per_seq
+
+    k_per_user = torch.randn(B, num_kv_heads, max_seq_len, head_dim).bfloat16().float()
+    v_per_user = torch.randn(B, num_kv_heads, max_seq_len, head_dim).bfloat16().float()
+    page_table = torch.randperm(max_num_blocks, dtype=torch.int32).reshape(B, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    k_paged = _paged_layout(k_per_user, page_table, num_kv_heads, block_size, head_dim)
+    v_paged = _paged_layout(v_per_user, page_table, num_kv_heads, block_size, head_dim)
+    k_tt, _ = _alloc_paged_cache_on_device(max_num_blocks, num_kv_heads, block_size, head_dim, device, fill=k_paged)
+    v_tt, _ = _alloc_paged_cache_on_device(max_num_blocks, num_kv_heads, block_size, head_dim, device, fill=v_paged)
+
+    cur_pos = torch.tensor([13 + b * 7 for b in range(B)], dtype=torch.int32)
+    q = torch.randn(1, B, num_q_heads, head_dim).bfloat16().float()
+    q_padded = torch.nn.functional.pad(q, (0, 0, 0, 32 - num_q_heads), "constant", 0)
+    q_tt = ttnn.Tensor(q_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    cur_pos_tt = ttnn.Tensor(cur_pos, ttnn.int32).to(device)
+
+    scale = 1.0 / (head_dim**0.5)
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(8, 4),
+        q_chunk_size=32,
+        k_chunk_size=32,
+        exp_approx_mode=False,
+    )
+
+    out_tt = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+        q_tt,
+        k_tt,
+        v_tt,
+        page_table_tensor=page_table_tt,
+        cur_pos_tensor=cur_pos_tt,
+        scale=scale,
+        program_config=program_config,
+    )
+
+    out = ttnn.to_torch(out_tt)[:, :, :num_q_heads, :]
+    ref = _torch_sdpa_reference(q, k_per_user, v_per_user, cur_pos, scale)
+    eq, msg = comp_pcc(ref, out, pcc=0.99)
+    assert eq, f"legacy path PCC failed: {msg}"
+
+
+def test_override_matches_alloc_is_noop(device):
+    """``block_size`` equal to the cache's declared block_size should PCC-match the
+    no-override path — confirms the override plumbing is inert when it's a no-op."""
+    torch.manual_seed(1)
+    B = 4
+    num_kv_heads = 1
+    num_q_heads = num_kv_heads
+    block_size = 64
+    head_dim = 256
+    max_seq_len = 256
+    max_num_blocks_per_seq = max_seq_len // block_size
+    max_num_blocks = B * max_num_blocks_per_seq
+
+    k_per_user = torch.randn(B, num_kv_heads, max_seq_len, head_dim).bfloat16().float()
+    v_per_user = torch.randn(B, num_kv_heads, max_seq_len, head_dim).bfloat16().float()
+    page_table = torch.randperm(max_num_blocks, dtype=torch.int32).reshape(B, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+    k_paged = _paged_layout(k_per_user, page_table, num_kv_heads, block_size, head_dim)
+    v_paged = _paged_layout(v_per_user, page_table, num_kv_heads, block_size, head_dim)
+
+    def _build_q():
+        cur_pos = torch.tensor([7 + b * 11 for b in range(B)], dtype=torch.int32)
+        q = torch.randn(1, B, num_q_heads, head_dim).bfloat16().float()
+        q_padded = torch.nn.functional.pad(q, (0, 0, 0, 32 - num_q_heads), "constant", 0)
+        return q, q_padded, cur_pos
+
+    q_torch, q_padded, cur_pos = _build_q()
+    cur_pos_tt = ttnn.Tensor(cur_pos, ttnn.int32).to(device)
+    scale = 1.0 / (head_dim**0.5)
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(8, 4),
+        q_chunk_size=32,
+        k_chunk_size=32,
+        exp_approx_mode=False,
+    )
+
+    # Separate tensor allocations per run so K/V cache state is identical between them.
+    def _run(use_override):
+        k_tt, _ = _alloc_paged_cache_on_device(max_num_blocks, num_kv_heads, block_size, head_dim, device, fill=k_paged)
+        v_tt, _ = _alloc_paged_cache_on_device(max_num_blocks, num_kv_heads, block_size, head_dim, device, fill=v_paged)
+        q_tt = ttnn.Tensor(q_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+        kwargs = dict(
+            page_table_tensor=page_table_tt,
+            cur_pos_tensor=cur_pos_tt,
+            scale=scale,
+            program_config=program_config,
+        )
+        if use_override:
+            kwargs["block_size"] = block_size
+        return ttnn.to_torch(ttnn.transformer.paged_scaled_dot_product_attention_decode(q_tt, k_tt, v_tt, **kwargs))[
+            :, :, :num_q_heads, :
+        ]
+
+    out_legacy = _run(use_override=False)
+    out_override = _run(use_override=True)
+    eq, msg = comp_pcc(out_legacy, out_override, pcc=0.999)
+    assert eq, f"override-is-noop diverged from legacy: {msg}"
+
+
+def _run_flexible_geometry_test(
+    device,
+    alloc_block_size,
+    alloc_head_dim,
+    view_block_size,
+    view_head_dim,
+    B=4,
+    max_seq_len_view=256,
+):
+    """Shared body for the two flip-view directions. Pre-fills a cache allocated under
+    ``(alloc_block_size, alloc_head_dim)``, runs SDPA decode with the view's
+    ``block_size`` and Q's ``head_dim``, and compares against a torch reference computed
+    on the same DRAM bytes re-interpreted through the view's tile-grid.
+    """
+    num_kv_heads = 1
+    num_q_heads = num_kv_heads
+    assert num_kv_heads * alloc_block_size * alloc_head_dim == num_kv_heads * view_block_size * view_head_dim
+    max_num_blocks_per_seq = max_seq_len_view // view_block_size
+    assert max_num_blocks_per_seq * view_block_size == max_seq_len_view
+    max_num_blocks = B * max_num_blocks_per_seq
+
+    # Pre-fill cache in alloc's tile-grid (simulating a peer layer's allocation).
+    k_alloc = torch.randn(max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim).bfloat16().float()
+    v_alloc = torch.randn(max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim).bfloat16().float()
+    k_tt, _ = _alloc_paged_cache_on_device(
+        max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device, fill=k_alloc
+    )
+    v_tt, _ = _alloc_paged_cache_on_device(
+        max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device, fill=v_alloc
+    )
+
+    # Same bytes, reinterpreted through the view's tile-grid — what SDPA (with
+    # block_size=view_block_size) will read.
+    k_view = _permute_tile_grid(k_alloc, view_block_size, view_head_dim)
+    v_view = _permute_tile_grid(v_alloc, view_block_size, view_head_dim)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(B, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    # Reconstruct per-user K/V in view coords by inverting page_table.
+    k_per_user = torch.zeros(B, num_kv_heads, max_seq_len_view, view_head_dim, dtype=torch.float32)
+    v_per_user = torch.zeros(B, num_kv_heads, max_seq_len_view, view_head_dim, dtype=torch.float32)
+    for b in range(B):
+        for vb in range(max_num_blocks_per_seq):
+            pb = int(page_table[b, vb].item())
+            k_per_user[b, :, vb * view_block_size : (vb + 1) * view_block_size, :] = k_view[pb, :, :, :]
+            v_per_user[b, :, vb * view_block_size : (vb + 1) * view_block_size, :] = v_view[pb, :, :, :]
+
+    cur_pos = torch.tensor([10 + b * 7 for b in range(B)], dtype=torch.int32)
+    q = torch.randn(1, B, num_q_heads, view_head_dim).bfloat16().float()
+    q_padded = torch.nn.functional.pad(q, (0, 0, 0, 32 - num_q_heads), "constant", 0)
+    q_tt = ttnn.Tensor(q_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    cur_pos_tt = ttnn.Tensor(cur_pos, ttnn.int32).to(device)
+
+    scale = 1.0 / (view_head_dim**0.5)
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(8, 4),
+        q_chunk_size=32,
+        k_chunk_size=32,
+        exp_approx_mode=False,
+    )
+
+    out_tt = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+        q_tt,
+        k_tt,
+        v_tt,
+        page_table_tensor=page_table_tt,
+        cur_pos_tensor=cur_pos_tt,
+        scale=scale,
+        program_config=program_config,
+        block_size=view_block_size,
+    )
+    out = ttnn.to_torch(out_tt)[:, :, :num_q_heads, :]
+
+    ref = _torch_sdpa_reference(q, k_per_user, v_per_user, cur_pos, scale)
+    eq, msg = comp_pcc(ref, out, pcc=0.99)
+    assert eq, f"override view PCC failed: {msg}"
+
+
+def test_override_view_full_into_sliding_buffer(device):
+    """Cache allocated sliding (block=128, head=256); SDPA reads via override with full
+    view (block=64, head=512). Canonical Gemma4 scenario."""
+    torch.manual_seed(2)
+    _run_flexible_geometry_test(
+        device,
+        alloc_block_size=128,
+        alloc_head_dim=256,
+        view_block_size=64,
+        view_head_dim=512,
+    )
+
+
+def test_override_view_sliding_into_full_buffer(device):
+    """Symmetric: cache allocated full (block=64, head=512); SDPA reads sliding view
+    (block=128, head=256) via override."""
+    torch.manual_seed(3)
+    _run_flexible_geometry_test(
+        device,
+        alloc_block_size=64,
+        alloc_head_dim=512,
+        view_block_size=128,
+        view_head_dim=256,
+    )
+
+
+def test_negative_byte_count_mismatch(device):
+    """Override breaking the per-block byte invariant must be rejected at validation."""
+    torch.manual_seed(4)
+    B = 2
+    num_kv_heads = 1
+    num_q_heads = 1
+    # Cache: 32768 elem/block. Call view: 65536 (mismatched).
+    alloc_block_size = 64
+    alloc_head_dim = 512
+    view_block_size = 256
+    view_head_dim = 256
+    max_num_blocks = 4
+
+    k_tt, _ = _alloc_paged_cache_on_device(max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device)
+    v_tt, _ = _alloc_paged_cache_on_device(max_num_blocks, num_kv_heads, alloc_block_size, alloc_head_dim, device)
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(B, 2)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+    cur_pos_tt = ttnn.Tensor(torch.zeros(B, dtype=torch.int32), ttnn.int32).to(device)
+    q = torch.zeros(1, B, num_q_heads, view_head_dim).bfloat16().float()
+    q_padded = torch.nn.functional.pad(q, (0, 0, 0, 32 - num_q_heads), "constant", 0)
+    q_tt = ttnn.Tensor(q_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    with pytest.raises(RuntimeError, match="geometry mismatch"):
+        ttnn.transformer.paged_scaled_dot_product_attention_decode(
+            q_tt,
+            k_tt,
+            v_tt,
+            page_table_tensor=page_table_tt,
+            cur_pos_tensor=cur_pos_tt,
+            block_size=view_block_size,
+        )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -9,6 +9,8 @@
 #include <cmath>
 #include <cstdint>
 
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
@@ -211,6 +213,11 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
 
         TT_FATAL(k_shape[2] == v_shape[2], "K and V must have same block size");
 
+        // block_size_override + MLA not yet exercised; reject until needed.
+        if (operation_attributes.block_size_override.has_value()) {
+            TT_FATAL(!use_mla, "block_size_override is not supported with multi-latent attention");
+        }
+
         if (use_mla) {
             TT_FATAL(
                 k_shape[3] == q_shape[3], "Q and K must have same hidden size, got {} and {}", k_shape[3], q_shape[3]);
@@ -221,6 +228,50 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
                     v_shape[3],
                     operation_attributes.head_dim_v.value());
             }
+        } else if (operation_attributes.block_size_override.has_value()) {
+            // Shared-buffer path: the K/V cache was allocated for a different layer's
+            // (block_size, head_dim) shape, and this call reads through its own view.
+            // Q's last dim drives head_dim; block_size_override drives block_size.
+            // K and V caches still share their per-layer allocation pair, and the
+            // per-block element count (num_kv_heads * block_size * head_dim) must equal
+            // what the cache was allocated for.
+            TT_FATAL(
+                k_shape[3] == v_shape[3],
+                "K and V cache must have same hidden size with block_size_override, got {} and {}",
+                k_shape[3],
+                v_shape[3]);
+            const uint32_t cache_num_kv_heads = k_shape[1];
+            const uint32_t cache_block_size = k_shape[2];
+            const uint32_t cache_head_dim = k_shape[3];
+            const uint32_t q_head_dim = q_shape[3];
+            const uint32_t effective_block_size = operation_attributes.block_size_override.value();
+            const uint64_t cache_elems_per_block =
+                static_cast<uint64_t>(cache_num_kv_heads) * cache_block_size * cache_head_dim;
+            const uint64_t view_elems_per_block =
+                static_cast<uint64_t>(cache_num_kv_heads) * effective_block_size * q_head_dim;
+            TT_FATAL(
+                view_elems_per_block == cache_elems_per_block,
+                "paged_scaled_dot_product_attention_decode geometry mismatch: cache has {} elems/block "
+                "(kv_heads={}, block_size={}, head_dim={}) but call view is {} "
+                "(kv_heads={}, block_size={}, head_dim={} from Q.padded_shape[-1]).",
+                cache_elems_per_block,
+                cache_num_kv_heads,
+                cache_block_size,
+                cache_head_dim,
+                view_elems_per_block,
+                cache_num_kv_heads,
+                effective_block_size,
+                q_head_dim);
+            TT_FATAL(
+                effective_block_size % tt::constants::TILE_HEIGHT == 0,
+                "effective block_size ({}) must be a multiple of TILE_HEIGHT ({})",
+                effective_block_size,
+                tt::constants::TILE_HEIGHT);
+            TT_FATAL(
+                q_head_dim % tt::constants::TILE_WIDTH == 0,
+                "Q last dim ({}) must be a multiple of TILE_WIDTH ({})",
+                q_head_dim,
+                tt::constants::TILE_WIDTH);
         } else {
             TT_FATAL(k_shape[3] == v_shape[3] && k_shape[3] == q_shape[3], "Q, K, V must have same hidden size");
         }
@@ -444,6 +495,8 @@ ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
         operation_attributes.use_mla,
         operation_attributes.head_dim_v,
         operation_attributes.sliding_window_size,
+        // Enters compile-time args (page_block_size_t, DHt, St).
+        operation_attributes.block_size_override,
         tensor_args.q,
         tensor_args.k,
         tensor_args.v,
@@ -474,7 +527,8 @@ Tensor sdpa_decode(
     uint32_t k_chunk_size,
     std::optional<bool> share_cache,
     std::optional<bool> use_mla,
-    std::optional<uint32_t> head_dim_v) {
+    std::optional<uint32_t> head_dim_v,
+    std::optional<uint32_t> block_size_override) {
     using OperationType = SdpaDecodeDeviceOperation;
     auto operation_attributes = OperationType::operation_attributes_t{
         .is_causal = is_causal,
@@ -489,6 +543,7 @@ Tensor sdpa_decode(
         .share_cache = share_cache,
         .use_mla = use_mla,
         .head_dim_v = head_dim_v,
+        .block_size_override = block_size_override,
     };
 
     auto tensor_args = OperationType::tensor_args_t{

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
@@ -55,6 +55,7 @@ Tensor sdpa_decode(
     uint32_t k_chunk_size,
     std::optional<bool> share_cache,
     std::optional<bool> use_mla,
-    std::optional<uint32_t> head_dim_v);
+    std::optional<uint32_t> head_dim_v,
+    std::optional<uint32_t> block_size_override = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
@@ -28,6 +28,12 @@ struct SdpaDecodeParams {
     // When true, enables multi-latent attention (MLA) path where V is derived from K.
     std::optional<bool> use_mla = std::nullopt;
     std::optional<uint32_t> head_dim_v = std::nullopt;
+    // Optional per-call block_size for paged attention. Lets this call read a K/V cache
+    // that was allocated for a different layer's (block_size, head_dim) shape — Q's last
+    // dim then drives head_dim. Required when vLLM's shared kv-cache groups place layers
+    // with different specs on one physical buffer. num_kv_heads * block_size * head_dim
+    // must be preserved across views (checked in validate_on_program_cache_miss).
+    std::optional<uint32_t> block_size_override = std::nullopt;
 };
 
 struct SdpaDecodeInputs {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -70,11 +70,17 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
 
     // ========== Core Dimensions ==========
     // B = batch size, PNH = padded num Q heads, S = sequence length, DH = head dim
+    //
+    // With block_size_override set, this call reads a K/V cache allocated for a
+    // different layer's shape; Q's last dim drives DH. Without it, k_shape[3] is used
+    // and the strict q.head_dim == k.head_dim check in validate keeps legacy callers
+    // byte-identical.
+    const bool has_block_size_override = operation_attributes.block_size_override.has_value();
     uint32_t B = q_shape[1];
     uint32_t PNH = q_shape[2];
     uint32_t S = k_shape[2];
-    uint32_t DH = k_shape[3];
-    uint32_t vDH = use_mla ? head_dim_v : v_shape[3];
+    uint32_t DH = has_block_size_override ? q_shape[3] : k_shape[3];
+    uint32_t vDH = use_mla ? head_dim_v : (has_block_size_override ? q_shape[3] : v_shape[3]);
     uint32_t Bkv = k_shape[0];
     uint32_t Bmask = attn_mask.has_value() ? attn_mask->padded_shape()[0] : Bkv;
     uint32_t num_kv_heads = k_shape[1];
@@ -89,10 +95,13 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         B = page_table_tensor->is_sharded() ? page_table_tensor->padded_shape()[0] /
                                                   page_table_tensor->memory_config().shard_spec()->grid.num_cores()
                                             : page_table_tensor->padded_shape()[0];
-        uint32_t block_size = k_shape[2];
-        original_block_size = input_tensor_k.logical_shape()[2];
+        uint32_t block_size = operation_attributes.block_size_override.value_or(k_shape[2]);
+        // original_block_size gates the sub-tile padding mask. With an override active,
+        // validate already enforces it's a multiple of TILE_HEIGHT (no padding path).
+        original_block_size = has_block_size_override ? block_size : input_tensor_k.logical_shape()[2];
         page_block_size_t = block_size / TILE_HEIGHT;
-        S = page_table_tensor.value().padded_shape()[-1] * S;
+        // kv_seq_len = max_num_blocks_per_seq * effective block_size.
+        S = page_table_tensor.value().padded_shape()[-1] * block_size;
         has_block_padding = original_block_size < TILE_HEIGHT;
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -105,7 +105,8 @@ ttnn::Tensor paged_scaled_dot_product_attention_decode(
     std::optional<uint32_t> sliding_window_size,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    std::optional<uint32_t> block_size_override) {
     [[maybe_unused]] auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
                                      ? input_tensor_q.device()->arch()
                                      : ttnn::GetDefaultDevice()->arch();
@@ -146,7 +147,8 @@ ttnn::Tensor paged_scaled_dot_product_attention_decode(
         k_chunk_size,
         std::nullopt,
         std::nullopt,
-        std::nullopt);
+        std::nullopt,
+        block_size_override);
 }
 
 ttnn::Tensor flash_multi_latent_attention_decode(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -39,7 +39,8 @@ ttnn::Tensor paged_scaled_dot_product_attention_decode(
     std::optional<uint32_t> sliding_window_size = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<operations::transformer::SDPAProgramConfig> program_config = std::nullopt,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<uint32_t> block_size_override = std::nullopt);
 
 ttnn::Tensor flash_multi_latent_attention_decode(
     const ttnn::Tensor& input_tensor_q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -92,7 +92,11 @@ void bind_sdpa_decode(nb::module_& mod) {
         nb::arg("sliding_window_size") = nb::none(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("program_config") = nb::none(),
-        nb::arg("compute_kernel_config") = nb::none());
+        nb::arg("compute_kernel_config") = nb::none(),
+        // block_size reads the K/V cache through a different (block_size, head_dim)
+        // view than its declared shape; needed for vLLM's shared kv-cache groups. See
+        // ttnn.experimental.paged_update_cache's kwarg of the same name.
+        nb::arg("block_size") = nb::none());
 
     ttnn::bind_function<"flash_multi_latent_attention_decode", "ttnn.transformer.">(
         mod,


### PR DESCRIPTION
## Summary

Adds an optional `block_size` kwarg to `ttnn.transformer.paged_scaled_dot_product_attention_decode` so callers can read from a paged K/V cache buffer that was physically allocated with a different `(block_size, head_dim)` view than the layer's query — as long as `num_kv_heads * block_size * head_dim` (per-block element count) is preserved across views.

This is **Path A** from the Gemma4 hybrid kv-cache-groups unblock. The sibling PR for `paged_update_cache` / `paged_fill_cache` is #44073. Both together complete the read+write story so a hybrid-attention model with per-spec `head_dim` (e.g. Gemma4) can share one physical DRAM buffer across layers with different specs without the kernel-side last-dim assertion firing.

## Why

vLLM's hybrid kv-cache-groups manager equalises per-block bytes across attention groups by adjusting `block_size` per group. For models like Gemma4 with per-spec `head_dim` (sliding=256 vs full=512), one DRAM buffer is shared by layers with different `(block_size, head_dim)` views.

The cache-update PR (#44073) fixed the *write* side. Without this op also reading via the layer's view, SDPA would interpret the shared bytes through the *cache's declared* tile-grid and read garbage for the layer whose spec didn't win the buffer's allocation shape. The existing strict assertion in validate (`sdpa_decode_device_operation.cpp:225`) catches the simpler case:

> `TT_FATAL(k_shape[3] == v_shape[3] && k_shape[3] == q_shape[3], "Q, K, V must have same hidden size");`

— but even if relaxed, the kernel would stride through DRAM with the wrong geometry.

## Design (CUDA-style, identical to #44073's approach)

In the program factory:
- `DH` (head_dim) and `vDH` come from `q.padded_shape[3]` when the override is set — Q is the source of truth for the layer's effective head_dim.
- `block_size` and `page_block_size_t` come from the override when set, else `k.padded_shape[2]`.
- `S` (kv_seq_len) recomputed as `page_table.padded_shape[-1] * effective_block_size`.

Validation:
- Strict `q.head_dim == k.head_dim` check in the paged-non-MLA path is relaxed when the override is set.
- Replaced with a per-block byte-count consistency check (mirror of #44073's invariant).
- MLA path explicitly rejects the override for now (out of scope; would multiply test matrix).

Reader / writer / compute kernels are **unchanged** — they already consume `Wt` / `vDHt` / `page_block_size_t` / `St` as compile-time args; only the program factory's source of those values changes.

## Public API

```python
ttnn.transformer.paged_scaled_dot_product_attention_decode(
    q, k_cache, v_cache,
    page_table_tensor=...,
    cur_pos_tensor=...,
    sliding_window_size=...,
    ...,
    block_size=None,   # NEW: optional, defaults to k_cache.padded_shape[2]
)
```

Other public functions in `sdpa_decode.cpp` (`scaled_dot_product_attention_decode` non-paged, MLA variants) pass `std::nullopt` and aren't touched.

## Files changed

```
ttnn/cpp/ttnn/operations/transformer/sdpa_decode/
├── sdpa_decode.{hpp,cpp}                                    public signature
├── sdpa_decode_nanobind.cpp                                 Python kwarg
└── device/
    ├── sdpa_decode_device_operation_types.hpp               attr field
    ├── sdpa_decode_device_operation.{hpp,cpp}               prim signature, validation, hash
    └── sdpa_decode_program_factory.cpp                      geometry derivation
```

New test: `tests/ttnn/unit_tests/operations/sdpa/test_paged_sdpa_decode_flexible_geometry.py` (8 cases).

## Test plan

- [x] All 8 new tests pass on Wormhole:
  - `test_legacy_no_override` (×4 shape combos): backward-compat sanity
  - `test_override_matches_alloc_is_noop`: when override == cache's declared block_size, output PCC-matches no-override path
  - `test_override_view_full_into_sliding_buffer`: cache (128, 256), Q+override (64, 512)
  - `test_override_view_sliding_into_full_buffer`: cache (64, 512), Q+override (128, 256)
  - `test_negative_byte_count_mismatch`: per-block byte invariant violation raises
- [x] Regression: `test_sdpa_decode_paged_attention` (9 passed, 6 skipped) — no failures
- [x] Regression: `test_sdpa_decode.py` unit tests (11 passed, 1 skipped) — no failures

## Notable subtlety (in the test, not the op)

Verifying a round trip when alloc shape differs from the call's view requires a *tile-grid-aware* permutation between cache torch tensor and view torch tensor (not a plain `torch.view`) — ttnn's TILE layout stores tiles row-major in the cache's declared tile-grid, so reinterpreting the same DRAM bytes under a different `(block_size, head_dim)` shape needs the linear-tile-index-preserving rearrangement. See `_permute_tile_grid` docstring. The kernel writes/reads the right physical bytes; the test just has to track them through the same tile-grid translation.

## Composability with #44073

Once both PRs land, the Gemma4 vLLM bridge can:
1. Allow vLLM's hybrid kv-cache-groups manager to do cross-spec HMA sharing (one DRAM buffer for layers of different specs).
2. Each Gemma4 attention layer calls `paged_update_cache(cache, k, ..., block_size=layer_block_size)` and `paged_scaled_dot_product_attention_decode(q, cache, ..., block_size=layer_block_size)` with its own per-spec block_size.
3. The kernel addresses the right DRAM bytes for each layer's view; HMA sharing works without the last-dim assertion.

## Follow-up

`chunked_scaled_dot_product_attention` (paged prefill, also reads from cache) needs the same treatment for vLLM serving with prefix caching. Gemma4's current prefill reads K/V directly from fresh projection tensors (not from cache), so it's not blocking for the current Gemma4 unblock. Will be a separate small PR.

### Manually-dispatched verification runs

Triggered to exercise the new tests directly on this branch:

- [Sanity tests nightly debug run (#25799075026)](https://github.com/tenstorrent/tt-metal/actions/runs/25799075026) — calls `sanity-tests.yaml` and `blackhole-post-commit.yaml`, each of which calls `ttnn-post-commit.yaml`. _(Exercises the 8 new tests in `tests/ttnn/unit_tests/operations/sdpa/test_paged_sdpa_decode_flexible_geometry.py` via the "ttnn sdpa group" matrix entry on both Wormhole and Blackhole.)_
- [Nightly tt-metal L2 tests (#25799096620)](https://github.com/tenstorrent/tt-metal/actions/runs/25799096620) — `additional_test_categories=sdpa,transformers,misc`. _(Regression coverage: existing `test_sdpa_decode_paged_attention` and `test_sdpa_decode` suites in `tests/ttnn/nightly/unit_tests/operations/sdpa/` to confirm the new optional `block_size` kwarg does not break legacy callers.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/sdpa-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/sdpa-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/sdpa-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/sdpa-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/sdpa-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/sdpa-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/sdpa-flexible-geometry)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/sdpa-flexible-geometry)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/sdpa-flexible-geometry)
