### PR TITLE
Draft: Binary ops local L1 allocator support via sub_device_id

### DIFF
--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -22,7 +22,18 @@ class TensorSpec;
 // Allocates a tensor on host.
 // Uses `mesh_device` to allocate sufficient number of host buffers for each multi-device shard.
 Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);
-Tensor create_device_tensor(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device, std::optional<TensorTopology> tensor_topology = std::nullopt);
+Tensor create_device_tensor(
+    const TensorSpec& tensor_spec,
+    distributed::MeshDevice* mesh_device,
+    std::optional<TensorTopology> tensor_topology = std::nullopt);
+
+// Overload with sub_device_id for local L1 allocator support.
+// See tech_reports/SubDevices/SubDevices.md Section 1.2
+Tensor create_device_tensor(
+    const TensorSpec& tensor_spec,
+    distributed::MeshDevice* mesh_device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    std::optional<TensorTopology> tensor_topology = std::nullopt);
 
 tt::tt_metal::Tensor to_device(
     const tt::tt_metal::Tensor& input_tensor,

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -44,7 +44,9 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
 }
 
 Tensor create_device_tensor(
-    const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device, std::optional<TensorTopology> tensor_topology) {
+    const TensorSpec& tensor_spec,
+    distributed::MeshDevice* mesh_device,
+    std::optional<TensorTopology> tensor_topology) {
     GraphTracker::instance().track_function_start(
         "tt::tt_metal::create_device_tensor",
         tensor_spec.logical_shape(),
@@ -83,6 +85,19 @@ Tensor create_device_tensor(
 
     return output;
 }
+
+Tensor create_device_tensor(
+    const TensorSpec& tensor_spec,
+    distributed::MeshDevice* mesh_device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    std::optional<TensorTopology> tensor_topology) {
+    // TODO: Plumb sub_device_id through MeshTensor::allocate_on_device
+    // to use local L1 allocators instead of the global allocator.
+    // For now, delegate to the standard create_device_tensor.
+    // See tech_reports/SubDevices/SubDevices.md Section 1.2
+    return create_device_tensor(tensor_spec, mesh_device, tensor_topology);
+}
+
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
@@ -463,5 +478,17 @@ Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
 }
 
 std::string to_string(const Tensor& tensor) { return tensor_impl::to_string(tensor); }
+
+Tensor create_device_tensor(
+    const TensorSpec& tensor_spec,
+    distributed::MeshDevice* mesh_device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    std::optional<TensorTopology> tensor_topology) {
+    // TODO: Plumb sub_device_id through MeshTensor::allocate_on_device
+    // to use local L1 allocators instead of the global allocator.
+    // For now, delegate to the standard create_device_tensor.
+    // See tech_reports/SubDevices/SubDevices.md Section 1.2
+    return create_device_tensor(tensor_spec, mesh_device, tensor_topology);
+}
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -464,8 +464,14 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
         return output_tensor.value();
     }
 
-    return create_device_tensor(
-        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
+    auto* device = tensor_args.input_tensor_a.device();
+    if (operation_attributes.sub_device_id.has_value()) {
+        return create_device_tensor(
+            compute_output_specs(operation_attributes, tensor_args),
+            device,
+            operation_attributes.sub_device_id.value());
+    }
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), device);
 }
 
 ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(


### PR DESCRIPTION
## Summary

Follow-up to #44067 (sub_device_id parameter for binary ops). Addresses feedback from @fbajraktariTT about local L1 allocator usage.

Currently, binary ops resolve `sub_device_id` to a `CoreRangeSet` for core selection but allocate output buffers on the **global** L1 allocator. This PR adds the plumbing to allocate on **local** L1 allocators when `sub_device_id` is specified.

Reference: [SubDevices tech report Section 1.2](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/SubDevices/SubDevices.md#12-allocators)

## Changes

- Add `create_device_tensor` overload accepting `SubDeviceId`
- Binary ops `create_output_tensors` passes `sub_device_id` to the new overload
- TODO: plumb `sub_device_id` through `MeshTensor::allocate_on_device` to actually use local allocators

## Status

Draft — the new `create_device_tensor` overload currently delegates to the standard path. Full local allocator integration requires deeper plumbing through the MeshBuffer/MeshTensor allocation stack.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/binary-subdevice-local-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/binary-subdevice-local-allocator)