### PR TITLE
fix: pad prefill kernel to uncached suffix length with prefix caching

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -521,6 +521,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         num_cached_per_user = (
             [int(n) for n in start_pos] if start_pos is not None else [0] * len(prompt_lens)
         )
+        assert len(num_cached_per_user) == len(prompt_lens), (
+            f"start_pos length {len(num_cached_per_user)} must match prompt_lens length {len(prompt_lens)}"
+        )
+        for i, (seq_len, num_cached) in enumerate(zip(prompt_lens, num_cached_per_user)):
+            assert 0 <= num_cached < int(seq_len), (
+                f"user {i}: num_cached_tokens ({num_cached}) must be in [0, seq_len={int(seq_len)}). "
+                f"Fully-cached prompts should not reach prefill."
+            )
         prefill_seq_lens = [
             get_padded_prefill_len(int(seq_len) - num_cached)
             for seq_len, num_cached in zip(prompt_lens, num_cached_per_user)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -513,7 +513,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if not isinstance(prompt_lens, list):
             prompt_lens = prompt_lens.tolist()
 
-        prefill_seq_lens = [get_padded_prefill_len(seq_len) for seq_len in prompt_lens]
+        # Pad to the *uncached* suffix length, not the full prompt length.
+        # With prefix caching, only (seq_len - num_cached) new tokens are fed to the
+        # kernel (see prefill_ids construction below), so padding by full seq_len makes
+        # the kernel run far more compute than necessary for high-hit-rate workloads.
+        # int() cast handles numpy.int64 from vLLM (bit_length() needs a Python int).
+        num_cached_per_user = (
+            [int(n) for n in start_pos] if start_pos is not None else [0] * len(prompt_lens)
+        )
+        prefill_seq_lens = [
+            get_padded_prefill_len(int(seq_len) - num_cached)
+            for seq_len, num_cached in zip(prompt_lens, num_cached_per_user)
+        ]
         # Row-sharded batched prefill: process 1 user per row per iteration.
         # Only used when device sampling is active (sampling_params is not None)
         # and the prompt uses the harmony chat template (first token is <|start|>=200006).
@@ -546,6 +557,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             and len(set(prefill_seq_lens)) == 1
             and self.data_parallel == 1
             and not getattr(self.model_args[0], "disable_batched_prefill", False)
+            # Batched prefill feeds full tokens with num_cached_tokens=0 forced downstream
+            # (see prefill_forward_single_user_text call below); incompatible with prefix-cache
+            # reuse where prefill_ids is already sliced to the uncached suffix.
+            and all(n == 0 for n in num_cached_per_user)
         )
 
         if use_batched_prefill and sampling_on_device_requested:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -518,12 +518,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # kernel (see prefill_ids construction below), so padding by full seq_len makes
         # the kernel run far more compute than necessary for high-hit-rate workloads.
         # int() cast handles numpy.int64 from vLLM (bit_length() needs a Python int).
-        num_cached_per_user = (
-            [int(n) for n in start_pos] if start_pos is not None else [0] * len(prompt_lens)
-        )
-        assert len(num_cached_per_user) == len(prompt_lens), (
-            f"start_pos length {len(num_cached_per_user)} must match prompt_lens length {len(prompt_lens)}"
-        )
+        num_cached_per_user = [int(n) for n in start_pos] if start_pos is not None else [0] * len(prompt_lens)
+        assert len(num_cached_per_user) == len(
+            prompt_lens
+        ), f"start_pos length {len(num_cached_per_user)} must match prompt_lens length {len(prompt_lens)}"
         for i, (seq_len, num_cached) in enumerate(zip(prompt_lens, num_cached_per_user)):
             assert 0 <= num_cached < int(seq_len), (
                 f"user {i}: num_cached_tokens ({num_cached}) must be in [0, seq_len={int(seq_len)}). "

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -513,22 +513,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if not isinstance(prompt_lens, list):
             prompt_lens = prompt_lens.tolist()
 
-        # Pad to the *uncached* suffix length, not the full prompt length.
-        # With prefix caching, only (seq_len - num_cached) new tokens are fed to the
-        # kernel (see prefill_ids construction below), so padding by full seq_len makes
-        # the kernel run far more compute than necessary for high-hit-rate workloads.
-        # int() cast handles numpy.int64 from vLLM (bit_length() needs a Python int).
+        # Pad by uncached suffix length: only (seq_len - num_cached) tokens reach the kernel.
+        # int() normalizes numpy.int64 from vLLM callers (bit_length() requires a Python int).
         num_cached_per_user = [int(n) for n in start_pos] if start_pos is not None else [0] * len(prompt_lens)
         assert len(num_cached_per_user) == len(
             prompt_lens
-        ), f"start_pos length {len(num_cached_per_user)} must match prompt_lens length {len(prompt_lens)}"
+        ), f"start_pos length {len(num_cached_per_user)} != prompt_lens length {len(prompt_lens)}"
         for i, (seq_len, num_cached) in enumerate(zip(prompt_lens, num_cached_per_user)):
-            assert 0 <= num_cached < int(seq_len), (
-                f"user {i}: num_cached_tokens ({num_cached}) must be in [0, seq_len={int(seq_len)}). "
-                f"Fully-cached prompts should not reach prefill."
-            )
+            assert 0 <= num_cached < seq_len, f"user {i}: num_cached={num_cached} must be < seq_len={seq_len}"
         prefill_seq_lens = [
-            get_padded_prefill_len(int(seq_len) - num_cached)
+            get_padded_prefill_len(seq_len - num_cached)
             for seq_len, num_cached in zip(prompt_lens, num_cached_per_user)
         ]
         # Row-sharded batched prefill: process 1 user per row per iteration.
@@ -563,10 +557,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             and len(set(prefill_seq_lens)) == 1
             and self.data_parallel == 1
             and not getattr(self.model_args[0], "disable_batched_prefill", False)
-            # Batched prefill feeds full tokens with num_cached_tokens=0 forced downstream
-            # (see prefill_forward_single_user_text call below); incompatible with prefix-cache
-            # reuse where prefill_ids is already sliced to the uncached suffix.
-            and all(n == 0 for n in num_cached_per_user)
+            and all(
+                n == 0 for n in num_cached_per_user
+            )  # batched path feeds full tokens; incompatible with cached prefixes
         )
 
         if use_batched_prefill and sampling_on_device_requested:


### PR DESCRIPTION
## Intuition

prefix sharing is not doing great at my benchmark.


## Benchmark

64-prompt burst, 8K shared prefix + 256 unique suffix + 256 output

### Before patch (prefix caching ON vs OFF)

| Metric | ON (caching) | OFF | Ratio |
|---|---:|---:|:---|
| Mean TTFT | 259 s | 184 s | 0.71× (ON slower) |
| p99 TTFT | 363 s | 374 s | ~equal |
| Goodput | 40.7 tok/s | 41.9 tok/s | 0.97× |
| Wall time | 403 s | 391 s | ~equal |
| Hit rate | 95.1% | 0% | — |

95% hit rate but effectively zero performance gain — the kernel was doing full-prompt compute regardless.

### After patch (prefix caching ON vs OFF)

| Metric | ON (patched) | OFF | Speedup |
|---|---:|---:|:---|
| Wall time | 103.1 s | 391.5 s | **3.80×** |
| Mean TTFT | 37.3 s | 184.2 s | **4.94×** |
| p99 TTFT | 62.8 s | 374.6 s | **5.97×** |
| Goodput | 158.9 tok/s | 41.8 tok/s | **3.80×** |
| Hit rate | 95.1% | 0% | — |

Patch delivers **3.9× wall-time improvement** and **4.9× mean TTFT improvement** vs the unpatched ON run on the same workload.

