### PR TITLE
Add prefill long seq len test to quad test suite

### DIFF
--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -219,7 +219,8 @@ def test_demo_teacher_forcing_accuracy(
         force_recalculate=force_recalculate_weight_config,
         stop_at_eos=False,
         sample_on_device=True,
-        sampling_temperature=1.0,
+        sampling_temperature=0.0,
+        sampling_top_k=1,
         sampling_top_p=1.0,
     )
 

--- a/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
+++ b/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
@@ -599,3 +599,34 @@ def test_stacked_only_subview_iterates_stacked_keys(tmp_path: Path):
     assert list(materialized.keys()) == ["gate_proj.weight"]
     assert len(stacked_view) == 1
     assert torch.equal(materialized["gate_proj.weight"], stacked_tensor)
+
+
+def test_quad_ring_prepared_keys_hidden_at_root_visible_under_mlp(tmp_path: Path) -> None:
+    """Quad-ring tensors are in the index for TT MoE but are not HF reference parameters."""
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    qr_w0 = "model.layers.3.mlp.experts_quad_ring.w0_w1.weight"
+    qr_w2 = "model.layers.3.mlp.experts_quad_ring.w2.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    prepared_w0 = torch.full((2, 2), 3.0, dtype=torch.bfloat16)
+    prepared_w2 = torch.full((2, 2), 4.0, dtype=torch.bfloat16)
+    safetensors.torch.save_file(
+        {stacked_key: stacked_tensor, qr_w0: prepared_w0, qr_w2: prepared_w2},
+        str(shard),
+    )
+    _write_index(
+        model_dir,
+        {stacked_key: shard.name, qr_w0: shard.name, qr_w2: shard.name},
+    )
+
+    state = load_state_dict(model_dir, "")
+    assert qr_w0 not in state and qr_w2 not in state
+    with pytest.raises(KeyError):
+        _ = state[qr_w0]
+
+    mlp_view = sub_state_dict(state, "model.layers.3.mlp.")
+    assert "experts_quad_ring.w0_w1.weight" in mlp_view
+    assert torch.equal(mlp_view["experts_quad_ring.w0_w1.weight"], prepared_w0)

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -15,6 +15,11 @@ import torch
 from loguru import logger
 from safetensors import safe_open
 
+# TT-only prepared tensors in the HF index; must not appear on the root view (reference load_state_dict).
+_QUAD_RING_EXPERT_FULL_RE = re.compile(
+    r"^model\.layers\.(?P<layer>\d+)\.mlp\.experts_quad_ring\.(?P<projection>w0_w1|w2)\.weight$"
+)
+
 _STACKED_EXPERT_ALIAS_RE = re.compile(
     r"^model\.layers\.(?P<layer>\d+)\.mlp\.experts\.(?P<expert>\d+)\.(?P<projection>gate_proj|down_proj|up_proj)\.weight$"
 )
@@ -257,6 +262,18 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         layer_part = full_key[len(prefix) :].split(".", 1)[0]
         return (not layer_part.isdigit()) or (int(layer_part) < self._num_layers)
 
+    def _visible_quad_ring_physical_key(self, full_key: str) -> bool:
+        """
+        Quad-ring prepared tensors live in the HF index but are not part of DeepseekV3ForCausalLM.
+
+        Hide them from the root mapping (so reference load_state_dict stays strict) while keeping
+        them visible under ``*.mlp.`` views used by TT MoE expert conversion.
+        """
+        if _QUAD_RING_EXPERT_FULL_RE.match(full_key) is None:
+            return True
+        base = self._base_prefix
+        return base.endswith("mlp.") and full_key.startswith(base)
+
     def _get_stacked_num_experts(self, stacked_full_key: str) -> int:
         num_experts = self._stacked_num_experts.get(stacked_full_key)
         if num_experts is None:
@@ -288,6 +305,8 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             FileNotFoundError: if the index points to a weight file that does not exist on disk.
         """
         full_key = self._full_key(key)
+        if not self._visible_quad_ring_physical_key(full_key):
+            raise KeyError(key)
         if full_key in self._cache:
             if (
                 full_key in self._full_to_file
@@ -326,6 +345,8 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         if not isinstance(key, str):
             raise TypeError(f"Key must be a string but got {type(key)}")
         full_key = self._full_key(key)
+        if not self._visible_quad_ring_physical_key(full_key):
+            return False
         if (
             full_key in self._full_to_file
             and self._passes_layer_filter(full_key)
@@ -363,6 +384,8 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
                 continue
 
             if full_key.startswith(base):
+                if not self._visible_quad_ring_physical_key(full_key):
+                    continue
                 yield full_key[len(base) :]
 
     def __len__(self) -> int:

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -622,6 +622,25 @@ run_quad_teacher_forced_test() {
     fi
 }
 
+run_quad_teacher_forced_long_seq_prefill_single_galaxy_test() {
+    fail=0
+    setup_quad_galaxy_env
+    local timeout=$(_demo_timeout 7200)
+    local test_node="models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy[8-8192-reference_file0]"
+    local junit_path="$(_test_run_summary_junit_path teacher_forced_long_prefill_single_galaxy_quad)"
+    local junit_flag="--junitxml=${junit_path}"
+
+    # Force CI=false so this long-sequence case is executed in CI instead of skipped.
+    _test_run_summary_exec _run_deepseekv3_tt bash -c "set -f -o pipefail; CI=false pytest -svvv --timeout=$timeout ${junit_flag} ${test_node} 2>&1 | tee generated/artifacts/quad_teacher_forced_long_prefill_single_galaxy_output.log"
+    local ec="${_TEST_RUN_LAST_EC}"
+    fail+=$((fail + ec))
+    _test_run_summary_append_junit_rows "teacher_forced_long_prefill_single_galaxy_quad" "${junit_path}" "${ec}"
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
+}
+
 ###############################################################################
 # Demo tests (full)
 ###############################################################################
@@ -728,6 +747,7 @@ run_all_needed_local_tests() {
     run_dual_demo_test
     run_dual_demo_stress_test
     run_quad_teacher_forced_test
+    run_quad_teacher_forced_long_seq_prefill_single_galaxy_test
     run_quad_demo_test
     run_quad_demo_stress_test
 

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -622,19 +622,18 @@ run_quad_teacher_forced_test() {
     fi
 }
 
-run_quad_teacher_forced_long_seq_prefill_single_galaxy_test() {
+run_quad_test_model_long_prefill_single_galaxy_test() {
     fail=0
     setup_quad_galaxy_env
-    local timeout=$(_demo_timeout 7200)
-    local test_node="models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy[8-8192-reference_file0]"
-    local junit_path="$(_test_run_summary_junit_path teacher_forced_long_prefill_single_galaxy_quad)"
+    local timeout=$(_demo_timeout 1250)
+    local selector="mode_prefill"
+    local junit_path="$(_test_run_summary_junit_path test_model_long_prefill_single_galaxy_quad)"
     local junit_flag="--junitxml=${junit_path}"
 
-    # Force CI=false so this long-sequence case is executed in CI instead of skipped.
-    _test_run_summary_exec _run_deepseekv3_tt bash -c "set -f -o pipefail; CI=false pytest -svvv --timeout=$timeout ${junit_flag} ${test_node} 2>&1 | tee generated/artifacts/quad_teacher_forced_long_prefill_single_galaxy_output.log"
+    _test_run_summary_exec _run_deepseekv3_tt bash -c "set -o pipefail; DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=32768 pytest -svvv --timeout=$timeout ${junit_flag} models/demos/deepseek_v3/tests/test_model.py -k '$selector' 2>&1 | tee generated/artifacts/quad_test_model_long_prefill_single_galaxy_output.log"
     local ec="${_TEST_RUN_LAST_EC}"
     fail+=$((fail + ec))
-    _test_run_summary_append_junit_rows "teacher_forced_long_prefill_single_galaxy_quad" "${junit_path}" "${ec}"
+    _test_run_summary_append_junit_rows "test_model_long_prefill_single_galaxy_quad" "${junit_path}" "${ec}"
 
     if [[ $fail -ne 0 ]]; then
         exit 1
@@ -747,7 +746,7 @@ run_all_needed_local_tests() {
     run_dual_demo_test
     run_dual_demo_stress_test
     run_quad_teacher_forced_test
-    run_quad_teacher_forced_long_seq_prefill_single_galaxy_test
+    run_quad_test_model_long_prefill_single_galaxy_test
     run_quad_demo_test
     run_quad_demo_stress_test
 

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -945,6 +945,9 @@ main() {
         "quad_demo_stress")
             run_quad_demo_stress_test
             ;;
+        "quad_test_model_long_prefill")
+            run_quad_test_model_long_prefill_single_galaxy_test
+            ;;
         "dual_deepseekv3_integration_tests")
             run_dual_deepseekv3_integration_tests
             ;;
@@ -959,7 +962,7 @@ main() {
             ;;
         *)
             echo "Unknown test function: $test_function" 1>&2
-            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all_needed_local_tests, all" 1>&2
+            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, quad_test_model_long_prefill, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all_needed_local_tests, all" 1>&2
             echo "Optional second argument: UPR mode (all|32|8)" 1>&2
             echo "Optional flags: --no-torus  --model-path <path>  --cache-path <path>" 1>&2
             echo "Example: $0 quad_demo 32 --no-torus --model-path /data/deepseek/DeepSeek-R1-0528-dequantized-stacked --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/CI" 1>&2


### PR DESCRIPTION
### PR Category
Feature

### Summary
Add prefill long seq len test to quad test suite. 
Also includes changes to allow long prefill seq len test selection from command line + fix quad-ring unrecognized keys in reference model.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
