### PR TITLE
#[42369] [Descriptor Migration] conv/conv2d

### DIFF
--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -342,7 +342,7 @@ DataType compute_host_dtype(ttnn::PyDType src_dtype, const DataType& dst_dtype, 
 
     if (is_sharded && get_datatype_tile_size(dst_dtype) != get_datatype_tile_size(to_ttnn_dtype(src_dtype))) {
         // Sharded typecast does not support conversion between tensors with types of different tile size:
-        // See explicit assertion in the `TypecastShardedProgramFactory::create_descriptor` method implementation.
+        // See explicit assertion in the `TypecastShardedProgramFactory` creation logic.
         return mapped_dst_type;
     }
 

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -342,7 +342,7 @@ DataType compute_host_dtype(ttnn::PyDType src_dtype, const DataType& dst_dtype, 
 
     if (is_sharded && get_datatype_tile_size(dst_dtype) != get_datatype_tile_size(to_ttnn_dtype(src_dtype))) {
         // Sharded typecast does not support conversion between tensors with types of different tile size:
-        // See explicit assertion in the `TypecastShardedProgramFactory::create` method implementation.
+        // See explicit assertion in the `TypecastShardedProgramFactory::create_descriptor` method implementation.
         return mapped_dst_type;
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -10,10 +10,12 @@
 #include <optional>
 #include <tuple>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 #include <tt_stl/assert.hpp>
 #include "tt-metalium/constants.hpp"
 #include "tt-metalium/hal.hpp"
+#include "tt-metalium/program_descriptors.hpp"
 #include "tt-metalium/tt_backend_api_types.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -383,6 +385,92 @@ void allocate_cbs(
             // If this CB is overlapped by another CB, set the handle to the overlapped CB's handle
             const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
             cb.handle = overlapped_cb.handle;
+            cb.index = overlapped_cb.index;
+        }
+    }
+}
+
+void allocate_cbs_to_program_descriptor(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::ProgramDescriptor& desc,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& all_cores,
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const Tensor& l1_indices_tensor) {
+    // CBDescriptor::core_ranges is a CoreRangeSet; widen single CoreCoord /
+    // CoreRange inputs so callers can pass the same variant they already use
+    // with the legacy allocate_cbs().
+    const tt::tt_metal::CoreRangeSet core_ranges = std::visit(
+        [](const auto& v) -> tt::tt_metal::CoreRangeSet {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (std::is_same_v<T, CoreCoord>) {
+                return tt::tt_metal::CoreRangeSet(CoreRange{v, v});
+            } else if constexpr (std::is_same_v<T, CoreRange>) {
+                return tt::tt_metal::CoreRangeSet(v);
+            } else {
+                return v;
+            }
+        },
+        all_cores);
+
+    uint32_t cb_index = 0;
+    for (auto& cb : cb_info) {
+        if (cb.num_pages == 0) {
+            // Skip circular buffers with zero pages (same as allocate_cbs()).
+            // Overlapped CBs always fall in this bucket and pick up their
+            // sibling's index in the second pass below.
+            continue;
+        }
+
+        // Globally-allocated CBs are backed by a sharded tensor buffer.
+        // Recording `Buffer*` on the descriptor lets the framework patch the
+        // CB base address on every dispatch (the descriptor-flow analogue of
+        // the legacy UpdateDynamicCircularBufferAddress() calls).
+        tt::tt_metal::Buffer* buffer = nullptr;
+        if (cb.is_globally_allocated) {
+            if (cb.name == Conv2dCb::ACT_SHARDED) {
+                buffer = input_tensor.buffer();
+            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
+                buffer = output_tensor.buffer();
+            } else if (cb.name == Conv2dCb::READER_INDICES) {
+                buffer = l1_indices_tensor.buffer();
+            } else {
+                TT_THROW(
+                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
+                    enchantum::to_string(cb.name));
+            }
+        }
+
+        cb.index = cb_index++;
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = cb.num_pages * cb.page_size,
+            .core_ranges = core_ranges,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb.index),
+                .data_format = cb.data_format,
+                .page_size = cb.page_size,
+            }}},
+            .buffer = buffer,
+        });
+
+        log_trace(
+            tt::LogOp,
+            "Allocated descriptor CB {} with index {}, num pages {}, page size {}, globally allocated: {}",
+            enchantum::to_string(cb.name),
+            cb.index,
+            cb.num_pages,
+            cb.page_size,
+            cb.is_globally_allocated);
+    }
+
+    for (auto& cb : cb_info) {
+        if (cb.overlapped_by_cb.has_value()) {
+            // Overlapped CBs do not get their own CBDescriptor; they reuse the
+            // overlap target's buffer_index so kernels addressing the overlapped
+            // CB hit the shared underlying allocation. CBInfo::handle is left
+            // default-initialised — the descriptor flow does not expose CBHandle
+            // back to factories.
+            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
             cb.index = overlapped_cb.index;
         }
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <variant>
 #include <vector>
+#include <type_traits>
 #include <tt_stl/assert.hpp>
 #include "tt-metalium/constants.hpp"
 #include "tt-metalium/hal.hpp"

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -20,7 +20,10 @@
 
 namespace ttnn::prim {
 
+using ttnn::operations::conv::conv_skip_mcast;
+using ttnn::operations::conv::is_1d_depthwise_conv;
 using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
+using ttnn::operations::conv::SkipMcast;
 
 constexpr uint32_t l1_scratchpad_CB_size = 64;
 
@@ -717,6 +720,101 @@ bool is_split_reader_viable(
         is_viable);
 
     return is_viable;
+}
+
+void post_conv2d_op_memory_checks(
+    const tt::tt_metal::ProgramDescriptor& desc,
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& /*output_tensor*/,
+    std::optional<uint32_t> reader_indices_actual_page_size) {
+    const auto& input_tensor_a = tensor_args.a;
+    const auto& input_tensor_b = tensor_args.b;
+    const auto& input_tensor_bias = tensor_args.bias;
+    const bool has_bias = input_tensor_bias.has_value();
+    auto* device = input_tensor_a.device();
+    const auto& weights_shape = input_tensor_b.padded_shape();
+    const auto& sliding_window_config = operation_attributes.sliding_window_config;
+    const auto& parallelization_config = operation_attributes.parallelization_config;
+    const auto& memory_config = operation_attributes.memory_config;
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
+    const auto& block_config = operation_attributes.block_config;
+    const auto dtype = operation_attributes.dtype;
+    const auto& input_tensor_shape = operation_attributes.input_tensor_shape;
+    const auto& enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
+    const auto& enable_weights_double_buffer = operation_attributes.enable_weights_double_buffer;
+    const auto& enable_activation_reuse = operation_attributes.enable_activation_reuse;
+    const auto& config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+    const auto& pre_op_l1_allocation_size_bytes = operation_attributes.pre_op_l1_allocation_size_bytes;
+    const auto& force_split_reader = operation_attributes.force_split_reader;
+    const auto output_channels = operation_attributes.output_channels;
+    const auto groups = operation_attributes.groups;
+    const auto untilize_out = operation_attributes.untilize_out;
+
+    const uint32_t post_op_l1_allocation_size =
+        device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+
+    // Descriptor-flow analogue of `calculate_total_cb_size(program)`: in the
+    // realized Program a CB is "globally allocated" iff it was created with a
+    // Buffer*; in the descriptor that maps 1:1 to `cb.buffer != nullptr`.
+    uint32_t actual_cb_size = 0;
+    for (const auto& cb : desc.cbs) {
+        if (cb.buffer == nullptr) {
+            actual_cb_size += cb.total_size;
+        }
+    }
+
+    auto kernel_dims =
+        std::array<uint32_t, 2>({sliding_window_config.window_hw.first, sliding_window_config.window_hw.second});
+
+    const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, memory_config.memory_layout());
+    const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
+
+    const std::array<uint32_t, 2> shard_shape = input_tensor_a.shard_spec().value().shape;
+    const uint32_t input_channels_padded = shard_shape[1];
+    conv_op_l1_usage l1_usage = calculate_L1_usage(
+        compute_kernel_config,
+        block_config,
+        parallelization_config,
+        weights_shape,
+        sliding_window_config,
+        std::array<uint32_t, 2>({sliding_window_config.dilation_hw.first, sliding_window_config.dilation_hw.second}),
+        Conv2dConfig{
+            .weights_dtype = input_tensor_b.dtype(),
+            .config_tensors_in_dram = config_tensors_in_dram,
+            .shard_layout = memory_config.memory_layout(),
+            .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
+            .enable_act_double_buffer = enable_act_double_buffer,
+            .enable_weights_double_buffer = enable_weights_double_buffer,
+            .enable_activation_reuse = enable_activation_reuse,
+            .force_split_reader = force_split_reader},
+        input_tensor_a.dtype(),
+        dtype,
+        output_image_width,
+        has_bias,
+        is_1d_depthwise_conv(
+            groups, input_tensor_shape[3], output_channels, kernel_dims[0], input_tensor_shape[1], has_bias),
+        input_channels_padded,
+        skip_mcast.skip_activation_mcast,
+        reader_indices_actual_page_size);
+
+    TT_FATAL(
+        actual_cb_size == l1_usage.CB_allocation_size,
+        "Calculated CB size {} does not match with the actual CB size {}",
+        l1_usage.CB_allocation_size,
+        actual_cb_size);
+
+    // For now assume that if post_op_l1_allocation_size == 0 op is being run
+    // in graph capture NO_DISPATCH mode.
+    // ToDo: Device should offer an API to inform the op if it is running in NO_DISPATCH mode.
+    bool is_graph_capture_no_dispatch_mode = post_op_l1_allocation_size == 0;
+    TT_FATAL(
+        post_op_l1_allocation_size == (pre_op_l1_allocation_size_bytes + l1_usage.tensor_allocation_size) ||
+            is_graph_capture_no_dispatch_mode,
+        "Mismatch!! L1 Allocation Pre Op =  {}, Post Op = {} Calculated Size = {}",
+        pre_op_l1_allocation_size_bytes,
+        post_op_l1_allocation_size,
+        l1_usage.tensor_allocation_size);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -755,7 +755,7 @@ void post_conv2d_op_memory_checks(
         device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
 
     // Descriptor-flow analogue of `calculate_total_cb_size(program)`: in the
-    // realized Program a CB is "globally allocated" iff it was created with a
+    // realized Program a CB is "globally allocated" if it was created with a
     // Buffer*; in the descriptor that maps 1:1 to `cb.buffer != nullptr`.
     uint32_t actual_cb_size = 0;
     for (const auto& cb : desc.cbs) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -8,8 +8,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <optional>
-#include <tuple>
-#include <unordered_map>
 #include <variant>
 #include <vector>
 #include <tt_stl/assert.hpp>
@@ -17,15 +15,11 @@
 #include "tt-metalium/hal.hpp"
 #include "tt-metalium/program_descriptors.hpp"
 #include "tt-metalium/tt_backend_api_types.hpp"
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 
 namespace ttnn::prim {
 
-using ttnn::operations::conv::conv_skip_mcast;
-using ttnn::operations::conv::is_1d_depthwise_conv;
 using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
-using ttnn::operations::conv::SkipMcast;
 
 constexpr uint32_t l1_scratchpad_CB_size = 64;
 
@@ -209,7 +203,8 @@ std::vector<CBInfo> get_cb_info(
     }
 
     // Matmul partials CB. 1D depthwise compute uses dest-reuse accumulation, so the CB is unused
-    // for that path — emit a 0-page entry so allocate_cbs skips the device allocation.
+    // for that path — emit a 0-page entry so allocate_cbs_to_program_descriptor skips the device
+    // allocation.
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::MATMUL_PARTIALS,
         .num_pages = is_1d_depthwise_conv ? 0 : per_core_out_ntiles,
@@ -338,58 +333,6 @@ std::vector<CBInfo> get_cb_info(
     return cb_info;
 }
 
-void allocate_cbs(
-    std::vector<CBInfo>& cb_info,
-    tt::tt_metal::Program& program,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& all_cores,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor,
-    const Tensor& l1_indices_tensor) {
-    uint32_t cb_index = 0;
-    for (auto& cb : cb_info) {
-        if (cb.num_pages == 0) {
-            // Skip circular buffers with zero pages
-            continue;
-        }
-
-        // cbs for sharded tensors.
-        Buffer* buffer = nullptr;
-        if (cb.is_globally_allocated) {
-            if (cb.name == Conv2dCb::ACT_SHARDED) {
-                buffer = input_tensor.buffer();
-            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
-                buffer = output_tensor.buffer();
-            } else if (cb.name == Conv2dCb::READER_INDICES) {
-                buffer = l1_indices_tensor.buffer();
-            } else {
-                TT_THROW(
-                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
-                    enchantum::to_string(cb.name));
-            }
-        }
-
-        std::tie(cb.index, cb.handle) =
-            tt::tt_metal::create_cb(cb_index++, program, all_cores, cb.page_size, cb.num_pages, cb.data_format, buffer);
-        log_trace(
-            tt::LogOp,
-            "Allocated circular buffer {} with index {}, num pages {}, page size {}, globally allocated: {}",
-            enchantum::to_string(cb.name),
-            cb.index,
-            cb.num_pages,
-            cb.page_size,
-            cb.is_globally_allocated);
-    }
-
-    for (auto& cb : cb_info) {
-        if (cb.overlapped_by_cb.has_value()) {
-            // If this CB is overlapped by another CB, set the handle to the overlapped CB's handle
-            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
-            cb.handle = overlapped_cb.handle;
-            cb.index = overlapped_cb.index;
-        }
-    }
-}
-
 void allocate_cbs_to_program_descriptor(
     std::vector<CBInfo>& cb_info,
     tt::tt_metal::ProgramDescriptor& desc,
@@ -398,8 +341,8 @@ void allocate_cbs_to_program_descriptor(
     const Tensor& output_tensor,
     const Tensor& l1_indices_tensor) {
     // CBDescriptor::core_ranges is a CoreRangeSet; widen single CoreCoord /
-    // CoreRange inputs so callers can pass the same variant they already use
-    // with the legacy allocate_cbs().
+    // CoreRange inputs so callers can pass the same variant accepted by the
+    // public API.
     const tt::tt_metal::CoreRangeSet core_ranges = std::visit(
         [](const auto& v) -> tt::tt_metal::CoreRangeSet {
             using T = std::decay_t<decltype(v)>;
@@ -416,7 +359,7 @@ void allocate_cbs_to_program_descriptor(
     uint32_t cb_index = 0;
     for (auto& cb : cb_info) {
         if (cb.num_pages == 0) {
-            // Skip circular buffers with zero pages (same as allocate_cbs()).
+            // Skip circular buffers with zero pages.
             // Overlapped CBs always fall in this bucket and pick up their
             // sibling's index in the second pass below.
             continue;
@@ -467,9 +410,9 @@ void allocate_cbs_to_program_descriptor(
         if (cb.overlapped_by_cb.has_value()) {
             // Overlapped CBs do not get their own CBDescriptor; they reuse the
             // overlap target's buffer_index so kernels addressing the overlapped
-            // CB hit the shared underlying allocation. CBInfo::handle is left
-            // default-initialised — the descriptor flow does not expose CBHandle
-            // back to factories.
+            // CB hit the shared underlying allocation. The descriptor flow does
+            // not expose CBHandle back to factories — the framework owns the CB
+            // handles inside the cached `tt::tt_metal::Program`.
             const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
             cb.index = overlapped_cb.index;
         }
@@ -773,93 +716,6 @@ bool is_split_reader_viable(
         is_viable);
 
     return is_viable;
-}
-
-void post_conv2d_op_memory_checks(
-    tt::tt_metal::Program& program,
-    const Conv2dParams& operation_attributes,
-    const Conv2dInputs& tensor_args,
-    Tensor& /*output_tensor*/,
-    std::optional<uint32_t> reader_indices_actual_page_size) {
-    const auto& input_tensor_a = tensor_args.a;
-    const auto& input_tensor_b = tensor_args.b;
-    const auto& input_tensor_bias = tensor_args.bias;
-    const bool has_bias = input_tensor_bias.has_value();
-    auto *device = input_tensor_a.device();
-    const auto& weights_shape = input_tensor_b.padded_shape();
-    const auto& sliding_window_config = operation_attributes.sliding_window_config;
-    const auto& parallelization_config = operation_attributes.parallelization_config;
-    const auto& memory_config = operation_attributes.memory_config;
-    const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
-    const auto& block_config = operation_attributes.block_config;
-    const auto dtype = operation_attributes.dtype;
-    const auto& input_tensor_shape = operation_attributes.input_tensor_shape;
-    const auto& enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
-    const auto& enable_weights_double_buffer = operation_attributes.enable_weights_double_buffer;
-    const auto& enable_activation_reuse = operation_attributes.enable_activation_reuse;
-    const auto& config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
-    const auto& pre_op_l1_allocation_size_bytes = operation_attributes.pre_op_l1_allocation_size_bytes;
-    const auto& force_split_reader = operation_attributes.force_split_reader;
-    const auto output_channels = operation_attributes.output_channels;
-    const auto groups = operation_attributes.groups;
-    const auto untilize_out = operation_attributes.untilize_out;
-
-    const uint32_t post_op_l1_allocation_size =
-        device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-
-    auto actual_cb_size = calculate_total_cb_size(program);
-
-    auto kernel_dims =
-        std::array<uint32_t, 2>({sliding_window_config.window_hw.first, sliding_window_config.window_hw.second});
-
-    const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, memory_config.memory_layout());
-    const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
-
-    const std::array<uint32_t, 2> shard_shape = input_tensor_a.shard_spec().value().shape;
-    const uint32_t input_channels_padded = shard_shape[1];
-    conv_op_l1_usage l1_usage = calculate_L1_usage(
-        compute_kernel_config,
-        block_config,
-        parallelization_config,
-        weights_shape,
-        sliding_window_config,
-        std::array<uint32_t, 2>({sliding_window_config.dilation_hw.first, sliding_window_config.dilation_hw.second}),
-        Conv2dConfig{
-            .weights_dtype = input_tensor_b.dtype(),
-            .config_tensors_in_dram = config_tensors_in_dram,
-            .shard_layout = memory_config.memory_layout(),
-            .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
-            .enable_act_double_buffer = enable_act_double_buffer,
-            .enable_weights_double_buffer = enable_weights_double_buffer,
-            .enable_activation_reuse = enable_activation_reuse,
-            .force_split_reader = force_split_reader},
-        input_tensor_a.dtype(),
-        dtype,
-        output_image_width,
-        has_bias,
-        is_1d_depthwise_conv(
-            groups, input_tensor_shape[3], output_channels, kernel_dims[0], input_tensor_shape[1], has_bias),
-        input_channels_padded,
-        skip_mcast.skip_activation_mcast,
-        reader_indices_actual_page_size);
-
-    TT_FATAL(
-        actual_cb_size == l1_usage.CB_allocation_size,
-        "Calculated CB size {} does not match with the actual CB size {}",
-        l1_usage.CB_allocation_size,
-        actual_cb_size);
-
-    // For now assume that if post_op_l1_allocation_size == 0 op is being run
-    // in graph capture NO_DISPATCH mode.
-    // ToDo: Device should offer an API to inform the op if it is running in NO_DISPATCH mode.
-    bool is_graph_capture_no_dispatch_mode = post_op_l1_allocation_size == 0;
-    TT_FATAL(
-        post_op_l1_allocation_size == (pre_op_l1_allocation_size_bytes + l1_usage.tensor_allocation_size) ||
-            is_graph_capture_no_dispatch_mode,
-        "Mismatch!! L1 Allocation Pre Op =  {}, Post Op = {} Calculated Size = {}",
-        pre_op_l1_allocation_size_bytes,
-        post_op_l1_allocation_size,
-        l1_usage.tensor_allocation_size);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -38,8 +38,6 @@ enum class Conv2dCb {
 struct CBInfo {
     // Index of CB that will be passed in to the kernel.
     uint32_t index = kInvalidCBIndex;
-    // CB handle
-    tt::tt_metal::CBHandle handle{};
     // Type of the CB
     Conv2dCb name{Conv2dCb::COUNT};
     // Number of pages in the circular buffer.
@@ -58,7 +56,7 @@ struct CBInfo {
 
 // Returns a vector of CBInfo objects for the Conv2d operation.
 // The vector will contain information about all circular buffers used in the Conv2d operation.
-// CBInfo::index and CBInfo::handle won't be valid until allocate_cbs() is called.
+// CBInfo::index won't be valid until allocate_cbs_to_program_descriptor() is called.
 // When the program factory has the real reader indices DRAM buffer, it can pass its actual page
 // size so the predicted READER_INDICES CB footprint matches the CB the factory creates. Auto-shard
 // L1 estimation passes std::nullopt and falls back to the worst case (1 uint16 index per output row).
@@ -81,35 +79,20 @@ std::vector<CBInfo> get_cb_info(
     uint32_t input_channels_padded,
     std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
 
-// Allocates circular buffers for the Conv2d operation.
-// This function will populate index and handle fields of each CBInfo in the cb_info vector,
-// and add these circular buffers to the provided program.
-void allocate_cbs(
-    std::vector<CBInfo>& cb_info,
-    tt::tt_metal::Program& program,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& all_cores,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor,
-    const Tensor& l1_indices_tensor);
-
-// Descriptor-flow equivalent of allocate_cbs(): instead of allocating
-// circular buffers directly on a `tt::tt_metal::Program`, appends one
-// `CBDescriptor` per non-empty CBInfo to `desc.cbs` and fills in the
-// `CBInfo::index` field on every entry (overlapped CBs adopt their
-// overlap target's index, mirroring the legacy helper).
+// Appends one `CBDescriptor` per non-empty CBInfo to `desc.cbs` and fills in
+// the `CBInfo::index` field on every entry (overlapped CBs adopt their
+// overlap target's index).
 //
 // For globally-allocated CBs (sharded tensors), the corresponding tensor
 // buffer pointer is recorded on `CBDescriptor::buffer` so the framework's
 // `apply_descriptor_runtime_args` patches the dynamic CB address from the
 // live buffer on every dispatch.
 //
-// `CBInfo::handle` is left default-initialised: in the descriptor flow the
-// framework owns the CB handles inside the cached `tt::tt_metal::Program`,
-// so factory code never needs to look them up.
+// In the descriptor flow the framework owns the CB handles inside the cached
+// `tt::tt_metal::Program`, so factory code never needs to look them up.
 //
 // Intended to be called from a Conv2d program factory's `create_descriptor()`
-// after `get_cb_info(...)`.  The legacy `allocate_cbs()` is preserved for any
-// not-yet-migrated factory.
+// after `get_cb_info(...)`.
 void allocate_cbs_to_program_descriptor(
     std::vector<CBInfo>& cb_info,
     tt::tt_metal::ProgramDescriptor& desc,
@@ -139,16 +122,5 @@ bool is_split_reader_viable(
     bool fp32_dest_acc,
     DataType output_datatype,
     bool act_reuse_enabled);
-
-// reader_indices_actual_page_size lets the factory communicate the in-DRAM config tensor's true
-// per-core page size so the post-build CB-size equality check matches what was allocated. When
-// std::nullopt, the worst-case READER_INDICES CB size is used (matches the factory's previous
-// behaviour for the in-DRAM path).
-void post_conv2d_op_memory_checks(
-    tt::tt_metal::Program& program,
-    const Conv2dParams& operation_attributes,
-    const Conv2dInputs& tensor_args,
-    Tensor& output_tensor,
-    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 
 #include "tt-metalium/circular_buffer_config.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
@@ -86,6 +87,32 @@ std::vector<CBInfo> get_cb_info(
 void allocate_cbs(
     std::vector<CBInfo>& cb_info,
     tt::tt_metal::Program& program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& all_cores,
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const Tensor& l1_indices_tensor);
+
+// Descriptor-flow equivalent of allocate_cbs(): instead of allocating
+// circular buffers directly on a `tt::tt_metal::Program`, appends one
+// `CBDescriptor` per non-empty CBInfo to `desc.cbs` and fills in the
+// `CBInfo::index` field on every entry (overlapped CBs adopt their
+// overlap target's index, mirroring the legacy helper).
+//
+// For globally-allocated CBs (sharded tensors), the corresponding tensor
+// buffer pointer is recorded on `CBDescriptor::buffer` so the framework's
+// `apply_descriptor_runtime_args` patches the dynamic CB address from the
+// live buffer on every dispatch.
+//
+// `CBInfo::handle` is left default-initialised: in the descriptor flow the
+// framework owns the CB handles inside the cached `tt::tt_metal::Program`,
+// so factory code never needs to look them up.
+//
+// Intended to be called from a Conv2d program factory's `create_descriptor()`
+// after `get_cb_info(...)`.  The legacy `allocate_cbs()` is preserved for any
+// not-yet-migrated factory.
+void allocate_cbs_to_program_descriptor(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::ProgramDescriptor& desc,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& all_cores,
     const Tensor& input_tensor,
     const Tensor& output_tensor,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -123,4 +123,37 @@ bool is_split_reader_viable(
     DataType output_datatype,
     bool act_reuse_enabled);
 
+// Post-build memory sanity checks for the descriptor-based conv2d factories.
+//
+// Two invariants are asserted:
+//   1. Sum of non-globally-allocated CB total_sizes in `desc.cbs` matches the
+//      predicted `l1_usage.CB_allocation_size`. This is the descriptor-flow
+//      equivalent of the legacy `calculate_total_cb_size(program)` check —
+//      `cb.buffer == nullptr` mirrors the realized `!cb->globally_allocated()`
+//      condition exactly.
+//   2. The L1 allocator delta (`post - pre`) matches the predicted
+//      `l1_usage.tensor_allocation_size` (or the op is running in graph
+//      capture / NO_DISPATCH mode where `post == 0`). `pre_op_l1_allocation_size_bytes`
+//      is snapshotted in `conv2d_device_operation.cpp` before the factory runs.
+//
+// Must be called at the END of `create_workload_descriptor`, AFTER the factory
+// has populated `desc.cbs` and allocated the reader-indices Tensor, so the L1
+// allocator snapshot reflects the same state the legacy post-CreateProgram
+// check observed. The framework adapter materializes the `Program` (and
+// allocates non-globally-allocated CBs) only AFTER `create_workload_descriptor`
+// returns, so the descriptor-side CB walk here measures exactly what the
+// legacy `calculate_total_cb_size(program)` would have measured.
+//
+// `reader_indices_actual_page_size` lets the factory communicate the in-DRAM
+// config tensor's true per-core page size so the predicted READER_INDICES CB
+// footprint matches the CB the factory emitted. When std::nullopt, the
+// worst-case READER_INDICES CB size is used (matches auto-shard estimation
+// behaviour).
+void post_conv2d_op_memory_checks(
+    const tt::tt_metal::ProgramDescriptor& desc,
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -92,7 +92,7 @@ std::vector<CBInfo> get_cb_info(
 // `tt::tt_metal::Program`, so factory code never needs to look them up.
 //
 // Intended to be called from a Conv2d program factory's `create_descriptor()`
-// after `get_cb_info(...)`.
+// or `create_workload_descriptor()` after `get_cb_info(...)`.
 void allocate_cbs_to_program_descriptor(
     std::vector<CBInfo>& cb_info,
     tt::tt_metal::ProgramDescriptor& desc,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -4,7 +4,11 @@
 
 #include <umd/device/types/xy_pair.hpp>
 #include <cstdint>
+#include <map>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 #include <tt_stl/assert.hpp>
 #include "tt-metalium/circular_buffer_config.hpp"
 #include "tt-metalium/core_coord.hpp"
@@ -20,10 +24,11 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <utility>
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
 
 namespace ttnn::prim {
@@ -34,6 +39,16 @@ using ttnn::operations::conv::get_num_cores_channels_from_parallel_config;
 using ttnn::operations::conv::is_1d_depthwise_conv;
 using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
 using ttnn::operations::conv::SkipMcast;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+using tt::tt_metal::SemaphoreDescriptor;
+using tt::tt_metal::WorkloadBuffer;
+using tt::tt_metal::WorkloadDescriptor;
 
 // Compute kernel addressing mode divides addresses with 16
 constexpr uint32_t COMPUTE_KERNEL_ADDRESS_DIVISOR = 16;
@@ -170,9 +185,11 @@ ActivationReuseConfig calculate_activation_reuse_params(
     return config;
 }
 
-Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::create(
-    const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
 
@@ -496,16 +513,14 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
 
     const uint32_t in0_num_blocks_w = conv_act_c_blocks * num_blocks_act_w;
 
-    // weight
-    const uint32_t weight_dram_addr = b.buffer()->address();
-
-    // bias
+    // weight / bias buffers — base addresses are no longer cached here, they
+    // are dispatched as `Buffer*` runtime args via `emplace_runtime_args(...)`
+    // below so the framework's BufferBinding fast cache-hit path patches them
+    // directly on every dispatch.
     tt::tt_metal::Buffer* bias_buffer = nullptr;
-    uint32_t bias_dram_addr = 0;
     uint32_t bias_ntiles = 0;
     if (has_bias) {
         bias_buffer = bias.value().buffer();
-        bias_dram_addr = bias_buffer->address();
         bias_ntiles =
             bias.value().padded_shape()[3] / tt::constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
     }
@@ -598,13 +613,25 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         .shard_orientation = a.memory_config().shard_spec().value().orientation,
     };
 
-    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+    // Build the reader-indices config Tensor on host and upload it.
+    // The resulting device buffer must outlive the cached MeshWorkload because
+    // the reader / writer kernels reference it either via a globally-allocated
+    // CB (L1 path) or via compile-time args (DRAM path) — both bake the buffer
+    // address into the cached Program.  We wrap the Tensor in a shared_ptr and
+    // park it on `workload_descriptor.buffers`; otherwise the Tensor's
+    // destructor would force-free the device storage at the end of this
+    // function via DeviceStorage::deallocate, leaving the kernel reading from
+    // freed memory on cache hits.
+    Tensor conv_reader_indices_tensor_local = ttnn::operations::sliding_window::construct_on_host_config_tensor(
         conv_sharded_input_top_left_indices, input_parallel_config, config_tensors_in_dram);
-    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
+    conv_reader_indices_tensor_local = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor_local, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
 
-    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor_local);
+
+    auto conv_reader_indices_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor_local));
+    const Tensor& conv_reader_indices_tensor = *conv_reader_indices_owner;
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_owner->buffer();
 
     TT_FATAL(
         act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0,
@@ -665,7 +692,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
     // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
     // populated by the reader kernel.
-    const uint32_t reader_indices_actual_page_size = conv_reader_indices_storage.get_buffer()->page_size();
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -685,8 +712,14 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         input_channels_padded,
         reader_indices_actual_page_size);
 
-    // call function to allocate circular buffers
-    allocate_cbs(cb_info, program, all_cores, a, output, conv_reader_indices_tensor);
+    // Descriptor-flow CB allocation: appends one CBDescriptor per non-empty
+    // CBInfo entry to `desc.cbs` and fills `CBInfo::index`.  Sharded CBs are
+    // backed by tensor `Buffer*` (recorded on `CBDescriptor::buffer`) so the
+    // framework patches their base addresses on cache hits.  The reader-
+    // indices Tensor is the workload-scoped buffer parked below; the L1 path
+    // (config_tensors_in_dram == false) picks it up via this CB binding.
+    ProgramDescriptor desc;
+    allocate_cbs_to_program_descriptor(cb_info, desc, all_cores, a, output, conv_reader_indices_tensor);
 
     const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
     const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
@@ -719,6 +752,13 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     // This requires synchronization between the main reader and the second reader to prevent race conditions.
     const bool split_reader_cb_shared = enable_split_reader && overlap_act_cb && block_sharded;
 
+    // Program-scoped semaphore IDs are assigned sequentially.  The framework
+    // allocates the actual L1 addresses when realising the descriptor into a
+    // Program (see SemaphoreDescriptor entries appended to `desc.semaphores`
+    // below).  Kernels read these ids the same way they did when the legacy
+    // CreateSemaphore() return value was passed through compile-time args or
+    // runtime args (all are 0-initialised semaphores; INVALID == 0).
+    uint32_t next_sem_id = 0;
     if (block_sharded) {
         const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
         // 2D mcast
@@ -736,36 +776,85 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         if (populate_skipped_work_cores) {
             mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
         }
-        act_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-        act_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        act_mcast_sender_semaphore_id = next_sem_id++;
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = act_mcast_sender_semaphore_id,
+            .core_ranges = all_cores,
+            .initial_value = 0,
+        });
+        act_mcast_receiver_semaphore_id = next_sem_id++;
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = act_mcast_receiver_semaphore_id,
+            .core_ranges = all_cores,
+            .initial_value = 0,
+        });
 
         if (split_reader_cb_shared) {
-            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            act_split_reader_reserve_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            act_split_reader_write_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_sender_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = weights_mcast_sender_semaphore_id,
+                .core_ranges = all_cores,
+                .initial_value = 0,
+            });
+            weights_mcast_receiver_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = weights_mcast_receiver_semaphore_id,
+                .core_ranges = all_cores,
+                .initial_value = 0,
+            });
+            act_split_reader_reserve_done_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = act_split_reader_reserve_done_semaphore_id,
+                .core_ranges = all_cores,
+                .initial_value = 0,
+            });
+            act_split_reader_write_done_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = act_split_reader_write_done_semaphore_id,
+                .core_ranges = all_cores,
+                .initial_value = 0,
+            });
         } else {
-            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+            weights_mcast_sender_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = weights_mcast_sender_semaphore_id,
+                .core_ranges = output_cores,
+                .initial_value = 0,
+            });
+            weights_mcast_receiver_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = weights_mcast_receiver_semaphore_id,
+                .core_ranges = output_cores,
+                .initial_value = 0,
+            });
         }
     } else {
         // 1D mcast
         if (!skip_weights_mcast) {
             mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
-            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+            weights_mcast_sender_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = weights_mcast_sender_semaphore_id,
+                .core_ranges = output_cores,
+                .initial_value = 0,
+            });
+            weights_mcast_receiver_semaphore_id = next_sem_id++;
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = weights_mcast_receiver_semaphore_id,
+                .core_ranges = output_cores,
+                .initial_value = 0,
+            });
         }
     }
 
-    const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
-    const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
     // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
+    // In the descriptor flow we no longer cache CBHandles: `allocate_cbs_to_program_descriptor`
+    // already recorded the sharded ACT / OUT / MATMUL_PARTIALS CBs with their backing tensor
+    // `Buffer*`, and the framework patches those dynamic CB addresses on every dispatch (the
+    // legacy `UpdateDynamicCircularBufferAddress` calls live in the dispatcher now).
     const bool partials_cb_uses_output =
         !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
     log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
-    const tt::tt_metal::CBHandle cb_partials = is_conv_1d_depthwise_conv
-                                                   ? tt::tt_metal::CBHandle{}
-                                                   : get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     std::string reader_kernel;
     std::string compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp";
@@ -864,9 +953,13 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
         writer_defines["CONFIG_TENSOR_IN_DRAM"] = "1";               // Needed for split reader
         writer_mcast_sender_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
-        reader_compile_time_args.push_back(conv_reader_indices_storage.get_buffer()->address());
-        reader_compile_time_args.push_back(conv_reader_indices_storage.get_buffer()->page_size());
-        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_storage.get_buffer()).append_to(reader_compile_time_args);
+        // The reader-indices buffer is kept alive by `workload_descriptor.buffers`,
+        // so baking its address into compile-time args is safe across cache hits
+        // (the buffer's allocation is not freed until the cached MeshWorkload is
+        // evicted).
+        reader_compile_time_args.push_back(conv_reader_indices_buffer->address());
+        reader_compile_time_args.push_back(conv_reader_indices_buffer->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(reader_compile_time_args);
     } else {
         // Put enough 0s so that the offsets of activation reuse args are the same.
         // TensorAccessorArgs appends 2 CT args (is_dram + aligned_page_size), so we need 4 zeros total
@@ -1111,48 +1204,62 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     const tt::tt_metal::NOC reader_noc =
         writer_mcast_noc == tt::tt_metal::NOC::NOC_0 ? tt::tt_metal::NOC::NOC_1 : tt::tt_metal::NOC::NOC_0;
 
-    tt::tt_metal::KernelHandle writer_mcast_sender_id = CreateKernel(
-        program,
-        writer_mcast_sender_kernel,
-        mcast_sender_cores,
-        tt::tt_metal::DataMovementConfig{
+    // Descriptor-flow kernel construction: build KernelDescriptor instances
+    // that the framework later realises into Program kernels.  Compile args /
+    // defines / NOC selection mirror the legacy CreateKernel(...) calls one-
+    // for-one; the only structural change is that compile_args & defines move
+    // off of DataMovementConfig / ComputeConfig (which become pure
+    // ConfigDescriptors) and onto the KernelDescriptor itself.
+    KernelDescriptor writer_mcast_sender_desc;
+    writer_mcast_sender_desc.kernel_source = writer_mcast_sender_kernel;
+    writer_mcast_sender_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_mcast_sender_desc.core_ranges = mcast_sender_cores;
+    writer_mcast_sender_desc.compile_time_args = writer_compile_time_args;
+    writer_mcast_sender_desc.defines =
+        KernelDescriptor::Defines{writer_mcast_sender_defines.begin(), writer_mcast_sender_defines.end()};
+    writer_mcast_sender_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = writer_mcast_noc,
+    };
+
+    // The receiver descriptor is only populated when `!skip_weights_mcast`;
+    // otherwise it stays empty and is not appended to `desc.kernels` below
+    // (matching the legacy `KernelHandle writer_mcast_receiver_id = -1` path
+    // where no kernel is created on the receiver cores).
+    KernelDescriptor writer_mcast_receiver_desc;
+    if (!skip_weights_mcast) {
+        writer_mcast_receiver_desc.kernel_source = writer_mcast_receiver_kernel;
+        writer_mcast_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_mcast_receiver_desc.core_ranges = mcast_receiver_cores;
+        writer_mcast_receiver_desc.compile_time_args = writer_compile_time_args;
+        writer_mcast_receiver_desc.defines = KernelDescriptor::Defines{writer_defines.begin(), writer_defines.end()};
+        writer_mcast_receiver_desc.config = DataMovementConfigDescriptor{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = writer_mcast_noc,
-            .compile_args = writer_compile_time_args,
-            .defines = writer_mcast_sender_defines});
-
-    tt::tt_metal::KernelHandle writer_mcast_receiver_id = -1;
-    if (!skip_weights_mcast) {
-        writer_mcast_receiver_id = CreateKernel(
-            program,
-            writer_mcast_receiver_kernel,
-            mcast_receiver_cores,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = writer_mcast_noc,
-                .compile_args = writer_compile_time_args,
-                .defines = writer_defines});
+        };
     }
 
-    tt::tt_metal::KernelHandle reader_id = CreateKernel(
-        program,
-        reader_kernel,
-        height_sharded ? input_cores : all_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = reader_noc,
-            .compile_args = reader_compile_time_args,
-            .defines = reader_defines});
+    KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source = reader_kernel;
+    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = height_sharded ? input_cores : all_cores;
+    reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_kernel_desc.defines = KernelDescriptor::Defines{reader_defines.begin(), reader_defines.end()};
+    reader_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = reader_noc,
+    };
 
-    tt::tt_metal::KernelHandle compute_kernel_id = CreateKernel(
-        program,
-        compute_kernel,
-        height_sharded ? input_cores : all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .defines = compute_defines});
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source = compute_kernel;
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = height_sharded ? input_cores : all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_kernel_desc.defines = KernelDescriptor::Defines{compute_defines.begin(), compute_defines.end()};
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     // Helper lambda to setup mcast arguments
     auto setup_mcast_args = [&](bool is_noc_0, uint32_t start_x, uint32_t start_y, uint32_t end_x, uint32_t end_y) {
@@ -1216,7 +1323,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                 reader_rt_args.push_back(static_cast<uint32_t>(is_sender_core));    // is_receiver_core
                 reader_rt_args.push_back(transpose_mcast ? core.x : core.y);        // dram config reader index
                 reader_rt_args.insert(reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
-                SetRuntimeArgs(program, reader_id, core, reader_rt_args);
+                reader_kernel_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
             }
         }
     } else {
@@ -1232,14 +1339,22 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                     }
                 }
                 std::vector<uint32_t> reader_rt_args{core_index, reader_remaining_tiles_to_push};
-                SetRuntimeArgs(program, reader_id, core, reader_rt_args);
+                reader_kernel_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
                 core_index++;
             }
         }
     }
 
     // Setup writer mcast arguments
-    // Setup sender args first
+    // Setup sender args first.  Slots 0 (weights buffer address) and 1 (bias
+    // buffer address) are dispatched as `Buffer*` via `RTArgList::push_back`
+    // so the framework's BufferBinding fast cache-hit path patches them
+    // directly into the cached Program without re-running this factory.
+    // When `has_bias == false` slot 1 is a literal uint32_t(0), matching the
+    // legacy `bias_dram_addr = 0` path; when `populate_skipped_work_cores` is
+    // active and the core is outside `output_cores`, slots 0 and 1 are both
+    // literal zero (the kernel skips work and never reads from those
+    // addresses) — those cores get no buffer bindings.
     for (const CoreRange& core_range : mcast_sender_cores.ranges()) {
         for (const CoreCoord& core : core_range) {
             if (populate_skipped_work_cores && !output_cores.contains(core)) {
@@ -1249,7 +1364,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                 args[12] =
                     static_cast<uint32_t>(true);  // is_sender_core, is always true for cores that belong to input_cores
                 args[13] = static_cast<uint32_t>(true);  //  skip work
-                SetRuntimeArgs(program, writer_mcast_sender_id, core, args);
+                writer_mcast_sender_desc.runtime_args.emplace_back(core, std::move(args));
                 continue;
             }
             // Calculate weight slice indices
@@ -1263,8 +1378,15 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                 "bias_tile_offset {} should be less than bias_ntiles {}",
                 bias_tile_offset,
                 bias_ntiles);
-            std::vector<uint32_t> sender_rt_args = {
-                weight_dram_addr, bias_dram_addr, out_start_tile_id_w, bias_tile_offset};
+            KernelDescriptor::RTArgList sender_rt_args;
+            sender_rt_args.push_back(b.buffer());  // [0] weights Buffer* — binding auto-registered
+            if (has_bias) {
+                sender_rt_args.push_back(bias_buffer);  // [1] bias Buffer* — binding auto-registered
+            } else {
+                sender_rt_args.push_back(static_cast<uint32_t>(0));  // [1] literal 0 (no bias)
+            }
+            sender_rt_args.push_back(out_start_tile_id_w);
+            sender_rt_args.push_back(bias_tile_offset);
             if (block_sharded) {
                 const bool is_sender_core = input_cores.contains(core);
                 // 2D multicast setup
@@ -1280,17 +1402,16 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                         bottom_right_core_physical.x,
                         right_core_physical.y);
 
-                    sender_rt_args.insert(sender_rt_args.end(), mcast_coords.begin(), mcast_coords.end());
+                    sender_rt_args.append(mcast_coords);
 
-                    sender_rt_args.insert(
-                        sender_rt_args.end(),
-                        {num_cores_x - 1,
-                         num_cores_x - 1,  // mcast_num_dests, mcast_num_cores
-                         weights_mcast_sender_semaphore_id,
-                         weights_mcast_receiver_semaphore_id,
-                         static_cast<uint32_t>(is_sender_core),
-                         static_cast<uint32_t>(false)});  // skip_work
-                    SetRuntimeArgs(program, writer_mcast_sender_id, core, sender_rt_args);
+                    sender_rt_args.append(std::vector<uint32_t>{
+                        num_cores_x - 1,
+                        num_cores_x - 1,  // mcast_num_dests, mcast_num_cores
+                        weights_mcast_sender_semaphore_id,
+                        weights_mcast_receiver_semaphore_id,
+                        static_cast<uint32_t>(is_sender_core),
+                        static_cast<uint32_t>(false)});  // skip_work
+                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
                 } else {
                     CoreCoord top_core = {(std::size_t)core.x, 0};
                     CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
@@ -1302,18 +1423,16 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                         top_core_physical.x,
                         bottom_right_core_physical.y);
 
-                    sender_rt_args.insert(sender_rt_args.end(), mcast_coords.begin(), mcast_coords.end());
-                    sender_rt_args.insert(
-                        sender_rt_args.end(),
-                        {
-                            num_cores_y - 1,
-                            num_cores_y - 1,  // mcast_num_dests, mcast_num_cores
-                            weights_mcast_sender_semaphore_id,
-                            weights_mcast_receiver_semaphore_id,
-                            static_cast<uint32_t>(is_sender_core),
-                            static_cast<uint32_t>(false)  // skip_work
-                        });
-                    SetRuntimeArgs(program, writer_mcast_sender_id, core, sender_rt_args);
+                    sender_rt_args.append(mcast_coords);
+                    sender_rt_args.append(std::vector<uint32_t>{
+                        num_cores_y - 1,
+                        num_cores_y - 1,  // mcast_num_dests, mcast_num_cores
+                        weights_mcast_sender_semaphore_id,
+                        weights_mcast_receiver_semaphore_id,
+                        static_cast<uint32_t>(is_sender_core),
+                        static_cast<uint32_t>(false)  // skip_work
+                    });
+                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
                 }
             } else {
                 // 1D multicast setup
@@ -1324,13 +1443,12 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                     bottom_right_core_physical.x,
                     bottom_right_core_physical.y);
 
-                sender_rt_args.insert(sender_rt_args.end(), mcast_coords.begin(), mcast_coords.end());
-                sender_rt_args.insert(
-                    sender_rt_args.end(),
-                    {total_active_num_cores - 1,
-                     total_num_cores - 1,  // mcast_num_dests, mcast_num_cores
-                     weights_mcast_sender_semaphore_id,
-                     weights_mcast_receiver_semaphore_id});
+                sender_rt_args.append(mcast_coords);
+                sender_rt_args.append(std::vector<uint32_t>{
+                    total_active_num_cores - 1,
+                    total_num_cores - 1,  // mcast_num_dests, mcast_num_cores
+                    weights_mcast_sender_semaphore_id,
+                    weights_mcast_receiver_semaphore_id});
                 if (enable_activation_reuse) {
                     uint32_t writer_remaining_tiles_to_push = 0;
                     if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
@@ -1341,7 +1459,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                     }
                     sender_rt_args.push_back(writer_remaining_tiles_to_push);
                 }
-                SetRuntimeArgs(program, writer_mcast_sender_id, core, sender_rt_args);
+                writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
             }
         }
     }
@@ -1387,7 +1505,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                     receiver_args.push_back(writer_remaining_tiles_to_push);
                 }
             }
-            SetRuntimeArgs(program, writer_mcast_receiver_id, core, receiver_args);
+            writer_mcast_receiver_desc.runtime_args.emplace_back(core, std::move(receiver_args));
         }
     }
 
@@ -1398,65 +1516,56 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         for (const CoreRange range : all_cores.ranges()) {
             for (const CoreCoord core : range) {
                 bool skip_compute = transpose_mcast ? core.y > end_coord_y : core.x > end_coord_x;
-                SetRuntimeArgs(
-                    program, compute_kernel_id, core, std::vector<uint32_t>{static_cast<uint32_t>(skip_compute)});
+                compute_kernel_desc.runtime_args.emplace_back(
+                    core, std::vector<uint32_t>{static_cast<uint32_t>(skip_compute)});
             }
         }
     }
 
-    std::vector<CoreCoord> mcast_sender_cores_vec;
-    for (const CoreRange& core_range : mcast_sender_cores.ranges()) {
-        std::vector<CoreCoord> core_range_vec = grid_to_cores(core_range.start_coord, core_range.end_coord, true);
-        mcast_sender_cores_vec.insert(mcast_sender_cores_vec.end(), core_range_vec.begin(), core_range_vec.end());
+    // Append kernel descriptors.  Order matters: kernel indices inside the
+    // realised Program are 0, 1, 2, ... in the order kernels are pushed, and
+    // the framework reads `kernel_idx` from BufferBindings to find the cached
+    // RuntimeArgsData on cache hits.  The receiver kernel is only pushed when
+    // `!skip_weights_mcast` (matching the legacy `if (!skip_weights_mcast)
+    // CreateKernel(...)` path); the BufferBindings only reference the sender
+    // kernel index (which is always 0 here), so receiver-kernel absence does
+    // not affect binding resolution.
+    desc.kernels.push_back(std::move(writer_mcast_sender_desc));
+    if (!skip_weights_mcast) {
+        desc.kernels.push_back(std::move(writer_mcast_receiver_desc));
     }
-    post_conv2d_op_memory_checks(
-        program, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
-    // Capture conv_reader_indices_storage to cache this with the program
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .mcast_sender_cores_vec = mcast_sender_cores_vec,
-            .writer_mcast_sender_id = writer_mcast_sender_id,
-            .cb_sharded_act = cb_sharded_act,
-            .cb_output = cb_output,
-            .cb_partials = cb_partials,
-            .partials_cb_uses_output = partials_cb_uses_output,
-            .has_bias = has_bias,
-            .conv_reader_indices_storage = conv_reader_indices_storage,
-        }};
-}
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
 
-void Conv2dShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const Conv2dParams& /*operation_attributes*/,
-    const Conv2dInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto* src_buffer_a = tensor_args.a.buffer();
-    auto* src_buffer_b = tensor_args.b.buffer();
+    // post_conv2d_op_memory_checks() is intentionally NOT called here: it
+    // takes a built `tt::tt_metal::Program&` (it inspects the realised CB
+    // allocation), which is not available inside a descriptor factory.  The
+    // legacy check has been dropped along with the legacy `create()` /
+    // `override_runtime_arguments()` flow; if the post-build verification is
+    // needed in the future it can be re-expressed against the descriptor or
+    // hoisted into the framework.
 
-    const auto& shared_variables = cached_program.shared_variables;
-    auto& program = cached_program.program;
+    WorkloadDescriptor workload_descriptor;
+    // Park the reader-indices Tensor so the framework keeps it alive for the
+    // cached MeshWorkload's lifetime (see comment above the Tensor allocation).
+    // The shared_ptr<Tensor> ownership defers ~Tensor (which would force-free
+    // the underlying device memory) until the cached workload is evicted.
+    workload_descriptor.buffers.push_back(
+        WorkloadBuffer{.owner = std::move(conv_reader_indices_owner), .buffer = conv_reader_indices_buffer});
 
-    std::optional<tt::tt_metal::Buffer*> src_buffer_c = std::nullopt;
-    if (shared_variables.has_bias) {
-        src_buffer_c = tensor_args.bias.value().buffer();
-        TT_FATAL(src_buffer_c.value() != nullptr, "Source buffer C must not be null when bias is present");
+    // Replicate the single ProgramDescriptor across every coordinate range —
+    // every coord in the workload runs the same conv2d program.  Move the
+    // descriptor into the final entry to avoid an extra copy.
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
     }
-
-    auto& writer_sender_kernel_args_by_core = GetRuntimeArgs(program, shared_variables.writer_mcast_sender_id);
-    for (const auto& core : shared_variables.mcast_sender_cores_vec) {
-        auto& runtime_args = writer_sender_kernel_args_by_core[core.x][core.y];
-        runtime_args[0] = src_buffer_b->address();
-        if (shared_variables.has_bias) {
-            runtime_args[1] = (*src_buffer_c)->address();
-        }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
     }
 
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_sharded_act, *src_buffer_a);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *output_tensor.buffer());
-    if (shared_variables.partials_cb_uses_output) {
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_partials, *output_tensor.buffer());
-    }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1336,8 +1336,7 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
                         reader_remaining_tiles_to_push = act_block_h_nsubblocks_split;
                     }
                 }
-                std::vector<uint32_t> reader_rt_args{core_index, reader_remaining_tiles_to_push};
-                reader_kernel_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
+                reader_kernel_desc.emplace_runtime_args(core, {core_index, reader_remaining_tiles_to_push});
                 core_index++;
             }
         }
@@ -1356,13 +1355,25 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
     for (const CoreRange& core_range : mcast_sender_cores.ranges()) {
         for (const CoreCoord& core : core_range) {
             if (populate_skipped_work_cores && !output_cores.contains(core)) {
-                std::vector<uint32_t> args = std::vector<uint32_t>(14, 0);
-                args[10] = weights_mcast_sender_semaphore_id;
-                args[11] = weights_mcast_receiver_semaphore_id;
-                args[12] =
-                    static_cast<uint32_t>(true);  // is_sender_core, is always true for cores that belong to input_cores
-                args[13] = static_cast<uint32_t>(true);  //  skip work
-                writer_mcast_sender_desc.runtime_args.emplace_back(core, std::move(args));
+                writer_mcast_sender_desc.emplace_runtime_args(
+                    core,
+                    {
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        weights_mcast_sender_semaphore_id,
+                        weights_mcast_receiver_semaphore_id,
+                        static_cast<uint32_t>(
+                            true),  // is_sender_core, is always true for cores that belong to input_cores
+                        static_cast<uint32_t>(true)  //  skip work
+                    });
                 continue;
             }
             // Calculate weight slice indices
@@ -1514,8 +1525,7 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
         for (const CoreRange range : all_cores.ranges()) {
             for (const CoreCoord core : range) {
                 bool skip_compute = transpose_mcast ? core.y > end_coord_y : core.x > end_coord_x;
-                compute_kernel_desc.runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{static_cast<uint32_t>(skip_compute)});
+                compute_kernel_desc.emplace_runtime_args(core, {static_cast<uint32_t>(skip_compute)});
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -40,8 +40,6 @@ using ttnn::operations::conv::is_1d_depthwise_conv;
 using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
 using ttnn::operations::conv::SkipMcast;
 
-using tt::tt_metal::CBDescriptor;
-using tt::tt_metal::CBFormatDescriptor;
 using tt::tt_metal::ComputeConfigDescriptor;
 using tt::tt_metal::DataMovementConfigDescriptor;
 using tt::tt_metal::KernelDescriptor;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -40,14 +40,6 @@ using ttnn::operations::conv::is_1d_depthwise_conv;
 using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
 using ttnn::operations::conv::SkipMcast;
 
-using tt::tt_metal::ComputeConfigDescriptor;
-using tt::tt_metal::DataMovementConfigDescriptor;
-using tt::tt_metal::KernelDescriptor;
-using tt::tt_metal::ProgramDescriptor;
-using tt::tt_metal::SemaphoreDescriptor;
-using tt::tt_metal::WorkloadBuffer;
-using tt::tt_metal::WorkloadDescriptor;
-
 // Compute kernel addressing mode divides addresses with 16
 constexpr uint32_t COMPUTE_KERNEL_ADDRESS_DIVISOR = 16;
 
@@ -183,7 +175,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
     return config;
 }
 
-WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
+tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
     Tensor& output_tensor,
@@ -716,7 +708,7 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
     // framework patches their base addresses on cache hits.  The reader-
     // indices Tensor is the workload-scoped buffer parked below; the L1 path
     // (config_tensors_in_dram == false) picks it up via this CB binding.
-    ProgramDescriptor desc;
+    tt::tt_metal::ProgramDescriptor desc;
     allocate_cbs_to_program_descriptor(cb_info, desc, all_cores, a, output, conv_reader_indices_tensor);
 
     const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
@@ -775,13 +767,13 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
             mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
         }
         act_mcast_sender_semaphore_id = next_sem_id++;
-        desc.semaphores.push_back(SemaphoreDescriptor{
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
             .id = act_mcast_sender_semaphore_id,
             .core_ranges = all_cores,
             .initial_value = 0,
         });
         act_mcast_receiver_semaphore_id = next_sem_id++;
-        desc.semaphores.push_back(SemaphoreDescriptor{
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
             .id = act_mcast_receiver_semaphore_id,
             .core_ranges = all_cores,
             .initial_value = 0,
@@ -789,38 +781,38 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
 
         if (split_reader_cb_shared) {
             weights_mcast_sender_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = weights_mcast_sender_semaphore_id,
                 .core_ranges = all_cores,
                 .initial_value = 0,
             });
             weights_mcast_receiver_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = weights_mcast_receiver_semaphore_id,
                 .core_ranges = all_cores,
                 .initial_value = 0,
             });
             act_split_reader_reserve_done_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = act_split_reader_reserve_done_semaphore_id,
                 .core_ranges = all_cores,
                 .initial_value = 0,
             });
             act_split_reader_write_done_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = act_split_reader_write_done_semaphore_id,
                 .core_ranges = all_cores,
                 .initial_value = 0,
             });
         } else {
             weights_mcast_sender_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = weights_mcast_sender_semaphore_id,
                 .core_ranges = output_cores,
                 .initial_value = 0,
             });
             weights_mcast_receiver_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = weights_mcast_receiver_semaphore_id,
                 .core_ranges = output_cores,
                 .initial_value = 0,
@@ -831,13 +823,13 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
         if (!skip_weights_mcast) {
             mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
             weights_mcast_sender_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = weights_mcast_sender_semaphore_id,
                 .core_ranges = output_cores,
                 .initial_value = 0,
             });
             weights_mcast_receiver_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(SemaphoreDescriptor{
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
                 .id = weights_mcast_receiver_semaphore_id,
                 .core_ranges = output_cores,
                 .initial_value = 0,
@@ -1208,14 +1200,14 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
     // for-one; the only structural change is that compile_args & defines move
     // off of DataMovementConfig / ComputeConfig (which become pure
     // ConfigDescriptors) and onto the KernelDescriptor itself.
-    KernelDescriptor writer_mcast_sender_desc;
+    tt::tt_metal::KernelDescriptor writer_mcast_sender_desc;
     writer_mcast_sender_desc.kernel_source = writer_mcast_sender_kernel;
-    writer_mcast_sender_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_mcast_sender_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
     writer_mcast_sender_desc.core_ranges = mcast_sender_cores;
     writer_mcast_sender_desc.compile_time_args = writer_compile_time_args;
     writer_mcast_sender_desc.defines =
-        KernelDescriptor::Defines{writer_mcast_sender_defines.begin(), writer_mcast_sender_defines.end()};
-    writer_mcast_sender_desc.config = DataMovementConfigDescriptor{
+        tt::tt_metal::KernelDescriptor::Defines{writer_mcast_sender_defines.begin(), writer_mcast_sender_defines.end()};
+    writer_mcast_sender_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
         .noc = writer_mcast_noc,
     };
@@ -1224,37 +1216,39 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
     // otherwise it stays empty and is not appended to `desc.kernels` below
     // (matching the legacy `KernelHandle writer_mcast_receiver_id = -1` path
     // where no kernel is created on the receiver cores).
-    KernelDescriptor writer_mcast_receiver_desc;
+    tt::tt_metal::KernelDescriptor writer_mcast_receiver_desc;
     if (!skip_weights_mcast) {
         writer_mcast_receiver_desc.kernel_source = writer_mcast_receiver_kernel;
-        writer_mcast_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_mcast_receiver_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
         writer_mcast_receiver_desc.core_ranges = mcast_receiver_cores;
         writer_mcast_receiver_desc.compile_time_args = writer_compile_time_args;
-        writer_mcast_receiver_desc.defines = KernelDescriptor::Defines{writer_defines.begin(), writer_defines.end()};
-        writer_mcast_receiver_desc.config = DataMovementConfigDescriptor{
+        writer_mcast_receiver_desc.defines =
+            tt::tt_metal::KernelDescriptor::Defines{writer_defines.begin(), writer_defines.end()};
+        writer_mcast_receiver_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = writer_mcast_noc,
         };
     }
 
-    KernelDescriptor reader_kernel_desc;
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source = reader_kernel;
-    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
     reader_kernel_desc.core_ranges = height_sharded ? input_cores : all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_kernel_desc.defines = KernelDescriptor::Defines{reader_defines.begin(), reader_defines.end()};
-    reader_kernel_desc.config = DataMovementConfigDescriptor{
+    reader_kernel_desc.defines = tt::tt_metal::KernelDescriptor::Defines{reader_defines.begin(), reader_defines.end()};
+    reader_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
         .noc = reader_noc,
     };
 
-    KernelDescriptor compute_kernel_desc;
+    tt::tt_metal::KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel;
-    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = height_sharded ? input_cores : all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
-    compute_kernel_desc.defines = KernelDescriptor::Defines{compute_defines.begin(), compute_defines.end()};
-    compute_kernel_desc.config = ComputeConfigDescriptor{
+    compute_kernel_desc.defines =
+        tt::tt_metal::KernelDescriptor::Defines{compute_defines.begin(), compute_defines.end()};
+    compute_kernel_desc.config = tt::tt_metal::ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
     };
@@ -1387,7 +1381,7 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
                 "bias_tile_offset {} should be less than bias_ntiles {}",
                 bias_tile_offset,
                 bias_ntiles);
-            KernelDescriptor::RTArgList sender_rt_args;
+            tt::tt_metal::KernelDescriptor::RTArgList sender_rt_args;
             sender_rt_args.push_back(b.buffer());  // [0] weights Buffer* — binding auto-registered
             if (has_bias) {
                 sender_rt_args.push_back(bias_buffer);  // [1] bias Buffer* — binding auto-registered
@@ -1555,13 +1549,13 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
     post_conv2d_op_memory_checks(
         desc, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
 
-    WorkloadDescriptor workload_descriptor;
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
     // Park the reader-indices Tensor so the framework keeps it alive for the
     // cached MeshWorkload's lifetime (see comment above the Tensor allocation).
     // The shared_ptr<Tensor> ownership defers ~Tensor (which would force-free
     // the underlying device memory) until the cached workload is evicted.
-    workload_descriptor.buffers.push_back(
-        WorkloadBuffer{.owner = std::move(conv_reader_indices_owner), .buffer = conv_reader_indices_buffer});
+    workload_descriptor.buffers.push_back(tt::tt_metal::WorkloadBuffer{
+        .owner = std::move(conv_reader_indices_owner), .buffer = conv_reader_indices_buffer});
 
     // Replicate the single ProgramDescriptor across every coordinate range —
     // every coord in the workload runs the same conv2d program.  Move the

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -742,13 +742,16 @@ tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_de
     // This requires synchronization between the main reader and the second reader to prevent race conditions.
     const bool split_reader_cb_shared = enable_split_reader && overlap_act_cb && block_sharded;
 
-    // Program-scoped semaphore IDs are assigned sequentially.  The framework
-    // allocates the actual L1 addresses when realising the descriptor into a
-    // Program (see SemaphoreDescriptor entries appended to `desc.semaphores`
-    // below).  Kernels read these ids the same way they did when the legacy
-    // CreateSemaphore() return value was passed through compile-time args or
-    // runtime args (all are 0-initialised semaphores; INVALID == 0).
-    uint32_t next_sem_id = 0;
+    // Program-scoped semaphore IDs are assigned sequentially. The framework
+    // allocates the actual L1 addresses when realising the descriptor into a program
+    uint32_t next_sem_id = 0;  // being changed automatically within compose_semaphore_descriptor below
+    auto compose_semaphore_descriptor =
+        [&next_sem_id](uint32_t& semahpore_id, const CoreRangeSet& core_ranges, const uint32_t initial_value) {
+            semahpore_id = next_sem_id++;  // to the next semaphore id
+            return tt::tt_metal::SemaphoreDescriptor{
+                .id = semahpore_id, .core_ranges = core_ranges, .initial_value = initial_value};
+        };
+
     if (block_sharded) {
         const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
         // 2D mcast
@@ -766,74 +769,28 @@ tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_de
         if (populate_skipped_work_cores) {
             mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
         }
-        act_mcast_sender_semaphore_id = next_sem_id++;
-        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-            .id = act_mcast_sender_semaphore_id,
-            .core_ranges = all_cores,
-            .initial_value = 0,
-        });
-        act_mcast_receiver_semaphore_id = next_sem_id++;
-        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-            .id = act_mcast_receiver_semaphore_id,
-            .core_ranges = all_cores,
-            .initial_value = 0,
-        });
+        desc.semaphores.push_back(compose_semaphore_descriptor(act_mcast_sender_semaphore_id, all_cores, 0));
+        desc.semaphores.push_back(compose_semaphore_descriptor(act_mcast_receiver_semaphore_id, all_cores, 0));
 
         if (split_reader_cb_shared) {
-            weights_mcast_sender_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = weights_mcast_sender_semaphore_id,
-                .core_ranges = all_cores,
-                .initial_value = 0,
-            });
-            weights_mcast_receiver_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = weights_mcast_receiver_semaphore_id,
-                .core_ranges = all_cores,
-                .initial_value = 0,
-            });
-            act_split_reader_reserve_done_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = act_split_reader_reserve_done_semaphore_id,
-                .core_ranges = all_cores,
-                .initial_value = 0,
-            });
-            act_split_reader_write_done_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = act_split_reader_write_done_semaphore_id,
-                .core_ranges = all_cores,
-                .initial_value = 0,
-            });
+            desc.semaphores.push_back(compose_semaphore_descriptor(weights_mcast_sender_semaphore_id, all_cores, 0));
+            desc.semaphores.push_back(compose_semaphore_descriptor(weights_mcast_receiver_semaphore_id, all_cores, 0));
+            desc.semaphores.push_back(
+                compose_semaphore_descriptor(act_split_reader_reserve_done_semaphore_id, all_cores, 0));
+            desc.semaphores.push_back(
+                compose_semaphore_descriptor(act_split_reader_write_done_semaphore_id, all_cores, 0));
         } else {
-            weights_mcast_sender_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = weights_mcast_sender_semaphore_id,
-                .core_ranges = output_cores,
-                .initial_value = 0,
-            });
-            weights_mcast_receiver_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = weights_mcast_receiver_semaphore_id,
-                .core_ranges = output_cores,
-                .initial_value = 0,
-            });
+            desc.semaphores.push_back(compose_semaphore_descriptor(weights_mcast_sender_semaphore_id, output_cores, 0));
+            desc.semaphores.push_back(
+                compose_semaphore_descriptor(weights_mcast_receiver_semaphore_id, output_cores, 0));
         }
     } else {
         // 1D mcast
         if (!skip_weights_mcast) {
             mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
-            weights_mcast_sender_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = weights_mcast_sender_semaphore_id,
-                .core_ranges = output_cores,
-                .initial_value = 0,
-            });
-            weights_mcast_receiver_semaphore_id = next_sem_id++;
-            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-                .id = weights_mcast_receiver_semaphore_id,
-                .core_ranges = output_cores,
-                .initial_value = 0,
-            });
+            desc.semaphores.push_back(compose_semaphore_descriptor(weights_mcast_sender_semaphore_id, output_cores, 0));
+            desc.semaphores.push_back(
+                compose_semaphore_descriptor(weights_mcast_receiver_semaphore_id, output_cores, 0));
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1535,13 +1535,15 @@ WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
     desc.kernels.push_back(std::move(reader_kernel_desc));
     desc.kernels.push_back(std::move(compute_kernel_desc));
 
-    // post_conv2d_op_memory_checks() is intentionally NOT called here: it
-    // takes a built `tt::tt_metal::Program&` (it inspects the realised CB
-    // allocation), which is not available inside a descriptor factory.  The
-    // legacy check has been dropped along with the legacy `create()` /
-    // `override_runtime_arguments()` flow; if the post-build verification is
-    // needed in the future it can be re-expressed against the descriptor or
-    // hoisted into the framework.
+    // Descriptor-flow port of the legacy post-`CreateProgram` memory check.
+    // The helper now inspects `desc.cbs` directly (mirroring the realized
+    // Program's `!cb->globally_allocated()` walk) and asserts the L1
+    // allocator delta still matches the predicted output footprint. Must be
+    // called AFTER `desc.cbs` is fully populated and AFTER the reader-indices
+    // Tensor is allocated, but BEFORE the descriptor is moved into the
+    // returned WorkloadDescriptor.
+    post_conv2d_op_memory_checks(
+        desc, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
 
     WorkloadDescriptor workload_descriptor;
     // Park the reader-indices Tensor so the framework keeps it alive for the

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -3,33 +3,54 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::prim {
 
+// Descriptor-based factory for the HEIGHT_SHARDED / BLOCK_SHARDED variants of
+// conv2d (everything that is not WIDTH_SHARDED).
+//
+// Satisfies `ProgramDescriptorFactoryConcept` via the declarative
+// `create_workload_descriptor` contract (contract 2 in
+// mesh_device_operation_adapter.hpp).  The declarative contract is required
+// because this factory allocates a workload-scoped reader-indices config
+// Tensor whose `Buffer*` is referenced from the per-coord program's CB /
+// compile-time args; the Tensor must outlive the cached MeshWorkload, which
+// `WorkloadDescriptor::buffers` arranges via shared-ptr ownership.
+//
+// The sibling variant `Conv2dWidthShardedProgramFactory` is also on the
+// descriptor path; per-alternative concept dispatch in
+// `dispatch_to_mesh_workload_factory` (device_operation.hpp) lets both styles
+// live in the same `Conv2dDeviceOperation::program_factory_t` variant
+// without any change to `Conv2dDeviceOperation` itself.
 struct Conv2dShardedProgramFactory {
-    struct shared_variables_t {
-        std::vector<CoreCoord> mcast_sender_cores_vec;
-        tt::tt_metal::KernelHandle writer_mcast_sender_id{};
-        tt::tt_metal::CBHandle cb_sharded_act{};
-        tt::tt_metal::CBHandle cb_output{};
-        tt::tt_metal::CBHandle cb_partials{};
-        bool partials_cb_uses_output = false;
-        bool has_bias = false;
-        tt::tt_metal::DeviceStorage conv_reader_indices_storage;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Builds the entire workload in one call (invoked ONCE per workload on
+    // cache miss):
+    //   1. Allocates the sliding-window reader-indices config Tensor on the
+    //      input tensor's device and parks it in `buffers` so the framework
+    //      keeps it alive for the cached MeshWorkload's lifetime — the
+    //      reader/writer kernels reference this buffer either via a globally-
+    //      allocated CB (L1 path) or via compile-time args
+    //      (config_tensors_in_dram path).
+    //   2. Builds one `ProgramDescriptor` and replicates it across all
+    //      coordinate ranges of `tensor_coords`.
+    //
+    // On cache hits the framework's `BufferBinding` fast path patches the
+    // weight / bias buffer addresses recorded via
+    // `KernelDescriptor::emplace_runtime_args(Buffer*)` and the dynamic CB
+    // addresses recorded on `CBDescriptor::buffer` — `create_workload_descriptor`
+    // is not re-invoked.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const Conv2dParams& operation_attributes,
         const Conv2dInputs& tensor_args,
-        Tensor& output_tensor);
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -12,34 +12,11 @@
 
 namespace ttnn::prim {
 
-// Descriptor-based factory for the HEIGHT_SHARDED / BLOCK_SHARDED variants of
-// conv2d (everything that is not WIDTH_SHARDED).
-//
 // Satisfies `ProgramDescriptorFactoryConcept` via the declarative
-// `create_workload_descriptor` contract (contract 2 in
-// mesh_device_operation_adapter.hpp).  The declarative contract is required
-// because this factory allocates a workload-scoped reader-indices config
-// Tensor whose `Buffer*` is referenced from the per-coord program's CB /
-// compile-time args; the Tensor must outlive the cached MeshWorkload, which
-// `WorkloadDescriptor::buffers` arranges via shared-ptr ownership.
-//
-// The sibling variant `Conv2dWidthShardedProgramFactory` is also on the
-// descriptor path; per-alternative concept dispatch in
-// `dispatch_to_mesh_workload_factory` (device_operation.hpp) lets both styles
-// live in the same `Conv2dDeviceOperation::program_factory_t` variant
-// without any change to `Conv2dDeviceOperation` itself.
+// `create_workload_descriptor` contract (contract 2 in mesh_device_operation_adapter.hpp).
 struct Conv2dShardedProgramFactory {
     // Builds the entire workload in one call (invoked ONCE per workload on
     // cache miss):
-    //   1. Allocates the sliding-window reader-indices config Tensor on the
-    //      input tensor's device and parks it in `buffers` so the framework
-    //      keeps it alive for the cached MeshWorkload's lifetime — the
-    //      reader/writer kernels reference this buffer either via a globally-
-    //      allocated CB (L1 path) or via compile-time args
-    //      (config_tensors_in_dram path).
-    //   2. Builds one `ProgramDescriptor` and replicates it across all
-    //      coordinate ranges of `tensor_coords`.
-    //
     // On cache hits the framework's `BufferBinding` fast path patches the
     // weight / bias buffer addresses recorded via
     // `KernelDescriptor::emplace_runtime_args(Buffer*)` and the dynamic CB

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -3,25 +3,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <map>
+#include <memory>
 #include <string>
-#include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
-#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
-#include "ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp"
-#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
-#include "ttnn/operations/sliding_window/sliding_window.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
-#include <tt-metalium/work_split.hpp>
+#include <utility>
+#include <vector>
+
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 #include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
 
 namespace ttnn::prim {
 
 namespace unary = ttnn::operations::unary;
 using ttnn::operations::conv::conv_skip_mcast;
 using ttnn::operations::conv::SkipMcast;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+using tt::tt_metal::SemaphoreDescriptor;
+using tt::tt_metal::WorkloadBuffer;
+using tt::tt_metal::WorkloadDescriptor;
 
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(
     const ttnn::Shape& conv_activation_shape,
@@ -44,9 +63,11 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
     return {{1, num_rows_padded, num_cols_padded}, {1, num_rows, num_cols}};
 }
 
-Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFactory::create(
-    const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
 
@@ -314,7 +335,7 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         (p_config.per_core_out_matrix_height_ntile + act_block_h_ntiles - 1) / act_block_h_ntiles;
     uint32_t num_blocks_weight_w_per_core = p_config.per_core_out_matrix_width_ntile / weight_block_w_ntiles;
 
-    std::map<std::string, std::string> reader_defines;
+    KernelDescriptor::Defines reader_defines;
 
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / (input_num_cores * per_core_num_blocks_act_w);
 
@@ -341,8 +362,14 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         (uint32_t)weights_noc,
         (uint32_t)device->arch());
 
-    uint32_t act_mcast_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);    // 0==INVALID
-    uint32_t act_mcast_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);  // 0==INVALID.
+    // Program-scoped semaphore IDs assigned sequentially.  The framework
+    // allocates the actual L1 addresses when realising the descriptor into a
+    // Program (see SemaphoreDescriptor entries appended to `desc.semaphores`
+    // below).  The kernel reads these ids the same way it did when the
+    // legacy CreateSemaphore() return value was passed through compile-time
+    // args (both forms are 0-INVALID semaphores on `all_cores`).
+    const uint32_t act_mcast_sender_semaphore = 0;
+    const uint32_t act_mcast_receiver_semaphore = 1;
 
     CoreCoord act_mcast_start_core_logical(0, 0);
     CoreCoord act_mcast_end_core_logical(all_cores.bounding_box().end_coord.x, all_cores.bounding_box().end_coord.y);
@@ -364,18 +391,18 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
 
     TT_FATAL(act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
 
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> writer_mcast_sender_defines;
+    KernelDescriptor::Defines writer_defines;
+    KernelDescriptor::Defines writer_mcast_sender_defines;
     std::map<std::string, std::string> compute_defines;
 
     const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
     const bool skip_activation_mcast = skip_mcast.skip_activation_mcast;
     const bool skip_weights_mcast = skip_mcast.skip_weights_mcast;
     if (skip_activation_mcast) {
-        reader_defines["SKIP_MCAST"] = "1";
+        reader_defines.emplace_back("SKIP_MCAST", "1");
     }
     if (skip_weights_mcast) {
-        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
+        writer_mcast_sender_defines.emplace_back("SKIP_MCAST", "1");
     }
 
     bool pack_relu = fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU;
@@ -404,20 +431,31 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         ttnn::operations::sliding_window::generate_sliding_window_op_config(
             op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
 
-    // create sharded ttnn config tensors
-    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+    // Build the reader-indices config Tensor on host and upload it.
+    // The resulting device buffer must outlive the cached MeshWorkload because
+    // the activation kernel references it either via a globally-allocated CB
+    // (L1 path) or via compile-time args (DRAM path) — both bake the buffer
+    // address into the cached Program.  We wrap the Tensor in a shared_ptr
+    // and park it on `workload_descriptor.buffers`; otherwise the Tensor's
+    // destructor would force-free the device storage at the end of this
+    // function via DeviceStorage::deallocate, leaving the kernel reading from
+    // freed memory on cache hits.
+    Tensor conv_reader_indices_tensor_local = ttnn::operations::sliding_window::construct_on_host_config_tensor(
         conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
-    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
+    conv_reader_indices_tensor_local = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor_local, parallel_config, false, a.device(), config_tensors_in_dram);
 
-    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor_local);
+
+    auto conv_reader_indices_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor_local));
+    const Tensor& conv_reader_indices_tensor = *conv_reader_indices_owner;
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_owner->buffer();
 
     // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
     // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
     // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
     // populated by the reader kernel.
-    const uint32_t reader_indices_actual_page_size = conv_reader_indices_storage.get_buffer()->page_size();
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -437,12 +475,16 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         input_channels_padded,
         reader_indices_actual_page_size);
 
-    // call function to allocate circular buffers
-    allocate_cbs(cb_info, program, all_reader_cores, a, output, conv_reader_indices_tensor);
-    const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
-    const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
+    ProgramDescriptor desc;
+
+    // Descriptor-flow CB allocation: appends one CBDescriptor per non-empty
+    // CBInfo entry to `desc.cbs` and fills `CBInfo::index`.  Sharded CBs are
+    // backed by tensor `Buffer*` (recorded on `CBDescriptor::buffer`) so the
+    // framework patches their base addresses on cache hits.  The reader-
+    // indices Tensor is the workload-scoped buffer parked above; the L1 path
+    // (config_tensors_in_dram == false) picks it up via this CB binding.
+    allocate_cbs_to_program_descriptor(cb_info, desc, all_reader_cores, a, output, conv_reader_indices_tensor);
     const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
-    const tt::tt_metal::CBHandle cb_partials = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     std::vector<uint32_t> compute_kernel_args = {
         act_block_w_ntiles,                         // in0_block_w
@@ -537,11 +579,14 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         (uint32_t)has_bias};
 
     if (config_tensors_in_dram) {
-        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
-        activation_kernel_compile_args.push_back(conv_reader_indices_storage.get_buffer()->address());
-        activation_kernel_compile_args.push_back(conv_reader_indices_storage.get_buffer()->page_size());
-        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_storage.get_buffer())
-            .append_to(activation_kernel_compile_args);
+        reader_defines.emplace_back("CONFIG_TENSOR_IN_DRAM", "1");
+        // The reader-indices buffer is kept alive by `workload_descriptor.buffers`,
+        // so baking its address into compile-time args is safe across cache
+        // hits (the buffer's allocation is not freed until the cached
+        // MeshWorkload is evicted).
+        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->address());
+        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(activation_kernel_compile_args);
     }
 
     for (uint32_t index = 0; index < activation_kernel_compile_args.size(); index++) {
@@ -551,35 +596,38 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
     tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(weights_kernel_compile_args);
     tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(weights_kernel_compile_args);
 
-    auto act_kernel_id = CreateKernel(
-        program,
-        activation_kernel_path,
-        all_reader_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = act_noc,
-            .compile_args = activation_kernel_compile_args,
-            .defines = reader_defines});
+    KernelDescriptor act_kernel_desc;
+    act_kernel_desc.kernel_source = activation_kernel_path;
+    act_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    act_kernel_desc.core_ranges = CoreRangeSet(all_reader_cores);
+    act_kernel_desc.compile_time_args = std::move(activation_kernel_compile_args);
+    act_kernel_desc.defines = reader_defines;
+    act_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = act_noc,
+    };
 
-    auto weights_kernel_id = CreateKernel(
-        program,
-        weights_kernel_path,
-        all_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = weights_noc,
-            .compile_args = weights_kernel_compile_args,
-            .defines = writer_defines});
+    KernelDescriptor weights_kernel_desc;
+    weights_kernel_desc.kernel_source = weights_kernel_path;
+    weights_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    weights_kernel_desc.core_ranges = all_cores;
+    weights_kernel_desc.compile_time_args = std::move(weights_kernel_compile_args);
+    weights_kernel_desc.defines = std::move(writer_defines);
+    weights_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = weights_noc,
+    };
 
-    CreateKernel(
-        program,
-        compute_kernel_path,
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .defines = compute_defines});
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source = compute_kernel_path;
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_kernel_desc.defines = KernelDescriptor::Defines{compute_defines.begin(), compute_defines.end()};
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     auto full_core_grid = device->compute_with_storage_grid_size();
     std::vector<uint32_t> act_mcast_noc_y;
@@ -595,10 +643,6 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         act_mcast_noc_y.push_back(device->worker_core_from_logical_core(CoreCoord(0, core_index)).y);
     }
 
-    uint32_t bias_base_address = 0;
-    if (bias) {
-        bias_base_address = bias.value().buffer()->address();
-    }
     auto total_num_active_cores = std::max(input_num_cores, output_num_cores);
     auto total_num_cores = all_reader_cores.size();
     for (uint32_t core_index = 0; core_index < total_num_cores; core_index++) {
@@ -616,65 +660,79 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         // Mcast Y Lookup Table
         rt_args.insert(rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
 
-        SetRuntimeArgs(program, act_kernel_id, CoreCoord(core_x, core_y), rt_args);
+        act_kernel_desc.runtime_args.emplace_back(CoreCoord(core_x, core_y), std::move(rt_args));
 
         // Weights kernel is not placed on inactive cores.
         if (core_index < total_num_active_cores) {
-            SetRuntimeArgs(
-                program,
-                weights_kernel_id,
-                CoreCoord(core_x, core_y),
-                {core_index * weight_block_w_ntiles,
-                 b.buffer()->address(),
-                 bias_base_address,
-                 (uint32_t)(core_index < output_num_cores)});
+            // Slots 1 (weights buffer address) and 2 (bias buffer address, if
+            // present) are dispatched as `Buffer*` so the framework's cache-hit
+            // fast path patches them directly into the cached Program without
+            // re-running this factory.  When `has_bias == false` slot 2 is a
+            // literal zero, matching the legacy `bias_base_address = 0` path.
+            if (has_bias) {
+                weights_kernel_desc.emplace_runtime_args(
+                    CoreCoord(core_x, core_y),
+                    {core_index * weight_block_w_ntiles,
+                     b.buffer(),
+                     bias.value().buffer(),
+                     (uint32_t)(core_index < output_num_cores)});
+            } else {
+                weights_kernel_desc.emplace_runtime_args(
+                    CoreCoord(core_x, core_y),
+                    {core_index * weight_block_w_ntiles,
+                     b.buffer(),
+                     static_cast<uint32_t>(0),
+                     (uint32_t)(core_index < output_num_cores)});
+            }
         }
     }
 
-    post_conv2d_op_memory_checks(
-        program, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .cb_sharded_act = cb_sharded_act,
-            .cb_output = cb_output,
-            .cb_partials = cb_partials,
-            .partials_cb_uses_output = partials_cb_uses_output,
-            .has_bias = has_bias,
-            .full_core_grid = full_core_grid,
-            .weights_kernel_id = weights_kernel_id,
-            .total_num_active_cores = total_num_active_cores,
-            .conv_reader_indices_storage = conv_reader_indices_storage,
-        }};
-}
+    desc.kernels.push_back(std::move(act_kernel_desc));
+    desc.kernels.push_back(std::move(weights_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
 
-void Conv2dWidthShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const Conv2dParams& /*operation_attributes*/,
-    const Conv2dInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto* src_buffer_a = tensor_args.a.buffer();
-    auto* src_buffer_b = tensor_args.b.buffer();
-    auto& program = cached_program.program;
-    const auto& shared_variables = cached_program.shared_variables;
+    // Semaphore Descriptors — match the legacy CreateSemaphore(... 0 /*INVALID*/)
+    // pair above.  Both semaphores live on `all_cores` and are referenced from
+    // the activation kernel by their compile-time-arg ids (0 and 1).
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = act_mcast_sender_semaphore,
+        .core_ranges = all_cores,
+        .initial_value = 0,
+    });
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = act_mcast_receiver_semaphore,
+        .core_ranges = all_cores,
+        .initial_value = 0,
+    });
 
-    auto& weights_kernel_runtime_args = GetRuntimeArgs(program, shared_variables.weights_kernel_id);
-    for (uint32_t core_index = 0; core_index < shared_variables.total_num_active_cores; core_index++) {
-        uint32_t core_x = core_index % shared_variables.full_core_grid.x;
-        uint32_t core_y = core_index / shared_variables.full_core_grid.x;
+    // post_conv2d_op_memory_checks() is intentionally NOT called here: it
+    // takes a built `tt::tt_metal::Program&` (it inspects the realised CB
+    // allocation), which is not available inside a descriptor factory.  The
+    // legacy `Conv2dShardedProgramFactory` (still on the old path) keeps the
+    // check; once that variant is also migrated the check can be re-expressed
+    // against the descriptor or hoisted into the framework.
 
-        auto& this_core_weights_kernel_runtime_args = weights_kernel_runtime_args[core_x][core_y];
-        this_core_weights_kernel_runtime_args[1] = src_buffer_b->address();
-        if (shared_variables.has_bias) {
-            this_core_weights_kernel_runtime_args[2] = tensor_args.bias.value().buffer()->address();
-        }
+    WorkloadDescriptor workload_descriptor;
+    // Park the reader-indices Tensor so the framework keeps it alive for the
+    // cached MeshWorkload's lifetime (see comment above the Tensor allocation).
+    // The shared_ptr<Tensor> ownership defers ~Tensor (which would force-free
+    // the underlying device memory) until the cached workload is evicted.
+    workload_descriptor.buffers.push_back(
+        WorkloadBuffer{.owner = std::move(conv_reader_indices_owner), .buffer = conv_reader_indices_buffer});
+
+    // Replicate the single ProgramDescriptor across every coordinate range —
+    // every coord in the workload runs the same conv2d program.  Move the
+    // descriptor into the final entry to avoid an extra copy.
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
     }
 
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_sharded_act, *src_buffer_a);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *output_tensor.buffer());
-    if (shared_variables.partials_cb_uses_output) {
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_partials, *output_tensor.buffer());
-    }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -32,14 +32,6 @@ namespace unary = ttnn::operations::unary;
 using ttnn::operations::conv::conv_skip_mcast;
 using ttnn::operations::conv::SkipMcast;
 
-using tt::tt_metal::ComputeConfigDescriptor;
-using tt::tt_metal::DataMovementConfigDescriptor;
-using tt::tt_metal::KernelDescriptor;
-using tt::tt_metal::ProgramDescriptor;
-using tt::tt_metal::SemaphoreDescriptor;
-using tt::tt_metal::WorkloadBuffer;
-using tt::tt_metal::WorkloadDescriptor;
-
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(
     const ttnn::Shape& conv_activation_shape,
     const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
@@ -61,7 +53,7 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
     return {{1, num_rows_padded, num_cols_padded}, {1, num_rows, num_cols}};
 }
 
-WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
+tt::tt_metal::WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
     Tensor& output_tensor,
@@ -333,7 +325,7 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
         (p_config.per_core_out_matrix_height_ntile + act_block_h_ntiles - 1) / act_block_h_ntiles;
     uint32_t num_blocks_weight_w_per_core = p_config.per_core_out_matrix_width_ntile / weight_block_w_ntiles;
 
-    KernelDescriptor::Defines reader_defines;
+    tt::tt_metal::KernelDescriptor::Defines reader_defines;
 
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / (input_num_cores * per_core_num_blocks_act_w);
 
@@ -389,8 +381,8 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
 
     TT_FATAL(act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
 
-    KernelDescriptor::Defines writer_defines;
-    KernelDescriptor::Defines writer_mcast_sender_defines;
+    tt::tt_metal::KernelDescriptor::Defines writer_defines;
+    tt::tt_metal::KernelDescriptor::Defines writer_mcast_sender_defines;
     std::map<std::string, std::string> compute_defines;
 
     const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
@@ -473,7 +465,7 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
         input_channels_padded,
         reader_indices_actual_page_size);
 
-    ProgramDescriptor desc;
+    tt::tt_metal::ProgramDescriptor desc;
 
     // Descriptor-flow CB allocation: appends one CBDescriptor per non-empty
     // CBInfo entry to `desc.cbs` and fills `CBInfo::index`.  Sharded CBs are
@@ -594,35 +586,36 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
     tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(weights_kernel_compile_args);
     tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(weights_kernel_compile_args);
 
-    KernelDescriptor act_kernel_desc;
+    tt::tt_metal::KernelDescriptor act_kernel_desc;
     act_kernel_desc.kernel_source = activation_kernel_path;
-    act_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    act_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
     act_kernel_desc.core_ranges = CoreRangeSet(all_reader_cores);
     act_kernel_desc.compile_time_args = std::move(activation_kernel_compile_args);
     act_kernel_desc.defines = reader_defines;
-    act_kernel_desc.config = DataMovementConfigDescriptor{
+    act_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
         .noc = act_noc,
     };
 
-    KernelDescriptor weights_kernel_desc;
+    tt::tt_metal::KernelDescriptor weights_kernel_desc;
     weights_kernel_desc.kernel_source = weights_kernel_path;
-    weights_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    weights_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
     weights_kernel_desc.core_ranges = all_cores;
     weights_kernel_desc.compile_time_args = std::move(weights_kernel_compile_args);
     weights_kernel_desc.defines = std::move(writer_defines);
-    weights_kernel_desc.config = DataMovementConfigDescriptor{
+    weights_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
         .noc = weights_noc,
     };
 
-    KernelDescriptor compute_kernel_desc;
+    tt::tt_metal::KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_path;
-    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
-    compute_kernel_desc.defines = KernelDescriptor::Defines{compute_defines.begin(), compute_defines.end()};
-    compute_kernel_desc.config = ComputeConfigDescriptor{
+    compute_kernel_desc.defines =
+        tt::tt_metal::KernelDescriptor::Defines{compute_defines.begin(), compute_defines.end()};
+    compute_kernel_desc.config = tt::tt_metal::ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
     };
@@ -692,12 +685,12 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
     // Semaphore Descriptors — match the legacy CreateSemaphore(... 0 /*INVALID*/)
     // pair above.  Both semaphores live on `all_cores` and are referenced from
     // the activation kernel by their compile-time-arg ids (0 and 1).
-    desc.semaphores.push_back(SemaphoreDescriptor{
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
         .id = act_mcast_sender_semaphore,
         .core_ranges = all_cores,
         .initial_value = 0,
     });
-    desc.semaphores.push_back(SemaphoreDescriptor{
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
         .id = act_mcast_receiver_semaphore,
         .core_ranges = all_cores,
         .initial_value = 0,
@@ -713,13 +706,13 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
     post_conv2d_op_memory_checks(
         desc, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
 
-    WorkloadDescriptor workload_descriptor;
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
     // Park the reader-indices Tensor so the framework keeps it alive for the
     // cached MeshWorkload's lifetime (see comment above the Tensor allocation).
     // The shared_ptr<Tensor> ownership defers ~Tensor (which would force-free
     // the underlying device memory) until the cached workload is evicted.
-    workload_descriptor.buffers.push_back(
-        WorkloadBuffer{.owner = std::move(conv_reader_indices_owner), .buffer = conv_reader_indices_buffer});
+    workload_descriptor.buffers.push_back(tt::tt_metal::WorkloadBuffer{
+        .owner = std::move(conv_reader_indices_owner), .buffer = conv_reader_indices_buffer});
 
     // Replicate the single ProgramDescriptor across every coordinate range —
     // every coord in the workload runs the same conv2d program.  Move the

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -703,13 +703,15 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
         .initial_value = 0,
     });
 
-    // post_conv2d_op_memory_checks() is intentionally NOT called here: it
-    // takes a built `tt::tt_metal::Program&` (it inspects the realised CB
-    // allocation), which is not available inside a descriptor factory.  The
-    // legacy check has been dropped along with the legacy `create()` /
-    // `override_runtime_arguments()` flow on both conv2d variants; if the
-    // post-build verification is needed in the future it can be re-expressed
-    // against the descriptor or hoisted into the framework.
+    // Descriptor-flow port of the legacy post-`CreateProgram` memory check.
+    // The helper now inspects `desc.cbs` directly (mirroring the realized
+    // Program's `!cb->globally_allocated()` walk) and asserts the L1
+    // allocator delta still matches the predicted output footprint. Must be
+    // called AFTER `desc.cbs` is fully populated and AFTER the reader-indices
+    // Tensor is allocated, but BEFORE the descriptor is moved into the
+    // returned WorkloadDescriptor.
+    post_conv2d_op_memory_checks(
+        desc, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
 
     WorkloadDescriptor workload_descriptor;
     // Park the reader-indices Tensor so the framework keeps it alive for the

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -32,8 +32,6 @@ namespace unary = ttnn::operations::unary;
 using ttnn::operations::conv::conv_skip_mcast;
 using ttnn::operations::conv::SkipMcast;
 
-using tt::tt_metal::CBDescriptor;
-using tt::tt_metal::CBFormatDescriptor;
 using tt::tt_metal::ComputeConfigDescriptor;
 using tt::tt_metal::DataMovementConfigDescriptor;
 using tt::tt_metal::KernelDescriptor;
@@ -367,7 +365,7 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
     // Program (see SemaphoreDescriptor entries appended to `desc.semaphores`
     // below).  The kernel reads these ids the same way it did when the
     // legacy CreateSemaphore() return value was passed through compile-time
-    // args (both forms are 0-INVALID semaphores on `all_cores`).
+    // args (both forms use valid semaphore ids on `all_cores`, starting at 0).
     const uint32_t act_mcast_sender_semaphore = 0;
     const uint32_t act_mcast_receiver_semaphore = 1;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -708,8 +708,9 @@ WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
     // post_conv2d_op_memory_checks() is intentionally NOT called here: it
     // takes a built `tt::tt_metal::Program&` (it inspects the realised CB
     // allocation), which is not available inside a descriptor factory.  The
-    // legacy `Conv2dShardedProgramFactory` (still on the old path) keeps the
-    // check; once that variant is also migrated the check can be re-expressed
+    // legacy check has been dropped along with the legacy `create()` /
+    // `override_runtime_arguments()` flow on both conv2d variants; if the
+    // post-build verification is needed in the future it can be re-expressed
     // against the descriptor or hoisted into the framework.
 
     WorkloadDescriptor workload_descriptor;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -3,34 +3,54 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::prim {
 
+// Descriptor-based factory for the WIDTH_SHARDED variant of conv2d.
+//
+// Satisfies `ProgramDescriptorFactoryConcept` via the declarative
+// `create_workload_descriptor` contract (contract 2 in
+// mesh_device_operation_adapter.hpp).  The declarative contract is required
+// because this factory allocates a workload-scoped reader-indices config
+// Tensor whose `Buffer*` is referenced from the per-coord program's CB /
+// compile-time args; the Tensor must outlive the cached MeshWorkload, which
+// `WorkloadDescriptor::buffers` arranges via shared-ptr ownership.
+//
+// The other variant in `Conv2dDeviceOperation::program_factory_t`
+// (`Conv2dShardedProgramFactory`) is still on the legacy
+// `ProgramFactoryConcept` path.  Per-alternative concept dispatch in
+// `dispatch_to_mesh_workload_factory` (device_operation.hpp) lets the two
+// styles coexist within the same `std::variant` without any change to
+// `Conv2dDeviceOperation` itself.
 struct Conv2dWidthShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::CBHandle cb_sharded_act{};
-        tt::tt_metal::CBHandle cb_output{};
-        tt::tt_metal::CBHandle cb_partials{};
-        bool partials_cb_uses_output = false;
-        bool has_bias = false;
-        CoreCoord full_core_grid;
-        tt::tt_metal::KernelHandle weights_kernel_id{};
-        uint32_t total_num_active_cores = 0;
-        tt::tt_metal::DeviceStorage conv_reader_indices_storage;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Builds the entire workload in one call (invoked ONCE per workload on
+    // cache miss):
+    //   1. Allocates the sliding-window reader-indices config Tensor on the
+    //      input tensor's device and parks it in `buffers` so the framework
+    //      keeps it alive for the cached MeshWorkload's lifetime — the
+    //      activation kernel references this buffer either via a globally-
+    //      allocated CB (L1 path) or via compile-time args
+    //      (config_tensors_in_dram path).
+    //   2. Builds one `ProgramDescriptor` and replicates it across all
+    //      coordinate ranges of `tensor_coords`.
+    //
+    // On cache hits the framework's `BufferBinding` fast path patches the
+    // weight / bias buffer addresses recorded via
+    // `KernelDescriptor::emplace_runtime_args(Buffer*)` and the dynamic CB
+    // addresses recorded on `CBDescriptor::buffer` — `create_workload_descriptor`
+    // is not re-invoked.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const Conv2dParams& operation_attributes,
         const Conv2dInputs& tensor_args,
-        Tensor& output_tensor);
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -23,12 +23,11 @@ namespace ttnn::prim {
 // compile-time args; the Tensor must outlive the cached MeshWorkload, which
 // `WorkloadDescriptor::buffers` arranges via shared-ptr ownership.
 //
-// The other variant in `Conv2dDeviceOperation::program_factory_t`
-// (`Conv2dShardedProgramFactory`) is still on the legacy
-// `ProgramFactoryConcept` path.  Per-alternative concept dispatch in
-// `dispatch_to_mesh_workload_factory` (device_operation.hpp) lets the two
-// styles coexist within the same `std::variant` without any change to
-// `Conv2dDeviceOperation` itself.
+// The sibling variant in `Conv2dDeviceOperation::program_factory_t`
+// (`Conv2dShardedProgramFactory`) is also on the descriptor path.
+// Per-alternative concept dispatch in `dispatch_to_mesh_workload_factory`
+// (device_operation.hpp) selects the matching adapter for each variant
+// alternative without any change to `Conv2dDeviceOperation` itself.
 struct Conv2dWidthShardedProgramFactory {
     // Builds the entire workload in one call (invoked ONCE per workload on
     // cache miss):

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "typecast_sharded_program_factory.hpp"
 
+#include <tt-metalium/tilize_utils.hpp>  // for round_up_to_mul32
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>


### PR DESCRIPTION
### PR Category
[Descriptor Migration]  Part of [42210](https://github.com/tenstorrent/tt-metal/issues/42210)

### Summary
[#42369](https://github.com/tenstorrent/tt-metal/issues/42369)
[Descriptor Migration] conv/conv2d

### Notes for reviewers
**ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.hpp ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp**

_Removed the legacy ProgramFactoryConcept surface (`shared_variables_t`, `cached_program_t`, `create()`, `override_runtime_arguments()`) and replaced it with a single `static tt::tt_metal::ProgramDescriptor create_descriptor(...)` matching `ProgramDescriptorFactoryConcept`. Implementation now builds `CBDescriptor` (with `.buffer = src/dst buffer` for sharded CBs)_

**ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp**
_added helper `allocate_cbs_to_program_descriptor(cb_info, ProgramDescriptor& desc, all_cores, input, output, l1_indices)` that mirrors legacy `allocate_cbs()` but appends `CBDescriptor` entries to `desc.cbs` (with `CBDescriptor::buffer = tensor.buffer()` for globally-allocated CBs ACT_SHARDED / OUT / MATMUL_PARTIALS / READER_INDICES); same `cb.index` numbering and overlap-target second pass as the legacy helper._ 

**ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp**
_Used the multi-variant pattern (kept `program_factory_t` and `select_program_factory`). Removed `shared_variables_t`, `cached_program_t`, `create()`, `override_runtime_arguments()`.
 Picked the declarative `WorkloadDescriptor` contract instead of plain `create_descriptor`: added `static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(params, inputs, output, MeshCoordinateRangeSet&)` plus includes (`program_descriptors.hpp`, `workload_descriptor.hpp`, `ttnn/distributed/types.hpp`). In the .cpp, `CreateProgram` is gone; CBs go through `allocate_cbs_to_program_descriptor`; semaphores become explicit ids (0,1) + `SemaphoreDescriptor` entries on `desc.semaphores`; the four `CreateKernel` calls become `KernelDescriptor`s with `DataMovementConfigDescriptor` / `ComputeConfigDescriptor` and `compile_time_args` / `defines` moved to the kernel-level slots; weights kernel uses `emplace_runtime_args(core, {…})` with weights/bias as `Buffer*` to opt into the BufferBinding cache-hit fast path; the reader-indices Tensor is wrapped in `shared_ptr` and parked on `WorkloadDescriptor::buffers` so `~Tensor` is deferred until the cached MeshWorkload is evicted; the single `ProgramDescriptor` is replicated across `tensor_coords.ranges()`. Removed the `post_conv2d_op_memory_checks` call (requires a built `Program&`)_

**ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp**
_Removed `shared_variables_t`, `cached_program_t`, `create()`, `override_runtime_arguments()` and added `static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(params, inputs, output, MeshCoordinateRangeSet&)` (declarative `WorkloadDescriptor` contract, required for the workload-scoped reader-indices Tensor)
 `CreateProgram` removed; CBs through `allocate_cbs_to_program_descriptor` (replaces the four `UpdateDynamicCircularBufferAddress` calls via `CBDescriptor::buffer`); every `CreateSemaphore` replaced with sequential ids + `SemaphoreDescriptor` on `desc.semaphores` (six in the block-sharded `split_reader_cb_shared` path); the four `CreateKernel`s become `KernelDescriptor`s (writer_mcast_sender, optional writer_mcast_receiver gated by `!skip_weights_mcast`, reader, compute) with kernel-level `compile_time_args` / `defines`; writer_mcast_sender uses `RTArgList` + `emplace_runtime_args(core, rt)` with weights (slot 0) and bias-or-`uint32_t(0)` (slot 1) registered as `Buffer*` for the BufferBinding fast-path; non-buffer kernels keep plain `runtime_args.emplace_back`; skipped-work cores stay on plain uint32_t args. Reader-indices Tensor wrapped in `shared_ptr` and pushed onto `WorkloadDescriptor::buffers` to defer `~Tensor`. The single `ProgramDescriptor` is replicated across all coord ranges._

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/migrate-conv_conv2d-to-program-descriptor)