### PR TITLE
Improve performance of MeshDispatchFixture unit test times

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -26,6 +26,9 @@ namespace tt::tt_metal {
 // #22835: These Fixtures will be removed once tests are fully migrated, and replaced by UnitMeshCQFixtures
 class UnitMeshCQFixture : public MeshDispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
@@ -321,6 +324,9 @@ using UnitMeshCQSingleCardSharedBufferFixture = UnitMeshCQSingleCardSharedFixtur
 
 class UnitMeshCQMultiDeviceFixture : public MeshDispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         this->slow_dispatch_ = false;
         auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -20,6 +20,9 @@ private:
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
 
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         // Save time. Don't do any setup if invalid dispatch mode
         if (!this->validate_dispatch_mode()) {
@@ -94,6 +97,9 @@ public:
 
 class MeshDeviceSingleCardFixture : public MeshDispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -6,7 +6,10 @@
 
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "gtest/gtest.h"
+#include <functional>
 #include <map>
+#include <memory>
+#include <vector>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "hostdevcommon/common_values.hpp"
@@ -20,10 +23,63 @@
 
 namespace tt::tt_metal {
 
+struct SharedDevices {
+    std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device;
+    std::vector<std::shared_ptr<distributed::MeshDevice>> devices;
+    size_t l1_small_size {DEFAULT_L1_SMALL_SIZE};
+    size_t trace_region_size {DEFAULT_TRACE_REGION_SIZE};
+    bool initialized {false};
+    bool needs_recovery {false};
+};
+
 // A dispatch-agnostic test fixture
 class MeshDispatchFixture : public ::testing::Test {
 private:
-    std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
+    static SharedDevices& get_shared_devices() {
+        static SharedDevices devices;
+        return devices;
+    }
+
+    static void create_shared_devices(size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
+        auto& shared = get_shared_devices();
+        if (shared.initialized) {
+            return;
+        }
+
+        std::vector<ChipId> ids;
+        for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
+            ids.push_back(id);
+        }
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        shared.id_to_device = distributed::MeshDevice::create_unit_meshes(
+            ids, l1_small_size, trace_region_size, 1, dispatch_core_config);
+        shared.devices.clear();
+        for (const auto& [device_id, device] : shared.id_to_device) {
+            shared.devices.push_back(device);
+        }
+        shared.l1_small_size = l1_small_size;
+        shared.trace_region_size = trace_region_size;
+        shared.initialized = true;
+        shared.needs_recovery = false;
+    }
+
+    static void destroy_shared_devices() {
+        auto& shared = get_shared_devices();
+        if (!shared.initialized) {
+            shared.needs_recovery = false;
+            return;
+        }
+
+        for (auto& [device_id, device] : shared.id_to_device) {
+            device->close();
+            device.reset();
+        }
+        shared.id_to_device.clear();
+        shared.devices.clear();
+        shared.initialized = false;
+        shared.needs_recovery = false;
+    }
 
 public:
     // A function to run a program, according to which dispatch mode is set.
@@ -68,37 +124,36 @@ protected:
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
         l1_small_size_{l1_small_size}, trace_region_size_{trace_region_size} {};
 
+    // Derived fixtures should override SetUpTestSuite/TearDownTestSuite and SetUp/TearDown if
+    // different device instantiation is needed
+    static void SetUpTestSuite() {
+        // Create a shared device to reduce individual test startup time
+        create_shared_devices();
+    }
+
+    static void TearDownTestSuite() {
+        destroy_shared_devices();
+    }
+
     void SetUp() override {
+        auto& shared = get_shared_devices();
+        if (shared.needs_recovery || shared.l1_small_size != l1_small_size_ || shared.trace_region_size != trace_region_size_) {
+            destroy_shared_devices();
+        }
+        if (!shared.initialized) {
+            create_shared_devices(l1_small_size_, trace_region_size_);
+        }
+        this->devices_ = shared.devices;
+
         this->DetectDispatchMode();
-        // Must set up all available devices
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         init_max_cbs();
-
-        std::vector<ChipId> ids;
-        for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
-            ids.push_back(id);
-        }
-        const auto& dispatch_core_config =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
-        id_to_device_ = distributed::MeshDevice::create_unit_meshes(
-            ids, l1_small_size_, trace_region_size_, 1, dispatch_core_config);
-        devices_.clear();
-        for (const auto& [device_id, device] : id_to_device_) {
-            devices_.push_back(device);
-        }
     }
 
     void TearDown() override {
-        // Checking if devices are empty because DPrintFixture.TensixTestPrintFinish already
-        // closed all devices
-        if (!id_to_device_.empty()) {
-            for (auto [device_id, device] : id_to_device_) {
-                device->close();
-                device.reset();
-            }
-
-            id_to_device_.clear();
-            devices_.clear();
+        devices_.clear();
+        if (HasFailure()) {
+            get_shared_devices().needs_recovery = true;
         }
     }
 

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -137,6 +137,10 @@ protected:
 
     void SetUp() override {
         auto& shared = get_shared_devices();
+        ASSERT_TRUE(shared.initialized) << "Shared devices not initialized, if this is a derived fixture then "
+                                           "MeshDispatchFixture::SetUpTestSuite may have been overridden but not "
+                                           "MeshDispatchFixture::SetUp";
+
         if (shared.needs_recovery || shared.l1_small_size != l1_small_size_ || shared.trace_region_size != trace_region_size_) {
             destroy_shared_devices();
         }
@@ -151,6 +155,10 @@ protected:
     }
 
     void TearDown() override {
+        ASSERT_TRUE(get_shared_devices().initialized)
+            << "Shared devices not initialized, if this is a derived fixture then "
+               "MeshDispatchFixture::SetUpTestSuite may have been overridden but not "
+               "MeshDispatchFixture::TearDown";
         devices_.clear();
         if (HasFailure()) {
             get_shared_devices().needs_recovery = true;

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -34,7 +34,49 @@ struct SharedDevices {
 
 // A dispatch-agnostic test fixture
 class MeshDispatchFixture : public ::testing::Test {
-private:
+public:
+    // A function to run a program, according to which dispatch mode is set.
+    void RunProgram(
+        const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+        distributed::MeshWorkload& workload,
+        const bool skip_finish = false) {
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        if (!skip_finish) {
+            distributed::Finish(mesh_device->mesh_command_queue());
+        }
+    }
+    void FinishCommands(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+        distributed::Finish(mesh_device->mesh_command_queue());
+    }
+    void WriteBuffer(
+        const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+        const std::shared_ptr<distributed::MeshBuffer>& in_buffer,
+        std::vector<uint32_t>& src_vec) {
+        distributed::WriteShard(
+            mesh_device->mesh_command_queue(), in_buffer, src_vec, distributed::MeshCoordinate(0, 0));
+    }
+    void ReadBuffer(
+        const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+        const std::shared_ptr<distributed::MeshBuffer>& out_buffer,
+        std::vector<uint32_t>& dst_vec) {
+        distributed::ReadShard(
+            mesh_device->mesh_command_queue(), dst_vec, out_buffer, distributed::MeshCoordinate(0, 0));
+    }
+    int NumDevices() { return this->devices_.size(); }
+    bool IsSlowDispatch() const { return this->slow_dispatch_; }
+
+protected:
+    tt::ARCH arch_{tt::ARCH::Invalid};
+    std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+    bool slow_dispatch_{};
+    const size_t l1_small_size_{DEFAULT_L1_SMALL_SIZE};
+    const size_t trace_region_size_{DEFAULT_TRACE_REGION_SIZE};
+    uint32_t max_cbs_{};
+
+    MeshDispatchFixture(
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
+        l1_small_size_{l1_small_size}, trace_region_size_{trace_region_size} {};
+
     static SharedDevices& get_shared_devices() {
         static SharedDevices devices;
         return devices;
@@ -80,49 +122,6 @@ private:
         shared.initialized = false;
         shared.needs_recovery = false;
     }
-
-public:
-    // A function to run a program, according to which dispatch mode is set.
-    void RunProgram(
-        const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-        distributed::MeshWorkload& workload,
-        const bool skip_finish = false) {
-        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
-        if (!skip_finish) {
-            distributed::Finish(mesh_device->mesh_command_queue());
-        }
-    }
-    void FinishCommands(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-        distributed::Finish(mesh_device->mesh_command_queue());
-    }
-    void WriteBuffer(
-        const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-        const std::shared_ptr<distributed::MeshBuffer>& in_buffer,
-        std::vector<uint32_t>& src_vec) {
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), in_buffer, src_vec, distributed::MeshCoordinate(0, 0));
-    }
-    void ReadBuffer(
-        const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-        const std::shared_ptr<distributed::MeshBuffer>& out_buffer,
-        std::vector<uint32_t>& dst_vec) {
-        distributed::ReadShard(
-            mesh_device->mesh_command_queue(), dst_vec, out_buffer, distributed::MeshCoordinate(0, 0));
-    }
-    int NumDevices() { return this->devices_.size(); }
-    bool IsSlowDispatch() const { return this->slow_dispatch_; }
-
-protected:
-    tt::ARCH arch_{tt::ARCH::Invalid};
-    std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
-    bool slow_dispatch_{};
-    const size_t l1_small_size_{DEFAULT_L1_SMALL_SIZE};
-    const size_t trace_region_size_{DEFAULT_TRACE_REGION_SIZE};
-    uint32_t max_cbs_{};
-
-    MeshDispatchFixture(
-        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
-        l1_small_size_{l1_small_size}, trace_region_size_{trace_region_size} {};
 
     // Derived fixtures should override SetUpTestSuite/TearDownTestSuite and SetUp/TearDown if
     // different device instantiation is needed

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -26,18 +26,21 @@
 namespace tt::tt_metal {
 
 class DebugToolsMeshFixture : public MeshDispatchFixture {
-   protected:
-       bool watcher_previous_enabled{};
+public:
+    using MeshDispatchFixture::TearDownTestSuite;
 
-       void TearDown() override { MeshDispatchFixture::TearDown(); }
+protected:
+    bool watcher_previous_enabled{};
 
-       template <typename T>
-       void RunTestOnDevice(
-           const std::function<void(T*, std::shared_ptr<distributed::MeshDevice>)>& run_function,
-           const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-           auto run_function_no_args = [this, run_function, mesh_device]() { run_function(static_cast<T*>(this), mesh_device); };
-           MeshDispatchFixture::RunTestOnDevice(run_function_no_args, mesh_device);
-       }
+    void TearDown() override { MeshDispatchFixture::TearDown(); }
+
+    template <typename T>
+    void RunTestOnDevice(
+        const std::function<void(T*, std::shared_ptr<distributed::MeshDevice>)>& run_function,
+        const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+        auto run_function_no_args = [this, run_function, mesh_device]() { run_function(static_cast<T*>(this), mesh_device); };
+        MeshDispatchFixture::RunTestOnDevice(run_function_no_args, mesh_device);
+    }
 };
 
 // A version of MeshDispatchFixture with DPrint enabled on all cores.

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -27,12 +27,40 @@ namespace tt::tt_metal {
 
 class DebugToolsMeshFixture : public MeshDispatchFixture {
 public:
-    using MeshDispatchFixture::TearDownTestSuite;
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
 
 protected:
     bool watcher_previous_enabled{};
+    std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
 
-    void TearDown() override { MeshDispatchFixture::TearDown(); }
+    void SetUp() override {
+        std::vector<ChipId> ids;
+        for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
+            ids.push_back(id);
+        }
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        id_to_device_ = distributed::MeshDevice::create_unit_meshes(
+            ids, l1_small_size_, trace_region_size_, 1, dispatch_core_config);
+        this->devices_.clear();
+        for (const auto& [device_id, device] : id_to_device_) {
+            this->devices_.push_back(device);
+        }
+
+        this->DetectDispatchMode();
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        init_max_cbs();
+    }
+
+    void TearDown() override {
+        for (auto& [device_id, device] : id_to_device_) {
+            device->close();
+            device.reset();
+        }
+        id_to_device_.clear();
+        this->devices_.clear();
+    }
 
     template <typename T>
     void RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -385,11 +385,13 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
 class EarlyReturnFixture : public MeshDispatchFixture {
     void SetUp() override {
         tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_early_return(true);
+        get_shared_devices().needs_recovery = true;
         MeshDispatchFixture::SetUp();
     }
     void TearDown() override {
         MeshDispatchFixture::TearDown();
         tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_early_return(false);
+        get_shared_devices().needs_recovery = true;
     }
 };
 

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -114,6 +114,9 @@ protected:
 };
 class UnitMeshMultiCQMultiDeviceFixture : public MeshDispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         this->slow_dispatch_ = false;
         auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");


### PR DESCRIPTION
Closes #25168

### PR Category
Performance

### Summary
Moved intantiating the mesh device in MeshDispatchFixture from SetUp to SetUpTestSuite. This makes the run times for unit tests under this fixture more accurate, and also reduces overall unit test runtime time by removing repeated setup calls.

Derived fixtures can opt out of instantiating the shared mesh devices by creating SetUp/Teardown TestSuite functions.

### Notes for reviewers
Improved test times of `build/test/tt_metal/unit_tests_api` as tested on Wormhole N300, all tests were conducted "warm", with tt-metal JIT cache already compiled.

#### Before change
Test Iterations: 10
mean: 120835.9 ms (120.836 s)
min: 111507 ms (111.507 s)
max: 193797 ms (193.797 s)

#### After change
Test Iterations: 10
mean: 99946.3 ms (99.946 s)
min: 98214 ms (98.214 s)
max: 110805 ms (110.805 s)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/25168-speed-up-mesh-dispatch-ficture-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/25168-speed-up-mesh-dispatch-ficture-utests)