### PR TITLE
[LLK] Add LLK debug API for writing to and dumping DEST

### DIFF
--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -804,6 +804,72 @@ ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
     MATH((dbg_get_array_row(dbg_array_id::DEST, row_addr, rd_data)));
 }
 
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Reads a single tile from the DEST register through the RISC-V memory-mapped
+ * dest register and copies it into the provided buffer.
+ *
+ * Supported data formats: Float32, Float16, Float16_b, Int32, UInt32, UInt16,
+ * Int8, UInt8.
+ *
+ * Return value: None
+ *
+ * | Template Param  | Description                                                                                  | Type       | Valid Range                                                | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|------------|------------------------------------------------------------|----------|
+ * | fmt             | Data format of the values stored in DEST                                        | DataFormat | See supported formats above                                | True     |
+ *
+ * | Argument        | Description                                                                                  | Type       | Valid Range                                                | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|------------|------------------------------------------------------------|----------|
+ * | tile_id         | Index of the tile within DEST to read                                           | uint32_t   | Must be less than the size of the DST register buffer      | True     |
+ * | dst_buffer      | Destination buffer with space for TILE_HEIGHT * TILE_WIDTH elements of *fmt*    | void*      | Non-null                                                   | True     |
+ * | enable_swizzle  | When true, read with hardware swizzling enabled                                 | bool       | true or false                                              | False    |
+ */
+// clang-format on
+template <DataFormat fmt>
+ALWI void dbg_read_dest_tile(uint32_t tile_id, void* dst_buffer, bool enable_swizzle = true) {
+    static_assert(
+        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b ||
+            fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 || fmt == DataFormat::UInt16 ||
+            fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
+        "dbg_read_dest_tile: unsupported DataFormat");
+    MATH((dbg_dump_dest_tile<MathThreadId>(fmt, tile_id, dst_buffer, enable_swizzle)));
+}
+
+// clang-format off
+/**
+ * Writes a single tile into the DEST register through the RISC-V memory-mapped
+ * dest register.
+ *
+ * Supported data formats: Float32, Float16, Float16_b, Int32, UInt32, UInt16,
+ * Int8, UInt8.
+ *
+ * Return value: None
+ *
+ * | Template Param  | Description                                                                                  | Type        | Valid Range                                                | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|----------|
+ * | fmt             | Data format of the values to be stored in DEST                                               | DataFormat  | See supported formats above                                | True     |
+ *
+ * | Argument        | Description                                                                                  | Type        | Valid Range                                                | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|----------|
+ * | tile_id         | Index of the tile within DEST to write                                                       | uint32_t    | Must be less than the size of the DST register buffer      | True     |
+ * | src_buffer      | Source buffer containing TILE_HEIGHT * TILE_WIDTH elements of *fmt*                          | const void* | Non-null                                                   | True     |
+ * | enable_swizzle  | When true, write with hardware swizzling enabled (matches the FPU's view of DEST)            | bool        | true or false                                              | False    |
+ */
+// clang-format on
+template <DataFormat fmt>
+ALWI void dbg_write_dest_tile(uint32_t tile_id, const void* src_buffer, bool enable_swizzle = true) {
+    static_assert(
+        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b ||
+            fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 || fmt == DataFormat::UInt16 ||
+            fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
+        "dbg_write_dest_tile: unsupported DataFormat");
+    MATH((dbg_write_dest_tile<MathThreadId>(fmt, tile_id, src_buffer, enable_swizzle)));
+}
+
+#endif
+
 // unary_max : if x > value --> x, else value
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -816,12 +816,12 @@ ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
  *
  * Return value: None
  *
- * | Template Param  | Description                                                                                  | Type       | Valid Range                                                | Required |
- * |-----------------|----------------------------------------------------------------------------------------------|------------|------------------------------------------------------------|----------|
- * | fmt             | Data format of the values stored in DEST                                        | DataFormat | See supported formats above                                | True     |
+ * | Template Param  | Description                                                                                  | Type       | Valid Range                                   | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|------------|-----------------------------------------------|----------|
+ * | fmt             | Data format of the values stored in DEST                                                     | DataFormat | See supported formats above                   | True     |
  *
- * | Argument        | Description                                                                                  | Type       | Valid Range                                                | Required |
- * |-----------------|----------------------------------------------------------------------------------------------|------------|------------------------------------------------------------|----------|
+ * | Argument        | Description                                                                                  | Type       | Valid Range                                   | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|------------|-----------------------------------------------|----------|
  * | tile_id         | Index of the tile within DEST to read                                           | uint32_t   | Must be less than the size of the DST register buffer      | True     |
  * | dst_buffer      | Destination buffer with space for TILE_HEIGHT * TILE_WIDTH elements of *fmt*    | void*      | Non-null                                                   | True     |
  * | enable_swizzle  | When true, read with hardware swizzling enabled                                 | bool       | true or false                                              | False    |

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -691,7 +691,7 @@ ALWI void max_reduce_with_indices_init() {
  * | rt_dim          | Tile dimension along rows (runtime); must be 1 when reduce_dim is REDUCE_COL    | uint32_t  | >= 1; default 1
  */
 // clang-format on
-template <PoolType pool_type, DataFormat format, ReduceDim reduce_dim=ReduceDim::REDUCE_COL>
+template <PoolType pool_type, DataFormat format, ReduceDim reduce_dim = ReduceDim::REDUCE_COL>
 ALWI void sfpu_reduce(uint32_t idst, uint32_t ct_dim = 1, uint32_t rt_dim = 1) {
     static_assert(
         reduce_dim == ReduceDim::REDUCE_COL ||
@@ -829,11 +829,7 @@ ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
 // clang-format on
 template <DataFormat fmt>
 ALWI void dbg_read_dest_tile(uint32_t tile_id, void* dst_buffer, bool enable_swizzle = true) {
-    static_assert(
-        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b ||
-            fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 || fmt == DataFormat::UInt16 ||
-            fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
-        "dbg_read_dest_tile: unsupported DataFormat");
+    static_assert(dbg_dest_fmt_supported(fmt), "dbg_read_dest_tile: unsupported DataFormat");
     MATH((dbg_dump_dest_tile<MathThreadId>(fmt, tile_id, dst_buffer, enable_swizzle)));
 }
 
@@ -860,11 +856,7 @@ ALWI void dbg_read_dest_tile(uint32_t tile_id, void* dst_buffer, bool enable_swi
 // clang-format on
 template <DataFormat fmt>
 ALWI void dbg_write_dest_tile(uint32_t tile_id, const void* src_buffer, bool enable_swizzle = true) {
-    static_assert(
-        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b ||
-            fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 || fmt == DataFormat::UInt16 ||
-            fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
-        "dbg_write_dest_tile: unsupported DataFormat");
+    static_assert(dbg_dest_fmt_supported(fmt), "dbg_write_dest_tile: unsupported DataFormat");
     MATH((dbg_write_dest_tile<MathThreadId>(fmt, tile_id, src_buffer, enable_swizzle)));
 }
 

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -804,64 +804,6 @@ ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
     MATH((dbg_get_array_row(dbg_array_id::DEST, row_addr, rd_data)));
 }
 
-#ifdef ARCH_BLACKHOLE
-
-// clang-format off
-/**
- * Reads a single tile from the DEST register through the RISC-V memory-mapped
- * dest register and copies it into the provided buffer.
- *
- * Supported data formats: Float32, Float16, Float16_b, Int32, UInt32, UInt16,
- * Int8, UInt8.
- *
- * Return value: None
- *
- * | Template Param  | Description                                                                                  | Type       | Valid Range                                   | Required |
- * |-----------------|----------------------------------------------------------------------------------------------|------------|-----------------------------------------------|----------|
- * | fmt             | Data format of the values stored in DEST                                                     | DataFormat | See supported formats above                   | True     |
- *
- * | Argument        | Description                                                                                  | Type       | Valid Range                                   | Required |
- * |-----------------|----------------------------------------------------------------------------------------------|------------|-----------------------------------------------|----------|
- * | tile_id         | Index of the tile within DEST to read                                           | uint32_t   | Must be less than the size of the DST register buffer      | True     |
- * | dst_buffer      | Destination buffer with space for TILE_HEIGHT * TILE_WIDTH elements of *fmt*    | void*      | Non-null                                                   | True     |
- * | enable_swizzle  | When true, read with hardware swizzling enabled                                 | bool       | true or false                                              | False    |
- */
-// clang-format on
-template <DataFormat fmt>
-ALWI void dbg_read_dest_tile(uint32_t tile_id, void* dst_buffer, bool enable_swizzle = true) {
-    static_assert(dbg_dest_fmt_supported(fmt), "dbg_read_dest_tile: unsupported DataFormat");
-    MATH((dbg_dump_dest_tile<MathThreadId>(fmt, tile_id, dst_buffer, enable_swizzle)));
-}
-
-// clang-format off
-/**
- * Writes a single tile into the DEST register through the RISC-V memory-mapped
- * dest register.
- *
- * Supported data formats: Float32, Float16, Float16_b, Int32, UInt32, UInt16,
- * Int8, UInt8.
- *
- * Return value: None
- *
- * | Template Param  | Description                                                                                  | Type        | Valid Range                                                | Required |
- * |-----------------|----------------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|----------|
- * | fmt             | Data format of the values to be stored in DEST                                               | DataFormat  | See supported formats above                                | True     |
- *
- * | Argument        | Description                                                                                  | Type        | Valid Range                                                | Required |
- * |-----------------|----------------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|----------|
- * | tile_id         | Index of the tile within DEST to write                                                       | uint32_t    | Must be less than the size of the DST register buffer      | True     |
- * | src_buffer      | Source buffer containing TILE_HEIGHT * TILE_WIDTH elements of *fmt*                          | const void* | Non-null                                                   | True     |
- * | enable_swizzle  | When true, write with hardware swizzling enabled (matches the FPU's view of DEST)            | bool        | true or false                                              | False    |
- */
-// clang-format on
-template <DataFormat fmt>
-ALWI void dbg_write_dest_tile(uint32_t tile_id, const void* src_buffer, bool enable_swizzle = true) {
-    static_assert(dbg_dest_fmt_supported(fmt), "dbg_write_dest_tile: unsupported DataFormat");
-    MATH((dbg_write_dest_tile<MathThreadId>(fmt, tile_id, src_buffer, enable_swizzle)));
-}
-
-#endif
-
 // unary_max : if x > value --> x, else value
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api_debug.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api_debug.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#ifdef ARCH_BLACKHOLE
+#include "ckernel_debug.h"
+#endif
+
+namespace ckernel {
+
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Reads a single tile from the DEST register through the RISC-V memory-mapped
+ * dest register and copies it into the provided buffer.
+ *
+ * Supported data formats: Float32, Float16, Float16_b, Int32, UInt32, UInt16,
+ * Int8, UInt8.
+ *
+ * Return value: None
+ *
+ * | Template Param  | Description                                                                                  | Type       | Valid Range                                   | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|------------|-----------------------------------------------|----------|
+ * | fmt             | Data format of the values stored in DEST                                                     | DataFormat | See supported formats above                   | True     |
+ *
+ * | Argument        | Description                                                                                  | Type       | Valid Range                                   | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|------------|-----------------------------------------------|----------|
+ * | tile_id         | Index of the tile within DEST to read                                           | uint32_t   | Must be less than the size of the DST register buffer      | True     |
+ * | dst_buffer      | Destination buffer with space for TILE_HEIGHT * TILE_WIDTH elements of *fmt*    | void*      | Non-null                                                   | True     |
+ * | enable_swizzle  | When true, read with hardware swizzling enabled                                 | bool       | true or false                                              | False    |
+ */
+// clang-format on
+template <DataFormat fmt>
+ALWI void dbg_read_dest_tile(uint32_t tile_id, void* dst_buffer, bool enable_swizzle = true) {
+    static_assert(dbg_dest_fmt_supported(fmt), "dbg_read_dest_tile: unsupported DataFormat");
+    MATH((dbg_copy_dest_tile<DbgDestTileOp::Read, MathThreadId>(fmt, tile_id, dst_buffer, enable_swizzle)));
+}
+
+// clang-format off
+/**
+ * Writes a single tile into the DEST register through the RISC-V memory-mapped
+ * dest register.
+ *
+ * Supported data formats: Float32, Float16, Float16_b, Int32, UInt32, UInt16,
+ * Int8, UInt8.
+ *
+ * Return value: None
+ *
+ * | Template Param  | Description                                                                                  | Type        | Valid Range                                                | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|----------|
+ * | fmt             | Data format of the values to be stored in DEST                                               | DataFormat  | See supported formats above                                | True     |
+ *
+ * | Argument        | Description                                                                                  | Type        | Valid Range                                                | Required |
+ * |-----------------|----------------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|----------|
+ * | tile_id         | Index of the tile within DEST to write                                                       | uint32_t    | Must be less than the size of the DST register buffer      | True     |
+ * | src_buffer      | Source buffer containing TILE_HEIGHT * TILE_WIDTH elements of *fmt*                          | const void* | Non-null                                                   | True     |
+ * | enable_swizzle  | When true, write with hardware swizzling enabled (matches the FPU's view of DEST)            | bool        | true or false                                              | False    |
+ */
+// clang-format on
+template <DataFormat fmt>
+ALWI void dbg_write_dest_tile(uint32_t tile_id, const void* src_buffer, bool enable_swizzle = true) {
+    static_assert(dbg_dest_fmt_supported(fmt), "dbg_write_dest_tile: unsupported DataFormat");
+    MATH((dbg_copy_dest_tile<DbgDestTileOp::Write, MathThreadId>(fmt, tile_id, src_buffer, enable_swizzle)));
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/python_tests/test_dest_copy.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_dest_copy.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.format_config import DataFormat
+from helpers.llk_params import format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+
+
+@parametrize(
+    formats=input_output_formats(
+        [
+            DataFormat.Float32,
+        ],
+        same=True,
+    ),
+)
+def test_dump_dest(formats):
+
+    formats = formats[0]
+
+    if get_chip_architecture() != ChipArchitecture.BLACKHOLE:
+        pytest.skip("The RISC-DEST debug window is only available on Blackhole.")
+
+    input_dimensions = [32, 32]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    configuration = TestConfig(
+        "sources/debug_dest_copy.cpp",
+        formats,
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+        ),
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert (
+        len(res_from_L1) == src_A.numel()
+    ), f"Result tensor length {len(res_from_L1)} does not match source length {src_A.numel()}"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    # The kernel performs a bit-exact copy through DEST, so the result must
+    # match the source exactly (no tolerance needed).
+    assert torch.equal(
+        src_A.to(torch_format), res_tensor
+    ), "L1 -> DEST -> L1 round-trip did not preserve the tile bit-exactly."

--- a/tt_metal/tt-llk/tests/python_tests/test_dest_copy.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_dest_copy.py
@@ -8,7 +8,7 @@ from helpers.format_config import DataFormat
 from helpers.llk_params import format_dict
 from helpers.param_config import input_output_formats, parametrize
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator_v2 import generate_stimuli_v2
 from helpers.test_config import TestConfig
 
 
@@ -16,6 +16,13 @@ from helpers.test_config import TestConfig
     formats=input_output_formats(
         [
             DataFormat.Float32,
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+            DataFormat.Int32,
+            DataFormat.Int8,
+            DataFormat.UInt32,
+            DataFormat.UInt16,
+            DataFormat.UInt8,
         ],
         same=True,
     ),
@@ -29,7 +36,7 @@ def test_dump_dest(formats):
 
     input_dimensions = [32, 32]
 
-    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli_v2(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,

--- a/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
+++ b/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
@@ -36,8 +36,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t TILE_IDX = 0;
 
     // L1 -> DEST -> L1 round trip through the RISC-V debug dest.
-    dbg_write_dest_tile<MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<const void*>(params.buffer_A[0]));
-    dbg_dump_dest_tile<MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<void*>(params.buffer_Res[0]));
+    dbg_copy_dest_tile<DbgDestTileOp::Write, MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<void*>(params.buffer_A[0]));
+    dbg_copy_dest_tile<DbgDestTileOp::Read, MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<void*>(params.buffer_Res[0]));
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
+++ b/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
@@ -6,7 +6,7 @@
 
 #include "build.h"
 #include "ckernel.h"
-#include "ckernel_dest.h"
+#include "ckernel_debug.h"
 
 // Globals
 std::uint32_t unp_cfg_context          = 0;
@@ -26,106 +26,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 using namespace ckernel;
 
-namespace
-{
-constexpr std::uint32_t risc_dest_bytes_per_elem(std::uint32_t data_format)
-{
-    switch (data_format)
-    {
-        case to_underlying(DataFormat::Float32):
-        case to_underlying(DataFormat::Int32):
-        case to_underlying(DataFormat::UInt32):
-            return 4;
-        case to_underlying(DataFormat::Float16):
-        case to_underlying(DataFormat::Float16_b):
-        case to_underlying(DataFormat::UInt16):
-            return 2;
-        case to_underlying(DataFormat::Int8):
-        case to_underlying(DataFormat::UInt8):
-            return 1;
-        default:
-            return 2;
-    }
-}
-
-constexpr bool risc_dest_is_unsigned(std::uint32_t data_format)
-{
-    switch (data_format)
-    {
-        case to_underlying(DataFormat::UInt8):
-        case to_underlying(DataFormat::UInt16):
-        case to_underlying(DataFormat::UInt32):
-            return true;
-        default:
-            return false;
-    }
-}
-} // namespace
-
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
 
-    const std::uint32_t l1_fmt         = formats.unpack_A_src;
-    const std::uint32_t bytes_per_elem = risc_dest_bytes_per_elem(l1_fmt);
-    const bool is_unsigned_int         = risc_dest_is_unsigned(l1_fmt);
+    const DataFormat l1_fmt          = static_cast<DataFormat>(formats.unpack_A_src);
+    constexpr std::uint32_t TILE_IDX = 0;
 
-    set_dest_fmt<MathThreadId>(l1_fmt);
-    set_dest_enable_swizzling<MathThreadId, true>();
-    set_dest_int8_int16_signed<MathThreadId>(!is_unsigned_int);
-    tensix_sync();
-
-    if (bytes_per_elem == 4)
-    {
-        volatile std::uint32_t* src_l1 = reinterpret_cast<volatile std::uint32_t*>(params.buffer_A[0]);
-        volatile std::uint32_t* dst_l1 = reinterpret_cast<volatile std::uint32_t*>(params.buffer_Res[0]);
-        volatile std::uint32_t* dest32 = reinterpret_cast<volatile std::uint32_t*>(RISCV_DEST_START_ADDR);
-
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dest32[i] = src_l1[i];
-        }
-        tensix_sync();
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dst_l1[i] = dest32[i];
-        }
-    }
-    else if (bytes_per_elem == 2)
-    {
-        volatile std::uint16_t* src_l1 = reinterpret_cast<volatile std::uint16_t*>(params.buffer_A[0]);
-        volatile std::uint16_t* dst_l1 = reinterpret_cast<volatile std::uint16_t*>(params.buffer_Res[0]);
-        volatile std::uint16_t* dest16 = reinterpret_cast<volatile std::uint16_t*>(RISCV_DEST_START_ADDR);
-
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dest16[i] = src_l1[i];
-        }
-        tensix_sync();
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dst_l1[i] = dest16[i];
-        }
-    }
-    else
-    {
-        volatile std::uint8_t* src_l1 = reinterpret_cast<volatile std::uint8_t*>(params.buffer_A[0]);
-        volatile std::uint8_t* dst_l1 = reinterpret_cast<volatile std::uint8_t*>(params.buffer_Res[0]);
-        volatile std::uint8_t* dest8  = reinterpret_cast<volatile std::uint8_t*>(RISCV_DEST_START_ADDR);
-
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dest8[i] = src_l1[i];
-        }
-        tensix_sync();
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dst_l1[i] = dest8[i];
-        }
-    }
+    // L1 -> DEST -> L1 round trip through the RISC-V debug dest pathway.
+    dbg_write_dest_tile<MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<const void*>(params.buffer_A[0]));
+    dbg_dump_dest_tile<MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<void*>(params.buffer_Res[0]));
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
+++ b/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "build.h"
+#include "ckernel.h"
+#include "ckernel_dest.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    // idle
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+using namespace ckernel;
+
+namespace
+{
+constexpr std::uint32_t risc_dest_bytes_per_elem(std::uint32_t data_format)
+{
+    switch (data_format)
+    {
+        case to_underlying(DataFormat::Float32):
+        case to_underlying(DataFormat::Int32):
+        case to_underlying(DataFormat::UInt32):
+            return 4;
+        case to_underlying(DataFormat::Float16):
+        case to_underlying(DataFormat::Float16_b):
+        case to_underlying(DataFormat::UInt16):
+            return 2;
+        case to_underlying(DataFormat::Int8):
+        case to_underlying(DataFormat::UInt8):
+            return 1;
+        default:
+            return 2;
+    }
+}
+
+constexpr bool risc_dest_is_unsigned(std::uint32_t data_format)
+{
+    switch (data_format)
+    {
+        case to_underlying(DataFormat::UInt8):
+        case to_underlying(DataFormat::UInt16):
+        case to_underlying(DataFormat::UInt32):
+            return true;
+        default:
+            return false;
+    }
+}
+} // namespace
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
+
+    const std::uint32_t l1_fmt         = formats.unpack_A_src;
+    const std::uint32_t bytes_per_elem = risc_dest_bytes_per_elem(l1_fmt);
+    const bool is_unsigned_int         = risc_dest_is_unsigned(l1_fmt);
+
+    set_dest_fmt<MathThreadId>(l1_fmt);
+    set_dest_enable_swizzling<MathThreadId, true>();
+    set_dest_int8_int16_signed<MathThreadId>(!is_unsigned_int);
+    tensix_sync();
+
+    if (bytes_per_elem == 4)
+    {
+        volatile std::uint32_t* src_l1 = reinterpret_cast<volatile std::uint32_t*>(params.buffer_A[0]);
+        volatile std::uint32_t* dst_l1 = reinterpret_cast<volatile std::uint32_t*>(params.buffer_Res[0]);
+        volatile std::uint32_t* dest32 = reinterpret_cast<volatile std::uint32_t*>(RISCV_DEST_START_ADDR);
+
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dest32[i] = src_l1[i];
+        }
+        tensix_sync();
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dst_l1[i] = dest32[i];
+        }
+    }
+    else if (bytes_per_elem == 2)
+    {
+        volatile std::uint16_t* src_l1 = reinterpret_cast<volatile std::uint16_t*>(params.buffer_A[0]);
+        volatile std::uint16_t* dst_l1 = reinterpret_cast<volatile std::uint16_t*>(params.buffer_Res[0]);
+        volatile std::uint16_t* dest16 = reinterpret_cast<volatile std::uint16_t*>(RISCV_DEST_START_ADDR);
+
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dest16[i] = src_l1[i];
+        }
+        tensix_sync();
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dst_l1[i] = dest16[i];
+        }
+    }
+    else
+    {
+        volatile std::uint8_t* src_l1 = reinterpret_cast<volatile std::uint8_t*>(params.buffer_A[0]);
+        volatile std::uint8_t* dst_l1 = reinterpret_cast<volatile std::uint8_t*>(params.buffer_Res[0]);
+        volatile std::uint8_t* dest8  = reinterpret_cast<volatile std::uint8_t*>(RISCV_DEST_START_ADDR);
+
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dest8[i] = src_l1[i];
+        }
+        tensix_sync();
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dst_l1[i] = dest8[i];
+        }
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    // idle
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
+++ b/tt_metal/tt-llk/tests/sources/debug_dest_copy.cpp
@@ -35,7 +35,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const DataFormat l1_fmt          = static_cast<DataFormat>(formats.unpack_A_src);
     constexpr std::uint32_t TILE_IDX = 0;
 
-    // L1 -> DEST -> L1 round trip through the RISC-V debug dest pathway.
+    // L1 -> DEST -> L1 round trip through the RISC-V debug dest.
     dbg_write_dest_tile<MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<const void*>(params.buffer_A[0]));
     dbg_dump_dest_tile<MathThreadId>(l1_fmt, TILE_IDX, reinterpret_cast<void*>(params.buffer_Res[0]));
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -158,11 +158,6 @@ inline void dbg_thread_unhalt()
 // Dump a single tile from the DEST register through the RISC-V memory-mapped
 // dest register.
 //
-// SyncHalf note: tile_id is a direct index into DEST starting at offset 0.
-// In SyncHalf mode the math thread uses the upper half of DEST when
-// dest_offset_id == 1; in that case pass (DEST_NUM_TILES_FP16_HALF + logical_tile_id)
-// or precompute the offset via get_dest_buffer_base().
-//
 // Parameters:
 //   fmt:             data format of the values stored in DEST.
 //   tile_id:         index of the tile within DEST to dump.
@@ -177,8 +172,6 @@ inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_
         thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
         "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
 
-    // Only the formats explicitly handled by fmt_to_dest_type and the byte-width
-    // dispatch below are supported on the RISC-V debug dest pathway.
     LLK_ASSERT(
         fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b || fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 ||
             fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
@@ -225,6 +218,16 @@ inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_
     }
 }
 
+// Write a single tile into the DEST register through the RISC-V memory-mapped
+// dest register.
+//
+// Parameters:
+//   fmt:             data format of the values to be stored in DEST.
+//   tile_id:         index of the tile within DEST to overwrite.
+//   src_buffer:      source buffer pointer to copy the tile from. Must hold
+//                    TILE_HEIGHT * TILE_WIDTH elements of `fmt`.
+//   enable_swizzle:  when true, write with hardware swizzling enabled (matches
+//                    the FPU's view of DEST); when false, write the raw layout.
 template <ThreadId thread_id = ThreadId::MathThreadId>
 inline void dbg_write_dest_tile(DataFormat fmt, std::uint32_t tile_id, const void *src_buffer, bool enable_swizzle = true)
 {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -232,8 +232,6 @@ inline void dbg_write_dest_tile(DataFormat fmt, std::uint32_t tile_id, const voi
         thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
         "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
 
-    // Only the formats explicitly handled by fmt_to_dest_type and the byte-width
-    // dispatch below are supported on the RISC-V debug dest pathway.
     LLK_ASSERT(
         fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b || fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 ||
             fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "ckernel_defs.h"
 #include "ckernel_dest.h"
 
 // Debug bus and register array dump
@@ -103,9 +104,7 @@ typedef union
 template <ThreadId thread_id>
 inline void dbg_thread_halt()
 {
-    static_assert(
-        (thread_id == ThreadId::MathThreadId) || (thread_id == ThreadId::UnpackThreadId) || (thread_id == ThreadId::PackThreadId),
-        "Invalid thread id set in dbg_wait_for_thread_idle(...)");
+    static_assert(IS_TRISC_THREAD<thread_id>, "Invalid thread id set in dbg_wait_for_thread_idle(...)");
 
     if constexpr (thread_id == ThreadId::UnpackThreadId)
     {
@@ -132,9 +131,7 @@ inline void dbg_thread_halt()
 template <ThreadId thread_id>
 inline void dbg_thread_unhalt()
 {
-    static_assert(
-        (thread_id == ThreadId::MathThreadId) || (thread_id == ThreadId::UnpackThreadId) || (thread_id == ThreadId::PackThreadId),
-        "Invalid thread id set in dbg_wait_for_thread_idle(...)");
+    static_assert(IS_TRISC_THREAD<thread_id>, "Invalid thread id set in dbg_wait_for_thread_idle(...)");
 
     if constexpr (thread_id == ThreadId::MathThreadId)
     {
@@ -174,9 +171,7 @@ constexpr bool dbg_dest_fmt_supported(DataFormat fmt)
 template <ThreadId thread_id = ThreadId::MathThreadId>
 inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_buffer, bool enable_swizzle = true)
 {
-    static_assert(
-        thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
-        "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
+    static_assert(IS_TRISC_THREAD<thread_id>, "dbg_dump_dest_tile: invalid thread id");
 
     LLK_ASSERT(dbg_dest_fmt_supported(fmt), "dbg_dump_dest_tile: unsupported DataFormat");
 
@@ -234,9 +229,7 @@ inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_
 template <ThreadId thread_id = ThreadId::MathThreadId>
 inline void dbg_write_dest_tile(DataFormat fmt, std::uint32_t tile_id, const void *src_buffer, bool enable_swizzle = true)
 {
-    static_assert(
-        thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
-        "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
+    static_assert(IS_TRISC_THREAD<thread_id>, "dbg_write_dest_tile: invalid thread id");
 
     LLK_ASSERT(dbg_dest_fmt_supported(fmt), "dbg_write_dest_tile: unsupported DataFormat");
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -155,6 +155,12 @@ inline void dbg_thread_unhalt()
     }
 }
 
+constexpr bool dbg_dest_fmt_supported(DataFormat fmt)
+{
+    return fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b || fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 ||
+           fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8;
+}
+
 // Dump a single tile from the DEST register through the RISC-V memory-mapped
 // dest register.
 //
@@ -172,10 +178,7 @@ inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_
         thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
         "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
 
-    LLK_ASSERT(
-        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b || fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 ||
-            fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
-        "dbg_dump_dest_tile: unsupported DataFormat");
+    LLK_ASSERT(dbg_dest_fmt_supported(fmt), "dbg_dump_dest_tile: unsupported DataFormat");
 
     constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
 
@@ -235,10 +238,7 @@ inline void dbg_write_dest_tile(DataFormat fmt, std::uint32_t tile_id, const voi
         thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
         "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
 
-    LLK_ASSERT(
-        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b || fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 ||
-            fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
-        "dbg_write_dest_tile: unsupported DataFormat");
+    LLK_ASSERT(dbg_dest_fmt_supported(fmt), "dbg_write_dest_tile: unsupported DataFormat");
 
     constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "ckernel_dest.h"
 
 // Debug bus and register array dump
 // TODO: RT Review this debug file for BH, currently copy from whb0
@@ -152,6 +153,135 @@ inline void dbg_thread_unhalt()
         // Unhalt unpack thread
         mailbox_write(ThreadId::UnpackThreadId, 1);
     }
+}
+
+// Dump a single tile from the DEST register through the RISC-V memory-mapped
+// dest register.
+//
+// SyncHalf note: tile_id is a direct index into DEST starting at offset 0.
+// In SyncHalf mode the math thread uses the upper half of DEST when
+// dest_offset_id == 1; in that case pass (DEST_NUM_TILES_FP16_HALF + logical_tile_id)
+// or precompute the offset via get_dest_buffer_base().
+//
+// Parameters:
+//   fmt:             data format of the values stored in DEST.
+//   tile_id:         index of the tile within DEST to dump.
+//   dst_buffer:      destination buffer pointer to copy the tile into. Must have
+//                    space for TILE_HEIGHT * TILE_WIDTH elements of `fmt`.
+//   enable_swizzle:  when true, read with hardware swizzling enabled (matches
+//                    the FPU's view of DEST); when false, read the raw layout.
+template <ThreadId thread_id = ThreadId::MathThreadId>
+inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_buffer, bool enable_swizzle = true)
+{
+    static_assert(
+        thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
+        "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
+
+    // Only the formats explicitly handled by fmt_to_dest_type and the byte-width
+    // dispatch below are supported on the RISC-V debug dest pathway.
+    LLK_ASSERT(
+        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b || fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 ||
+            fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
+        "dbg_dump_dest_tile: unsupported DataFormat");
+
+    constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
+
+    const std::uint8_t dest_type = fmt_to_dest_type(fmt);
+    const bool is_signed         = (fmt != DataFormat::UInt8) && (fmt != DataFormat::UInt16) && (fmt != DataFormat::UInt32);
+
+    set_dest_fmt<thread_id>(dest_type);
+    set_dest_enable_swizzling<thread_id>(enable_swizzle);
+    set_dest_int8_int16_signed<thread_id>(is_signed);
+    tensix_sync();
+
+    const std::uint32_t offset = tile_id * TILE_ELEMENTS;
+
+    if (dest_type == RISC_DEST_FMT_FP32 || dest_type == RISC_DEST_FMT_INT32)
+    {
+        volatile std::uint32_t *dest32 = reinterpret_cast<volatile std::uint32_t *>(RISCV_DEST_START_ADDR);
+        volatile std::uint32_t *dst32  = reinterpret_cast<volatile std::uint32_t *>(dst_buffer);
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dst32[i] = dest32[offset + i];
+        }
+    }
+    else if (dest_type == RISC_DEST_FMT_INT8)
+    {
+        volatile std::uint8_t *dest8 = reinterpret_cast<volatile std::uint8_t *>(RISCV_DEST_START_ADDR);
+        volatile std::uint8_t *dst8  = reinterpret_cast<volatile std::uint8_t *>(dst_buffer);
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dst8[i] = dest8[offset + i];
+        }
+    }
+    else // FP16A, FP16B, INT16
+    {
+        volatile std::uint16_t *dest16 = reinterpret_cast<volatile std::uint16_t *>(RISCV_DEST_START_ADDR);
+        volatile std::uint16_t *dst16  = reinterpret_cast<volatile std::uint16_t *>(dst_buffer);
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dst16[i] = dest16[offset + i];
+        }
+    }
+}
+
+template <ThreadId thread_id = ThreadId::MathThreadId>
+inline void dbg_write_dest_tile(DataFormat fmt, std::uint32_t tile_id, const void *src_buffer, bool enable_swizzle = true)
+{
+    static_assert(
+        thread_id == ThreadId::MathThreadId || thread_id == ThreadId::PackThreadId || thread_id == ThreadId::UnpackThreadId,
+        "Thread must be UnpackThreadId, MathThreadId, or PackThreadId");
+
+    // Only the formats explicitly handled by fmt_to_dest_type and the byte-width
+    // dispatch below are supported on the RISC-V debug dest pathway.
+    LLK_ASSERT(
+        fmt == DataFormat::Float32 || fmt == DataFormat::Float16 || fmt == DataFormat::Float16_b || fmt == DataFormat::Int32 || fmt == DataFormat::UInt32 ||
+            fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8,
+        "dbg_write_dest_tile: unsupported DataFormat");
+
+    constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
+
+    const std::uint8_t dest_type = fmt_to_dest_type(fmt);
+    const bool is_signed         = (fmt != DataFormat::UInt8) && (fmt != DataFormat::UInt16) && (fmt != DataFormat::UInt32);
+
+    set_dest_fmt<thread_id>(dest_type);
+    set_dest_enable_swizzling<thread_id>(enable_swizzle);
+    set_dest_int8_int16_signed<thread_id>(is_signed);
+    tensix_sync();
+
+    const std::uint32_t offset = tile_id * TILE_ELEMENTS;
+
+    if (dest_type == RISC_DEST_FMT_FP32 || dest_type == RISC_DEST_FMT_INT32)
+    {
+        volatile std::uint32_t *dest32      = reinterpret_cast<volatile std::uint32_t *>(RISCV_DEST_START_ADDR);
+        const volatile std::uint32_t *src32 = reinterpret_cast<const volatile std::uint32_t *>(src_buffer);
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dest32[offset + i] = src32[i];
+        }
+    }
+    else if (dest_type == RISC_DEST_FMT_INT8)
+    {
+        volatile std::uint8_t *dest8      = reinterpret_cast<volatile std::uint8_t *>(RISCV_DEST_START_ADDR);
+        const volatile std::uint8_t *src8 = reinterpret_cast<const volatile std::uint8_t *>(src_buffer);
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dest8[offset + i] = src8[i];
+        }
+    }
+    else // FP16A, FP16B, INT16
+    {
+        volatile std::uint16_t *dest16      = reinterpret_cast<volatile std::uint16_t *>(RISCV_DEST_START_ADDR);
+        const volatile std::uint16_t *src16 = reinterpret_cast<const volatile std::uint16_t *>(src_buffer);
+        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        {
+            dest16[offset + i] = src16[i];
+        }
+    }
+
+    // Ensure stores have drained before the caller resumes math/pack ops that
+    // will observe the freshly-written tile.
+    tensix_sync();
 }
 
 inline void dbg_get_array_row(const std::uint32_t array_id, const std::uint32_t row_addr, std::uint32_t *rd_data)

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -158,27 +158,44 @@ constexpr bool dbg_dest_fmt_supported(DataFormat fmt)
            fmt == DataFormat::UInt16 || fmt == DataFormat::Int8 || fmt == DataFormat::UInt8;
 }
 
-// Dump a single tile from the DEST register through the RISC-V memory-mapped
-// dest register.
+// Direction of the copy performed by `dbg_copy_dest_tile`.
+//   Read:  copy a tile from DEST into the caller's buffer.
+//   Write: copy a tile from the caller's buffer into DEST.
+enum class DbgDestTileOp : std::uint8_t
+{
+    Read,
+    Write,
+};
+
+// Copy a single tile between the DEST register and a memory buffer through the
+// RISC-V memory-mapped dest register.
+//
+// Template parameters:
+//   op:         direction of the copy (see `DbgDestTileOp`).
+//   thread_id:  TRISC thread issuing the copy (defaults to `MathThreadId`).
 //
 // Parameters:
 //   fmt:             data format of the values stored in DEST.
-//   tile_id:         index of the tile within DEST to dump.
-//   dst_buffer:      destination buffer pointer to copy the tile into. Must have
-//                    space for TILE_HEIGHT * TILE_WIDTH elements of `fmt`.
-//   enable_swizzle:  when true, read with hardware swizzling enabled (matches
-//                    the FPU's view of DEST); when false, read the raw layout.
-template <ThreadId thread_id = ThreadId::MathThreadId>
-inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_buffer, bool enable_swizzle = true)
+//   tile_id:         index of the tile within DEST to copy.
+//   buffer:          memory buffer holding TILE_HEIGHT * TILE_WIDTH elements of
+//                    `fmt`. For `DbgDestTileOp::Read` it receives the tile read
+//                    from DEST; for `DbgDestTileOp::Write` its contents are
+//                    written into DEST.
+//   enable_swizzle:  when true, access DEST with hardware swizzling enabled
+//                    (matches the FPU's view of DEST); when false, access the
+//                    raw layout.
+template <DbgDestTileOp op, ThreadId thread_id = ThreadId::MathThreadId>
+inline void dbg_copy_dest_tile(
+    DataFormat fmt, std::uint32_t tile_id, std::conditional_t<op == DbgDestTileOp::Write, const void *, void *> buffer, bool enable_swizzle = true)
 {
-    static_assert(IS_TRISC_THREAD<thread_id>, "dbg_dump_dest_tile: invalid thread id");
+    static_assert(IS_TRISC_THREAD<thread_id>, "dbg_copy_dest_tile: invalid thread id");
 
-    LLK_ASSERT(dbg_dest_fmt_supported(fmt), "dbg_dump_dest_tile: unsupported DataFormat");
+    LLK_ASSERT(dbg_dest_fmt_supported(fmt), "dbg_copy_dest_tile: unsupported DataFormat");
 
     constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
 
     const std::uint8_t dest_type = fmt_to_dest_type(fmt);
-    const bool is_signed         = (fmt != DataFormat::UInt8) && (fmt != DataFormat::UInt16) && (fmt != DataFormat::UInt32);
+    const bool is_signed = (fmt != DataFormat::UInt8) && (fmt != DataFormat::UInt16) && (fmt != DataFormat::UInt32);
 
     set_dest_fmt<thread_id>(dest_type);
     set_dest_enable_swizzling<thread_id>(enable_swizzle);
@@ -187,95 +204,47 @@ inline void dbg_dump_dest_tile(DataFormat fmt, std::uint32_t tile_id, void *dst_
 
     const std::uint32_t offset = tile_id * TILE_ELEMENTS;
 
-    if (dest_type == RISC_DEST_FMT_FP32 || dest_type == RISC_DEST_FMT_INT32)
+    auto copy_with_element_type = [&](auto element_tag)
     {
-        volatile std::uint32_t *dest32 = reinterpret_cast<volatile std::uint32_t *>(RISCV_DEST_START_ADDR);
-        volatile std::uint32_t *dst32  = reinterpret_cast<volatile std::uint32_t *>(dst_buffer);
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        using elem_t                = decltype(element_tag);
+        volatile elem_t *dest_array = reinterpret_cast<volatile elem_t *>(RISCV_DEST_START_ADDR);
+        if constexpr (op == DbgDestTileOp::Write)
         {
-            dst32[i] = dest32[offset + i];
+            const volatile elem_t *src = reinterpret_cast<const volatile elem_t *>(buffer);
+            for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+            {
+                dest_array[offset + i] = src[i];
+            }
         }
-    }
-    else if (dest_type == RISC_DEST_FMT_INT8)
-    {
-        volatile std::uint8_t *dest8 = reinterpret_cast<volatile std::uint8_t *>(RISCV_DEST_START_ADDR);
-        volatile std::uint8_t *dst8  = reinterpret_cast<volatile std::uint8_t *>(dst_buffer);
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+        else
         {
-            dst8[i] = dest8[offset + i];
+            volatile elem_t *dst = reinterpret_cast<volatile elem_t *>(buffer);
+            for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
+            {
+                dst[i] = dest_array[offset + i];
+            }
         }
-    }
-    else // FP16A, FP16B, INT16
-    {
-        volatile std::uint16_t *dest16 = reinterpret_cast<volatile std::uint16_t *>(RISCV_DEST_START_ADDR);
-        volatile std::uint16_t *dst16  = reinterpret_cast<volatile std::uint16_t *>(dst_buffer);
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dst16[i] = dest16[offset + i];
-        }
-    }
-}
-
-// Write a single tile into the DEST register through the RISC-V memory-mapped
-// dest register.
-//
-// Parameters:
-//   fmt:             data format of the values to be stored in DEST.
-//   tile_id:         index of the tile within DEST to overwrite.
-//   src_buffer:      source buffer pointer to copy the tile from. Must hold
-//                    TILE_HEIGHT * TILE_WIDTH elements of `fmt`.
-//   enable_swizzle:  when true, write with hardware swizzling enabled (matches
-//                    the FPU's view of DEST); when false, write the raw layout.
-template <ThreadId thread_id = ThreadId::MathThreadId>
-inline void dbg_write_dest_tile(DataFormat fmt, std::uint32_t tile_id, const void *src_buffer, bool enable_swizzle = true)
-{
-    static_assert(IS_TRISC_THREAD<thread_id>, "dbg_write_dest_tile: invalid thread id");
-
-    LLK_ASSERT(dbg_dest_fmt_supported(fmt), "dbg_write_dest_tile: unsupported DataFormat");
-
-    constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
-
-    const std::uint8_t dest_type = fmt_to_dest_type(fmt);
-    const bool is_signed         = (fmt != DataFormat::UInt8) && (fmt != DataFormat::UInt16) && (fmt != DataFormat::UInt32);
-
-    set_dest_fmt<thread_id>(dest_type);
-    set_dest_enable_swizzling<thread_id>(enable_swizzle);
-    set_dest_int8_int16_signed<thread_id>(is_signed);
-    tensix_sync();
-
-    const std::uint32_t offset = tile_id * TILE_ELEMENTS;
+    };
 
     if (dest_type == RISC_DEST_FMT_FP32 || dest_type == RISC_DEST_FMT_INT32)
     {
-        volatile std::uint32_t *dest32      = reinterpret_cast<volatile std::uint32_t *>(RISCV_DEST_START_ADDR);
-        const volatile std::uint32_t *src32 = reinterpret_cast<const volatile std::uint32_t *>(src_buffer);
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dest32[offset + i] = src32[i];
-        }
+        copy_with_element_type(std::uint32_t {});
     }
     else if (dest_type == RISC_DEST_FMT_INT8)
     {
-        volatile std::uint8_t *dest8      = reinterpret_cast<volatile std::uint8_t *>(RISCV_DEST_START_ADDR);
-        const volatile std::uint8_t *src8 = reinterpret_cast<const volatile std::uint8_t *>(src_buffer);
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dest8[offset + i] = src8[i];
-        }
+        copy_with_element_type(std::uint8_t {});
     }
     else // FP16A, FP16B, INT16
     {
-        volatile std::uint16_t *dest16      = reinterpret_cast<volatile std::uint16_t *>(RISCV_DEST_START_ADDR);
-        const volatile std::uint16_t *src16 = reinterpret_cast<const volatile std::uint16_t *>(src_buffer);
-        for (std::uint32_t i = 0; i < TILE_ELEMENTS; ++i)
-        {
-            dest16[offset + i] = src16[i];
-        }
+        copy_with_element_type(std::uint16_t {});
     }
 
-    // Ensure stores have drained before the caller resumes math/pack ops that
-    // will observe the freshly-written tile.
-    tensix_sync();
+    if constexpr (op == DbgDestTileOp::Write)
+    {
+        // Ensure stores have drained before the caller resumes math/pack ops
+        // that will observe the freshly-written tile.
+        tensix_sync();
+    }
 }
 
 inline void dbg_get_array_row(const std::uint32_t array_id, const std::uint32_t row_addr, std::uint32_t *rd_data)

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -126,6 +126,9 @@ constexpr auto to_underlying(T t) noexcept
     return static_cast<std::underlying_type_t<T>>(t);
 }
 
+template <ThreadId thread_id>
+constexpr bool IS_TRISC_THREAD = thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId;
+
 inline constexpr static std::uint32_t masked_data_format(std::uint32_t data_format)
 {
     return data_format & DATA_FORMAT_CONFIG_MASK;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifndef CKERNEL_DEST_H
+#define CKERNEL_DEST_H 1
+
+#include <cstdint>
+
+#include "cfg_defines.h"
+#include "ckernel.h"
+#include "tensix_types.h"
+
+#define RISCV_DEST_START_ADDR 0xFFBD8000
+
+#define RISC_DEST_FMT_FP32  0b000
+#define RISC_DEST_FMT_INT32 0b001
+#define RISC_DEST_FMT_FP16A 0b010
+#define RISC_DEST_FMT_FP16B 0b011
+#define RISC_DEST_FMT_INT16 0b100
+#define RISC_DEST_FMT_INT8  0b101
+
+namespace ckernel
+{
+
+template <ThreadId thread_id>
+inline void set_dest_fmt(std::uint32_t fmt)
+{
+    static_assert(
+        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    if constexpr (thread_id == UnpackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_fmt_RMW, fmt);
+    }
+    else if constexpr (thread_id == MathThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_fmt_RMW, fmt);
+    }
+    else if constexpr (thread_id == PackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_fmt_RMW, fmt);
+    }
+
+    tensix_sync();
+}
+
+inline void set_dest_fmt(std::uint32_t fmt, ThreadId thread_id)
+{
+    // FWLOG1("Setting RISC-dest access format to %d", fmt);
+    if (thread_id == UnpackThreadId)
+    {
+        set_dest_fmt<UnpackThreadId>(fmt);
+    }
+    else if (thread_id == MathThreadId)
+    {
+        set_dest_fmt<MathThreadId>(fmt);
+    }
+    else
+    {
+        set_dest_fmt<PackThreadId>(fmt);
+    }
+
+    tensix_sync();
+}
+
+template <ThreadId thread_id, bool is_signed>
+inline void set_dest_int8_int16_signed()
+{
+    static_assert(
+        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    if (is_signed)
+    {
+        // FWLOG0("Setting RISC-dest int8 access mode to signed");
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 0);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 0);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 0);
+        }
+    }
+    else
+    {
+        // FWLOG0("Setting RISC-dest int8 access mode to unsigned");
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 1);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 1);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 1);
+        }
+    }
+}
+
+template <ThreadId thread_id>
+inline void set_dest_int8_int16_signed(bool const is_signed)
+{
+    static_assert(
+        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    if (is_signed)
+    {
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 0);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 0);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 0);
+        }
+    }
+    else
+    {
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 1);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 1);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 1);
+        }
+    }
+}
+
+inline void set_dest_int8_int16_signed(ThreadId const thread_id, bool const is_signed)
+{
+    if (thread_id == UnpackThreadId)
+    {
+        set_dest_int8_int16_signed<UnpackThreadId>(is_signed);
+    }
+    else if (thread_id == MathThreadId)
+    {
+        set_dest_int8_int16_signed<MathThreadId>(is_signed);
+    }
+    else
+    {
+        set_dest_int8_int16_signed<PackThreadId>(is_signed);
+    }
+}
+
+template <ThreadId thread_id, bool enable>
+inline void set_dest_enable_swizzling()
+{
+    static_assert(
+        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    if (enable)
+    {
+        // In unswizzled mode, values are written into dest as-is with
+        // no saturation checks and no bit shuffling. This means they
+        // are incompatible with the FPU, but it could be useful for
+        // debugging
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 0);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 0);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 0);
+        }
+    }
+    else
+    {
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 1);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 1);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 1);
+        }
+    }
+}
+
+template <ThreadId thread_id>
+inline void set_dest_enable_swizzling(bool const enable)
+{
+    static_assert(
+        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    if (enable)
+    {
+        // In unswizzled mode, values are written into dest as-is with
+        // no saturation checks and no bit shuffling. This means they
+        // are incompatible with the FPU, but it could be useful for
+        // debugging
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 0);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 0);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 0);
+        }
+    }
+    else
+    {
+        if constexpr (thread_id == UnpackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 1);
+        }
+        else if constexpr (thread_id == MathThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 1);
+        }
+        else if constexpr (thread_id == PackThreadId)
+        {
+            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 1);
+        }
+    }
+}
+
+inline void set_dest_enable_swizzling(ThreadId const thread_id, bool const enable)
+{
+    if (thread_id == UnpackThreadId)
+    {
+        set_dest_enable_swizzling<UnpackThreadId>(enable);
+    }
+    else if (thread_id == MathThreadId)
+    {
+        set_dest_enable_swizzling<MathThreadId>(enable);
+    }
+    else
+    {
+        set_dest_enable_swizzling<PackThreadId>(enable);
+    }
+}
+
+inline std::uint8_t fmt_to_dest_type(DataFormat fmt)
+{
+    switch (fmt)
+    {
+        case DataFormat::Float32:
+            return RISC_DEST_FMT_FP32;
+        case DataFormat::Float16:
+            return RISC_DEST_FMT_FP16A;
+        case DataFormat::Float16_b:
+            return RISC_DEST_FMT_FP16B;
+        case DataFormat::Int32:
+        case DataFormat::UInt32:
+            return RISC_DEST_FMT_INT32;
+        case DataFormat::UInt16:
+            return RISC_DEST_FMT_INT16;
+        case DataFormat::Int8:
+        case DataFormat::UInt8:
+            return RISC_DEST_FMT_INT8;
+        default:
+            return RISC_DEST_FMT_INT16;
+    }
+}
+
+template <ThreadId thread_id>
+inline void set_dest_fmt(DataFormat fmt)
+{
+    set_dest_fmt<thread_id>(fmt_to_dest_type(fmt));
+}
+
+} // namespace ckernel
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
@@ -11,6 +11,7 @@
 
 #include "cfg_defines.h"
 #include "ckernel.h"
+#include "ckernel_defs.h"
 #include "tensix_types.h"
 
 #define RISCV_DEST_START_ADDR 0xFFBD8000
@@ -24,170 +25,6 @@
 
 namespace ckernel
 {
-
-template <ThreadId thread_id>
-inline void set_dest_fmt(std::uint32_t fmt)
-{
-    static_assert(
-        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
-
-    if constexpr (thread_id == UnpackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_fmt_RMW, fmt);
-    }
-    else if constexpr (thread_id == MathThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_fmt_RMW, fmt);
-    }
-    else if constexpr (thread_id == PackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_fmt_RMW, fmt);
-    }
-}
-
-inline void set_dest_fmt(std::uint32_t fmt, ThreadId thread_id)
-{
-    // FWLOG1("Setting RISC-dest access format to %d", fmt);
-    if (thread_id == UnpackThreadId)
-    {
-        set_dest_fmt<UnpackThreadId>(fmt);
-    }
-    else if (thread_id == MathThreadId)
-    {
-        set_dest_fmt<MathThreadId>(fmt);
-    }
-    else
-    {
-        set_dest_fmt<PackThreadId>(fmt);
-    }
-}
-
-template <ThreadId thread_id, bool is_signed>
-inline void set_dest_int8_int16_signed()
-{
-    static_assert(
-        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
-
-    constexpr int val = is_signed ? 0 : 1;
-
-    if constexpr (thread_id == UnpackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, val);
-    }
-    else if constexpr (thread_id == MathThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, val);
-    }
-    else if constexpr (thread_id == PackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, val);
-    }
-}
-
-template <ThreadId thread_id>
-inline void set_dest_int8_int16_signed(bool const is_signed)
-{
-    static_assert(
-        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
-
-    const int val = is_signed ? 0 : 1;
-
-    if constexpr (thread_id == UnpackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, val);
-    }
-    else if constexpr (thread_id == MathThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, val);
-    }
-    else if constexpr (thread_id == PackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, val);
-    }
-}
-
-template <ThreadId thread_id, bool enable>
-inline void set_dest_enable_swizzling()
-{
-    static_assert(
-        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
-
-    constexpr int val = enable ? 0 : 1;
-    // In unswizzled mode, values are written into dest as-is with
-    // no saturation checks and no bit shuffling. This means they
-    // are incompatible with the FPU, but it could be useful for
-    // debugging
-    if constexpr (thread_id == UnpackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, val);
-    }
-    else if constexpr (thread_id == MathThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, val);
-    }
-    else if constexpr (thread_id == PackThreadId)
-    {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, val);
-    }
-}
-
-template <ThreadId thread_id>
-inline void set_dest_enable_swizzling(bool const enable)
-{
-    static_assert(
-        thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
-
-    if (enable)
-    {
-        // In unswizzled mode, values are written into dest as-is with
-        // no saturation checks and no bit shuffling. This means they
-        // are incompatible with the FPU, but it could be useful for
-        // debugging
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 0);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 0);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 0);
-        }
-    }
-    else
-    {
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 1);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 1);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 1);
-        }
-    }
-}
-
-inline void set_dest_enable_swizzling(ThreadId const thread_id, bool const enable)
-{
-    if (thread_id == UnpackThreadId)
-    {
-        set_dest_enable_swizzling<UnpackThreadId>(enable);
-    }
-    else if (thread_id == MathThreadId)
-    {
-        set_dest_enable_swizzling<MathThreadId>(enable);
-    }
-    else
-    {
-        set_dest_enable_swizzling<PackThreadId>(enable);
-    }
-}
 
 inline std::uint8_t fmt_to_dest_type(DataFormat fmt)
 {
@@ -213,9 +50,94 @@ inline std::uint8_t fmt_to_dest_type(DataFormat fmt)
 }
 
 template <ThreadId thread_id>
+inline void set_dest_fmt(std::uint32_t fmt)
+{
+    static_assert(IS_TRISC_THREAD<thread_id>, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    if constexpr (thread_id == UnpackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_fmt_RMW, fmt);
+    }
+    else if constexpr (thread_id == MathThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_fmt_RMW, fmt);
+    }
+    else if constexpr (thread_id == PackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_fmt_RMW, fmt);
+    }
+}
+
+template <ThreadId thread_id>
 inline void set_dest_fmt(DataFormat fmt)
 {
     set_dest_fmt<thread_id>(fmt_to_dest_type(fmt));
+}
+
+template <ThreadId thread_id>
+constexpr void set_dest_unsigned_int_rmw(const int val)
+{
+    static_assert(IS_TRISC_THREAD<thread_id>, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    if constexpr (thread_id == UnpackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, val);
+    }
+    else if constexpr (thread_id == MathThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, val);
+    }
+    else if constexpr (thread_id == PackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, val);
+    }
+}
+
+template <ThreadId thread_id, bool is_signed>
+constexpr void set_dest_int8_int16_signed()
+{
+    set_dest_unsigned_int_rmw<thread_id>(is_signed ? 0 : 1);
+}
+
+template <ThreadId thread_id>
+inline void set_dest_int8_int16_signed(bool const is_signed)
+{
+    set_dest_unsigned_int_rmw<thread_id>(is_signed ? 0 : 1);
+}
+
+template <ThreadId thread_id>
+constexpr void set_dest_no_swizzle_rmw(const int val)
+{
+    static_assert(IS_TRISC_THREAD<thread_id>, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
+
+    // In unswizzled mode, values are written into dest as-is with
+    // no saturation checks and no bit shuffling. This means they
+    // are incompatible with the FPU, but it could be useful for
+    // debugging
+    if constexpr (thread_id == UnpackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, val);
+    }
+    else if constexpr (thread_id == MathThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, val);
+    }
+    else if constexpr (thread_id == PackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, val);
+    }
+}
+
+template <ThreadId thread_id, bool enable>
+constexpr void set_dest_enable_swizzling()
+{
+    set_dest_no_swizzle_rmw<thread_id>(enable ? 0 : 1);
+}
+
+template <ThreadId thread_id>
+inline void set_dest_enable_swizzling(bool const enable)
+{
+    set_dest_no_swizzle_rmw<thread_id>(enable ? 0 : 1);
 }
 
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef CKERNEL_DEST_H
-#define CKERNEL_DEST_H 1
-
 #include <cstdint>
 
 #include "cfg_defines.h"
@@ -93,12 +90,6 @@ constexpr void set_dest_unsigned_int_rmw(const int val)
     }
 }
 
-template <ThreadId thread_id, bool is_signed>
-constexpr void set_dest_int8_int16_signed()
-{
-    set_dest_unsigned_int_rmw<thread_id>(is_signed ? 0 : 1);
-}
-
 template <ThreadId thread_id>
 inline void set_dest_int8_int16_signed(bool const is_signed)
 {
@@ -128,12 +119,6 @@ constexpr void set_dest_no_swizzle_rmw(const int val)
     }
 }
 
-template <ThreadId thread_id, bool enable>
-constexpr void set_dest_enable_swizzling()
-{
-    set_dest_no_swizzle_rmw<thread_id>(enable ? 0 : 1);
-}
-
 template <ThreadId thread_id>
 inline void set_dest_enable_swizzling(bool const enable)
 {
@@ -141,5 +126,3 @@ inline void set_dest_enable_swizzling(bool const enable)
 }
 
 } // namespace ckernel
-
-#endif

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
@@ -68,37 +68,19 @@ inline void set_dest_int8_int16_signed()
     static_assert(
         thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
 
-    if (is_signed)
+    constexpr int val = is_signed ? 0 : 1;
+
+    if constexpr (thread_id == UnpackThreadId)
     {
-        // FWLOG0("Setting RISC-dest int8 access mode to signed");
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 0);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 0);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 0);
-        }
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, val);
     }
-    else
+    else if constexpr (thread_id == MathThreadId)
     {
-        // FWLOG0("Setting RISC-dest int8 access mode to unsigned");
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 1);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 1);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 1);
-        }
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, val);
+    }
+    else if constexpr (thread_id == PackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, val);
     }
 }
 
@@ -108,51 +90,19 @@ inline void set_dest_int8_int16_signed(bool const is_signed)
     static_assert(
         thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
 
-    if (is_signed)
-    {
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 0);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 0);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 0);
-        }
-    }
-    else
-    {
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, 1);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, 1);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, 1);
-        }
-    }
-}
+    const int val = is_signed ? 0 : 1;
 
-inline void set_dest_int8_int16_signed(ThreadId const thread_id, bool const is_signed)
-{
-    if (thread_id == UnpackThreadId)
+    if constexpr (thread_id == UnpackThreadId)
     {
-        set_dest_int8_int16_signed<UnpackThreadId>(is_signed);
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, val);
     }
-    else if (thread_id == MathThreadId)
+    else if constexpr (thread_id == MathThreadId)
     {
-        set_dest_int8_int16_signed<MathThreadId>(is_signed);
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, val);
     }
-    else
+    else if constexpr (thread_id == PackThreadId)
     {
-        set_dest_int8_int16_signed<PackThreadId>(is_signed);
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, val);
     }
 }
 
@@ -162,39 +112,22 @@ inline void set_dest_enable_swizzling()
     static_assert(
         thread_id == MathThreadId || thread_id == PackThreadId || thread_id == UnpackThreadId, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
 
-    if (enable)
+    constexpr int val = enable ? 0 : 1;
+    // In unswizzled mode, values are written into dest as-is with
+    // no saturation checks and no bit shuffling. This means they
+    // are incompatible with the FPU, but it could be useful for
+    // debugging
+    if constexpr (thread_id == UnpackThreadId)
     {
-        // In unswizzled mode, values are written into dest as-is with
-        // no saturation checks and no bit shuffling. This means they
-        // are incompatible with the FPU, but it could be useful for
-        // debugging
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 0);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 0);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 0);
-        }
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, val);
     }
-    else
+    else if constexpr (thread_id == MathThreadId)
     {
-        if constexpr (thread_id == UnpackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, 1);
-        }
-        else if constexpr (thread_id == MathThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, 1);
-        }
-        else if constexpr (thread_id == PackThreadId)
-        {
-            cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, 1);
-        }
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, val);
+    }
+    else if constexpr (thread_id == PackThreadId)
+    {
+        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, val);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
@@ -43,8 +43,6 @@ inline void set_dest_fmt(std::uint32_t fmt)
     {
         cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_fmt_RMW, fmt);
     }
-
-    tensix_sync();
 }
 
 inline void set_dest_fmt(std::uint32_t fmt, ThreadId thread_id)
@@ -62,8 +60,6 @@ inline void set_dest_fmt(std::uint32_t fmt, ThreadId thread_id)
     {
         set_dest_fmt<PackThreadId>(fmt);
     }
-
-    tensix_sync();
 }
 
 template <ThreadId thread_id, bool is_signed>


### PR DESCRIPTION
### PR Category
Feature

### Summary
closes https://github.com/tenstorrent/tt-metal/issues/43808

Debugging LLK behavior would be easier if we had a dedicated API to directly manipulate and inspect DEST.
Added functions to dump and write to tiles in dest. Internally can pick which thread is accessing dest.
Added a test that shows the behaviour.
Exposed a compute kernel api that dumps a tile using math thread.

### Notes for reviewers
- Is this API usable enough, or does it need more documentation, etc.
- I noticed Quasar has similar functionality, can it be ported to Quasar in the future

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:halgh/dest_debug_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:halgh/dest_debug_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:halgh/dest_debug_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:halgh/dest_debug_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:halgh/dest_debug_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:halgh/dest_debug_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:halgh/dest_debug_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=halgh/dest_debug_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:halgh/dest_debug_api)