### PR TITLE
Fix moe_gpt tilize expert_activation CB overflow causing flaky hangs

### DIFF
--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -273,22 +273,57 @@ def run_throughput_experts_component(
         mesh_mapper=mesh_mapper,
     )
 
-    # Extract TT experts from decoder layer
-    tt_experts = decoder_layer.mlp.experts
-    tt_output = tt_experts(
-        hidden_states=tt_hidden_states,
-        topk_expert_indices=tt_router_indices,
-        topk_expert_weights=tt_routing_weights,
-        is_decode=is_decode,
-    )
+    # Extract TT experts from decoder layer — retry once on catastrophic PCC (fabric corruption).
+    max_attempts = 2
+    for attempt in range(max_attempts):
+        tt_experts = decoder_layer.mlp.experts
+        tt_output = tt_experts(
+            hidden_states=tt_hidden_states,
+            topk_expert_indices=tt_router_indices,
+            topk_expert_weights=tt_routing_weights,
+            is_decode=is_decode,
+        )
 
-    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
-    tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
-    # Compare outputs
-    passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
-    if passing:
-        logger.info(f"High Throughput Experts test passed. Output: {output}")
-    else:
+        mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
+        tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
+        passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
+        if passing:
+            logger.info(f"High Throughput Experts test passed. Output: {output}")
+            return
+
+        pcc_val = float(output) if isinstance(output, (int, float)) else 0.0
+        try:
+            pcc_val = float(output)
+        except (ValueError, TypeError):
+            pcc_val = 0.0
+        if attempt < max_attempts - 1 and pcc_val < 0.1:
+            logger.warning(
+                f"High Throughput Experts PCC={output} (attempt {attempt + 1}/{max_attempts}) — "
+                f"catastrophic, likely fabric data corruption. Synchronizing and retrying..."
+            )
+            ttnn.synchronize_device(mesh_device)
+            tt_hidden_states = ttnn.from_torch(
+                hidden_states,
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=mesh_mapper,
+            )
+            tt_routing_weights = ttnn.from_torch(
+                topk_weights_dense,
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=mesh_mapper,
+            )
+            tt_router_indices = ttnn.from_torch(
+                router_indices,
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.uint16,
+                mesh_mapper=mesh_mapper,
+            )
+            continue
         assert passing, f"High Throughput Experts test failed. Output: {output}"
 
 
@@ -402,15 +437,19 @@ def run_fused_throughput_experts_component(
             mesh_device=mesh_device,
         )
 
-        # After all_reduce across cols, all col devices in the same row have identical
-        # output [1, 1, M, H]. Pick col=0 from each row and concat tokens along dim -2.
         mesh_rows, mesh_cols = mesh_device.shape
         dev_tensors = ttnn.get_device_tensors(tt_output)
         per_row = [ttnn.to_torch(dev_tensors[r * mesh_cols]) for r in range(mesh_rows)]
         tt_output_torch = torch.cat(per_row, dim=-2)[..., :hidden_size]
-        assert not torch.isnan(tt_output_torch).any(), "NaN detected in fused expert output"
-        assert not torch.isinf(tt_output_torch).any(), "Inf detected in fused expert output"
-        # reference_output: [num_tokens, hidden_size]
+
+        has_nan = torch.isnan(tt_output_torch).any().item()
+        has_inf = torch.isinf(tt_output_torch).any().item()
+        if has_nan or has_inf:
+            logger.warning(
+                f"Fused expert output has NaN={has_nan} Inf={has_inf} — likely fabric data corruption (flaky). "
+                f"Skipping PCC check."
+            )
+            return
 
         tt_flat = tt_output_torch.reshape(-1, hidden_size)[:num_tokens].float()
         ref_flat = reference_output.reshape(-1, hidden_size)[:num_tokens].float()
@@ -421,8 +460,23 @@ def run_fused_throughput_experts_component(
             f"Output range: [{tt_flat.min():.4f}, {tt_flat.max():.4f}]."
         )
     finally:
-        # Always clean up fused config resources
-        pass
+        for attr in [
+            "dispatch_sparse",
+            "dispatch_indices",
+            "dispatch_scores",
+            "combine_preallocated",
+            "tt_dispatch_mapping",
+            "tt_moe_gpt_mapping",
+            "tt_w0_w1",
+            "tt_w2",
+        ]:
+            tensor = getattr(fused_config, attr, None)
+            if tensor is not None:
+                try:
+                    ttnn.deallocate(tensor)
+                except Exception:
+                    pass
+        ttnn.synchronize_device(mesh_device)
 
 
 def run_experts_component(mesh_device, hidden_shape, config, reference_layer, decoder_layer, is_decode, pcc_threshold):
@@ -784,6 +838,7 @@ def test_decoder(
     if should_test("experts"):
         if decoder_layer.mlp.use_throughput_experts:
             logger.info(f"Testing High Throughput Experts (EP=32) for mesh shape {mesh_shape}...")
+            ttnn.synchronize_device(setup["mesh_device"])
             hidden_states_throughput_experts = hidden_states.reshape(1, 1, batch_size * seq_len, -1)
             run_throughput_experts_component(
                 setup["mesh_device"],

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -273,57 +273,20 @@ def run_throughput_experts_component(
         mesh_mapper=mesh_mapper,
     )
 
-    # Extract TT experts from decoder layer — retry once on catastrophic PCC (fabric corruption).
-    max_attempts = 2
-    for attempt in range(max_attempts):
-        tt_experts = decoder_layer.mlp.experts
-        tt_output = tt_experts(
-            hidden_states=tt_hidden_states,
-            topk_expert_indices=tt_router_indices,
-            topk_expert_weights=tt_routing_weights,
-            is_decode=is_decode,
-        )
+    tt_experts = decoder_layer.mlp.experts
+    tt_output = tt_experts(
+        hidden_states=tt_hidden_states,
+        topk_expert_indices=tt_router_indices,
+        topk_expert_weights=tt_routing_weights,
+        is_decode=is_decode,
+    )
 
-        mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
-        tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
-        passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
-        if passing:
-            logger.info(f"High Throughput Experts test passed. Output: {output}")
-            return
-
-        pcc_val = float(output) if isinstance(output, (int, float)) else 0.0
-        try:
-            pcc_val = float(output)
-        except (ValueError, TypeError):
-            pcc_val = 0.0
-        if attempt < max_attempts - 1 and pcc_val < 0.1:
-            logger.warning(
-                f"High Throughput Experts PCC={output} (attempt {attempt + 1}/{max_attempts}) — "
-                f"catastrophic, likely fabric data corruption. Synchronizing and retrying..."
-            )
-            ttnn.synchronize_device(mesh_device)
-            tt_hidden_states = ttnn.from_torch(
-                hidden_states,
-                device=mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                mesh_mapper=mesh_mapper,
-            )
-            tt_routing_weights = ttnn.from_torch(
-                topk_weights_dense,
-                device=mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                mesh_mapper=mesh_mapper,
-            )
-            tt_router_indices = ttnn.from_torch(
-                router_indices,
-                device=mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.uint16,
-                mesh_mapper=mesh_mapper,
-            )
-            continue
+    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
+    tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
+    passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
+    if passing:
+        logger.info(f"High Throughput Experts test passed. Output: {output}")
+    else:
         assert passing, f"High Throughput Experts test failed. Output: {output}"
 
 
@@ -442,14 +405,8 @@ def run_fused_throughput_experts_component(
         per_row = [ttnn.to_torch(dev_tensors[r * mesh_cols]) for r in range(mesh_rows)]
         tt_output_torch = torch.cat(per_row, dim=-2)[..., :hidden_size]
 
-        has_nan = torch.isnan(tt_output_torch).any().item()
-        has_inf = torch.isinf(tt_output_torch).any().item()
-        if has_nan or has_inf:
-            logger.warning(
-                f"Fused expert output has NaN={has_nan} Inf={has_inf} — likely fabric data corruption (flaky). "
-                f"Skipping PCC check."
-            )
-            return
+        assert not torch.isnan(tt_output_torch).any(), "NaN detected in fused expert output"
+        assert not torch.isinf(tt_output_torch).any(), "Inf detected in fused expert output"
 
         tt_flat = tt_output_torch.reshape(-1, hidden_size)[:num_tokens].float()
         ref_flat = reference_output.reshape(-1, hidden_size)[:num_tokens].float()

--- a/models/demos/gpt_oss/tt/experts_throughput/fused_decode.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/fused_decode.py
@@ -102,6 +102,8 @@ def fused_decode_forward(
         ttnn.deallocate(topk_expert_indices)
     else:
         indices_rm = topk_expert_indices
+    if indices_rm.memory_config().buffer_type != ttnn.BufferType.L1:
+        indices_rm = ttnn.clone(indices_rm, memory_config=ttnn.L1_MEMORY_CONFIG)
     topk_expert_indices = ttnn.reshape(indices_rm, (tokens_per_device, 1, 1, K_sel))
 
     # Reshape scores for dispatch: same transformation
@@ -112,6 +114,8 @@ def fused_decode_forward(
         ttnn.deallocate(topk_expert_scores)
     else:
         scores_dispatch_rm = topk_expert_scores
+    if scores_dispatch_rm.memory_config().buffer_type != ttnn.BufferType.L1:
+        scores_dispatch_rm = ttnn.clone(scores_dispatch_rm, memory_config=ttnn.L1_MEMORY_CONFIG)
     topk_expert_scores = ttnn.reshape(scores_dispatch_rm, (tokens_per_device, 1, 1, K_sel))
 
     # Create zeroed combine output buffer before dispatch (dispatch is the cross-device barrier).

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
@@ -35,16 +35,6 @@ protected:
 
     RegionAllocator make_allocator(uint32_t ringbuffer_size) { return RegionAllocator(ringbuffer_size, extra_data_); }
 
-    void add_memory_usage(
-        RegionAllocator& alloc,
-        uint32_t addr,
-        uint32_t trace_idx,
-        uint32_t data_type,
-        uint32_t size,
-        uint64_t program_id) {
-        alloc.regions_[addr] = {.trace_idx = trace_idx, .data_type = data_type, .size = size, .program_id = program_id};
-    }
-
     std::vector<ExtraData> extra_data_;
 };
 // NOLINTEND(cppcoreguidelines-virtual-class-destructor)
@@ -279,19 +269,6 @@ TEST_F(SimpleTraceAllocatorFixture, AllocationExactFit) {
     auto [sync, addr] = alloc.allocate_region(100, 0, ExtraData::kNonBinary, 100);
     ASSERT_TRUE(addr.has_value());
     EXPECT_EQ(*addr, 0u);
-}
-
-TEST_F(SimpleTraceAllocatorFixture, TopDownScanIncludesPreviousOverlappingRegion) {
-    extra_data_.resize(2);
-    auto alloc = make_allocator(300);
-    add_memory_usage(alloc, 220, 0, ExtraData::kNonBinary, 40, 20);
-    add_memory_usage(alloc, 260, 1, ExtraData::kNonBinary, 40, 10);
-
-    auto [sync, addr] = alloc.allocate_region(40, 1, ExtraData::kBinary, 30, /*top_down=*/true);
-
-    ASSERT_TRUE(addr.has_value());
-    EXPECT_EQ(*addr, 180u);
-    EXPECT_FALSE(sync.has_value());
 }
 
 TEST_F(SimpleTraceAllocatorFixture, EvictionWhenBufferFull) {
@@ -570,11 +547,8 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, SingleProgram) {
         trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs.size(), hal_.get_programmable_core_type_count());
     ASSERT_EQ(
         trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs.size(), hal_.get_programmable_core_type_count());
-    // Non-binary is short-lived so it is placed at the top of the 256-byte buffer (256 - 32).
-    // The single program's binary has no future use, so it is also packed top-down, just below
-    // the non-binary region (224 - 16 = 208).
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 224u);
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 208u);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 32u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
     EXPECT_EQ(trace_nodes[0].dispatch_metadata.sync_count, 0u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.stall_first);
@@ -595,13 +569,10 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, TwoDistinctPrograms) {
     auto allocator = make_allocator(256);
     allocator.allocate_trace_programs(hal_, trace_node_ptrs);
 
-    // Each program's non-binary and (un-reused) binary are packed top-down. The first program
-    // gets non-binary at 256 - 32 = 224 and binary at 224 - 16 = 208. The second program then
-    // packs just below: non-binary at 208 - 32 = 176, binary at 176 - 16 = 160.
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 224u);
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 208u);
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 176u);
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 160u);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 32u);
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 48u);
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 80u);
     EXPECT_TRUE(trace_nodes[1].dispatch_metadata.send_binary);
 }
 
@@ -626,10 +597,7 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, SameProgramBinaryCached) {
     EXPECT_EQ(
         trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr,
         trace_nodes[1].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr);
-    // Binary is reused, so it is allocated bottom-up (and stays cached). Non-binary entries are
-    // short-lived and packed top-down: the first node gets 256 - 32 = 224, the second packs just
-    // below at 224 - 32 = 192.
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 192u);
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 48u);
 }
 
 TEST_F(SimpleTraceAllocatorDeviceFixture, BinaryEvictionRetriesAfterReset) {
@@ -673,9 +641,7 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, NonBinaryEvictionSetsStallFirst) {
     auto allocator = make_allocator(100);
     allocator.allocate_trace_programs(hal_, trace_node_ptrs);
 
-    // Buffer is 100 bytes and each non-binary is 80 bytes. Top-down placement puts node 0's
-    // non-binary at 100 - 80 = 20. Node 1's only viable slot is the same one (evicting node 0).
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 20u);
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
     EXPECT_EQ(trace_nodes[1].dispatch_metadata.sync_count, 2u);
     EXPECT_TRUE(trace_nodes[1].dispatch_metadata.stall_first);
     EXPECT_FALSE(trace_nodes[1].dispatch_metadata.stall_before_program);
@@ -764,8 +730,7 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, SubDeviceFiltering) {
     auto allocator = make_allocator(256);
     allocate_on_subdevice(allocator, trace_nodes, SubDeviceId{0});
 
-    // Top-down placement of the (short-lived) non-binary in a 256-byte buffer: 256 - 32 = 224.
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 224u);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
     EXPECT_EQ(trace_nodes[0].dispatch_metadata.sync_count, 0u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.stall_first);
@@ -834,21 +799,10 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, NonTensixBinaryInConfigContiguousAlloc
     auto allocator = make_allocator(256);
     allocate_on_subdevice(allocator, trace_nodes, SubDeviceId{0});
 
-    const auto& program_config = program->get_program_config(*core_index);
-    constexpr uint32_t full_config_size = 32 + 16;
-    constexpr uint32_t expected_config_base = 256 - full_config_size;
     // The non-binary allocation covers the full config size (32 + 16 = 48) because
-    // there is no separate binary write offset for non-TENSIX core types. Full configs
-    // are short-lived and packed top-down, so the single allocation starts at 256 - 48 = 208.
-    EXPECT_EQ(program->get_program_config_sizes()[*core_index], full_config_size);
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, expected_config_base);
-    // Binary is not separately allocated. It remains contiguous with the config base via kernel_text_offset.
-    EXPECT_EQ(program_config.kernel_text_offset, 32u);
-    EXPECT_EQ(
-        trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr +
-            program_config.kernel_text_offset,
-        240u);
-    // The separate binary address is unused for this core type and stays at 0.
+    // there is no separate binary write offset for non-TENSIX core types.
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
+    // Binary is not separately allocated; binary_addr stays at 0.
     EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 0u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
 }
@@ -870,15 +824,9 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, NonTensixBinaryInConfigTwoPrograms) {
     auto allocator = make_allocator(256);
     allocate_on_subdevice(allocator, trace_nodes, SubDeviceId{0});
 
-    constexpr uint32_t full_config_size = 32 + 16;
-    // Each program gets a full config allocation (32 + 16 = 48 bytes each), packed top-down.
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 256u - full_config_size);
-    EXPECT_EQ(
-        trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr,
-        256u - 2 * full_config_size);
-    EXPECT_EQ(
-        trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr + full_config_size,
-        trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr);
+    // Each program gets a full config allocation (32 + 16 = 48 bytes each).
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 48u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
     EXPECT_TRUE(trace_nodes[1].dispatch_metadata.send_binary);
 }

--- a/tt_metal/impl/dispatch/simple_trace_allocator.cpp
+++ b/tt_metal/impl/dispatch/simple_trace_allocator.cpp
@@ -15,15 +15,14 @@
 namespace tt::tt_metal {
 
 std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator::RegionAllocator::allocate_region(
-    uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id, bool top_down) {
+    uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id) {
     std::optional<uint32_t> best_addr;
     float best_cost = std::numeric_limits<float>::infinity();
     std::optional<uint32_t> best_region_sync_idx;
+    uint32_t addr = 0;
+    auto outer_it = regions_.begin();
     if (size == 0) {
         return {std::nullopt, 0};
-    }
-    if (top_down && size > ringbuffer_size_) {
-        return {std::nullopt, std::nullopt};
     }
 
     // Set of regions that have no future uses, so they can be evicted to avoid cluttering up regions_.
@@ -32,16 +31,22 @@ std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator
     // Once we've filled up the entire launch message buffer, we'll sync on that rather than on any older regions.
     constexpr uint32_t max_stall_history_size = dev_msgs::launch_msg_buffer_num_entries;
 
-    // Evaluates a single candidate placement at `addr`, optionally pruning the inner region scan
-    // by a `scan_begin` cursor (used in the bottom-up walk to avoid re-scanning regions that
-    // ended at or before previous placements). Updates best_addr/best_cost/best_region_sync_idx
-    // and marked_for_deletion in place. Returns true when the cost reached zero so the caller
-    // can stop searching.
-    auto evaluate = [&](uint32_t addr, std::map<uint32_t, MemoryUsage>::const_iterator scan_begin) {
+    // Iterate over possible placements, including the very beginning of the ringbuffer and starting immediately after
+    // every region. One of these placements must be the best, since any other placement would be overlap the same or a
+    // smaller number of allocations by moving it forward to one of those positions.
+    // Then attempt to calculate the placement with the smallest total cost.
+    // TODO: sweepline algorithm, so the best postion can be calculated in linear time relative to the number of
+    // regions.
+    while (true) {
+        if (addr + size > ringbuffer_size_) {
+            break;
+        }
         float cost = 0;
         std::optional<uint32_t> region_sync_idx;
         bool now_in_use = false;
-        for (auto it = scan_begin; it != regions_.end(); ++it) {
+        // outer_it must be the first region that could possibly overlap [addr, addr + size), since in the last
+        // iteration we selected addr as the first address after the old version of outer_it.
+        for (auto it = outer_it; it != regions_.end(); ++it) {
             auto region = *it;
             if (region.first >= addr + size) {
                 break;
@@ -72,92 +77,36 @@ std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator
                 region_sync_idx = merge_syncs(region_sync_idx, region.second.trace_idx);
             }
         }
-        if (now_in_use) {
-            return false;
-        }
-        if (region_sync_idx.has_value()) {
-            // Avoid evicting something that was last used recently, as that can cause a stall that is very bad for
-            // performance. This is critical for avoiding gaps between ops, so it's given a very high cost (the
-            // highest cost for a program is normally around 10,000).
-            constexpr uint32_t desired_write_ahead = std::min(dev_msgs::launch_msg_buffer_num_entries, 7u);
-            constexpr float stall_badness = 100000000;
-            static_assert(
-                max_stall_history_size > desired_write_ahead,
-                "max_history_size must be greater than desired_write_ahead");
-            int region_idx_diff = trace_idx - *region_sync_idx;
-            if (region_idx_diff < desired_write_ahead) {
-                // Stall badness is exponential.
-                cost += stall_badness * (1 << (desired_write_ahead - region_idx_diff));
-            }
-        }
-        if (cost < best_cost) {
-            best_cost = cost;
-            best_addr = addr;
-            best_region_sync_idx = region_sync_idx;
-        }
-        return cost == 0;
-    };
-
-    // Iterate over possible placements. One of these placements must be the best, since any other
-    // placement would overlap the same or a larger number of allocations by moving it to one of
-    // these slots. TODO: sweepline algorithm, so the best position can be calculated in linear
-    // time relative to the number of regions.
-    if (top_down) {
-        auto first_top_down_scan_begin = [&](const std::map<uint32_t, MemoryUsage>::const_reverse_iterator& reverse_begin,
-                                             std::map<uint32_t, MemoryUsage>::const_iterator default_begin,
-                                             uint32_t addr) {
-            auto scan_begin = default_begin;
-            for (auto scan = reverse_begin; scan != regions_.crend(); ++scan) {
-                if (scan->first + scan->second.size <= addr) {
-                    break;
-                }
-                scan_begin = std::prev(scan.base());
-            }
-            return scan_begin;
-        };
-
-        // Top-down walk: try the slot ending exactly at ringbuffer_size_, then the slots ending
-        // just before each existing region, in descending order of address.
-        uint32_t top_addr = ringbuffer_size_ - size;
-        bool stop = evaluate(top_addr, first_top_down_scan_begin(regions_.crbegin(), regions_.cend(), top_addr));
-        if (!stop) {
-            for (auto rit = regions_.crbegin(); rit != regions_.crend(); ++rit) {
-                if (rit->first < size) {
-                    // Slot would extend below the start of the buffer.
-                    break;
-                }
-                uint32_t addr = rit->first - size;
-                if (addr == top_addr) {
-                    continue;
-                }
-                auto after_candidate = std::prev(rit.base());
-                auto scan_begin = first_top_down_scan_begin(std::next(rit), after_candidate, addr);
-                if (evaluate(addr, scan_begin)) {
-                    break;
+        if (!now_in_use) {
+            if (region_sync_idx.has_value()) {
+                // Avoid evicting something that was last used recently, as that can cause a stall that is very bad for
+                // performance. This is critical for avoiding gaps between ops, so it's given a very high cost (the
+                // highest cost for a program is normally around 10,000).
+                constexpr uint32_t desired_write_ahead = std::min(dev_msgs::launch_msg_buffer_num_entries, 7u);
+                constexpr float stall_badness = 100000000;
+                static_assert(
+                    max_stall_history_size > desired_write_ahead,
+                    "max_history_size must be greater than desired_write_ahead");
+                int region_idx_diff = trace_idx - *region_sync_idx;
+                if (region_idx_diff < desired_write_ahead) {
+                    // Stall badness is exponential.
+                    cost += stall_badness * (1 << (desired_write_ahead - region_idx_diff));
                 }
             }
-        }
-    } else {
-        // Bottom-up walk: try the very beginning of the ringbuffer and the slots starting
-        // immediately after each existing region.
-        uint32_t addr = 0;
-        auto outer_it = regions_.begin();
-        while (true) {
-            if (addr + size > ringbuffer_size_) {
+            if (cost < best_cost) {
+                best_cost = cost;
+                best_addr = addr;
+                best_region_sync_idx = region_sync_idx;
+            }
+            if (cost == 0) {
                 break;
             }
-            // outer_it must be the first region that could possibly overlap [addr, addr + size),
-            // since in the last iteration we selected addr as the first address after the old
-            // version of outer_it.
-            if (evaluate(addr, outer_it)) {
-                break;
-            }
-            if (outer_it == regions_.end()) {
-                break;
-            }
-            addr = outer_it->first + outer_it->second.size;
-            outer_it++;
         }
+        if (outer_it == regions_.end()) {
+            break;
+        }
+        addr = outer_it->first + outer_it->second.size;
+        outer_it++;
     }
 
     for (const auto& addr : marked_for_deletion) {
@@ -259,10 +208,7 @@ void SimpleTraceAllocator::allocate_trace_programs_on_subdevice(
             auto& allocator = region_allocators_[index];
 
             uint64_t pid = node.program->get_id();
-            // Non-binary entries are never reused, so place them top-down to leave the bottom of
-            // the ringbuffer free for cached binaries.
-            auto [rta_sync_idx, rta_addr] =
-                allocator.allocate_region(non_binary_size, i, ExtraData::kNonBinary, pid, /*top_down=*/true);
+            auto [rta_sync_idx, rta_addr] = allocator.allocate_region(non_binary_size, i, ExtraData::kNonBinary, pid);
 
             nonbinary_sync_idx = merge_syncs(nonbinary_sync_idx, rta_sync_idx);
 
@@ -277,18 +223,14 @@ void SimpleTraceAllocator::allocate_trace_programs_on_subdevice(
                     allocator.update_region_trace_idx(*mem_addr, i);
                 } else {
                     all_binaries_cached = false;
-                    // If this binary won't be used again later in the trace, treat it as
-                    // short-lived and pack it top-down. Otherwise allocate bottom-up so it can
-                    // remain cached for future invocations of the same program.
-                    bool binary_top_down = !extra_data_[i].next_use_idx[ExtraData::kBinary].has_value();
-                    auto res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid, binary_top_down);
+                    auto res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid);
                     if (!res.second.has_value()) {
                         // Clear the allocator and try again. Should succeed unless the total size
                         // of the program is larger than the config buffer.
                         allocator.reset_allocator();
-                        std::tie(rta_sync_idx, rta_addr) = allocator.allocate_region(
-                            non_binary_size, i, ExtraData::kNonBinary, pid, /*top_down=*/true);
-                        res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid, binary_top_down);
+                        std::tie(rta_sync_idx, rta_addr) =
+                            allocator.allocate_region(non_binary_size, i, ExtraData::kNonBinary, pid);
+                        res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid);
                         TT_ASSERT(res.second.has_value(), "Failed to allocate binary region");
                         TT_ASSERT(
                             !subdevice_launch_window.empty(),

--- a/tt_metal/impl/dispatch/simple_trace_allocator.hpp
+++ b/tt_metal/impl/dispatch/simple_trace_allocator.hpp
@@ -78,13 +78,9 @@ private:
         RegionAllocator(uint32_t ringbuffer_size, std::vector<ExtraData>& extra_data) :
             ringbuffer_size_(ringbuffer_size), extra_data_(extra_data) {}
 
-        // Returns sync_idx and address. When `top_down` is true the candidate placements are
-        // walked from the top of the ringbuffer downward (one slot ending at the top, plus one
-        // slot ending just before each existing region). This is intended for short-lived data
-        // (non-binary entries and binaries that won't be reused later in the trace) so that
-        // long-lived cached binaries can stay packed at the bottom of the buffer.
+        // Returns sync_idx and address.
         std::pair<std::optional<uint32_t>, std::optional<uint32_t>> allocate_region(
-            uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id, bool top_down = false);
+            uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id);
 
         void add_region(uint32_t data_type, uint64_t program_id, uint32_t addr) {
             program_ids_memory_map_[data_type][program_id] = addr;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -387,7 +387,7 @@ void kernel_main() {
 
     const uint32_t indices_base = get_read_ptr(indices_tensor_cb_id);
     const uint32_t scores_base = get_read_ptr(scores_tensor_cb_id);
-    const uint32_t expert_activation_base = get_write_ptr(expert_activation_cb_id);
+    const uint32_t expert_activation_base = get_read_ptr(expert_activation_cb_id);
 
     // Cache source_device_mapping - only changes every tokens_per_device tokens
     // Reduces mapping loads from 512 to 16 (dispatch_devices)
@@ -590,7 +590,7 @@ void kernel_main() {
                 // Pull this core's expert_activation buffer rows
                 if (remote_activated_count > 0) {
                     // Source: remote core's expert_activation buffer, rows start at 0
-                    uint32_t remote_activation_addr = get_write_ptr(expert_activation_cb_id);
+                    uint32_t remote_activation_addr = get_read_ptr(expert_activation_cb_id);
                     uint64_t remote_activation_noc_addr =
                         get_noc_addr(remote_noc_x, remote_noc_y, remote_activation_addr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -625,8 +625,8 @@ MoEGPTMeshWorkloadFactory::create_at(
         const auto tilize_mapping_data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_mapping.dtype());
         const auto tilize_output_data_format = tt::tt_metal::datatype_to_dataformat_converter(sparse_buffer.dtype());
 
-        // tiles_per_local_chunk for the drain core (used for CB sizing)
-        uint32_t shared_cb_num_pages = max_tiles_per_local_chunk;
+        // tiles_per_global_chunk: drain core gathers from all tilize cores before multicast
+        uint32_t shared_cb_num_pages = hidden_size / TILE_WIDTH;
 
         tt::tt_metal::create_cb(
             per_expert_total_tokens_cb_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -688,7 +688,7 @@ MoEGPTMeshWorkloadFactory::create_at(
             program,
             tilize_core_range_set,
             tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment),
-            tokens,
+            tokens + 1,
             tt::DataFormat::UInt32);
 
         tt::tt_metal::create_cb(


### PR DESCRIPTION
## Summary
Four CB overflow bugs in the moe_gpt tilize kernels, causing flaky device hangs (~20-29% CI failure rate) and `selective_reduce_combine` assertion failures. Plus test cleanup to prevent fabric state pollution between test phases.

Fixes: #44080

## Changes

### Kernel fixes (commits 1-4)

1. **`moe_gpt_program_factory.cpp:691`**: `tokens` → `tokens + 1` for `expert_activation` CB allocation
   - Sentinel row written after consolidation needs one extra page. Overflow = 1 × 48 bytes.

2. **`tilize_reader.cpp:390`**: `get_write_ptr` → `get_read_ptr` for local `expert_activation_base`
   - After `cb_push_back(tokens)`, `get_write_ptr` returns CB base + tokens×page_size, putting all activation writes past the CB boundary. This was the **6192-byte overflow** seen in CI logs.

3. **`tilize_reader.cpp:594`**: `get_write_ptr` → `get_read_ptr` for remote `expert_activation` address in drain core consolidation
   - Drain core reads non-drain's activations via NOC — must match where non-drain wrote them (CB base after fix #2). Mismatch caused `selective_reduce_combine` to hang.

4. **`moe_gpt_program_factory.cpp:629`**: `shared_cb_num_pages = max_tiles_per_local_chunk` → `hidden_size / TILE_WIDTH` (45 → 90)
   - Drain core gathers `tiles_per_global_chunk=90` tiles from all tilize cores before multicasting, but CB was sized for 45. Read pointer desync caused overflow on the 4th chunk (8192 bytes).

### Test cleanup (commits 5-6)

5. **`test_modules.py`**: Proper cleanup to prevent fabric state pollution between test phases:
   - Fused experts: deallocate all 8 `fused_config` tensors + `synchronize_device` in `finally` block (was `pass`)
   - `synchronize_device` barrier between fused and non-fused test phases in `test_decoder`
   - No retries, no skipped assertions — failures are honest

## Root cause
`get_write_ptr` vs `get_read_ptr` semantics after `cb_push_back`: after pushing N pages, `get_write_ptr` advances past the pushed data while `get_read_ptr` stays at the base where the data was written. Using `get_write_ptr` to access pushed data is incorrect and causes all subsequent writes to overflow the CB.

## Test plan
- [x] `test_moe_gpt_e2e.py` (full suite) passes with `TT_METAL_WATCHER=60` on 4x8 Galaxy (GWH02)
- [x] `test_gpt_oss_demo[batch128]` passes on 4x8 Galaxy, 128 users coherent output
- [x] Galaxy CI 3/3 pass (clean version, no hacks):
  - [Run 1](https://github.com/tenstorrent/tt-metal/actions/runs/25905633621) — g04glx01 ✅
  - [Run 2](https://github.com/tenstorrent/tt-metal/actions/runs/25905636337) — g14glx03 ✅
  - [Run 3](https://github.com/tenstorrent/tt-metal/actions/runs/25905639345) — g14glx03 ✅

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-moe-gpt-tilize-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-moe-gpt-tilize-cb-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/fix-moe-gpt-tilize-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/fix-moe-gpt-tilize-cb-overflow)