### PR TITLE
#40182: Replace sfpi::setsgn with sfpi::copysgn as needed

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/sfpu/llk.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/sfpu/llk.rst
@@ -264,8 +264,8 @@ Replaces the mantissa of  ''v'' with the mantissa in the low bits of ''man'' and
 .. code-block:: c++
 
     vFloat setsgn(const vFloat v, const int32_t sgn)
-    vFloat setsgn(const vFloat v, const vFloat sgn)
-    vFloat setsgn(const vFloat v, const vInt sgn)
+    vFloat copysgn(const vFloat v, const vFloat sgn)
+    vFloat copysgn(const vFloat v, const vInt sgn)
 
 Replaces the sign bit of ''v'' with the sign in ''sgn'' and returns the result (preserving the exponent and mantissa of ''v'').  Note that the ''int32_t'' version takes the sign from bit 0 while the ''vFloat'' and ''vInt'' versions take the sign from the sign bit location (bit 19 on GS and bit 32 on WH).
 

--- a/tests/tt_metal/tt_metal/test_kernels/sfpi/01-int-representation.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/sfpi/01-int-representation.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
     {  // test loading 0x80000001 loads as expected
         vUInt value = vUInt(1) | vUInt(0x8000) << 16;
 
-        vUInt signOne = setsgn(vUInt(1), 1);
+        vUInt signOne = as<vUInt>(setsgn(vUInt(1), 1));
 
         vUInt notCorrect = value ^ signOne;
         FAIL_IF(notCorrect != 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -91,7 +91,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
         r = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
     }
 
-    r = sfpi::setsgn(r, y);
+    r = sfpi::copysgn(r, y);
 
     // If |x| = NaN or |y| = NaN, vec_min_max will ensure max=NaN as mentioned above.
     sfpi::vFloat infinity = std::numeric_limits<float>::infinity();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -81,7 +81,7 @@ inline void calculate_sfpu_binary_div(const uint dst_index_in0, const uint dst_i
             v_if(in0 == 0) { result = std::numeric_limits<float>::quiet_NaN(); }
             v_else {
                 result = std::numeric_limits<float>::infinity();
-                result = sfpi::setsgn(result, in0);
+                result = sfpi::copysgn(result, in0);
             }
             v_endif;
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -129,7 +129,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
@@ -191,8 +191,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vInt sign_bit = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(exp) >> 31);  // 0 or 1
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
-    // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
+    // copysgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::copysgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -225,7 +225,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = sfpi::setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -17,7 +17,7 @@ inline void calculate_bitwise_or(const uint value) {
         vInt res = input | scalar_value;
         v_if(res > INT_MIN && res < 0) {
             res = 0 - res;
-            res = setsgn(res, scalar_value);
+            res = copysgn(res, scalar_value);
         }
         v_endif dst_reg[0] = res;
         dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -22,7 +22,7 @@ inline void calculate_bitwise_xor(const uint value) {
         vInt res = input ^ v;
         v_if(res > INT_MIN && res < 0) {
             res = 0 - res;
-            res = setsgn(res, v);
+            res = copysgn(res, v);
         }
         v_endif dst_reg[0] = res;
         dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -53,7 +53,7 @@ inline void calculate_cube_root() {
             c = d * y + sfpi::vConstNeg1;
             sfpi::vFloat negative_third = sfpi::addexp(negative_third_256, 8);
             sfpi::vFloat t = c * negative_third + sfpi::vConst1;
-            d = sfpi::setsgn(d, a);
+            d = sfpi::copysgn(d, a);
             y = d * (t * t);
 
             sfpi::dst_reg[0] = y;
@@ -61,7 +61,7 @@ inline void calculate_cube_root() {
             sfpi::vFloat d = x * (y * y);
             sfpi::vFloat c = d * y;
             sfpi::vFloat t = c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0;
-            d = sfpi::setsgn(d, a);
+            d = sfpi::copysgn(d, a);
             y = d * (t * t);
 
             sfpi::dst_reg[0] = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -41,7 +41,7 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
             sfpi::vFloat float_in0 = sfpi::int32_to_float(pos_in0, sfpi::RoundMode::NearestEven);
             sfpi::vFloat float_in1 = sfpi::int32_to_float(pos_in1, sfpi::RoundMode::NearestEven);
             result = float_in0 * _sfpu_reciprocal_<2>(float_in1);
-            result = sfpi::setsgn(result, in0 ^ in1);
+            result = sfpi::copysgn(result, in0 ^ in1);
         }
         v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
@@ -59,7 +59,7 @@ inline void calculate_erf() {
         sfpi::vFloat ax = sfpi::setsgn(x, 0);
         sfpi::vFloat threshold = 10.0f;
         sfpi::vec_min_max(ax, threshold);
-        x = sfpi::setsgn(ax, x);
+        x = sfpi::copysgn(ax, x);
         sfpi::vFloat result = piecewise_rational_eval<
             ERF_NUM_DEGREE,
             ERF_DEN_DEGREE,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -68,7 +68,7 @@ inline void calculate_erfinv() {
         v_else { result = calculate_erfinv_body<true>(abs_v); }
         v_endif;
 
-        result = sfpi::setsgn(result, v);  // restore sign
+        result = sfpi::copysgn(result, v);  // restore sign
 
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -53,7 +53,7 @@ inline void calculate_fmod(const uint value, const uint recip) {
         v_endif;
         v = v - quotient * s;
 
-        v = setsgn(v, val);
+        v = copysgn(v, val);
 
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -139,8 +139,8 @@ inline sfpi::vFloat calculate_gelu_chebyshev(sfpi::vFloat val) {
             2.98325768482e-05,
             val);
 
-        // Ensure result has the same sign as input using setsgn
-        result = setsgn(result, val);
+        // Ensure result has the same sign as input using copysgn
+        result = copysgn(result, val);
     }
     v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -78,7 +78,7 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
 #endif
 
     // i1 is odd: copy sign of original x onto positive magnitude.
-    return sfpi::setsgn(exp_abs * rsqrt_y * correction, x_signed);
+    return sfpi::copysgn(exp_abs * rsqrt_y * correction, x_signed);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -113,7 +113,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         }
         // int32_to_float returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
-        e_float = sfpi::setsgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
+        e_float = sfpi::copysgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
         r = r * s + m;
         sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
         r = e_float * sfpi::vConstFloatPrgm0 + r;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -59,7 +59,7 @@ inline void calculate_remainder(const uint value, const uint recip) {
 
         v_if(value_tmp < 0 && v != 0) { v = v + value_tmp; }
         v_endif;
-        v = setsgn(v, value_tmp);
+        v = sfpi::copysgn(v, value_tmp);
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -83,7 +83,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 
-    result = sfpi::setsgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
+    result = sfpi::copysgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
 
     return result;
 }
@@ -112,7 +112,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 
-    result = sfpi::setsgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
+    result = sfpi::copysgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
 
     return result;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -343,7 +343,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
         v_if(absval_minus_1 > 0.0f) { t1 = PI_2 - t1; }
         v_endif;
 
-        result = sfpi::setsgn(t1, val);
+        result = sfpi::copysgn(t1, val);
     }
     v_endif;
 
@@ -416,7 +416,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
     }
     v_endif;
 
-    return sfpi::setsgn(asin_abs, val);
+    return sfpi::copysgn(asin_abs, val);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -64,8 +64,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     sfpi::vInt sign_bit = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(exp) >> 31);  // 0 or 1
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
-    // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
+    // copysgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::copysgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
@@ -136,7 +136,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = sfpi::setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
@@ -223,8 +223,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vInt sign_bit = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(exp) >> 31);  // 0 or 1
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
-    // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
+    // copysgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::copysgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -251,7 +251,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = sfpi::setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -91,7 +91,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
         r = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
     }
 
-    r = sfpi::setsgn(r, y);
+    r = sfpi::copysgn(r, y);
 
     // If |x| = NaN or |y| = NaN, vec_min_max will ensure max=NaN as mentioned above.
     sfpi::vFloat infinity = std::numeric_limits<float>::infinity();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -80,7 +80,7 @@ inline void calculate_sfpu_binary_div(const uint dst_index_in0, const uint dst_i
             v_if(in0 == 0) { result = std::numeric_limits<float>::quiet_NaN(); }
             v_else {
                 result = std::numeric_limits<float>::infinity();
-                result = sfpi::setsgn(result, in0);
+                result = sfpi::copysgn(result, in0);
             }
             v_endif;
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -129,7 +129,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
@@ -191,8 +191,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vInt sign_bit = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(exp) >> 31);  // 0 or 1
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
-    // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
+    // copysgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::copysgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -225,7 +225,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = sfpi::setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -17,7 +17,7 @@ inline void calculate_bitwise_or(const uint value) {
         vInt res = input | scalar_value;
         v_if(res > INT_MIN && res < 0) {
             res = 0 - res;
-            res = setsgn(res, scalar_value);
+            res = copysgn(res, scalar_value);
         }
         v_endif dst_reg[0] = res;
         dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -22,7 +22,7 @@ inline void calculate_bitwise_xor(const uint value) {
         vInt res = input ^ v;
         v_if(res > INT_MIN && res < 0) {
             res = 0 - res;
-            res = setsgn(res, v);
+            res = copysgn(res, v);
         }
         v_endif dst_reg[0] = res;
         dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -53,7 +53,7 @@ inline void calculate_cube_root() {
             c = d * y + sfpi::vConstNeg1;
             sfpi::vFloat negative_third = sfpi::addexp(negative_third_256, 8);
             sfpi::vFloat t = c * negative_third + sfpi::vConst1;
-            d = sfpi::setsgn(d, a);
+            d = sfpi::copysgn(d, a);
             y = d * (t * t);
 
             sfpi::dst_reg[0] = y;
@@ -61,7 +61,7 @@ inline void calculate_cube_root() {
             sfpi::vFloat d = x * (y * y);
             sfpi::vFloat c = d * y;
             sfpi::vFloat t = c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0;
-            d = sfpi::setsgn(d, a);
+            d = sfpi::copysgn(d, a);
             y = d * (t * t);
 
             sfpi::dst_reg[0] = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
@@ -68,7 +68,7 @@ inline void calculate_erf() {
         sfpi::vFloat ax = sfpi::setsgn(x, 0);
         sfpi::vFloat threshold = 10.0f;
         sfpi::vec_min_max(ax, threshold);
-        x = sfpi::setsgn(ax, x);
+        x = sfpi::copysgn(ax, x);
         sfpi::vFloat result = piecewise_rational_eval<
             ERF_NUM_DEGREE,
             ERF_DEN_DEGREE,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -68,7 +68,7 @@ inline void calculate_erfinv() {
         v_else { result = calculate_erfinv_body<true>(abs_v); }
         v_endif;
 
-        result = sfpi::setsgn(result, v);  // restore sign
+        result = sfpi::copysgn(result, v);  // restore sign
 
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -53,7 +53,7 @@ inline void calculate_fmod(const uint value, const uint recip) {
         v_endif;
         v = v - quotient * s;
 
-        v = setsgn(v, val);
+        v = copysgn(v, val);
 
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -139,8 +139,8 @@ inline sfpi::vFloat calculate_gelu_chebyshev(sfpi::vFloat val) {
             2.98325768482e-05,
             val);
 
-        // Ensure result has the same sign as input using setsgn
-        result = setsgn(result, val);
+        // Ensure result has the same sign as input using copysgn
+        result = copysgn(result, val);
     }
     v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -78,7 +78,7 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
 #endif
 
     // i1 is odd: copy sign of original x onto positive magnitude.
-    return sfpi::setsgn(exp_abs * rsqrt_y * correction, x_signed);
+    return sfpi::copysgn(exp_abs * rsqrt_y * correction, x_signed);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -113,7 +113,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         }
         // int32_to_float returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
-        e_float = sfpi::setsgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
+        e_float = sfpi::copysgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
         r = r * s + m;
         sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
         r = e_float * sfpi::vConstFloatPrgm0 + r;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -59,7 +59,7 @@ inline void calculate_remainder(const uint value, const uint recip) {
 
         v_if(value_tmp < 0 && v != 0) { v = v + value_tmp; }
         v_endif;
-        v = setsgn(v, value_tmp);
+        v = copysgn(v, value_tmp);
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
@@ -23,7 +23,7 @@ inline void calculate_right_shift(const uint shift_amt) {
         v_endif;
         vInt res = reinterpret<vInt>(val >> shift_amt);
 
-        v_if(input < 0) { res = setsgn(res + 1, input); }
+        v_if(input < 0) { res = copysgn(res + 1, input); }
         v_endif;
 
         dst_reg[0] = res;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -81,7 +81,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 
-    result = sfpi::setsgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
+    result = sfpi::copysgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
 
     return result;
 }
@@ -110,7 +110,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 
-    result = sfpi::setsgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
+    result = sfpi::copysgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
 
     return result;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -363,7 +363,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
         v_if(absval_minus_1 > 0.0f) { t1 = PI_2 - t1; }
         v_endif;
 
-        result = sfpi::setsgn(t1, val);
+        result = sfpi::copysgn(t1, val);
     }
     v_endif;
 
@@ -436,7 +436,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
     }
     v_endif;
 
-    return sfpi::setsgn(asin_abs, val);
+    return sfpi::copysgn(asin_abs, val);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -67,7 +67,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::copysgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
@@ -138,7 +138,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = sfpi::setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
@@ -226,7 +226,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::copysgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -253,7 +253,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
         // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = sfpi::setsgn(y, pow_int << 31);
+        y = sfpi::copysgn(y, pow_int << 31);
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -136,7 +136,7 @@ sfpi_inline sfpi::vFloat _round_even_(sfpi::vFloat v)
     v_if (exp < 23)
     {
         // v.{Exp,Man}=tmp.{Exp,Man}; retaining original sign.
-        v = sfpi::setsgn(tmp, v);
+        v = sfpi::copysgn(tmp, v);
     }
     v_endif;
     return v;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -200,14 +200,14 @@ inline void _calculate_atanh_()
         v_elseif (abs_inp == sfpi::vConst1)
         {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            res              = sfpi::setsgn(inf, inp);
+            res              = sfpi::copysgn(inf, inp);
         }
         v_else
         {
             sfpi::vFloat num = sfpi::vConst1 + inp;
             sfpi::vFloat den = sfpi::vConst1 - inp;
             sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
-            tmp              = sfpi::setsgn(tmp, den);
+            tmp              = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE)
             {
                 den = tmp;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -70,7 +70,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 
     // Apply scaling factor, and set sign to match input.
     y = y * scale;
-    y = sfpi::setsgn(y, in);
+    y = sfpi::copysgn(y, in);
 
     return y;
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -144,7 +144,7 @@ sfpi_inline sfpi::vFloat _round_even_(sfpi::vFloat v)
     v_if (exp < 23)
     {
         // v.{Exp,Man}=tmp.{Exp,Man}; retaining original sign.
-        v = sfpi::setsgn(tmp, v);
+        v = sfpi::copysgn(tmp, v);
     }
     v_endif;
     return v;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -200,14 +200,14 @@ inline void _calculate_atanh_()
         v_elseif (abs_inp == sfpi::vConst1)
         {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            res              = sfpi::setsgn(inf, inp);
+            res              = sfpi::copysgn(inf, inp);
         }
         v_else
         {
             sfpi::vFloat num = sfpi::vConst1 + inp;
             sfpi::vFloat den = sfpi::vConst1 - inp;
             sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
-            tmp              = sfpi::setsgn(tmp, den);
+            tmp              = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE)
             {
                 den = tmp;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
sfpi::setsgn has two ways of setting the sign -- from a scalar or from a vector.  With the scalar, bit0 is used, but with the vector bit 31 is used.  This is confusing.  I added sfpi::copying functions for the latter case, and this uses them.  That's clearer IMHO.

### Notes for reviewers
This is part of the continuing cleanup of SFPI's type system

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/setsgn-40182)