### PR TITLE
Cleanup of UNPACR Uint8 data format encoding on WH

### DIFF
--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -129,6 +129,10 @@ std::vector<DataFormat> get_unpack_src_formats(std::span<const DataFormat> data_
 
 DataFormat get_single_unpack_dst_format(
     const DataFormat src_format, const DataFormat /*pack_format*/, const DataFormat unpack_conditional_dst_format) {
+    // NOTE: DataFormat::UInt8 is intentionally not remapped to Int8 here. The unpacker's 4-bit
+    // OutDataFormat register field has no UInt8 encoding; the LLK applies masked_data_format()
+    // at the register-write site so UInt8 (=30) lands as INT8 (=14) in the bitfield. We preserve
+    // UInt8 in the dst format because downstream LLK paths (e.g. math-MOP selection) key off the original dtype value.
     DataFormat dst_format = src_format;
     if (src_format == DataFormat::Float32) {
         TT_FATAL(

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -800,7 +800,9 @@ inline void configure_unpack_AB(
     {
         tile_descriptor.val[i] = 0;
     }
-    tile_descriptor.f.in_data_format = unpA_src_format;
+    // in_data_format is a 4-bit bitfield. masked_data_format() drops the high bits so e.g. UInt8 (=30)
+    // becomes INT8 (=14) at the register. Signedness lives separately in ALU_FORMAT_SPEC_REG0_SrcA/BUnsigned.
+    tile_descriptor.f.in_data_format = masked_data_format(unpA_src_format);
     tile_descriptor.f.uncompressed   = 1; // Input tile is uncompressed
     tile_descriptor.f.x_dim          = 0; // Not used for unpA as value is overridden by per context x_dim set below. Used for unpB
     tile_descriptor.f.y_dim          = 1;
@@ -811,7 +813,7 @@ inline void configure_unpack_AB(
     {
         cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32 + i] = tile_descriptor.val[i];
     }
-    tile_descriptor.f.in_data_format = row_pool ? to_underlying(DataFormat::Float32) : unpB_src_format;
+    tile_descriptor.f.in_data_format = row_pool ? to_underlying(DataFormat::Float32) : masked_data_format(unpB_src_format);
     tile_descriptor.f.x_dim          = unpB_face_r_dim * FACE_C_DIM;
     tile_descriptor.f.z_dim          = unpB_num_faces;
     for (std::uint32_t i = 0; i < TILE_DESC_SIZE; i++)
@@ -825,7 +827,7 @@ inline void configure_unpack_AB(
     {
         config.val[i] = 0;
     }
-    config.f.out_data_format = unpA_dst_format;
+    config.f.out_data_format = masked_data_format(unpA_dst_format);
     config.f.throttle_mode   = 2;
     config.f.context_count   = 0;
     config.f.haloize_mode    = transpose_xy_srca_en ? 1 : 0;
@@ -841,7 +843,7 @@ inline void configure_unpack_AB(
         cfg[THCON_SEC0_REG2_Out_data_format_ADDR32 + i] = config.val[i];
     }
 
-    config.f.out_data_format = row_pool ? (to_underlying(DataFormat::Float16) | (exp_width << 2)) : unpB_dst_format;
+    config.f.out_data_format = row_pool ? (to_underlying(DataFormat::Float16) | (exp_width << 2)) : masked_data_format(unpB_dst_format);
     config.f.haloize_mode    = 0;
 
     for (std::uint32_t i = 0; i < CONFIG_SIZE; i++)


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Closes [#37796 ](https://github.com/tenstorrent/tt-metal/issues/37796)
Replaces the implicit data format bitfield truncation with explicit `masked_data_format(value)` calls at the four register-write sites in `configure_unpack_AB`. The cleanup just makes the 4-bit truncation explicit. There should be no functional impact.

### Notes for reviewers
The unpacker's 4-bit `InDataFormat` / `OutDataFormat` register fields have no encoding for `DataFormat::UInt8 = 30 = 0b11110`, in result JIT/LLK need to lower Uint8 into an Int8 with ALU_FORMAT_SPEC_REG0_SrcA/BUnsigned enabled. Before, looking at the JIT get_single_unpack_dst_format() function alone, there was an impression that the lowering is not taking place.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/uint8_fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/uint8_fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/uint8_fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/uint8_fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/uint8_fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/uint8_fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/uint8_fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/uint8_fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/uint8_fmt)