### PR TITLE
Bug fix: Fix runtime perf test benchmark artifact upload paths

### DIFF
--- a/.github/workflows/runtime-perf-tests-impl.yaml
+++ b/.github/workflows/runtime-perf-tests-impl.yaml
@@ -99,8 +99,8 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           path: |
-            pgm_bench.json
-            buffer_bench.json
+            docker-job/pgm_bench.json
+            docker-job/buffer_bench.json
           prefix: "perf_benchmarks_json_"
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The pipeline reorg in #40962 moved the repository checkout into a `docker-job/` subdirectory, but the benchmark artifact upload step in `runtime-perf-tests-impl.yaml` still referenced `pgm_bench.json` and `buffer_bench.json` at the workspace root. Since the test runs inside a container with `/work` mapped to `docker-job/`, the benchmark output files end up at `docker-job/pgm_bench.json` on the host — but the upload step looked for them at the workspace root and silently found nothing.

This meant benchmark JSON artifacts (`perf_benchmarks_json_*`) were never uploaded from any runtime perf test job, preventing golden file updates from CI data.

### Notes for reviewers
The fix simply prepends `docker-job/` to the artifact paths. The `test_reports_` upload step (line 92-96) may have the same issue if its default path also resolves relative to the workspace root — worth checking separately.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-perf-benchmark-artifact-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-perf-benchmark-artifact-upload)