### PR TITLE
sdxl: retune clip_encoder_1 wormhole baseline to actual run average

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -140,7 +140,7 @@ DEVICE_PERF_EXPECTATIONS = {
         "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "clip_encoder_1": {
-        "wormhole": 40_995_000,  # Note: this is an average value of 30 test runs due to high variability
+        "wormhole": 40_479_595,  # Average of last 5 main CI runs (May 12-13, 2026); previous 40_995_000 was above observed range causing failures
         "blackhole": 19_377_824,
     },
     "clip_encoder_2": {


### PR DESCRIPTION
## Summary

The `clip_encoder_1` wormhole baseline at `models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py:143` is set to **40,995,000 ns**, but the actual measured kernel duration on main has been clustering around **40.5M ns**. With the ±1.5% margin, the lower threshold (40,380,075 ns) cuts through the middle of the natural noise distribution, so any run on the fast side fails — even though "faster than expected" is not a regression.

Two such failures were observed within 24h on unrelated SHAs, with no bisectable code change between them.

**Root cause of the speedup**: #43824 ("Fix unroll pragmas, warn on unknown pragma", merged May 8 23:35 UTC) corrected `#pragma unroll` → `#pragma GCC unroll N` in `pad_tile.hpp::fill_pad_face` and the fabric route-buffer shift loops, which were previously being silently ignored under `-Wno-unknown-pragmas`. This shaved ~0.4% off `clip_encoder_1` and pushed the population mean from 40,626,160 ns (n=9, pre-pragma, 0% fail rate) down to 40,467,702 ns (n=29, post-pragma, 24% fail rate below the lower bound). The follow-up #43996 retuned only `clip_encoder_2` Blackhole and missed the wormhole `clip_encoder_1` baseline — which is what this PR fixes.

## Data — last 5 main CI runs of `sdxl_clip_encoder_1` on N300 WH B0 (Set 1)

| Run ID | Date (UTC) | SHA | Kernel Duration | Samples/s | Status |
|---|---|---|---|---|---|
| [25786442090](https://github.com/tenstorrent/tt-metal/actions/runs/25786442090) | 2026-05-13 08:03 | `af933e8035c6` | **40,277,169 ns** | 24.83 | ❌ fail (below lower) |
| [25776096347](https://github.com/tenstorrent/tt-metal/actions/runs/25776096347) | 2026-05-13 03:17 | `adf9b0b56aa0` | 40,543,140 ns | 24.67 | ✅ pass |
| [25768278565](https://github.com/tenstorrent/tt-metal/actions/runs/25768278565) | 2026-05-12 23:28 | `67c740484dd0` | 40,646,927 ns | 24.60 | ✅ pass |
| [25760824094](https://github.com/tenstorrent/tt-metal/actions/runs/25760824094) | 2026-05-12 20:38 | `f8f3d4109fc8` | 40,437,141 ns | 24.73 | ✅ pass |
| [25751903331](https://github.com/tenstorrent/tt-metal/actions/runs/25751903331) | 2026-05-12 17:45 | `1f8a36eafb94` | 40,493,597 ns | 24.70 | ✅ pass |

- **Average: 40,479,594.8 ns (≈ 24.70 samples/s)**
- Min: 40,277,169 · Max: 40,646,927 · Spread: 369,758 ns (~0.91% of mean)

## Change

```diff
-        "wormhole": 40_995_000,  # Note: this is an average value of 30 test runs due to high variability
+        "wormhole": 40_479_595,  # Average of last 5 main CI runs (May 12-13, 2026); previous 40_995_000 was above observed range causing failures
```

With the new baseline and the existing ±1.5% margin, the allowed range becomes **39,872,401 – 41,086,789 ns**, which contains all 5 observed runs comfortably.

## Test plan
- [ ] Device-perf CI green on N300 WH B0 Set 1 (`test_sdxl_perf_device[test_sdxl_clip_encoder_1]`)
- [ ] Confirm new range no longer flakes on next scheduled run

## Notes
- The previous comment claimed the value was averaged over 30 runs, but it sits 1.27% above the current 5-run mean — likely calibrated on hardware/firmware that since shifted.
- The blackhole baseline (19,377,824 ns) is untouched.
