### PR TITLE
Cleanup: Move internal mesh CQ methods from public to internal header

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -148,11 +148,6 @@ public:
     virtual void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) = 0;
     virtual void record_end() = 0;
     virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
-
-    // Internal function.
-    virtual void wait_for_completion(bool) {}
-    // May only be called after wait_for_completion has been called on both command queues on the device.
-    virtual void finish_and_reset_in_use() {}
 };
 
 // Specifies host data to be written to or read from a MeshBuffer shard.

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -156,6 +156,10 @@ public:
         uint32_t value,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
+
+    virtual void wait_for_completion(bool) {}
+    // May only be called after wait_for_completion has been called on both command queues on the device.
+    virtual void finish_and_reset_in_use() {}
 };
 
 }  // namespace tt::tt_metal::distributed


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Move `wait_for_completion` and `finish_and_reset_in_use` virtual methods from the public `MeshCommandQueue` interface (`mesh_command_queue.hpp`) to the internal `MeshCommandQueueBase` class (`mesh_command_queue_base.hpp`).

These methods are internal-only and should not be part of the public API surface. No functional change.

### Notes for reviewers
Straightforward move of two virtual method declarations. No callers change since they already go through the internal base class.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/movemeshmethodinternal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/movemeshmethodinternal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/movemeshmethodinternal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/movemeshmethodinternal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/movemeshmethodinternal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/movemeshmethodinternal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/movemeshmethodinternal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/movemeshmethodinternal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/movemeshmethodinternal)