### PR TITLE
[LLK]: tt-llk tests: add narrow_tile unpack-tilize coverage (WH)

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -37,18 +37,8 @@ from helpers.utils import passed_test
     # Int32 is Int32→Int32 only (unpacker constraint); concatenated via same=True.
     formats=lambda narrow_tile: (
         input_output_formats(
-            [
-                DataFormat.Float32,
-                DataFormat.Float16,
-                DataFormat.Float16_b,
-                DataFormat.Bfp8_b,
-            ]
-            if narrow_tile == NarrowTile.No
-            else [
-                DataFormat.Float32,
-                DataFormat.Float16,
-                DataFormat.Float16_b,
-            ]
+            [DataFormat.Float32, DataFormat.Float16, DataFormat.Float16_b]
+            + ([DataFormat.Bfp8_b] if narrow_tile == NarrowTile.No else [])
         )
         + input_output_formats([DataFormat.Int32], same=True)
     ),

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -18,6 +18,7 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
+    INPUT_DIMENSIONS,
     NARROW_TILE,
     NUM_FACES,
     STOCHASTIC_ROUNDING,
@@ -30,26 +31,46 @@ from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
 
+# narrow_tile=Yes covers [32, 16] tiles (2 vertical 16x16 faces, num_faces=2).
+# BH narrow_tile unimplemented for non-8-bit formats (tt-llk#1281).
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float32,
-            DataFormat.Float16,
-            DataFormat.Float16_b,
-            DataFormat.Bfp8_b,
-        ]
+    # Int32 is Int32→Int32 only (unpacker constraint); concatenated via same=True.
+    formats=lambda narrow_tile: (
+        input_output_formats(
+            [
+                DataFormat.Float32,
+                DataFormat.Float16,
+                DataFormat.Float16_b,
+                DataFormat.Bfp8_b,
+            ]
+            if narrow_tile == NarrowTile.No
+            else [
+                DataFormat.Float32,
+                DataFormat.Float16,
+                DataFormat.Float16_b,
+            ]
+        )
+        + input_output_formats([DataFormat.Int32], same=True)
     ),
-    stoch_rnd_type=[
-        StochasticRounding.No,
-        StochasticRounding.Fpu,
-        StochasticRounding.Pack,
-        StochasticRounding.All,
-    ],
+    stoch_rnd_type=lambda narrow_tile: (
+        [
+            StochasticRounding.No,
+            StochasticRounding.Fpu,
+            StochasticRounding.Pack,
+            StochasticRounding.All,
+        ]
+        if narrow_tile == NarrowTile.No
+        else [StochasticRounding.No]
+    ),
     transpose=[Transpose.No],
-    narrow_tile=[NarrowTile.No],
+    narrow_tile=[NarrowTile.No, NarrowTile.Yes],
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    num_faces=[4, 2, 1],
-    input_dimensions=[[32, 32], [64, 64], [32, 64], [32, 128], [128, 32]],
+    num_faces=lambda narrow_tile: ([4, 2, 1] if narrow_tile == NarrowTile.No else [2]),
+    input_dimensions=lambda narrow_tile: (
+        [[32, 32], [64, 64], [32, 64], [32, 128], [128, 32]]
+        if narrow_tile == NarrowTile.No
+        else [[32, 16], [64, 16], [128, 16]]
+    ),
 )
 def test_unpack_tilize_comprehensive(
     formats,
@@ -64,6 +85,20 @@ def test_unpack_tilize_comprehensive(
 
     # Get architecture for architecture-specific skips
     arch = get_chip_architecture()
+
+    # BH narrow_tile unimplemented for non-8-bit formats (tt-llk#1281).
+    if narrow_tile == NarrowTile.Yes and arch == ChipArchitecture.BLACKHOLE:
+        pytest.skip("BH narrow_tile unimplemented for non-8-bit formats (tt-llk#1281)")
+
+    # Wormhole unpack_tilize has 0-loop for num_faces=1
+    # File: tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h:220
+    # num_loops = num_faces / 2 → when num_faces=1, this is 1/2=0 (integer division)
+    # Result: for (n=0; n<0; n++) never executes, no data unpacked, packer timeout
+    if arch == ChipArchitecture.WORMHOLE and num_faces == 1:
+        pytest.skip(
+            "Wormhole LLK: num_loops = num_faces/2 = 0 when num_faces=1 "
+            "(tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h:220)"
+        )
 
     # BFP8_b input format not supported by tilize unpacker
     # Tilize unpacker cannot correctly read row-major BFP8_b data with shared exponents
@@ -96,24 +131,63 @@ def test_unpack_tilize_comprehensive(
             "Bfp8_b output with StochasticRounding.Pack/All causes the resulting value to be 0 when input is -508"
         )
 
-    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+    if (
+        formats.input_format == DataFormat.Int32
+        and stoch_rnd_type != StochasticRounding.No
+    ):
+        pytest.skip("StochasticRounding does not apply to Int32")
+
+    is_narrow = narrow_tile == NarrowTile.Yes
+    tile_dimensions = [32, 16] if is_narrow else None
+
+    stimuli_kwargs = {"tile_dimensions": tile_dimensions} if is_narrow else {}
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli_v2(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        **stimuli_kwargs,
     )
 
     torch_format = format_dict[formats.output_format]
 
-    # Generate golden reference using TilizeGolden model
-    tilize_function = get_golden_generator(TilizeGolden)
-    golden_tensor = tilize_function(
-        src_A,
-        input_dimensions,
-        formats.output_format,
-        num_faces,
-    )
-    golden_tensor = golden_tensor.to(torch_format)
+    if is_narrow:
+        # TilizeGolden hardcodes 32x32; narrow tiles need tilize_block directly.
+        golden_tensor = (
+            tilize_block(
+                src_A,
+                input_dimensions,
+                formats.output_format,
+                num_faces=num_faces,
+                tile_dimensions=tile_dimensions,
+            )
+            .flatten()
+            .to(torch_format)
+        )
+    else:
+        tilize_function = get_golden_generator(TilizeGolden)
+        golden_tensor = tilize_function(
+            src_A,
+            input_dimensions,
+            formats.output_format,
+            num_faces,
+        ).to(torch_format)
+
+    if is_narrow:
+        num_narrow_tiles = input_dimensions[0] // 32
+        input_dim_runtime = INPUT_DIMENSIONS(
+            full_rt_dim=num_narrow_tiles,
+            full_ct_dim=1,
+            block_ct_dim=1,
+            block_rt_dim=num_narrow_tiles,
+        )
+        stimuli_extra = {
+            "tile_dimensions": tile_dimensions,
+            "use_dense_tile_dimensions": True,
+        }
+    else:
+        input_dim_runtime = generate_input_dim(input_dimensions, input_dimensions)
+        stimuli_extra = {}
 
     configuration = TestConfig(
         "sources/unpack_tilize_sweep_test.cpp",
@@ -122,7 +196,7 @@ def test_unpack_tilize_comprehensive(
             STOCHASTIC_ROUNDING(stoch_rnd_type),
         ],
         runtimes=[
-            generate_input_dim(input_dimensions, input_dimensions),
+            input_dim_runtime,
             UNPACK_TRANS_FACES(Transpose.No),
             UNPACK_TRANS_WITHIN_FACE(transpose),
             NARROW_TILE(narrow_tile),
@@ -140,6 +214,7 @@ def test_unpack_tilize_comprehensive(
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
             write_full_tiles=True,  # Tilize tests need full tiles in L1
+            **stimuli_extra,
         ),
         unpack_to_dest=(formats.input_format in [DataFormat.Int32, DataFormat.UInt32]),
         dest_acc=dest_acc,
@@ -155,126 +230,3 @@ def test_unpack_tilize_comprehensive(
     assert passed_test(
         golden_tensor, res_tensor, formats.output_format
     ), "Assert against golden failed"
-
-
-# A narrow tile has num_faces_c_dim < num_faces_r_dim: a single column of 16-wide
-# faces stacked vertically. The canonical narrow shape is [32, 16] — 2 faces of
-# 16x16 stacked vertically (num_faces=2).
-#
-# With narrow_tile=true the unpack-tilize kernel uses block_c_dim = ct_dim *
-# FACE_C_DIM (vs TILE_C_DIM) and num_loops = 2, so the inner stride changes;
-# the input must therefore be 16-wide. The pack side on WH also has narrow_tile
-# wiring (_llk_pack_init_/hw_configure_/dest_init_), so the source threads
-# params.NARROW_TILE through both unpack and pack for end-to-end validation.
-@parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float16,
-            DataFormat.Float16_b,
-        ]
-    ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    num_faces=[2],
-    num_narrow_tiles=[1, 2, 4],
-)
-def test_unpack_tilize_narrow_tile(formats, dest_acc, num_faces, num_narrow_tiles):
-    """Exercise the narrow_tile=true path of _llk_unpack_tilize_ end-to-end.
-
-    Validates that the unpack-tilize kernel correctly tilizes [32, 16] narrow
-    tiles (2 faces of 16x16 stacked vertically) when narrow_tile=true, and the
-    pack writes them back in the matching narrow layout. Multiple narrow tiles
-    can be processed sequentially by stacking them vertically in L1.
-    """
-
-    arch = get_chip_architecture()
-
-    # BH unpack-tilize narrow_tile=true is unimplemented for non-8-bit formats:
-    # tt_llk_blackhole/llk_lib/llk_unpack_tilize.h:184 has a FIXME ("This should
-    # be revisited for narrow tiles") and the corresponding num_loops=2 /
-    # bot_face_offset logic is commented out. Tracked by tt-llk#1281. Skip BH
-    # end-to-end pending the kernel work; the test still compiles on BH.
-    if arch == ChipArchitecture.BLACKHOLE:
-        pytest.skip(
-            "BH unpack-tilize narrow_tile=true unimplemented for non-8-bit "
-            "formats (FIXME at tt_llk_blackhole/llk_lib/llk_unpack_tilize.h:184, "
-            "tt-llk#1281). Test compiles; promote once kernel is fixed."
-        )
-
-    tile_dimensions = [32, 16]
-    tile_r, tile_c = tile_dimensions
-    input_dimensions = [tile_r * num_narrow_tiles, tile_c]
-
-    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli_v2(
-        stimuli_format_A=formats.input_format,
-        input_dimensions_A=input_dimensions,
-        stimuli_format_B=formats.input_format,
-        input_dimensions_B=input_dimensions,
-        tile_dimensions=tile_dimensions,
-    )
-
-    torch_format = format_dict[formats.output_format]
-
-    # TilizeGolden hardcodes 32x32 tile shape; for narrow tiles tilize_block
-    # must be called directly with tile_dimensions=[32, 16].
-    golden_tensor = (
-        tilize_block(
-            src_A,
-            input_dimensions,
-            formats.output_format,
-            num_faces=num_faces,
-            tile_dimensions=tile_dimensions,
-        )
-        .flatten()
-        .to(torch_format)
-    )
-
-    # The unpack-tilize kernel walks BLOCK_CT_DIM x BLOCK_RT_DIM narrow tiles;
-    # with input [num_narrow_tiles*32, 16] that's 1 column x num_narrow_tiles rows.
-    from helpers.test_variant_parameters import INPUT_DIMENSIONS
-
-    configuration = TestConfig(
-        "sources/unpack_tilize_sweep_test.cpp",
-        formats,
-        templates=[
-            STOCHASTIC_ROUNDING(StochasticRounding.No),
-        ],
-        runtimes=[
-            INPUT_DIMENSIONS(
-                full_rt_dim=num_narrow_tiles,
-                full_ct_dim=1,
-                block_ct_dim=1,
-                block_rt_dim=num_narrow_tiles,
-            ),
-            UNPACK_TRANS_FACES(Transpose.No),
-            UNPACK_TRANS_WITHIN_FACE(Transpose.No),
-            NARROW_TILE(NarrowTile.Yes),
-            NUM_FACES(num_faces),
-            TILE_COUNT(tile_cnt_A),
-        ],
-        variant_stimuli=StimuliConfig(
-            src_A,
-            formats.input_format,
-            src_B,
-            formats.input_format,
-            formats.output_format,
-            tile_count_A=tile_cnt_A,
-            tile_count_B=tile_cnt_B,
-            tile_count_res=tile_cnt_A,
-            num_faces=num_faces,
-            tile_dimensions=tile_dimensions,
-            use_dense_tile_dimensions=True,
-            write_full_tiles=True,
-        ),
-        dest_acc=dest_acc,
-    )
-
-    res_from_L1 = configuration.run().result
-
-    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
-    assert len(res_tensor) == len(
-        golden_tensor
-    ), f"Result length {len(res_tensor)} != golden length {len(golden_tensor)}"
-
-    assert passed_test(
-        golden_tensor, res_tensor, formats.output_format
-    ), "Narrow-tile unpack-tilize result did not match golden"

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -27,6 +27,7 @@ from helpers.test_variant_parameters import (
     UNPACK_TRANS_WITHIN_FACE,
     generate_input_dim,
 )
+from helpers.tile_constants import DEFAULT_TILE_R_DIM, FACE_C_DIM
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
@@ -46,7 +47,7 @@ def _narrow_path(
         .flatten()
         .to(torch_format)
     )
-    num_narrow_tiles = input_dimensions[0] // 32
+    num_narrow_tiles = input_dimensions[0] // tile_dimensions[0]
     input_dim_runtime = INPUT_DIMENSIONS(
         full_rt_dim=num_narrow_tiles,
         full_ct_dim=1,
@@ -79,6 +80,8 @@ def _regular_path(src_A, input_dimensions, formats, num_faces, torch_format):
 # BH narrow_tile unimplemented for non-8-bit formats (tt-llk#1281).
 @parametrize(
     # Int32 is Int32→Int32 only (unpacker constraint); concatenated via same=True.
+    # Intentionally added to both narrow and non-narrow sweeps to exercise the
+    # Int32 unpack_to_dest tilize path in each.
     formats=lambda narrow_tile: (
         input_output_formats(
             [DataFormat.Float32, DataFormat.Float16, DataFormat.Float16_b]
@@ -124,16 +127,6 @@ def test_unpack_tilize_comprehensive(
     if narrow_tile == NarrowTile.Yes and arch == ChipArchitecture.BLACKHOLE:
         pytest.skip("BH narrow_tile unimplemented for non-8-bit formats (tt-llk#1281)")
 
-    # Wormhole unpack_tilize has 0-loop for num_faces=1
-    # File: tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h:220
-    # num_loops = num_faces / 2 → when num_faces=1, this is 1/2=0 (integer division)
-    # Result: for (n=0; n<0; n++) never executes, no data unpacked, packer timeout
-    if arch == ChipArchitecture.WORMHOLE and num_faces == 1:
-        pytest.skip(
-            "Wormhole LLK: num_loops = num_faces/2 = 0 when num_faces=1 "
-            "(tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h:220)"
-        )
-
     # BFP8_b input format not supported by tilize unpacker
     # Tilize unpacker cannot correctly read row-major BFP8_b data with shared exponents
     # Note: BFP8_b input works in regular unpack mode (test_eltwise_unary_datacopy with tilize_en=false)
@@ -172,7 +165,8 @@ def test_unpack_tilize_comprehensive(
         pytest.skip("StochasticRounding does not apply to Int32")
 
     is_narrow = narrow_tile == NarrowTile.Yes
-    tile_dimensions = [32, 16] if is_narrow else None
+    # Narrow tile: 2 vertical 16x16 faces (num_faces=2).
+    tile_dimensions = [DEFAULT_TILE_R_DIM, FACE_C_DIM] if is_narrow else None
 
     stimuli_kwargs = {"tile_dimensions": tile_dimensions} if is_narrow else {}
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -31,6 +31,50 @@ from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
 
+def _narrow_path(
+    src_A, input_dimensions, formats, num_faces, tile_dimensions, torch_format
+):
+    # TilizeGolden hardcodes 32x32; narrow tiles need tilize_block directly.
+    golden_tensor = (
+        tilize_block(
+            src_A,
+            input_dimensions,
+            formats.output_format,
+            num_faces=num_faces,
+            tile_dimensions=tile_dimensions,
+        )
+        .flatten()
+        .to(torch_format)
+    )
+    num_narrow_tiles = input_dimensions[0] // 32
+    input_dim_runtime = INPUT_DIMENSIONS(
+        full_rt_dim=num_narrow_tiles,
+        full_ct_dim=1,
+        block_ct_dim=1,
+        block_rt_dim=num_narrow_tiles,
+    )
+    stimuli_extra = {
+        "tile_dimensions": tile_dimensions,
+        "use_dense_tile_dimensions": True,
+    }
+    return golden_tensor, input_dim_runtime, stimuli_extra
+
+
+def _regular_path(src_A, input_dimensions, formats, num_faces, torch_format):
+    tilize_function = get_golden_generator(TilizeGolden)
+    golden_tensor = tilize_function(
+        src_A,
+        input_dimensions,
+        formats.output_format,
+        num_faces,
+    ).to(torch_format)
+    return (
+        golden_tensor,
+        generate_input_dim(input_dimensions, input_dimensions),
+        {},
+    )
+
+
 # narrow_tile=Yes covers [32, 16] tiles (2 vertical 16x16 faces, num_faces=2).
 # BH narrow_tile unimplemented for non-8-bit formats (tt-llk#1281).
 @parametrize(
@@ -131,7 +175,7 @@ def test_unpack_tilize_comprehensive(
     tile_dimensions = [32, 16] if is_narrow else None
 
     stimuli_kwargs = {"tile_dimensions": tile_dimensions} if is_narrow else {}
-    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli_v2(
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
@@ -141,43 +185,13 @@ def test_unpack_tilize_comprehensive(
 
     torch_format = format_dict[formats.output_format]
 
-    if is_narrow:
-        # TilizeGolden hardcodes 32x32; narrow tiles need tilize_block directly.
-        golden_tensor = (
-            tilize_block(
-                src_A,
-                input_dimensions,
-                formats.output_format,
-                num_faces=num_faces,
-                tile_dimensions=tile_dimensions,
-            )
-            .flatten()
-            .to(torch_format)
+    golden_tensor, input_dim_runtime, stimuli_extra = (
+        _narrow_path(
+            src_A, input_dimensions, formats, num_faces, tile_dimensions, torch_format
         )
-    else:
-        tilize_function = get_golden_generator(TilizeGolden)
-        golden_tensor = tilize_function(
-            src_A,
-            input_dimensions,
-            formats.output_format,
-            num_faces,
-        ).to(torch_format)
-
-    if is_narrow:
-        num_narrow_tiles = input_dimensions[0] // 32
-        input_dim_runtime = INPUT_DIMENSIONS(
-            full_rt_dim=num_narrow_tiles,
-            full_ct_dim=1,
-            block_ct_dim=1,
-            block_rt_dim=num_narrow_tiles,
-        )
-        stimuli_extra = {
-            "tile_dimensions": tile_dimensions,
-            "use_dense_tile_dimensions": True,
-        }
-    else:
-        input_dim_runtime = generate_input_dim(input_dimensions, input_dimensions)
-        stimuli_extra = {}
+        if is_narrow
+        else _regular_path(src_A, input_dimensions, formats, num_faces, torch_format)
+    )
 
     configuration = TestConfig(
         "sources/unpack_tilize_sweep_test.cpp",

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -26,6 +26,7 @@ from helpers.test_variant_parameters import (
     UNPACK_TRANS_WITHIN_FACE,
     generate_input_dim,
 )
+from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
 
 
@@ -154,3 +155,126 @@ def test_unpack_tilize_comprehensive(
     assert passed_test(
         golden_tensor, res_tensor, formats.output_format
     ), "Assert against golden failed"
+
+
+# A narrow tile has num_faces_c_dim < num_faces_r_dim: a single column of 16-wide
+# faces stacked vertically. The canonical narrow shape is [32, 16] — 2 faces of
+# 16x16 stacked vertically (num_faces=2).
+#
+# With narrow_tile=true the unpack-tilize kernel uses block_c_dim = ct_dim *
+# FACE_C_DIM (vs TILE_C_DIM) and num_loops = 2, so the inner stride changes;
+# the input must therefore be 16-wide. The pack side on WH also has narrow_tile
+# wiring (_llk_pack_init_/hw_configure_/dest_init_), so the source threads
+# params.NARROW_TILE through both unpack and pack for end-to-end validation.
+@parametrize(
+    formats=input_output_formats(
+        [
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+        ]
+    ),
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    num_faces=[2],
+    num_narrow_tiles=[1, 2, 4],
+)
+def test_unpack_tilize_narrow_tile(formats, dest_acc, num_faces, num_narrow_tiles):
+    """Exercise the narrow_tile=true path of _llk_unpack_tilize_ end-to-end.
+
+    Validates that the unpack-tilize kernel correctly tilizes [32, 16] narrow
+    tiles (2 faces of 16x16 stacked vertically) when narrow_tile=true, and the
+    pack writes them back in the matching narrow layout. Multiple narrow tiles
+    can be processed sequentially by stacking them vertically in L1.
+    """
+
+    arch = get_chip_architecture()
+
+    # BH unpack-tilize narrow_tile=true is unimplemented for non-8-bit formats:
+    # tt_llk_blackhole/llk_lib/llk_unpack_tilize.h:184 has a FIXME ("This should
+    # be revisited for narrow tiles") and the corresponding num_loops=2 /
+    # bot_face_offset logic is commented out. Tracked by tt-llk#1281. Skip BH
+    # end-to-end pending the kernel work; the test still compiles on BH.
+    if arch == ChipArchitecture.BLACKHOLE:
+        pytest.skip(
+            "BH unpack-tilize narrow_tile=true unimplemented for non-8-bit "
+            "formats (FIXME at tt_llk_blackhole/llk_lib/llk_unpack_tilize.h:184, "
+            "tt-llk#1281). Test compiles; promote once kernel is fixed."
+        )
+
+    tile_dimensions = [32, 16]
+    tile_r, tile_c = tile_dimensions
+    input_dimensions = [tile_r * num_narrow_tiles, tile_c]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli_v2(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        tile_dimensions=tile_dimensions,
+    )
+
+    torch_format = format_dict[formats.output_format]
+
+    # TilizeGolden hardcodes 32x32 tile shape; for narrow tiles tilize_block
+    # must be called directly with tile_dimensions=[32, 16].
+    golden_tensor = (
+        tilize_block(
+            src_A,
+            input_dimensions,
+            formats.output_format,
+            num_faces=num_faces,
+            tile_dimensions=tile_dimensions,
+        )
+        .flatten()
+        .to(torch_format)
+    )
+
+    # The unpack-tilize kernel walks BLOCK_CT_DIM x BLOCK_RT_DIM narrow tiles;
+    # with input [num_narrow_tiles*32, 16] that's 1 column x num_narrow_tiles rows.
+    from helpers.test_variant_parameters import INPUT_DIMENSIONS
+
+    configuration = TestConfig(
+        "sources/unpack_tilize_sweep_test.cpp",
+        formats,
+        templates=[
+            STOCHASTIC_ROUNDING(StochasticRounding.No),
+        ],
+        runtimes=[
+            INPUT_DIMENSIONS(
+                full_rt_dim=num_narrow_tiles,
+                full_ct_dim=1,
+                block_ct_dim=1,
+                block_rt_dim=num_narrow_tiles,
+            ),
+            UNPACK_TRANS_FACES(Transpose.No),
+            UNPACK_TRANS_WITHIN_FACE(Transpose.No),
+            NARROW_TILE(NarrowTile.Yes),
+            NUM_FACES(num_faces),
+            TILE_COUNT(tile_cnt_A),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            tile_dimensions=tile_dimensions,
+            use_dense_tile_dimensions=True,
+            write_full_tiles=True,
+        ),
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+    assert len(res_tensor) == len(
+        golden_tensor
+    ), f"Result length {len(res_tensor)} != golden length {len(golden_tensor)}"
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Narrow-tile unpack-tilize result did not match golden"

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -46,15 +46,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         for (std::uint32_t col = 0; col < params.BLOCK_CT_DIM; ++col)
         {
             _llk_unpack_tilize_wrapper_(
-                tile_row_addr,
-                col,
-                formats.unpack_A_src,
-                formats.unpack_A_dst,
-                block_ct_dim,
-                FACE_R_DIM,
-                num_faces,
-                false // narrow_tile disabled for now
-            );
+                tile_row_addr, col, formats.unpack_A_src, formats.unpack_A_dst, block_ct_dim, FACE_R_DIM, num_faces, params.NARROW_TILE);
         }
         read_offset += params.BLOCK_CT_DIM;
     }
@@ -115,10 +107,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DATUM_COUNT = 16 * 16 * params.num_faces;
 
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
-        formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, TILE_C_DIM, params.num_faces, false /* partial_face */, params.NARROW_TILE);
     _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
-        formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces, false /* partial_face */, params.NARROW_TILE);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
+        FACE_R_DIM, params.NARROW_TILE);
 
     _llk_packer_wait_for_math_done_();
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The `narrow_tile` feature of `_llk_unpack_tilize_` had no end-to-end coverage. `test_unpack_tilize_sweep.py` only ran `NarrowTile.No`, and the C++ source dropped `params.NARROW_TILE` on the floor: `_llk_unpack_tilize_wrapper_` hardcoded `false`, and the pack-side wrappers were never passed `narrow_tile`. As a result, even flipping the Python parametrize wouldn't reach the LLK.

This PR threads `params.NARROW_TILE` through the LLK end-to-end on both unpack and pack sides, and adds a new `test_unpack_tilize_narrow_tile` exercising the canonical narrow shape (`tile_dimensions=[32, 16]`, `num_faces=2`, 1/2/4 stacked tiles) on `Float16`/`Float16_b`. Runs end-to-end on WHB0; skipped on BH (FIXME at `tt_llk_blackhole/llk_lib/llk_unpack_tilize.h:184`, kernel-side work tracked by [tt-llk#1281](https://github.com/tenstorrent/tt-llk/issues/1281)).

Relates to #18948.

### Notes for reviewers
- The C++ changes in `unpack_tilize_sweep_test.cpp` are mechanical: flip the hardcoded `false` on `_llk_unpack_tilize_wrapper_` to `params.NARROW_TILE`, pass `params.NARROW_TILE` to `_llk_pack_hw_configure_wrapper_` and `_llk_pack_init_wrapper_`, and switch the raw `_llk_pack_dest_init_` call to `_llk_pack_dest_init_wrapper_`. Worth a quick check that the argument positions and template params match the WH wrapper signatures.
- The new test uses `tilize_block` directly to build its golden rather than `TilizeGolden`, because `TilizeGolden` hardcodes a 32×32 tile shape and cannot represent narrow tiles.
- `test_unpack_tilize_comprehensive` is intentionally unchanged - it still sweeps only `NarrowTile.No`. The narrow-tile coverage is in a separate test rather than added to the comprehensive sweep to keep the goldens, shapes, and BH skip logic isolated.
- The BH skip is bounded to a known kernel gap: BH narrow_tile is unimplemented only for non-8-bit formats. Once tt-llk#1281 lands, flipping the `if arch == ChipArchitecture.BLACKHOLE` skip is the one-line follow-up.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue-18948-narrow-tile-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue-18948-narrow-tile-unpack-tilize)