### PR TITLE
[LLK] Enforce single-ADDR32 invariant for combined-mask packer RMW writes (BH)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -379,11 +379,15 @@ inline void reconfigure_exp_threshold(const std::uint32_t pack_dst_format)
         }
     }
 
+    static_assert(
+        THCON_SEC0_REG1_Exp_threshold_en_ADDR32 == THCON_SEC0_REG1_Exp_threshold_ADDR32,
+        "THCON_SEC0_REG1_Exp_threshold_en and Exp_threshold must share ADDR32 for combined RMW");
+
     constexpr std::uint32_t THRESHOLD_RMW_MASK = THCON_SEC0_REG1_Exp_threshold_en_MASK | THCON_SEC0_REG1_Exp_threshold_MASK;
 
     std::uint32_t threshold_rmw_data = (threshold << THCON_SEC0_REG1_Exp_threshold_SHAMT) | (enable << THCON_SEC0_REG1_Exp_threshold_en_SHAMT);
 
-    cfg_reg_rmw_tensix<THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 3, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG1_Exp_threshold_ADDR32, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
 }
 
 template <bool is_fp32_dest_acc_en>
@@ -539,6 +543,12 @@ inline void reconfig_packer_data_format(
     {
         dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Round_10b_mant = 1;
     }
+    static_assert(
+        PCK_DEST_RD_CTRL_Read_32b_data_ADDR32 == PCK_DEST_RD_CTRL_Read_unsigned_ADDR32,
+        "PCK_DEST_RD_CTRL_Read_32b_data and Read_unsigned must share ADDR32 for combined RMW");
+    static_assert(
+        PCK_DEST_RD_CTRL_Read_32b_data_ADDR32 == PCK_DEST_RD_CTRL_Round_10b_mant_ADDR32,
+        "PCK_DEST_RD_CTRL_Read_32b_data and Round_10b_mant must share ADDR32 for combined RMW");
     cfg_reg_rmw_tensix<
         PCK_DEST_RD_CTRL_Read_32b_data_ADDR32,
         PCK_DEST_RD_CTRL_Read_32b_data_SHAMT,
@@ -598,6 +608,8 @@ inline void configure_pack(
     relu_config_u hw_relu_config;
     hw_relu_config.r.STACC_RELU_ApplyRelu     = relu_config & 0xffff;
     hw_relu_config.r.STACC_RELU_ReluThreshold = (relu_config >> 16) & 0xffff;
+
+    static_assert(STACC_RELU_ApplyRelu_ADDR32 == STACC_RELU_ReluThreshold_ADDR32, "STACC_RELU_ApplyRelu and ReluThreshold must share ADDR32 for combined RMW");
 
     constexpr std::uint32_t hw_relu_mask = STACC_RELU_ApplyRelu_MASK | STACC_RELU_ReluThreshold_MASK;
     cfg_reg_rmw_tensix<STACC_RELU_ApplyRelu_ADDR32, 0, hw_relu_mask>(hw_relu_config.val[0]);


### PR DESCRIPTION
### Summary

`cfg_reg_rmw_tensix` performs a read-modify-write on a **single** config register named by its template `ADDR32`. On Wormhole, several packer fields that needed to be updated together happened to live in the same register, so the LLK code combined two fields into one call with an OR'd mask — one trip to the config bus instead of two:

```cpp
cfg_reg_rmw_tensix<Pack_L1_Acc_ADDR32, Pack_L1_Acc_SHAMT,
                   Disable_pack_zero_flags_MASK | Pack_L1_Acc_MASK>(value);
```

On Blackhole those two fields moved to **different** registers (`Disable_pack_zero_flags` is in `ADDR32=70`, `Pack_L1_Acc` is in `ADDR32=71`). The combined call only writes the register named in the template parameter, so the other field's update is silently dropped. tt-llk#1342 already fixed the one site the issue named (`reconfigure_packer_l1_acc`) by splitting it into two single-field calls.

This PR closes out the rest of what tt-llk#239 asked for: *"all such instances should be looked at and fixed"* and *"cfg_defines.h files should be used as they are generated from RTL as ground truth."*

What changed:

- Audited every remaining combined-mask `cfg_reg_rmw_tensix` call site in the Blackhole packer/unpacker against `cfg_defines.h`. All currently keep their OR'd fields in one `ADDR32`. No silently-broken sites remain.
- Audited every packer bit-field helper struct (`pack_config_t`, `relu_config_t`, `dest_rd_ctrl_t`, `pck_edge_offset_t`, `pack_counters_t`) against the RTL-generated `cfg_defines.h`. All bit positions match.
- Added `static_assert`s next to each remaining combined-mask call in `cpack_common.h` so future copy-pastes from Wormhole that violate the invariant fail to **compile** instead of silently dropping bits at runtime.
- Replaced a magic `THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 3` offset with the directly-named `THCON_SEC0_REG1_Exp_threshold_ADDR32` from `cfg_defines.h`.

No runtime behavior change.

Closes https://github.com/tenstorrent/tt-llk/issues/239

### Notes for reviewers

- All edits are confined to `tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h`.
- Audit results (each row is one combined-mask call site; verified against `tt_metal/hw/inc/internal/tt-1xx/blackhole/cfg_defines.h`):

  | Call site | OR'd fields | Shared ADDR32 |
  |---|---|---|
  | `reconfigure_exp_threshold` | `Exp_threshold_en`, `Exp_threshold` | 71 |
  | `reconfig_packer_data_format` | `Read_32b_data`, `Read_unsigned`, `Round_10b_mant` | 18 |
  | `configure_pack` | `STACC_RELU_ApplyRelu`, `ReluThreshold` | 2 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/fix-combined-mask-rmw-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/fix-combined-mask-rmw-blackhole)