### PR TITLE
42784 migrate remaining models to centralized perf/accuracy targets

### DIFF
--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -25,7 +25,6 @@ from transformers import (
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
-from models.common.utility_functions import is_blackhole
 from models.demos.audio.whisper.tt.ttnn_optimized_functional_whisper import (
     WHISPER_BATCH_SIZE,
     WHISPER_L1_SMALL_SIZE,

--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -39,6 +39,9 @@ from models.demos.audio.whisper.tt.ttnn_optimized_functional_whisper import (
 from models.demos.audio.whisper.tt.whisper_generator import GenerationParams, WhisperGenerator
 from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.demos.utils.llm_demo_utils import verify_perf
+from models.demos.utils.model_targets import resolve_perf_targets
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from models.tt_transformers.tt.model_config import determine_device_name
 
 available_devices = len(ttnn.get_device_ids()) if ttnn.get_device_ids() else 1
 
@@ -864,6 +867,8 @@ def test_demo_for_conditional_generation(
         and not use_per_request_params
     )
 
+    profiler = BenchmarkProfiler()
+    profiler.start("run")
     ttft, decode_throughput = run_demo_whisper_for_conditional_generation_inference(
         input_path,
         mesh_device,
@@ -877,44 +882,79 @@ def test_demo_for_conditional_generation(
         stream=stream,
         run_both_batch_sizes=run_both_batch_sizes and not should_check_perf,
     )
+    profiler.end("run")
 
     if should_check_perf:
-        metrics_dictionary = {
-            2: {"prefill_time_to_first_token": 0.13, "decode_t/s/u": 124.0},
-            8: {"prefill_time_to_first_token": 0.14, "decode_t/s/u": 105.0},
-            32: {"prefill_time_to_first_token": 0.22, "decode_t/s/u": 77.5},
+        total_batch = mesh_device.get_num_devices() * batch_size_per_device
+        sku = determine_device_name(mesh_device)
+        measurements = {
+            "prefill_time_to_first_token": ttft,
+            "decode_t/s": decode_throughput * total_batch,
+            "decode_t/s/u": decode_throughput,
         }
-        expected_perf_metrics = None
-        if is_blackhole():
-            if mesh_device.dram_grid_size().x == 7:  # P100 DRAM grid is 7x1
-                expected_perf_metrics = {"prefill_time_to_first_token": 0.06, "decode_t/s/u": 310.0}
-            else:
-                expected_perf_metrics = {"prefill_time_to_first_token": 0.05, "decode_t/s/u": 530.0}
-        elif mesh_device.get_num_devices() in metrics_dictionary:  # wormhole_b0
-            expected_perf_metrics = metrics_dictionary[mesh_device.get_num_devices()]
-
-        if expected_perf_metrics is not None:
-            total_batch = mesh_device.get_num_devices() * batch_size_per_device
-            expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"] * total_batch
-            measurements = {
-                "prefill_time_to_first_token": ttft,
-                "decode_t/s": decode_throughput * total_batch,
-                "decode_t/s/u": decode_throughput,
-            }
+        expected_perf_metrics = resolve_perf_targets(
+            model_name=model_repo,
+            sku=sku,
+            batch_size=total_batch,
+        ) or resolve_perf_targets(
+            model_name=model_repo,
+            sku=sku,
+            batch_size=None,
+        )
+        if expected_perf_metrics:
             expected_measurements = {
-                "prefill_time_to_first_token": True,
-                "decode_t/s": True,
-                "decode_t/s/u": True,
+                metric: True
+                for metric in expected_perf_metrics
+                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
             }
             verify_perf(
                 measurements,
-                expected_perf_metrics,
+                expected_perf_metrics=expected_perf_metrics,
                 high_tol_percentage=1.20,
                 expected_measurements=expected_measurements,
             )
+            profiler.start("inference_prefill", iteration=0)
+            profiler.end("inference_prefill", iteration=0)
+            profiler.start("inference_decode", iteration=0)
+            profiler.end("inference_decode", iteration=0)
+            benchmark_data = BenchmarkData()
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                "inference_prefill",
+                "time_to_token",
+                measurements["prefill_time_to_first_token"],
+                target=expected_perf_metrics.get("prefill_time_to_first_token"),
+            )
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                "inference_decode",
+                "tokens/s/user",
+                measurements["decode_t/s/u"],
+                target=expected_perf_metrics.get("decode_t/s/u"),
+            )
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                "inference_decode",
+                "tokens/s",
+                measurements["decode_t/s"],
+                target=expected_perf_metrics.get("decode_t/s"),
+            )
+            benchmark_data.save_partial_run_json(
+                profiler,
+                run_type="demo",
+                ml_model_name=model_repo,
+                ml_model_type="asr",
+                device_name=sku,
+                batch_size=total_batch,
+                input_sequence_length=None,
+                output_sequence_length=None,
+            )
         else:
             logger.warning(
-                f"Skipping perf check: no expected perf target for {mesh_device.get_num_devices()}-device wormhole_b0 mesh"
+                f"Skipping perf check: no centralized perf target for model={model_repo}, sku={sku}, batch={total_batch}"
             )
 
 

--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -20,7 +20,8 @@ from models.common.utils import top_k_top_p_filtering
 from models.demos.falcon7b_common.tests.test_utils import get_num_devices, initialize_kv_cache, load_hf_model
 from models.demos.falcon7b_common.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.falcon7b_common.tt.model_config import get_model_config
-from models.demos.utils.llm_demo_utils import check_tokens_match, create_benchmark_data  # , verify_perf
+from models.demos.utils.llm_demo_utils import check_tokens_match, create_benchmark_data, verify_perf
+from models.demos.utils.model_targets import resolve_perf_targets
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import get_hf_tt_cache_path
 from models.tt_transformers.tt.model_config import determine_device_name
@@ -132,7 +133,8 @@ def run_falcon_demo_kv(
     expected_perf_metrics=None,  # Expected perf (t/s) for prefill and decode in perf mode
     expected_greedy_output_path=None,  # Path for expected outputs for greedy decoding
     save_generated_text_path=None,  # If provided, save generated text to this path (e.g. set to expected_greedy_output_path to update expected output)
-    json_perf_targets={},  # Optional perf targets for CSV output
+    json_perf_targets=None,  # Optional perf targets for CSV output
+    model_name: str = "falcon-7b",  # Canonical model key for centralized targets
     is_ci_env=False,  # Whether is running in CI environment
 ):
     profiler = BenchmarkProfiler()
@@ -155,6 +157,9 @@ def run_falcon_demo_kv(
 
     num_devices = get_num_devices(mesh_device)
     global_batch = batch_size * num_devices
+    sku = determine_device_name(mesh_device)
+    if json_perf_targets is None:
+        json_perf_targets = {}
 
     torch.manual_seed(0)
 
@@ -536,8 +541,26 @@ def run_falcon_demo_kv(
     profiler.end("run")
     logger.info(f"Total demo duration: {(profiler.get_duration('run')):.2f} s")
 
+    if perf_mode and expected_perf_metrics is None:
+        expected_perf_metrics = resolve_perf_targets(
+            model_name=model_name,
+            sku=sku,
+            batch_size=global_batch,
+            seq_len=num_input_tokens,
+        ) or resolve_perf_targets(
+            model_name=model_name,
+            sku=sku,
+            batch_size=None,
+            seq_len=max_seq_len,
+        )
+        if expected_perf_metrics is None:
+            logger.warning(
+                f"No centralized perf targets found for model={model_name}, sku={sku}, batch={global_batch}, seq={num_input_tokens}"
+            )
+
     # Save benchmark data (will only save if running in CI environment)
-    benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, json_perf_targets)
+    benchmark_targets = expected_perf_metrics if perf_mode and expected_perf_metrics else json_perf_targets
+    benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, benchmark_targets)
     run_type = "demo_perf" if perf_mode else "demo_generate"
 
     benchmark_data.save_partial_run_json(
@@ -557,11 +580,17 @@ def run_falcon_demo_kv(
     # Verify output or perf if expected values are provided
     assert expected_perf_metrics is None or expected_greedy_output_path is None
     if expected_perf_metrics is not None:
-        pass  # see issue #31939
-    #     if num_devices == 32:  # set higher margin to 20% for Galaxy due to larger variance on CI
-    #         verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.20)
-    #     else:
-    #         verify_perf(measurements, expected_perf_metrics)
+        expected_measurements = {
+            metric: True
+            for metric in expected_perf_metrics
+            if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+        }
+        verify_perf(
+            measurements,
+            expected_perf_metrics=expected_perf_metrics,
+            high_tol_percentage=1.20 if num_devices == 32 else 1.15,
+            expected_measurements=expected_measurements,
+        )
     elif expected_greedy_output_path is not None:
         if token_check_does_pass:
             logger.info("Output Check Passed!")

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -27,7 +27,6 @@ import ttnn
 from models.common.sampling import SamplingParams
 from models.common.utility_functions import run_for_wormhole_b0_or_blackhole
 from models.demos.gpt_oss.tests.test_factory import TestFactory, parametrize_mesh_with_fabric
-from models.demos.utils.model_targets import resolve_perf_targets
 
 # Import GPT-OSS components using our refactored patterns
 from models.demos.gpt_oss.tt.common import create_tt_model

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -968,9 +968,7 @@ def test_gpt_oss_demo(
         )
         if targets:
             expected_measurements = {
-                metric: True
-                for metric in targets
-                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+                metric: True for metric in targets if not metric.endswith("_tolerance") and metric not in {"tolerance"}
             }
             verify_perf(
                 measurements=measurements,

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -17,9 +17,7 @@ Updated to use refactored TestFactory and MeshConfig patterns:
 - Passes mesh_config to create_tt_model for proper sharding
 """
 
-import json
 import os
-from pathlib import Path
 
 import pytest
 import torch
@@ -29,6 +27,7 @@ import ttnn
 from models.common.sampling import SamplingParams
 from models.common.utility_functions import run_for_wormhole_b0_or_blackhole
 from models.demos.gpt_oss.tests.test_factory import TestFactory, parametrize_mesh_with_fabric
+from models.demos.utils.model_targets import resolve_perf_targets
 
 # Import GPT-OSS components using our refactored patterns
 from models.demos.gpt_oss.tt.common import create_tt_model
@@ -907,29 +906,20 @@ def test_gpt_oss_demo(
     if is_ci_env:
         tt_device_name = determine_device_name(mesh_device)  # submesh device should not decide performance target
         tt_device_name = "GLX" if tt_device_name == "TG" else tt_device_name  # TG is old nomenclature of 4U galaxy.
-        model_name = model_args[0].model_name
-        model_device_key = f"{tt_device_name}_{model_name}"
-
-        with open(Path(__file__).parent.parent.joinpath("perf_targets.json"), "r") as f:
-            perf_targets = json.load(f)
+        model_name = model_args[0].base_model_name
         prefill_pad_length = get_padded_prefill_len(max(prefill_lens))
-        targets = {}
-        if (
-            f"batch_{batch_size}" in perf_targets["targets"]
-            and f"prefill_{prefill_pad_length}" in perf_targets["targets"][f"batch_{batch_size}"]
-            and model_device_key in perf_targets["targets"][f"batch_{batch_size}"][f"prefill_{prefill_pad_length}"]
-        ):
-            targets = {
-                "prefill_t/s": perf_targets["targets"][f"batch_{batch_size}"][f"prefill_{prefill_pad_length}"][
-                    model_device_key
-                ]["TTFT"],
-                "decode_t/s": perf_targets["targets"][f"batch_{batch_size}"][f"prefill_{prefill_pad_length}"][
-                    model_device_key
-                ]["decode_tok_s"],
-                "decode_t/s/u": perf_targets["targets"][f"batch_{batch_size}"][f"prefill_{prefill_pad_length}"][
-                    model_device_key
-                ]["decode_tok_s_u"],
-            }
+        targets = resolve_perf_targets(
+            model_name=model_name,
+            sku=tt_device_name,
+            batch_size=global_batch_size,
+            seq_len=prefill_pad_length,
+        ) or resolve_perf_targets(
+            model_name=model_name,
+            sku=tt_device_name,
+            batch_size=None,
+            seq_len=None,
+        )
+        targets = targets or {}
         # Instead of running warmup iterations, the demo profiles the initial compile iteration
         bench_n_warmup_iter = {"inference_prefill": 0, "inference_decode": 1}
         benchmark_data = create_benchmark_data(profiler, measurements, bench_n_warmup_iter, targets)
@@ -977,66 +967,18 @@ def test_gpt_oss_demo(
         logger.info(
             f"Checking measurements against CI performance targets for {model_name} on {tt_device_name} for padded prefill length {prefill_pad_length}"
         )
-        # Only call verify_perf if the model_device_key exists in the targets
-        if f"batch_{batch_size}" in perf_targets["ci"] and False:
-            if f"prefill_{prefill_pad_length}" in perf_targets["ci"][f"batch_{batch_size}"]:
-                if model_device_key in perf_targets["ci"][f"batch_{batch_size}"][f"prefill_{prefill_pad_length}"]:
-                    perf_config = perf_targets["ci"][f"batch_{batch_size}"][f"prefill_{prefill_pad_length}"][
-                        model_device_key
-                    ]
-
-                    # Parse TTFT target with tolerance
-                    current_ttft_target = perf_config["TTFT"]
-                    if isinstance(current_ttft_target, list):
-                        ttft_tolerance = current_ttft_target[1]
-                        current_ttft_target = current_ttft_target[0]
-                    else:
-                        ttft_tolerance = 1.15  # Default 15% tolerance
-
-                    # Parse decode_tok_s_u target with tolerance
-                    decode_tsu_target = perf_config["decode_tok_s_u"]
-                    if isinstance(decode_tsu_target, list):
-                        decode_tolerance = decode_tsu_target[1]
-                        decode_tsu_target = decode_tsu_target[0]
-                    else:
-                        decode_tolerance = 1.15  # Default 15% tolerance
-
-                    # Verify prefill performance with prefill-specific tolerance
-                    prefill_targets = {
-                        "prefill_time_to_first_token": current_ttft_target / 1000,  # convert to seconds
-                    }
-                    verify_perf(
-                        measurements,
-                        prefill_targets,
-                        high_tol_percentage=ttft_tolerance,
-                        expected_measurements={k: True for k in prefill_targets.keys()},
-                    )
-
-                    # Verify decode performance with decode-specific tolerance
-                    decode_ts_target = perf_config.get("decode_tok_s")
-                    if isinstance(decode_ts_target, list):
-                        decode_ts_target = decode_ts_target[0]
-                    if decode_ts_target is None:
-                        decode_ts_target = decode_tsu_target * global_batch_size
-                    decode_targets = {
-                        "decode_t/s/u": decode_tsu_target,
-                        "decode_t/s": decode_ts_target,
-                    }
-                    verify_perf(
-                        measurements,
-                        decode_targets,
-                        high_tol_percentage=decode_tolerance,
-                        expected_measurements={k: True for k in decode_targets.keys()},
-                    )
-                else:
-                    logger.warning(
-                        f"No CI performance targets found for model {model_name} on device {tt_device_name} for prefill length {prefill_pad_length}. Skipping performance verification."
-                    )
-            else:
-                logger.warning(
-                    f"No CI performance targets found for prefill length {prefill_pad_length}. Skipping performance verification."
-                )
+        if targets:
+            expected_measurements = {
+                metric: True
+                for metric in targets
+                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+            }
+            verify_perf(
+                measurements=measurements,
+                expected_perf_metrics=targets,
+                expected_measurements=expected_measurements,
+            )
         else:
             logger.warning(
-                f"No CI performance targets found for batch size {batch_size}. Skipping performance verification."
+                f"No centralized CI performance targets found for model={model_name}, sku={tt_device_name}, batch={global_batch_size}, seq={prefill_pad_length}. Skipping performance verification."
             )

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -23,6 +23,7 @@ from models.perf.benchmarking_utils import BenchmarkProfiler, BenchmarkData
 from models.common.utility_functions import (
     comp_pcc,
 )
+from models.demos.utils.llm_demo_utils import verify_perf
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):
@@ -1463,37 +1464,29 @@ def test_demo_text(
         f"Average speed: {round(avg_decode_iteration_time * 1000, 2)}ms @ {round(decode_tok_s_user, 2)} tok/s/user ({round(decode_tok_s, 2)} tok/s throughput)"
     )
 
-    PERFORMANCE_TARGETS = {
-        "TG_Llama-3.1-70B": {"ttft": 73.00 if galaxy_type == "6U" else 99.00, "tsu": 71.5},
-        "TG_Llama-3.3-70B": {"ttft": 73.00 if galaxy_type == "6U" else 99.00, "tsu": 71.5},
-    }
-
-    model_key = f"{model_args.device_name}_{model_args.base_model_name}"
-
-    if model_key in PERFORMANCE_TARGETS:
-        test_id = request.node.callspec.id
-        if "repeat2" in test_id:
-            PERF_TOLERANCE_PERCENTAGE = 2.2
-            model_perf_targets = PERFORMANCE_TARGETS[model_key]
-            assert_perf_within_tolerance(
-                "TTFT (ms)",
-                avg_time_to_first_token * 1000,
-                model_perf_targets["ttft"],
-                PERF_TOLERANCE_PERCENTAGE,
-            )
-            assert_perf_within_tolerance(
-                "Decode throughput (tok/s/user)",
-                decode_tok_s_user,
-                model_perf_targets["tsu"],
-                PERF_TOLERANCE_PERCENTAGE,
-            )
-        else:
-            logger.info(
-                f"Test '{test_id}' currently doesn't have performance targets set! Skipping performance checks..."
-            )
-    else:
-        logger.warning(
-            f"Model '{model_args.base_model_name}' currently doesn't have performance targets on {model_args.device_name} device!"
+    target_model_name = {
+        "Llama-3.1-70B": "llama3.3-70b-galaxy",
+        "Llama-3.3-70B": "llama3.3-70b-galaxy",
+        "Qwen3-32B": "qwen3-32b-galaxy",
+    }.get(model_args.base_model_name)
+    test_id = request.node.callspec.id
+    if target_model_name and "repeat2" in test_id:
+        verify_perf(
+            measurements={
+                "prefill_time_to_first_token": avg_time_to_first_token,
+                "decode_t/s/u": decode_tok_s_user,
+                "decode_t/s": decode_tok_s,
+            },
+            model_name=target_model_name,
+            sku=model_args.device_name,
+            batch_size=batch_size,
+            seq_len=max_encoded_prompt_len,
+            high_tol_percentage=1.022,
+            expected_measurements={
+                "prefill_time_to_first_token": True,
+                "decode_t/s/u": True,
+                "decode_t/s": True,
+            },
         )
 
     # Save benchmark data for CI dashboard
@@ -1509,5 +1502,5 @@ def test_demo_text(
         benchmark_data.save_partial_run_json(
             profiler,
             run_type=f"tg_llama_text_demo_prefill",
-            ml_model_name="llama70b-tg",
+            ml_model_name=target_model_name or "llama3.3-70b-galaxy",
         )

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -25,6 +25,7 @@ import torch
 
 import ttnn
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
+from models.demos.utils.model_targets import resolve_perf_targets
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import hf_multimodal_encode
 from models.tt_transformers.tt.generator import Generator
@@ -445,30 +446,25 @@ def test_multimodal_demo_text(
     if is_ci_env and max_batch_size == 1 and enable_trace:  # Only profiling these parametrizations
         tt_device_name = model_args[0].device_name
         base_model_name = model_args[0].base_model_name
-        target_prefill_tok_s = {
-            "N300_Llama-3.2-11B": 23,
-            "T3K_Llama-3.2-11B": 20,
-            "T3K_Llama-3.2-90B": 3,
-            "N150_gemma-3-4b": 285,
-            "N300_gemma-3-4b": 390,
-            "T3K_gemma-3-27b": 265,
-        }[f"{tt_device_name}_{base_model_name}"]
-
-        target_decode_tok_s_u = {
-            "N300_Llama-3.2-11B": 21.5,
-            "T3K_Llama-3.2-11B": 35,
-            "T3K_Llama-3.2-90B": 6,
-            "N150_gemma-3-4b": 24,
-            "N300_gemma-3-4b": 28,
-            "T3K_gemma-3-27b": 13,
-        }[f"{tt_device_name}_{base_model_name}"]
-
-        target_decode_tok_s = target_decode_tok_s_u * max_batch_size
-        targets = {
-            "prefill_t/s": target_prefill_tok_s,
-            "decode_t/s": target_decode_tok_s,
-            "decode_t/s/u": target_decode_tok_s_u,
-        }
+        target_model_name = {
+            "Llama-3.2-11B": "llama3.2-11b-vision",
+            "Llama-3.2-90B": "llama90b-vl",
+            "gemma-3-4b": "gemma-3-4b-vision",
+            "gemma-3-27b": "gemma-3-27b-vision",
+        }.get(base_model_name)
+        targets = {}
+        if target_model_name:
+            targets = resolve_perf_targets(
+                model_name=target_model_name,
+                sku=tt_device_name,
+                batch_size=max_batch_size,
+                seq_len=max(prefill_lens).item(),
+            ) or resolve_perf_targets(
+                model_name=target_model_name,
+                sku=tt_device_name,
+                batch_size=None,
+                seq_len=None,
+            )
 
         # Save benchmark data for CI
         N_warmup_iter = {"inference_prefill": 0, "inference_decode": 0}
@@ -476,7 +472,7 @@ def test_multimodal_demo_text(
         benchmark_data.save_partial_run_json(
             profiler,
             run_type="demo",
-            ml_model_name=f"{base_model_name}-vision",
+            ml_model_name=target_model_name or f"{base_model_name}-vision",
             ml_model_type="vlm",
             device_name=tt_device_name,
             num_layers=model_args[0].n_layers,
@@ -490,5 +486,19 @@ def test_multimodal_demo_text(
             "gemma-3-4b",  # Gemma-3 functional only - perf tests are not reliable yet
             "gemma-3-27b",  # Gemma-3 functional only - perf tests are not reliable yet
         ]
-        if base_model_name not in skip_perf_verification:
-            verify_perf(measurements, targets, high_tol_percentage=1.15)
+        if not targets:
+            logger.warning(
+                f"No centralized perf targets found for model={target_model_name or base_model_name}, sku={tt_device_name}"
+            )
+        elif base_model_name not in skip_perf_verification:
+            expected_measurements = {
+                metric: True
+                for metric in targets
+                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+            }
+            verify_perf(
+                measurements,
+                expected_perf_metrics=targets,
+                high_tol_percentage=1.15,
+                expected_measurements=expected_measurements,
+            )

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -492,9 +492,7 @@ def test_multimodal_demo_text(
             )
         elif base_model_name not in skip_perf_verification:
             expected_measurements = {
-                metric: True
-                for metric in targets
-                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+                metric: True for metric in targets if not metric.endswith("_tolerance") and metric not in {"tolerance"}
             }
             verify_perf(
                 measurements,

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -25,7 +25,8 @@ from models.demos.qwen25_vl.tt.common import (
 from models.demos.qwen25_vl.tt.generator import Generator
 from models.demos.qwen25_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
-from models.demos.utils.llm_demo_utils import create_benchmark_data
+from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
+from models.demos.utils.model_targets import resolve_perf_targets
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
 
@@ -768,30 +769,28 @@ def test_demo(
         f"Text model average speed: {round(avg_decode_iteration_time * 1000, 2)}ms @ {round(decode_tok_s_user, 2)} tok/s/user ({round(decode_tok_s, 2)} tok/s throughput)"
     )
 
-    # Benchmark targets
-    supported_models = []
-    supported_devices = []
-
     tt_device_name = model_args.device_name
-
-    if model_args.base_model_name in supported_models:
-        assert tt_device_name in supported_devices, f"Device {tt_device_name} not supported"
-
-        # Set the target times to first token for every combination of device and model
-        target_prefill_tok_s = {}[f"{tt_device_name}_{model_args.base_model_name}"]
-
-        # Set the target decode timesfor every combination of device and model
-        target_decode_tok_s_u = {}[f"{tt_device_name}_{model_args.base_model_name}"]
-
-        target_decode_tok_s = target_decode_tok_s_u * batch_size
-        targets = {
-            "prefill_t/s": target_prefill_tok_s,
-            "decode_t/s": target_decode_tok_s,
-            "decode_t/s/u": target_decode_tok_s_u,
-        }
-    else:
-        logger.warning(f"Model {model_args.base_model_name} not does not have performance targets set")
-        targets = {}
+    target_model_name = {
+        "Qwen2.5-VL-72B": "qwen2.5-72b-vl",
+        "Qwen2.5-VL-32B": "qwen2.5-vl-32b",
+    }.get(model_args.base_model_name)
+    targets = {}
+    if target_model_name:
+        targets = resolve_perf_targets(
+            model_name=target_model_name,
+            sku=tt_device_name,
+            batch_size=batch_size,
+            seq_len=max(prefill_lens),
+        ) or resolve_perf_targets(
+            model_name=target_model_name,
+            sku=tt_device_name,
+            batch_size=None,
+            seq_len=None,
+        )
+    if not targets:
+        logger.warning(
+            f"No centralized perf targets found for model={target_model_name or model_args.base_model_name}, sku={tt_device_name}"
+        )
 
     # Save benchmark data for CI dashboard
     if is_ci_env:
@@ -828,7 +827,7 @@ def test_demo(
         benchmark_data.save_partial_run_json(
             profiler,
             run_type="demo",
-            ml_model_name=model_args.base_model_name,
+            ml_model_name=target_model_name or model_args.base_model_name,
             ml_model_type="llm",
             device_name=tt_device_name,
             num_layers=model_args.n_layers,
@@ -837,6 +836,18 @@ def test_demo(
             input_sequence_length=max(prefill_lens),
             output_sequence_length=num_tokens_generated_decode[0],
         )
+
+        if targets:
+            expected_measurements = {
+                metric: True
+                for metric in targets
+                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+            }
+            verify_perf(
+                measurements=measurements,
+                expected_perf_metrics=targets,
+                expected_measurements=expected_measurements,
+            )
 
 
 def load_inputs(input_file, batch_size):

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -839,9 +839,7 @@ def test_demo(
 
         if targets:
             expected_measurements = {
-                metric: True
-                for metric in targets
-                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+                metric: True for metric in targets if not metric.endswith("_tolerance") and metric not in {"tolerance"}
             }
             verify_perf(
                 measurements=measurements,

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -628,7 +628,9 @@ def run_falcon_demo_kv(
     if perf_mode:
         if perf_targets:
             expected_measurements = {
-                metric: True for metric in perf_targets if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+                metric: True
+                for metric in perf_targets
+                if not metric.endswith("_tolerance") and metric not in {"tolerance"}
             }
             verify_perf(
                 measurements,

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -21,7 +21,8 @@ from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconConf
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.falcon_common import PytorchFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config, model_config_entries
-from models.demos.utils.llm_demo_utils import create_benchmark_data
+from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
+from models.demos.utils.model_targets import resolve_perf_targets
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.model_config import determine_device_name
 
@@ -195,11 +196,18 @@ def run_falcon_demo_kv(
         logger.info("Running in performance measurement mode (invalid outputs)!")
 
         N_warmup_iter = {"inference_prefill": 5, "inference_decode": 5}
-        perf_targets = {
-            "prefill_t/s": None,
-            "decode_t/s": 36 * batch_size,
-            "decode_t/s/u": 36,
-        }
+        perf_targets = resolve_perf_targets(
+            model_name="falcon-40b",
+            sku=determine_device_name(mesh_device),
+            batch_size=batch_size,
+            seq_len=max_seq_len,
+        ) or resolve_perf_targets(
+            model_name="falcon-40b",
+            sku=determine_device_name(mesh_device),
+            batch_size=None,
+            seq_len=max_seq_len,
+        )
+        perf_targets = perf_targets or {}
 
     configuration = FalconConfig(**model_config_entries)
 
@@ -616,6 +624,21 @@ def run_falcon_demo_kv(
         input_sequence_length=num_input_tokens,
         output_sequence_length=1 if perf_mode else output_token_index + 1,
     )
+
+    if perf_mode:
+        if perf_targets:
+            expected_measurements = {
+                metric: True for metric in perf_targets if not metric.endswith("_tolerance") and metric not in {"tolerance"}
+            }
+            verify_perf(
+                measurements,
+                expected_perf_metrics=perf_targets,
+                expected_measurements=expected_measurements,
+            )
+        else:
+            logger.warning(
+                f"No centralized perf targets found for model=falcon-40b, sku={determine_device_name(mesh_device)}, seq={max_seq_len}"
+            )
 
     return generated_text, measurements
 

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -9,22 +9,16 @@ from models.demos.falcon7b_common.demo.demo import run_falcon_demo_kv
 
 
 @pytest.mark.parametrize(
-    "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
+    "perf_mode, max_seq_len, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 1990, "decode_t/s": 549, "decode_t/s/u": 17.16}, False, None),
-        (True, 1024, {"prefill_t/s": 2855, "decode_t/s": 487, "decode_t/s/u": 15.24}, False, None),
-        (True, 2048, {"prefill_t/s": 2450, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
-        (True, 128, None, False, None),
-        (True, 1024, None, False, None),
-        (True, 2048, None, False, None),
-        (False, 1024, None, True, "models/demos/wormhole/falcon7b/expected_greedy_output.json"),
-        (False, 1024, None, True, None),
-        (False, 1024, None, False, None),
+        (True, 128, False, None),
+        (True, 1024, False, None),
+        (True, 2048, False, None),
+        (False, 1024, True, "models/demos/wormhole/falcon7b/expected_greedy_output.json"),
+        (False, 1024, True, None),
+        (False, 1024, False, None),
     ),
     ids=[
-        "perf_mode_128_stochastic_verify",
-        "perf_mode_1024_stochastic_verify",
-        "perf_mode_2048_stochastic_verify",
         "perf_mode_128_stochastic",
         "perf_mode_1024_stochastic",
         "perf_mode_2048_stochastic",
@@ -37,7 +31,6 @@ from models.demos.falcon7b_common.demo.demo import run_falcon_demo_kv
 def test_demo(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
     max_seq_len,
-    expected_perf_metrics,  # Expected perf (t/s) for prefill and decode in perf mode
     greedy_sampling,  # Option to use greedy decoding instead of top-k/p
     expected_greedy_output_path,  # Path for expected outputs for greedy decoding
     user_input,
@@ -45,21 +38,12 @@ def test_demo(
     is_ci_env,
 ):
     if is_ci_env:
-        if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:
+        if not expected_greedy_output_path and not perf_mode and not len(user_input) == 1:
             pytest.skip("Skipping test in CI since it provides redundant testing")
 
     assert is_wormhole_b0()
 
     batch_size = 32
-    if perf_mode:
-        json_perf_targets = {
-            "prefill_t/s": {128: 2034, 1024: 9880, 2048: 9881}[max_seq_len],
-            "decode_t/s": 26 * batch_size,
-            "decode_t/s/u": 26,
-        }  # performance targets that we aim for (wormhole)
-    else:
-        json_perf_targets = {}
-
     return run_falcon_demo_kv(
         user_input=user_input,
         batch_size=batch_size,
@@ -68,8 +52,7 @@ def test_demo(
         mesh_device=mesh_device,
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
-        expected_perf_metrics=expected_perf_metrics,
         expected_greedy_output_path=expected_greedy_output_path,
-        json_perf_targets=json_perf_targets,
+        model_name="falcon-7b",
         is_ci_env=is_ci_env,
     )

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -259,8 +259,49 @@ targets:
               decode_tolerance: 1.15
             accuracy: {}
 
+  gemma-3-4b-vision:
+    aliases: ["gemma-3-4b-vision", "gemma-3-4b-vision-demo"]
+    skus:
+      wh_n150:
+        entries:
+          - batch_size: 1
+            seq_len: null
+            status: active
+            perf:
+              prefill_t/s: 285.0
+              decode_t/s/u: 24.0
+              decode_t/s: 24.0
+              decode_tolerance: 1.15
+            accuracy: {}
+      wh_n300:
+        entries:
+          - batch_size: 1
+            seq_len: null
+            status: active
+            perf:
+              prefill_t/s: 390.0
+              decode_t/s/u: 28.0
+              decode_t/s: 28.0
+              decode_tolerance: 1.15
+            accuracy: {}
+
+  gemma-3-27b-vision:
+    aliases: ["gemma-3-27b-vision", "gemma-3-27b-vision-demo"]
+    skus:
+      wh_llmbox_perf:
+        entries:
+          - batch_size: 1
+            seq_len: null
+            status: active
+            perf:
+              prefill_t/s: 265.0
+              decode_t/s/u: 13.0
+              decode_t/s: 13.0
+              decode_tolerance: 1.15
+            accuracy: {}
+
   gemma-4-e2b:
-    aliases: ["gemma-4-e2b", "google/gemma-4-E2B-it"]
+    aliases: ["gemma-4-e2b", "google/gemma-4-E2B-it", "gemma4"]
     skus:
       wh_n150:
         entries:
@@ -492,14 +533,19 @@ targets:
             owner_id: U03PUAKE719 # Miguel Tairum Cruz
             team: models
   llama3.3-70b-galaxy:
-    aliases: ["llama3.3-70b-galaxy"]
+    aliases: ["llama3.3-70b-galaxy", "llama70b-tg"]
     skus:
       wh_galaxy_perf:
         entries:
           - batch_size: null
             seq_len: null
-            status: TODO
-            perf: {}
+            status: active
+            perf:
+              prefill_time_to_first_token: 99.0
+              prefill_tolerance: 1.15
+              decode_t/s/u: 71.5
+              decode_t/s: 2288.0
+              decode_tolerance: 1.15
             accuracy: {}
             owner_id: U053W15B6JF # Djordje Ivanovic
             team: models
@@ -618,26 +664,33 @@ targets:
               top1: 98.0
               top5: 100.0
   falcon-7b:
-    aliases: ["falcon-7b"]
+    aliases: ["falcon-7b", "falcon-7b-instruct", "tiiuae/falcon-7b-instruct"]
     skus:
       wh_n150:
         entries:
-          - batch_size: null
+          - batch_size: 32
             seq_len: 1024
-            status: TODO
-            perf: {}
+            status: active
+            perf:
+              prefill_t/s: 2855.0
+              decode_t/s/u: 15.24
+              decode_t/s: 487.0
+              decode_tolerance: 1.15
             accuracy: {}
             owner_id: U07RY6B5FLJ # Gongyu Wang
             team: models
   falcon-40b:
-    aliases: ["falcon-40b"]
+    aliases: ["falcon-40b", "falcon-40b-instruct", "tiiuae/falcon-40b-instruct"]
     skus:
       wh_llmbox_perf:
         entries:
-          - batch_size: null
-            seq_len: 128
-            status: TODO
-            perf: {}
+          - batch_size: 32
+            seq_len: null
+            status: active
+            perf:
+              decode_t/s/u: 36.0
+              decode_t/s: 1152.0
+              decode_tolerance: 1.15
             accuracy: {}
             owner_id: U053W15B6JF # Djordje Ivanovic
             team: models
@@ -648,20 +701,30 @@ targets:
         entries:
           - batch_size: 128
             seq_len: null
-            status: TODO
-            perf: {}
+            status: active
+            perf:
+              prefill_time_to_first_token: 400
+              prefill_tolerance: 1.15
+              decode_t/s/u: 3.0
+              decode_t/s: 380.0
+              decode_tolerance: 1.15
             accuracy: {}
             owner_id: U08TJ70UFRT # Stuti Raizada
             team: models
   whisper:
-    aliases: ["whisper"]
+    aliases: ["whisper", "distil-whisper/distil-large-v3"]
     skus:
       wh_n150:
         entries:
           - batch_size: null
             seq_len: null
-            status: TODO
-            perf: {}
+            status: active
+            perf:
+              prefill_time_to_first_token: 130
+              prefill_tolerance: 1.20
+              decode_t/s/u: 124.0
+              decode_t/s: 124.0
+              decode_tolerance: 1.20
             accuracy: {}
             owner_id: U0491KT8MNY # Mohamed Bahnas
             team: models


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Github issue: https://github.com/tenstorrent/tt-metal/issues/42784

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Migrate all remaining model demo scripts (those outside models/tt_transformers/ entry points) to the centralized targets YAML, and remove all legacy inline target definitions so the YAML is the sole source of truth.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

All Model Tests pipeline run: https://github.com/tenstorrent/tt-metal/actions/runs/25828360727

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:42784-Migrate-remaining-models-to-centralized-perf/accuracy-targets)