### PR TITLE
fix(sdpa): restore wan ring SDPA perf after #43985

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -85,7 +85,12 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
     llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize, tilize>(&llk_pack_params, face_r_dim, num_faces);
 }
 
-template <bool untilize = false, bool zero_output = false, bool tilize = false, bool skip_addrmod_config = false>
+template <
+    bool untilize = false,
+    bool zero_output = false,
+    bool tilize = false,
+    bool skip_addrmod_config = false,
+    bool skip_packer_strides = false>
 inline void llk_pack_init(
     const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1, const std::uint32_t input_operand = 0) {
     // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile
@@ -103,7 +108,7 @@ inline void llk_pack_init(
     // 8-bit datums (Int8, UInt8, Fp8_e4m3, Lf8) do not require the tilize workaround on Blackhole.
     const std::uint32_t src_format = static_cast<std::uint32_t>(unpack_src_format[input_operand]);
     const bool is_input_8bit_format = IS_8BIT_FORMAT(src_format);
-    _llk_pack_init_<untilize, zero_output, tilize, skip_addrmod_config>(
+    _llk_pack_init_<untilize, zero_output, tilize, skip_addrmod_config, skip_packer_strides>(
         pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles, is_input_8bit_format);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -90,7 +90,8 @@ template <
     bool untilize = false,
     bool zero_output = false,
     bool tilize = false /*unused*/,
-    bool skip_addrmod_config = false>
+    bool skip_addrmod_config = false,
+    bool skip_packer_strides = false>
 inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1) {
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -103,7 +104,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
             pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
     }
 
-    _llk_pack_init_<untilize, zero_output, tilize, skip_addrmod_config>(
+    _llk_pack_init_<untilize, zero_output, tilize, skip_addrmod_config, skip_packer_strides>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -365,7 +365,7 @@ inline void _llk_pack_init_(
 }
 
 // TODO NC: Clean up as the part of tt-metal#34587
-template <bool untilize = false, bool zero_output = false, bool tilize = false, bool skip_addrmod_config = false>
+template <bool untilize = false, bool zero_output = false, bool tilize = false, bool skip_addrmod_config = false, bool skip_packer_strides = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_src_format,
     const std::uint32_t face_r_dim,
@@ -394,7 +394,10 @@ inline void _llk_pack_init_(
             _llk_pack_configure_addrmod_<untilize, false /* tilize */>();
         }
         _llk_pack_mop_config_<untilize, zero_output, false /* tilize */>(face_r_dim, tile_c_dim, num_faces, num_tiles);
-        set_packer_strides<untilize, false /* tilize */>(pack_src_format, tile_c_dim);
+        if constexpr (!skip_packer_strides)
+        {
+            set_packer_strides<untilize, false /* tilize */>(pack_src_format, tile_c_dim);
+        }
     }
     else
     {
@@ -403,7 +406,10 @@ inline void _llk_pack_init_(
             _llk_pack_configure_addrmod_<untilize, tilize>();
         }
         _llk_pack_mop_config_<untilize, zero_output, tilize>(face_r_dim, tile_c_dim, num_faces, num_tiles);
-        set_packer_strides<untilize, tilize>(pack_src_format, tile_c_dim);
+        if constexpr (!skip_packer_strides)
+        {
+            set_packer_strides<untilize, tilize>(pack_src_format, tile_c_dim);
+        }
     }
 
     TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -235,7 +235,7 @@ inline void _llk_pack_hw_configure_(
 }
 
 // TODO NC: Clean up as the part of tt-metal#34587
-template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/, bool skip_addrmod_config = false>
+template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/, bool skip_addrmod_config = false, bool skip_packer_strides = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim = FACE_R_DIM,
@@ -251,7 +251,10 @@ inline void _llk_pack_init_(
     }
     _llk_pack_mop_config_<untilize, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
 
-    set_packer_l1_offset(pack_dst_format, face_r_dim);
+    if constexpr (!skip_packer_strides)
+    {
+        set_packer_l1_offset(pack_dst_format, face_r_dim);
+    }
     const std::uint32_t face_dim   = face_r_dim * FACE_C_DIM;
     const std::uint32_t pack_x_dim = (narrow_tile || !untilize) ? face_dim : FACE_R_DIM;
     TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -81,11 +81,16 @@ constexpr uint32_t MIN_BLOCKED_PACK_TILES = 8;
 ALWI bool should_use_blocked_pack_width(uint32_t pack_width) { return pack_width >= MIN_BLOCKED_PACK_TILES; }
 
 ALWI void configure_pack_width(uint32_t cb, uint32_t pack_width) {
+    // Pure MOP refresh: addrmod and packer strides are already configured from
+    // the initial pack init, and changing pack_width only requires re-issuing
+    // the MOP. Skipping the packer-strides reconfig saves a THCON stall per
+    // call on the SDPA streaming hot path.
     PACK((llk_pack_init<
           false /* untilize */,
           false /* zero_output */,
           false /* tilize */,
-          true /* skip_addrmod_config */>(cb, pack_width)));
+          true /* skip_addrmod_config */,
+          true /* skip_packer_strides */>(cb, pack_width)));
 }
 
 ALWI void configure_single_tile_pack(uint32_t cb) { configure_pack_width(cb, 1); }


### PR DESCRIPTION
## Summary

PR #43985 regressed wan ring SDPA on Blackhole because `configure_pack_width` (hot-path MOP refresh) was rewritten to call `llk_pack_init`, which always re-programs the packer stride registers — a THCON drain + two config-register writes per call. The strides depend on format and tile geometry, not on `num_tiles`, so re-programming them on every change of MOP block size is redundant.

This adds a `skip_packer_strides` template param to `llk_pack_init` / `_llk_pack_init_` (symmetric with the existing `skip_addrmod_config`) and opts into it in `configure_pack_width`. Default is `false` for every other caller — no behavior change anywhere else.

ring SDPA `wan2_2_1xGLX-q288-k512-ring4` (BH 2xP300):

| | duration | math util |
|---|---|---|
| pre-#43985 (`cc5c31a991a`) | 7.86 ms | 68.8% |
| broken (`d59351bff64`)     | 7.96 ms | 67.9%  ❌ |
| **this PR**                | **7.87 ms** | **68.8%**  ✅ |

`mla_100k-q160-k320-ring4` unaffected (61.4% before/after). Accuracy unchanged (wan PCC 0.9997).

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25792551550)
- [x] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25792566971) (sdpa only)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25792553750)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25792555682)
- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25824675140) (ops perf tests only)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25792570754)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25792572470)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/runs/25792574028) (deepseek_prefill only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sdpa-pack-init-skip-strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-pack-init-skip-strides)