### PR TITLE
#42370 [Descriptor Migration] copy/typecast

### DIFF
--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <optional>
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "typecast_program_factory.hpp"

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
@@ -14,7 +14,7 @@ namespace ttnn::prim {
 
 using namespace tt::constants;
 
-TypecastProgramFactory::cached_program_t TypecastProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TypecastProgramFactory::create_descriptor(
     const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
@@ -24,7 +24,7 @@ TypecastProgramFactory::cached_program_t TypecastProgramFactory::create(
     const DataType& output_dtype = args.output_dtype;
     const bool is_row_major = input.layout() == Layout::ROW_MAJOR;
 
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     const tt::DataFormat cb_data_format_input = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t single_tile_size_input = tt::tile_size(cb_data_format_input);
@@ -46,41 +46,54 @@ TypecastProgramFactory::cached_program_t TypecastProgramFactory::create(
     const uint32_t output_page_size = is_row_major ? dst_buffer->page_size() : single_tile_size_output;
 
     const CoreCoord compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_items_per_core_group_1, num_items_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_pages, is_row_major);
+    (void)num_cores;
 
     constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;
     constexpr uint32_t num_input_pages = 2;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_pages * input_page_size, {{src0_cb_index, cb_data_format_input}})
-            .set_page_size(src0_cb_index, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_input_pages * input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format_input,
+            .page_size = input_page_size,
+        }}},
+    });
 
     constexpr uint32_t output_cb_index = tt::CBIndex::c_2;
     constexpr uint32_t num_output_pages = 2;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_pages * output_page_size, {{output_cb_index, cb_data_format_output}})
-            .set_page_size(output_cb_index, output_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_output_pages * output_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = cb_data_format_output,
+            .page_size = output_page_size,
+        }}},
+    });
 
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
     tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle typecast_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    tt::tt_metal::KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle typecast_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    tt::tt_metal::KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
 
     std::vector<uint32_t> compute_kernel_args_group_1 = {
         num_items_per_core_group_1,  // per_core_block_cnt
@@ -107,19 +120,22 @@ TypecastProgramFactory::cached_program_t TypecastProgramFactory::create(
 
     const char* const path = "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp";
 
-    tt::tt_metal::CreateKernel(
-        program,
-        path,
-        core_group_1,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-            .fp32_dest_acc_en = args.fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .bfp8_pack_precise = args.bfp8_pack_precise,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args_group_1,
-            .defines = unary_defines});
+    tt::tt_metal::KernelDescriptor compute_desc_group_1;
+    compute_desc_group_1.kernel_source = path;
+    compute_desc_group_1.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_group_1.core_ranges = core_group_1;
+    compute_desc_group_1.compile_time_args = compute_kernel_args_group_1;
+    for (const auto& [name, value] : unary_defines) {
+        compute_desc_group_1.defines.emplace_back(name, value);
+    }
+    compute_desc_group_1.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+        .fp32_dest_acc_en = args.fp32_dest_acc_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .bfp8_pack_precise = args.bfp8_pack_precise,
+        .math_approx_mode = math_approx_mode};
 
+    std::optional<tt::tt_metal::KernelDescriptor> compute_desc_group_2;
     if (!core_group_2.ranges().empty()) {
         std::vector<uint32_t> compute_kernel_args_group_2 = {
             num_items_per_core_group_2,  // per_core_block_cnt
@@ -127,18 +143,20 @@ TypecastProgramFactory::cached_program_t TypecastProgramFactory::create(
             src0_cb_index,
             output_cb_index};
 
-        tt::tt_metal::CreateKernel(
-            program,
-            path,
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-                .fp32_dest_acc_en = args.fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .bfp8_pack_precise = args.bfp8_pack_precise,
-                .math_approx_mode = math_approx_mode,
-                .compile_args = compute_kernel_args_group_2,
-                .defines = unary_defines});
+        compute_desc_group_2.emplace();
+        compute_desc_group_2->kernel_source = path;
+        compute_desc_group_2->source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_group_2->core_ranges = core_group_2;
+        compute_desc_group_2->compile_time_args = compute_kernel_args_group_2;
+        for (const auto& [name, value] : unary_defines) {
+            compute_desc_group_2->defines.emplace_back(name, value);
+        }
+        compute_desc_group_2->config = tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .fp32_dest_acc_en = args.fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .bfp8_pack_precise = args.bfp8_pack_precise,
+            .math_approx_mode = math_approx_mode};
     }
 
     // Convert CoreRangeSet to vector of cores in the correct order
@@ -156,51 +174,23 @@ TypecastProgramFactory::cached_program_t TypecastProgramFactory::create(
             TT_THROW("Core not in specified core ranges");
         }
 
-        tt::tt_metal::SetRuntimeArgs(
-            program, typecast_reader_kernel_id, core, {src_buffer->address(), num_items_per_core, num_items_written});
-
-        tt::tt_metal::SetRuntimeArgs(
-            program, typecast_writer_kernel_id, core, {dst_buffer->address(), num_items_per_core, num_items_written});
+        reader_desc.emplace_runtime_args(core, {src_buffer, num_items_per_core, num_items_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_items_per_core, num_items_written});
         num_items_written += num_items_per_core;
     }
 
-    return cached_program_t{
-        std::move(program), {typecast_reader_kernel_id, typecast_writer_kernel_id, num_cores, num_cores_y}};
-}
-
-void TypecastProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TypecastParams& /*operation_attributes*/,
-    const TypecastInputs& tensor_args,
-    Tensor& output) {
-    auto& typecast_reader_kernel_id = cached_program.shared_variables.typecast_reader_kernel_id;
-    auto& typecast_writer_kernel_id = cached_program.shared_variables.typecast_writer_kernel_id;
-    const uint32_t num_cores = cached_program.shared_variables.num_cores;
-    const uint32_t num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    auto& program = cached_program.program;
-
-    const auto& input = tensor_args.input;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, typecast_reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, typecast_writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_group_1));
+    if (compute_desc_group_2.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_group_2));
     }
+
+    return desc;
 }
 
 // For sub_core_grids
-TypecastSubgridProgramFactory::cached_program_t TypecastSubgridProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TypecastSubgridProgramFactory::create_descriptor(
     const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
@@ -212,7 +202,7 @@ TypecastSubgridProgramFactory::cached_program_t TypecastSubgridProgramFactory::c
 
     TT_FATAL(sub_core_grids.has_value(), "sub_core_grids cannot be null");
 
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
@@ -239,22 +229,29 @@ TypecastSubgridProgramFactory::cached_program_t TypecastSubgridProgramFactory::c
         all_cores = ttnn::CoreRangeSet(ttnn::CoreRange(cores[0]));
     }
 
-    std::vector<CoreCoord> cores_with_rtargs;
-
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     constexpr uint32_t num_input_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_2;
     constexpr uint32_t num_output_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * single_tile_size_output, {{output_cb_index, cb_data_format_output}})
-            .set_page_size(output_cb_index, single_tile_size_output);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_output_tiles * single_tile_size_output,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = cb_data_format_output,
+            .page_size = single_tile_size_output,
+        }}},
+    });
 
     auto* src_buffer = input.buffer();
     auto* dst_buffer = output.buffer();
@@ -264,17 +261,21 @@ TypecastSubgridProgramFactory::cached_program_t TypecastSubgridProgramFactory::c
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
     tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle typecast_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    tt::tt_metal::KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle typecast_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    tt::tt_metal::KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
 
     uint32_t ntiles_per_core = ntiles / ncores;
     std::vector<uint32_t> compute_kernel_args = {
@@ -302,66 +303,34 @@ TypecastSubgridProgramFactory::cached_program_t TypecastSubgridProgramFactory::c
 
     const auto* path = "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp";
 
-    tt::tt_metal::CreateKernel(
-        program,
-        path,
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-            .fp32_dest_acc_en = args.fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .bfp8_pack_precise = args.bfp8_pack_precise,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args,
-            .defines = unary_defines});
+    tt::tt_metal::KernelDescriptor compute_desc;
+    compute_desc.kernel_source = path;
+    compute_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = compute_kernel_args;
+    for (const auto& [name, value] : unary_defines) {
+        compute_desc.defines.emplace_back(name, value);
+    }
+    compute_desc.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+        .fp32_dest_acc_en = args.fp32_dest_acc_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .bfp8_pack_precise = args.bfp8_pack_precise,
+        .math_approx_mode = math_approx_mode};
 
     uint32_t tile_start_id = 0;
 
     for (auto core : cores) {
-        tt::tt_metal::SetRuntimeArgs(
-            program, typecast_reader_kernel_id, core, {src_buffer->address(), ntiles_per_core, tile_start_id});
-
-        tt::tt_metal::SetRuntimeArgs(
-            program, typecast_writer_kernel_id, core, {dst_buffer->address(), ntiles_per_core, tile_start_id});
-
-        cores_with_rtargs.push_back(core);
+        reader_desc.emplace_runtime_args(core, {src_buffer, ntiles_per_core, tile_start_id});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, ntiles_per_core, tile_start_id});
         tile_start_id += ntiles_per_core;
     }
 
-    return cached_program_t{
-        std::move(program), {typecast_reader_kernel_id, typecast_writer_kernel_id, cores_with_rtargs}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void TypecastSubgridProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TypecastParams& /*operation_attributes*/,
-    const TypecastInputs& tensor_args,
-    Tensor& output) {
-    auto& typecast_reader_kernel_id = cached_program.shared_variables.typecast_reader_kernel_id;
-    auto& typecast_writer_kernel_id = cached_program.shared_variables.typecast_writer_kernel_id;
-    auto& cores_with_rtargs = cached_program.shared_variables.cores_with_rtargs;
-
-    auto& program = cached_program.program;
-
-    const auto& input = tensor_args.input;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, typecast_reader_kernel_id);
-        for (const CoreCoord& core : cores_with_rtargs) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-    }
-
-    {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, typecast_writer_kernel_id);
-        for (const CoreCoord& core : cores_with_rtargs) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
@@ -229,7 +229,7 @@ tt::tt_metal::ProgramDescriptor TypecastSubgridProgramFactory::create_descriptor
         all_cores = ttnn::CoreRangeSet(ttnn::CoreRange(cores[0]));
     }
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint8_t src0_cb_index = tt::CBIndex::c_0;
     constexpr uint32_t num_input_tiles = 2;
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
         .total_size = num_input_tiles * single_tile_size,
@@ -241,7 +241,7 @@ tt::tt_metal::ProgramDescriptor TypecastSubgridProgramFactory::create_descriptor
         }}},
     });
 
-    uint32_t output_cb_index = tt::CBIndex::c_2;
+    const uint8_t output_cb_index = tt::CBIndex::c_2;
     constexpr uint32_t num_output_tiles = 2;
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
         .total_size = num_output_tiles * single_tile_size_output,

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
@@ -50,7 +50,7 @@ tt::tt_metal::ProgramDescriptor TypecastProgramFactory::create_descriptor(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_pages, is_row_major);
     (void)num_cores;
 
-    constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     constexpr uint32_t num_input_pages = 2;
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
         .total_size = num_input_pages * input_page_size,
@@ -62,7 +62,7 @@ tt::tt_metal::ProgramDescriptor TypecastProgramFactory::create_descriptor(
         }}},
     });
 
-    constexpr uint32_t output_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_2;
     constexpr uint32_t num_output_pages = 2;
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
         .total_size = num_output_pages * output_page_size,
@@ -229,7 +229,7 @@ tt::tt_metal::ProgramDescriptor TypecastSubgridProgramFactory::create_descriptor
         all_cores = ttnn::CoreRangeSet(ttnn::CoreRange(cores[0]));
     }
 
-    const uint8_t src0_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     constexpr uint32_t num_input_tiles = 2;
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
         .total_size = num_input_tiles * single_tile_size,
@@ -241,7 +241,7 @@ tt::tt_metal::ProgramDescriptor TypecastSubgridProgramFactory::create_descriptor
         }}},
     });
 
-    const uint8_t output_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_2;
     constexpr uint32_t num_output_tiles = 2;
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
         .total_size = num_output_tiles * single_tile_size_output,

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.hpp
@@ -5,43 +5,18 @@
 #pragma once
 
 #include "typecast_device_op_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TypecastProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle typecast_reader_kernel_id{};
-        tt::tt_metal::KernelHandle typecast_writer_kernel_id{};
-        uint32_t num_cores{};
-        uint32_t num_cores_y{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TypecastParams& operation_attributes,
-        const TypecastInputs& tensor_args,
-        Tensor& output);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
 };
 
 struct TypecastSubgridProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle typecast_reader_kernel_id{};
-        tt::tt_metal::KernelHandle typecast_writer_kernel_id{};
-        std::vector<CoreCoord> cores_with_rtargs;
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TypecastParams& operation_attributes,
-        const TypecastInputs& tensor_args,
-        Tensor& output);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -62,7 +62,7 @@ ChunkSizeConfig calculate_chunk_config(
 
 }  // anonymous namespace
 
-TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TypecastRowMajorChunkedProgramFactory::create_descriptor(
     const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
@@ -73,7 +73,7 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
 
     TT_FATAL(input.layout() == Layout::ROW_MAJOR, "This factory is only for ROW_MAJOR layout");
 
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     const tt::DataFormat cb_data_format_input = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_element_size = tt::datum_size(cb_data_format_input);
@@ -108,6 +108,7 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
     // Split work by rows (each core handles complete rows with both full and partial chunks)
     auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, true);
+    (void)num_cores;
 
     constexpr uint32_t input_cb_index = tt::CBIndex::c_0;
     constexpr uint32_t output_cb_index = tt::CBIndex::c_2;
@@ -124,17 +125,25 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
     const uint32_t input_cb_page_size_bytes = tt::align(padded_input_full_chunk_size_bytes, src_buffer->alignment());
     const uint32_t output_cb_page_size_bytes = tt::align(padded_output_full_chunk_size_bytes, dst_buffer->alignment());
 
-    tt::tt_metal::CircularBufferConfig cb_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_pages * input_cb_page_size_bytes, {{input_cb_index, cb_data_format_input}})
-            .set_page_size(input_cb_index, input_cb_page_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_input_pages * input_cb_page_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = cb_data_format_input,
+            .page_size = input_cb_page_size_bytes,
+        }}},
+    });
 
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_pages * output_cb_page_size_bytes, {{output_cb_index, cb_data_format_output}})
-            .set_page_size(output_cb_index, output_cb_page_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_output_pages * output_cb_page_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = cb_data_format_output,
+            .page_size = output_cb_page_size_bytes,
+        }}},
+    });
 
     std::vector<uint32_t> reader_compile_time_args = {
         input_cb_index,                  // 0: cb_id_in
@@ -154,17 +163,21 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
     };
     tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle typecast_reader_kernel = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    tt::tt_metal::KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp";
+    reader_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle typecast_writer_kernel = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    tt::tt_metal::KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp";
+    writer_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
 
     // Create compute kernels - compute per_core_block_cnt as total chunks (full + partial) per core
     const uint32_t chunks_per_row_total = full_chunks_per_row + partial_chunks_per_row;
@@ -200,34 +213,40 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
 
     const char* const path = "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp";
 
+    std::optional<tt::tt_metal::KernelDescriptor> compute_desc_group_1;
     if (!core_group_1.ranges().empty()) {
-        tt::tt_metal::CreateKernel(
-            program,
-            path,
-            core_group_1,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-                .fp32_dest_acc_en = args.fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .bfp8_pack_precise = args.bfp8_pack_precise,
-                .math_approx_mode = math_approx_mode,
-                .compile_args = compute_kernel_args_group_1,
-                .defines = unary_defines});
+        compute_desc_group_1.emplace();
+        compute_desc_group_1->kernel_source = path;
+        compute_desc_group_1->source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_group_1->core_ranges = core_group_1;
+        compute_desc_group_1->compile_time_args = compute_kernel_args_group_1;
+        for (const auto& [name, value] : unary_defines) {
+            compute_desc_group_1->defines.emplace_back(name, value);
+        }
+        compute_desc_group_1->config = tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .fp32_dest_acc_en = args.fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .bfp8_pack_precise = args.bfp8_pack_precise,
+            .math_approx_mode = math_approx_mode};
     }
 
+    std::optional<tt::tt_metal::KernelDescriptor> compute_desc_group_2;
     if (!core_group_2.ranges().empty()) {
-        tt::tt_metal::CreateKernel(
-            program,
-            path,
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-                .fp32_dest_acc_en = args.fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .bfp8_pack_precise = args.bfp8_pack_precise,
-                .math_approx_mode = math_approx_mode,
-                .compile_args = compute_kernel_args_group_2,
-                .defines = unary_defines});
+        compute_desc_group_2.emplace();
+        compute_desc_group_2->kernel_source = path;
+        compute_desc_group_2->source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_group_2->core_ranges = core_group_2;
+        compute_desc_group_2->compile_time_args = compute_kernel_args_group_2;
+        for (const auto& [name, value] : unary_defines) {
+            compute_desc_group_2->defines.emplace_back(name, value);
+        }
+        compute_desc_group_2->config = tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .fp32_dest_acc_en = args.fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .bfp8_pack_precise = args.bfp8_pack_precise,
+            .math_approx_mode = math_approx_mode};
     }
 
     // Assign runtime args to cores (distributing rows)
@@ -239,77 +258,22 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
         uint32_t num_rows_for_core = is_group_1 ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
         uint32_t start_row_id = row_idx;
 
-        tt::tt_metal::SetRuntimeArgs(
-            program, typecast_reader_kernel, core, {src_buffer->address(), num_rows_for_core, start_row_id});
-
-        tt::tt_metal::SetRuntimeArgs(
-            program, typecast_writer_kernel, core, {dst_buffer->address(), num_rows_for_core, start_row_id});
+        reader_desc.emplace_runtime_args(core, {src_buffer, num_rows_for_core, start_row_id});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_rows_for_core, start_row_id});
 
         row_idx += num_rows_for_core;
     }
 
-    return cached_program_t{
-        std::move(program),
-        {typecast_reader_kernel,
-         typecast_writer_kernel,
-         num_cores,
-         full_chunks_per_row,
-         input_full_chunk_size_bytes,
-         output_full_chunk_size_bytes,
-         core_group_1,
-         core_group_2,
-         num_rows_per_core_group_1,
-         num_rows_per_core_group_2}};
-}
-
-void TypecastRowMajorChunkedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TypecastParams& /*operation_attributes*/,
-    const TypecastInputs& tensor_args,
-    Tensor& output) {
-    const tt::tt_metal::KernelHandle typecast_reader_kernel_id =
-        cached_program.shared_variables.typecast_reader_kernel_id;
-    const tt::tt_metal::KernelHandle typecast_writer_kernel_id =
-        cached_program.shared_variables.typecast_writer_kernel_id;
-    const uint32_t num_cores = cached_program.shared_variables.num_cores;
-
-    auto& program = cached_program.program;
-
-    const Tensor& input = tensor_args.input;
-    Buffer* src_buffer = input.buffer();
-    Buffer* dst_buffer = output.buffer();
-
-    // Use the same two-group row distribution as create() to match compile-time per_core_block_cnt.
-    const CoreRangeSet& core_group_1 = cached_program.shared_variables.core_group_1;
-    const uint32_t num_rows_per_core_group_1 = cached_program.shared_variables.num_rows_per_core_group_1;
-    const uint32_t num_rows_per_core_group_2 = cached_program.shared_variables.num_rows_per_core_group_2;
-
-    const CoreCoord compute_with_storage_grid_size = input.device()->compute_with_storage_grid_size();
-    const CoreRangeSet all_cores =
-        tt::tt_metal::num_cores_to_corerangeset(num_cores, compute_with_storage_grid_size, true);
-    auto cores_vec = corerange_to_cores(all_cores, std::nullopt, true);
-
-    uint32_t num_rows_written = 0;
-    for (const CoreCoord& core : cores_vec) {
-        bool is_group_1 = core_group_1.contains(core);
-        uint32_t rows_for_this_core = is_group_1 ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, typecast_reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-            runtime_args[1] = rows_for_this_core;
-            runtime_args[2] = num_rows_written;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, typecast_writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-            runtime_args[1] = rows_for_this_core;
-            runtime_args[2] = num_rows_written;
-        }
-
-        num_rows_written += rows_for_this_core;
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (compute_desc_group_1.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_group_1));
     }
+    if (compute_desc_group_2.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_group_2));
+    }
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -110,8 +110,8 @@ tt::tt_metal::ProgramDescriptor TypecastRowMajorChunkedProgramFactory::create_de
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, true);
     (void)num_cores;
 
-    constexpr uint32_t input_cb_index = tt::CBIndex::c_0;
-    constexpr uint32_t output_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_2;
     constexpr uint32_t num_input_pages = 2;   // Always use double buffering
     constexpr uint32_t num_output_pages = 2;  // Always use double buffering
 

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.hpp
@@ -5,32 +5,13 @@
 #pragma once
 
 #include "typecast_device_op_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TypecastRowMajorChunkedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle typecast_reader_kernel_id{};
-        tt::tt_metal::KernelHandle typecast_writer_kernel_id{};
-        uint32_t num_cores{};
-        uint32_t chunks_per_row{};
-        uint32_t input_chunk_size_bytes{};
-        uint32_t output_chunk_size_bytes{};
-        CoreRangeSet core_group_1{};
-        CoreRangeSet core_group_2{};
-        uint32_t num_rows_per_core_group_1{};
-        uint32_t num_rows_per_core_group_2{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TypecastParams& operation_attributes,
-        const TypecastInputs& tensor_args,
-        Tensor& output);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
@@ -13,7 +13,7 @@ namespace ttnn::prim {
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
-TypecastShardedProgramFactory::cached_program_t TypecastShardedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TypecastShardedProgramFactory::create_descriptor(
     const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
@@ -22,7 +22,7 @@ TypecastShardedProgramFactory::cached_program_t TypecastShardedProgramFactory::c
     const auto& input_dtype = args.input_dtype;
     const auto& output_dtype = args.output_dtype;
 
-    tt::tt_metal::Program program = CreateProgram();
+    tt::tt_metal::ProgramDescriptor desc;
 
     auto shard_spec = input.shard_spec().value();
     auto all_cores = shard_spec.grid;
@@ -82,11 +82,16 @@ TypecastShardedProgramFactory::cached_program_t TypecastShardedProgramFactory::c
         round_up_to_mul32(input_tile_size);  // will have issue if the page is not multiple of 32
     uint32_t in_cb_pagesize = aligned_input_tile_nbytes;
     uint32_t in_cb_npages = num_tile_per_core * buffering_factor;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(in_cb_pagesize * in_cb_npages, {{in_cb_id, act_df}})
-            .set_page_size(in_cb_id, in_cb_pagesize)
-            .set_globally_allocated_address(*input.buffer());
-    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = in_cb_pagesize * in_cb_npages,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = in_cb_id,
+            .data_format = act_df,
+            .page_size = in_cb_pagesize,
+        }}},
+        .buffer = input.buffer(),
+    });
 
     // output sharded CB
     uint32_t out_cb_id = tt::CBIndex::c_2;
@@ -94,11 +99,16 @@ TypecastShardedProgramFactory::cached_program_t TypecastShardedProgramFactory::c
         round_up_to_mul32(output_tile_size);  // will have issue if the page is not multiple of 32
     uint32_t out_cb_pagesize = aligned_output_tile_nbytes;
     uint32_t out_cb_npages = num_tile_per_core * buffering_factor;
-    tt::tt_metal::CircularBufferConfig out_cb_config =
-        tt::tt_metal::CircularBufferConfig(out_cb_pagesize * out_cb_npages, {{out_cb_id, out_df}})
-            .set_page_size(out_cb_id, out_cb_pagesize)
-            .set_globally_allocated_address(*output.buffer());
-    auto out_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, out_cb_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = out_cb_pagesize * out_cb_npages,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = out_cb_id,
+            .data_format = out_df,
+            .page_size = out_cb_pagesize,
+        }}},
+        .buffer = output.buffer(),
+    });
 
     log_debug(tt::LogOp, "input_cb: {}, npages: {}, pagesize: {}", in_cb_id, in_cb_npages, in_cb_pagesize);
     log_debug(tt::LogOp, "out_cb_id: {}, npages: {}, pagesize: {}", out_cb_id, out_cb_npages, out_cb_pagesize);
@@ -134,11 +144,16 @@ TypecastShardedProgramFactory::cached_program_t TypecastShardedProgramFactory::c
     TT_FATAL(dst_is_dram == 0, "Output buffer should be in L1");
 
     std::map<std::string, std::string> kernel_defines;
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
+    tt::tt_metal::KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    for (const auto& [name, value] : kernel_defines) {
+        reader_desc.defines.emplace_back(name, value);
+    }
+    reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
     std::vector<uint32_t> compute_kernel_args_group_1 = {
         1,                  // per_core_block_cnt
@@ -163,43 +178,29 @@ TypecastShardedProgramFactory::cached_program_t TypecastShardedProgramFactory::c
         static_cast<uint32_t>(datatype_to_dataformat_converter(input_dtype)),
         static_cast<uint32_t>(datatype_to_dataformat_converter(output_dtype)));
 
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-            .fp32_dest_acc_en = args.fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .bfp8_pack_precise = args.bfp8_pack_precise,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args_group_1,
-            .defines = unary_defines});
+    tt::tt_metal::KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp";
+    compute_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = compute_kernel_args_group_1;
+    for (const auto& [name, value] : unary_defines) {
+        compute_desc.defines.emplace_back(name, value);
+    }
+    compute_desc.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+        .fp32_dest_acc_en = args.fp32_dest_acc_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .bfp8_pack_precise = args.bfp8_pack_precise,
+        .math_approx_mode = math_approx_mode};
 
-    tt::tt_metal::SetRuntimeArgs(
-        program,
-        unary_reader_kernel_id,
-        all_cores,
-        {
-            static_cast<uint32_t>(num_tile_per_core),
-        });
+    for (const CoreCoord& core : corerange_to_cores(all_cores)) {
+        reader_desc.runtime_args.emplace_back(core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{num_tile_per_core});
+    }
 
-    return cached_program_t{std::move(program), {cb_src0, out_cb}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void TypecastShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TypecastParams& /*operation_attributes*/,
-    const TypecastInputs& tensor_args,
-    Tensor& output) {
-    auto& program = cached_program.program;
-    const auto& cb_src0 = cached_program.shared_variables.cb_src0;
-    const auto& out_cb = cached_program.shared_variables.out_cb;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = output.buffer();
-    tt::tt_metal::UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
-    tt::tt_metal::UpdateDynamicCircularBufferAddress(program, out_cb, *dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tilize_utils.hpp>
 
 namespace ttnn::prim {
 
@@ -76,7 +77,7 @@ tt::tt_metal::ProgramDescriptor TypecastShardedProgramFactory::create_descriptor
         num_tile_per_core = (shard_size_in_bytes + input_tile_size - 1) / input_tile_size;  // ceil value
     }
 
-    uint32_t in_cb_id = tt::CBIndex::c_0;
+    const uint8_t in_cb_id = tt::CBIndex::c_0;
     uint32_t buffering_factor = 1;  // data is already fully buffered in the CBs since its sharded
     uint32_t aligned_input_tile_nbytes =
         round_up_to_mul32(input_tile_size);  // will have issue if the page is not multiple of 32
@@ -94,7 +95,7 @@ tt::tt_metal::ProgramDescriptor TypecastShardedProgramFactory::create_descriptor
     });
 
     // output sharded CB
-    uint32_t out_cb_id = tt::CBIndex::c_2;
+    const uint8_t out_cb_id = tt::CBIndex::c_2;
     uint32_t aligned_output_tile_nbytes =
         round_up_to_mul32(output_tile_size);  // will have issue if the page is not multiple of 32
     uint32_t out_cb_pagesize = aligned_output_tile_nbytes;

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.hpp
@@ -5,24 +5,13 @@
 #pragma once
 
 #include "typecast_device_op_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TypecastShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::CBHandle cb_src0{};
-        tt::tt_metal::CBHandle out_cb{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TypecastParams& operation_attributes,
-        const TypecastInputs& tensor_args,
-        Tensor& output);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TypecastParams& args, const TypecastInputs& tensor_args, Tensor& output);
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### PR Category
Closes [#42370](https://github.com/tenstorrent/tt-metal/issues/42370)
Migrate `copy/typecast` from the legacy OldDeviceOperation pattern to ProgramDescriptor.

### Summary
- TypecastProgramFactory and TypecastSubgridProgramFactory now build ProgramDescriptor circular buffers, reader/writer KernelDescriptors, compute KernelDescriptors, and per-core runtime args.
- TypecastRowMajorChunkedProgramFactory now builds descriptor CBs/kernels while keeping the chunk sizing and alignment logic intact.
- TypecastShardedProgramFactory now builds descriptor-backed sharded CBs with buffer bindings and descriptor kernels.
- Removed cached shared variable state and manual cache-hit runtime arg override code from all migrated typecast factories.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/migrate-copy_typecast-to-program-descriptor)
