### PR TITLE
Fix for Global Pool Regression

### DIFF
--- a/ttnn/ttnn/operations/pool.py
+++ b/ttnn/ttnn/operations/pool.py
@@ -83,6 +83,19 @@ def global_avg_pool2d(input_tensor, *, memory_config=None, dtype=None):
     else:
         raise ValueError(f"global_avg_pool2d expects rank 2, 3, or 4 input, got rank {rank}")
 
+    # The avg_pool2d reduction fast path opts out for sharded inputs (it would force a
+    # sharded→interleaved round-trip that erases the win for direct MobileNetV2-style
+    # callers). For the global_avg_pool2d wrapper specifically, falling through to the
+    # sliding-window path is wrong: it goes through halo, which needs L1_SMALL, and the
+    # legacy C++ global_avg_pool2d device op called pool_sum directly with no halo —
+    # so callers don't reserve L1_SMALL. Convert sharded inputs to interleaved here to
+    # match legacy behavior. Buffer type is preserved.
+    if input_tensor.memory_config().is_sharded():
+        input_tensor = ttnn.to_memory_config(
+            input_tensor,
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, input_tensor.memory_config().buffer_type),
+        )
+
     out_dtype = dtype if dtype is not None else ttnn.bfloat16
     result = ttnn.avg_pool2d(
         input_tensor=input_tensor,


### PR DESCRIPTION
### Problem
A test failure surfaced on N300 after #43820 landed: test_global_avg_pool2d_nd_sharded_row_major_non_tile_aligned_h[h_w=49-channels=1280-grid_end=(7, 0)]

### Fix
In ttnn/ttnn/operations/pool.py, detect a sharded input in the global_avg_pool2d wrapper and reshard to INTERLEAVED (preserving buffer_type) before delegating to avg_pool2d. This routes the call through the reduction fast path (pool_sum) — matching legacy behavior — instead of falling through to the sliding-window + halo path.

Direct avg_pool2d callers are unaffected: they continue to hit the sharded-input gate and run the sliding-window kernel natively on their sharded layout.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wransom/gp_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wransom/gp_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:wransom/gp_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wransom/gp_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wransom/gp_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wransom/gp_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wransom/gp_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wransom/gp_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wransom/gp_fix)