### PR TITLE
[MeshTensor Integration] Matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -33,9 +33,9 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
         TT_FATAL(!tensor_args.optional_input_tensors[0].has_value(), "Bias is not supported for matmul multi core");
     }
 
-    const auto& a = tensor_args.input_tensors.at(0);
-    const auto& b = tensor_args.input_tensors.at(1);
-    auto& output = tensor_return_value.at(0);
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    auto& output = tensor_return_value.at(0).mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     bool bcast_batch = operation_attributes.bcast_batch.value();
@@ -50,14 +50,11 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
     uint32_t output_single_tile_size = tt::tile_size(output_data_format);
 
-    tt::tt_metal::IDevice* device = a.device();
+    MeshDevice& device = a.device_mut();
     TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
+        get_compute_kernel_config_args(device.arch(), operation_attributes.compute_kernel_config.value());
     (void)packer_l1_acc;
-
-    tt_metal::Buffer* src0_buffer = a.buffer();
-    tt_metal::Buffer* src1_buffer = b.buffer();
 
     const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
 
@@ -72,7 +69,7 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
             "from device compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() should invoke "
             "ttnn::operations::matmul::normalize_program_config() on the program config first. This will become "
             "a hard error in a future release.");
-        auto device_grid = device->compute_with_storage_grid_size();
+        auto device_grid = device.compute_with_storage_grid_size();
         pc.allowed_worker_cores =
             CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(device_grid.x - 1, device_grid.y - 1)));
     }
@@ -88,9 +85,6 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
          num_output_tiles_per_core_group_1,
          num_output_tiles_per_core_group_2] =
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
-
-    tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     // C = A*B*...
     // MN = MK*KN
@@ -140,8 +134,8 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     uint32_t last_ktile_w = a.logical_shape()[-1] % TILE_WIDTH;
     uint32_t last_ktile_h = 0;
     std::vector<uint32_t> reader_compile_time_args = {(uint32_t)last_ktile_w, (uint32_t)last_ktile_h};
-    tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -154,7 +148,7 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
 
     // Writer kernel
     std::vector<uint32_t> writer_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
@@ -179,8 +173,8 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
         }
         reader_desc.emplace_runtime_args(
             core,
-            {src0_buffer,
-             src1_buffer,
+            {a,
+             b,
              Mt,
              Kt,
              Nt,
@@ -191,7 +185,7 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
              num_tiles_written,
              num_output_tiles_per_core,
              MtNt});
-        writer_desc.emplace_runtime_args(core, {dst_buffer, num_output_tiles_per_core, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {output, num_output_tiles_per_core, num_tiles_written});
         num_tiles_written += num_output_tiles_per_core;
     }
 
@@ -201,9 +195,9 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
     std::map<std::string, std::string> mm_kernel_defines;
     ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
-        device->arch(), num_cores, mm_kernel_defines);
+        device.arch(), num_cores, mm_kernel_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
-        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+        device.arch(), num_cores, mm_kernel_defines, throttle_level);
 
     // Compute kernel(s) — one per core group with different tile counts
     // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -50,10 +50,10 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
     uint32_t output_single_tile_size = tt::tile_size(output_data_format);
 
-    MeshDevice& device = a.device_mut();
+    tt::tt_metal::IDevice* device = &a.device_mut();
     TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device.arch(), operation_attributes.compute_kernel_config.value());
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
     (void)packer_l1_acc;
 
     const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
@@ -69,7 +69,7 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
             "from device compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() should invoke "
             "ttnn::operations::matmul::normalize_program_config() on the program config first. This will become "
             "a hard error in a future release.");
-        auto device_grid = device.compute_with_storage_grid_size();
+        auto device_grid = device->compute_with_storage_grid_size();
         pc.allowed_worker_cores =
             CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(device_grid.x - 1, device_grid.y - 1)));
     }
@@ -195,9 +195,9 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
     std::map<std::string, std::string> mm_kernel_defines;
     ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
-        device.arch(), num_cores, mm_kernel_defines);
+        device->arch(), num_cores, mm_kernel_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
-        device.arch(), num_cores, mm_kernel_defines, throttle_level);
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
 
     // Compute kernel(s) — one per core group with different tile counts
     // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -50,7 +50,7 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
     uint32_t output_single_tile_size = tt::tile_size(output_data_format);
 
-    tt::tt_metal::IDevice* device = &a.device_mut();
+    tt::tt_metal::IDevice* device = &a.mutable_device();
     TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -35,7 +35,7 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
 
     const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
     const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
-    auto& output = tensor_return_value.at(0).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     bool bcast_batch = operation_attributes.bcast_batch.value();

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -562,15 +562,15 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         in0_reader_args.push_back(uint32_t{1u});
         in0_reader_args.push_back(uint32_t{input_storage_noc_x[worker_idx]});
         in0_reader_args.push_back(uint32_t{input_storage_noc_y[worker_idx]});
-        in0_reader_args.push_back(in0_tensor.mesh_buffer().get_reference_buffer());
+        in0_reader_args.push_back(in0_tensor);
         in0_reader_kernel_desc.emplace_runtime_args(core, in0_reader_args);
 
         // in1 writer runtime args
         KernelDescriptor::RTArgList in1_writer_args;
         in1_writer_args.push_back(uint32_t{1u});
-        in1_writer_args.push_back(in1_tensor.mesh_buffer().get_reference_buffer());
+        in1_writer_args.push_back(in1_tensor);
         if (opt_bias.has_value()) {
-            in1_writer_args.push_back(opt_bias->mesh_buffer().get_reference_buffer());
+            in1_writer_args.push_back(opt_bias);
         } else {
             in1_writer_args.push_back(uint32_t{0u});
         }
@@ -578,7 +578,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         in1_writer_args.push_back(uint32_t{vc});
         in1_writer_args.push_back(uint32_t{output_storage_noc_x[worker_idx]});
         in1_writer_args.push_back(uint32_t{output_storage_noc_y[worker_idx]});
-        in1_writer_args.push_back(out_tensor.mesh_buffer().get_reference_buffer());
+        in1_writer_args.push_back(out_tensor);
         in1_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
 
         // Compute runtime args
@@ -630,14 +630,11 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
         const auto& c = bias.value();
         TT_FATAL(c.storage_type() == StorageType::DEVICE, "Bias tensor must be on device");
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(
-            c.mesh_tensor().mesh_buffer().get_reference_buffer() != nullptr,
-            "Operands to matmul need to be allocated in buffers on device!");
         bias_tensor = c.mesh_tensor();
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt::tt_metal::IDevice* device = a.mesh_tensor().mesh_buffer().get_reference_buffer()->device();
+    tt::tt_metal::IDevice* device = &a.mesh_tensor().device_mut();
 
     TT_FATAL(
         a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
@@ -660,8 +657,6 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
         "Input B buffer size ({}) must be divisible by single tile size ({})",
         b.mesh_buffer().device_local_size(),
         in1_single_tile_size);
-    TT_FATAL(
-        out_tensor.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
     TT_FATAL(
         ashape[-1] == bshape[-2],

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -62,10 +62,10 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const tt_metal::MeshTensor& in0_tensor,
+    const tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_tensor,
+    const tt_metal::MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -77,6 +77,10 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     bool untilize_out,
     bool skip_compute,
     bool skip_write_back) {
+    ttsl::optional_reference<const tt_metal::MeshTensor> opt_bias;
+    if (bias_tensor) {
+        opt_bias = *bias_tensor;
+    }
     tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
 
     std::vector<CoreCoord> all_worker_cores_ordered;
@@ -182,15 +186,15 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     uint32_t out_block_tiles = per_core_M * per_core_N;
     uint32_t interm0_CB_size = out_block_tiles * interm0_single_tile_size;
 
-    uint32_t in0_shard_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_tile_shape()[0] *
-                               in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in0_shard_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_tile_shape()[0] *
+                               in0_tensor.shard_spec()->shape[1] / in0_tile.get_tile_shape()[1];
     uint32_t in2_CB_size = in0_shard_tiles * in0_single_tile_size;
 
     uint32_t in3_block_tiles = per_core_N;
     uint32_t in3_CB_size = in3_block_tiles * bias_single_tile_size;
 
-    uint32_t out_shard_tiles = out_buffer->shard_spec().shape()[0] / output_tile.get_tile_shape()[0] *
-                               out_buffer->shard_spec().shape()[1] / output_tile.get_tile_shape()[1];
+    uint32_t out_shard_tiles = out_tensor.shard_spec()->shape[0] / output_tile.get_tile_shape()[0] *
+                               out_tensor.shard_spec()->shape[1] / output_tile.get_tile_shape()[1];
     uint32_t out_reshard_CB_size = out_shard_tiles * output_single_tile_size;
 
     // Page sizes for DRAM reads
@@ -253,12 +257,12 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
             .data_format = in0_data_format,
             .page_size = in0_single_tile_size,
             .tile = in0_tile_desc});
-        cb_desc.buffer = in0_buffer;
+        cb_desc.tensor = &in0_tensor;
         desc.cbs.push_back(std::move(cb_desc));
     }
 
     // CB 3: bias (if fused) - on all cores in bounding box
-    if (bias_buffer != nullptr) {
+    if (opt_bias.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = all_cores_in_rect_grid;
@@ -325,7 +329,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
             .data_format = output_data_format,
             .page_size = output_single_tile_size,
             .tile = output_tile_desc});
-        cb_desc.buffer = out_buffer;
+        cb_desc.tensor = &out_tensor;
         desc.cbs.push_back(std::move(cb_desc));
     }
 
@@ -336,7 +340,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
-    if (bias_buffer != nullptr) {
+    if (opt_bias.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         writer_defines["FUSE_BIAS"] = "1";
     }
@@ -400,7 +404,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         (uint32_t)out_batch_stride_bytes,
         (uint32_t)out_reshard_CB_size,
     };
-    if (bias_buffer != nullptr) {
+    if (opt_bias.has_value()) {
         in1_writer_compile_args.push_back(bias_buffer_page_size);
         in1_writer_compile_args.push_back(bias_buffer_num_pages);
         in1_writer_compile_args.push_back(in3_block_tiles);
@@ -431,7 +435,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         0u,
         0u,
     };
-    if (bias_buffer != nullptr) {
+    if (opt_bias.has_value()) {
         compute_kernel_args.push_back(1u);  // row_broadcast_bias: DRAM sharded always uses row broadcast
     }
 
@@ -558,15 +562,15 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         in0_reader_args.push_back(uint32_t{1u});
         in0_reader_args.push_back(uint32_t{input_storage_noc_x[worker_idx]});
         in0_reader_args.push_back(uint32_t{input_storage_noc_y[worker_idx]});
-        in0_reader_args.push_back(in0_buffer);
+        in0_reader_args.push_back(in0_tensor.mesh_buffer().get_reference_buffer());
         in0_reader_kernel_desc.emplace_runtime_args(core, in0_reader_args);
 
         // in1 writer runtime args
         KernelDescriptor::RTArgList in1_writer_args;
         in1_writer_args.push_back(uint32_t{1u});
-        in1_writer_args.push_back(in1_buffer);
-        if (bias_buffer != nullptr) {
-            in1_writer_args.push_back(bias_buffer);
+        in1_writer_args.push_back(in1_tensor.mesh_buffer().get_reference_buffer());
+        if (opt_bias.has_value()) {
+            in1_writer_args.push_back(opt_bias->mesh_buffer().get_reference_buffer());
         } else {
             in1_writer_args.push_back(uint32_t{0u});
         }
@@ -574,7 +578,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         in1_writer_args.push_back(uint32_t{vc});
         in1_writer_args.push_back(uint32_t{output_storage_noc_x[worker_idx]});
         in1_writer_args.push_back(uint32_t{output_storage_noc_y[worker_idx]});
-        in1_writer_args.push_back(out_buffer);
+        in1_writer_args.push_back(out_tensor.mesh_buffer().get_reference_buffer());
         in1_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
 
         // Compute runtime args
@@ -604,7 +608,7 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
     const auto& output_tensors = tensor_return_value;
 
     const auto& a = input_tensors.at(0);
-    const auto& b = input_tensors.at(1);
+    const auto& b = input_tensors.at(1).mesh_tensor();
     const auto& bias = optional_input_tensors.at(0);
     const auto& output = output_tensors.at(0);
     const auto& ashape = a.padded_shape();
@@ -620,42 +624,44 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_tensor;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
     if (bias.has_value()) {
         const auto& c = bias.value();
         TT_FATAL(c.storage_type() == StorageType::DEVICE, "Bias tensor must be on device");
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
-        bias_buffer = c.buffer();
+        TT_FATAL(
+            c.mesh_tensor().mesh_buffer().get_reference_buffer() != nullptr,
+            "Operands to matmul need to be allocated in buffers on device!");
+        bias_tensor = c.mesh_tensor();
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt::tt_metal::IDevice* device = a.buffer()->device();
+    tt::tt_metal::IDevice* device = a.mesh_tensor().mesh_buffer().get_reference_buffer()->device();
 
     TT_FATAL(
         a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
     CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
     CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
 
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
-    tt_metal::Buffer* out_buffer = output.buffer();
+    const tt_metal::MeshTensor& in0_tensor = a.mesh_tensor();
+    const tt_metal::MeshTensor& out_tensor = output.mesh_tensor();
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(a.dtype()));
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(b.dtype()));
 
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        in0_tensor.mesh_buffer().device_local_size(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        b.mesh_buffer().device_local_size(),
         in1_single_tile_size);
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(
+        out_tensor.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
     TT_FATAL(
         ashape[-1] == bshape[-2],
@@ -707,10 +713,10 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
         per_core_M,
         per_core_N,
         fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        in0_tensor,
+        b,
+        bias_tensor,
+        out_tensor,
         in0_tile,
         in1_tile,
         bias.has_value() ? bias->tensor_spec().tile() : output_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -19,6 +19,7 @@
 #include "ttnn/operations/compute_throttle_utils.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/matmul/shared_with_host/activation_type.hpp"
 
 using namespace tt;
@@ -77,10 +78,6 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     bool untilize_out,
     bool skip_compute,
     bool skip_write_back) {
-    ttsl::optional_reference<const tt_metal::MeshTensor> opt_bias;
-    if (bias_tensor) {
-        opt_bias = *bias_tensor;
-    }
     tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
 
     std::vector<CoreCoord> all_worker_cores_ordered;
@@ -262,7 +259,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     }
 
     // CB 3: bias (if fused) - on all cores in bounding box
-    if (opt_bias.has_value()) {
+    if (bias_tensor.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = all_cores_in_rect_grid;
@@ -340,7 +337,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
-    if (opt_bias.has_value()) {
+    if (bias_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         writer_defines["FUSE_BIAS"] = "1";
     }
@@ -404,7 +401,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         (uint32_t)out_batch_stride_bytes,
         (uint32_t)out_reshard_CB_size,
     };
-    if (opt_bias.has_value()) {
+    if (bias_tensor.has_value()) {
         in1_writer_compile_args.push_back(bias_buffer_page_size);
         in1_writer_compile_args.push_back(bias_buffer_num_pages);
         in1_writer_compile_args.push_back(in3_block_tiles);
@@ -435,7 +432,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         0u,
         0u,
     };
-    if (opt_bias.has_value()) {
+    if (bias_tensor.has_value()) {
         compute_kernel_args.push_back(1u);  // row_broadcast_bias: DRAM sharded always uses row broadcast
     }
 
@@ -569,8 +566,8 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         KernelDescriptor::RTArgList in1_writer_args;
         in1_writer_args.push_back(uint32_t{1u});
         in1_writer_args.push_back(in1_tensor);
-        if (opt_bias.has_value()) {
-            in1_writer_args.push_back(opt_bias);
+        if (bias_tensor.has_value()) {
+            in1_writer_args.push_back(*bias_tensor);
         } else {
             in1_writer_args.push_back(uint32_t{0u});
         }
@@ -607,10 +604,10 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
     const auto& optional_input_tensors = tensor_args.optional_input_tensors;
     const auto& output_tensors = tensor_return_value;
 
-    const auto& a = input_tensors.at(0);
+    const auto& a = input_tensors.at(0).mesh_tensor();
     const auto& b = input_tensors.at(1).mesh_tensor();
-    const auto& bias = optional_input_tensors.at(0);
-    const auto& output = output_tensors.at(0);
+    auto bias = tt::tt_metal::as_optional_mesh_tensor(optional_input_tensors.at(0));
+    const auto& output = output_tensors.at(0).mesh_tensor();
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
     auto in0_tile = a.tensor_spec().tile();
@@ -624,33 +621,27 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    ttsl::optional_reference<const tt_metal::MeshTensor> bias_tensor;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
     if (bias.has_value()) {
         const auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Bias tensor must be on device");
-        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        bias_tensor = c.mesh_tensor();
+        TT_FATAL(&a.device() == &c.device(), "Operands to matmul need to be on the same device!");
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt::tt_metal::IDevice* device = &a.mesh_tensor().mutable_device();
+    tt::tt_metal::IDevice* device = &a.mutable_device();
 
     TT_FATAL(
         a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
     CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
     CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
 
-    const tt_metal::MeshTensor& in0_tensor = a.mesh_tensor();
-    const tt_metal::MeshTensor& out_tensor = output.mesh_tensor();
-
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(a.dtype()));
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(b.dtype()));
 
     TT_FATAL(
-        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        a.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_tensor.mesh_buffer().device_local_size(),
+        a.mesh_buffer().device_local_size(),
         in0_single_tile_size);
     TT_FATAL(
         b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
@@ -708,10 +699,10 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
         per_core_M,
         per_core_N,
         fused_activation,
-        in0_tensor,
+        a,
         b,
-        bias_tensor,
-        out_tensor,
+        bias,
+        output,
         in0_tile,
         in1_tile,
         bias.has_value() ? bias->tensor_spec().tile() : output_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -634,7 +634,7 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt::tt_metal::IDevice* device = &a.mesh_tensor().device_mut();
+    tt::tt_metal::IDevice* device = &a.mesh_tensor().mutable_device();
 
     TT_FATAL(
         a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -3953,7 +3953,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 in1_sender_variant[0] = in1_tensor;
                 in1_sender_variant[7] = out_tensor;
                 if (bias_mesh_tensor.has_value()) {
-                    in1_sender_variant[18] = bias_mesh_tensor;
+                    in1_sender_variant[18] = *bias_mesh_tensor;
                 }
                 in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
             }
@@ -4735,7 +4735,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
                 (std::uint32_t)0};
 
             if (bias_mesh_tensor.has_value()) {
-                mm_in1_sender_writer_args.push_back(bias_mesh_tensor);
+                mm_in1_sender_writer_args.push_back(*bias_mesh_tensor);
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -4752,7 +4752,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
                 in1_sender_variant[0] = in1_tensor;
                 in1_sender_variant[7] = out_tensor;
                 if (bias_mesh_tensor.has_value()) {
-                    in1_sender_variant[18] = bias_mesh_tensor;
+                    in1_sender_variant[18] = *bias_mesh_tensor;
                 }
                 in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -117,11 +117,6 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
-    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
-    if (bias_tensor.has_value()) {
-        bias_mesh_tensor = *bias_tensor;
-    }
-
     using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
 
     // currently only support transpose of the full tile
@@ -455,7 +450,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -468,8 +463,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
     tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
-    if (bias_mesh_tensor.has_value()) {
-        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in0_receiver_compile_time_args = {
@@ -490,7 +485,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
@@ -714,7 +709,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -871,7 +866,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         out_CB_size);
 
     tt_metal::CBHandle cb_src3 = 0;
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -879,7 +874,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 .set_tile_dims(src3_cb_index, bias_tile);
 
         if (bias_is_sharded) {
-            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias_mesh_tensor);
+            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias_tensor);
         }
 
         cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
@@ -1080,11 +1075,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 mm_in1_sender_writer_args.push_back(0);
             }
 
+            mm_in1_sender_writer_args.push_back(bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);
             mm_in1_sender_writer_args.push_back(
-                bias_mesh_tensor.has_value() ? (std::uint32_t)bias_mesh_tensor->address() : 0);
-            mm_in1_sender_writer_args.push_back(
-                bias_mesh_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x
-                                             : 0);  // in3_tensor_start_tile_id
+                bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
                 if (output_idx_x == num_blocks_x - 1) {
                     mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -1155,11 +1148,6 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     bool untilize_out,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
-    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
-    if (bias_tensor.has_value()) {
-        bias_mesh_tensor = *bias_tensor;
-    }
-
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
@@ -1171,7 +1159,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -1401,7 +1389,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -1414,8 +1402,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
     tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
-    if (bias_mesh_tensor.has_value()) {
-        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
@@ -1448,7 +1436,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -1460,7 +1448,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     std::map<std::string, std::string> mm_kernel_in0_sender_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -1628,7 +1616,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -1777,7 +1765,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         out_CB_size / output_single_tile_size,
         out_CB_size);
 
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -1876,8 +1864,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 (std::uint32_t)0,
                 (std::uint32_t)0};
 
-            if (bias_mesh_tensor.has_value()) {
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_mesh_tensor->address());
+            if (bias_tensor.has_value()) {
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -2974,11 +2962,6 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
-    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
-    if (bias_tensor.has_value()) {
-        bias_mesh_tensor = *bias_tensor;
-    }
-
     using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
 
     // currently only support transpose of the full tile
@@ -3310,7 +3293,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -3323,8 +3306,8 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
     tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
-    if (bias_mesh_tensor.has_value()) {
-        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in0_receiver_compile_time_args = {
@@ -3345,7 +3328,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
@@ -3566,7 +3549,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -3719,7 +3702,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     }
 
     // CB for bias
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = all_cores;
@@ -3729,7 +3712,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             .page_size = bias_single_tile_size,
             .tile = bias_tile_desc});
         if (bias_is_sharded) {
-            cb_desc.tensor = &*bias_mesh_tensor;
+            cb_desc.tensor = &*bias_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
@@ -3930,11 +3913,9 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 mm_in1_sender_writer_args.push_back(0);
             }
 
+            mm_in1_sender_writer_args.push_back(bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);
             mm_in1_sender_writer_args.push_back(
-                bias_mesh_tensor.has_value() ? (std::uint32_t)bias_mesh_tensor->address() : 0);
-            mm_in1_sender_writer_args.push_back(
-                bias_mesh_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x
-                                             : 0);  // in3_tensor_start_tile_id
+                bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
                 if (output_idx_x == num_blocks_x - 1) {
                     mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -3952,8 +3933,8 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                     mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
                 in1_sender_variant[0] = in1_tensor;
                 in1_sender_variant[7] = out_tensor;
-                if (bias_mesh_tensor.has_value()) {
-                    in1_sender_variant[18] = *bias_mesh_tensor;
+                if (bias_tensor.has_value()) {
+                    in1_sender_variant[18] = *bias_tensor;
                 }
                 in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
             }
@@ -4021,11 +4002,6 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     bool untilize_out,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
-    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
-    if (bias_tensor.has_value()) {
-        bias_mesh_tensor = *bias_tensor;
-    }
-
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
@@ -4037,7 +4013,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -4257,7 +4233,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -4270,8 +4246,8 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
     tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
-    if (bias_mesh_tensor.has_value()) {
-        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
@@ -4304,7 +4280,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -4316,7 +4292,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     std::map<std::string, std::string> mm_kernel_in0_sender_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -4478,7 +4454,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -4619,7 +4595,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     }
 
     // CB for bias
-    if (bias_mesh_tensor.has_value()) {
+    if (bias_tensor.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = all_cores;
@@ -4734,8 +4710,8 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
                 (std::uint32_t)0,
                 (std::uint32_t)0};
 
-            if (bias_mesh_tensor.has_value()) {
-                mm_in1_sender_writer_args.push_back(*bias_mesh_tensor);
+            if (bias_tensor.has_value()) {
+                mm_in1_sender_writer_args.push_back(*bias_tensor);
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -4751,8 +4727,8 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
                     mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
                 in1_sender_variant[0] = in1_tensor;
                 in1_sender_variant[7] = out_tensor;
-                if (bias_mesh_tensor.has_value()) {
-                    in1_sender_variant[18] = *bias_mesh_tensor;
+                if (bias_tensor.has_value()) {
+                    in1_sender_variant[18] = *bias_tensor;
                 }
                 in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -5253,7 +5253,7 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt_metal::IDevice* device = &in0_tensor.device_mut();
+    tt_metal::IDevice* device = &in0_tensor.mutable_device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -30,6 +30,7 @@ using tt::tt_metal::CBFormatDescriptor;
 using tt::tt_metal::ComputeConfigDescriptor;
 using tt::tt_metal::DataMovementConfigDescriptor;
 using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::MeshTensor;
 using tt::tt_metal::ProgramDescriptor;
 
 namespace ttnn::prim {
@@ -96,10 +97,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -116,6 +117,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = *bias_tensor;
+    }
+
     using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
 
     // currently only support transpose of the full tile
@@ -160,8 +166,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     uint32_t in0_shard_width_in_tiles = 0;
     uint32_t in0_shard_height_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
         in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     }
     uint32_t in2_CB_tiles = in2_block_tiles;
@@ -173,7 +179,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
     }
     if (in1_is_sharded) {
-        uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+        uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
         in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
     }
 
@@ -403,7 +409,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -449,7 +455,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -459,11 +465,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in0_receiver_compile_time_args = {
@@ -484,7 +490,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
@@ -708,7 +714,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -772,7 +778,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             .set_tile_dims(src1_cb_index, in1_tile);
 
     if (in1_is_sharded) {
-        src1_cb_config = src1_cb_config.set_globally_allocated_address(*in1_buffer);
+        src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
     }
 
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
@@ -790,7 +796,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         tt_metal::CircularBufferConfig src2_cb_config =
             tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
                 .set_page_size(src2_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*in0_buffer)
+                .set_globally_allocated_address(in0_tensor)
                 .set_tile_dims(src2_cb_index, in0_tile);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(
@@ -853,7 +859,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     }
 
     if (output_is_sharded) {
-        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
     log_debug(
@@ -865,7 +871,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         out_CB_size);
 
     tt_metal::CBHandle cb_src3 = 0;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -873,7 +879,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 .set_tile_dims(src3_cb_index, bias_tile);
 
         if (bias_is_sharded) {
-            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias_buffer);
+            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias_mesh_tensor);
         }
 
         cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
@@ -989,7 +995,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)in0_tensor.address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -1028,7 +1034,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)in1_tensor.address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -1041,7 +1047,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),
+                (std::uint32_t)out_tensor.address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1074,9 +1080,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 mm_in1_sender_writer_args.push_back(0);
             }
 
-            mm_in1_sender_writer_args.push_back(bias_buffer ? (std::uint32_t)bias_buffer->address() : 0);
             mm_in1_sender_writer_args.push_back(
-                bias_buffer ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
+                bias_mesh_tensor.has_value() ? (std::uint32_t)bias_mesh_tensor->address() : 0);
+            mm_in1_sender_writer_args.push_back(
+                bias_mesh_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x
+                                             : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
                 if (output_idx_x == num_blocks_x - 1) {
                     mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -1130,10 +1138,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -1147,6 +1155,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     bool untilize_out,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = *bias_tensor;
+    }
+
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
@@ -1158,7 +1171,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -1213,8 +1226,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     uint32_t in0_shard_height_in_tiles = 0;
     uint32_t in0_shard_width_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
         // NOTE: Criteria for extract_shard_sub_blocks is different from mcast in0
         // In the reader kernel, always need to copy to cb0 even for height=1 shards since we may not always do mcast
         // In mcast in0 sharded reader kernel, this is handled by mcast with loopback src
@@ -1341,7 +1354,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)false  // get_batch_from_reader
     };
     in0_sender_compile_time_args.push_back((std::uint32_t)fuse_op);
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -1388,7 +1401,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -1398,11 +1411,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
@@ -1435,19 +1448,19 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
     }
     in1_receiver_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_receiver_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
 
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -1615,7 +1628,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -1666,7 +1679,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
             .set_page_size(src0_cb_index, in0_single_tile_size)
             .set_tile_dims(src0_cb_index, in0_tile);
     if (in0_is_sharded and not extract_shard_sub_blocks) {
-        src0_cb_config = src0_cb_config.set_globally_allocated_address(*in0_buffer);
+        src0_cb_config = src0_cb_config.set_globally_allocated_address(in0_tensor);
     }
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
     log_debug(
@@ -1683,7 +1696,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         tt_metal::CircularBufferConfig src2_cb_config =
             tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
                 .set_page_size(src2_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*in0_buffer)
+                .set_globally_allocated_address(in0_tensor)
                 .set_tile_dims(src2_cb_index, in0_tile);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(
@@ -1753,7 +1766,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     }
 
     if (output_is_sharded) {
-        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
     log_debug(
@@ -1764,7 +1777,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         out_CB_size / output_single_tile_size,
         out_CB_size);
 
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -1834,7 +1847,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)in1_tensor.address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
@@ -1847,7 +1860,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),
+                (std::uint32_t)out_tensor.address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
 
@@ -1863,8 +1876,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 (std::uint32_t)0,
                 (std::uint32_t)0};
 
-            if (bias_buffer != nullptr) {
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_buffer->address());
+            if (bias_mesh_tensor.has_value()) {
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_mesh_tensor->address());
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -1888,7 +1901,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),  // out_tensor_addr
+                (std::uint32_t)out_tensor.address(),  // out_tensor_addr
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1934,7 +1947,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         }
         std::vector<uint32_t> mm_in0_sender_args = {
             // in0 tensor args
-            (std::uint32_t)in0_buffer->address(),
+            (std::uint32_t)in0_tensor.address(),
             (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
             // in0 mcast args
             (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
@@ -1987,8 +2000,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
     const CoreRangeSet& hop_cores,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
     std::vector<tt_metal::Buffer*> out_buffers,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
@@ -2005,9 +2018,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     const auto& b = b_tensors[0];
     const auto num_output_cb = out_buffers.size();
     const auto batch = b_tensors.size();
-    const bool in1_is_dram_interleaved = in1_buffer->is_dram() && !b.is_sharded();
+    const bool in1_is_dram_interleaved = in1_tensor.memory_config().is_dram() && !b.is_sharded();
     const bool in1_is_dram_sharded =
-        in1_buffer->is_dram() && b.is_sharded() && !global_cb.has_value();  // read from DRAM directly
+        in1_tensor.memory_config().is_dram() && b.is_sharded() && !global_cb.has_value();  // read from DRAM directly
 
     /* Core setup */
     constexpr bool row_major = true;
@@ -2048,7 +2061,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     bool use_hop_cores = num_hop_cores > 0;
 
     /* Inner dim padding */
-    const uint32_t Kt_pad = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width() * num_cores;
+    const uint32_t Kt_pad = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width() * num_cores;
     in0_block_w = Kt_pad / num_cores;
 
     uint32_t num_blocks = Kt_pad / in0_block_w;
@@ -2069,7 +2082,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
 
     /* in0 */
-    uint32_t in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
+    uint32_t in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
     uint32_t in0_CB_tiles = per_core_M * in0_shard_width_in_tiles;
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
 
@@ -2084,8 +2097,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     if (in1_is_dram_sharded || in1_is_dram_interleaved) {
         in1_CB_tiles = 2 * in0_shard_width_in_tiles * per_core_N;  // Double buffered
     } else {
-        in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
-        in1_shard_width_in_tiles = in1_buffer->shard_spec().shape()[1] / in1_tile.get_width() / num_global_cb_receivers;
+        in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+        in1_shard_width_in_tiles = in1_tensor.shard_spec()->shape[1] / in1_tile.get_width() / num_global_cb_receivers;
         in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
     }
     uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
@@ -2099,7 +2112,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t in1_block_width_num_pages = (per_core_N_size_bytes + in1_block_page_size - 1) / in1_block_page_size;
     uint32_t in1_shard_width_in_dram = 0;
     if (in1_is_dram_sharded) {
-        in1_shard_width_in_dram = in1_buffer->shard_spec().shape()[1] / in1_tile.get_width();
+        in1_shard_width_in_dram = in1_tensor.shard_spec()->shape[1] / in1_tile.get_width();
     }
 
     /* in2 */
@@ -2140,7 +2153,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
             .set_page_size(src0_cb_index, in0_single_tile_size)
             .set_tile_dims(src0_cb_index, in0_tile)
-            .set_globally_allocated_address(*in0_buffer);
+            .set_globally_allocated_address(in0_tensor);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
 
     uint32_t src1_cb_index = base_cb_index + 1;
@@ -2161,7 +2174,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
                 .set_page_size(src1_cb_index, in1_single_tile_size)
                 .set_tile_dims(src1_cb_index, in1_tile);
         if (!in1_is_dram_interleaved && !in1_is_dram_sharded) {
-            src1_cb_config = src1_cb_config.set_globally_allocated_address(*in1_buffer);
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
         }
         cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     }
@@ -2283,7 +2296,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         (std::uint32_t)in1_shard_width_in_dram,
         (std::uint32_t)fused_op_signaler.has_value(),
     };
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
 
     /* compute kernel args */
     const uint32_t out_block_num_subblocks = out_block_tiles / out_subblock_num_tiles;
@@ -2464,7 +2477,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t first_col_max_x = device->arch() == tt::ARCH::WORMHOLE_B0 ? 3 : 7;
     uint32_t num_receiver_cores_per_dram = 2;  // default to 2 for wormhole b0 and blackhole
     if (in1_is_dram_sharded) {
-        num_receiver_cores_per_dram = ring_size / in1_buffer->shard_spec().grid().num_cores();
+        num_receiver_cores_per_dram = ring_size / in1_tensor.shard_spec()->grid.num_cores();
         if (device->arch() == tt::ARCH::WORMHOLE_B0) {
             worker_y_to_dram_bank_first_col[0] = 1;
             worker_y_to_dram_bank_first_col[4] = 2;
@@ -2568,8 +2581,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         /* in1 */
         std::vector<uint32_t> mm_in1_args = {
             (std::uint32_t)core_type,
-            in1_buffer->address(),  // in1_tensor_addr
-            i,                      // ring_idx
+            in1_tensor.address(),  // in1_tensor_addr
+            i,                     // ring_idx
         };
         if (in1_is_dram_sharded) {
             // Look up bank_id based on core.y and which column group core.x belongs to
@@ -2718,16 +2731,16 @@ inline void override_mcast_in1_program_parameters(
     TT_FATAL(
         output_tensors.size() == 1, "matmul mcast in1 requires 1 output tensor, {} provided", output_tensors.size());
 
-    auto* src_buffer_a = input_tensors.at(0).buffer();
-    auto* src_buffer_b = input_tensors.at(1).buffer();
+    const MeshTensor& src_a_tensor = input_tensors.at(0).mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors.at(1).mesh_tensor();
     const auto& bias_tensor = optional_input_tensors.at(0);
 
-    std::optional<tt::tt_metal::Buffer*> bias_buffer;
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
     if (bias_tensor.has_value()) {
-        bias_buffer = bias_tensor.value().buffer();
+        bias_mesh_tensor = bias_tensor.value().mesh_tensor();
     }
 
-    auto* dst_buffer = output_tensors.at(0).buffer();
+    const MeshTensor& dst_tensor = output_tensors.at(0).mesh_tensor();
 
     bool src0_sharded = input_tensors[0].is_sharded();
     bool out_sharded = output_tensors[0].is_sharded();
@@ -2739,15 +2752,15 @@ inline void override_mcast_in1_program_parameters(
         // in0 sender
         auto& reader_runtime_args =
             reader_runtime_args_by_core[override_variables.start_core.x][override_variables.start_core.y];
-        reader_runtime_args[0] = src_buffer_a->address();
+        reader_runtime_args[0] = src_a_tensor.address();
 
         // in1 sender
         auto& sender_writer_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(1), override_variables.start_core);
-        sender_writer_runtime_args[0] = src_buffer_b->address();
-        sender_writer_runtime_args[7] = dst_buffer->address();
+        sender_writer_runtime_args[0] = src_b_tensor.address();
+        sender_writer_runtime_args[7] = dst_tensor.address();
         if (bias_tensor.has_value()) {
-            sender_writer_runtime_args[18] = (*bias_buffer)->address();
+            sender_writer_runtime_args[18] = bias_mesh_tensor->address();
         }
     }
 
@@ -2761,21 +2774,21 @@ inline void override_mcast_in1_program_parameters(
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
 
         // in0 sender
-        reader_runtime_args[0] = src_buffer_a->address();
+        reader_runtime_args[0] = src_a_tensor.address();
         // in1 receiver
-        writer_runtime_args[2] = dst_buffer->address();
+        writer_runtime_args[2] = dst_tensor.address();
     }
 
     if (src0_sharded) {
         if (override_variables.extract_shard_sub_blocks) {
-            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), *src_buffer_a);
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a_tensor);
         } else {
-            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), *src_buffer_a);
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_a_tensor);
         }
     }
 
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *dst_buffer);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), dst_tensor);
     }
 }
 
@@ -2796,16 +2809,16 @@ static void override_mcast_in0_program_parameters(
     TT_FATAL(
         output_tensors.size() == 1, "matmul mcast in0 requires 1 output tensor, {} provided", output_tensors.size());
 
-    auto* src_buffer_a = input_tensors.at(0).buffer();
-    auto* src_buffer_b = input_tensors.at(1).buffer();
+    const MeshTensor& src_a_tensor = input_tensors.at(0).mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors.at(1).mesh_tensor();
     const auto& bias_tensor = optional_input_tensors.at(0);
 
-    std::optional<tt::tt_metal::Buffer*> bias_buffer;
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
     if (bias_tensor.has_value()) {
-        bias_buffer = bias_tensor.value().buffer();
+        bias_mesh_tensor = bias_tensor.value().mesh_tensor();
     }
 
-    auto* dst_buffer = output_tensors.at(0).buffer();
+    const MeshTensor& dst_tensor = output_tensors.at(0).mesh_tensor();
 
     bool src0_sharded = input_tensors[0].is_sharded();
     bool src1_sharded = input_tensors[1].is_sharded();
@@ -2813,20 +2826,20 @@ static void override_mcast_in0_program_parameters(
 
     // Manually unroll sender core
     if (src0_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), *src_buffer_a);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a_tensor);
     } else {
         // in0 sender
         auto& reader_sender_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(0), override_variables.start_core);
-        reader_sender_runtime_args[0] = src_buffer_a->address();
+        reader_sender_runtime_args[0] = src_a_tensor.address();
     }
 
     if (src1_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), *src_buffer_b);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_b_tensor);
     }
 
     if (bias_tensor.has_value() && bias_tensor.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *bias_buffer.value());
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *bias_mesh_tensor);
     }
 
     auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(1));
@@ -2837,15 +2850,15 @@ static void override_mcast_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         // in1 sender
-        writer_runtime_args[0] = src_buffer_b->address();
-        writer_runtime_args[7] = dst_buffer->address();
+        writer_runtime_args[0] = src_b_tensor.address();
+        writer_runtime_args[7] = dst_tensor.address();
         if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = (*bias_buffer)->address();
+            writer_runtime_args[18] = bias_mesh_tensor->address();
         }
     }
 
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(3), *dst_buffer);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(3), dst_tensor);
     }
 }
 
@@ -2857,8 +2870,8 @@ inline void override_gather_in0_program_parameters(
     const std::vector<ttnn::Tensor>& output_tensors) {
     const auto& input_tensors = tensor_args.input_tensors;
 
-    auto* src_buffer_a = input_tensors[0].buffer();
-    auto* src_buffer_b = input_tensors[1].buffer();
+    const MeshTensor& src_a_tensor = input_tensors[0].mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors[1].mesh_tensor();
 
     bool src0_sharded = input_tensors[0].is_sharded();
     bool src1_sharded = input_tensors[1].is_sharded();
@@ -2866,11 +2879,11 @@ inline void override_gather_in0_program_parameters(
 
     // Manually unroll sender core
     if (src0_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], *src_buffer_a);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], src_a_tensor);
     }
     if (src1_sharded) {
-        if (!global_cb.has_value() && !src_buffer_b->is_dram()) {
-            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], *src_buffer_b);
+        if (!global_cb.has_value() && !src_b_tensor.memory_config().is_dram()) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b_tensor);
         }
     }
     if (out_sharded) {
@@ -2878,8 +2891,8 @@ inline void override_gather_in0_program_parameters(
             // cbs 0 and 1 contain cb_src0 and cb_src1
             // the rest contains the actual output cbs
             const auto& cb_output = override_variables.cbs[i + 2];
-            const auto& out_buffer = output_tensors[i].buffer();
-            UpdateDynamicCircularBufferAddress(program, cb_output, *out_buffer);
+            const MeshTensor& out_tensor = output_tensors[i].mesh_tensor();
+            UpdateDynamicCircularBufferAddress(program, cb_output, out_tensor);
         }
     }
 
@@ -2891,7 +2904,7 @@ inline void override_gather_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         /* in1 */
-        writer_runtime_args[1] = src_buffer_b->address();
+        writer_runtime_args[1] = src_b_tensor.address();
     }
 }
 
@@ -2941,10 +2954,10 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -2961,6 +2974,11 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = *bias_tensor;
+    }
+
     using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
 
     // currently only support transpose of the full tile
@@ -3005,8 +3023,8 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     uint32_t in0_shard_width_in_tiles = 0;
     uint32_t in0_shard_height_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
         in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     }
     uint32_t in2_CB_tiles = in2_block_tiles;
@@ -3018,7 +3036,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
     }
     if (in1_is_sharded) {
-        uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+        uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
         in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
     }
 
@@ -3246,7 +3264,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -3292,7 +3310,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -3302,11 +3320,11 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in0_receiver_compile_time_args = {
@@ -3327,7 +3345,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
@@ -3548,7 +3566,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -3617,7 +3635,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             .page_size = in1_single_tile_size,
             .tile = in1_tile_desc});
         if (in1_is_sharded) {
-            cb_desc.buffer = in1_buffer;
+            cb_desc.tensor = &in1_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
@@ -3633,7 +3651,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 .data_format = in0_data_format,
                 .page_size = in0_single_tile_size,
                 .tile = in0_tile_desc});
-            cb_desc.buffer = in0_buffer;
+            cb_desc.tensor = &in0_tensor;
             desc.cbs.push_back(std::move(cb_desc));
         }
 
@@ -3663,7 +3681,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 .page_size = output_single_tile_size,
                 .tile = output_tile_desc});
             if (output_is_sharded) {
-                cb_desc.buffer = out_buffer;
+                cb_desc.tensor = &out_tensor;
             }
             desc.cbs.push_back(std::move(cb_desc));
         }
@@ -3695,13 +3713,13 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             .page_size = interm0_single_tile_size,
             .tile = output_tile_desc});
         if (output_is_sharded) {
-            cb_desc.buffer = out_buffer;
+            cb_desc.tensor = &out_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
 
     // CB for bias
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = all_cores;
@@ -3711,7 +3729,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             .page_size = bias_single_tile_size,
             .tile = bias_tile_desc});
         if (bias_is_sharded) {
-            cb_desc.buffer = bias_buffer;
+            cb_desc.tensor = &*bias_mesh_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
@@ -3827,7 +3845,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)in0_tensor.address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -3847,9 +3865,9 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             }
 
             {
-                std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in0_sender_variant(
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in0_sender_variant(
                     mm_in0_sender_args.begin(), mm_in0_sender_args.end());
-                in0_sender_variant[0] = in0_buffer;
+                in0_sender_variant[0] = in0_tensor;
                 in0_sender_kernel_desc.emplace_runtime_args(core, in0_sender_variant);
             }
         }
@@ -3866,7 +3884,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)in1_tensor.address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -3879,7 +3897,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),
+                (std::uint32_t)out_tensor.address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -3912,9 +3930,11 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 mm_in1_sender_writer_args.push_back(0);
             }
 
-            mm_in1_sender_writer_args.push_back(bias_buffer ? (std::uint32_t)bias_buffer->address() : 0);
             mm_in1_sender_writer_args.push_back(
-                bias_buffer ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
+                bias_mesh_tensor.has_value() ? (std::uint32_t)bias_mesh_tensor->address() : 0);
+            mm_in1_sender_writer_args.push_back(
+                bias_mesh_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x
+                                             : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
                 if (output_idx_x == num_blocks_x - 1) {
                     mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -3928,12 +3948,12 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             }
 
             {
-                std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in1_sender_variant(
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_sender_variant(
                     mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
-                in1_sender_variant[0] = in1_buffer;
-                in1_sender_variant[7] = out_buffer;
-                if (bias_buffer != nullptr) {
-                    in1_sender_variant[18] = bias_buffer;
+                in1_sender_variant[0] = in1_tensor;
+                in1_sender_variant[7] = out_tensor;
+                if (bias_mesh_tensor.has_value()) {
+                    in1_sender_variant[18] = bias_mesh_tensor;
                 }
                 in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
             }
@@ -3984,10 +4004,10 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -4001,6 +4021,11 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     bool untilize_out,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = *bias_tensor;
+    }
+
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
@@ -4012,7 +4037,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -4059,8 +4084,8 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     uint32_t in0_shard_height_in_tiles = 0;
     uint32_t in0_shard_width_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
         if (in0_shard_width_in_tiles / in0_block_w > 1) {
             extract_shard_sub_blocks = true;
         }
@@ -4185,7 +4210,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         (std::uint32_t)false  // get_batch_from_reader
     };
     in0_sender_compile_time_args.push_back((std::uint32_t)fuse_op);
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -4232,7 +4257,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -4242,11 +4267,11 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
@@ -4279,19 +4304,19 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
     }
     in1_receiver_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_receiver_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
 
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -4453,7 +4478,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -4509,7 +4534,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
             .page_size = in0_single_tile_size,
             .tile = in0_tile_desc});
         if (in0_is_sharded && !extract_shard_sub_blocks) {
-            cb_desc.buffer = in0_buffer;
+            cb_desc.tensor = &in0_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
@@ -4524,7 +4549,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
             .data_format = in0_data_format,
             .page_size = in0_single_tile_size,
             .tile = in0_tile_desc});
-        cb_desc.buffer = in0_buffer;
+        cb_desc.tensor = &in0_tensor;
         desc.cbs.push_back(std::move(cb_desc));
     }
 
@@ -4556,7 +4581,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
                 .page_size = output_single_tile_size,
                 .tile = output_tile_desc});
             if (output_is_sharded) {
-                cb_desc.buffer = out_buffer;
+                cb_desc.tensor = &out_tensor;
             }
             desc.cbs.push_back(std::move(cb_desc));
         }
@@ -4588,13 +4613,13 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
             .page_size = interm0_single_tile_size,
             .tile = output_tile_desc});
         if (output_is_sharded) {
-            cb_desc.buffer = out_buffer;
+            cb_desc.tensor = &out_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
 
     // CB for bias
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = all_cores;
@@ -4677,10 +4702,10 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 
         // in0 sender and in1 sender
         if (core == start_core) {
-            std::vector<uint32_t> mm_in1_sender_writer_args = {
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_buffer->address(),
+                in1_tensor,
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
@@ -4693,7 +4718,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),
+                out_tensor,
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
 
@@ -4709,43 +4734,44 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
                 (std::uint32_t)0,
                 (std::uint32_t)0};
 
-            if (bias_buffer != nullptr) {
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_buffer->address());
+            if (bias_mesh_tensor.has_value()) {
+                mm_in1_sender_writer_args.push_back(bias_mesh_tensor);
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
-                mm_in1_sender_writer_args.push_back(0);
-                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0u);
+                mm_in1_sender_writer_args.push_back(0u);
             }
             if (!output_is_sharded) {
                 mm_in1_sender_writer_args.push_back(out_num_blocks_x);
             }
 
             {
-                std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in1_sender_variant(
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_sender_variant(
                     mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
-                in1_sender_variant[0] = in1_buffer;
-                in1_sender_variant[7] = out_buffer;
-                if (bias_buffer != nullptr) {
-                    in1_sender_variant[18] = bias_buffer;
+                in1_sender_variant[0] = in1_tensor;
+                in1_sender_variant[7] = out_tensor;
+                if (bias_mesh_tensor.has_value()) {
+                    in1_sender_variant[18] = bias_mesh_tensor;
                 }
                 in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
             }
         }
         // in0 sender and in1 receiver
         else {
-            std::vector<uint32_t> mm_in1_receiver_writer_args = {
-                // READER
-                // in1 mcast args
-                (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
-                (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in1_receiver_writer_args =
+                {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
 
-                // WRITER
-                // out tensor args
-                (std::uint32_t)out_buffer->address(),  // out_tensor_addr
-                ((std::uint32_t)output_idx_x * per_core_N) +
-                    (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
-            };
+                    // WRITER
+                    // out tensor args
+                    out_tensor,  // out_tensor_addr
+                    ((std::uint32_t)output_idx_x * per_core_N) +
+                        (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+                };
 
             if (output_idx_y == num_blocks_y - 1) {
                 // padding args (WRITER)
@@ -4756,19 +4782,19 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
                 mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
                 mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
                 mm_in1_receiver_writer_args.push_back(out_subblock_w);
-                mm_in1_receiver_writer_args.push_back(0);
-                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(0u);
             } else {
                 // padding args (WRITER)
                 mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
                 mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
                 mm_in1_receiver_writer_args.push_back(out_subblock_h);
-                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(0u);
                 mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
                 mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
                 mm_in1_receiver_writer_args.push_back(out_subblock_w);
-                mm_in1_receiver_writer_args.push_back(0);
-                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(0u);
             }
             if (!output_is_sharded) {
                 if (output_idx_y == num_blocks_y - 1) {
@@ -4781,15 +4807,15 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
             }
 
             {
-                std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in1_recv_variant(
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_recv_variant(
                     mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
-                in1_recv_variant[2] = out_buffer;
+                in1_recv_variant[2] = out_tensor;
                 in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
             }
         }
-        std::vector<uint32_t> mm_in0_sender_args = {
+        std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in0_sender_args = {
             // in0 tensor args
-            (std::uint32_t)in0_buffer->address(),
+            in0_tensor,
             (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
             // in0 mcast args
             (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
@@ -4804,9 +4830,9 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
             (std::uint32_t)0,  // sparsity_addr
         };
         {
-            std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in0_sender_variant(
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in0_sender_variant(
                 mm_in0_sender_args.begin(), mm_in0_sender_args.end());
-            in0_sender_variant[0] = in0_buffer;
+            in0_sender_variant[0] = in0_tensor;
             in0_sender_kernel_desc.emplace_runtime_args(core, in0_sender_variant);
         }
     }
@@ -4858,7 +4884,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     uint32_t start_cb_index,
     std::optional<CoreRangeSet> restricted_cores) {
     const auto& b = b_tensors[0];
-    const auto& output = output_tensors[0];
+    const auto& output = output_tensors[0].mesh_tensor();
 
     TT_FATAL(output_tensors.size() == b_tensors.size(), "number of outputs must match number of inputs b");
 
@@ -4871,10 +4897,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
 
     // CB dataformats
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());          // in0
-    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());          // in1
+    const MeshTensor& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());  // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         const auto& c = bias.value();
@@ -4883,9 +4910,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             "Bias tensor must be on device, got storage type: {}",
             c.storage_type());
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
-        bias_buffer = c.buffer();
+        bias_mesh_tensor = c.mesh_tensor();
 
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
@@ -4894,17 +4920,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
+    const MeshTensor& in0_tensor = a.mesh_tensor();
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        in0_tensor.mesh_buffer().device_local_size(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        in1_tensor.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        in1_tensor.mesh_buffer().device_local_size(),
         in1_single_tile_size);
 
     TT_FATAL(
@@ -4972,8 +4997,6 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
@@ -4991,7 +5014,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         std::vector<tt_metal::Buffer*> out_buffers;
         out_buffers.reserve(output_tensors.size());
         for (const auto& output_tensor : output_tensors) {
-            out_buffers.push_back(output_tensor.buffer());
+            out_buffers.push_back(output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer());
         }
         return reuse_mcast_1d_optimized_helpers::process_gather_in0_program_and_create_override_variables(
             program,
@@ -5018,8 +5041,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             per_core_N,
             fused_activation,
             hop_cores,
-            in0_buffer,
-            in1_buffer,
+            in0_tensor,
+            in1_tensor,
             out_buffers,
             in0_tile,
             in1_tile,
@@ -5090,10 +5113,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             per_core_M,
             per_core_N,
             fused_activation,
-            in0_buffer,
-            in1_buffer,
-            bias_buffer,
-            out_buffer,
+            in0_tensor,
+            in1_tensor,
+            bias_mesh_tensor,
+            output,
             in0_tile,
             in1_tile,
             bias.has_value() ? bias->tensor_spec().tile() : output_tile,
@@ -5103,7 +5126,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             bias_data_format,
             output_data_format,
             a.memory_config().is_sharded(),
-            b.memory_config().is_sharded(),
+            in1_tensor.memory_config().is_sharded(),
             bias.has_value() ? bias->memory_config().is_sharded() : false,
             output.memory_config().is_sharded(),
             untilize_out,
@@ -5137,10 +5160,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         per_core_M,
         per_core_N,
         fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh_tensor,
+        output,
         in0_tile,
         in1_tile,
         bias.has_value() ? bias->tensor_spec().tile() : output_tile,
@@ -5177,7 +5200,7 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
     const auto& a = tensor_args.input_tensors.at(0);
     const auto& b = tensor_args.input_tensors.at(1);
     const auto& bias = tensor_args.optional_input_tensors.at(0);
-    const auto& output = tensor_return_value.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
@@ -5216,22 +5239,21 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
     const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
 
     // CB dataformats
-    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    const MeshTensor& in0_tensor = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_tensor.dtype());
+    const MeshTensor& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
     if (bias.has_value()) {
         const auto& c = bias.value();
-        bias_buffer = c.buffer();
+        bias_mesh_tensor = c.mesh_tensor();
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt_metal::IDevice* device = a.device();
-
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
+    tt_metal::IDevice* device = &in0_tensor.device_mut();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -5241,8 +5263,6 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
     const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
     const auto Kt = get_K_dim(a_shape_padded, in0_tile);
     const auto Nt = get_N_dim(b_shape_padded, in1_tile);
-
-    tt_metal::Buffer* out_buffer = output.buffer();
 
     // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
     // multicast targets a single bounding-box rectangle and the per-core index math assumes a
@@ -5312,10 +5332,10 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
             per_core_M,
             per_core_N,
             program_config.fused_activation,
-            in0_buffer,
-            in1_buffer,
-            bias_buffer,
-            out_buffer,
+            in0_tensor,
+            in1_tensor,
+            bias_mesh_tensor,
+            output,
             in0_tile,
             in1_tile,
             bias.has_value() ? bias->tensor_spec().tile() : output_tile,
@@ -5324,8 +5344,8 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
             in1_data_format,
             bias_data_format,
             output_data_format,
-            a.memory_config().is_sharded(),
-            b.memory_config().is_sharded(),
+            in0_tensor.memory_config().is_sharded(),
+            in1_tensor.memory_config().is_sharded(),
             bias.has_value() ? bias->memory_config().is_sharded() : false,
             output.memory_config().is_sharded(),
             untilize_out,
@@ -5358,10 +5378,10 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
         per_core_M,
         per_core_N,
         program_config.fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh_tensor,
+        output,
         in0_tile,
         in1_tile,
         bias.has_value() ? bias->tensor_spec().tile() : output_tile,
@@ -5370,7 +5390,7 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
         in1_data_format,
         bias_data_format,
         output_data_format,
-        a.memory_config().is_sharded(),
+        in0_tensor.memory_config().is_sharded(),
         output.memory_config().is_sharded(),
         untilize_out,
         fused_matmul_bias_row_broadcastable(bias),

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2002,7 +2002,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     const CoreRangeSet& hop_cores,
     const MeshTensor& in0_tensor,
     const MeshTensor& in1_tensor,
-    std::vector<tt_metal::Buffer*> out_buffers,
+    std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> out_buffers,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& output_tile,
@@ -2236,7 +2236,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
             output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
                                    .set_page_size(output_cb_index, output_single_tile_size)
                                    .set_tile_dims(output_cb_index, output_tile)
-                                   .set_globally_allocated_address(*out_buffer);
+                                   .set_globally_allocated_address(out_buffer);
             auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
             cb_outputs.push_back(cb_output);
             output_cb_indices.push_back(output_cb_index);
@@ -2265,7 +2265,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
                                    .set_page_size(interm0_cb_index, interm0_single_tile_size)
                                    .set_tile_dims(output_cb_index, output_tile)
                                    .set_tile_dims(interm0_cb_index, output_tile)
-                                   .set_globally_allocated_address(*out_buffer);
+                                   .set_globally_allocated_address(out_buffer);
             auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
             cb_outputs.push_back(cb_output);
             output_cb_indices.push_back(output_cb_index);
@@ -5011,10 +5011,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             !transpose_b,
             "Transpose B is ({}) not supported for gather_in0, please use a different program configuration",
             transpose_b);
-        std::vector<tt_metal::Buffer*> out_buffers;
+        std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> out_buffers;
         out_buffers.reserve(output_tensors.size());
         for (const auto& output_tensor : output_tensors) {
-            out_buffers.push_back(output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer());
+            out_buffers.push_back(output_tensor.mesh_tensor());
         }
         return reuse_mcast_1d_optimized_helpers::process_gather_in0_program_and_create_override_variables(
             program,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3390,7 +3390,7 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt_metal::IDevice* device = &in0_tensor.device_mut();
+    tt_metal::IDevice* device = &in0_tensor.mutable_device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -61,10 +61,10 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     uint32_t per_core_N,
     bool transpose_mcast,
     std::optional<UnaryWithParam> fused_activation,
-    tt::tt_metal::Buffer* in0_buffer,
-    tt::tt_metal::Buffer* in1_buffer,
-    tt::tt_metal::Buffer* bias_buffer,
-    tt::tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -80,13 +80,18 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     using namespace tt;
     using tt::tt_metal::TensorMemoryLayout;
 
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = *bias_tensor;
+    }
+
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
 
     bool fuse_op = fused_op_signaler.has_value();
 
-    TensorMemoryLayout in0_memory_layout = in0_buffer->buffer_layout();
+    TensorMemoryLayout in0_memory_layout = in0_tensor.memory_config().memory_layout();
 
     uint32_t num_blocks = K / in0_block_w;
 
@@ -94,7 +99,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh.has_value()) && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -110,10 +115,10 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
     const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
-    const bool in1_is_width_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED;
-    const bool in1_is_height_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_width_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
-    const bool output_is_sharded = out_buffer->buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
 
     bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
 
@@ -151,8 +156,8 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     uint32_t in0_shard_width_in_tiles = 0;
     uint32_t in0_shard_height_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
         in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     }
 
@@ -192,7 +197,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     // Only used for in0 block sharded
     std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
     if (in0_block_sharded) {
-        CoreCoord in0_shard_grid = in0_buffer->shard_spec().grid().bounding_box().grid_size();
+        CoreCoord in0_shard_grid = in0_tensor.shard_spec()->grid.bounding_box().grid_size();
         // in0 shard grid already accounts for transpose_mcast
         // ie. If transpose_mcast, in0 width is along y
         in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
@@ -321,7 +326,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     uint32_t in1_mcast_sender_semaphore_id = 2;
     uint32_t in1_mcast_receiver_semaphore_id = 3;
 
-    bool in1_is_dram = in1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool in1_is_dram = in1_tensor.mesh_buffer().device_local_config().buffer_type == tt_metal::BufferType::DRAM;
 
     uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
@@ -344,7 +349,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
             per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
         } else {
             // Height sharded: batches are distributed across DRAM banks
-            uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+            uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
             batches_per_bank = in1_shard_height_in_tiles / K;
         }
     }
@@ -436,7 +441,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -482,7 +487,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -492,11 +497,11 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh).append_to(in1_sender_writer_compile_time_args);
     }
 
     if (in1_is_sharded and in1_is_dram) {
@@ -552,13 +557,13 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
     }
     in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_receiver_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
 
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
@@ -566,7 +571,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -877,7 +882,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -938,7 +943,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
             .page_size = in0_single_tile_size,
             .tile = in0_tile_desc});
         if (in0_height_sharded) {
-            cb_desc.buffer = in0_buffer;
+            cb_desc.tensor = &in0_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
@@ -954,7 +959,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
             .page_size = in1_single_tile_size,
             .tile = in1_tile_desc});
         if (in1_is_sharded and not in1_is_dram) {
-            cb_desc.buffer = in1_buffer;
+            cb_desc.tensor = &in1_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
@@ -970,7 +975,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 .data_format = in0_data_format,
                 .page_size = in0_single_tile_size,
                 .tile = in0_tile_desc});
-            cb_desc.buffer = in0_buffer;
+            cb_desc.tensor = &in0_tensor;
             desc.cbs.push_back(std::move(cb_desc));
         }
 
@@ -1000,7 +1005,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 .page_size = output_single_tile_size,
                 .tile = output_tile_desc});
             if (output_is_sharded) {
-                cb_desc.buffer = out_buffer;
+                cb_desc.tensor = &out_tensor;
             }
             desc.cbs.push_back(std::move(cb_desc));
         }
@@ -1032,13 +1037,13 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
             .page_size = interm0_single_tile_size,
             .tile = output_tile_desc});
         if (output_is_sharded) {
-            cb_desc.buffer = out_buffer;
+            cb_desc.tensor = &out_tensor;
         }
         desc.cbs.push_back(std::move(cb_desc));
     }
 
     // CB for bias
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = CoreRangeSet(all_cores);
@@ -1209,7 +1214,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)in0_tensor.address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -1234,7 +1239,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
             {
                 std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in0_args(
                     mm_in0_sender_args.begin(), mm_in0_sender_args.end());
-                in0_args[0] = in0_buffer;
+                in0_args[0] = in0_tensor.mesh_buffer().get_reference_buffer();
                 in0_sender_kernel_desc.emplace_runtime_args(core, in0_args);
             }
 
@@ -1261,7 +1266,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_buffer->address(),
+                    (std::uint32_t)in1_tensor.address(),
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -1274,7 +1279,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_buffer->address(),
+                    (std::uint32_t)out_tensor.address(),
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -1306,9 +1311,9 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(bias_buffer ? (std::uint32_t)bias_buffer->address() : 0);
+                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
                 mm_in1_sender_writer_args.push_back(
-                    bias_buffer ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                    bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
                     if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
                         mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -1396,10 +1401,10 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 {
                     std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in1_sender_variant(
                         mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
-                    in1_sender_variant[0] = in1_buffer;
-                    in1_sender_variant[7] = out_buffer;
-                    if (bias_buffer != nullptr) {
-                        in1_sender_variant[18] = bias_buffer;
+                    in1_sender_variant[0] = in1_tensor.mesh_buffer().get_reference_buffer();
+                    in1_sender_variant[7] = out_tensor.mesh_buffer().get_reference_buffer();
+                    if (bias_mesh.has_value()) {
+                        in1_sender_variant[18] = bias_mesh->mesh_buffer().get_reference_buffer();
                     }
                     in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
                 }
@@ -1414,7 +1419,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_buffer->address(),                               // out_tensor_addr
+                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -1487,7 +1492,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 {
                     std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in1_recv_variant(
                         mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
-                    in1_recv_variant[2] = out_buffer;
+                    in1_recv_variant[2] = out_tensor.mesh_buffer().get_reference_buffer();
                     // left half
                     if (core.x <= half_core || (transpose_mcast and core.y == start_core_y)) {
                         in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
@@ -1556,10 +1561,10 @@ create_program_mcast_in0_in1(
     uint32_t per_core_N,
     bool transpose_mcast,
     std::optional<UnaryWithParam> fused_activation,
-    tt::tt_metal::Buffer* in0_buffer,
-    tt::tt_metal::Buffer* in1_buffer,
-    tt::tt_metal::Buffer* bias_buffer,
-    tt::tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -1575,13 +1580,18 @@ create_program_mcast_in0_in1(
     using namespace tt;
     using tt::tt_metal::TensorMemoryLayout;
 
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = *bias_tensor;
+    }
+
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
 
     bool fuse_op = fused_op_signaler.has_value();
 
-    TensorMemoryLayout in0_memory_layout = in0_buffer->buffer_layout();
+    TensorMemoryLayout in0_memory_layout = in0_tensor.memory_config().memory_layout();
 
     uint32_t num_blocks = K / in0_block_w;
 
@@ -1589,7 +1599,7 @@ create_program_mcast_in0_in1(
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh.has_value()) && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -1605,10 +1615,10 @@ create_program_mcast_in0_in1(
     const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
     const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
-    const bool in1_is_width_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED;
-    const bool in1_is_height_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_width_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
-    const bool output_is_sharded = out_buffer->buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
 
     TT_FATAL(
         !(output_is_sharded && B > 1),
@@ -1654,8 +1664,8 @@ create_program_mcast_in0_in1(
     uint32_t in0_shard_width_in_tiles = 0;
     uint32_t in0_shard_height_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
         in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     }
 
@@ -1695,7 +1705,7 @@ create_program_mcast_in0_in1(
     // Only used for in0 block sharded
     std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
     if (in0_block_sharded) {
-        CoreCoord in0_shard_grid = in0_buffer->shard_spec().grid().bounding_box().grid_size();
+        CoreCoord in0_shard_grid = in0_tensor.shard_spec()->grid.bounding_box().grid_size();
         // in0 shard grid already accounts for transpose_mcast
         // ie. If transpose_mcast, in0 width is along y
         in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
@@ -1824,7 +1834,7 @@ create_program_mcast_in0_in1(
     auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
     auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
-    bool in1_is_dram = in1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool in1_is_dram = in1_tensor.mesh_buffer().device_local_config().buffer_type == tt_metal::BufferType::DRAM;
 
     uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
@@ -1847,7 +1857,7 @@ create_program_mcast_in0_in1(
             per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
         } else {
             // Height sharded: batches are distributed across DRAM banks
-            uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+            uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
             batches_per_bank = in1_shard_height_in_tiles / K;
         }
     }
@@ -1939,7 +1949,7 @@ create_program_mcast_in0_in1(
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -1985,7 +1995,7 @@ create_program_mcast_in0_in1(
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -1995,11 +2005,11 @@ create_program_mcast_in0_in1(
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh).append_to(in1_sender_writer_compile_time_args);
     }
 
     if (in1_is_sharded and in1_is_dram) {
@@ -2055,13 +2065,13 @@ create_program_mcast_in0_in1(
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
     }
     in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_receiver_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
 
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
@@ -2069,7 +2079,7 @@ create_program_mcast_in0_in1(
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -2352,7 +2362,7 @@ create_program_mcast_in0_in1(
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -2402,7 +2412,7 @@ create_program_mcast_in0_in1(
             .set_page_size(src0_cb_index, in0_single_tile_size)
             .set_tile_dims(src0_cb_index, in0_tile);
     if (in0_height_sharded) {
-        src0_cb_config.set_globally_allocated_address(*in0_buffer);
+        src0_cb_config.set_globally_allocated_address(in0_tensor);
     }
     tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
     log_debug(
@@ -2419,7 +2429,7 @@ create_program_mcast_in0_in1(
             .set_page_size(src1_cb_index, in1_single_tile_size)
             .set_tile_dims(src1_cb_index, in1_tile);
     if (in1_is_sharded and not in1_is_dram) {
-        src1_cb_config.set_globally_allocated_address(*in1_buffer);
+        src1_cb_config.set_globally_allocated_address(in1_tensor);
     }
     tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     log_debug(
@@ -2436,7 +2446,7 @@ create_program_mcast_in0_in1(
         tt_metal::CircularBufferConfig src2_cb_config =
             tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
                 .set_page_size(src2_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*in0_buffer)
+                .set_globally_allocated_address(in0_tensor)
                 .set_tile_dims(src2_cb_index, in0_tile);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(
@@ -2499,7 +2509,7 @@ create_program_mcast_in0_in1(
     }
 
     if (output_is_sharded) {
-        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), output_cb_config);
     log_debug(
@@ -2511,7 +2521,7 @@ create_program_mcast_in0_in1(
         out_CB_size);
 
     // CB for bias
-    if (bias_buffer != nullptr) {
+    if (bias_mesh.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -2677,7 +2687,7 @@ create_program_mcast_in0_in1(
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)in0_tensor.address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -2725,7 +2735,7 @@ create_program_mcast_in0_in1(
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_buffer->address(),
+                    (std::uint32_t)in1_tensor.address(),
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -2738,7 +2748,7 @@ create_program_mcast_in0_in1(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_buffer->address(),
+                    (std::uint32_t)out_tensor.address(),
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -2770,9 +2780,9 @@ create_program_mcast_in0_in1(
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(bias_buffer ? (std::uint32_t)bias_buffer->address() : 0);
+                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
                 mm_in1_sender_writer_args.push_back(
-                    bias_buffer ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                    bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
                     if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
                         mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -2870,7 +2880,7 @@ create_program_mcast_in0_in1(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_buffer->address(),                               // out_tensor_addr
+                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -3003,28 +3013,28 @@ void override_runtime_arguments_impl(
         input_tensors.size() + optional_input_tensors.size());
     TT_FATAL(output_tensors.size() == 1, "Number of output tensors must be 1, but got {}", output_tensors.size());
 
-    auto* src_buffer_a = input_tensors.at(0).buffer();
-    auto* src_buffer_b = input_tensors.at(1).buffer();
+    const auto& in0 = input_tensors.at(0).mesh_tensor();
+    const auto& in1 = input_tensors.at(1).mesh_tensor();
     const auto& bias_tensor = optional_input_tensors.at(0);
 
-    auto* dst_buffer = output_tensors.at(0).buffer();
+    const auto& out = output_tensors.at(0).mesh_tensor();
 
     bool src0_sharded = input_tensors[0].memory_config().is_sharded();
     bool out_sharded = output_tensors[0].memory_config().is_sharded();
 
-    std::optional<tt::tt_metal::Buffer*> bias_buffer;
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_mesh;
     if (bias_tensor.has_value()) {
-        bias_buffer = bias_tensor.value().buffer();
+        bias_mesh = bias_tensor.value().mesh_tensor();
     }
 
     // in0 sender
     if (src0_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_src2, *src_buffer_a);
+        UpdateDynamicCircularBufferAddress(program, cb_src2, in0);
     } else {
         auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
         for (const auto& core : in0_sender_interleaved_cores) {
             auto& reader_runtime_args = reader_sender_runtime_args_by_core[core.x][core.y];
-            reader_runtime_args[0] = src_buffer_a->address();
+            reader_runtime_args[0] = in0.address();
         }
     }
 
@@ -3032,10 +3042,10 @@ void override_runtime_arguments_impl(
     auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
     for (const auto& core : in1_sender_cores) {
         auto& writer_runtime_args = sender_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[0] = src_buffer_b->address();
-        writer_runtime_args[7] = dst_buffer->address();
+        writer_runtime_args[0] = in1.address();
+        writer_runtime_args[7] = out.address();
         if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = (*bias_buffer)->address();
+            writer_runtime_args[18] = bias_mesh->address();
         }
     }
 
@@ -3043,19 +3053,19 @@ void override_runtime_arguments_impl(
     auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id);
     for (const auto& core : in1_receiver_cores) {
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[2] = dst_buffer->address();
+        writer_runtime_args[2] = out.address();
     }
     if (mm_kernel_in1_receiver_writer_id != mm_kernel_in1_receiver_writer_other_noc_setup_id) {
         auto& receiver_writer_runtime_args_by_core =
             GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_other_noc_setup_id);
         for (const auto& core : in1_receiver_other_cores) {
             auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-            writer_runtime_args[2] = dst_buffer->address();
+            writer_runtime_args[2] = out.address();
         }
     }
 
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_output, out);
     }
 }
 }  // namespace reuse_mcast_optimized_helpers
@@ -3073,7 +3083,7 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
     const auto& a = tensor_args.input_tensors.at(0);
     const auto& b = tensor_args.input_tensors.at(1);
     const auto& bias = tensor_args.optional_input_tensors.at(0);
-    const auto& output = tensor_return_value.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
@@ -3126,7 +3136,8 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
 
     // CB dataformats
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());          // in0
-    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());          // in1
+    const auto& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());  // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
 
     const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
@@ -3142,7 +3153,7 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
         in0_last_ktile_w,
         in0_last_ktile_h);
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         const auto& c = bias.value();
@@ -3151,9 +3162,9 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
             "Bias tensor must be on device, got storage type: {}",
             c.storage_type());
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+        TT_FATAL(c.is_allocated(), "Operands to matmul need to be allocated in buffers on device!");
 
-        bias_buffer = c.buffer();
+        bias_mesh = c.mesh_tensor();
 
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
@@ -3162,17 +3173,16 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
+    const auto& in0_tensor = a.mesh_tensor();
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        in0_tensor.mesh_buffer().device_local_size(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        in1_tensor.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        in1_tensor.mesh_buffer().device_local_size(),
         in1_single_tile_size);
 
     TT_FATAL(
@@ -3243,8 +3253,7 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Sub-device start core
@@ -3288,10 +3297,10 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
         per_core_N,
         transpose_mcast,
         program_config.fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh,
+        output,
         in0_tile,
         in1_tile,
         bias.has_value() ? bias->tensor_spec().tile() : output_tile,
@@ -3327,7 +3336,7 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
     const auto& a = tensor_args.input_tensors.at(0);
     const auto& b = tensor_args.input_tensors.at(1);
     const auto& bias = tensor_args.optional_input_tensors.at(0);
-    const auto& output = tensor_return_value.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
@@ -3363,8 +3372,10 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
     const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
 
     // CB dataformats
-    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    const auto& in0_tensor = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_tensor.dtype());
+    const auto& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
 
     const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
@@ -3376,18 +3387,15 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
         in0_last_ktile_w,
         in0_last_ktile_h);
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
     if (bias.has_value()) {
         const auto& c = bias.value();
-        bias_buffer = c.buffer();
+        bias_mesh = c.mesh_tensor();
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt_metal::IDevice* device = a.device();
-
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
+    tt_metal::IDevice* device = &in0_tensor.device_mut();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -3397,8 +3405,6 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
     const auto Mt_per_batch = get_M_dim(a_shape_padded, in0_tile, false);
     const auto Kt = get_K_dim(a_shape_padded, in0_tile);
     const auto Nt = get_N_dim(b_shape_padded, in1_tile);
-
-    tt_metal::Buffer* out_buffer = output.buffer();
 
     CoreCoord sub_device_start_core = {0, 0};
     if (operation_attributes.sub_device_id.has_value()) {
@@ -3436,10 +3442,10 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
         per_core_N,
         transpose_mcast,
         program_config.fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh,
+        output,
         in0_tile,
         in1_tile,
         bias.has_value() ? bias->tensor_spec().tile() : output_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1237,9 +1237,9 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
             }
 
             {
-                std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in0_args(
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>> in0_args(
                     mm_in0_sender_args.begin(), mm_in0_sender_args.end());
-                in0_args[0] = in0_tensor.mesh_buffer().get_reference_buffer();
+                in0_args[0] = in0_tensor;
                 in0_sender_kernel_desc.emplace_runtime_args(core, in0_args);
             }
 
@@ -1399,12 +1399,12 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     }
                 }
                 {
-                    std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in1_sender_variant(
-                        mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
-                    in1_sender_variant[0] = in1_tensor.mesh_buffer().get_reference_buffer();
-                    in1_sender_variant[7] = out_tensor.mesh_buffer().get_reference_buffer();
+                    std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>>
+                        in1_sender_variant(mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+                    in1_sender_variant[0] = in1_tensor;
+                    in1_sender_variant[7] = out_tensor;
                     if (bias_mesh.has_value()) {
-                        in1_sender_variant[18] = bias_mesh->mesh_buffer().get_reference_buffer();
+                        in1_sender_variant[18] = bias_mesh;
                     }
                     in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
                 }
@@ -1490,9 +1490,9 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 }
 
                 {
-                    std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> in1_recv_variant(
-                        mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
-                    in1_recv_variant[2] = out_tensor.mesh_buffer().get_reference_buffer();
+                    std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>>
+                        in1_recv_variant(mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
+                    in1_recv_variant[2] = out_tensor;
                     // left half
                     if (core.x <= half_core || (transpose_mcast and core.y == start_core_y)) {
                         in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
@@ -3249,11 +3249,6 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
         "Num output blocks along y ({}) must be smaller than or equal to the number of rows in compute grid ({})!",
         num_blocks_y,
         num_cores_y);
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Grayskull Device Setup
-    ////////////////////////////////////////////////////////////////////////////
-    TT_FATAL(output.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Sub-device start core

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1404,7 +1404,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     in1_sender_variant[0] = in1_tensor;
                     in1_sender_variant[7] = out_tensor;
                     if (bias_mesh.has_value()) {
-                        in1_sender_variant[18] = bias_mesh;
+                        in1_sender_variant[18] = *bias_mesh;
                     }
                     in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -858,11 +858,11 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         }
 
         // Build variant args: positions [1] and [2] are buffer addresses
-        std::vector<std::variant<uint32_t, Buffer*>> in1_writer_args(
+        std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>> in1_writer_args(
             mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
-        in1_writer_args[1] = in1_tensor.mesh_buffer().get_reference_buffer();
+        in1_writer_args[1] = in1_tensor;
         if (bias.has_value()) {
-            in1_writer_args[2] = bias->mesh_buffer().get_reference_buffer();
+            in1_writer_args[2] = *bias;
         }
         in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
         TT_FATAL(
@@ -1003,8 +1003,6 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
     TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
     const auto& output_mesh = output.mesh_tensor();
-    TT_FATAL(
-        output_mesh.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
     return reuse_dram_sharded_optimized_helpers::create_program_dram_sharded_descriptor(
         device,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -57,10 +57,10 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     uint32_t per_core_M,
     uint32_t per_core_N_storage,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -76,10 +76,15 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     bool row_broadcast_bias) {
     using namespace tt;
 
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias;
+    if (bias_tensor.has_value()) {
+        bias = *bias_tensor;
+    }
+
     // currently only support transpose of the full tile
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
     TT_FATAL(
-        in1_buffer->shard_spec().orientation() == ShardOrientation::ROW_MAJOR, "Only ROW_MAJOR sharding is supported");
+        in1_tensor.shard_spec()->orientation == ShardOrientation::ROW_MAJOR, "Only ROW_MAJOR sharding is supported");
 
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
@@ -112,7 +117,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     uint32_t num_dram_banks = all_worker_cores_ordered.size();
 
     // Remove cores assigned to padding-only DRAM banks from the workers category
-    uint32_t in1_shard_width_tiles = in1_buffer->shard_spec().shape()[1] / in1_tile.get_tile_shape()[1];
+    uint32_t in1_shard_width_tiles = in1_tensor.shard_spec()->shape[1] / in1_tile.get_tile_shape()[1];
     uint32_t in1_tensor_padded_width_tiles = in1_shard_width_tiles * num_dram_banks;
 
     if (in1_tensor_padded_width_tiles > N) {
@@ -206,7 +211,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     uint32_t out_reshard_CB_tiles = out_reshard_block_tiles;
     uint32_t out_reshard_CB_size = out_reshard_CB_tiles * output_single_tile_size;
 
-    uint32_t in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_tile_shape()[1];
     uint32_t in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     uint32_t in2_CB_tiles = in2_block_tiles;
     uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
@@ -319,7 +324,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         (std::uint32_t)per_core_N_compute * output_single_tile_size,  // out_tensor_stride_w_bytes
         (std::uint32_t)per_core_N_storage * output_single_tile_size,  // out_reshard_tensor_stride_w_bytes
         (std::uint32_t)per_core_M};
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         in1_sender_writer_compile_time_args.push_back(bias_buffer_page_size);
         in1_sender_writer_compile_time_args.push_back(bias_buffer_num_pages);
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
@@ -328,7 +333,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_define;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
@@ -445,7 +450,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         false,         // get_batch_from_reader
         false,         // in0_transpose_tile
     };
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
     }
 
@@ -532,7 +537,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             .data_format = in0_data_format,
             .page_size = in0_single_tile_size,
             .tile = in0_tile_desc});
-        cb_desc.buffer = in0_buffer;
+        cb_desc.tensor = &in0_tensor;
         desc.cbs.push_back(std::move(cb_desc));
     }
 
@@ -589,12 +594,12 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             .data_format = output_data_format,
             .page_size = output_single_tile_size,
             .tile = output_tile_desc});
-        cb_desc.buffer = out_buffer;
+        cb_desc.tensor = &out_tensor;
         desc.cbs.push_back(std::move(cb_desc));
     }
 
     // CB 3: bias
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         CBDescriptor cb_desc;
         cb_desc.total_size = in3_CB_size;
         cb_desc.core_ranges = all_cores_in_rect_grid;
@@ -746,8 +751,8 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         bool is_worker_core = true;
         std::vector<uint32_t> mm_in1_sender_writer_args;
         mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
-        mm_in1_sender_writer_args.push_back(in1_buffer->address());  // [1]: will be replaced by Buffer*
-        mm_in1_sender_writer_args.push_back(bias_buffer ? bias_buffer->address() : 0u);  // [2]: may be replaced
+        mm_in1_sender_writer_args.push_back(in1_tensor.address());  // [1]: will be replaced by Buffer*
+        mm_in1_sender_writer_args.push_back(bias.has_value() ? bias->address() : 0u);  // [2]: may be replaced
 
         uint32_t vc = bank_id & 0x3;
         bank_ids.push_back(bank_id);
@@ -855,9 +860,9 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         // Build variant args: positions [1] and [2] are buffer addresses
         std::vector<std::variant<uint32_t, Buffer*>> in1_writer_args(
             mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
-        in1_writer_args[1] = in1_buffer;
-        if (bias_buffer != nullptr) {
-            in1_writer_args[2] = bias_buffer;
+        in1_writer_args[1] = in1_tensor.mesh_buffer().get_reference_buffer();
+        if (bias.has_value()) {
+            in1_writer_args[2] = bias->mesh_buffer().get_reference_buffer();
         }
         in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
         TT_FATAL(
@@ -894,7 +899,7 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
     const auto& output_tensors = tensor_return_value;
 
     const auto& a = input_tensors.at(0);
-    const auto& b = input_tensors.at(1);
+    const auto& b = input_tensors.at(1).mesh_tensor();
     const auto& bias = optional_input_tensors.at(0);
     const auto& output = output_tensors.at(0);
     const auto& ashape = a.padded_shape();
@@ -910,7 +915,7 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
     tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.dtype());
     tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    tt::tt_metal::Buffer* bias_buffer = nullptr;
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_mesh;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
     if (bias.has_value()) {
         const auto& c = bias.value();
@@ -919,9 +924,8 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
             "Bias tensor must be on device, got storage type: {}",
             c.storage_type());
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
-        bias_buffer = c.buffer();
+        bias_mesh = c.mesh_tensor();
         bias_data_format = tt::tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
@@ -936,17 +940,16 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
-    tt::tt_metal::Buffer* in0_buffer = a.buffer();
-    tt::tt_metal::Buffer* in1_buffer = b.buffer();
+    const auto& a_mesh = a.mesh_tensor();
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        a_mesh.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        a_mesh.mesh_buffer().device_local_size(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        b.mesh_buffer().device_local_size(),
         in1_single_tile_size);
 
     TT_FATAL(
@@ -999,8 +1002,9 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
 
     TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
-    tt::tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    const auto& output_mesh = output.mesh_tensor();
+    TT_FATAL(
+        output_mesh.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
     return reuse_dram_sharded_optimized_helpers::create_program_dram_sharded_descriptor(
         device,
@@ -1021,10 +1025,10 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
         per_core_M,
         per_core_N,
         fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        a_mesh,
+        b,
+        bias_mesh,
+        output_mesh,
         in0_tile,
         in1_tile,
         bias.has_value() ? bias->tensor_spec().tile() : output_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -72,7 +72,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     tt::DataFormat output_data_format =
         tt_metal::datatype_to_dataformat_converter(operation_attributes.output_dtype.value());
 
-    tt_metal::IDevice* device = &in0_buffer.device_mut();
+    tt_metal::IDevice* device = &in0_buffer.mutable_device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -47,7 +47,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
     const auto& a = tensor_args.input_tensors.at(0);
     const auto& b = tensor_args.input_tensors.at(1);
-    auto& output = tensor_return_value.at(0);
+    auto& output = tensor_return_value.at(0).mesh_tensor();
 
     bool bcast_batch = operation_attributes.bcast_batch.value();
     bool transpose_a = operation_attributes.transpose_a;
@@ -65,12 +65,14 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     auto in0_tile = operations::matmul::utilities::get_matmul_tile(a, transpose_a);
     auto in1_tile = operations::matmul::utilities::get_matmul_tile(b, transpose_b);
 
-    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    const auto& in0_buffer = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_buffer.dtype());
+    const auto& in1_buffer = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_buffer.dtype());
     tt::DataFormat output_data_format =
         tt_metal::datatype_to_dataformat_converter(operation_attributes.output_dtype.value());
 
-    tt_metal::IDevice* device = a.device();
+    tt_metal::IDevice* device = &in0_buffer.device_mut();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
@@ -121,11 +123,8 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
     uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
 
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
-    tt_metal::Buffer* out_buffer = output.buffer();
-    bool in0_is_sharded = a.is_sharded();
-    bool in1_is_sharded = b.is_sharded();
+    bool in0_is_sharded = in0_buffer.is_sharded();
+    bool in1_is_sharded = in1_buffer.is_sharded();
     bool output_is_sharded = output.is_sharded();
 
     // CB sizes
@@ -163,9 +162,9 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
     std::optional<tt::tt_metal::ShardSpec> shard_spec = std::nullopt;
     if (in0_is_sharded) {
-        shard_spec = a.shard_spec().value();
+        shard_spec = in0_buffer.shard_spec().value();
     } else if (in1_is_sharded) {
-        shard_spec = b.shard_spec().value();
+        shard_spec = in1_buffer.shard_spec().value();
     } else if (output_is_sharded) {
         shard_spec = output.shard_spec().value();
     }
@@ -237,7 +236,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         (std::uint32_t)bcast_batch,
         (std::uint32_t)M * K,
     };
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
 
     // Compile time args for reader/writer
     std::vector<uint32_t> reader_writer_compile_time_args = {
@@ -261,8 +260,8 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         (std::uint32_t)out_num_subblocks_h,
         (std::uint32_t)M * N,
     };
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(reader_writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(reader_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_buffer).append_to(reader_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(reader_writer_compile_time_args);
 
     // Reader defines
     KernelDescriptor::Defines reader_defines;
@@ -410,7 +409,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
             {in1_buffer,
              in1_start_tile_id,
              num_output_blocks_per_core,
-             out_buffer,
+             output,
              num_blocks_written * num_tiles_per_block_out});
 
         // Compute kernels have no per-core runtime args
@@ -493,14 +492,14 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
                                   tt::DataFormat data_format,
                                   uint32_t page_size,
                                   const tt::tt_metal::Tile& tile,
-                                  Buffer* buffer = nullptr) {
+                                  const tt_metal::MeshTensor* tensor = nullptr) {
         CBDescriptor cb_desc;
         cb_desc.total_size = total_size;
         cb_desc.core_ranges = all_cores;
         tt::tt_metal::TileDescriptor tile_desc{tile};
         cb_desc.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = buffer_index, .data_format = data_format, .page_size = page_size, .tile = tile_desc});
-        cb_desc.buffer = buffer;
+        cb_desc.tensor = tensor;
         return cb_desc;
     };
 
@@ -511,7 +510,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         in0_data_format,
         in0_single_tile_size,
         in0_tile,
-        in0_is_sharded ? in0_buffer : nullptr));
+        in0_is_sharded ? &in0_buffer : nullptr));
 
     // CB 1: Input B
     program_descriptor.cbs.push_back(make_cb_descriptor(
@@ -520,7 +519,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         in1_data_format,
         in1_single_tile_size,
         in1_tile,
-        in1_is_sharded ? in1_buffer : nullptr));
+        in1_is_sharded ? &in1_buffer : nullptr));
 
     // CB 4 and CB 5: Output and intermediate accumulator
     if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
@@ -532,7 +531,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
             output_data_format,
             output_single_tile_size,
             output_tile,
-            output_is_sharded ? out_buffer : nullptr));
+            output_is_sharded ? &output : nullptr));
         program_descriptor.cbs.push_back(make_cb_descriptor(
             interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
     } else {
@@ -551,7 +550,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
             .data_format = interm0_data_format,
             .page_size = interm0_single_tile_size,
             .tile = output_tile_desc});
-        output_cb_desc.buffer = output_is_sharded ? out_buffer : nullptr;
+        output_cb_desc.tensor = output_is_sharded ? &output : nullptr;
         program_descriptor.cbs.push_back(std::move(output_cb_desc));
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -47,7 +47,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
     const auto& a = tensor_args.input_tensors.at(0);
     const auto& b = tensor_args.input_tensors.at(1);
-    auto& output = tensor_return_value.at(0).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     bool bcast_batch = operation_attributes.bcast_batch.value();
     bool transpose_a = operation_attributes.transpose_a;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Mechanical migration of the `matmul` op family program factories
to the `MeshTensor`/`MeshBuffer` APIs.

Candidate program factories (7, before pre-filtering):

- matmul/device/factory/matmul_multicore_program_factory.cpp
- matmul/device/factory/matmul_multicore_reuse_program_factory.cpp
- matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
- matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
- matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
- matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
- matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp

Closes #44643

### Notes for reviewers

#### Runtime Tensor overview

Runtime Tensor is a recently introduced core runtime data structure. It
is closely modelled on `ttnn::Tensor` — the two share very similar
semantics and are designed to be drop-in interchangeable where
appropriate.

The motivation for Runtime Tensor is that it lets the runtime capture
the shape and sharding information of the true storage data structure.
That information is plumbed through `TensorAccessorArgs` and is
critical for the upcoming Metal 2.0 refactoring: gen 2 hardware needs
to understand the shape and sharding of device memory directly.

Runtime Tensor is not meant to replace `ttnn::Tensor` outright. This
PR replaces `ttnn::Tensor` usage in program factories specifically,
where Runtime Tensor is the most appropriate abstraction level.
(`MeshTensor` — the type you will see in the diff — is the
device-side part of Runtime Tensor.)

#### This refactoring

- **Primary goal:** ensure ops leverage Runtime Tensor so we no longer
  lose shape and sharding information when passing `Buffer` into
  runtime / compile arguments (notably into `TensorAccessorArgs`).
- **Secondary goal:** complete the migration away from single-device
  data classes now that the rest of our infrastructure is
  multi-device-aware (`Buffer` → `MeshTensor`).

#### Risk

This migration should carry minimal regression risk: it is a
type-substitution refactor, not a behavioural change. No control flow
or computational logic is modified.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mt-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-matmul)
