### PR TITLE
Fix moreh cumsum test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -76,7 +76,6 @@ def test_moreh_cumsum_dim(input_shape, dim, device):
 
     torch_output = torch.cumsum(torch_input, dim)
 
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     tt_output_cpu = ttnn.to_torch(ttnn.operations.moreh.cumsum(tt_input, dim, output=tt_output))
 
     # test for equivalance

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -77,13 +77,7 @@ def test_moreh_cumsum_dim(input_shape, dim, device):
     torch_output = torch.cumsum(torch_input, dim)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = (
-        ttnn.operations.moreh.cumsum(tt_input, dim, output=tt_output)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(output_shape)
-        .to_torch()
-    )
+    tt_output_cpu = ttnn.to_torch(ttnn.operations.moreh.cumsum(tt_input, dim, output=tt_output))
 
     # test for equivalance
     rtol = atol = 0.1


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

moreh tests are failing on L2 nightly. This fixes the existing failure. If more crop out, new PRs will be opened.
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-0_fix_moreh_cumsum_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-0_fix_moreh_cumsum_test)