### PR TITLE
Fix shared_expert matmul grid for sub-device usage in DeepSeek V3 d_p

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -31,7 +31,7 @@ COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
 
 def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Blackhole."""
-    grid = ttnn.CoreCoord(11, 10)
+    grid = ttnn.CoreCoord(11, 9)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=4,
@@ -68,7 +68,7 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
 
 def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Wormhole."""
-    grid = ttnn.CoreCoord(8, 8)
+    grid = ttnn.CoreCoord(8, 7)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=4,


### PR DESCRIPTION
## Summary
After #44028 ("Matmul Bug Fix - Correct Sub Core Grid Usage"), 1D mcast matmul factories now use `num_cores_to_corerangeset_in_subcoregrids` and validate that the sub-device worker cores form a rectangle whose anchor (`bbox.start`) is respected.

The DeepSeek V3 d_p shared expert module hard-coded full-device grids (BH: `CoreCoord(11, 10)`, WH: `CoreCoord(8, 8)`) for the gate / up / down matmul program configs since that was the original intended behavior.

## Fix
Shrink the program-config grid by one row in `models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py` so it matches the sub-device worker rectangle used by the shared expert:
- Blackhole: `(11, 10)` → `(11, 9)`
- Wormhole:  `(8, 8)`  → `(8, 7)`

## CI Pipelines
[![Galaxy DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=fbajraktari/bugfix_subdevice_matmul_api_in_dsprefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch%3Afbajraktari%2Fbugfix_subdevice_matmul_api_in_dsprefill)
[![T3K e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=fbajraktari/bugfix_subdevice_matmul_api_in_dsprefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch%3Afbajraktari%2Fbugfix_subdevice_matmul_api_in_dsprefill)
[![SP Release DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=fbajraktari/bugfix_subdevice_matmul_api_in_dsprefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch%3Afbajraktari%2Fbugfix_subdevice_matmul_api_in_dsprefill)
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=fbajraktari/bugfix_subdevice_matmul_api_in_dsprefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Afbajraktari%2Fbugfix_subdevice_matmul_api_in_dsprefill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)