### PR TITLE
[skip ci] Remove Llama-3.3-70B-Instruct hostsample from vllm nightly tests

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -222,23 +222,6 @@ jobs:
               "co-owner-2-id": "U08CEGF78ET"
             },
             {
-              "name": "[WH-GLX] Llama-3.3-70B-Instruct hostsample (prefix caching)",
-              "model": "meta-llama/Llama-3.3-70B-Instruct",
-              "server-timeout": 35,
-              "benchmark-timeout": 10,
-              "runner-label": "topology-6u",
-              "arch": "arch-wormhole_b0",
-              "mesh-device": "TG",
-              "tt-llama-text-ver": "llama3_70b_galaxy",
-              "override-tt-config": "{\"dispatch_core_axis\": \"col\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 216580672}",
-              "additional-server-args": "--data_parallel_size 4 --max_num_seqs 8 --async-scheduling",
-              "additional-benchmark-args": "--random-prefix-len 256",
-              "structured-output": true,
-              "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08CEGF78ET"
-            },
-            {
               "name": "[WH-GLX] Qwen3-32B device with sampling-tests",
               "model": "Qwen/Qwen3-32B",
               "server-timeout": 35,


### PR DESCRIPTION
## Summary
Removes the `[WH-GLX] Llama-3.3-70B-Instruct hostsample (prefix caching)` entry from the vLLM nightly test matrix.

**Motivation:** The hostsample job is no longer necessary for the following reasons:

1. **CI resource savings** — Eliminating this job reduces WH Galaxy CI resource consumption in the nightly pipeline.
2. **Coverage already provided** — On-device sampling is now in place with some tests that include fallback to host sampling paths, meaning host sampling behavior remains implicitly exercised without requiring a dedicated hostsample job. Caution: it does not exhaust all code paths for hostsampling.

## Linked Issue
#43908 — [vLLM nightly] Audit queue / runtime and identify optimization opportunities

## Test plan
- [ ] Verify vllm nightly workflow no longer includes the hostsample job

🤖 Generated with [Claude Code](https://claude.com/claude-code)