### PR TITLE
Use device-side argmax sampling in DeepSeek V3 teacher-forced demo test.

### DIFF
--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -219,7 +219,8 @@ def test_demo_teacher_forcing_accuracy(
         force_recalculate=force_recalculate_weight_config,
         stop_at_eos=False,
         sample_on_device=True,
-        sampling_temperature=1.0,
+        sampling_temperature=0.0,
+        sampling_top_k=1,
         sampling_top_p=1.0,
     )
 


### PR DESCRIPTION
Set teacher-forced demo sampling to temperature 0 with top-k 1 so on-device decode uses deterministic greedy token selection.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
