### PR TITLE
[Feature] Enable static TLB support for Quasar simulator

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -4,8 +4,10 @@
 
 #include <fmt/base.h>
 #include <gtest/gtest.h>
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <numeric>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
@@ -28,7 +30,9 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/program.hpp>
 #include "impl/context/metal_context.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include <umd/device/pcie/tlb_window.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
@@ -67,6 +71,49 @@ TEST_F(SimulatorFixture, SimulatorDeviceInitialization) {
         // Verify we can get base addresses
         EXPECT_GT(mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1), 0);
         EXPECT_GT(mesh_device->allocator()->get_base_allocator_addr(HalMemType::DRAM), 0);
+    }
+}
+
+TEST_F(SimulatorFixture, QuasarStaticTlbReadWrite) {
+    auto& cluster = MetalContext::instance().get_cluster();
+    if (cluster.arch() != tt::ARCH::QUASAR) {
+        GTEST_SKIP();
+    }
+
+    const auto& hal = MetalContext::instance().hal();
+    const uint64_t scratch_addr =
+        hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    constexpr uint16_t value16 = 0xCAFE;
+    constexpr uint32_t value32 = 0xDEADBEEF;
+
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        const auto mesh_device = devices_.at(id);
+        const ChipId chip_id = mesh_device->get_devices()[0]->id();
+        const auto& sdesc = cluster.get_soc_desc(chip_id);
+
+        const std::vector<tt::umd::CoreCoord> tensix_cores =
+            sdesc.get_cores(tt::CoreType::TENSIX, tt::CoordSystem::TRANSLATED);
+        ASSERT_FALSE(tensix_cores.empty());
+        const tt::umd::CoreCoord tensix = tensix_cores.front();
+        const tt_cxy_pair target(chip_id, tensix.x, tensix.y);
+
+        ASSERT_TRUE(cluster.get_tlb_data(target).has_value());
+
+        tt::umd::TlbWindow* window = cluster.get_static_tlb_window(target);
+        ASSERT_NE(window, nullptr);
+
+        window->write16(scratch_addr, value16);
+        EXPECT_EQ(window->read16(scratch_addr), value16);
+
+        window->write32(scratch_addr, value32);
+        EXPECT_EQ(window->read32(scratch_addr), value32);
+
+        std::array<uint32_t, 16> tx;
+        std::iota(tx.begin(), tx.end(), 0x12345678);
+        std::array<uint32_t, 16> rx{};
+        window->write_block(scratch_addr, tx.data(), tx.size() * sizeof(uint32_t));
+        window->read_block(scratch_addr, rx.data(), rx.size() * sizeof(uint32_t));
+        EXPECT_EQ(tx, rx);
     }
 }
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -83,7 +83,6 @@ TEST_F(SimulatorFixture, QuasarStaticTlbReadWrite) {
     const auto& hal = MetalContext::instance().hal();
     const uint64_t scratch_addr =
         hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
-    constexpr uint16_t value16 = 0xCAFE;
     constexpr uint32_t value32 = 0xDEADBEEF;
 
     for (unsigned int id = 0; id < num_devices_; id++) {
@@ -101,9 +100,6 @@ TEST_F(SimulatorFixture, QuasarStaticTlbReadWrite) {
 
         tt::umd::TlbWindow* window = cluster.get_static_tlb_window(target);
         ASSERT_NE(window, nullptr);
-
-        window->write16(scratch_addr, value16);
-        EXPECT_EQ(window->read16(scratch_addr), value16);
 
         window->write32(scratch_addr, value32);
         EXPECT_EQ(window->read32(scratch_addr), value32);

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -25,8 +25,8 @@ namespace ll_api {
 
 namespace wormhole {
 
-int32_t get_static_tlb_size() {
-    return 1 << 20;
+uint64_t get_static_tlb_size() {
+    return 1ULL << 20;
 }
 
 }  // namespace wormhole
@@ -36,8 +36,8 @@ namespace blackhole {
 static constexpr uint32_t NUM_PORTS_PER_DRAM_CHANNEL = 3;
 static constexpr uint32_t NUM_DRAM_CHANNELS = 8;
 
-int32_t get_static_tlb_size() {
-    return 2 * (1 << 20);
+uint64_t get_static_tlb_size() {
+    return 2 * (1ULL << 20);
 }
 
 // Returns last port of dram channel passed as the argument to align with dram_preferred_worker_endpoint
@@ -50,13 +50,13 @@ tt_xy_pair ddr_to_noc0(unsigned i) {
 
 namespace quasar {
 
-int32_t get_static_tlb_size() { return 2 * (1 << 20); }
+uint64_t get_static_tlb_size() { return 4ULL * (1ULL << 30); }
 
 }  // namespace quasar
 
 void configure_static_tlbs(
     tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver) {
-    using get_static_tlb_size_ptr = std::int32_t (*)();
+    using get_static_tlb_size_ptr = uint64_t (*)();
     get_static_tlb_size_ptr get_static_tlb_size;
 
     // Need to set these values based on arch because UMD does not expose architecture_implementation

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -48,6 +48,12 @@ tt_xy_pair ddr_to_noc0(unsigned i) {
 
 }  // namespace blackhole
 
+namespace quasar {
+
+int32_t get_static_tlb_size() { return 2 * (1 << 20); }
+
+}  // namespace quasar
+
 void configure_static_tlbs(
     tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver) {
     using get_static_tlb_size_ptr = std::int32_t (*)();
@@ -61,6 +67,7 @@ void configure_static_tlbs(
         case tt::ARCH::BLACKHOLE:
             get_static_tlb_size = blackhole::get_static_tlb_size;
             break;
+        case tt::ARCH::QUASAR: get_static_tlb_size = quasar::get_static_tlb_size; break;
         default: TT_THROW("Configuring static TLBs is not supported for {}", tt::get_string(arch));
     }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -472,7 +472,9 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
     // May block waiting for other processes to release the device.
     this->driver_->start_device(device_params);
 
-    if (this->target_type_ == TargetDevice::Silicon && device_params.init_device) {
+    if ((this->target_type_ == TargetDevice::Silicon ||
+         (this->target_type_ == TargetDevice::Simulator && this->arch_ == tt::ARCH::QUASAR)) &&
+        device_params.init_device) {
         // Configure TLBs on all MMIO devices in parallel
         std::vector<std::shared_future<void>> futures;
         const auto& mmio_device_ids = driver_->get_target_mmio_device_ids();


### PR DESCRIPTION
### PR Category
Feature

### Summary
This PR extends static TLB initialization to Quasar simulation. The `start_driver()` function in `tt_cluster.cpp` now also triggers TLB configuration when running on the Quasar simulator. A `quasar` namespace has been added to `tlb_config.cpp` with a `get_static_tlb_size()` function that returns 4 GB, and the existing `get_static_tlb_size()` functions for Wormhole and Blackhole have been updated from `int32_t` to `uint64_t` to avoid overflow issues.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_tlb_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_tlb_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_tlb_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_tlb_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_tlb_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_tlb_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_tlb_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_tlb_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_tlb_test)