### PR TITLE
sdpa: hoist id_of out of fetch_block for PaddedAddrGenerator

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1172,7 +1172,7 @@ RING_JOINT_PERF_CHECK_CONFIGS = [
     # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
     # 4-device ring (QuietBox)
     ("wan2_2_1xGLX", 288, 512, 4, 68.9),
-    ("mla_100k", 160, 320, 4, 61.7),
+    ("mla_100k", 160, 320, 4, 62.6),
 ]
 
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1172,7 +1172,7 @@ RING_JOINT_PERF_CHECK_CONFIGS = [
     # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
     # 4-device ring (QuietBox)
     ("wan2_2_1xGLX", 288, 512, 4, 68.9),
-    ("mla_100k", 160, 320, 4, 62.6),
+    ("mla_100k", 160, 320, 4, 62.9),
 ]
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -982,6 +982,24 @@ inline void issue_block_writes(
     }
 }
 
+struct Slice {
+    uint32_t d0;  // batch dimension
+    uint32_t d1;  // head dimension
+
+    uint32_t d2_start;  // sequence start
+    uint32_t d2_end;    // sequence end
+    uint32_t d3_start;  // feature start
+    uint32_t d3_end;    // feature end
+
+    Slice() = default;
+
+    Slice(uint32_t d0, uint32_t d1, uint32_t d2_start, uint32_t d2_end, uint32_t d3_start, uint32_t d3_end) :
+        d0(d0), d1(d1), d2_start(d2_start), d2_end(d2_end), d3_start(d3_start), d3_end(d3_end) {}
+
+    uint32_t get_d2_size() const { return d2_end - d2_start; }
+    uint32_t get_d3_size() const { return d3_end - d3_start; }
+};
+
 template <typename FirstReaderType, typename SecondReaderType>
 struct CatAddrGenerator {
     FirstReaderType first_reader;
@@ -1005,33 +1023,30 @@ struct CatAddrGenerator {
         first_seq_padded(first_seq_padded),
         second_seq_padded(second_seq_padded) {}
 
-    // Issue async NoC reads for a (rows × cols) block to L1. No barrier — caller must
-    // noc_async_read_barrier(). Splits [d2_start, d2_start+rows) into up to four segments
+    // Issue async NoC reads for a slice to L1. No barrier — caller must
+    // noc_async_read_barrier(). Splits [slice.d2_start, slice.d2_end) into up to four segments
     // (first tensor / gap / second tensor / tail); each valid segment hoists id_of once.
     void issue_reads(
-        uint32_t d0,
-        uint32_t d1,
-        uint32_t d2_start,
-        uint32_t d3_start,
-        uint32_t rows,
-        uint32_t cols,
+        const Slice& slice,
         uint32_t end_seq_tile,
         uint32_t dst_addr,
         uint32_t outer_stride,
         uint32_t inner_stride,
-        uint32_t barrier_threshold,
-        uint32_t& barrier_count) const {
-        const uint32_t d2_end = d2_start + rows;
+        uint32_t barrier_threshold) const {
+        const uint32_t d2_start = slice.d2_start;
+        const uint32_t d2_end = slice.d2_end;
+        const uint32_t cols = slice.get_d3_size();
         const uint32_t first_end = first_shape.shape[2];
         const uint32_t gap_end = first_seq_padded;
         const uint32_t second_end = first_seq_padded + second_shape.shape[2];
+        uint32_t barrier_count = 0;
 
         // Segment 0: first tensor.
         const uint32_t s0_end = std::min(d2_end, first_end);
         if (d2_start < s0_end) {
             issue_block_reads(
                 first_reader,
-                first_shape.id_of(d0, d1, d2_start, d3_start),
+                first_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
                 first_shape.strides[2],
                 s0_end - d2_start,
                 cols,
@@ -1063,7 +1078,7 @@ struct CatAddrGenerator {
         if (s2_start < s2_end) {
             issue_block_reads(
                 second_reader,
-                second_shape.id_of(d0, d1, s2_start - first_seq_padded, d3_start),
+                second_shape.id_of(slice.d0, slice.d1, s2_start - first_seq_padded, slice.d3_start),
                 second_shape.strides[2],
                 s2_end - s2_start,
                 cols,
@@ -1090,21 +1105,18 @@ struct CatAddrGenerator {
         }
     }
 
-    // Issue async NoC writes for a (rows × cols) block from L1. No barrier — caller must
+    // Issue async NoC writes for a slice from L1. No barrier — caller must
     // noc_async_write_barrier(). Same segment split as issue_reads; gap and tail produce no
     // writes (those rows aren't mapped to either tensor).
     void issue_writes(
-        uint32_t d0,
-        uint32_t d1,
-        uint32_t d2_start,
-        uint32_t d3_start,
-        uint32_t rows,
-        uint32_t cols,
+        const Slice& slice,
         uint32_t end_seq_tile,
         uint32_t src_addr,
         uint32_t outer_stride,
         uint32_t inner_stride) const {
-        const uint32_t d2_end = d2_start + rows;
+        const uint32_t d2_start = slice.d2_start;
+        const uint32_t d2_end = slice.d2_end;
+        const uint32_t cols = slice.get_d3_size();
         const uint32_t first_end = first_shape.shape[2];
         const uint32_t gap_end = first_seq_padded;
         const uint32_t second_end = first_seq_padded + second_shape.shape[2];
@@ -1114,7 +1126,7 @@ struct CatAddrGenerator {
         if (d2_start < s0_end) {
             issue_block_writes(
                 first_reader,
-                first_shape.id_of(d0, d1, d2_start, d3_start),
+                first_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
                 first_shape.strides[2],
                 s0_end - d2_start,
                 cols,
@@ -1130,7 +1142,7 @@ struct CatAddrGenerator {
         if (s2_start < s2_end) {
             issue_block_writes(
                 second_reader,
-                second_shape.id_of(d0, d1, s2_start - first_seq_padded, d3_start),
+                second_shape.id_of(slice.d0, slice.d1, s2_start - first_seq_padded, slice.d3_start),
                 second_shape.strides[2],
                 s2_end - s2_start,
                 cols,
@@ -1151,30 +1163,28 @@ struct PaddedAddrGenerator {
     PaddedAddrGenerator(const ReaderType& reader, TensorTileShape tensor_shape) :
         reader(reader), tensor_shape(tensor_shape) {}
 
-    // Issue async NoC reads for a (rows × cols) block to L1. No barrier — caller must
+    // Issue async NoC reads for a slice to L1. No barrier — caller must
     // noc_async_read_barrier(). Splits valid rows from the padded tail at loop level (no
     // in_bounds branch in the hot path); valid rows advance tile_id by arithmetic only.
     void issue_reads(
-        uint32_t d0,
-        uint32_t d1,
-        uint32_t d2_start,
-        uint32_t d3_start,
-        uint32_t rows,
-        uint32_t cols,
+        const Slice& slice,
         uint32_t end_seq_tile,
         uint32_t dst_addr,
         uint32_t outer_stride,
         uint32_t inner_stride,
-        uint32_t barrier_threshold,
-        uint32_t& barrier_count) const {
+        uint32_t barrier_threshold) const {
+        const uint32_t d2_start = slice.d2_start;
+        const uint32_t rows = slice.get_d2_size();
+        const uint32_t cols = slice.get_d3_size();
         const uint32_t shape_d2 = tensor_shape.shape[2];
         const uint32_t bound = shape_d2 < end_seq_tile ? shape_d2 : end_seq_tile;
         const uint32_t valid_rows = (d2_start >= bound) ? 0 : std::min(rows, bound - d2_start);
+        uint32_t barrier_count = 0;
 
         // Valid segment: real reads.
         issue_block_reads(
             reader,
-            tensor_shape.id_of(d0, d1, d2_start, d3_start),
+            tensor_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
             tensor_shape.strides[2],
             valid_rows,
             cols,
@@ -1197,19 +1207,17 @@ struct PaddedAddrGenerator {
             barrier_count);
     }
 
-    // Issue async NoC writes for a (rows × cols) block from L1. No barrier — caller must
+    // Issue async NoC writes for a slice from L1. No barrier — caller must
     // noc_async_write_barrier(). Out-of-bound rows produce no writes.
     void issue_writes(
-        uint32_t d0,
-        uint32_t d1,
-        uint32_t d2_start,
-        uint32_t d3_start,
-        uint32_t rows,
-        uint32_t cols,
+        const Slice& slice,
         uint32_t end_seq_tile,
         uint32_t src_addr,
         uint32_t outer_stride,
         uint32_t inner_stride) const {
+        const uint32_t d2_start = slice.d2_start;
+        const uint32_t rows = slice.get_d2_size();
+        const uint32_t cols = slice.get_d3_size();
         const uint32_t shape_d2 = tensor_shape.shape[2];
         const uint32_t bound = shape_d2 < end_seq_tile ? shape_d2 : end_seq_tile;
         const uint32_t valid_rows = (d2_start >= bound) ? 0 : std::min(rows, bound - d2_start);
@@ -1217,7 +1225,7 @@ struct PaddedAddrGenerator {
         // Valid segment only; out-of-bound rows produce no writes.
         issue_block_writes(
             reader,
-            tensor_shape.id_of(d0, d1, d2_start, d3_start),
+            tensor_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
             tensor_shape.strides[2],
             valid_rows,
             cols,
@@ -1226,24 +1234,6 @@ struct PaddedAddrGenerator {
             outer_stride,
             inner_stride);
     }
-};
-
-struct Slice {
-    uint32_t d0;        // batch dimension
-    uint32_t d1;        // head dimension
-
-    uint32_t d2_start;  // sequence start
-    uint32_t d2_end;    // sequence end
-    uint32_t d3_start;  // feature start
-    uint32_t d3_end;    // feature end
-
-    Slice() = default;
-
-    Slice(uint32_t d0, uint32_t d1, uint32_t d2_start, uint32_t d2_end, uint32_t d3_start, uint32_t d3_end) :
-        d0(d0), d1(d1), d2_start(d2_start), d2_end(d2_end), d3_start(d3_start), d3_end(d3_end) {}
-
-    uint32_t get_d2_size() const { return d2_end - d2_start; }
-    uint32_t get_d3_size() const { return d3_end - d3_start; }
 };
 
 // Fetch tiles via NOC reads into a given L1 address. No CB lifecycle — caller manages
@@ -1266,20 +1256,8 @@ void fetch_block(
     const uint32_t outer_ptr_stride = transpose ? tile_bytes : src_cols * tile_bytes;
     const uint32_t inner_ptr_stride = transpose ? tile_bytes * src_rows : tile_bytes;
 
-    uint32_t barrier_count = 0;
     cat_addr_generator.issue_reads(
-        src_slice.d0,
-        src_slice.d1,
-        src_slice.d2_start,
-        src_slice.d3_start,
-        src_rows,
-        src_cols,
-        end_seq_tile,
-        dst_addr,
-        outer_ptr_stride,
-        inner_ptr_stride,
-        barrier_threshold,
-        barrier_count);
+        src_slice, end_seq_tile, dst_addr, outer_ptr_stride, inner_ptr_stride, barrier_threshold);
     noc_async_read_barrier();
 }
 
@@ -1318,17 +1296,7 @@ void write_block(
     const uint32_t inner_ptr_stride = tile_bytes;
 
     cb_wait_front(cb_id, num_tiles);
-    cat_addr_generator.issue_writes(
-        dst_slice.d0,
-        dst_slice.d1,
-        dst_slice.d2_start,
-        dst_slice.d3_start,
-        dst_rows,
-        dst_cols,
-        end_seq_tile,
-        base_read_ptr,
-        outer_ptr_stride,
-        inner_ptr_stride);
+    cat_addr_generator.issue_writes(dst_slice, end_seq_tile, base_read_ptr, outer_ptr_stride, inner_ptr_stride);
     noc_async_write_barrier();
     cb_pop_front(cb_id, num_tiles);
 }
@@ -1443,17 +1411,14 @@ void write_block_row_grouped_trid(
         const uint32_t rows_this_group = (rg < num_full_groups) ? sbh : remainder_rows;
         const uint32_t tiles_this_group = rows_this_group * cols;
         cb_wait_front(cb_out, tiles_this_group);
-        cat_addr_generator.issue_writes(
+        const Slice group_slice(
             dst_slice.d0,
             dst_slice.d1,
             dst_slice.d2_start + rg * sbh,
+            dst_slice.d2_start + rg * sbh + rows_this_group,
             dst_slice.d3_start,
-            rows_this_group,
-            cols,
-            end_seq_tile,
-            get_read_ptr(cb_out),
-            outer_stride,
-            tile_bytes);
+            dst_slice.d3_end);
+        cat_addr_generator.issue_writes(group_slice, end_seq_tile, get_read_ptr(cb_out), outer_stride, tile_bytes);
         noc_async_write_flushed_with_trid(flush_trid);
         cb_pop_front(cb_out, tiles_this_group);
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -893,6 +893,95 @@ void generate_noncausal_padded_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, ui
     cb_push_back(cb_mask_in, mask_size_tiles);
 }
 
+// Issue noc_async_read_tile for a (num_rows × cols) tile block. tile_id starts at base_tile_id,
+// advances by ++ per col and by row_stride per row (i.e., tile_id += row_stride - cols after each
+// inner col loop). dst starts at dst_addr + dst_row_origin * outer_stride, advances by
+// inner_stride per col and outer_stride per row. No barrier — caller must noc_async_read_barrier().
+// barrier_threshold > 0 fires a partial barrier every barrier_threshold tiles.
+template <typename ReaderType>
+inline void issue_block_reads(
+    const ReaderType& reader,
+    uint32_t base_tile_id,
+    uint32_t row_stride,
+    uint32_t num_rows,
+    uint32_t cols,
+    uint32_t dst_row_origin,
+    uint32_t dst_addr,
+    uint32_t outer_stride,
+    uint32_t inner_stride,
+    uint32_t barrier_threshold,
+    uint32_t& barrier_count) {
+    uint32_t tile_id = base_tile_id;
+    for (uint32_t r = 0; r < num_rows; ++r) {
+        uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;
+        for (uint32_t col = 0; col < cols; ++col) {
+            noc_async_read_tile(tile_id, reader, dst);
+            ++tile_id;
+            dst += inner_stride;
+            if (barrier_threshold > 0 && ++barrier_count == barrier_threshold) {
+                noc_async_read_barrier();
+                barrier_count = 0;
+            }
+        }
+        tile_id += row_stride - cols;
+    }
+}
+
+// Zero-fill a (num_rows × cols) tile block in L1. Same dst arithmetic as issue_block_reads.
+// reader is used only to derive the per-tile page size.
+template <typename ReaderType>
+inline void zero_fill_block(
+    const ReaderType& reader,
+    uint32_t num_rows,
+    uint32_t cols,
+    uint32_t dst_row_origin,
+    uint32_t dst_addr,
+    uint32_t outer_stride,
+    uint32_t inner_stride,
+    uint32_t barrier_threshold,
+    uint32_t& barrier_count) {
+    for (uint32_t r = 0; r < num_rows; ++r) {
+        uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;
+        for (uint32_t col = 0; col < cols; ++col) {
+            if constexpr (has_get_aligned_page_size_v<ReaderType>) {
+                fill_zeros_async(dst, reader.get_aligned_page_size());
+            } else {
+                fill_zeros_async(dst, reader.page_size);
+            }
+            dst += inner_stride;
+            if (barrier_threshold > 0 && ++barrier_count == barrier_threshold) {
+                noc_async_read_barrier();
+                barrier_count = 0;
+            }
+        }
+    }
+}
+
+// Issue noc_async_write_tile for a (num_rows × cols) tile block. Same tile_id/src arithmetic
+// as issue_block_reads (with src instead of dst). No barrier — caller must noc_async_write_barrier().
+template <typename WriterType>
+inline void issue_block_writes(
+    const WriterType& writer,
+    uint32_t base_tile_id,
+    uint32_t row_stride,
+    uint32_t num_rows,
+    uint32_t cols,
+    uint32_t src_row_origin,
+    uint32_t src_addr,
+    uint32_t outer_stride,
+    uint32_t inner_stride) {
+    uint32_t tile_id = base_tile_id;
+    for (uint32_t r = 0; r < num_rows; ++r) {
+        uint32_t src = src_addr + (src_row_origin + r) * outer_stride;
+        for (uint32_t col = 0; col < cols; ++col) {
+            noc_async_write_tile(tile_id, writer, src);
+            ++tile_id;
+            src += inner_stride;
+        }
+        tile_id += row_stride - cols;
+    }
+}
+
 template <typename FirstReaderType, typename SecondReaderType>
 struct CatAddrGenerator {
     FirstReaderType first_reader;
@@ -916,41 +1005,141 @@ struct CatAddrGenerator {
         first_seq_padded(first_seq_padded),
         second_seq_padded(second_seq_padded) {}
 
-    uint32_t maybe_read_tile(
-        uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3, uint32_t end_seq_tile, uint32_t dst_addr) const {
-        if (d2 < first_shape.shape[2]) {
-            uint32_t tile_id = first_shape.id_of(d0, d1, d2, d3);
-            noc_async_read_tile(tile_id, first_reader, dst_addr);
-            return 1;
-        } else if (d2 >= first_seq_padded && (d2 - first_seq_padded) < second_shape.shape[2]) {
-            uint32_t adjusted_seq = d2 - first_seq_padded;
-            uint32_t tile_id = second_shape.id_of(d0, d1, adjusted_seq, d3);
-            noc_async_read_tile(tile_id, second_reader, dst_addr);
-            return 1;
-        } else {
-            // fill with zeros
-            if constexpr (has_get_aligned_page_size_v<FirstReaderType>) {
-                fill_zeros_async(dst_addr, first_reader.get_aligned_page_size());
-            } else {
-                fill_zeros_async(dst_addr, first_reader.page_size);
-            }
-            return 1;
+    // Issue async NoC reads for a (rows × cols) block to L1. No barrier — caller must
+    // noc_async_read_barrier(). Splits [d2_start, d2_start+rows) into up to four segments
+    // (first tensor / gap / second tensor / tail); each valid segment hoists id_of once.
+    void issue_reads(
+        uint32_t d0,
+        uint32_t d1,
+        uint32_t d2_start,
+        uint32_t d3_start,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t end_seq_tile,
+        uint32_t dst_addr,
+        uint32_t outer_stride,
+        uint32_t inner_stride,
+        uint32_t barrier_threshold,
+        uint32_t& barrier_count) const {
+        const uint32_t d2_end = d2_start + rows;
+        const uint32_t first_end = first_shape.shape[2];
+        const uint32_t gap_end = first_seq_padded;
+        const uint32_t second_end = first_seq_padded + second_shape.shape[2];
+
+        // Segment 0: first tensor.
+        const uint32_t s0_end = std::min(d2_end, first_end);
+        if (d2_start < s0_end) {
+            issue_block_reads(
+                first_reader,
+                first_shape.id_of(d0, d1, d2_start, d3_start),
+                first_shape.strides[2],
+                s0_end - d2_start,
+                cols,
+                /*dst_row_origin=*/0,
+                dst_addr,
+                outer_stride,
+                inner_stride,
+                barrier_threshold,
+                barrier_count);
+        }
+        // Segment 1: gap (zero-fill).
+        const uint32_t s1_start = std::max(d2_start, first_end);
+        const uint32_t s1_end = std::min(d2_end, gap_end);
+        if (s1_start < s1_end) {
+            zero_fill_block(
+                first_reader,
+                s1_end - s1_start,
+                cols,
+                s1_start - d2_start,
+                dst_addr,
+                outer_stride,
+                inner_stride,
+                barrier_threshold,
+                barrier_count);
+        }
+        // Segment 2: second tensor (d2 shifted by first_seq_padded).
+        const uint32_t s2_start = std::max(d2_start, gap_end);
+        const uint32_t s2_end = std::min(d2_end, second_end);
+        if (s2_start < s2_end) {
+            issue_block_reads(
+                second_reader,
+                second_shape.id_of(d0, d1, s2_start - first_seq_padded, d3_start),
+                second_shape.strides[2],
+                s2_end - s2_start,
+                cols,
+                s2_start - d2_start,
+                dst_addr,
+                outer_stride,
+                inner_stride,
+                barrier_threshold,
+                barrier_count);
+        }
+        // Segment 3: tail (zero-fill).
+        const uint32_t s3_start = std::max(d2_start, second_end);
+        if (s3_start < d2_end) {
+            zero_fill_block(
+                first_reader,
+                d2_end - s3_start,
+                cols,
+                s3_start - d2_start,
+                dst_addr,
+                outer_stride,
+                inner_stride,
+                barrier_threshold,
+                barrier_count);
         }
     }
 
-    uint32_t maybe_write_tile(
-        uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3, uint32_t end_seq_tile, uint32_t src_addr) const {
-        if (d2 < first_shape.shape[2]) {
-            uint32_t tile_id = first_shape.id_of(d0, d1, d2, d3);
-            noc_async_write_page(tile_id, first_reader, src_addr);
-            return 1;
-        } else if (d2 >= first_seq_padded && (d2 - first_seq_padded) < second_shape.shape[2]) {
-            uint32_t adjusted_seq = d2 - first_seq_padded;
-            uint32_t tile_id = second_shape.id_of(d0, d1, adjusted_seq, d3);
-            noc_async_write_page(tile_id, second_reader, src_addr);
-            return 1;
+    // Issue async NoC writes for a (rows × cols) block from L1. No barrier — caller must
+    // noc_async_write_barrier(). Same segment split as issue_reads; gap and tail produce no
+    // writes (those rows aren't mapped to either tensor).
+    void issue_writes(
+        uint32_t d0,
+        uint32_t d1,
+        uint32_t d2_start,
+        uint32_t d3_start,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t end_seq_tile,
+        uint32_t src_addr,
+        uint32_t outer_stride,
+        uint32_t inner_stride) const {
+        const uint32_t d2_end = d2_start + rows;
+        const uint32_t first_end = first_shape.shape[2];
+        const uint32_t gap_end = first_seq_padded;
+        const uint32_t second_end = first_seq_padded + second_shape.shape[2];
+
+        // Segment 0: first tensor.
+        const uint32_t s0_end = std::min(d2_end, first_end);
+        if (d2_start < s0_end) {
+            issue_block_writes(
+                first_reader,
+                first_shape.id_of(d0, d1, d2_start, d3_start),
+                first_shape.strides[2],
+                s0_end - d2_start,
+                cols,
+                /*src_row_origin=*/0,
+                src_addr,
+                outer_stride,
+                inner_stride);
         }
-        return 0;
+        // Gap rows: no writes.
+        // Segment 2: second tensor.
+        const uint32_t s2_start = std::max(d2_start, gap_end);
+        const uint32_t s2_end = std::min(d2_end, second_end);
+        if (s2_start < s2_end) {
+            issue_block_writes(
+                second_reader,
+                second_shape.id_of(d0, d1, s2_start - first_seq_padded, d3_start),
+                second_shape.strides[2],
+                s2_end - s2_start,
+                cols,
+                s2_start - d2_start,
+                src_addr,
+                outer_stride,
+                inner_stride);
+        }
+        // Tail rows: no writes.
     }
 };
 
@@ -962,31 +1151,80 @@ struct PaddedAddrGenerator {
     PaddedAddrGenerator(const ReaderType& reader, TensorTileShape tensor_shape) :
         reader(reader), tensor_shape(tensor_shape) {}
 
-    uint32_t maybe_read_tile(
-        uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3, uint32_t end_seq_tile, uint32_t dst_addr) const {
-        if (d2 < tensor_shape.shape[2] && d2 < end_seq_tile) {
-            uint32_t tile_id = tensor_shape.id_of(d0, d1, d2, d3);
-            noc_async_read_tile(tile_id, reader, dst_addr);
-            return 1;
-        } else {
-            // fill with zeros
-            if constexpr (has_get_aligned_page_size_v<ReaderType>) {
-                fill_zeros_async(dst_addr, reader.get_aligned_page_size());
-            } else {
-                fill_zeros_async(dst_addr, reader.page_size);
-            }
-            return 1;
-        }
+    // Issue async NoC reads for a (rows × cols) block to L1. No barrier — caller must
+    // noc_async_read_barrier(). Splits valid rows from the padded tail at loop level (no
+    // in_bounds branch in the hot path); valid rows advance tile_id by arithmetic only.
+    void issue_reads(
+        uint32_t d0,
+        uint32_t d1,
+        uint32_t d2_start,
+        uint32_t d3_start,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t end_seq_tile,
+        uint32_t dst_addr,
+        uint32_t outer_stride,
+        uint32_t inner_stride,
+        uint32_t barrier_threshold,
+        uint32_t& barrier_count) const {
+        const uint32_t shape_d2 = tensor_shape.shape[2];
+        const uint32_t bound = shape_d2 < end_seq_tile ? shape_d2 : end_seq_tile;
+        const uint32_t valid_rows = (d2_start >= bound) ? 0 : std::min(rows, bound - d2_start);
+
+        // Valid segment: real reads.
+        issue_block_reads(
+            reader,
+            tensor_shape.id_of(d0, d1, d2_start, d3_start),
+            tensor_shape.strides[2],
+            valid_rows,
+            cols,
+            /*dst_row_origin=*/0,
+            dst_addr,
+            outer_stride,
+            inner_stride,
+            barrier_threshold,
+            barrier_count);
+        // Padded tail: zero-fill.
+        zero_fill_block(
+            reader,
+            rows - valid_rows,
+            cols,
+            /*dst_row_origin=*/valid_rows,
+            dst_addr,
+            outer_stride,
+            inner_stride,
+            barrier_threshold,
+            barrier_count);
     }
 
-    uint32_t maybe_write_tile(
-        uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3, uint32_t end_seq_tile, uint32_t src_addr) const {
-        if (d2 < tensor_shape.shape[2] && d2 < end_seq_tile) {
-            uint32_t tile_id = tensor_shape.id_of(d0, d1, d2, d3);
-            noc_async_write_tile(tile_id, reader, src_addr);
-            return 1;
-        }
-        return 0;
+    // Issue async NoC writes for a (rows × cols) block from L1. No barrier — caller must
+    // noc_async_write_barrier(). Out-of-bound rows produce no writes.
+    void issue_writes(
+        uint32_t d0,
+        uint32_t d1,
+        uint32_t d2_start,
+        uint32_t d3_start,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t end_seq_tile,
+        uint32_t src_addr,
+        uint32_t outer_stride,
+        uint32_t inner_stride) const {
+        const uint32_t shape_d2 = tensor_shape.shape[2];
+        const uint32_t bound = shape_d2 < end_seq_tile ? shape_d2 : end_seq_tile;
+        const uint32_t valid_rows = (d2_start >= bound) ? 0 : std::min(rows, bound - d2_start);
+
+        // Valid segment only; out-of-bound rows produce no writes.
+        issue_block_writes(
+            reader,
+            tensor_shape.id_of(d0, d1, d2_start, d3_start),
+            tensor_shape.strides[2],
+            valid_rows,
+            cols,
+            /*src_row_origin=*/0,
+            src_addr,
+            outer_stride,
+            inner_stride);
     }
 };
 
@@ -1010,6 +1248,10 @@ struct Slice {
 
 // Fetch tiles via NOC reads into a given L1 address. No CB lifecycle — caller manages
 // cb_reserve_back / cb_push_back. Used by forwarding paths that mcast before pushing.
+//
+// Dispatches to the generator's issue_reads. PaddedAddrGenerator's overload hoists id_of
+// (4 muls + 3 adds) and the row-only validity check out of the inner col loop;
+// CatAddrGenerator keeps per-tile dispatch (off the ring SDPA hot path).
 template <typename CatAddrGeneratorType>
 void fetch_block(
     const CatAddrGeneratorType& cat_addr_generator,
@@ -1021,28 +1263,23 @@ void fetch_block(
     const uint32_t barrier_threshold = 0) {
     const uint32_t src_rows = src_slice.get_d2_size();
     const uint32_t src_cols = src_slice.get_d3_size();
-    uint32_t outer_ptr_stride = transpose ? tile_bytes : src_cols * tile_bytes;
-    uint32_t inner_ptr_stride = transpose ? tile_bytes * src_rows : tile_bytes;
+    const uint32_t outer_ptr_stride = transpose ? tile_bytes : src_cols * tile_bytes;
+    const uint32_t inner_ptr_stride = transpose ? tile_bytes * src_rows : tile_bytes;
 
     uint32_t barrier_count = 0;
-    for (uint32_t row = 0; row < src_rows; ++row) {
-        uint32_t write_ptr = dst_addr + row * outer_ptr_stride;
-        for (uint32_t col = 0; col < src_cols; ++col) {
-            uint32_t did_read = cat_addr_generator.maybe_read_tile(
-                src_slice.d0,
-                src_slice.d1,
-                src_slice.d2_start + row,
-                src_slice.d3_start + col,
-                end_seq_tile,
-                write_ptr);
-
-            write_ptr += inner_ptr_stride;
-            if (barrier_threshold > 0 && ++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
-                barrier_count = 0;
-            }
-        }
-    }
+    cat_addr_generator.issue_reads(
+        src_slice.d0,
+        src_slice.d1,
+        src_slice.d2_start,
+        src_slice.d3_start,
+        src_rows,
+        src_cols,
+        end_seq_tile,
+        dst_addr,
+        outer_ptr_stride,
+        inner_ptr_stride,
+        barrier_threshold,
+        barrier_count);
     noc_async_read_barrier();
 }
 
@@ -1062,6 +1299,10 @@ void read_block(
     cb_push_back(cb_id, num_tiles);
 }
 
+// Pop a (rows × cols) tile block out of a CB and write it via NoC. Symmetric to read_block:
+// cb_wait_front + dispatch + barrier + cb_pop_front. Dispatches to the generator's issue_writes
+// (PaddedAddrGenerator hoists id_of out of the inner col loop; CatAddrGenerator keeps per-tile
+// dispatch). Out-of-bound rows are skipped (no zero-fill on writes).
 template <typename CatAddrGeneratorType>
 void write_block(
     const CatAddrGeneratorType& cat_addr_generator,
@@ -1073,20 +1314,21 @@ void write_block(
     const uint32_t dst_cols = dst_slice.get_d3_size();
     const uint32_t num_tiles = dst_rows * dst_cols;
     const uint32_t base_read_ptr = get_read_ptr(cb_id);
-    uint32_t outer_ptr_stride = dst_cols * tile_bytes;
-    uint32_t inner_ptr_stride = tile_bytes;
-
-    uint32_t barrier_count = 0;
+    const uint32_t outer_ptr_stride = dst_cols * tile_bytes;
+    const uint32_t inner_ptr_stride = tile_bytes;
 
     cb_wait_front(cb_id, num_tiles);
-    for (uint32_t row = 0; row < dst_rows; ++row) {
-        uint32_t read_ptr = base_read_ptr + row * outer_ptr_stride;
-        for (uint32_t col = 0; col < dst_cols; ++col) {
-            uint32_t did_write = cat_addr_generator.maybe_write_tile(
-                dst_slice.d0, dst_slice.d1, dst_slice.d2_start + row, dst_slice.d3_start + col, end_seq_tile, read_ptr);
-            read_ptr += inner_ptr_stride;
-        }
-    }
+    cat_addr_generator.issue_writes(
+        dst_slice.d0,
+        dst_slice.d1,
+        dst_slice.d2_start,
+        dst_slice.d3_start,
+        dst_rows,
+        dst_cols,
+        end_seq_tile,
+        base_read_ptr,
+        outer_ptr_stride,
+        inner_ptr_stride);
     noc_async_write_barrier();
     cb_pop_front(cb_id, num_tiles);
 }
@@ -1123,52 +1365,11 @@ void write_block(
     cb_pop_front(cb_out, out_chunk_tiles);
 }
 
-// Row-grouped drain skeleton: iterates total_rows in groups of sbh rows (last group is a
-// smaller remainder if not divisible). Per-group cb_wait_front + flush-before-pop lets
-// cb_out be sized to a few groups instead of the full chunk. The callback is invoked for
-// every (row, col) tile with the L1 read address; it decides whether to issue a NoC write
-// (e.g. to skip padding rows).
-//
-// flush_trid: TRID the caller stamped writes with via noc_async_write_set_trid (0 = default
-// trid, i.e. caller never set a non-zero trid). The per-group flush uses
-// noc_async_write_flushed_with_trid(flush_trid) so it waits exactly for THIS drain's writes
-// to be source-L1-acked, not for unrelated trids that may be in flight from elsewhere.
-//
-// Caller is responsible for any final NoC barrier (DRAM-arrival).
-template <typename WriteTileFn>
-void drain_cb_row_grouped(
-    const uint32_t cb_out,
-    const uint32_t total_rows,
-    const uint32_t cols,
-    const uint32_t tile_bytes,
-    const uint32_t sbh,
-    const uint32_t flush_trid,
-    WriteTileFn write_tile) {
-    const uint32_t num_full_groups = total_rows / sbh;
-    const uint32_t remainder_rows = total_rows - num_full_groups * sbh;
-    const uint32_t num_groups = num_full_groups + (remainder_rows ? 1 : 0);
-
-    for (uint32_t rg = 0; rg < num_groups; ++rg) {
-        const uint32_t rows_this_group = (rg < num_full_groups) ? sbh : remainder_rows;
-        const uint32_t tiles_this_group = rows_this_group * cols;
-        cb_wait_front(cb_out, tiles_this_group);
-        uint32_t l1_read_addr = get_read_ptr(cb_out);
-        for (uint32_t r = 0; r < rows_this_group; ++r) {
-            const uint32_t row = rg * sbh + r;
-            for (uint32_t col = 0; col < cols; ++col) {
-                write_tile(row, col, l1_read_addr + col * tile_bytes);
-            }
-            l1_read_addr += cols * tile_bytes;
-        }
-        // Flush THIS drain's writes (by trid) before pop so compute can safely reuse the L1 slot.
-        noc_async_write_flushed_with_trid(flush_trid);
-        cb_pop_front(cb_out, tiles_this_group);
-    }
-}
-
-// Single-chip linear-tile-id drain. Rows in [write_rows, total_rows) are padding —
-// popped but not written. Periodic barrier_threshold flushes guard the NoC ack queue;
-// final noc_async_write_barrier ensures DRAM arrival before return. Single-chip never
+// Single-chip linear-tile-id drain. Iterates total_rows in groups of sbh rows (last group is
+// a smaller remainder if not divisible); per-group cb_wait_front + flush-before-pop lets
+// cb_out be sized to a few groups instead of the full chunk. Rows in [write_rows, total_rows)
+// are padding — popped but not written. Periodic barrier_threshold flushes guard the NoC ack
+// queue; final noc_async_write_barrier ensures DRAM arrival before return. Single-chip never
 // sets a non-zero trid → drain flushes trid 0 (the default trid all writes here carry).
 template <typename TensorAccessorType>
 void write_block_row_grouped(
@@ -1184,18 +1385,78 @@ void write_block_row_grouped(
     constexpr uint32_t default_trid = 0;
     uint32_t tile_id = out_tile_id;
     uint32_t barrier_count = 0;
-    drain_cb_row_grouped(
-        cb_out, total_rows, cols, tile_bytes, sbh, default_trid, [&](uint32_t row, uint32_t /*col*/, uint32_t l1_addr) {
+
+    const uint32_t num_full_groups = total_rows / sbh;
+    const uint32_t remainder_rows = total_rows - num_full_groups * sbh;
+    const uint32_t num_groups = num_full_groups + (remainder_rows ? 1 : 0);
+
+    for (uint32_t rg = 0; rg < num_groups; ++rg) {
+        const uint32_t rows_this_group = (rg < num_full_groups) ? sbh : remainder_rows;
+        const uint32_t tiles_this_group = rows_this_group * cols;
+        cb_wait_front(cb_out, tiles_this_group);
+        uint32_t l1_read_addr = get_read_ptr(cb_out);
+        for (uint32_t r = 0; r < rows_this_group; ++r) {
+            const uint32_t row = rg * sbh + r;
             if (row < write_rows) {
-                noc_async_write_tile(tile_id, out_writer, l1_addr);
-                ++tile_id;
-                if (++barrier_count == barrier_threshold) {
-                    noc_async_write_flushed_with_trid(default_trid);
-                    barrier_count = 0;
+                for (uint32_t col = 0; col < cols; ++col) {
+                    noc_async_write_tile(tile_id, out_writer, l1_read_addr + col * tile_bytes);
+                    ++tile_id;
+                    if (++barrier_count == barrier_threshold) {
+                        noc_async_write_flushed_with_trid(default_trid);
+                        barrier_count = 0;
+                    }
                 }
             }
-        });
+            l1_read_addr += cols * tile_bytes;
+        }
+        // Flush THIS drain's writes (default trid) before pop so compute can safely reuse the L1 slot.
+        noc_async_write_flushed_with_trid(default_trid);
+        cb_pop_front(cb_out, tiles_this_group);
+    }
     noc_async_write_barrier();
+}
+
+// Multi-chip row-grouped drain of cb_out to DRAM via cat_addr_generator.issue_writes; writes
+// overlap with compute's next row-group push. Padding past end_seq_tile is silently skipped
+// (out-of-bound rows produce no writes). flush_trid is the TRID the caller stamped writes
+// with via noc_async_write_set_trid (0 = default); per-group flush uses
+// noc_async_write_flushed_with_trid(flush_trid) so it waits exactly for THIS drain's writes
+// to be source-L1-acked. Caller handles any final DRAM-arrival NoC barrier.
+template <typename CatAddrGeneratorType>
+void write_block_row_grouped_trid(
+    const CatAddrGeneratorType& cat_addr_generator,
+    const Slice& dst_slice,
+    const uint32_t end_seq_tile,
+    const uint32_t cb_out,
+    const uint32_t tile_bytes,
+    const uint32_t sbh,
+    const uint32_t flush_trid) {
+    const uint32_t total_rows = dst_slice.get_d2_size();
+    const uint32_t cols = dst_slice.get_d3_size();
+    const uint32_t outer_stride = cols * tile_bytes;
+
+    const uint32_t num_full_groups = total_rows / sbh;
+    const uint32_t remainder_rows = total_rows - num_full_groups * sbh;
+    const uint32_t num_groups = num_full_groups + (remainder_rows ? 1 : 0);
+
+    for (uint32_t rg = 0; rg < num_groups; ++rg) {
+        const uint32_t rows_this_group = (rg < num_full_groups) ? sbh : remainder_rows;
+        const uint32_t tiles_this_group = rows_this_group * cols;
+        cb_wait_front(cb_out, tiles_this_group);
+        cat_addr_generator.issue_writes(
+            dst_slice.d0,
+            dst_slice.d1,
+            dst_slice.d2_start + rg * sbh,
+            dst_slice.d3_start,
+            rows_this_group,
+            cols,
+            end_seq_tile,
+            get_read_ptr(cb_out),
+            outer_stride,
+            tile_bytes);
+        noc_async_write_flushed_with_trid(flush_trid);
+        cb_pop_front(cb_out, tiles_this_group);
+    }
 }
 
 template <uint32_t tile_bytes>

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -928,7 +928,9 @@ inline void issue_block_reads(
 }
 
 // Zero-fill a (num_rows × cols) tile block in L1. Same dst arithmetic as issue_block_reads.
-// reader is used only to derive the per-tile page size.
+// reader is used only to derive the per-tile page size. No periodic barrier: fills source
+// from local L1 (MEM_ZEROS_BASE) and completes fast, so they don't push the NIU outstanding
+// counter the way DRAM reads do. Caller's trailing noc_async_read_barrier() handles visibility.
 template <typename ReaderType>
 inline void zero_fill_block(
     const ReaderType& reader,
@@ -937,9 +939,7 @@ inline void zero_fill_block(
     uint32_t dst_row_origin,
     uint32_t dst_addr,
     uint32_t outer_stride,
-    uint32_t inner_stride,
-    uint32_t barrier_threshold,
-    uint32_t& barrier_count) {
+    uint32_t inner_stride) {
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;
         for (uint32_t col = 0; col < cols; ++col) {
@@ -949,10 +949,6 @@ inline void zero_fill_block(
                 fill_zeros_async(dst, reader.page_size);
             }
             dst += inner_stride;
-            if (barrier_threshold > 0 && ++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
-                barrier_count = 0;
-            }
         }
     }
 }
@@ -1026,9 +1022,11 @@ struct CatAddrGenerator {
     // Issue async NoC reads for a slice to L1. No barrier — caller must
     // noc_async_read_barrier(). Splits [slice.d2_start, slice.d2_end) into up to four segments
     // (first tensor / gap / second tensor / tail); each valid segment hoists id_of once.
+    // end_seq_tile is unused: bounds come from first_shape/second_shape; signature kept for
+    // API symmetry with PaddedAddrGenerator (fetch_block dispatches generically).
     void issue_reads(
         const Slice& slice,
-        uint32_t end_seq_tile,
+        uint32_t /*end_seq_tile*/,
         uint32_t dst_addr,
         uint32_t outer_stride,
         uint32_t inner_stride,
@@ -1062,15 +1060,7 @@ struct CatAddrGenerator {
         const uint32_t s1_end = std::min(d2_end, gap_end);
         if (s1_start < s1_end) {
             zero_fill_block(
-                first_reader,
-                s1_end - s1_start,
-                cols,
-                s1_start - d2_start,
-                dst_addr,
-                outer_stride,
-                inner_stride,
-                barrier_threshold,
-                barrier_count);
+                first_reader, s1_end - s1_start, cols, s1_start - d2_start, dst_addr, outer_stride, inner_stride);
         }
         // Segment 2: second tensor (d2 shifted by first_seq_padded).
         const uint32_t s2_start = std::max(d2_start, gap_end);
@@ -1093,24 +1083,16 @@ struct CatAddrGenerator {
         const uint32_t s3_start = std::max(d2_start, second_end);
         if (s3_start < d2_end) {
             zero_fill_block(
-                first_reader,
-                d2_end - s3_start,
-                cols,
-                s3_start - d2_start,
-                dst_addr,
-                outer_stride,
-                inner_stride,
-                barrier_threshold,
-                barrier_count);
+                first_reader, d2_end - s3_start, cols, s3_start - d2_start, dst_addr, outer_stride, inner_stride);
         }
     }
 
     // Issue async NoC writes for a slice from L1. No barrier — caller must
     // noc_async_write_barrier(). Same segment split as issue_reads; gap and tail produce no
-    // writes (those rows aren't mapped to either tensor).
+    // writes (those rows aren't mapped to either tensor). end_seq_tile unused (see issue_reads).
     void issue_writes(
         const Slice& slice,
-        uint32_t end_seq_tile,
+        uint32_t /*end_seq_tile*/,
         uint32_t src_addr,
         uint32_t outer_stride,
         uint32_t inner_stride) const {
@@ -1202,9 +1184,7 @@ struct PaddedAddrGenerator {
             /*dst_row_origin=*/valid_rows,
             dst_addr,
             outer_stride,
-            inner_stride,
-            barrier_threshold,
-            barrier_count);
+            inner_stride);
     }
 
     // Issue async NoC writes for a slice from L1. No barrier — caller must

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -1222,8 +1222,12 @@ struct PaddedAddrGenerator {
 // Dispatches to the generator's issue_reads. PaddedAddrGenerator's overload hoists id_of
 // (4 muls + 3 adds) and the row-only validity check out of the inner col loop;
 // CatAddrGenerator keeps per-tile dispatch (off the ring SDPA hot path).
+//
+// noinline: reader (NCRISC) has 3+ call sites and the issue_reads body is large enough that
+// inlining at every site overflows the TENSIX kernel-config ringbuffer. Function-call
+// overhead is negligible next to the per-block NoC reads.
 template <typename CatAddrGeneratorType>
-void fetch_block(
+__attribute__((noinline)) void fetch_block(
     const CatAddrGeneratorType& cat_addr_generator,
     const Slice& src_slice,
     const uint32_t end_seq_tile,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -19,33 +19,6 @@
 using namespace tt::tt_fabric::linear::experimental;
 #endif
 
-// Row-by-row drain of cb_out to DRAM; writes overlap with compute's next row-group push.
-// Padding past end_seq_tile is silently skipped by maybe_write_tile.
-//
-// flush_trid: TRID the caller stamped writes with via noc_async_write_set_trid (0 = default).
-// This file's only call site uses default trid → pass 0. Caller handles any final NoC barrier.
-template <typename ReaderType>
-void write_out_row_by_row(
-    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
-    const Slice& out_slice,
-    const uint32_t end_seq_tile,
-    const uint32_t cb_out,
-    const uint32_t tile_bytes,
-    const uint32_t sbh,
-    const uint32_t flush_trid) {
-    drain_cb_row_grouped(
-        cb_out,
-        out_slice.get_d2_size(),
-        out_slice.get_d3_size(),
-        tile_bytes,
-        sbh,
-        flush_trid,
-        [&](uint32_t row, uint32_t col, uint32_t l1_addr) {
-            cat_out_generator.maybe_write_tile(
-                out_slice.d0, out_slice.d1, out_slice.d2_start + row, out_slice.d3_start + col, end_seq_tile, l1_addr);
-        });
-}
-
 struct QChunkInfo {
     bool is_joint_q;
     Slice out_slice;
@@ -484,7 +457,7 @@ void kernel_main() {
                 // On last ring iteration, drain normalized output to DRAM.
                 if (is_last_ring_iter) {
                     // Default trid here → pass 0 so per-group flush waits exactly for these writes.
-                    write_out_row_by_row(
+                    write_block_row_grouped_trid(
                         qi.is_joint_q ? joint_out_generator : out_generator,
                         qi.out_slice,
                         qi.end_seq_tile,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -34,7 +34,7 @@ void read_prev_output_and_lse(
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
-    const Slice out_slice,
+    const Slice& out_slice,
     const uint32_t end_seq_tile,
     const uint32_t stats_seq_start_tile,
     const uint32_t stats_seq_end_tile,
@@ -68,7 +68,7 @@ void issue_restore_reads(
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
-    const Slice out_slice,
+    const Slice& out_slice,
     const uint32_t stats_seq_start_tile,
     const uint32_t stats_seq_end_tile,
     const uint32_t sum_offset,
@@ -77,30 +77,26 @@ void issue_restore_reads(
     const uint32_t cb_sum_in,
     const uint32_t tile_bytes,
     const uint32_t stats_tile_bytes) {
-    // All accumulator tiles are valid (we wrote them); pass end_seq_tile=UINT32_MAX so
-    // issue_reads' bound = shape and no zero-fill tail fires. Decouples restore from
-    // ring_id, enabling cross-ring prefetch.
-    constexpr uint32_t end_seq_tile = 0xFFFFFFFF;
-
-    // Issue output reads (reserve + async reads, no barrier).
+    // All accumulator tiles are valid (we wrote them) — bypass issue_reads' bound/valid_rows
+    // compute and the zero-fill stub; dispatch directly to issue_block_reads. Decouples
+    // restore from ring_id, enabling cross-ring prefetch.
     const uint32_t out_rows = out_slice.get_d2_size();
     const uint32_t out_cols = out_slice.get_d3_size();
     const uint32_t out_num_tiles = out_rows * out_cols;
     cb_reserve_back(cb_prev_out, out_num_tiles);
-    uint32_t barrier_count = 0;
-    cat_out_generator.issue_reads(
-        out_slice.d0,
-        out_slice.d1,
-        out_slice.d2_start,
-        out_slice.d3_start,
+    uint32_t out_barrier_count = 0;
+    issue_block_reads(
+        cat_out_generator.reader,
+        cat_out_generator.tensor_shape.id_of(out_slice.d0, out_slice.d1, out_slice.d2_start, out_slice.d3_start),
+        cat_out_generator.tensor_shape.strides[2],
         out_rows,
         out_cols,
-        end_seq_tile,
+        /*dst_row_origin=*/0,
         get_write_ptr(cb_prev_out),
         /*outer_stride=*/out_cols * tile_bytes,
         /*inner_stride=*/tile_bytes,
         /*barrier_threshold=*/0,
-        barrier_count);
+        out_barrier_count);
 
     // Stats drains: single-column linear reads. Hoist id_of once per drain; advance by
     // strides[2] per row. All tiles assumed valid (no bounds clamp needed).
@@ -231,7 +227,7 @@ void write_output_and_lse(
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
-    const Slice out_slice,
+    const Slice& out_slice,
     const uint32_t end_seq_tile,
     const uint32_t stats_seq_start_tile,
     const uint32_t stats_seq_end_tile,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -77,43 +77,53 @@ void issue_restore_reads(
     const uint32_t cb_sum_in,
     const uint32_t tile_bytes,
     const uint32_t stats_tile_bytes) {
-    // All accumulator tiles are valid (we wrote them), so bypass maybe_read_tile's
-    // padding logic. This decouples restore from ring_id, enabling cross-ring prefetch.
+    // All accumulator tiles are valid (we wrote them); pass end_seq_tile=UINT32_MAX so
+    // issue_reads' bound = shape and no zero-fill tail fires. Decouples restore from
+    // ring_id, enabling cross-ring prefetch.
     constexpr uint32_t end_seq_tile = 0xFFFFFFFF;
 
-    // Issue output reads (reserve + async reads, no barrier)
+    // Issue output reads (reserve + async reads, no barrier).
     const uint32_t out_rows = out_slice.get_d2_size();
     const uint32_t out_cols = out_slice.get_d3_size();
     const uint32_t out_num_tiles = out_rows * out_cols;
     cb_reserve_back(cb_prev_out, out_num_tiles);
-    const uint32_t out_base_ptr = get_write_ptr(cb_prev_out);
-    for (uint32_t row = 0; row < out_rows; ++row) {
-        uint32_t write_ptr = out_base_ptr + row * out_cols * tile_bytes;
-        for (uint32_t col = 0; col < out_cols; ++col) {
-            cat_out_generator.maybe_read_tile(
-                out_slice.d0,
-                out_slice.d1,
-                out_slice.d2_start + row,
-                out_slice.d3_start + col,
-                end_seq_tile,
-                write_ptr);
-            write_ptr += tile_bytes;
-        }
-    }
+    uint32_t barrier_count = 0;
+    cat_out_generator.issue_reads(
+        out_slice.d0,
+        out_slice.d1,
+        out_slice.d2_start,
+        out_slice.d3_start,
+        out_rows,
+        out_cols,
+        end_seq_tile,
+        get_write_ptr(cb_prev_out),
+        /*outer_stride=*/out_cols * tile_bytes,
+        /*inner_stride=*/tile_bytes,
+        /*barrier_threshold=*/0,
+        barrier_count);
+
+    // Stats drains: single-column linear reads. Hoist id_of once per drain; advance by
+    // strides[2] per row. All tiles assumed valid (no bounds clamp needed).
+    const uint32_t stats_rows = stats_seq_end_tile - stats_seq_start_tile;
+    const uint32_t stats_row_stride = stats_tile_logical.strides[2];
 
     // Issue max reads
     cb_reserve_back(cb_max_in, Sq_chunk_t);
+    uint32_t max_tile_id = stats_tile_logical.id_of(nb, nq, stats_seq_start_tile, 0);
     uint32_t max_addr = get_write_ptr(cb_max_in);
-    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_read_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_addr);
+    for (uint32_t r = 0; r < stats_rows; ++r) {
+        noc_async_read_tile(max_tile_id, stats_writer, max_addr);
+        max_tile_id += stats_row_stride;
         max_addr += stats_tile_bytes;
     }
 
     // Issue sum reads
     cb_reserve_back(cb_sum_in, Sq_chunk_t);
+    uint32_t sum_tile_id = stats_tile_logical.id_of(nb, nq, sum_offset + stats_seq_start_tile, 0);
     uint32_t sum_addr = get_write_ptr(cb_sum_in);
-    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_read_tile(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_addr);
+    for (uint32_t r = 0; r < stats_rows; ++r) {
+        noc_async_read_tile(sum_tile_id, stats_writer, sum_addr);
+        sum_tile_id += stats_row_stride;
         sum_addr += stats_tile_bytes;
     }
     // NO barrier, NO push — caller must call complete_restore()
@@ -137,39 +147,11 @@ void complete_restore(
 // Only 3 barriers fire per ring iteration (one per TRID):
 //   Q[0]: wB(TRID_INNER), Q[N-2]: wB(TRID_LAST), Q[N-1]: wB(TRID_FIRST).
 // Start from 1 — TRID 0 is the default for all NOC writes and must not be used
-// for per-TRID barriers, as unrelated writes (e.g. write_out_row_by_row
+// for per-TRID barriers, as unrelated writes (e.g. write_block_row_grouped_trid
 // on last ring iter) would inflate the outstanding count and stall the barrier.
 constexpr uint32_t TRID_FIRST = 1;
 constexpr uint32_t TRID_INNER = 2;
 constexpr uint32_t TRID_LAST = 3;
-
-// Row-by-row drain of cb_out to DRAM; writes overlap with compute's next row-group push.
-// Padding past end_seq_tile is silently skipped by maybe_write_tile.
-//
-// flush_trid: TRID the caller stamped writes with via noc_async_write_set_trid (0 = default).
-// Save path passes save_trid; last-iter write_out path passes 0. Caller handles any final
-// NoC barrier (per-Q write_out path or the trid'd flush in save_accumulators).
-template <typename ReaderType>
-void write_out_row_by_row(
-    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
-    const Slice& out_slice,
-    const uint32_t end_seq_tile,
-    const uint32_t cb_out,
-    const uint32_t tile_bytes,
-    const uint32_t sbh,
-    const uint32_t flush_trid) {
-    drain_cb_row_grouped(
-        cb_out,
-        out_slice.get_d2_size(),
-        out_slice.get_d3_size(),
-        tile_bytes,
-        sbh,
-        flush_trid,
-        [&](uint32_t row, uint32_t col, uint32_t l1_addr) {
-            cat_out_generator.maybe_write_tile(
-                out_slice.d0, out_slice.d1, out_slice.d2_start + row, out_slice.d3_start + col, end_seq_tile, l1_addr);
-        });
-}
 
 // Save all 3 accumulators (out, max, sum) to DRAM, tagged with a TRID for prefetch barriers.
 // Output is drained row-by-row (overlapping with compute's SALAD pushes); max/sum are bulk-drained.
@@ -195,7 +177,7 @@ void save_accumulators_with_trid(
     const uint32_t save_trid) {
     noc_async_write_set_trid(save_trid);
 
-    write_out_row_by_row(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes, sbh, save_trid);
+    write_block_row_grouped_trid(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes, sbh, save_trid);
 
     // Bulk drain of max/sum
     cb_wait_front(cb_max_out, Sq_chunk_t);
@@ -217,7 +199,7 @@ void save_accumulators_with_trid(
     // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_out_row_by_row_no_pop on last ring iter).
     // Without this, subsequent noc_async_write calls would inflate save_trid's outstanding count,
     // causing noc_async_write_barrier_with_trid(save_trid) to wait for unrelated writes.
-    // cb_out was already popped per-group inside write_out_row_by_row (via drain_cb_row_grouped).
+    // cb_out was already popped per-group inside write_block_row_grouped_trid.
     noc_async_write_set_trid(0);
     cb_pop_front(cb_max_out, Sq_chunk_t);
     cb_pop_front(cb_sum_out, Sq_chunk_t);
@@ -655,7 +637,7 @@ void kernel_main() {
                 if (is_last_ring_iter) {
                     // Last-iter writes carry default trid (caller never set a non-zero trid here);
                     // pass 0 so the per-group flush waits exactly for these writes.
-                    write_out_row_by_row(
+                    write_block_row_grouped_trid(
                         qi.is_joint_q ? joint_out_generator : out_generator,
                         qi.out_slice,
                         end_seq_tile,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -192,7 +192,7 @@ void save_accumulators_with_trid(
     }
 
     noc_async_write_flushed_with_trid(save_trid);
-    // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_out_row_by_row_no_pop on last ring iter).
+    // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_block_row_grouped_trid on last ring iter).
     // Without this, subsequent noc_async_write calls would inflate save_trid's outstanding count,
     // causing noc_async_write_barrier_with_trid(save_trid) to wait for unrelated writes.
     // cb_out was already popped per-group inside write_block_row_grouped_trid.
@@ -657,7 +657,7 @@ void kernel_main() {
                     prefetch_intra_ring(q_index + 1);
                 }
             }
-            // Hoisted DRAM-arrival barrier: on the last ring iter, write_out_row_by_row_no_pop
+            // Hoisted DRAM-arrival barrier: on the last ring iter, write_block_row_grouped_trid
             // issued N untagged NOC writes (one per Q on this core). Wait once at the end of the
             // Q loop for all of them to land in DRAM, before the outer ring-iter loop advances
             // or the op teardown runs. Previously this was a per-Q barrier inside the loop.


### PR DESCRIPTION
## Summary
Hoist `tensor_shape.id_of` (4 muls + 3 adds) and the row-only `d2` bound check out of the inner col loop in SDPA's reader and writer dataflow paths. Both `PaddedAddrGenerator` and `CatAddrGenerator` use the same row-segment hoist pattern via shared free-function helpers. Same NOC traffic, same order, same semantics.

## Code shape

**Shared free-function helpers** — single definition, used by both generators:
- `issue_block_reads` — hoisted-`tile_id` `noc_async_read_tile` loop with optional throttle barrier
- `zero_fill_block` — `fill_zeros_async` loop (read padding)
- `issue_block_writes` — hoisted-`tile_id` `noc_async_write_tile` loop

**Address generators** — compute row segments and dispatch to the helpers:
- `PaddedAddrGenerator::issue_reads` / `issue_writes`: two segments — valid rows (real reads/writes) and the padded tail (zero-fill on reads; skipped on writes).
- `CatAddrGenerator::issue_reads` / `issue_writes`: four segments — first tensor, gap (zero-fill on reads; skipped on writes), second tensor (with `d2` shifted by `first_seq_padded`), tail (same as gap). Each valid segment hoists `id_of` once.

**Free wrappers handling CB lifecycle**:
- `read_block` (CB reserve + push) → `fetch_block` (NoC read barrier) → `generator.issue_reads`
- `write_block` (CB wait + NoC write barrier + pop) → `generator.issue_writes`

**Row-grouped CB drains** (both in `dataflow_common.hpp`):
- `write_block_row_grouped` — single-chip linear-`tile_id` drain (inlined the old `drain_cb_row_grouped` helper).
- `write_block_row_grouped_trid` — multi-chip per-trid drain via `generator.issue_writes`. Replaces the duplicated `write_out_row_by_row` helpers that used to live in `ring_joint_writer.cpp` and `exp_ring_joint_writer.cpp`.

**`issue_restore_reads`** (`ring_joint_writer.cpp`): output reads go through `cat_out_generator.issue_reads`; max/sum stats reads use a direct loop with hoisted `id_of` (single-column linear advance via `strides[2]`).

**Removed dead code**: `maybe_read_tile` / `maybe_write_tile` on both generators (no callers after the refactor), `drain_cb_row_grouped` helper (single caller inlined), duplicated `write_out_row_by_row` helpers (consolidated into `write_block_row_grouped_trid`).

**Behavior note**: `CatAddrGenerator::issue_writes` now uses `noc_async_write_tile` (via the shared helper) where the old per-tile path used `noc_async_write_page`. The two are functionally equivalent for tile-sized writes via TensorAccessor; this unifies a pre-existing Cat `read_tile`/`write_page` asymmetry.

## Perf — mla_100k q160-k320 ring4 on 2xP300
From the blackhole-e2e SDPA perf check job:

| Build | Math util |
|---|---|
| main | 61.7% |
| this PR | **62.9%** (+1.2 pp) |

Threshold in `test_ring_joint_sdpa.py` is bumped accordingly.

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26045073888)
- [x] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26046382816) (sdpa only)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26045078247)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26045080548)
- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26045082754) (ops perf tests only)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26045084700)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26102802913)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/runs/26045089087) (deepseek_prefill only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sdpa-fetch-block-padded-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-fetch-block-padded-fast-path)

