### PR TITLE
[Bug Fix] fix CELU SFPU test scalar float params and dispatch

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -21,6 +21,7 @@
 #include "sfpu/ckernel_sfpu_abs.h"
 #include "sfpu/ckernel_sfpu_activations.h"
 #include "sfpu/ckernel_sfpu_binary.h"
+#include "sfpu/ckernel_sfpu_celu.h"
 #include "sfpu/ckernel_sfpu_elu.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_exp2.h"
@@ -179,17 +180,15 @@ void call_unary_sfpu_operation(
     }
     else if constexpr (OPERATION == SfpuType::celu)
     {
-        // Two _calculate_activation_ overloads (runtime params vs none) — cast so Callable deduces.
-        SFPU_CALL_CAST(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
-            _calculate_activation_,
-            (APPROX_MODE, ActivationType::Celu, ITERATIONS),
-            (void (*)(std::uint32_t, std::uint32_t)),
+            _calculate_celu_,
+            (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS),
             dst_index,
             vector_mode,
-            0x41200000u /* alpha = 10.0f */,
-            0x3DCCCCCDu /* alpha_recip = 0.1f */);
+            0x3f800000u /* alpha = 1.0f */,
+            0x3f800000u /* 1/alpha = 1.0f */);
     }
     else if constexpr (OPERATION == SfpuType::cosine)
     {
@@ -204,7 +203,7 @@ void call_unary_sfpu_operation(
             (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS),
             dst_index,
             vector_mode,
-            0x3f800000 /* alpha = 1.0f */);
+            0x3f800000u /* alpha = 1.0f */);
     }
     else if constexpr (OPERATION == SfpuType::exp2)
     {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #43907

This PR fixes ELU/CELU scalar parameter handling in SFPU test helpers. Float-valued scalar params are now passed as raw IEEE-754 bit patterns, and CELU uses the dedicated CELU kernel path instead of the generic activation path.

### Notes for reviewers
Main changes are in sfpu_operations.h.

Please focus on:
- ELU scalar argument passing as float bit pattern
- CELU dispatch using the dedicated _calculate_celu_... path
- CELU scalar args (alpha, 1/alpha) passed as float bit patterns

EDIT: 
@ndivnicTT fixed the ELU portion of the issue via #42946. 
Changing the title to reflect CELU issue. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/fix-sfpu-elu-celu-float-scalar-bits)