### PR TITLE
Be explicit about type being negated

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -16,7 +16,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
 inline void calculate_alt_complex_rotate90() {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
-        dst_reg[0] = -dst_reg[1];
+        dst_reg[0] = -vFloat(dst_reg[1]);
         dst_reg[1] = val;
         dst_reg += 2;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -16,7 +16,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
 inline void calculate_alt_complex_rotate90() {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
-        dst_reg[0] = -dst_reg[1];
+        dst_reg[0] = -vFloat(dst_reg[1]);
         dst_reg[1] = val;
         dst_reg += 2;
     }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
You can read and write several different types from/to dst_reg.  I deprecated the negation operator that treated it as vFloat.
Be explicit at the point of negation that it is a vFloat.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/dstreg-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/dstreg-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/dstreg-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/dstreg-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/dstreg-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/dstreg-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/dstreg-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/dstreg-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/dstreg-40182)