### PR TITLE
Enable UINT16 support in ttnn.copy

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, tt_dtype_to_torch_dtype
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc, assert_with_ulp, tt_dtype_to_torch_dtype
 from tests.ttnn.unit_tests.operations.test_utils import get_ttnn_torch_dtype
 
 pytestmark = pytest.mark.use_module_device
@@ -37,6 +37,25 @@ def run_copy_test(N, C, H, W, layout, device):
 @pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
 def test_copy(N, C, H, W, layout, device):
     run_copy_test(N, C, H, W, layout, device)
+
+
+@pytest.mark.parametrize(
+    "N, C, H, W,",
+    ((1, 1, 32, 64),),
+)
+def test_copy_uint16(N, C, H, W, device):
+    torch.manual_seed(2005)
+    shape = [N, C, H, W]
+
+    input = torch.randint(0, 100, shape, dtype=torch.int16)
+    input = ttnn.from_torch(input, ttnn.uint16, layout=ttnn.Layout.ROW_MAJOR, device=device)
+
+    input_b = torch.zeros(shape, dtype=torch.int16)
+    input_b = ttnn.from_torch(input_b, ttnn.uint16, layout=ttnn.Layout.ROW_MAJOR, device=device)
+
+    ttnn.copy(input, input_b)
+    assert input_b.shape == input.shape
+    assert_equal(ttnn.to_torch(input), ttnn.to_torch(input_b))
 
 
 def run_assign_test(N, C, H, W, memory_config, dtype, device):

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -35,6 +35,20 @@ def test_copy(shape, layout, dtype, device):
     assert_equal(ttnn.to_torch(input), ttnn.to_torch(input_b))
 
 
+@pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [512, 6], [512, 4], [512, 10]])
+def test_copy_uint16(shape, device):
+    torch.manual_seed(2005)
+    input_torch = torch.randint(0, 1000, shape, dtype=torch.int16)
+    input_tensor = ttnn.from_torch(input_torch, ttnn.uint16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    output_torch = torch.zeros(shape, dtype=torch.int16)
+    output_tensor = ttnn.from_torch(output_torch, ttnn.uint16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    ttnn.copy(input_tensor, output_tensor)
+    assert output_tensor.shape == input_tensor.shape
+    assert_equal(ttnn.to_torch(input_tensor), ttnn.to_torch(output_tensor))
+
+
 # Test for block sharding
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
@@ -204,6 +218,34 @@ def test_copy_height_sharded(device, layout, shape, shard_scheme, dtype):
     input_tensor = ttnn.to_torch(input_tensor)
     outout_tensor = ttnn.to_torch(output_tensor)
     assert_equal(input_tensor, outout_tensor)
+
+
+@pytest.mark.parametrize("shard_width", [4, 6, 8, 10])
+def test_copy_uint16_to_memory_config(shard_width, device):
+    """Test that to_memory_config works for uint16 with various shard widths.
+
+    When shard_width * 2 is not L1-aligned (16 bytes), interleaved_to_sharded
+    rejects the tensor and to_memory_config falls back to ttnn::prim::copy.
+    This test verifies copy handles uint16 correctly for all shard widths.
+    """
+    torch.manual_seed(2005)
+    num_rows = 64
+    shape = [num_rows, shard_width]
+    input_torch = torch.randint(0, 1000, shape, dtype=torch.int16)
+
+    tt_input = ttnn.from_torch(
+        input_torch, ttnn.uint16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    num_cores = 4
+    shard_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))])
+    shard_shape = (num_rows // num_cores, shard_width)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    tt_output = ttnn.to_memory_config(tt_input, sharded_mem_config)
+    output_torch = ttnn.to_torch(tt_output)
+    assert_equal(input_torch, output_torch)
 
 
 def test_copy_width_sharded_unaligned_shard_width(device):

--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -15,17 +15,32 @@ pytestmark = pytest.mark.use_module_device
 
 # Test for int types
 @pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])
-@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32, ttnn.uint16])
+@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
 @pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
 def test_to_memory_config(shape, layout, dtype, device):
     torch.manual_seed(2005)
-    torch_dtype = torch.int16 if dtype == ttnn.uint16 else torch.int32
+    torch_dtype = torch.int32
 
     input = torch.randint(1, 100, shape, dtype=torch_dtype)
     input = ttnn.from_torch(input, dtype, layout=layout, device=device)
 
     input_b = torch.zeros(shape, dtype=torch_dtype)
     input_b = ttnn.from_torch(input_b, dtype, layout=layout, device=device)
+
+    ttnn.to_memory_config(input, input_b.memory_config(), output_tensor=input_b)
+    assert input_b.shape == input.shape
+    assert_equal(ttnn.to_torch(input), ttnn.to_torch(input_b))
+
+
+@pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])
+def test_to_memory_config_uint16(shape, device):
+    torch.manual_seed(2005)
+
+    input = torch.randint(1, 100, shape, dtype=torch.int16)
+    input = ttnn.from_torch(input, ttnn.uint16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    input_b = torch.zeros(shape, dtype=torch.int16)
+    input_b = ttnn.from_torch(input_b, ttnn.uint16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
     ttnn.to_memory_config(input, input_b.memory_config(), output_tensor=input_b)
     assert input_b.shape == input.shape

--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -15,11 +15,11 @@ pytestmark = pytest.mark.use_module_device
 
 # Test for int types
 @pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])
-@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
+@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32, ttnn.uint16])
 @pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
 def test_to_memory_config(shape, layout, dtype, device):
     torch.manual_seed(2005)
-    torch_dtype = torch.int32
+    torch_dtype = torch.int16 if dtype == ttnn.uint16 else torch.int32
 
     input = torch.randint(1, 100, shape, dtype=torch_dtype)
     input = ttnn.from_torch(input, dtype, layout=layout, device=device)
@@ -210,6 +210,29 @@ def test_to_memory_config_width_sharded_unaligned_shard_width(device):
     output_torch = torch.zeros(shape)
     ttnn_input = ttnn.from_torch(input_torch, ttnn.bfloat16, layout=ttnn.Layout.ROW_MAJOR)
     ttnn_output = ttnn.from_torch(output_torch, ttnn.bfloat16, layout=ttnn.Layout.ROW_MAJOR)
+
+    num_cores = 4
+    shard_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))])
+    shard_shape = (64, 25)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    input_tensor = ttnn.to_device(ttnn_input, device, memory_config=mem_config)
+    output_tensor = ttnn.to_device(ttnn_output, device, memory_config=mem_config)
+
+    ttnn.to_memory_config(input_tensor, output_tensor.memory_config(), output_tensor=output_tensor)
+    input_result = ttnn.to_torch(input_tensor)
+    output_result = ttnn.to_torch(output_tensor)
+    assert_equal(input_result, output_result)
+
+
+def test_to_memory_config_width_sharded_unaligned_shard_width_uint16(device):
+    torch.manual_seed(1234)
+    shape = [1, 1, 64, 100]
+    input_torch = torch.randint(0, 100, shape, dtype=torch.int16)
+    output_torch = torch.zeros(shape, dtype=torch.int16)
+    ttnn_input = ttnn.from_torch(input_torch, ttnn.uint16, layout=ttnn.Layout.ROW_MAJOR)
+    ttnn_output = ttnn.from_torch(output_torch, ttnn.uint16, layout=ttnn.Layout.ROW_MAJOR)
 
     num_cores = 4
     shard_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))])

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -82,8 +82,9 @@ void CopyDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::BFLOAT8_B or
             input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::BFLOAT4_B or
-            input_tensor_a.dtype() == DataType::UINT32 or input_tensor_a.dtype() == DataType::INT32,
-        "ttnn.copy only supports float, bfloat and int32 inputs but got {}",
+            input_tensor_a.dtype() == DataType::UINT32 or input_tensor_a.dtype() == DataType::INT32 or
+            input_tensor_a.dtype() == DataType::UINT16,
+        "ttnn.copy only supports float, bfloat, int32 and uint16 inputs but got {}",
         input_tensor_a.dtype());
     TT_FATAL(
         operation_attributes.output_dtype == DataType::BFLOAT16 or
@@ -91,8 +92,9 @@ void CopyDeviceOperation::validate_on_program_cache_miss(
             operation_attributes.output_dtype == DataType::FLOAT32 or
             operation_attributes.output_dtype == DataType::BFLOAT4_B or
             operation_attributes.output_dtype == DataType::UINT32 or
-            operation_attributes.output_dtype == DataType::INT32,
-        "ttnn.copy only supports float, bfloat and int32 output tensors but got {}",
+            operation_attributes.output_dtype == DataType::INT32 or
+            operation_attributes.output_dtype == DataType::UINT16,
+        "ttnn.copy only supports float, bfloat, int32 and uint16 output tensors but got {}",
         operation_attributes.output_dtype);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to copy need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to copy need to be allocated in buffers on device!");


### PR DESCRIPTION
### Summary

Add `DataType::UINT16` as a supported dtype in `ttnn.copy` / `ttnn::prim::copy`. This unblocks MoE workloads where topK values like k=6 produce UINT16 index tensors that need to be copied or resharded via `to_memory_config`.

- Add UINT16 to the input and output dtype allow-lists in `CopyDeviceOperation::validate_on_program_cache_miss`
- Add unit tests for basic copy, height-sharded, and width-sharded `to_memory_config` with UINT16
- Add nightly copy test for UINT16
- UINT16 tests use ROW_MAJOR layout only (TILE layout triggers unsupported type promotion in `from_torch`)

### Test plan

- [x] `test_copy_uint16` — basic copy across multiple shapes including non-tile-aligned widths (4, 6, 10)
- [x] `test_copy_uint16_to_memory_config` — height-sharded DRAM→L1 with various shard widths
- [x] `test_to_memory_config_uint16` — interleaved DRAM copy across multiple shapes
- [x] `test_to_memory_config_width_sharded_unaligned_shard_width_uint16` — width-sharded with unaligned shard width
- [x] `test_copy_uint16` (nightly) — basic copy sanity

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [ ] [![PR Gate](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [ ] [![Merge Gate](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [ ] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [x] New/Existing tests provide coverage for changes

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gchoudhary/41826-uint16-support-in-ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gchoudhary/41826-uint16-support-in-ttnn_copy)