### PR TITLE
Generating MPI rank IDs to match Mesh IDs where possible

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -1196,8 +1196,10 @@ TEST(MultiHost, TestBHBlitzPipelineControlPlaneInit) {
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
 
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
-    const int my_rank = static_cast<int>(*distributed_context.rank());
+    // Use the true MPI_COMM_WORLD rank. full_world_distributed_context() is misleadingly named and
+    // actually returns the sub-context communicator post MPI_Comm_split (see metal_context.hpp TODO).
+    const auto world_ctx = tt::tt_metal::distributed::multihost::DistributedContext::get_world_context();
+    const int my_rank = static_cast<int>(*world_ctx->rank());
     const auto local_mesh_ids = control_plane->get_local_mesh_id_bindings();
     ASSERT_EQ(local_mesh_ids.size(), 1u)
         << "bh_glx_split_4x2: one mesh_instance per MPI rank (each mesh host_topology dims [1,1])";

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -1196,6 +1196,14 @@ TEST(MultiHost, TestBHBlitzPipelineControlPlaneInit) {
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
 
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    const int my_rank = static_cast<int>(*distributed_context.rank());
+    const auto local_mesh_ids = control_plane->get_local_mesh_id_bindings();
+    ASSERT_EQ(local_mesh_ids.size(), 1u)
+        << "bh_glx_split_4x2: one mesh_instance per MPI rank (each mesh host_topology dims [1,1])";
+    EXPECT_EQ(static_cast<unsigned int>(my_rank), *local_mesh_ids[0])
+        << "MPI world rank must equal mesh_id (rank_bindings / discovery alignment for Blitz pipeline)";
+
     check_asic_mapping_against_golden("TestBHBlitzPipelineControlPlaneInit");
 }
 

--- a/tools/scaleout/src/generate_rank_bindings.cpp
+++ b/tools/scaleout/src/generate_rank_bindings.cpp
@@ -360,8 +360,8 @@ std::vector<RankBindingConfig> extract_rank_bindings(
     }
 
     // Build flat list of (mesh_id, hostname, chip_ids, mesh_host_rank, psd_rank) for canonical ordering
-    // Order: PSD rank first (so output rank i matches topology mapper's mpi_rank_to_host[i]),
-    // then mesh_id, mesh_host_rank, hostname - ensures alignment with physical discovery
+    // Order after sort: mesh_id ascending (rank 0 is first/lowest mesh), then mesh_host_rank, hostname,
+    // PSD rank tiebreaker — so sequential MPI rank tracks mesh topology; psd_mpi_rank field keeps PSD identity
     using Entry = std::tuple<int, std::string, std::vector<tt::ChipId>, int, int>;
     std::vector<Entry> entries;
     for (const auto& [mesh_id, hostname_map] : mesh_host_asics) {
@@ -385,18 +385,18 @@ std::vector<RankBindingConfig> extract_rank_bindings(
         }
     }
     std::sort(entries.begin(), entries.end(), [](const Entry& a, const Entry& b) {
-        // Primary: PSD rank - output rank must match topology mapper's mpi_rank_to_host expectation
-        if (std::get<4>(a) != std::get<4>(b)) {
-            return std::get<4>(a) < std::get<4>(b);
-        }
-        // Secondary: mesh_id, mesh_host_rank, hostname for deterministic ordering
+        // Primary: mesh_id ascending so binding.rank aligns with mesh order (rank 0 from mesh id 0 first)
         if (std::get<0>(a) != std::get<0>(b)) {
             return std::get<0>(a) < std::get<0>(b);
         }
         if (std::get<3>(a) != std::get<3>(b)) {
             return std::get<3>(a) < std::get<3>(b);
         }
-        return std::get<1>(a) < std::get<1>(b);
+        if (std::get<1>(a) != std::get<1>(b)) {
+            return std::get<1>(a) < std::get<1>(b);
+        }
+        // PSD rank last for deterministic ties only
+        return std::get<4>(a) < std::get<4>(b);
     });
 
     // Assign contiguous ranks 0..N-1 and track slot per host for rankfile
@@ -407,7 +407,8 @@ std::vector<RankBindingConfig> extract_rank_bindings(
         const auto& [mesh_id, hostname, chip_ids, mesh_host_rank, psd_rank] = entries[i];
 
         RankBindingConfig binding;
-        // binding.rank is a sequential MPI rank (0, 1, 2, ...) that must be unique and contiguous.
+        // binding.rank is a sequential MPI rank (0, 1, 2, ...) that must be unique and contiguous,
+        // assigned in mesh_id-major sorted order so low ranks correspond to low mesh ids.
         // It must match: (1) the rank in rank_bindings.yaml, and (2) the rank in rankfile.
         // binding.psd_mpi_rank stores the PSD MPI rank from discovery, used for phase2_mock_mapping.yaml lookup.
         binding.rank = static_cast<int>(i);  // Sequential rank for rankfile and rank_bindings.yaml

--- a/tools/scaleout/src/generate_rank_bindings.cpp
+++ b/tools/scaleout/src/generate_rank_bindings.cpp
@@ -238,25 +238,16 @@ TopologyMappingResult run_topology_mapping(
     config.strict_mode = true;
     config.disable_rank_bindings = false;  // Pass the rank bindings to make sure there isn't host rank boundary issues
 
-    // Provide hostname_to_asics from PSD so same-host constraint is applied (all ASICs on a host map to one rank)
+    // PSD hostname grouping and tray/ASIC-location map (logical mesh 0 anchor + pinnings support).
     for (const auto& [asic_id, desc] : psd.get_asic_descriptors()) {
         config.hostname_to_asics[desc.host_name].insert(asic_id);
+        config.asic_positions[asic_id] = std::make_pair(desc.tray_id, desc.asic_location);
     }
 
     // Extract pinnings from MGD and add to config (same as control plane)
     const auto& pinnings = mgd.get_pinnings();
     for (const auto& [pos, fabric_node] : pinnings) {
         config.pinnings.emplace_back(pos, fabric_node);
-    }
-
-    // Build ASIC positions map (required if pinnings are used)
-    if (!config.pinnings.empty()) {
-        const auto& asic_descriptors = psd.get_asic_descriptors();
-        for (const auto& [asic_id, _] : asic_descriptors) {
-            auto tray_id = psd.get_tray_id(asic_id);
-            auto asic_location = psd.get_asic_location(asic_id);
-            config.asic_positions[asic_id] = std::make_pair(tray_id, asic_location);
-        }
     }
 
     // Set per-mesh validation modes based on mesh graph policy
@@ -308,8 +299,10 @@ TopologyMappingResult run_topology_mapping(
 /**
  * @brief Extract rank bindings from topology mapping result with topology-aware splitting.
  *
- * Bindings are one row per (mesh_id, PSD hostname, mesh_host_rank), after sorting by PSD MPI rank
- * (physical host order), then mesh_id, mesh_host_rank, hostname.
+ * Bindings are one row per (mesh_id, PSD hostname, mesh_host_rank), sorted by mesh_id ascending,
+ * then mesh_host_rank, hostname, PSD rank tiebreaker — so sequential MPI rank tracks mesh topology; inter-mesh
+ * mapping in topology_mapper_utils biases logical mesh 0 toward this process's hostname and toward the physical
+ * partition that contains tray id 1 / ASIC location 1 when uniquely resolvable from discovery.
  *
  * - **Multi-process Phase 1** (several MPI ranks / PSD hostnames): each distinct hostname usually owns
  *   ASICs for a single mesh_host_rank, so the per-hostname map has one entry — behavior matches the

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <vector>
 
-#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 #include <tt-metalium/experimental/fabric/topology_solver.hpp>
@@ -39,8 +38,7 @@ using PhysicalAdjacencyMap = std::map<tt::tt_metal::AsicID, std::vector<tt::tt_m
 // Use ASICPosition from tt::tt_metal namespace
 using AsicPosition = tt::tt_metal::ASICPosition;
 
-// Map from AsicID to its physical position (TrayID, ASICLocation)
-// Required only when using pinning constraints
+// Map from AsicID to its physical position (TrayID, ASICLocation); used for pinning validation and anchors.
 using AsicPositionMap = std::map<tt::tt_metal::AsicID, AsicPosition>;
 
 // Pinning constraint: maps an ASIC position to a FabricNodeId
@@ -60,8 +58,8 @@ struct TopologyMappingConfig {
     // specific logical nodes can be mapped to
     std::vector<PinningConstraint> pinnings;
 
-    // Map from AsicID to (TrayID, ASICLocation) - required if pinnings is non-empty.
-    // Used to validate pinning constraints against the physical topology.
+    // Map from AsicID to (TrayID, ASICLocation) from discovery — required when pinnings are non-empty, and populated
+    // for topology mapping anchors (e.g. soft preference for tray 1 / ASIC location 1 on logical mesh 0).
     AsicPositionMap asic_positions;
 
     // Per-mesh validation modes for intra-mesh mapping (fabric node to ASIC).

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -476,16 +476,6 @@ void TopologyMapper::build_mapping(const Cluster& cluster) {
             }
         }
 
-        // Build ASIC positions map (required if pinnings are used)
-        if (!config.pinnings.empty()) {
-            const auto& asic_descriptors = physical_system_descriptor_.get_asic_descriptors();
-            for (const auto& [asic_id, _] : asic_descriptors) {
-                auto tray_id = physical_system_descriptor_.get_tray_id(asic_id);
-                auto asic_location = physical_system_descriptor_.get_asic_location(asic_id);
-                config.asic_positions[asic_id] = std::make_pair(tray_id, asic_location);
-            }
-        }
-
         // Set per-mesh validation modes based on mesh graph policy
         for (const auto& mesh_id : mesh_graph_.get_all_mesh_ids()) {
             config.mesh_validation_modes[mesh_id] = mesh_graph_.is_intra_mesh_policy_relaxed(mesh_id)
@@ -505,9 +495,10 @@ void TopologyMapper::build_mapping(const Cluster& cluster) {
         // Disable rank bindings if we're generating mapping locally (single host, single mesh)
         config.disable_rank_bindings = generate_mapping_locally_;
 
-        // Provide hostname_to_asics for host consistency constraint
+        // Hostname grouping and discovery ASIC positions (pinnings + logical-mesh-0 anchor preferences).
         for (const auto& [asic_id, desc] : physical_system_descriptor_.get_asic_descriptors()) {
             config.hostname_to_asics[desc.host_name].insert(asic_id);
+            config.asic_positions[asic_id] = std::make_pair(desc.tray_id, desc.asic_location);
         }
 
         // Use multi-mesh topology solver to map all meshes at once

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <tuple>
 #include <unordered_map>
@@ -28,6 +29,7 @@
 #include <tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
 #include <llrt/tt_cluster.hpp>
+#include <unistd.h>
 
 namespace tt::tt_metal::experimental::tt_fabric {
 
@@ -671,6 +673,46 @@ std::optional<std::string> hostname_for_asic_from_hostname_map(
     return std::nullopt;
 }
 
+std::string hostname_first_label(std::string_view h) {
+    const auto dot = h.find('.');
+    return std::string(dot == std::string_view::npos ? h : h.substr(0, dot));
+}
+
+// Map gethostname()+label matching → PSD/descriptor hostname key used in hostname_to_asics (ambiguous → nullopt).
+std::optional<std::string> resolve_local_hostname_from_hostname_asics_map(
+    const std::map<std::string, std::set<tt::tt_metal::AsicID>>& hostname_to_asics) {
+    if (hostname_to_asics.empty()) {
+        return std::nullopt;
+    }
+    char buf[256];
+    if (::gethostname(buf, sizeof(buf) - 1) != 0) {
+        return std::nullopt;
+    }
+    buf[sizeof(buf) - 1] = '\0';
+
+    std::string local_full(buf);
+    const std::string local_short = hostname_first_label(local_full);
+
+    for (const auto& [hn, _] : hostname_to_asics) {
+        if (hn == local_full || hn == local_short) {
+            return hn;
+        }
+    }
+
+    std::optional<std::string> only_with_label;
+    int label_matches = 0;
+    for (const auto& [hn, _] : hostname_to_asics) {
+        if (hostname_first_label(hn) == local_short) {
+            ++label_matches;
+            only_with_label = hn;
+        }
+    }
+    if (label_matches == 1) {
+        return only_with_label;
+    }
+    return std::nullopt;
+}
+
 // Minimal host cover for inter-mesh mapping: partition physical meshes by host, then apply.
 // `rank_bound_logical_to_physical`: logical meshes already fixed by rank bindings → skip those and their physical
 // meshes for host-alignment bias (empty when rank bindings are disabled).
@@ -761,6 +803,210 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
     }
 }
 
+// Physical mesh partition (among unbound) that minimally covers required_asics, else nullopt.
+std::optional<MeshId> smallest_physical_mesh_covering_required_asics(
+    const PhysicalMultiMeshGraph& physical_graph,
+    const std::set<MeshId>& bound_physical_mesh_ids,
+    const std::set<tt::tt_metal::AsicID>& required_asics) {
+    if (required_asics.empty()) {
+        return std::nullopt;
+    }
+
+    auto node_vec_contains = [](const std::vector<tt::tt_metal::AsicID>& nodes, tt::tt_metal::AsicID asic) -> bool {
+        return std::find(nodes.begin(), nodes.end(), asic) != nodes.end();
+    };
+
+    std::optional<MeshId> best_physical;
+    std::optional<std::size_t> best_node_count;
+    for (const auto& [physical_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
+        if (bound_physical_mesh_ids.contains(physical_mesh_id)) {
+            continue;
+        }
+        const auto& node_vec = adj.get_nodes();
+        if (node_vec.empty()) {
+            continue;
+        }
+
+        bool covers_all = true;
+        for (const auto& asic : required_asics) {
+            if (!node_vec_contains(node_vec, asic)) {
+                covers_all = false;
+                break;
+            }
+        }
+        if (!covers_all) {
+            continue;
+        }
+
+        const std::size_t n = node_vec.size();
+        if (!best_node_count.has_value() || n < *best_node_count) {
+            best_node_count = n;
+            best_physical = physical_mesh_id;
+        } else if (n == *best_node_count && physical_mesh_id < *best_physical) {
+            best_physical = physical_mesh_id;
+        }
+    }
+    return best_physical;
+}
+
+// Tray 1 / ASIC location 1 (discovery coordinate) used as soft inter-mesh anchor for logical mesh 0.
+inline const AsicPosition k_logical_mesh_zero_preferred_discovery_asic_position =
+    AsicPosition{tt::tt_metal::TrayID{1u}, tt::tt_metal::ASICLocation{1u}};
+
+// Resolve a single ASIC at `anchor_position` preferring resolved-local-host ASIC list; else unique global hit.
+std::optional<tt::tt_metal::AsicID> resolve_anchor_asic_at_discovery_position(
+    const TopologyMappingConfig& config,
+    const std::optional<std::string>& resolved_local_hostname_key,
+    const AsicPosition& anchor_position) {
+    if (config.asic_positions.empty()) {
+        return std::nullopt;
+    }
+
+    auto position_matches = [&](tt::tt_metal::AsicID asic_id) -> bool {
+        auto pos_it = config.asic_positions.find(asic_id);
+        return pos_it != config.asic_positions.end() && pos_it->second == anchor_position;
+    };
+
+    if (resolved_local_hostname_key.has_value()) {
+        auto host_it = config.hostname_to_asics.find(*resolved_local_hostname_key);
+        if (host_it != config.hostname_to_asics.end()) {
+            int local_count = 0;
+            std::optional<tt::tt_metal::AsicID> local_only;
+            for (const auto& asic : host_it->second) {
+                if (position_matches(asic)) {
+                    ++local_count;
+                    local_only = asic;
+                }
+            }
+            if (local_count == 1) {
+                return local_only;
+            }
+        }
+    }
+
+    int global_count = 0;
+    std::optional<tt::tt_metal::AsicID> global_only;
+    for (const auto& [asic_id, pos] : config.asic_positions) {
+        if (pos == anchor_position) {
+            ++global_count;
+            global_only = asic_id;
+        }
+    }
+    return global_count == 1 ? global_only : std::nullopt;
+}
+
+/**
+ * Biases inter-mesh solving so logical mesh id 0 prefers the right physical partition(s):
+ * - the partition covering the Phase-1 / mapping host (`gethostname` match in `hostname_to_asics`),
+ * - and the partition that contains discovery ASIC (tray id 1, ASIC location 1), which tracks the canonical
+ *   "starter" silicon on that stack.
+ *
+ * Rationale for CI / multihost: without this soft anchor, isomorphism in the mapper can associate logical mesh 0 with
+ * an arbitrary symmetric physical mesh, which shifts which host owns mesh 0 and which ASIC lands on which UMD-visible
+ * index after rank bindings (`TT_VISIBLE_DEVICES`, etc.). That makes rank-0 / mesh-0 / device-0 assumptions in tests
+ * and golden ASIC-mapping checks brittle across hosts or reorderings. Preferring localhost + tray 1 / location 1 keeps
+ * launched jobs and documented expectations aligned so we avoid those mismatches.
+ *
+ * Constraints are preferences only—the solver may still choose another isomorphism if constraints demand it.
+ * If localhost cover and tray/loc anchors disagree on the physical mesh, tray 1 / location 1 wins (see log line).
+ */
+void add_logical_mesh_zero_anchor_inter_mesh_preference(
+    const TopologyMappingConfig& config,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
+    const std::map<MeshId, MeshId>& rank_bound_logical_to_physical,
+    ::tt::tt_fabric::MappingConstraints<MeshId, MeshId>& inter_mesh_constraints) {
+    if (config.hostname_to_asics.empty() && config.asic_positions.empty()) {
+        return;
+    }
+
+    constexpr MeshId k_logical_anchor{0};
+    const auto& logical_nodes_vec = mesh_logical_level_graph.get_nodes();
+    const bool logical_anchor_exists =
+        std::find(logical_nodes_vec.begin(), logical_nodes_vec.end(), k_logical_anchor) != logical_nodes_vec.end();
+    if (!logical_anchor_exists) {
+        return;
+    }
+
+    std::set<MeshId> bound_physical_mesh_ids;
+    for (const auto& [_, physical_mesh_id] : rank_bound_logical_to_physical) {
+        bound_physical_mesh_ids.insert(physical_mesh_id);
+    }
+
+    std::optional<std::string> local_hostname_opt;
+    if (!config.hostname_to_asics.empty()) {
+        local_hostname_opt = resolve_local_hostname_from_hostname_asics_map(config.hostname_to_asics);
+    }
+
+    std::optional<MeshId> from_hostname_partition;
+    if (local_hostname_opt.has_value()) {
+        auto host_it = config.hostname_to_asics.find(*local_hostname_opt);
+        if (host_it != config.hostname_to_asics.end() && !host_it->second.empty()) {
+            from_hostname_partition = smallest_physical_mesh_covering_required_asics(
+                physical_graph, bound_physical_mesh_ids, host_it->second);
+        }
+    }
+    if (!from_hostname_partition.has_value() && !config.hostname_to_asics.empty()) {
+        log_debug(
+            tt::LogFabric,
+            "Logical mesh {} anchor: no partition from local hostname hostname_to_asics match",
+            k_logical_anchor.get());
+    }
+
+    std::optional<MeshId> from_discovery_position_partition;
+    const auto anchor_asic_coords = resolve_anchor_asic_at_discovery_position(
+        config, local_hostname_opt, k_logical_mesh_zero_preferred_discovery_asic_position);
+    if (anchor_asic_coords.has_value()) {
+        const std::set<tt::tt_metal::AsicID> single{*anchor_asic_coords};
+        from_discovery_position_partition =
+            smallest_physical_mesh_covering_required_asics(physical_graph, bound_physical_mesh_ids, single);
+    }
+    if (!from_discovery_position_partition.has_value()) {
+        if (!config.asic_positions.empty()) {
+            log_debug(
+                tt::LogFabric,
+                "Logical mesh {} anchor: could not resolve tray 1 / ASIC location 1 partition (ambiguous or missing in "
+                "TopologyMappingConfig::asic_positions / no smallest cover)",
+                k_logical_anchor.get());
+        }
+    }
+
+    std::optional<MeshId> chosen_physical;
+    if (from_hostname_partition.has_value() && from_discovery_position_partition.has_value()) {
+        if (*from_hostname_partition == *from_discovery_position_partition) {
+            chosen_physical = from_hostname_partition;
+        } else {
+            chosen_physical = from_discovery_position_partition;
+            log_info(
+                tt::LogFabric,
+                "Logical mesh {} anchor: localhost partition ({}) differs from tray-1/loc-1 partition ({}); preferring "
+                "the latter",
+                k_logical_anchor.get(),
+                from_hostname_partition->get(),
+                from_discovery_position_partition->get());
+        }
+    } else if (from_discovery_position_partition.has_value()) {
+        chosen_physical = from_discovery_position_partition;
+    } else if (from_hostname_partition.has_value()) {
+        chosen_physical = from_hostname_partition;
+    }
+
+    if (!chosen_physical.has_value()) {
+        return;
+    }
+
+    inter_mesh_constraints.add_preferred_constraint(k_logical_anchor, *chosen_physical);
+
+    log_info(
+        tt::LogFabric,
+        "Inter-mesh preference: logical mesh {} → physical mesh {} (hostname_anchor={}, "
+        "tray1_asic_location1_anchor={})",
+        k_logical_anchor.get(),
+        chosen_physical->get(),
+        from_hostname_partition.has_value(),
+        from_discovery_position_partition.has_value());
+}
+
 // Helper function to build ASIC positions to ASIC IDs map
 std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
     const ::tt::tt_fabric::AdjacencyGraph<tt::tt_metal::AsicID>& physical_graph, const TopologyMappingConfig& config) {
@@ -791,6 +1037,8 @@ std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
     if (config.disable_rank_bindings) {
         add_inter_mesh_minimal_host_cover_from_hostname_map(
             config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, {});
+        add_logical_mesh_zero_anchor_inter_mesh_preference(
+            config, physical_graph, mesh_logical_level_graph, {}, inter_mesh_constraints);
         return inter_mesh_constraints;
     }
 
@@ -848,6 +1096,8 @@ std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
 
     add_inter_mesh_minimal_host_cover_from_hostname_map(
         config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, rank_bound_logical_to_physical);
+    add_logical_mesh_zero_anchor_inter_mesh_preference(
+        config, physical_graph, mesh_logical_level_graph, rank_bound_logical_to_physical, inter_mesh_constraints);
     return inter_mesh_constraints;
 }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Closes #43630

When multiple Mesh instances are present (e.g. `bh_glx_split_4x2`), MPI world ranks were assigned in PSD-rank-primary order, causing `binding.rank` to differ from the corresponding `mesh_id`. This broke any code that assumes `MPI_rank == mesh_id`.

**Root cause:** `extract_rank_bindings()` in `tools/scaleout/src/generate_rank_bindings.cpp` sorted entries with PSD rank as the primary key. Entries were then numbered 0…N, so the rank index only accidentally matched the mesh ID.

**Fix:** Changed the sort comparator to use `mesh_id` as the primary key (then `mesh_host_rank`, then hostname, with PSD rank as a deterministic tiebreaker). Now `binding.rank` strictly follows mesh order, so `MPI_world_rank == mesh_id` for all standard split topologies.

**Test:** Added an assertion in `TestBHBlitzPipelineControlPlaneInit` that verifies `MPI world rank == local mesh_id` for the `bh_glx_split_4x2` topology (using `DistributedContext::get_world_context()->rank()` for the true world rank, not the sub-context).

### Notes for reviewers

- Only `extract_rank_bindings()` sort order changed — no API surface, no binary protocol changes.
- The added assertion is topology-specific (`bh_glx_split_4x2`, 1 mesh instance per rank). Other topologies are not affected by this PR.
- This is a correctness fix; any existing multi-host test that passed before may silently rely on the old (wrong) rank order. Please flag if you know of such tests.
- The deployment YAML (`bh_blitz_pipeline_rank_bindings.yaml`) will be regenerated on real hardware once this lands — that YAML is for a different physical cluster with non-sequential mesh IDs and is unrelated to the test topology.

### Test plan
- [x] `TestBHBlitzPipelineControlPlaneInit` asserts `rank == mesh_id` on `bh_glx_split_4x2` hardware
- [x] Sanity tests — pass
- [x] Merge gate — pass
- [ ] Multi-host deployment CI — re-run pending (prior run: infra failures unrelated to PR)

### CI Status

| Workflow | Status | Notes |
|---|---|---|
| PR Gate | ✅ Pass | [25754665504](https://github.com/tenstorrent/tt-metal/actions/runs/25754665504) |
| Sanity Tests | ✅ Pass | [25754457311](https://github.com/tenstorrent/tt-metal/actions/runs/25754457311) |
| Merge Gate | ✅ Pass | [25754455039](https://github.com/tenstorrent/tt-metal/actions/runs/25754455039) |
| Multi-host Physical | ❌ Infra failures (unrelated to PR) | [25754459601](https://github.com/tenstorrent/tt-metal/actions/runs/25754459601) — `multi-host-t3k`: NFS stale file handle (`chlkc_descriptors.h`); `multi-host-bh-lb-4x`: multiple `.whl` files in workspace. Both are runner infrastructure issues. `multi-host-glx-2x` and `multi-host-bh-lb-2x` passed. |

_PR code changes are not implicated in any CI failure. Re-running multi-host when infrastructure is stable._