### PR TITLE
[tt-train] Deduplicate benchmark utilities and fix from_vector startup

### DIFF
--- a/tt-train/tests/benchmark/adamw_benchmark.cpp
+++ b/tt-train/tests/benchmark/adamw_benchmark.cpp
@@ -5,12 +5,11 @@
 
 #include <chrono>
 
-#include "core/tt_tensor_utils.hpp"
+#include "benchmark_utils.hpp"
 #include "metal/optimizers/adamw/adamw.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
-#include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
 
 namespace {
@@ -51,7 +50,7 @@ void BM_AdamW(benchmark::State& state) {
 
     const auto dtype = ttnn::DataType::BFLOAT16;
     const ttnn::Shape shape(adamw_shape.shape);
-    const uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(adamw_shape.name));
+    const uint32_t seed = ttml::benchmark_utils::seed_from_name(adamw_shape.name);
     const auto tensor_spec = ttnn::TensorSpec(
         shape, tt::tt_metal::TensorLayout(dtype, tt::tt_metal::Layout::TILE, ttnn::DRAM_MEMORY_CONFIG));
 

--- a/tt-train/tests/benchmark/adamw_benchmark.cpp
+++ b/tt-train/tests/benchmark/adamw_benchmark.cpp
@@ -3,8 +3,6 @@
 
 #include <benchmark/benchmark.h>
 
-#include <chrono>
-
 #include "benchmark_utils.hpp"
 #include "metal/optimizers/adamw/adamw.hpp"
 #include "test_utils/random_data.hpp"
@@ -19,12 +17,7 @@ struct AdamWShape {
     std::string name;
 };
 
-struct TestConfig {
-    int num_warmup_iterations = 3;
-    int num_measurement_iterations = 20;
-};
-
-const TestConfig test_config = {
+constexpr ttml::benchmark_utils::BenchmarkIterationConfig test_config = {
     .num_warmup_iterations = 5,
     .num_measurement_iterations = 50,
 };
@@ -44,7 +37,7 @@ void BM_AdamW(benchmark::State& state) {
     const int shape_index = static_cast<int>(state.range(0));
     const auto& adamw_shape = adamw_shapes[shape_index];
 
-    const auto device_id = 0;
+    constexpr int device_id = 0;
     auto device = ttnn::device::open_mesh_device(device_id);
     device->enable_program_cache();
 
@@ -78,7 +71,7 @@ void BM_AdamW(benchmark::State& state) {
     const float weight_decay = 0.01f;
 
     // Warmup
-    for (int i = 0; i < test_config.num_warmup_iterations; ++i) {
+    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(test_config.num_warmup_iterations), [&]() {
         auto result = ttml::metal::adamw(
             param,
             grad,
@@ -94,35 +87,29 @@ void BM_AdamW(benchmark::State& state) {
             weight_decay);
         tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
         result.deallocate();
-    }
+    });
 
     for ([[maybe_unused]] auto _ : state) {
-        auto total_time = std::chrono::duration<double>::zero();
-
-        for (int iter = 0; iter < test_config.num_measurement_iterations; ++iter) {
-            auto start = std::chrono::high_resolution_clock::now();
-            auto result = ttml::metal::adamw(
-                param,
-                grad,
-                exp_avg,
-                exp_avg_sq,
-                std::nullopt,
-                lr,
-                beta1,
-                beta2,
-                beta1_pow,
-                beta2_pow,
-                epsilon,
-                weight_decay);
-            tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
-            auto end = std::chrono::high_resolution_clock::now();
-            total_time += end - start;
-            result.deallocate();
-        }
-
-        double avg_time_s = total_time.count() / test_config.num_measurement_iterations;
-        double time_us = avg_time_s * 1e6;
-        double gb_per_s = static_cast<double>(total_dram_bytes) / avg_time_s / 1e9;
+        const double avg_time_s =
+            ttml::benchmark_utils::measure_average_iteration_time_s(test_config.num_measurement_iterations, [&]() {
+                auto result = ttml::metal::adamw(
+                    param,
+                    grad,
+                    exp_avg,
+                    exp_avg_sq,
+                    std::nullopt,
+                    lr,
+                    beta1,
+                    beta2,
+                    beta1_pow,
+                    beta2_pow,
+                    epsilon,
+                    weight_decay);
+                tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
+                result.deallocate();
+            });
+        const double time_us = avg_time_s * 1e6;
+        const double gb_per_s = static_cast<double>(total_dram_bytes) / avg_time_s / 1e9;
 
         state.SetIterationTime(avg_time_s);
         state.SetLabel(adamw_shape.name);

--- a/tt-train/tests/benchmark/adamw_benchmark.cpp
+++ b/tt-train/tests/benchmark/adamw_benchmark.cpp
@@ -71,7 +71,7 @@ void BM_AdamW(benchmark::State& state) {
     const float weight_decay = 0.01f;
 
     // Warmup
-    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(test_config.num_warmup_iterations), [&]() {
+    for (int i = 0; i < test_config.num_warmup_iterations; ++i) {
         auto result = ttml::metal::adamw(
             param,
             grad,
@@ -87,7 +87,7 @@ void BM_AdamW(benchmark::State& state) {
             weight_decay);
         tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
         result.deallocate();
-    });
+    }
 
     for ([[maybe_unused]] auto _ : state) {
         const double avg_time_s =

--- a/tt-train/tests/benchmark/benchmark_utils.hpp
+++ b/tt-train/tests/benchmark/benchmark_utils.hpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace ttml::benchmark_utils {
+
+// Benchmark-only sweep helpers.
+//
+// Keep these separate from test_utils: test_utils owns reusable test data construction,
+// while benchmark_utils owns benchmark CLI/env plumbing and reporting conveniences.
+// Only place helpers here once they have real benchmark call sites; speculative helpers
+// should stay local to the benchmark that needs them.
+
+inline std::string join_u32_csv(const std::vector<uint32_t>& values) {
+    std::string out;
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (i > 0) {
+            out += ",";
+        }
+        out += std::to_string(values[i]);
+    }
+    return out;
+}
+
+inline std::vector<uint32_t> parse_u32_csv(std::string_view csv) {
+    std::vector<uint32_t> out;
+    std::stringstream ss{std::string(csv)};
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        if (token.empty()) {
+            continue;
+        }
+        out.push_back(static_cast<uint32_t>(std::stoul(token)));
+    }
+    return out;
+}
+
+inline std::vector<std::string> parse_string_csv(std::string_view csv) {
+    std::vector<std::string> out;
+    std::stringstream ss{std::string(csv)};
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        if (token.empty()) {
+            continue;
+        }
+        out.push_back(token);
+    }
+    return out;
+}
+
+inline bool name_is_enabled(const std::vector<std::string>& enabled_names, const std::string& name) {
+    return enabled_names.empty() || std::find(enabled_names.begin(), enabled_names.end(), name) != enabled_names.end();
+}
+
+inline uint32_t seed_from_name(const std::string& name) {
+    return static_cast<uint32_t>(std::hash<std::string>{}(name));
+}
+
+}  // namespace ttml::benchmark_utils

--- a/tt-train/tests/benchmark/benchmark_utils.hpp
+++ b/tt-train/tests/benchmark/benchmark_utils.hpp
@@ -5,14 +5,23 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace ttml::benchmark_utils {
+
+struct BenchmarkIterationConfig {
+    int num_warmup_iterations = 0;
+    int num_measurement_iterations = 0;
+};
 
 // Benchmark-only sweep helpers.
 //
@@ -32,7 +41,7 @@ inline std::string join_u32_csv(const std::vector<uint32_t>& values) {
     return out;
 }
 
-inline std::vector<uint32_t> parse_u32_csv(std::string_view csv) {
+inline std::vector<uint32_t> parse_u32_csv(const std::string_view csv) {
     std::vector<uint32_t> out;
     std::stringstream ss{std::string(csv)};
     std::string token;
@@ -45,7 +54,7 @@ inline std::vector<uint32_t> parse_u32_csv(std::string_view csv) {
     return out;
 }
 
-inline std::vector<std::string> parse_string_csv(std::string_view csv) {
+inline std::vector<std::string> parse_string_csv(const std::string_view csv) {
     std::vector<std::string> out;
     std::stringstream ss{std::string(csv)};
     std::string token;
@@ -58,12 +67,82 @@ inline std::vector<std::string> parse_string_csv(std::string_view csv) {
     return out;
 }
 
+inline void override_u32_from_env(const char* env_name, uint32_t& value) {
+    if (const char* env = std::getenv(env_name)) {
+        value = static_cast<uint32_t>(std::stoul(env));
+    }
+}
+
+inline void override_u32_csv_from_env(const char* env_name, std::vector<uint32_t>& values) {
+    if (const char* env = std::getenv(env_name)) {
+        auto parsed = parse_u32_csv(env);
+        if (!parsed.empty()) {
+            values = std::move(parsed);
+        }
+    }
+}
+
+inline void override_string_csv_from_env(const char* env_name, std::vector<std::string>& values) {
+    if (const char* env = std::getenv(env_name)) {
+        values = parse_string_csv(env);
+    }
+}
+
 inline bool name_is_enabled(const std::vector<std::string>& enabled_names, const std::string& name) {
     return enabled_names.empty() || std::find(enabled_names.begin(), enabled_names.end(), name) != enabled_names.end();
 }
 
 inline uint32_t seed_from_name(const std::string& name) {
     return static_cast<uint32_t>(std::hash<std::string>{}(name));
+}
+
+// Relative change from reference (%). Positive means value increased.
+inline double relative_change_pct(const double value, const double reference) {
+    if (reference == 0.0) {
+        return 0.0;
+    }
+    return (value - reference) / reference * 100.0;
+}
+
+// Reduction against baseline (%). Positive means value decreased.
+inline double reduction_pct(const double baseline, const double value) {
+    return -relative_change_pct(value, baseline);
+}
+
+inline double speedup_x(const double baseline, const double value) {
+    if (value == 0.0) {
+        return 0.0;
+    }
+    return baseline / value;
+}
+
+inline double average(const std::vector<double>& values) {
+    if (values.empty()) {
+        return 0.0;
+    }
+    return std::accumulate(values.begin(), values.end(), 0.0) / static_cast<double>(values.size());
+}
+
+template <typename Fn>
+inline void run_iterations(const uint32_t num_iterations, Fn&& fn) {
+    for (uint32_t i = 0; i < num_iterations; ++i) {
+        fn();
+    }
+}
+
+template <typename Fn>
+inline double measure_average_iteration_time_s(const int num_iterations, Fn&& fn) {
+    if (num_iterations <= 0) {
+        return 0.0;
+    }
+    auto total_time = std::chrono::duration<double>::zero();
+    for (int iter = 0; iter < num_iterations; ++iter) {
+        const auto start = std::chrono::high_resolution_clock::now();
+        fn();
+        const auto end = std::chrono::high_resolution_clock::now();
+        total_time += end - start;
+    }
+    return total_time.count() / static_cast<double>(num_iterations);
 }
 
 }  // namespace ttml::benchmark_utils

--- a/tt-train/tests/benchmark/benchmark_utils.hpp
+++ b/tt-train/tests/benchmark/benchmark_utils.hpp
@@ -155,13 +155,6 @@ inline double average(const std::vector<double>& values) {
 }
 
 template <typename Fn>
-inline void run_iterations(const uint32_t num_iterations, Fn&& fn) {
-    for (uint32_t i = 0; i < num_iterations; ++i) {
-        fn();
-    }
-}
-
-template <typename Fn>
 inline double measure_average_iteration_time_s(const int num_iterations, Fn&& fn) {
     if (num_iterations <= 0) {
         return 0.0;

--- a/tt-train/tests/benchmark/benchmark_utils.hpp
+++ b/tt-train/tests/benchmark/benchmark_utils.hpp
@@ -4,20 +4,11 @@
 
 #pragma once
 
-#include <algorithm>
-#include <charconv>
 #include <chrono>
 #include <cstdint>
-#include <cstdlib>
 #include <functional>
-#include <limits>
 #include <numeric>
-#include <sstream>
-#include <stdexcept>
 #include <string>
-#include <string_view>
-#include <system_error>
-#include <utility>
 #include <vector>
 
 namespace ttml::benchmark_utils {
@@ -27,101 +18,12 @@ struct BenchmarkIterationConfig {
     int num_measurement_iterations = 0;
 };
 
-// Benchmark-only sweep helpers.
+// Benchmark-only helper utilities.
 //
 // Keep these separate from test_utils: test_utils owns reusable test data construction,
-// while benchmark_utils owns benchmark CLI/env plumbing and reporting conveniences.
+// while benchmark_utils owns benchmark timing and reporting conveniences.
 // Only place helpers here once they have real benchmark call sites; speculative helpers
 // should stay local to the benchmark that needs them.
-
-inline std::string join_u32_csv(const std::vector<uint32_t>& values) {
-    std::string out;
-    for (size_t i = 0; i < values.size(); ++i) {
-        if (i > 0) {
-            out += ",";
-        }
-        out += std::to_string(values[i]);
-    }
-    return out;
-}
-
-inline std::string_view trim_ascii_whitespace(std::string_view value) {
-    constexpr std::string_view kWhitespace = " \t\n\r\f\v";
-    const auto begin = value.find_first_not_of(kWhitespace);
-    if (begin == std::string_view::npos) {
-        return {};
-    }
-    const auto end = value.find_last_not_of(kWhitespace);
-    return value.substr(begin, end - begin + 1U);
-}
-
-inline uint32_t parse_u32_strict(const std::string_view raw_token) {
-    const auto token = trim_ascii_whitespace(raw_token);
-    if (token.empty()) {
-        throw std::invalid_argument("Expected a non-empty uint32 token.");
-    }
-
-    uint64_t parsed_value = 0;
-    const auto* begin = token.data();
-    const auto* end = token.data() + token.size();
-    const auto [ptr, ec] = std::from_chars(begin, end, parsed_value, 10);
-    if (ec != std::errc{} || ptr != end || parsed_value > std::numeric_limits<uint32_t>::max()) {
-        throw std::invalid_argument("Invalid uint32 token: \"" + std::string(token) + "\"");
-    }
-
-    return static_cast<uint32_t>(parsed_value);
-}
-
-inline std::vector<uint32_t> parse_u32_csv(const std::string_view csv) {
-    std::vector<uint32_t> out;
-    std::stringstream ss{std::string(csv)};
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-        if (trim_ascii_whitespace(token).empty()) {
-            continue;
-        }
-        out.push_back(parse_u32_strict(token));
-    }
-    return out;
-}
-
-inline std::vector<std::string> parse_string_csv(const std::string_view csv) {
-    std::vector<std::string> out;
-    std::stringstream ss{std::string(csv)};
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-        if (token.empty()) {
-            continue;
-        }
-        out.push_back(token);
-    }
-    return out;
-}
-
-inline void override_u32_from_env(const char* env_name, uint32_t& value) {
-    if (const char* env = std::getenv(env_name)) {
-        value = parse_u32_strict(env);
-    }
-}
-
-inline void override_u32_csv_from_env(const char* env_name, std::vector<uint32_t>& values) {
-    if (const char* env = std::getenv(env_name)) {
-        auto parsed = parse_u32_csv(env);
-        if (!parsed.empty()) {
-            values = std::move(parsed);
-        }
-    }
-}
-
-inline void override_string_csv_from_env(const char* env_name, std::vector<std::string>& values) {
-    if (const char* env = std::getenv(env_name)) {
-        values = parse_string_csv(env);
-    }
-}
-
-inline bool name_is_enabled(const std::vector<std::string>& enabled_names, const std::string& name) {
-    return enabled_names.empty() || std::find(enabled_names.begin(), enabled_names.end(), name) != enabled_names.end();
-}
 
 inline uint32_t seed_from_name(const std::string& name) {
     return static_cast<uint32_t>(std::hash<std::string>{}(name));

--- a/tt-train/tests/benchmark/benchmark_utils.hpp
+++ b/tt-train/tests/benchmark/benchmark_utils.hpp
@@ -5,14 +5,18 @@
 #pragma once
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <limits>
 #include <numeric>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -41,15 +45,42 @@ inline std::string join_u32_csv(const std::vector<uint32_t>& values) {
     return out;
 }
 
+inline std::string_view trim_ascii_whitespace(std::string_view value) {
+    constexpr std::string_view kWhitespace = " \t\n\r\f\v";
+    const auto begin = value.find_first_not_of(kWhitespace);
+    if (begin == std::string_view::npos) {
+        return {};
+    }
+    const auto end = value.find_last_not_of(kWhitespace);
+    return value.substr(begin, end - begin + 1U);
+}
+
+inline uint32_t parse_u32_strict(const std::string_view raw_token) {
+    const auto token = trim_ascii_whitespace(raw_token);
+    if (token.empty()) {
+        throw std::invalid_argument("Expected a non-empty uint32 token.");
+    }
+
+    uint64_t parsed_value = 0;
+    const auto* begin = token.data();
+    const auto* end = token.data() + token.size();
+    const auto [ptr, ec] = std::from_chars(begin, end, parsed_value, 10);
+    if (ec != std::errc{} || ptr != end || parsed_value > std::numeric_limits<uint32_t>::max()) {
+        throw std::invalid_argument("Invalid uint32 token: \"" + std::string(token) + "\"");
+    }
+
+    return static_cast<uint32_t>(parsed_value);
+}
+
 inline std::vector<uint32_t> parse_u32_csv(const std::string_view csv) {
     std::vector<uint32_t> out;
     std::stringstream ss{std::string(csv)};
     std::string token;
     while (std::getline(ss, token, ',')) {
-        if (token.empty()) {
+        if (trim_ascii_whitespace(token).empty()) {
             continue;
         }
-        out.push_back(static_cast<uint32_t>(std::stoul(token)));
+        out.push_back(parse_u32_strict(token));
     }
     return out;
 }
@@ -69,7 +100,7 @@ inline std::vector<std::string> parse_string_csv(const std::string_view csv) {
 
 inline void override_u32_from_env(const char* env_name, uint32_t& value) {
     if (const char* env = std::getenv(env_name)) {
-        value = static_cast<uint32_t>(std::stoul(env));
+        value = parse_u32_strict(env);
     }
 }
 

--- a/tt-train/tests/benchmark/frobenius_normalize_benchmark.cpp
+++ b/tt-train/tests/benchmark/frobenius_normalize_benchmark.cpp
@@ -6,8 +6,9 @@
 
 #include <chrono>
 
+#include "benchmark_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
-#include "metal/operations.hpp"
+#include "metal/ops/frobenius_normalize/frobenius_normalize.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
@@ -53,7 +54,7 @@ void BM_FrobeniusNormalize_Fused(benchmark::State& state) {
     device->enable_program_cache();
 
     const ttnn::Shape shape(frobenius_shape.shape);
-    const uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(frobenius_shape.name));
+    const uint32_t seed = ttml::benchmark_utils::seed_from_name(frobenius_shape.name);
 
     const auto data = ttml::test_utils::make_uniform_vector<float>(shape.volume(), -1.0f, 1.0f, seed);
     auto input = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(data, shape, device.get());
@@ -95,7 +96,7 @@ void BM_FrobeniusNormalize_Composite(benchmark::State& state) {
     device->enable_program_cache();
 
     const ttnn::Shape shape(frobenius_shape.shape);
-    const uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(frobenius_shape.name));
+    const uint32_t seed = ttml::benchmark_utils::seed_from_name(frobenius_shape.name);
 
     const auto data = ttml::test_utils::make_uniform_vector<float>(shape.volume(), -1.0f, 1.0f, seed);
     auto input = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(data, shape, device.get());

--- a/tt-train/tests/benchmark/frobenius_normalize_benchmark.cpp
+++ b/tt-train/tests/benchmark/frobenius_normalize_benchmark.cpp
@@ -55,11 +55,11 @@ void BM_FrobeniusNormalize_Fused(benchmark::State& state) {
     const auto data = ttml::test_utils::make_uniform_vector<float>(shape.volume(), -1.0f, 1.0f, seed);
     auto input = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(data, shape, device.get());
 
-    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(test_config.num_warmup_iterations), [&]() {
+    for (int i = 0; i < test_config.num_warmup_iterations; ++i) {
         auto result = ttml::metal::frobenius_normalize(input, kEps);
         tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
         result.deallocate();
-    });
+    }
 
     for ([[maybe_unused]] auto _ : state) {
         const double avg_time_s =
@@ -91,11 +91,11 @@ void BM_FrobeniusNormalize_Composite(benchmark::State& state) {
     const auto data = ttml::test_utils::make_uniform_vector<float>(shape.volume(), -1.0f, 1.0f, seed);
     auto input = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(data, shape, device.get());
 
-    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(test_config.num_warmup_iterations), [&]() {
+    for (int i = 0; i < test_config.num_warmup_iterations; ++i) {
         auto result = composite_frobenius_normalize(input, kEps);
         tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
         result.deallocate();
-    });
+    }
 
     for ([[maybe_unused]] auto _ : state) {
         const double avg_time_s =

--- a/tt-train/tests/benchmark/frobenius_normalize_benchmark.cpp
+++ b/tt-train/tests/benchmark/frobenius_normalize_benchmark.cpp
@@ -4,8 +4,6 @@
 
 #include <benchmark/benchmark.h>
 
-#include <chrono>
-
 #include "benchmark_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/ops/frobenius_normalize/frobenius_normalize.hpp"
@@ -23,12 +21,10 @@ struct FrobeniusShape {
     std::string name;
 };
 
-struct TestConfig {
-    int num_warmup_iterations = 5;
-    int num_measurement_iterations = 20;
+constexpr ttml::benchmark_utils::BenchmarkIterationConfig test_config = {
+    .num_warmup_iterations = 5,
+    .num_measurement_iterations = 20,
 };
-
-constexpr TestConfig test_config;
 
 const std::vector<FrobeniusShape> frobenius_shapes = {
     {{1, 1, 2048, 5632}, "2048x5632"},
@@ -49,7 +45,7 @@ void BM_FrobeniusNormalize_Fused(benchmark::State& state) {
     const int shape_index = static_cast<int>(state.range(0));
     const auto& frobenius_shape = frobenius_shapes[shape_index];
 
-    const auto device_id = 0;
+    constexpr int device_id = 0;
     auto device = ttnn::device::open_mesh_device(device_id);
     device->enable_program_cache();
 
@@ -59,25 +55,19 @@ void BM_FrobeniusNormalize_Fused(benchmark::State& state) {
     const auto data = ttml::test_utils::make_uniform_vector<float>(shape.volume(), -1.0f, 1.0f, seed);
     auto input = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(data, shape, device.get());
 
-    for (int i = 0; i < test_config.num_warmup_iterations; ++i) {
+    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(test_config.num_warmup_iterations), [&]() {
         auto result = ttml::metal::frobenius_normalize(input, kEps);
         tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
         result.deallocate();
-    }
+    });
 
     for ([[maybe_unused]] auto _ : state) {
-        auto total_time = std::chrono::duration<double>::zero();
-
-        for (int iter = 0; iter < test_config.num_measurement_iterations; ++iter) {
-            const auto start = std::chrono::high_resolution_clock::now();
-            auto result = ttml::metal::frobenius_normalize(input, kEps);
-            tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
-            const auto end = std::chrono::high_resolution_clock::now();
-            total_time += end - start;
-            result.deallocate();
-        }
-
-        const double avg_time_s = total_time.count() / test_config.num_measurement_iterations;
+        const double avg_time_s =
+            ttml::benchmark_utils::measure_average_iteration_time_s(test_config.num_measurement_iterations, [&]() {
+                auto result = ttml::metal::frobenius_normalize(input, kEps);
+                tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
+                result.deallocate();
+            });
         state.SetIterationTime(avg_time_s);
         state.SetLabel(frobenius_shape.name);
         state.counters["Time_us"] = avg_time_s * 1e6;
@@ -91,7 +81,7 @@ void BM_FrobeniusNormalize_Composite(benchmark::State& state) {
     const int shape_index = static_cast<int>(state.range(0));
     const auto& frobenius_shape = frobenius_shapes[shape_index];
 
-    const auto device_id = 0;
+    constexpr int device_id = 0;
     auto device = ttnn::device::open_mesh_device(device_id);
     device->enable_program_cache();
 
@@ -101,25 +91,19 @@ void BM_FrobeniusNormalize_Composite(benchmark::State& state) {
     const auto data = ttml::test_utils::make_uniform_vector<float>(shape.volume(), -1.0f, 1.0f, seed);
     auto input = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(data, shape, device.get());
 
-    for (int i = 0; i < test_config.num_warmup_iterations; ++i) {
+    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(test_config.num_warmup_iterations), [&]() {
         auto result = composite_frobenius_normalize(input, kEps);
         tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
         result.deallocate();
-    }
+    });
 
     for ([[maybe_unused]] auto _ : state) {
-        auto total_time = std::chrono::duration<double>::zero();
-
-        for (int iter = 0; iter < test_config.num_measurement_iterations; ++iter) {
-            const auto start = std::chrono::high_resolution_clock::now();
-            auto result = composite_frobenius_normalize(input, kEps);
-            tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
-            const auto end = std::chrono::high_resolution_clock::now();
-            total_time += end - start;
-            result.deallocate();
-        }
-
-        const double avg_time_s = total_time.count() / test_config.num_measurement_iterations;
+        const double avg_time_s =
+            ttml::benchmark_utils::measure_average_iteration_time_s(test_config.num_measurement_iterations, [&]() {
+                auto result = composite_frobenius_normalize(input, kEps);
+                tt::tt_metal::distributed::Synchronize(device.get(), std::nullopt);
+                result.deallocate();
+            });
         state.SetIterationTime(avg_time_s);
         state.SetLabel(frobenius_shape.name);
         state.counters["Time_us"] = avg_time_s * 1e6;

--- a/tt-train/tests/benchmark/from_vector_benchmark.cpp
+++ b/tt-train/tests/benchmark/from_vector_benchmark.cpp
@@ -100,7 +100,8 @@ BENCHMARK(BM_FromVector_Uint32_UINT32)->Unit(benchmark::kMicrosecond)->RangeMult
 BENCHMARK(BM_FromVector_Int32_INT32)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1 << 16, 1 << 20);
 
 int main(int argc, char** argv) {
-    auto device = ttnn::device::open_mesh_device(0, /*l1_small_size=*/0, /*trace_region_size=*/1048576);
+    // Keep device initialization consistent with other tt-train benchmarks.
+    auto device = ttnn::device::open_mesh_device(0);
     g_device = device.get();
 
     ::benchmark::Initialize(&argc, argv);

--- a/tt-train/tests/benchmark/from_vector_benchmark.cpp
+++ b/tt-train/tests/benchmark/from_vector_benchmark.cpp
@@ -100,7 +100,6 @@ BENCHMARK(BM_FromVector_Uint32_UINT32)->Unit(benchmark::kMicrosecond)->RangeMult
 BENCHMARK(BM_FromVector_Int32_INT32)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1 << 16, 1 << 20);
 
 int main(int argc, char** argv) {
-    // Keep device initialization consistent with other tt-train benchmarks.
     auto device = ttnn::device::open_mesh_device(0);
     g_device = device.get();
 

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -11,8 +11,6 @@
 #include <llrt/tt_cluster.hpp>
 #include <memory>
 #include <optional>
-#include <random>
-#include <span>
 #include <string>
 #include <tracy/Tracy.hpp>
 #include <tt-metalium/base_types.hpp>
@@ -20,16 +18,14 @@
 #include <tt-metalium/device.hpp>
 #include <vector>
 
+#include "benchmark_utils.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "impl/context/metal_context.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/device.hpp"
-#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/tensor/tensor_utils.hpp"
-#include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
 
 struct CoreGridConfig {
@@ -271,7 +267,7 @@ void BM_TTTrainMatmulComparison(benchmark::State& state) {
 
         // Create inputs once per shape so each grid config sees identical tensors
         const auto dtype = ttnn::DataType::BFLOAT16;
-        const uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(matmul_shape.name));
+        const uint32_t seed = ttml::benchmark_utils::seed_from_name(matmul_shape.name);
 
         ttnn::Shape a_shape(matmul_shape.a_shape);
         ttnn::Shape b_shape(matmul_shape.b_shape);

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -56,11 +56,6 @@ struct BenchmarkResult {
     bool skipped = false;
 };
 
-struct TestConfig {
-    int num_warmup_iterations = 2;
-    int num_measurement_iterations = 25;
-};
-
 // CoreGrid configurations to compare
 const std::vector<CoreGridConfig> core_grid_configs = {
     {std::nullopt, "std::nullopt"},
@@ -107,7 +102,7 @@ const std::vector<MatmulTestShape> tt_train_shapes = {
     {{4096, 2304}, {4096, 768}, true, false, "bwd_4096x2304_x_4096x768_Ta"},
 };
 
-const TestConfig test_config = {
+constexpr ttml::benchmark_utils::BenchmarkIterationConfig test_config = {
     .num_warmup_iterations = 2,
     .num_measurement_iterations = 10,
 };
@@ -123,11 +118,11 @@ std::tuple<uint64_t, uint64_t, uint64_t> get_mkn_from_shapes(
     const auto& a_shape = input_a.logical_shape();
     const auto& b_shape = input_b.logical_shape();
 
-    uint64_t M = transpose_a ? a_shape[-1] : a_shape[-2];
-    uint64_t K = transpose_a ? a_shape[-2] : a_shape[-1];
-    uint64_t N = transpose_b ? b_shape[-2] : b_shape[-1];
+    const uint64_t M = transpose_a ? a_shape[-1] : a_shape[-2];
+    const uint64_t K = transpose_a ? a_shape[-2] : a_shape[-1];
+    const uint64_t N = transpose_b ? b_shape[-2] : b_shape[-1];
 
-    uint64_t batch = ttnn::get_batch_size(a_shape);
+    const uint64_t batch = ttnn::get_batch_size(a_shape);
 
     return {batch * M, K, N};
 }
@@ -143,7 +138,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
     const int num_measurement_iterations = test_config.num_measurement_iterations;
 
     auto* dev_ptr = device.get();
-    auto compute_grid_size = device->compute_with_storage_grid_size();
+    const auto compute_grid_size = device->compute_with_storage_grid_size();
 
     if (!grid_config.is_supported(compute_grid_size)) {
         return BenchmarkResult{.grid_name = grid_config.name, .skipped = true};
@@ -155,7 +150,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
     ttnn::Tensor output_tensor;
 
     // Warmup iterations
-    for (int iter = 0; iter < num_warmup_iterations; ++iter) {
+    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(num_warmup_iterations), [&]() {
         output_tensor = ttnn::matmul(
             input_tensor_a,
             input_tensor_b,
@@ -170,7 +165,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
             /*output_tile=*/std::nullopt);
         tt::tt_metal::distributed::Synchronize(dev_ptr, std::nullopt);
         output_tensor.deallocate();
-    }
+    });
 
     std::chrono::duration<double> total_time = std::chrono::duration<double>::zero();
 
@@ -178,7 +173,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
     {
         ZoneScopedN("TTTrain Matmul iterations");
         for (int iter = 0; iter < num_measurement_iterations; ++iter) {
-            auto start_time = std::chrono::high_resolution_clock::now();
+            const auto start_time = std::chrono::high_resolution_clock::now();
             output_tensor = ttnn::matmul(
                 input_tensor_a,
                 input_tensor_b,
@@ -192,7 +187,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
                 /*core_grid=*/grid_config.core_grid,
                 /*output_tile=*/std::nullopt);
             tt::tt_metal::distributed::Synchronize(dev_ptr, std::nullopt);
-            auto end_time = std::chrono::high_resolution_clock::now();
+            const auto end_time = std::chrono::high_resolution_clock::now();
             total_time += end_time - start_time;
             output_tensor.deallocate();
         }
@@ -201,21 +196,21 @@ BenchmarkResult RunSingleMatmulBenchmark(
     const double inference_time_avg_s = total_time.count() / num_measurement_iterations;
 
     // Calculate TFLOPS
-    auto [M, K, N] =
+    const auto [M, K, N] =
         get_mkn_from_shapes(input_tensor_a, input_tensor_b, matmul_shape.transpose_a, matmul_shape.transpose_b);
-    double tflops = 2.0 * M * K * N / 1e12 / inference_time_avg_s;
+    const double tflops = 2.0 * M * K * N / 1e12 / inference_time_avg_s;
 
     // Calculate utilization against full grid
-    constexpr int HiFi4_cycles_per_tile = 64;
-    int num_cores_full_grid = compute_grid_size.x * compute_grid_size.y;
+    constexpr int kHiFi4CyclesPerTile = 64;
+    const int num_cores_full_grid = compute_grid_size.x * compute_grid_size.y;
 
     const double num_tile_ops = static_cast<double>(M) * K * N / (32.0 * 32.0 * 32.0);
-    double ideal_cycle_full_grid = num_tile_ops * HiFi4_cycles_per_tile / num_cores_full_grid;
+    const double ideal_cycle_full_grid = num_tile_ops * kHiFi4CyclesPerTile / num_cores_full_grid;
 
     const int freq_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
-    double inference_cycle = inference_time_avg_s * freq_mhz * 1e6;
+    const double inference_cycle = inference_time_avg_s * freq_mhz * 1e6;
 
-    double utilization_full_grid = ideal_cycle_full_grid / inference_cycle;
+    const double utilization_full_grid = ideal_cycle_full_grid / inference_cycle;
 
     return BenchmarkResult{
         .grid_name = grid_config.name,
@@ -269,17 +264,17 @@ void BM_TTTrainMatmulComparison(benchmark::State& state) {
         const auto dtype = ttnn::DataType::BFLOAT16;
         const uint32_t seed = ttml::benchmark_utils::seed_from_name(matmul_shape.name);
 
-        ttnn::Shape a_shape(matmul_shape.a_shape);
-        ttnn::Shape b_shape(matmul_shape.b_shape);
+        const ttnn::Shape a_shape(matmul_shape.a_shape);
+        const ttnn::Shape b_shape(matmul_shape.b_shape);
 
-        auto data_a = ttml::test_utils::make_uniform_vector<float>(a_shape.volume(), -1.0F, 1.0F, seed);
+        const auto data_a = ttml::test_utils::make_uniform_vector<float>(a_shape.volume(), -1.0F, 1.0F, seed);
         ttnn::Tensor input_tensor_a = ttnn::Tensor::from_vector(
             data_a,
             ttnn::TensorSpec(
                 a_shape, tt::tt_metal::TensorLayout(dtype, tt::tt_metal::Layout::TILE, ttnn::DRAM_MEMORY_CONFIG)),
             device.get());
 
-        auto data_b = ttml::test_utils::make_uniform_vector<float>(b_shape.volume(), -1.0F, 1.0F, seed + 1);
+        const auto data_b = ttml::test_utils::make_uniform_vector<float>(b_shape.volume(), -1.0F, 1.0F, seed + 1);
         ttnn::Tensor input_tensor_b = ttnn::Tensor::from_vector(
             data_b,
             ttnn::TensorSpec(
@@ -288,7 +283,7 @@ void BM_TTTrainMatmulComparison(benchmark::State& state) {
 
         // Run benchmark for each grid configuration
         for (const auto& grid_config : core_grid_configs) {
-            auto result =
+            const auto result =
                 RunSingleMatmulBenchmark(matmul_shape, grid_config, device, input_tensor_a, input_tensor_b, device_id);
             results.push_back(result);
         }
@@ -297,7 +292,7 @@ void BM_TTTrainMatmulComparison(benchmark::State& state) {
         PrintComparisonTable(matmul_shape.name, results);
 
         // Report the best time to benchmark framework
-        auto fastest = std::min_element(results.begin(), results.end(), [](const auto& a, const auto& b) {
+        const auto fastest = std::min_element(results.begin(), results.end(), [](const auto& a, const auto& b) {
             if (a.skipped != b.skipped) {
                 return !a.skipped;  // non-skipped beats skipped
             }

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -150,7 +150,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
     ttnn::Tensor output_tensor;
 
     // Warmup iterations
-    ttml::benchmark_utils::run_iterations(static_cast<uint32_t>(num_warmup_iterations), [&]() {
+    for (int iter = 0; iter < num_warmup_iterations; ++iter) {
         output_tensor = ttnn::matmul(
             input_tensor_a,
             input_tensor_b,
@@ -165,7 +165,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
             /*output_tile=*/std::nullopt);
         tt::tt_metal::distributed::Synchronize(dev_ptr, std::nullopt);
         output_tensor.deallocate();
-    });
+    }
 
     std::chrono::duration<double> total_time = std::chrono::duration<double>::zero();
 

--- a/tt-train/tests/benchmark/moe_ffn_swiglu_benchmark.cpp
+++ b/tt-train/tests/benchmark/moe_ffn_swiglu_benchmark.cpp
@@ -147,8 +147,12 @@ CaseResult run_case(const Case& c, uint32_t num_warmup, uint32_t num_measure) {
         return std::chrono::duration<double, std::micro>(t1 - t0).count();
     };
 
-    ttml::benchmark_utils::run_iterations(num_warmup, [&]() { (void)run_forward(); });
-    ttml::benchmark_utils::run_iterations(num_measure, [&]() { fwd_times.push_back(run_forward()); });
+    for (uint32_t i = 0; i < num_warmup; ++i) {
+        (void)run_forward();
+    }
+    for (uint32_t i = 0; i < num_measure; ++i) {
+        fwd_times.push_back(run_forward());
+    }
 
     // Forward+backward timing pass.
     std::vector<double> fb_times;
@@ -166,8 +170,12 @@ CaseResult run_case(const Case& c, uint32_t num_warmup, uint32_t num_measure) {
         return std::chrono::duration<double, std::micro>(t1 - t0).count();
     };
 
-    ttml::benchmark_utils::run_iterations(num_warmup, [&]() { (void)run_fwd_bwd(); });
-    ttml::benchmark_utils::run_iterations(num_measure, [&]() { fb_times.push_back(run_fwd_bwd()); });
+    for (uint32_t i = 0; i < num_warmup; ++i) {
+        (void)run_fwd_bwd();
+    }
+    for (uint32_t i = 0; i < num_measure; ++i) {
+        fb_times.push_back(run_fwd_bwd());
+    }
 
     CaseResult r;
     r.forward = summarize(fwd_times);

--- a/tt-train/tests/benchmark/moe_ffn_swiglu_benchmark.cpp
+++ b/tt-train/tests/benchmark/moe_ffn_swiglu_benchmark.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <numeric>
 #include <random>
 #include <sstream>
 #include <string>
@@ -16,6 +15,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
+#include "benchmark_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/moe_ffn_swiglu_op.hpp"
 #include "test_utils/random_data.hpp"
@@ -99,7 +99,7 @@ Stats summarize(const std::vector<double>& times_us) {
     if (times_us.empty()) {
         return s;
     }
-    s.avg_us = std::accumulate(times_us.begin(), times_us.end(), 0.0) / static_cast<double>(times_us.size());
+    s.avg_us = ttml::benchmark_utils::average(times_us);
     s.min_us = *std::min_element(times_us.begin(), times_us.end());
     s.max_us = *std::max_element(times_us.begin(), times_us.end());
     std::vector<double> sorted = times_us;
@@ -147,12 +147,8 @@ CaseResult run_case(const Case& c, uint32_t num_warmup, uint32_t num_measure) {
         return std::chrono::duration<double, std::micro>(t1 - t0).count();
     };
 
-    for (uint32_t i = 0; i < num_warmup; ++i) {
-        (void)run_forward();
-    }
-    for (uint32_t i = 0; i < num_measure; ++i) {
-        fwd_times.push_back(run_forward());
-    }
+    ttml::benchmark_utils::run_iterations(num_warmup, [&]() { (void)run_forward(); });
+    ttml::benchmark_utils::run_iterations(num_measure, [&]() { fwd_times.push_back(run_forward()); });
 
     // Forward+backward timing pass.
     std::vector<double> fb_times;
@@ -170,12 +166,8 @@ CaseResult run_case(const Case& c, uint32_t num_warmup, uint32_t num_measure) {
         return std::chrono::duration<double, std::micro>(t1 - t0).count();
     };
 
-    for (uint32_t i = 0; i < num_warmup; ++i) {
-        (void)run_fwd_bwd();
-    }
-    for (uint32_t i = 0; i < num_measure; ++i) {
-        fb_times.push_back(run_fwd_bwd());
-    }
+    ttml::benchmark_utils::run_iterations(num_warmup, [&]() { (void)run_fwd_bwd(); });
+    ttml::benchmark_utils::run_iterations(num_measure, [&]() { fb_times.push_back(run_fwd_bwd()); });
 
     CaseResult r;
     r.forward = summarize(fwd_times);

--- a/tt-train/tests/benchmark/polynorm_fusion_benchmark.cpp
+++ b/tt-train/tests/benchmark/polynorm_fusion_benchmark.cpp
@@ -29,11 +29,9 @@
 #include <benchmark/benchmark.h>
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <tt-metalium/distributed.hpp>
@@ -42,6 +40,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
+#include "benchmark_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/polynorm_op.hpp"
 #include "test_utils/random_data.hpp"
@@ -96,50 +95,6 @@ double speedup_x(double baseline, double fused) {
     return baseline / fused;
 }
 
-std::string join_u32_csv(const std::vector<uint32_t>& values) {
-    std::string out;
-    for (size_t i = 0; i < values.size(); ++i) {
-        if (i > 0) {
-            out += ",";
-        }
-        out += std::to_string(values[i]);
-    }
-    return out;
-}
-
-std::vector<uint32_t> parse_u32_csv(const std::string& csv) {
-    std::vector<uint32_t> out;
-    std::stringstream ss(csv);
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-        if (token.empty()) {
-            continue;
-        }
-        out.push_back(static_cast<uint32_t>(std::stoul(token)));
-    }
-    return out;
-}
-
-std::vector<std::string> parse_string_csv(const std::string& csv) {
-    std::vector<std::string> out;
-    std::stringstream ss(csv);
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-        if (token.empty()) {
-            continue;
-        }
-        out.push_back(token);
-    }
-    return out;
-}
-
-bool model_is_enabled(const SweepConfig& cfg, const std::string& name) {
-    if (cfg.model_filter.empty()) {
-        return true;
-    }
-    return std::find(cfg.model_filter.begin(), cfg.model_filter.end(), name) != cfg.model_filter.end();
-}
-
 SweepConfig load_sweep_config_from_env() {
     SweepConfig sweep_cfg{};
     if (const char* env_warmup = std::getenv("TTML_POLYNORM_BENCH_WARMUP")) {
@@ -149,13 +104,13 @@ SweepConfig load_sweep_config_from_env() {
         sweep_cfg.num_measure = static_cast<uint32_t>(std::stoul(env_measure));
     }
     if (const char* env_batches = std::getenv("TTML_POLYNORM_BENCH_BATCHES")) {
-        auto parsed = parse_u32_csv(env_batches);
+        auto parsed = ttml::benchmark_utils::parse_u32_csv(env_batches);
         if (!parsed.empty()) {
             sweep_cfg.batch_sizes = std::move(parsed);
         }
     }
     if (const char* env_models = std::getenv("TTML_POLYNORM_BENCH_MODELS")) {
-        sweep_cfg.model_filter = parse_string_csv(env_models);
+        sweep_cfg.model_filter = ttml::benchmark_utils::parse_string_csv(env_models);
     }
     if (sweep_cfg.num_measure == 0U) {
         throw std::invalid_argument("TTML_POLYNORM_BENCH_MEASURE must be greater than zero.");
@@ -168,7 +123,7 @@ std::vector<BenchmarkCase> make_benchmark_cases(const SweepConfig& cfg) {
     const auto& models = all_models();
     cases.reserve(models.size() * cfg.batch_sizes.size());
     for (uint32_t model_index = 0; model_index < models.size(); ++model_index) {
-        if (!model_is_enabled(cfg, models[model_index].name)) {
+        if (!ttml::benchmark_utils::name_is_enabled(cfg.model_filter, models[model_index].name)) {
             continue;
         }
         for (const auto batch_size : cfg.batch_sizes) {
@@ -415,7 +370,7 @@ int main(int argc, char** argv) {
         fmt::print(
             "preset models=tinyllama,undisclosed-model batches={} warmup={} measure={} "
             "seq_lens=tinyllama:2048,undisclosed-model:4096\n",
-            join_u32_csv(g_sweep_cfg.batch_sizes),
+            ttml::benchmark_utils::join_u32_csv(g_sweep_cfg.batch_sizes),
             g_sweep_cfg.num_warmup,
             g_sweep_cfg.num_measure);
         fmt::print(

--- a/tt-train/tests/benchmark/polynorm_fusion_benchmark.cpp
+++ b/tt-train/tests/benchmark/polynorm_fusion_benchmark.cpp
@@ -18,12 +18,6 @@
 // Timed regions enqueue multiple steps and synchronize once at the end; this amortizes
 // dispatch/sync latency and is closer to how model-level runs queue TTNN operations.
 // Results are printed as % time and DRAM change relative to the baseline.
-//
-// Environment variables:
-//   TTML_POLYNORM_BENCH_WARMUP   — warmup iterations  (default 2)
-//   TTML_POLYNORM_BENCH_MEASURE  — measured iterations (default 5)
-//   TTML_POLYNORM_BENCH_BATCHES  — comma-separated batch sizes (default 1,2,4,8,16)
-//   TTML_POLYNORM_BENCH_MODELS   — comma-separated model names to include
 // ============================================================================
 
 #include <benchmark/benchmark.h>
@@ -51,7 +45,6 @@ struct SweepConfig {
     std::vector<uint32_t> batch_sizes = {1, 2, 4, 8, 16};
     uint32_t num_warmup = 2;
     uint32_t num_measure = 5;
-    std::vector<std::string> model_filter;
 };
 
 struct ModelShape {
@@ -80,16 +73,8 @@ const std::vector<ModelShape>& all_models() {
     return models;
 }
 
-SweepConfig load_sweep_config_from_env() {
-    SweepConfig sweep_cfg{};
-    ttml::benchmark_utils::override_u32_from_env("TTML_POLYNORM_BENCH_WARMUP", sweep_cfg.num_warmup);
-    ttml::benchmark_utils::override_u32_from_env("TTML_POLYNORM_BENCH_MEASURE", sweep_cfg.num_measure);
-    ttml::benchmark_utils::override_u32_csv_from_env("TTML_POLYNORM_BENCH_BATCHES", sweep_cfg.batch_sizes);
-    ttml::benchmark_utils::override_string_csv_from_env("TTML_POLYNORM_BENCH_MODELS", sweep_cfg.model_filter);
-    if (sweep_cfg.num_measure == 0U) {
-        throw std::invalid_argument("TTML_POLYNORM_BENCH_MEASURE must be greater than zero.");
-    }
-    return sweep_cfg;
+SweepConfig load_sweep_config() {
+    return SweepConfig{};
 }
 
 std::vector<BenchmarkCase> make_benchmark_cases(const SweepConfig& cfg) {
@@ -97,9 +82,6 @@ std::vector<BenchmarkCase> make_benchmark_cases(const SweepConfig& cfg) {
     const auto& models = all_models();
     cases.reserve(models.size() * cfg.batch_sizes.size());
     for (uint32_t model_index = 0; model_index < models.size(); ++model_index) {
-        if (!ttml::benchmark_utils::name_is_enabled(cfg.model_filter, models[model_index].name)) {
-            continue;
-        }
         for (const auto batch_size : cfg.batch_sizes) {
             cases.push_back(BenchmarkCase{.model_index = model_index, .batch_size = batch_size});
         }
@@ -334,7 +316,7 @@ int main(int argc, char** argv) {
             return 1;
         }
 
-        g_sweep_cfg = load_sweep_config_from_env();
+        g_sweep_cfg = load_sweep_config();
         g_cases = make_benchmark_cases(g_sweep_cfg);
         if (g_cases.empty()) {
             throw std::invalid_argument("No PolyNorm benchmark cases selected.");
@@ -344,7 +326,7 @@ int main(int argc, char** argv) {
         fmt::print(
             "preset models=tinyllama,undisclosed-model batches={} warmup={} measure={} "
             "seq_lens=tinyllama:2048,undisclosed-model:4096\n",
-            ttml::benchmark_utils::join_u32_csv(g_sweep_cfg.batch_sizes),
+            "1,2,4,8,16",
             g_sweep_cfg.num_warmup,
             g_sweep_cfg.num_measure);
         fmt::print(

--- a/tt-train/tests/benchmark/polynorm_fusion_benchmark.cpp
+++ b/tt-train/tests/benchmark/polynorm_fusion_benchmark.cpp
@@ -31,7 +31,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <cstdlib>
 #include <stdexcept>
 #include <string>
 #include <tt-metalium/distributed.hpp>
@@ -81,37 +80,12 @@ const std::vector<ModelShape>& all_models() {
     return models;
 }
 
-double reduction_pct(double baseline, double fused) {
-    if (baseline == 0.0) {
-        return 0.0;
-    }
-    return (baseline - fused) / baseline * 100.0;
-}
-
-double speedup_x(double baseline, double fused) {
-    if (fused == 0.0) {
-        return 0.0;
-    }
-    return baseline / fused;
-}
-
 SweepConfig load_sweep_config_from_env() {
     SweepConfig sweep_cfg{};
-    if (const char* env_warmup = std::getenv("TTML_POLYNORM_BENCH_WARMUP")) {
-        sweep_cfg.num_warmup = static_cast<uint32_t>(std::stoul(env_warmup));
-    }
-    if (const char* env_measure = std::getenv("TTML_POLYNORM_BENCH_MEASURE")) {
-        sweep_cfg.num_measure = static_cast<uint32_t>(std::stoul(env_measure));
-    }
-    if (const char* env_batches = std::getenv("TTML_POLYNORM_BENCH_BATCHES")) {
-        auto parsed = ttml::benchmark_utils::parse_u32_csv(env_batches);
-        if (!parsed.empty()) {
-            sweep_cfg.batch_sizes = std::move(parsed);
-        }
-    }
-    if (const char* env_models = std::getenv("TTML_POLYNORM_BENCH_MODELS")) {
-        sweep_cfg.model_filter = ttml::benchmark_utils::parse_string_csv(env_models);
-    }
+    ttml::benchmark_utils::override_u32_from_env("TTML_POLYNORM_BENCH_WARMUP", sweep_cfg.num_warmup);
+    ttml::benchmark_utils::override_u32_from_env("TTML_POLYNORM_BENCH_MEASURE", sweep_cfg.num_measure);
+    ttml::benchmark_utils::override_u32_csv_from_env("TTML_POLYNORM_BENCH_BATCHES", sweep_cfg.batch_sizes);
+    ttml::benchmark_utils::override_string_csv_from_env("TTML_POLYNORM_BENCH_MODELS", sweep_cfg.model_filter);
     if (sweep_cfg.num_measure == 0U) {
         throw std::invalid_argument("TTML_POLYNORM_BENCH_MEASURE must be greater than zero.");
     }
@@ -136,10 +110,10 @@ std::vector<BenchmarkCase> make_benchmark_cases(const SweepConfig& cfg) {
 RunResult run_single_mode(
     const ModelShape& shape,
     const SweepConfig& cfg,
-    uint32_t batch_size,
-    uint32_t sequence_length,
-    ttml::ops::PolyNorm3ForwardVariant polynorm3_forward_variant,
-    ttml::ops::PolyNorm3BackwardVariant polynorm3_backward_variant,
+    const uint32_t batch_size,
+    const uint32_t sequence_length,
+    const ttml::ops::PolyNorm3ForwardVariant polynorm3_forward_variant,
+    const ttml::ops::PolyNorm3BackwardVariant polynorm3_backward_variant,
     const tt::tt_metal::distributed::MeshShape& mesh) {
     ttml::autograd::ctx().open_device(mesh);
     auto* const device = &ttml::autograd::ctx().get_device();
@@ -243,8 +217,8 @@ void print_forward_table(const std::vector<RowSummary>& rows) {
             row.total_composite_ms,
             row.fw_fused_total_ms,
             saved_ms,
-            speedup_x(row.total_composite_ms, row.fw_fused_total_ms),
-            reduction_pct(row.total_composite_ms, row.fw_fused_total_ms));
+            ttml::benchmark_utils::speedup_x(row.total_composite_ms, row.fw_fused_total_ms),
+            ttml::benchmark_utils::reduction_pct(row.total_composite_ms, row.fw_fused_total_ms));
     }
 }
 
@@ -265,8 +239,8 @@ void print_backward_table(const std::vector<RowSummary>& rows) {
             row.total_composite_ms,
             row.bw_fused_total_ms,
             saved_ms,
-            speedup_x(row.total_composite_ms, row.bw_fused_total_ms),
-            reduction_pct(row.total_composite_ms, row.bw_fused_total_ms));
+            ttml::benchmark_utils::speedup_x(row.total_composite_ms, row.bw_fused_total_ms),
+            ttml::benchmark_utils::reduction_pct(row.total_composite_ms, row.bw_fused_total_ms));
     }
 }
 
@@ -291,11 +265,11 @@ void print_total_table(const std::vector<RowSummary>& rows) {
             row.total_composite_ms,
             row.total_fused_ms,
             saved_ms,
-            speedup_x(row.total_composite_ms, row.total_fused_ms),
-            reduction_pct(row.total_composite_ms, row.total_fused_ms),
+            ttml::benchmark_utils::speedup_x(row.total_composite_ms, row.total_fused_ms),
+            ttml::benchmark_utils::reduction_pct(row.total_composite_ms, row.total_fused_ms),
             row.dram_composite_mb,
             row.dram_fused_mb,
-            reduction_pct(row.dram_composite_mb, row.dram_fused_mb));
+            ttml::benchmark_utils::reduction_pct(row.dram_composite_mb, row.dram_fused_mb));
     }
 }
 

--- a/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
+++ b/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
@@ -10,14 +10,13 @@
 #include <cstdint>
 #include <cstdlib>
 #include <numeric>
-#include <random>
-#include <sstream>
 #include <string>
 #include <tt-metalium/distributed.hpp>
 #include <vector>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
+#include "benchmark_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "models/llama.hpp"
 #include "ops/losses.hpp"
@@ -77,39 +76,6 @@ size_t cumulative_peak_from_captured_traces() {
             static_cast<long long>(usage.total_allocations) - static_cast<long long>(usage.total_deallocations);
     }
     return static_cast<size_t>(std::max(0LL, cumulative_peak));
-}
-
-std::vector<uint32_t> parse_u32_csv(const std::string& csv) {
-    std::vector<uint32_t> out;
-    std::stringstream ss(csv);
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-        if (token.empty()) {
-            continue;
-        }
-        out.push_back(static_cast<uint32_t>(std::stoul(token)));
-    }
-    return out;
-}
-
-std::vector<std::string> parse_string_csv(const std::string& csv) {
-    std::vector<std::string> out;
-    std::stringstream ss(csv);
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-        if (token.empty()) {
-            continue;
-        }
-        out.push_back(token);
-    }
-    return out;
-}
-
-bool model_is_enabled(const SweepConfig& cfg, const std::string& name) {
-    if (cfg.model_filter.empty()) {
-        return true;
-    }
-    return std::find(cfg.model_filter.begin(), cfg.model_filter.end(), name) != cfg.model_filter.end();
 }
 
 RunResult run_single(const ModelShape& shape, const SweepConfig& cfg, uint32_t batch_size, bool use_fused) {
@@ -296,13 +262,13 @@ int main() {
             sweep_cfg.num_measure = static_cast<uint32_t>(std::stoul(env_measure));
         }
         if (const char* env_batches = std::getenv("TTML_SWIGLU_BENCH_BATCHES")) {
-            auto parsed = parse_u32_csv(env_batches);
+            auto parsed = ttml::benchmark_utils::parse_u32_csv(env_batches);
             if (!parsed.empty()) {
                 sweep_cfg.batch_sizes = std::move(parsed);
             }
         }
         if (const char* env_models = std::getenv("TTML_SWIGLU_BENCH_MODELS")) {
-            sweep_cfg.model_filter = parse_string_csv(env_models);
+            sweep_cfg.model_filter = ttml::benchmark_utils::parse_string_csv(env_models);
         }
         const auto& models = all_models();
 
@@ -321,7 +287,7 @@ int main() {
         fmt::print("Runs full training-like step: model forward + CE loss + backward + AdamW step.\n");
 
         for (const auto& model : models) {
-            if (!model_is_enabled(sweep_cfg, model.name)) {
+            if (!ttml::benchmark_utils::name_is_enabled(sweep_cfg.model_filter, model.name)) {
                 continue;
             }
             std::vector<RowSummary> rows;

--- a/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
+++ b/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <stdexcept>
 #include <string>
 #include <tt-metalium/distributed.hpp>
 #include <vector>
@@ -247,6 +248,9 @@ int main() {
         ttml::benchmark_utils::override_u32_from_env("TTML_SWIGLU_BENCH_MEASURE", sweep_cfg.num_measure);
         ttml::benchmark_utils::override_u32_csv_from_env("TTML_SWIGLU_BENCH_BATCHES", sweep_cfg.batch_sizes);
         ttml::benchmark_utils::override_string_csv_from_env("TTML_SWIGLU_BENCH_MODELS", sweep_cfg.model_filter);
+        if (sweep_cfg.num_measure == 0U) {
+            throw std::invalid_argument("TTML_SWIGLU_BENCH_MEASURE must be greater than zero.");
+        }
         const auto& models = all_models();
 
         const tt::tt_metal::distributed::MeshShape mesh(1, 1);

--- a/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
+++ b/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
-#include <stdexcept>
 #include <string>
 #include <tt-metalium/distributed.hpp>
 #include <vector>
@@ -33,7 +32,6 @@ struct SweepConfig {
     uint32_t sequence_length = 256;
     // 0 means: use model.num_blocks from the selected preset.
     uint32_t stacked_blocks = 0;
-    std::vector<std::string> model_filter;
 };
 
 struct ModelShape {
@@ -244,13 +242,6 @@ int main() {
                 sweep_cfg.stacked_blocks = static_cast<uint32_t>(parsed);
             }
         }
-        ttml::benchmark_utils::override_u32_from_env("TTML_SWIGLU_BENCH_WARMUP", sweep_cfg.num_warmup);
-        ttml::benchmark_utils::override_u32_from_env("TTML_SWIGLU_BENCH_MEASURE", sweep_cfg.num_measure);
-        ttml::benchmark_utils::override_u32_csv_from_env("TTML_SWIGLU_BENCH_BATCHES", sweep_cfg.batch_sizes);
-        ttml::benchmark_utils::override_string_csv_from_env("TTML_SWIGLU_BENCH_MODELS", sweep_cfg.model_filter);
-        if (sweep_cfg.num_measure == 0U) {
-            throw std::invalid_argument("TTML_SWIGLU_BENCH_MEASURE must be greater than zero.");
-        }
         const auto& models = all_models();
 
         const tt::tt_metal::distributed::MeshShape mesh(1, 1);
@@ -268,9 +259,6 @@ int main() {
         fmt::print("Runs full training-like step: model forward + CE loss + backward + AdamW step.\n");
 
         for (const auto& model : models) {
-            if (!ttml::benchmark_utils::name_is_enabled(sweep_cfg.model_filter, model.name)) {
-                continue;
-            }
             std::vector<RowSummary> rows;
             rows.reserve(sweep_cfg.batch_sizes.size());
             for (const auto batch_size : sweep_cfg.batch_sizes) {

--- a/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
+++ b/tt-train/tests/benchmark/swiglu_fusion_benchmark.cpp
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
-#include <numeric>
 #include <string>
 #include <tt-metalium/distributed.hpp>
 #include <vector>
@@ -61,10 +60,6 @@ const std::vector<ModelShape>& all_models() {
     return models;
 }
 
-double avg(const std::vector<double>& values) {
-    return std::accumulate(values.begin(), values.end(), 0.0) / static_cast<double>(values.size());
-}
-
 size_t cumulative_peak_from_captured_traces() {
     long long cumulative_current = 0;
     long long cumulative_peak = 0;
@@ -78,7 +73,7 @@ size_t cumulative_peak_from_captured_traces() {
     return static_cast<size_t>(std::max(0LL, cumulative_peak));
 }
 
-RunResult run_single(const ModelShape& shape, const SweepConfig& cfg, uint32_t batch_size, bool use_fused) {
+RunResult run_single(const ModelShape& shape, const SweepConfig& cfg, const uint32_t batch_size, const bool use_fused) {
     auto* const device = &ttml::autograd::ctx().get_device();
     device->clear_program_cache();
 
@@ -206,13 +201,6 @@ RunResult run_single(const ModelShape& shape, const SweepConfig& cfg, uint32_t b
     return result;
 }
 
-double pct(double fused, double baseline) {
-    if (baseline == 0.0) {
-        return 0.0;
-    }
-    return (fused - baseline) / baseline * 100.0;
-}
-
 struct RowSummary {
     uint32_t batch = 0;
     double baseline_total_ms = 0.0;
@@ -255,21 +243,10 @@ int main() {
                 sweep_cfg.stacked_blocks = static_cast<uint32_t>(parsed);
             }
         }
-        if (const char* env_warmup = std::getenv("TTML_SWIGLU_BENCH_WARMUP")) {
-            sweep_cfg.num_warmup = static_cast<uint32_t>(std::stoul(env_warmup));
-        }
-        if (const char* env_measure = std::getenv("TTML_SWIGLU_BENCH_MEASURE")) {
-            sweep_cfg.num_measure = static_cast<uint32_t>(std::stoul(env_measure));
-        }
-        if (const char* env_batches = std::getenv("TTML_SWIGLU_BENCH_BATCHES")) {
-            auto parsed = ttml::benchmark_utils::parse_u32_csv(env_batches);
-            if (!parsed.empty()) {
-                sweep_cfg.batch_sizes = std::move(parsed);
-            }
-        }
-        if (const char* env_models = std::getenv("TTML_SWIGLU_BENCH_MODELS")) {
-            sweep_cfg.model_filter = ttml::benchmark_utils::parse_string_csv(env_models);
-        }
+        ttml::benchmark_utils::override_u32_from_env("TTML_SWIGLU_BENCH_WARMUP", sweep_cfg.num_warmup);
+        ttml::benchmark_utils::override_u32_from_env("TTML_SWIGLU_BENCH_MEASURE", sweep_cfg.num_measure);
+        ttml::benchmark_utils::override_u32_csv_from_env("TTML_SWIGLU_BENCH_BATCHES", sweep_cfg.batch_sizes);
+        ttml::benchmark_utils::override_string_csv_from_env("TTML_SWIGLU_BENCH_MODELS", sweep_cfg.model_filter);
         const auto& models = all_models();
 
         const tt::tt_metal::distributed::MeshShape mesh(1, 1);
@@ -296,17 +273,18 @@ int main() {
                 const auto baseline = run_single(model, sweep_cfg, batch_size, /*use_fused=*/false);
                 const auto fused = run_single(model, sweep_cfg, batch_size, /*use_fused=*/true);
 
-                const double b_total = avg(baseline.step_times);
-                const double f_total = avg(fused.step_times);
+                const double b_total = ttml::benchmark_utils::average(baseline.step_times);
+                const double f_total = ttml::benchmark_utils::average(fused.step_times);
 
                 rows.push_back(RowSummary{
                     .batch = batch_size,
                     .baseline_total_ms = b_total,
                     .fused_total_ms = f_total,
-                    .total_pct = pct(f_total, b_total),
+                    .total_pct = ttml::benchmark_utils::relative_change_pct(f_total, b_total),
                     .baseline_dram_kb = static_cast<double>(baseline.dram_peak) / 1024.0,
                     .fused_dram_kb = static_cast<double>(fused.dram_peak) / 1024.0,
-                    .dram_pct = pct(static_cast<double>(fused.dram_peak), static_cast<double>(baseline.dram_peak)),
+                    .dram_pct = ttml::benchmark_utils::relative_change_pct(
+                        static_cast<double>(fused.dram_peak), static_cast<double>(baseline.dram_peak)),
                 });
             }
             print_model_table(model, rows);


### PR DESCRIPTION
## Summary
- As benchmark coverage grows, we want shared behavior and less copy-paste drift across benchmark binaries.
- This PR centralizes duplicated benchmark helpers in `ttml::benchmark_utils` for shared timing/reporting logic (`seed_from_name`, percent/speedup math, averaging, measured-iteration timing helper, shared iteration config type).
- Parsing/env-selection infrastructure was intentionally removed from this cleanup scope based on review feedback; `polynorm` and `swiglu` use fixed in-code sweep presets.
- `from_vector_benchmark` device initialization is aligned with the other benchmarks to avoid board-mismatch startup crashes.
- Reviewer follow-ups included replacing helper-based warmup loops with explicit `for` loops for readability.

## Validation
- Built benchmark targets:
  - `adamw_benchmark`
  - `frobenius_normalize_benchmark`
  - `from_vector_benchmark`
  - `matmuls_benchmark`
  - `polynorm_fusion_benchmark`
  - `swiglu_fusion_benchmark`
  - `moe_ffn_swiglu_benchmark`
- Executed benchmarks one-by-one (reduced subsets where supported, full run where needed) and verified completion.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/ttml-benchmark-utils)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/ttml-benchmark-utils)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/ttml-benchmark-utils)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/ttml-benchmark-utils)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/ttml-benchmark-utils)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/ttml-benchmark-utils)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/ttml-benchmark-utils)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/ttml-benchmark-utils)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/ttml-benchmark-utils)