### PR TITLE
[tt-triage] Test running operations

### DIFF
--- a/tools/tests/triage/hang_apps/CMakeLists.txt
+++ b/tools/tests/triage/hang_apps/CMakeLists.txt
@@ -3,3 +3,4 @@ link_libraries(TT::STL)
 add_compile_definitions(OVERRIDE_KERNEL_PREFIX="tools/tests/triage/hang_apps/")
 
 add_subdirectory(add_2_integers_hang)
+add_subdirectory(ttnn_add_integers_hang)

--- a/tools/tests/triage/hang_apps/ttnn_add_integers_hang/CMakeLists.txt
+++ b/tools/tests/triage/hang_apps/ttnn_add_integers_hang/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(triage_hang_app_ttnn_add_integers_hang)
+target_sources(
+    triage_hang_app_ttnn_add_integers_hang
+    PRIVATE
+        ttnn_add_integers_hang.cpp
+        add_integers_hang_op.cpp
+        single_core_program_factory.cpp
+)
+target_link_libraries(
+    triage_hang_app_ttnn_add_integers_hang
+    PUBLIC
+        TT::Metalium
+        TTNN::CPP
+)

--- a/tools/tests/triage/hang_apps/ttnn_add_integers_hang/add_integers_hang_op.cpp
+++ b/tools/tests/triage/hang_apps/ttnn_add_integers_hang/add_integers_hang_op.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "add_integers_hang_op.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+namespace triage_hang_apps {
+
+AddIntegersHangOperation::program_factory_t AddIntegersHangOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return SingleCore{};
+}
+
+void AddIntegersHangOperation::validate_on_program_cache_miss(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+    TT_FATAL(
+        a.logical_shape() == b.logical_shape(),
+        "add_integers_hang: input tensors must have the same shape (got {} and {})",
+        a.logical_shape(),
+        b.logical_shape());
+    TT_FATAL(
+        a.dtype() == b.dtype(),
+        "add_integers_hang: input tensors must have the same dtype (got {} and {})",
+        a.dtype(),
+        b.dtype());
+}
+
+AddIntegersHangOperation::spec_return_value_t AddIntegersHangOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    const auto& a = tensor_args.input_tensor_a;
+    return ttnn::TensorSpec(
+        a.logical_shape(),
+        tt::tt_metal::TensorLayout(a.dtype(), tt::tt_metal::PageConfig(a.layout()), ttnn::MemoryConfig{}));
+}
+
+AddIntegersHangOperation::tensor_return_value_t AddIntegersHangOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input_tensor_a.device());
+}
+
+ttnn::Tensor add_integers_hang(const ttnn::Tensor& input_tensor_a, const ttnn::Tensor& input_tensor_b) {
+    return ttnn::device_operation::launch<AddIntegersHangOperation>(
+        AddIntegersHangOperation::operation_attributes_t{},
+        AddIntegersHangOperation::tensor_args_t{input_tensor_a, input_tensor_b});
+}
+
+}  // namespace triage_hang_apps

--- a/tools/tests/triage/hang_apps/ttnn_add_integers_hang/add_integers_hang_op.hpp
+++ b/tools/tests/triage/hang_apps/ttnn_add_integers_hang/add_integers_hang_op.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace triage_hang_apps {
+
+struct AddIntegersHangOperation {
+    struct operation_attributes_t {};
+
+    struct tensor_args_t {
+        const ttnn::Tensor& input_tensor_a;
+        const ttnn::Tensor& input_tensor_b;
+    };
+
+    using spec_return_value_t = ttnn::TensorSpec;
+    using tensor_return_value_t = ttnn::Tensor;
+
+    struct SingleCore {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<SingleCore>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+ttnn::Tensor add_integers_hang(const ttnn::Tensor& input_tensor_a, const ttnn::Tensor& input_tensor_b);
+
+}  // namespace triage_hang_apps

--- a/tools/tests/triage/hang_apps/ttnn_add_integers_hang/single_core_program_factory.cpp
+++ b/tools/tests/triage/hang_apps/ttnn_add_integers_hang/single_core_program_factory.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "add_integers_hang_op.hpp"
+
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+namespace triage_hang_apps {
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+ProgramDescriptor AddIntegersHangOperation::SingleCore::create_descriptor(
+    const operation_attributes_t&, const tensor_args_t& tensor_args, tensor_return_value_t& tensor_return_value) {
+    const auto& a_tensor = tensor_args.input_tensor_a;
+    const auto& b_tensor = tensor_args.input_tensor_b;
+    auto& output_tensor = tensor_return_value;
+
+    auto* src0_buffer = a_tensor.buffer();
+    auto* src1_buffer = b_tensor.buffer();
+    auto* dst_buffer = output_tensor.buffer();
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(a_tensor.dtype());
+    uint32_t single_tile_size = tile_size(cb_data_format);
+    tt::DataFormat cb_data_format_output = datatype_to_dataformat_converter(output_tensor.dtype());
+    uint32_t single_tile_size_output = tt::tile_size(cb_data_format_output);
+
+    constexpr CoreCoord core = {0, 0};
+    CoreRangeSet core_set(CoreRange(core, core));
+
+    ProgramDescriptor desc;
+
+    constexpr uint32_t num_tiles = 1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * single_tile_size,
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = CBIndex::c_0,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * single_tile_size,
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = CBIndex::c_1,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * single_tile_size_output,
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = CBIndex::c_16,
+            .data_format = cb_data_format_output,
+            .page_size = single_tile_size_output,
+        }}},
+    });
+
+    // Reuse the sibling add_2_integers_hang kernels. CB indices c_0/c_1/c_16 are chosen
+    // above to match the constants those kernels expect.
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/reader_binary_1_tile.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_set;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.runtime_args.emplace_back(
+        core, KernelDescriptor::CoreRuntimeArgs{src0_buffer->address(), src1_buffer->address()});
+
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/writer_1_tile.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_set;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dst_buffer->address()});
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "tools/tests/triage/hang_apps/add_2_integers_hang/kernels/compute/add_2_tiles_hang.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_set;
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = MathFidelity::HiFi4,
+        .math_approx_mode = false,
+    };
+    compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{});
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace triage_hang_apps

--- a/tools/tests/triage/hang_apps/ttnn_add_integers_hang/ttnn_add_integers_hang.cpp
+++ b/tools/tests/triage/hang_apps/ttnn_add_integers_hang/ttnn_add_integers_hang.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Triage hang app that dispatches a TTNN-level operation which intentionally hangs.
+// Exercises the dispatcher op-id -> Inspector operationName/parameters decode path
+// in tools/triage/dump_running_operations.py.
+
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/distributed.hpp>
+
+#include "add_integers_hang_op.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/types.hpp"
+
+int main() {
+    auto mesh_device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(0);
+
+    constexpr uint32_t M = tt::constants::TILE_HEIGHT;
+    constexpr uint32_t N = tt::constants::TILE_WIDTH;
+    std::vector<bfloat16> a_data(M * N, bfloat16(1.0f));
+    std::vector<bfloat16> b_data(M * N, bfloat16(2.0f));
+
+    tt::tt_metal::TensorLayout tile_layout(
+        ttnn::DataType::BFLOAT16,
+        tt::tt_metal::PageConfig(ttnn::Layout::TILE),
+        ttnn::MemoryConfig(tt::tt_metal::BufferType::DRAM));
+    ttnn::TensorSpec spec(ttnn::Shape({M, N}), tile_layout);
+
+    ttnn::Tensor a = ttnn::Tensor::from_vector<bfloat16>(a_data, spec, mesh_device.get());
+    ttnn::Tensor b = ttnn::Tensor::from_vector<bfloat16>(b_data, spec, mesh_device.get());
+
+    try {
+        ttnn::Tensor result = triage_hang_apps::add_integers_hang(a, b);
+        // Force the dispatch to actually complete (which it won't — the kernel hangs).
+        // Reading back will block until the op finishes or times out.
+        auto _ = result.to_vector<bfloat16>();
+    } catch (const std::runtime_error& e) {
+        std::string error_msg = e.what();
+        if (error_msg.find("device timeout") != std::string::npos || error_msg.find("Timeout (") != std::string::npos) {
+            printf("Device timeout detected as expected.\n");
+            std::_Exit(0);
+        }
+        throw;
+    }
+
+    mesh_device->close();
+    return 0;
+}

--- a/tools/tests/triage/hang_apps/ttnn_add_integers_hang/ttnn_add_integers_hang.cpp
+++ b/tools/tests/triage/hang_apps/ttnn_add_integers_hang/ttnn_add_integers_hang.cpp
@@ -43,7 +43,7 @@ int main() {
         ttnn::Tensor result = triage_hang_apps::add_integers_hang(a, b);
         // Force the dispatch to actually complete (which it won't — the kernel hangs).
         // Reading back will block until the op finishes or times out.
-        auto _ = result.to_vector<bfloat16>();
+        std::cout << "Number of elements: " << result.to_vector<bfloat16>().size() << std::endl;
     } catch (const std::runtime_error& e) {
         std::string error_msg = e.what();
         if (error_msg.find("device timeout") != std::string::npos || error_msg.find("Timeout (") != std::string::npos) {

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -34,6 +34,9 @@ triage.progress_disabled = True  # Disable progress bars for tests
 
 # Mapping of hang application paths to their expected test results
 HANG_APP_ADD_2_INTEGERS = "tools/tests/triage/hang_apps/add_2_integers_hang/triage_hang_app_add_2_integers_hang"
+HANG_APP_TTNN_ADD_INTEGERS = (
+    "tools/tests/triage/hang_apps/ttnn_add_integers_hang/triage_hang_app_ttnn_add_integers_hang"
+)
 HANG_APP_EXPECTED_RESULTS = {
     HANG_APP_ADD_2_INTEGERS: {
         "lightweight_asserts": {
@@ -59,6 +62,36 @@ HANG_APP_EXPECTED_RESULTS = {
                     "line": 40,
                 },
             },
+        },
+    },
+    HANG_APP_TTNN_ADD_INTEGERS: {
+        "lightweight_asserts": {
+            "kernel_name": "add_2_tiles_hang",
+            "risc_names": {"trisc0", "trisc1", "trisc2"},
+            "first_callstack_file": "add_2_tiles_hang.cpp",
+            "first_callstack_line": 40,
+        },
+        "callstacks": {
+            "device_to_check": 0,
+            "location_to_check": "0,0",
+            "cores_to_check": {
+                "trisc0": {
+                    "file": "add_2_tiles_hang.cpp",
+                    "line": 40,
+                },
+                "trisc1": {
+                    "file": "add_2_tiles_hang.cpp",
+                    "line": 40,
+                },
+                "trisc2": {
+                    "file": "add_2_tiles_hang.cpp",
+                    "line": 40,
+                },
+            },
+        },
+        "running_operations": {
+            "expected_op_name_contains": "AddIntegersHang",
+            "assert_no_na": True,
         },
     },
 }
@@ -131,7 +164,7 @@ def cause_hang_with_app(request):
     "cause_hang_with_app",
     [
         (
-            # Manual hang detection with timeout from outside
+            # Manual hang detection with timeout from outside, fast dispatch
             HANG_APP_ADD_2_INTEGERS,
             [],
             {
@@ -140,7 +173,19 @@ def cause_hang_with_app(request):
             10,
         ),
         (
-            # Automatic hang detection with timeout inside the app and serialization of Inspector RPC data
+            # Manual hang detection with timeout from outside, slow dispatch
+            HANG_APP_ADD_2_INTEGERS,
+            [],
+            {
+                "env": {
+                    "TT_METAL_SLOW_DISPATCH_MODE": "1",
+                },
+                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_ADD_2_INTEGERS],
+            },
+            10,
+        ),
+        (
+            # Automatic hang detection with timeout inside the app and serialization of Inspector RPC data, fast dispatch
             HANG_APP_ADD_2_INTEGERS,
             [],
             {
@@ -154,7 +199,7 @@ def cause_hang_with_app(request):
             60,
         ),
         (
-            # Automatic hang detection with timeout inside the app and serialization of Inspector RPC data
+            # Automatic hang detection with timeout inside the app and serialization of Inspector RPC data, slow dispatch
             HANG_APP_ADD_2_INTEGERS,
             [],
             {
@@ -165,6 +210,56 @@ def cause_hang_with_app(request):
                     "TT_METAL_SLOW_DISPATCH_MODE": "1",
                 },
                 "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_ADD_2_INTEGERS],
+            },
+            60,
+        ),
+        (
+            # TTNN-dispatched hang: manual detection, fast dispatch
+            HANG_APP_TTNN_ADD_INTEGERS,
+            [],
+            {
+                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_TTNN_ADD_INTEGERS],
+            },
+            10,
+        ),
+        (
+            # TTNN-dispatched hang: manual detection, slow dispatch
+            HANG_APP_TTNN_ADD_INTEGERS,
+            [],
+            {
+                "env": {
+                    "TT_METAL_SLOW_DISPATCH_MODE": "1",
+                },
+                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_TTNN_ADD_INTEGERS],
+            },
+            10,
+        ),
+        (
+            # TTNN-dispatched hang: auto detection, fast dispatch
+            HANG_APP_TTNN_ADD_INTEGERS,
+            [],
+            {
+                "auto_timeout": True,
+                "env": {
+                    "TT_METAL_OPERATION_TIMEOUT_SECONDS": "0.5",
+                    "TT_METAL_LOGS_PATH": "/tmp/tt-metal/triage-test-ttnn",
+                },
+                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_TTNN_ADD_INTEGERS],
+            },
+            60,
+        ),
+        (
+            # TTNN-dispatched hang: auto detection, slow dispatch
+            HANG_APP_TTNN_ADD_INTEGERS,
+            [],
+            {
+                "auto_timeout": True,
+                "env": {
+                    "TT_METAL_OPERATION_TIMEOUT_SECONDS": "0.5",
+                    "TT_METAL_LOGS_PATH": "/tmp/tt-metal/inspector-ttnn",
+                    "TT_METAL_SLOW_DISPATCH_MODE": "1",
+                },
+                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_TTNN_ADD_INTEGERS],
             },
             60,
         ),
@@ -366,7 +461,40 @@ class TestTriage:
         assert len(result) > 0, "Expected at least one configuration entry"
 
     def test_dump_running_operations(self):
-        self.run_triage_script("dump_running_operations.py")
+        result = self.run_triage_script("dump_running_operations.py")
+
+        expected = self.expected_results.get("running_operations")
+        if not expected:
+            return
+
+        assert result is not None, "Expected non-None result from dump_running_operations.py"
+        assert len(result) > 0, "Expected at least one running operation in dump_running_operations output"
+
+        live_ops = [op for op in result if op.host_assigned_id]
+        assert len(live_ops) > 0, (
+            "Expected at least one running op with a non-zero host_assigned_id; "
+            "got only background entries (op_id == 0)"
+        )
+
+        if expected.get("assert_no_na"):
+            for op in live_ops:
+                assert op.operation_name != "N/A", (
+                    f"Op id {op.host_assigned_id}: operation_name resolved to N/A. "
+                    f"Dispatcher host_assigned_id failed to lookup against "
+                    f"Inspector getMeshWorkloadRuntimeEntries()."
+                )
+                assert op.operation_parameters != "N/A", (
+                    f"Op id {op.host_assigned_id}: operation_parameters resolved to N/A. "
+                    f"Op was named '{op.operation_name}' but params were empty in Inspector."
+                )
+
+        expected_name = expected.get("expected_op_name_contains")
+        if expected_name:
+            matching = [op for op in live_ops if expected_name in op.operation_name]
+            assert len(matching) > 0, (
+                f"No running op with name containing '{expected_name}'. "
+                f"Got: {[op.operation_name for op in live_ops]}"
+            )
 
     def test_dump_watcher_ringbuffer(self):
         self.run_triage_script("dump_watcher_ringbuffer.py")

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -164,22 +164,10 @@ def cause_hang_with_app(request):
     "cause_hang_with_app",
     [
         (
-            # Manual hang detection with timeout from outside, fast dispatch
+            # Manual hang detection with timeout from outside
             HANG_APP_ADD_2_INTEGERS,
             [],
             {
-                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_ADD_2_INTEGERS],
-            },
-            10,
-        ),
-        (
-            # Manual hang detection with timeout from outside, slow dispatch
-            HANG_APP_ADD_2_INTEGERS,
-            [],
-            {
-                "env": {
-                    "TT_METAL_SLOW_DISPATCH_MODE": "1",
-                },
                 "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_ADD_2_INTEGERS],
             },
             10,
@@ -212,27 +200,6 @@ def cause_hang_with_app(request):
                 "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_ADD_2_INTEGERS],
             },
             60,
-        ),
-        (
-            # TTNN-dispatched hang: manual detection, fast dispatch
-            HANG_APP_TTNN_ADD_INTEGERS,
-            [],
-            {
-                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_TTNN_ADD_INTEGERS],
-            },
-            10,
-        ),
-        (
-            # TTNN-dispatched hang: manual detection, slow dispatch
-            HANG_APP_TTNN_ADD_INTEGERS,
-            [],
-            {
-                "env": {
-                    "TT_METAL_SLOW_DISPATCH_MODE": "1",
-                },
-                "expected_results": HANG_APP_EXPECTED_RESULTS[HANG_APP_TTNN_ADD_INTEGERS],
-            },
-            10,
         ),
         (
             # TTNN-dispatched hang: auto detection, fast dispatch


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
- Adds new hang app that reuses `add_2_integers` kernels and creates a new op to be ran
- Expands test matrix to cover slow dispatch in manual and auto hang detection
- Expands `test_dump_running_operations` to actually verify correct operation name and parameters not being N/A for the new ttnn op

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-op-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-op-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/triage-op-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-op-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-op-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-op-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-op-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-op-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-op-test)