### PR TITLE
Cleanup: Quasar tilize/untilize cfg structs and writes

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cpack_common.h
@@ -9,6 +9,31 @@
 
 namespace ckernel::pack
 {
+// Pack untilize stride config register struct
+// Covers ADDR32 54-55 (THCON_PACKER0_REG1)
+constexpr std::uint32_t NUM_WORDS_PACK_UNTILIZE_STRIDE_CFG = 2;
+
+typedef struct
+{
+    // word 0 — ADDR32 54
+    std::uint32_t edge_mask_mode : 2;  // EDGE_MASK_MODE
+    std::uint32_t src_z_stride   : 8;  // PACK_UNTILIZE_SRC_Z_STRIDE
+    std::uint32_t dst_z_stride   : 16; // PACK_UNTILIZE_DST_Z_STRIDE
+    std::uint32_t reserved0      : 6;
+
+    // word 1 — ADDR32 55
+    std::uint32_t stride_offset_0 : 16; // PACK_STRIDE_OFFSET_0
+    std::uint32_t stride_offset_1 : 16; // PACK_STRIDE_OFFSET_1
+} pack_untilize_stride_cfg_t;
+
+static_assert(sizeof(pack_untilize_stride_cfg_t) == NUM_WORDS_PACK_UNTILIZE_STRIDE_CFG * sizeof(std::uint32_t));
+
+typedef union
+{
+    std::uint32_t val[NUM_WORDS_PACK_UNTILIZE_STRIDE_CFG];
+    pack_untilize_stride_cfg_t f;
+} pack_untilize_stride_cfg_u;
+
 constexpr static std::uint32_t TRISC_ID = 2;
 static std::uint32_t clear_dest_bank_id = 0;
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cpack_common.h
@@ -13,7 +13,7 @@ namespace ckernel::pack
 // Covers ADDR32 54-55 (THCON_PACKER0_REG1)
 constexpr std::uint32_t NUM_WORDS_PACK_UNTILIZE_STRIDE_CFG = 2;
 
-typedef struct
+struct pack_untilize_stride_cfg_t
 {
     // word 0 — ADDR32 54
     std::uint32_t edge_mask_mode : 2;  // EDGE_MASK_MODE
@@ -24,15 +24,15 @@ typedef struct
     // word 1 — ADDR32 55
     std::uint32_t stride_offset_0 : 16; // PACK_STRIDE_OFFSET_0
     std::uint32_t stride_offset_1 : 16; // PACK_STRIDE_OFFSET_1
-} pack_untilize_stride_cfg_t;
+};
 
 static_assert(sizeof(pack_untilize_stride_cfg_t) == NUM_WORDS_PACK_UNTILIZE_STRIDE_CFG * sizeof(std::uint32_t));
 
-typedef union
+union pack_untilize_stride_cfg_u
 {
     std::uint32_t val[NUM_WORDS_PACK_UNTILIZE_STRIDE_CFG];
     pack_untilize_stride_cfg_t f;
-} pack_untilize_stride_cfg_u;
+};
 
 constexpr static std::uint32_t TRISC_ID = 2;
 static std::uint32_t clear_dest_bank_id = 0;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cunpack_common.h
@@ -13,7 +13,7 @@ namespace ckernel::unpack
 // Covers ADDR32 18-20 for UNPACKER0, ADDR32 30-32 for UNPACKER1
 constexpr std::uint32_t NUM_WORDS_UNPACK_TILIZE_CFG = 3;
 
-typedef struct
+struct unpack_tilize_cfg_t
 {
     // word 0 — ADDR32 18 or 30
     std::uint32_t src_z_stride      : 16; // TILIZE_SRC_Z_STRIDE
@@ -28,15 +28,15 @@ typedef struct
     // word 2 — ADDR32 20 or 32
     std::uint32_t stride_offset_0 : 16; // STRIDE_OFFSET_0
     std::uint32_t stride_offset_1 : 16; // STRIDE_OFFSET_1
-} unpack_tilize_cfg_t;
+};
 
 static_assert(sizeof(unpack_tilize_cfg_t) == NUM_WORDS_UNPACK_TILIZE_CFG * sizeof(std::uint32_t));
 
-typedef union
+union unpack_tilize_cfg_u
 {
     std::uint32_t val[NUM_WORDS_UNPACK_TILIZE_CFG];
     unpack_tilize_cfg_t f;
-} unpack_tilize_cfg_u;
+};
 
 // Number of rows for Unpack functions
 constexpr static std::uint32_t UNPACR_STRIDE_MAX_ROWS = 8;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cunpack_common.h
@@ -9,6 +9,35 @@
 
 namespace ckernel::unpack
 {
+// Unpack tilize config register struct
+// Covers ADDR32 18-20 for UNPACKER0, ADDR32 30-32 for UNPACKER1
+constexpr std::uint32_t NUM_WORDS_UNPACK_TILIZE_CFG = 3;
+
+typedef struct
+{
+    // word 0 — ADDR32 18 or 30
+    std::uint32_t src_z_stride      : 16; // TILIZE_SRC_Z_STRIDE
+    std::uint32_t dst_z_stride      : 8;  // TILIZE_DST_Z_STRIDE
+    std::uint32_t stride_val_source : 1;  // STRIDE_VAL_SOURCE
+    std::uint32_t stride_no_write   : 1;  // STRIDE_NO_WRITE
+    std::uint32_t reserved0         : 6;
+
+    // word 1 — ADDR32 19 or 31
+    std::uint32_t stride_mask_val : 32; // STRIDE_MASK_VAL
+
+    // word 2 — ADDR32 20 or 32
+    std::uint32_t stride_offset_0 : 16; // STRIDE_OFFSET_0
+    std::uint32_t stride_offset_1 : 16; // STRIDE_OFFSET_1
+} unpack_tilize_cfg_t;
+
+static_assert(sizeof(unpack_tilize_cfg_t) == NUM_WORDS_UNPACK_TILIZE_CFG * sizeof(std::uint32_t));
+
+typedef union
+{
+    std::uint32_t val[NUM_WORDS_UNPACK_TILIZE_CFG];
+    unpack_tilize_cfg_t f;
+} unpack_tilize_cfg_u;
+
 // Number of rows for Unpack functions
 constexpr static std::uint32_t UNPACR_STRIDE_MAX_ROWS = 8;
 constexpr static std::uint32_t TRISC_ID               = 0;

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -11,7 +11,6 @@
 #include "llk_pack_common.h"
 
 using namespace ckernel;
-using namespace ckernel::pack;
 
 /**
  * @brief MOP configuration for pack untilize of contiguous tiles
@@ -49,7 +48,7 @@ inline void _llk_pack_untilize_mop_config_(const std::uint8_t buf_desc_id)
 template <std::uint32_t FULL_CT_DIM, std::uint32_t BLOCK_CT_DIM, std::uint32_t C_DIM_FACES>
 inline void _llk_pack_untilize_init_(const std::uint8_t buf_desc_id, const TileShape& tile_shape)
 {
-    pack_untilize_stride_cfg_u pk_cfg = {};
+    ckernel::pack::pack_untilize_stride_cfg_u pk_cfg = {};
 
     pk_cfg.f.src_z_stride    = tile_shape.num_faces * tile_shape.face_r_dim; // inc MATH DEST REG ptr by 64 16-datum rows
     pk_cfg.f.dst_z_stride    = C_DIM_FACES;                                  // inc L1 SRC ptr by 2 16-datum rows
@@ -180,7 +179,7 @@ inline void _llk_pack_untilize_strided_init_(const std::uint8_t buf_desc_id, con
     cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_VAL_SOURCE_RMW, 0); // sel STRIDE_OFFSET_0
     if constexpr (FACE_R_DIM != 1)
     {
-        pack_untilize_stride_cfg_u stride_cfg               = {};
+        ckernel::pack::pack_untilize_stride_cfg_u stride_cfg = {};
         stride_cfg.f.stride_offset_0                        = C_DIM_FACES * FULL_CT_DIM; // stride each row by 2*FULL_CT_DIM 16-datum rows
         cfg[THCON_PACKER0_REG1_PACK_STRIDE_OFFSET_0_ADDR32] = stride_cfg.val[1];
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -11,6 +11,7 @@
 #include "llk_pack_common.h"
 
 using namespace ckernel;
+using namespace ckernel::pack;
 
 /**
  * @brief MOP configuration for pack untilize of contiguous tiles
@@ -48,9 +49,15 @@ inline void _llk_pack_untilize_mop_config_(const std::uint8_t buf_desc_id)
 template <std::uint32_t FULL_CT_DIM, std::uint32_t BLOCK_CT_DIM, std::uint32_t C_DIM_FACES>
 inline void _llk_pack_untilize_init_(const std::uint8_t buf_desc_id, const TileShape& tile_shape)
 {
-    cfg_rmw(THCON_PACKER0_REG1_PACK_UNTILIZE_SRC_Z_STRIDE_RMW, tile_shape.num_faces * tile_shape.face_r_dim); // inc MATH DEST REG ptr by 64 16-datum rows
-    cfg_rmw(THCON_PACKER0_REG1_PACK_UNTILIZE_DST_Z_STRIDE_RMW, C_DIM_FACES);                                  // inc L1 SRC ptr by 2 16-datum rows
-    cfg_rmw(THCON_PACKER0_REG1_PACK_STRIDE_OFFSET_0_RMW, C_DIM_FACES * FULL_CT_DIM);                          // stride each row by 2*C_DIM 16-datum rows
+    pack_untilize_stride_cfg_u pk_cfg = {};
+
+    pk_cfg.f.src_z_stride    = tile_shape.num_faces * tile_shape.face_r_dim; // inc MATH DEST REG ptr by 64 16-datum rows
+    pk_cfg.f.dst_z_stride    = C_DIM_FACES;                                  // inc L1 SRC ptr by 2 16-datum rows
+    pk_cfg.f.stride_offset_0 = C_DIM_FACES * FULL_CT_DIM;                    // stride each row by 2*C_DIM 16-datum rows
+
+    cfg[THCON_PACKER0_REG1_PACK_UNTILIZE_SRC_Z_STRIDE_ADDR32] = pk_cfg.val[0];
+    cfg[THCON_PACKER0_REG1_PACK_STRIDE_OFFSET_0_ADDR32]       = pk_cfg.val[1];
+
     _llk_pack_untilize_mop_config_<BLOCK_CT_DIM>(buf_desc_id);
 }
 
@@ -171,25 +178,29 @@ template <std::uint32_t FULL_CT_DIM, std::uint32_t FACE_R_DIM, std::uint32_t NUM
 inline void _llk_pack_untilize_strided_init_(const std::uint8_t buf_desc_id, const TileShape& tile_shape)
 {
     cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_VAL_SOURCE_RMW, 0); // sel STRIDE_OFFSET_0
-    if constexpr (FACE_R_DIM >= 8)
-    {                                                                                    // 32x32 16x32 and 8x32
-        cfg_rmw(THCON_PACKER0_REG1_PACK_STRIDE_OFFSET_0_RMW, C_DIM_FACES * FULL_CT_DIM); // stride each row by 2*FULL_CT_DIM 16-datum rows
+    if constexpr (FACE_R_DIM != 1)
+    {
+        pack_untilize_stride_cfg_u stride_cfg               = {};
+        stride_cfg.f.stride_offset_0                        = C_DIM_FACES * FULL_CT_DIM; // stride each row by 2*FULL_CT_DIM 16-datum rows
+        cfg[THCON_PACKER0_REG1_PACK_STRIDE_OFFSET_0_ADDR32] = stride_cfg.val[1];
+    }
+
+    if constexpr (FACE_R_DIM >= 8) // 32x32, 16x32, 8x32
+    {
         _llk_pack_untilize_strided_mop_config_<FULL_CT_DIM, FACE_R_DIM, C_DIM_FACES>(buf_desc_id);
     }
-    else if constexpr (FACE_R_DIM == 4)
-    {                                                                                    // 4x32
-        cfg_rmw(THCON_PACKER0_REG1_PACK_STRIDE_OFFSET_0_RMW, C_DIM_FACES * FULL_CT_DIM); // stride each row by 2*FULL_CT_DIM 16-datum rows
+    else if constexpr (FACE_R_DIM == 4) // 4x32
+    {
         _llk_pack_untilize_strided_4x32_mop_config_<FULL_CT_DIM, NUM_TILES_PER_BLOCK, C_DIM_FACES>(buf_desc_id);
     }
-    else if constexpr (FACE_R_DIM == 2)
-    {                                                            // 2x32
-        cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_NO_WRITE_RMW, 1); // Need to mask off last 2 rows
+    else if constexpr (FACE_R_DIM == 2) // 2x32
+    {
+        cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_NO_WRITE_RMW, 1); // mask off last 2 rows
         cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_ROW_MASK_RMW, 0x1100);
-        cfg_rmw(THCON_PACKER0_REG1_PACK_STRIDE_OFFSET_0_RMW, C_DIM_FACES * FULL_CT_DIM);
         _llk_pack_untilize_strided_2x32_mop_config_<FULL_CT_DIM, NUM_TILES_PER_BLOCK, C_DIM_FACES>(buf_desc_id);
     }
-    else
-    { // 1x32
+    else // 1x32
+    {
         _llk_pack_untilize_strided_1x32_mop_config_<FULL_CT_DIM, NUM_TILES_PER_BLOCK, C_DIM_FACES>(buf_desc_id);
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -10,6 +10,7 @@
 #include "cunpack_common.h"
 #include "llk_unpack_common.h"
 using namespace ckernel;
+using namespace ckernel::unpack;
 
 /**
  * @brief MOP configuration for upk tilize for full 32x32 tiles using the fused HW instruction
@@ -75,23 +76,25 @@ inline void _llk_unpack_tilize_mop_config_(const std::uint32_t buf_desc_id, cons
 template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN, std::uint32_t C_DIM_FACES>
 inline void _llk_unpack_tilize_init_(const std::uint32_t buf_desc_id, const std::uint32_t full_ct_dim, const std::uint32_t block_ct_dim)
 {
+    // Pack all UNPACK_TILIZE stride fields into a single struct to perform a direct 32-bit cfg writes
+    unpack_tilize_cfg_u unpk_cfg = {};
+    unpk_cfg.f.src_z_stride      = C_DIM_FACES; // col dim of a tile in L1 in units of 16 datums (1 face). This is used for
+                                                // Src (L1) counter increments in the UNPACR_TILIZE instruction
+    unpk_cfg.f.dst_z_stride      = 1;           // col dim of a tile in dest reg (1 face)
+    unpk_cfg.f.stride_val_source = 0;
+    unpk_cfg.f.stride_offset_0   = full_ct_dim * C_DIM_FACES; // how much to stride to go to next row within the same tile
+
     if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
     {
-        cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0);                            // Disable transpose
-        cfg_rmw(THCON_UNPACKER0_REG1_UNPACK_TILIZE_SRC_Z_STRIDE_RMW, C_DIM_FACES); // col dim of a tile in L1 in units of 16 datums (1 face). This is used for
-                                                                                   // Src (L1) counter increments in the UNPACR_TILIZE instruction
-        cfg_rmw(THCON_UNPACKER0_REG1_UNPACK_TILIZE_DST_Z_STRIDE_RMW, 1);           // col dim of a tile in dest reg (1 face)
-        cfg_rmw(THCON_UNPACKER0_REG1_UNPACK_STRIDE_VAL_SOURCE_RMW, 0);
-        cfg_rmw(THCON_UNPACKER0_REG2_UNPACK_STRIDE_OFFSET_0_RMW, full_ct_dim * C_DIM_FACES); // how much to stride to go to next row within the same tile
+        cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0); // Disable transpose
+        cfg[THCON_UNPACKER0_REG1_UNPACK_TILIZE_SRC_Z_STRIDE_ADDR32] = unpk_cfg.val[0];
+        cfg[THCON_UNPACKER0_REG2_UNPACK_STRIDE_OFFSET_0_ADDR32]     = unpk_cfg.val[2];
     }
     else
     {
-        cfg_rmw(THCON_UNPACKER1_REG0_TRANSPOSE_RMW, 0);                            // Disable transpose
-        cfg_rmw(THCON_UNPACKER1_REG1_UNPACK_TILIZE_SRC_Z_STRIDE_RMW, C_DIM_FACES); // col dim of a tile in L1 in units of 16 datums (1 face). This is used for
-                                                                                   // Src (L1) counter increments in the UNPACR_TILIZE instruction
-        cfg_rmw(THCON_UNPACKER1_REG1_UNPACK_TILIZE_DST_Z_STRIDE_RMW, 1); // col dim of a tile in SRC reg - SRC reg will always be 16 datums across (1 face)
-        cfg_rmw(THCON_UNPACKER1_REG1_UNPACK_STRIDE_VAL_SOURCE_RMW, 0);
-        cfg_rmw(THCON_UNPACKER1_REG2_UNPACK_STRIDE_OFFSET_0_RMW, full_ct_dim * C_DIM_FACES); // how much to stride to go to next row within the same tile
+        cfg_rmw(THCON_UNPACKER1_REG0_TRANSPOSE_RMW, 0); // Disable transpose
+        cfg[THCON_UNPACKER1_REG1_UNPACK_TILIZE_SRC_Z_STRIDE_ADDR32] = unpk_cfg.val[0];
+        cfg[THCON_UNPACKER1_REG2_UNPACK_STRIDE_OFFSET_0_ADDR32]     = unpk_cfg.val[2];
     }
     _llk_unpack_tilize_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, block_ct_dim);
 }
@@ -165,12 +168,17 @@ inline void _llk_unpack_tilize_block_mop_config_(const std::uint32_t buf_desc_id
 template <std::uint32_t FULL_CT_DIM, std::uint32_t BLOCK_CT_DIM, std::uint32_t C_DIM_FACES, std::uint32_t NUM_FACES>
 inline void _llk_unpack_tilize_block_init_(const std::uint32_t buf_desc_id)
 {
-    cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0);                            // Disable transpose
-    cfg_rmw(THCON_UNPACKER0_REG1_UNPACK_TILIZE_SRC_Z_STRIDE_RMW, C_DIM_FACES); // col dim of a tile in L1 in units of 16 datums (1 face)
+    unpack_tilize_cfg_u unpk_cfg = {};
+    unpk_cfg.f.src_z_stride      = C_DIM_FACES; // col dim of a tile in L1 in units of 16 datums (1 face)
     // Z stride unit = FACE_R_DIM datums (1 face row = 16 datums). Each tile = NUM_FACES faces × FACE_R_DIM rows per face.
-    cfg_rmw(THCON_UNPACKER0_REG1_UNPACK_TILIZE_DST_Z_STRIDE_RMW, NUM_FACES * FACE_R_DIM); // stride between tiles in DEST
-    cfg_rmw(THCON_UNPACKER0_REG1_UNPACK_STRIDE_VAL_SOURCE_RMW, 0);
-    cfg_rmw(THCON_UNPACKER0_REG2_UNPACK_STRIDE_OFFSET_0_RMW, FULL_CT_DIM * C_DIM_FACES); // stride to next row within same tile
+    unpk_cfg.f.dst_z_stride      = NUM_FACES * FACE_R_DIM; // stride between tiles in DEST
+    unpk_cfg.f.stride_val_source = 0;
+    unpk_cfg.f.stride_offset_0   = FULL_CT_DIM * C_DIM_FACES; // stride to next row within same tile
+
+    cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0); // Disable transpose
+    cfg[THCON_UNPACKER0_REG1_UNPACK_TILIZE_SRC_Z_STRIDE_ADDR32] = unpk_cfg.val[0];
+    cfg[THCON_UNPACKER0_REG2_UNPACK_STRIDE_OFFSET_0_ADDR32]     = unpk_cfg.val[2];
+
     _llk_unpack_tilize_block_mop_config_<BLOCK_CT_DIM>(buf_desc_id);
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -76,7 +76,7 @@ inline void _llk_unpack_tilize_mop_config_(const std::uint32_t buf_desc_id, cons
 template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN, std::uint32_t C_DIM_FACES>
 inline void _llk_unpack_tilize_init_(const std::uint32_t buf_desc_id, const std::uint32_t full_ct_dim, const std::uint32_t block_ct_dim)
 {
-    // Pack all UNPACK_TILIZE stride fields into a single struct to perform a direct 32-bit cfg writes
+    // Pack all UNPACK_TILIZE stride fields into a single struct to perform a direct 32-bit cfg write
     unpack_tilize_cfg_u unpk_cfg = {};
     unpk_cfg.f.src_z_stride      = C_DIM_FACES; // col dim of a tile in L1 in units of 16 datums (1 face). This is used for
                                                 // Src (L1) counter increments in the UNPACR_TILIZE instruction

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -10,7 +10,6 @@
 #include "cunpack_common.h"
 #include "llk_unpack_common.h"
 using namespace ckernel;
-using namespace ckernel::unpack;
 
 /**
  * @brief MOP configuration for upk tilize for full 32x32 tiles using the fused HW instruction
@@ -77,7 +76,7 @@ template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN, std::uint32_t C_DIM_FACES>
 inline void _llk_unpack_tilize_init_(const std::uint32_t buf_desc_id, const std::uint32_t full_ct_dim, const std::uint32_t block_ct_dim)
 {
     // Pack all UNPACK_TILIZE stride fields into a single struct to perform a direct 32-bit cfg write
-    unpack_tilize_cfg_u unpk_cfg = {};
+    ckernel::unpack::unpack_tilize_cfg_u unpk_cfg = {};
     unpk_cfg.f.src_z_stride      = C_DIM_FACES; // col dim of a tile in L1 in units of 16 datums (1 face). This is used for
                                                 // Src (L1) counter increments in the UNPACR_TILIZE instruction
     unpk_cfg.f.dst_z_stride      = 1;           // col dim of a tile in dest reg (1 face)
@@ -168,7 +167,7 @@ inline void _llk_unpack_tilize_block_mop_config_(const std::uint32_t buf_desc_id
 template <std::uint32_t FULL_CT_DIM, std::uint32_t BLOCK_CT_DIM, std::uint32_t C_DIM_FACES, std::uint32_t NUM_FACES>
 inline void _llk_unpack_tilize_block_init_(const std::uint32_t buf_desc_id)
 {
-    unpack_tilize_cfg_u unpk_cfg = {};
+    ckernel::unpack::unpack_tilize_cfg_u unpk_cfg = {};
     unpk_cfg.f.src_z_stride      = C_DIM_FACES; // col dim of a tile in L1 in units of 16 datums (1 face)
     // Z stride unit = FACE_R_DIM datums (1 face row = 16 datums). Each tile = NUM_FACES faces × FACE_R_DIM rows per face.
     unpk_cfg.f.dst_z_stride      = NUM_FACES * FACE_R_DIM; // stride between tiles in DEST


### PR DESCRIPTION
### PR Category
     Cleanup 

### Summary
Closes Issue #858 in tt-llk
- Quasar pack/unpack tilize and untilize init paths used many `cfg_rmw` calls for fields that already live in aligned 32-bit words. This change adds bitfield structs, and programs full words with direct cfg[ADDR32] stores.

### Notes for reviewers
- Direct cfg[] writes only appear where we fully populate the struct for that word or offsets.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmohammed/issue_858)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmohammed/issue_858)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmohammed/issue_858)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmohammed/issue_858)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmohammed/issue_858)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmohammed/issue_858)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmohammed/issue_858)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmohammed/issue_858)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmohammed/issue_858)