### PR TITLE
moe_gpt: size expert_activation_cb for sentinel row to fix watcher CB overflow

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -387,7 +387,7 @@ void kernel_main() {
 
     const uint32_t indices_base = get_read_ptr(indices_tensor_cb_id);
     const uint32_t scores_base = get_read_ptr(scores_tensor_cb_id);
-    const uint32_t expert_activation_base = get_write_ptr(expert_activation_cb_id);
+    const uint32_t expert_activation_base = get_read_ptr(expert_activation_cb_id);
 
     // Cache source_device_mapping - only changes every tokens_per_device tokens
     // Reduces mapping loads from 512 to 16 (dispatch_devices)
@@ -590,7 +590,7 @@ void kernel_main() {
                 // Pull this core's expert_activation buffer rows
                 if (remote_activated_count > 0) {
                     // Source: remote core's expert_activation buffer, rows start at 0
-                    uint32_t remote_activation_addr = get_write_ptr(expert_activation_cb_id);
+                    uint32_t remote_activation_addr = get_read_ptr(expert_activation_cb_id);
                     uint64_t remote_activation_noc_addr =
                         get_noc_addr(remote_noc_x, remote_noc_y, remote_activation_addr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -625,8 +625,8 @@ MoEGPTMeshWorkloadFactory::create_at(
         const auto tilize_mapping_data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_mapping.dtype());
         const auto tilize_output_data_format = tt::tt_metal::datatype_to_dataformat_converter(sparse_buffer.dtype());
 
-        // tiles_per_local_chunk for the drain core (used for CB sizing)
-        uint32_t shared_cb_num_pages = max_tiles_per_local_chunk;
+        // tiles_per_global_chunk: drain core gathers from all tilize cores before multicast
+        uint32_t shared_cb_num_pages = hidden_size / TILE_WIDTH;
 
         tt::tt_metal::create_cb(
             per_expert_total_tokens_cb_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -688,7 +688,7 @@ MoEGPTMeshWorkloadFactory::create_at(
             program,
             tilize_core_range_set,
             tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment),
-            tokens + 1,  // +1 for sentinel row written at offset num_activated_tokens*row_bytes
+            tokens,
             tt::DataFormat::UInt32);
 
         tt::tt_metal::create_cb(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -688,7 +688,7 @@ MoEGPTMeshWorkloadFactory::create_at(
             program,
             tilize_core_range_set,
             tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment),
-            tokens,
+            tokens + 1,  // +1 for sentinel row written at offset num_activated_tokens*row_bytes
             tt::DataFormat::UInt32);
 
         tt::tt_metal::create_cb(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -688,7 +688,7 @@ MoEGPTMeshWorkloadFactory::create_at(
             program,
             tilize_core_range_set,
             tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment),
-            tokens,
+            tokens + 1,
             tt::DataFormat::UInt32);
 
         tt::tt_metal::create_cb(


### PR DESCRIPTION
## Summary

The tilize kernels in `moe_gpt` build a per-token `expert_activation` buffer with `tokens` rows followed by a sentinel row (token_id = -1). The CB on tilize cores (`expert_activation_cb_id`, c_8) was sized for `tokens` pages, but the kernel:

1. Writes the sentinel at `expert_activation_base + num_activated_tokens * aligned_activation_row_bytes` (== `tokens * row_bytes` at max) — one row past the CB end.
2. Issues a `noc_async_write` of `(num_activated_tokens + 1) * row_bytes` bytes from the CB base to the `expert_activation` output tensor.

With `TT_METAL_WATCHER` enabled, step 2 trips `DebugSanitizeCBOutOfBounds` ("NOC transaction overflows a circular buffer"). Without the watcher, step 1 silently corrupts whatever CB follows in L1.

## Fix

The output tensor spec already accounts for the sentinel:
```
activation_total_bytes = (total_tokens + 1) * activation_row_bytes
```
Bump the source CB capacity from `tokens` to `tokens + 1` pages so the sentinel row lives inside the CB. `cb_reserve_back` / `cb_push_back` calls still operate on `tokens` pages — the extra page is just space for the sentinel.

## Repro

```
TT_METAL_WATCHER=60 TT_MM_THROTTLE_PERF=2 pytest \
  models/demos/gpt_oss/demo/text_demo.py -k 'mesh_4x8 and batch128' --timeout 1200
```

Fires from CI run [25732614755](https://github.com/tenstorrent/tt-metal/actions/runs/25732614755/job/75562749274#step:6:1867) on Galaxy 4x8 (multiple SKUs reproduce). Stack:
`fused_decode_forward → moe_gpt → tilize_reader (NCRISC)`, at the line:
`noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size)`
where `expert_activation_write_size = (num_activated_tokens + 1) * 48 = 6192` for batch=128 and 4 experts/device, and the source CB was 128 * 48 = 6144 bytes.

## Test plan

- [ ] CI Tier 1 GPT-OSS 120B Galaxy run (`mesh_4x8 + batch128` with `TT_METAL_WATCHER=60`) passes 30-minute timeout without firing the CB sanitizer
- [ ] No regression in numerical output (CB size grows by 48 B per tilize core; sentinel row is in-bounds now)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/moe-gpt-cb-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/moe-gpt-cb-overflow-fix)