### PR TITLE
Add allowed_worker_cores to matmul program configs

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_custom_grids.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_custom_grids.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for allowed_worker_cores on matmul program configs, with and without sub-devices.
+
+Exercises the two-layer core resolution in all non-DRAM-sharded factories:
+  Layer 1: sub_device_id → base grid
+  Layer 2: allowed_worker_cores → fine constraint
+
+Note on offset grids:
+  The 1D and 2D multicast factories compute NOC multicast coordinates relative
+  to the core grid's start_core.  Offset-from-origin grids are only exercised
+  through the sub-device path (skip_rows >= 1), which is the production use
+  case (e.g. reserving row 0 for CCL while computing on remaining rows).
+  Using allowed_worker_cores offset from (0,0) *without* a sub-device has not
+  been validated for multicast factories and is NOT tested here.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import skip_for_slow_dispatch
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _crs(cols: int, rows: int, start_x: int = 0, start_y: int = 0) -> ttnn.CoreRangeSet:
+    """Shorthand: rectangular CoreRangeSet of size (cols x rows) starting at (start_x, start_y)."""
+    return ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(start_x, start_y),
+                ttnn.CoreCoord(start_x + cols - 1, start_y + rows - 1),
+            )
+        }
+    )
+
+
+def _tensors(device, m, k, n, *, batched_b=False):
+    """Random input tensors on device + torch reference."""
+    torch.manual_seed(42)
+    ta = torch.randn(1, 1, m, k, dtype=torch.bfloat16)
+    tb = torch.randn((1, 1, k, n) if batched_b else (k, n), dtype=torch.bfloat16)
+    a = ttnn.from_torch(ta, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    b = ttnn.from_torch(tb, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    return a, b, ta @ tb
+
+
+def _setup_subdevice(device, skip_rows=1):
+    """Split device: rows [0..skip_rows-1] = dummy, rest = worker.
+    Returns (manager, worker_sub_device_id, worker_cols, worker_rows, start_y).
+    """
+    grid = device.compute_with_storage_grid_size()
+    cols, rows = grid.x, grid.y
+    if rows <= skip_rows:
+        pytest.skip(f"Need >{skip_rows} rows, device has {rows}")
+
+    dummy = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(cols - 1, skip_rows - 1))})
+    worker = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, skip_rows), ttnn.CoreCoord(cols - 1, rows - 1))})
+    mgr = device.create_sub_device_manager([ttnn.SubDevice([dummy]), ttnn.SubDevice([worker])], 0)
+    device.load_sub_device_manager(mgr)
+    device.set_sub_device_stall_group([ttnn.SubDeviceId(0), ttnn.SubDeviceId(1)])
+    return mgr, ttnn.SubDeviceId(1), cols, rows - skip_rows, skip_rows
+
+
+def _teardown(device, mgr):
+    device.reset_sub_device_stall_group()
+    device.clear_loaded_sub_device_manager()
+    device.remove_sub_device_manager(mgr)
+
+
+# ---------------------------------------------------------------------------
+# 1) Auto-config (no explicit program_config)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoConfig:
+    def test_basic_matmul(self, device):
+        a, b, ref = _tensors(device, 128, 256, 128)
+        assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b)), 0.999)
+
+    @skip_for_slow_dispatch()
+    @pytest.mark.parametrize("skip_rows", [1, 2])
+    def test_matmul_on_subdevice(self, device, skip_rows):
+        mgr, sd_id, _, _, _ = _setup_subdevice(device, skip_rows)
+        try:
+            a, b, ref = _tensors(device, 128, 512, 512)
+            assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, sub_device_id=sd_id)), 0.999)
+        finally:
+            _teardown(device, mgr)
+
+    @skip_for_slow_dispatch()
+    @pytest.mark.parametrize("skip_rows", [1, 2])
+    def test_linear_on_subdevice(self, device, skip_rows):
+        mgr, sd_id, _, _, _ = _setup_subdevice(device, skip_rows)
+        try:
+            a, b, ref = _tensors(device, 128, 512, 512)
+            assert_with_pcc(ref, ttnn.to_torch(ttnn.linear(a, b, sub_device_id=sd_id)), 0.999)
+        finally:
+            _teardown(device, mgr)
+
+
+# ---------------------------------------------------------------------------
+# 2) MatmulMultiCoreReuseProgramConfig  (Factory B)
+# ---------------------------------------------------------------------------
+
+
+class TestReuse:
+    M, K, N = 128, 256, 128
+
+    def _cfg(self, grid_size, awc=None):
+        return ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=self.K // 32,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=self.M // 32,
+            per_core_N=self.N // 32,
+            allowed_worker_cores=awc,
+        )
+
+    def test_default_grid(self, device):
+        grid = device.compute_with_storage_grid_size()
+        a, b, ref = _tensors(device, self.M, self.K, self.N, batched_b=True)
+        assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=self._cfg(grid))), 0.999)
+
+    @pytest.mark.parametrize("gx, gy", [(4, 4), (8, 2)])
+    def test_custom_grid_at_origin(self, device, gx, gy):
+        a, b, ref = _tensors(device, self.M, self.K, self.N, batched_b=True)
+        grid = ttnn.CoreCoord(gx, gy)
+        assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=self._cfg(grid, _crs(gx, gy)))), 0.999)
+
+    @skip_for_slow_dispatch()
+    @pytest.mark.parametrize("skip_rows", [1, 2])
+    def test_on_subdevice(self, device, skip_rows):
+        mgr, sd_id, cols, wrows, sy = _setup_subdevice(device, skip_rows)
+        try:
+            a, b, ref = _tensors(device, self.M, self.K, self.N, batched_b=True)
+            grid = ttnn.CoreCoord(cols, wrows)
+            cfg = self._cfg(grid, _crs(cols, wrows, start_y=sy))
+            assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=cfg, sub_device_id=sd_id)), 0.999)
+        finally:
+            _teardown(device, mgr)
+
+
+# ---------------------------------------------------------------------------
+# 3) MatmulMultiCoreReuseMultiCast1DProgramConfig  (Factory C)
+# ---------------------------------------------------------------------------
+
+
+class TestMcast1D:
+    M, K, N = 32, 1024, 1024
+
+    def _cfg(self, mcast_in0, gx, gy, awc=None):
+        nc = gx * gy
+        if mcast_in0:
+            pcM, pcN = self.M // 32, max(1, (self.N // 32) // nc)
+        else:
+            pcM, pcN = max(1, (self.M // 32) // nc), self.N // 32
+        return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(gx, gy),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=pcM,
+            out_block_w=pcN,
+            per_core_M=pcM,
+            per_core_N=pcN,
+            fuse_batch=True,
+            mcast_in0=mcast_in0,
+            allowed_worker_cores=awc,
+        )
+
+    @pytest.mark.parametrize("mcast_in0", [True, False])
+    def test_default_grid(self, device, mcast_in0):
+        grid = device.compute_with_storage_grid_size()
+        a, b, ref = _tensors(device, self.M, self.K, self.N)
+        assert_with_pcc(
+            ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=self._cfg(mcast_in0, grid.x, grid.y))), 0.999
+        )
+
+    @pytest.mark.parametrize("mcast_in0", [True, False])
+    @pytest.mark.parametrize("gx, gy", [(4, 4), (8, 2)])
+    def test_custom_grid_at_origin(self, device, mcast_in0, gx, gy):
+        a, b, ref = _tensors(device, self.M, self.K, self.N)
+        cfg = self._cfg(mcast_in0, gx, gy, _crs(gx, gy))
+        assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=cfg)), 0.999)
+
+    @skip_for_slow_dispatch()
+    @pytest.mark.parametrize("mcast_in0", [True, False])
+    @pytest.mark.parametrize("skip_rows", [1, 2])
+    def test_on_subdevice(self, device, mcast_in0, skip_rows):
+        """Offset grid via sub-device — cores start at row `skip_rows`."""
+        mgr, sd_id, cols, wrows, sy = _setup_subdevice(device, skip_rows)
+        try:
+            a, b, ref = _tensors(device, self.M, self.K, self.N)
+            cfg = self._cfg(mcast_in0, cols, wrows, _crs(cols, wrows, start_y=sy))
+            assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=cfg, sub_device_id=sd_id)), 0.999)
+        finally:
+            _teardown(device, mgr)
+
+
+# ---------------------------------------------------------------------------
+# 4) MatmulMultiCoreReuseMultiCastProgramConfig  (Factory D — 2D mcast)
+# ---------------------------------------------------------------------------
+
+
+class TestMcast2D:
+    K = 512
+
+    def _cfg(self, gx, gy, awc=None):
+        M, N = 32 * gy, 32 * gx
+        return (
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=ttnn.CoreCoord(gx, gy),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=max(1, (M // 32) // gy),
+                per_core_N=max(1, (N // 32) // gx),
+                transpose_mcast=False,
+                allowed_worker_cores=awc,
+            ),
+            M,
+            N,
+        )
+
+    def test_default_grid(self, device):
+        grid = device.compute_with_storage_grid_size()
+        cfg, M, N = self._cfg(grid.x, grid.y)
+        a, b, ref = _tensors(device, M, self.K, N)
+        assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=cfg)), 0.999)
+
+    @pytest.mark.parametrize("gx, gy", [(4, 4), (4, 2)])
+    def test_custom_grid_at_origin(self, device, gx, gy):
+        cfg, M, N = self._cfg(gx, gy, _crs(gx, gy))
+        a, b, ref = _tensors(device, M, self.K, N)
+        assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=cfg)), 0.999)
+
+    @skip_for_slow_dispatch()
+    @pytest.mark.parametrize("skip_rows", [1, 2])
+    def test_on_subdevice(self, device, skip_rows):
+        """Offset grid via sub-device — cores start at row `skip_rows`."""
+        mgr, sd_id, cols, wrows, sy = _setup_subdevice(device, skip_rows)
+        try:
+            cfg, M, N = self._cfg(cols, wrows, _crs(cols, wrows, start_y=sy))
+            a, b, ref = _tensors(device, M, self.K, N)
+            assert_with_pcc(ref, ttnn.to_torch(ttnn.matmul(a, b, program_config=cfg, sub_device_id=sd_id)), 0.999)
+        finally:
+            _teardown(device, mgr)
+
+
+# ---------------------------------------------------------------------------
+# 5) Validation / property tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_property_roundtrip(self, device):
+        grid = device.compute_with_storage_grid_size()
+        awc = _crs(4, 4)
+        cfg = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=grid,
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            transpose_mcast=False,
+            allowed_worker_cores=awc,
+        )
+        assert cfg.allowed_worker_cores is not None
+        assert cfg.allowed_worker_cores == awc
+
+    def test_default_is_none(self, device):
+        grid = device.compute_with_storage_grid_size()
+        cfg = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=grid,
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+        )
+        assert cfg.allowed_worker_cores is None
+
+    def test_repr_contains_allowed_worker_cores(self, device):
+        grid = device.compute_with_storage_grid_size()
+        cfg = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=grid,
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            allowed_worker_cores=_crs(4, 4),
+        )
+        assert "allowed_worker_cores" in repr(cfg)

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -1043,6 +1043,23 @@ MatmulProgramConfig get_program_config(
                     program_config.per_core_N % program_config.out_subblock_w == 0,
                     "per_core_N must be divisible by out_subblock_w!");
             }
+            if constexpr (requires { program_config.allowed_worker_cores; }) {
+                if (program_config.allowed_worker_cores.has_value()) {
+                    const auto& awc = program_config.allowed_worker_cores.value();
+                    TT_FATAL(awc.num_cores() > 0, "allowed_worker_cores must be non-empty!");
+                    auto bbox = awc.bounding_box();
+                    TT_FATAL(
+                        awc.num_cores() == bbox.size(),
+                        "allowed_worker_cores must form a dense rectangle (got {} cores in a {} bounding box)",
+                        awc.num_cores(),
+                        bbox);
+                    auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                    CoreRangeSet device_cores({CoreRange({0, 0}, {device_grid.x - 1, device_grid.y - 1})});
+                    TT_FATAL(
+                        device_cores.contains(awc),
+                        "allowed_worker_cores must be a subset of the device compute grid!");
+                }
+            }
         },
         config);
     return config;

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -19,6 +19,7 @@ struct MatmulMultiCoreReuseProgramConfig {
     std::size_t out_subblock_w{};
     std::size_t per_core_M{};
     std::size_t per_core_N{};
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
 };
 
 struct MatmulMultiCoreReuseMultiCastProgramConfig {
@@ -33,6 +34,7 @@ struct MatmulMultiCoreReuseMultiCastProgramConfig {
     bool transpose_mcast{};
     std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
     bool fuse_batch = true;
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
 };
 
 // 1D mcast matmul program config.
@@ -63,6 +65,7 @@ struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
     CoreRangeSet hop_cores;
     std::size_t num_global_cb_receivers{};
     bool untilize_out{};
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
 };
 
 struct MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig {
@@ -79,7 +82,9 @@ struct MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig {
     std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
 };
 
-struct MatmulMultiCoreProgramConfig {};
+struct MatmulMultiCoreProgramConfig {
+    std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
+};
 
 using MatmulProgramConfig = std::variant<
     MatmulMultiCoreProgramConfig,
@@ -88,5 +93,34 @@ using MatmulProgramConfig = std::variant<
     MatmulMultiCoreReuseMultiCast1DProgramConfig,
     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig,
     MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>;
+
+// Ensures allowed_worker_cores is populated on every config variant that supports it.
+// If allowed_worker_cores is already set, it is left unchanged.  Otherwise it is
+// synthesized from compute_with_storage_grid_size (or from the device grid for
+// MatmulMultiCoreProgramConfig).  After this call, factories can read
+// config.allowed_worker_cores.value() unconditionally.
+inline void normalize_program_config(MatmulProgramConfig& config, const CoreCoord& device_grid) {
+    auto make_crs = [](const CoreCoord& grid) {
+        return CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(grid.x - 1, grid.y - 1)));
+    };
+    std::visit(
+        [&](auto& c) {
+            using T = std::decay_t<decltype(c)>;
+            if constexpr (
+                std::is_same_v<T, MatmulMultiCoreReuseProgramConfig> ||
+                std::is_same_v<T, MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<T, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                if (!c.allowed_worker_cores.has_value()) {
+                    c.allowed_worker_cores = make_crs(c.compute_with_storage_grid_size);
+                }
+            } else if constexpr (std::is_same_v<T, MatmulMultiCoreProgramConfig>) {
+                if (!c.allowed_worker_cores.has_value()) {
+                    c.allowed_worker_cores = make_crs(device_grid);
+                }
+            }
+            // DRAM-sharded configs have no grid fields to normalize.
+        },
+        config);
+}
 
 }  // namespace ttnn::operations::matmul

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -61,7 +61,11 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
 
     const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    TT_FATAL(
+        operation_attributes.program_config.has_value(),
+        "program_config must be provided for MatmulMultiCoreProgramFactory");
+    auto pc = std::get<operations::matmul::MatmulMultiCoreProgramConfig>(operation_attributes.program_config.value());
+    auto compute_with_storage_grid_size = pc.allowed_worker_cores.value().bounding_box().grid_size();
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t c_batch_size = get_batch_size(cshape);
     auto num_output_tiles_total = c_batch_size * cshape[-2] * cshape[-1] / TILE_HW;

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -5246,7 +5246,9 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
 
     // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
     // multicast targets a single bounding-box rectangle and the per-core index math assumes a
-    // contiguous row-major rectangle of width `compute_with_storage_grid_size.x`.
+    // contiguous row-major rectangle of width `grid_size.x`.
+    auto grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+
     CoreCoord sub_device_start_core = {0, 0};
     if (operation_attributes.sub_device_id.has_value()) {
         auto sd_worker_cores = device->worker_cores(
@@ -5259,11 +5261,11 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
             sd_worker_cores,
             bbox);
         TT_FATAL(
-            bbox.start_coord.x + program_config.compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
-                bbox.start_coord.y + program_config.compute_with_storage_grid_size.y - 1 <= bbox.end_coord.y,
-            "matmul_multicore_reuse_mcast_1d compute_with_storage_grid_size {} anchored at sub-device start {} "
+            bbox.start_coord.x + grid_size.x - 1 <= bbox.end_coord.x &&
+                bbox.start_coord.y + grid_size.y - 1 <= bbox.end_coord.y,
+            "matmul_multicore_reuse_mcast_1d grid_size {} anchored at sub-device start {} "
             "extends past the sub-device's worker bounding box {}",
-            program_config.compute_with_storage_grid_size,
+            grid_size,
             bbox.start_coord,
             bbox);
         sub_device_start_core = bbox.start_coord;
@@ -5279,7 +5281,7 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
             fp32_dest_acc_en,
             math_approx_mode,
             packer_l1_acc,
-            program_config.compute_with_storage_grid_size,
+            grid_size,
             ttnn::get_throttle_level(compute_kernel_config),
             in0_B,
             in1_B,
@@ -5325,7 +5327,7 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
         fp32_dest_acc_en,
         math_approx_mode,
         packer_l1_acc,
-        program_config.compute_with_storage_grid_size,
+        grid_size,
         ttnn::get_throttle_level(compute_kernel_config),
         in0_B,
         in1_B,
@@ -5380,6 +5382,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig config =
         std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(program_config);
 
+    auto resolved_grid = config.allowed_worker_cores.value().bounding_box().grid_size();
+
     return matmul_multi_core_reuse_mcast_1d_optimized_(
         program,
         a,
@@ -5389,7 +5393,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         broadcast_batch,
         /*transpose_a=*/false,
         /*transpose_b=*/false,
-        config.compute_with_storage_grid_size,
+        resolved_grid,
         compute_kernel_config,
         ttnn::get_throttle_level(compute_kernel_config),
         config.in0_block_w,
@@ -5426,6 +5430,7 @@ MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::create_mesh_workload(
             const ttnn::MeshCoordinateRange mesh_coord_range{mesh_coord, mesh_coord};
             auto pc = std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
                 attributes.program_config.value());
+            auto mesh_grid = pc.allowed_worker_cores.value().bounding_box().grid_size();
             DeviceComputeKernelConfig ckc = attributes.compute_kernel_config.value();
             tt_metal::Program program{};
             std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> empty_signaler = std::nullopt;
@@ -5440,7 +5445,7 @@ MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::create_mesh_workload(
                 attributes.bcast_batch.value_or(false),
                 attributes.transpose_a,
                 attributes.transpose_b,
-                pc.compute_with_storage_grid_size,
+                mesh_grid,
                 ckc,
                 ttnn::get_throttle_level(ckc),
                 pc.in0_block_w,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3080,7 +3080,7 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
 
     auto fuse_batch = program_config.fuse_batch;
     auto in0_block_w = program_config.in0_block_w;
-    auto compute_with_storage_grid_size = program_config.compute_with_storage_grid_size;
+    auto compute_with_storage_grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
     auto out_subblock_h = program_config.out_subblock_h;
     auto out_subblock_w = program_config.out_subblock_w;
     auto out_block_h = program_config.out_block_h;

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -188,7 +188,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         num_blocks_per_core_group_1 *= batch_scale_factor;
         num_blocks_per_core_group_2 *= batch_scale_factor;
     } else {
-        CoreCoord grid = program_config.compute_with_storage_grid_size;
+        CoreCoord grid = program_config.allowed_worker_cores.value().bounding_box().grid_size();
         std::tie(
             num_cores,
             all_cores,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -307,12 +307,13 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                 "Got sub-device worker cores: {} (bounding box: {})",
                 sub_device_cores,
                 bbox);
+            auto grid_size_1d = program_config_1d.allowed_worker_cores.value().bounding_box().grid_size();
             TT_FATAL(
-                bbox.start_coord.x + program_config_1d.compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
-                    bbox.start_coord.y + program_config_1d.compute_with_storage_grid_size.y - 1 <= bbox.end_coord.y,
-                "matmul_multicore_reuse_mcast_1d compute_with_storage_grid_size {} anchored at sub-device start {} "
+                bbox.start_coord.x + grid_size_1d.x - 1 <= bbox.end_coord.x &&
+                    bbox.start_coord.y + grid_size_1d.y - 1 <= bbox.end_coord.y,
+                "matmul grid_size {} anchored at sub-device start {} "
                 "extends past the sub-device's worker bounding box {}",
-                program_config_1d.compute_with_storage_grid_size,
+                grid_size_1d,
                 bbox.start_coord,
                 bbox);
         }
@@ -519,9 +520,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
                     TT_FATAL(!optional_bias.has_value(), "Bias is not supported when using gather_in0.");
                 } else {
-                    // Checks specific to non-gather configs
-                    check_tensor_in_grid(input_tensor_a, program_config.compute_with_storage_grid_size);
-                    check_tensor_in_grid(input_tensor_b, program_config.compute_with_storage_grid_size);
+                    auto grid_1d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+                    check_tensor_in_grid(input_tensor_a, grid_1d);
+                    check_tensor_in_grid(input_tensor_b, grid_1d);
                 }
                 if (program_config.mcast_in0 || program_config.gather_in0) {
                     if (input_tensor_a.is_sharded()) {
@@ -785,8 +786,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
-                check_tensor_in_grid(input_tensor_a, program_config.compute_with_storage_grid_size);
-                check_tensor_in_grid(input_tensor_b, program_config.compute_with_storage_grid_size);
+                auto grid_2d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+                check_tensor_in_grid(input_tensor_a, grid_2d);
+                check_tensor_in_grid(input_tensor_b, grid_2d);
                 TT_FATAL(
                     program_config.per_core_M % program_config.out_block_h == 0,
                     "Error: incompatible values {} and {}",
@@ -1249,8 +1251,8 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
                             uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
                             uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
                             uint32_t num_cores = num_blocks_x * num_blocks_y;
-                            CoreRangeSet all_cores = num_cores_to_corerangeset(
-                                num_cores, program_config.compute_with_storage_grid_size, true);
+                            auto cwsg_1d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+                            CoreRangeSet all_cores = num_cores_to_corerangeset(num_cores, cwsg_1d, true);
                             tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
                                 all_cores,
                                 {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
@@ -1383,10 +1385,9 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
                         shard_orientation = input_tensor_b.shard_spec().value().orientation;
                     }
 
-                    CoreRangeSet all_cores = num_cores_to_corerangeset(
-                        num_cores,
-                        program_config.compute_with_storage_grid_size,
-                        shard_orientation == ShardOrientation::ROW_MAJOR);
+                    auto cwsg_2d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+                    CoreRangeSet all_cores =
+                        num_cores_to_corerangeset(num_cores, cwsg_2d, shard_orientation == ShardOrientation::ROW_MAJOR);
                     tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
                         all_cores,
                         {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
@@ -1617,51 +1618,48 @@ MatmulDeviceOperation::tensor_return_value_t matmul(
     const std::optional<Tensor>& bias,
     const std::optional<Tensor>& optional_output_tensor,
     const MatmulParams& attributes) {
-    if (!attributes.program_config.has_value()) {
+    MatmulParams normalized_attributes = attributes;
+    if (!normalized_attributes.program_config.has_value()) {
         uint32_t bias_single_tile_size = 0;
         if (bias.has_value()) {
             auto bias_data_format = tt::tt_metal::datatype_to_dataformat_converter(bias.value().dtype());
             bias_single_tile_size = tt::tile_size(bias_data_format);
         }
 
-        MatmulParams attributes_with_program_config = attributes;
-        attributes_with_program_config.program_config = operations::matmul::get_program_config(
+        normalized_attributes.program_config = operations::matmul::get_program_config(
             input_tensor_a,
             input_tensor_b,
-            attributes.transpose_a,
-            attributes.transpose_b,
+            normalized_attributes.transpose_a,
+            normalized_attributes.transpose_b,
             bias_single_tile_size,
-            attributes);
-
-        return ttnn::device_operation::launch<MatmulDeviceOperation>(
-            attributes_with_program_config, {{input_tensor_a, input_tensor_b}, {bias}, {optional_output_tensor}});
+            normalized_attributes);
     }
+    operations::matmul::normalize_program_config(
+        normalized_attributes.program_config.value(), input_tensor_a.device()->compute_with_storage_grid_size());
     return ttnn::device_operation::launch<MatmulDeviceOperation>(
-        attributes, {{input_tensor_a, input_tensor_b}, {bias}, {optional_output_tensor}});
+        normalized_attributes, {{input_tensor_a, input_tensor_b}, {bias}, {optional_output_tensor}});
 }
 
 MatmulDeviceOperation::tensor_return_value_t matmul(
     const std::vector<Tensor>& input_tensors,
     const std::optional<Tensor>& optional_output_tensor,
     const MatmulParams& attributes) {
-    if (!attributes.program_config.has_value()) {
+    MatmulParams normalized_attributes = attributes;
+    if (!normalized_attributes.program_config.has_value()) {
         uint32_t bias_single_tile_size = 0;
 
-        MatmulParams attributes_with_program_config = attributes;
-        attributes_with_program_config.program_config = operations::matmul::get_program_config(
+        normalized_attributes.program_config = operations::matmul::get_program_config(
             input_tensors.at(0),
             input_tensors.at(1),
-            attributes.transpose_a,
-            attributes.transpose_b,
+            normalized_attributes.transpose_a,
+            normalized_attributes.transpose_b,
             bias_single_tile_size,
-            attributes);
-
-        return ttnn::device_operation::launch<MatmulDeviceOperation>(
-            attributes_with_program_config, {input_tensors, {}, {optional_output_tensor}});
+            normalized_attributes);
     }
-
+    operations::matmul::normalize_program_config(
+        normalized_attributes.program_config.value(), input_tensors.at(0).device()->compute_with_storage_grid_size());
     return ttnn::device_operation::launch<MatmulDeviceOperation>(
-        attributes, {input_tensors, {}, {optional_output_tensor}});
+        normalized_attributes, {input_tensors, {}, {optional_output_tensor}});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
 #include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
+#include "ttnn/operations/matmul/device/config/matmul_program_config_types.hpp"
 
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "tt-metalium/work_split.hpp"
@@ -47,6 +48,8 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
         /*transpose_b=*/false,
         /*bias_single_tile_size=*/0,
         matmul_attributes);
+    operations::matmul::normalize_program_config(
+        chosen_program_config, tensor_args.input_tensors.at(0).device()->compute_with_storage_grid_size());
 
     const auto& a = tensor_args.input_tensors.at(0);
     const auto& b = tensor_args.input_tensors.at(1);
@@ -54,7 +57,7 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
     const auto& output_tensor = tensor_return_value.at(0);
     auto program_config =
         std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config);
-    auto compute_with_storage_grid_size = program_config.compute_with_storage_grid_size;
+    auto compute_with_storage_grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
     auto in0_block_w = program_config.in0_block_w;
     auto out_subblock_h = program_config.out_subblock_h;
     auto out_subblock_w = program_config.out_subblock_w;

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation.hpp"
+#include "ttnn/operations/matmul/device/config/matmul_program_config_types.hpp"
 
 #include <tt-metalium/work_split.hpp>
 
@@ -341,6 +342,10 @@ SparseMatmulParams create_sparse_matmul_attributes(
 
     auto matmul_struct =
         create_matmul_attributes(input_tensor_a, input_tensor_b, matmul_attributes, {optional_output_tensors.at(0)});
+    if (matmul_struct.program_config.has_value()) {
+        auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+        operations::matmul::normalize_program_config(matmul_struct.program_config.value(), device_grid);
+    }
     return SparseMatmulParams{
         parameters.nnz,
         parameters.is_input_a_sparse,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -59,20 +59,30 @@ void py_module(nb::module_& mod) {
     )doc");
 
     matmul_multi_core_reuse_program_config.def(
-        nb::init<CoreCoord, std::size_t, std::size_t, std::size_t, std::size_t, std::size_t>(),
+        nb::init<
+            CoreCoord,
+            std::size_t,
+            std::size_t,
+            std::size_t,
+            std::size_t,
+            std::size_t,
+            std::optional<CoreRangeSet>>(),
         nb::kw_only(),
         nb::arg("compute_with_storage_grid_size"),
         nb::arg("in0_block_w").noconvert(),
         nb::arg("out_subblock_h").noconvert(),
         nb::arg("out_subblock_w").noconvert(),
         nb::arg("per_core_M").noconvert(),
-        nb::arg("per_core_N").noconvert());
+        nb::arg("per_core_N").noconvert(),
+        nb::arg("allowed_worker_cores") = nb::none());
     matmul_multi_core_reuse_program_config.def_rw(
         "compute_with_storage_grid_size", &MatmulMultiCoreReuseProgramConfig::compute_with_storage_grid_size, R"doc(
         Grid size for compute cores with storage capability.
 
         Specifies the 2D grid of cores (x, y) that will be used for computation and have
         access to storage. This determines how the computation is distributed across cores.
+
+        **DEPRECATED**: Use ``allowed_worker_cores`` instead for finer control over the compute grid.
     )doc");
     matmul_multi_core_reuse_program_config.def_rw("in0_block_w", &MatmulMultiCoreReuseProgramConfig::in0_block_w, R"doc(
         Block width for both input tensors along the K dimension (shared inner dimension).
@@ -112,16 +122,24 @@ void py_module(nb::module_& mod) {
         Larger values mean fewer cores are used but each core does more work.
         Must be chosen such that (total_N / per_core_N) cores are available.
     )doc");
+    matmul_multi_core_reuse_program_config.def_rw(
+        "allowed_worker_cores", &MatmulMultiCoreReuseProgramConfig::allowed_worker_cores, R"doc(
+        Optional set of worker cores to restrict the matmul computation to.
+
+        When set, overrides ``compute_with_storage_grid_size`` for determining the active
+        compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
+    )doc");
     matmul_multi_core_reuse_program_config.def("__repr__", [](const MatmulMultiCoreReuseProgramConfig& config) {
         return fmt::format(
             "MatmulMultiCoreReuseProgramConfig(compute_with_storage_grid_size={}, in0_block_w={}, out_subblock_h={}, "
-            "out_subblock_w={}, per_core_M={}, per_core_N={})",
+            "out_subblock_w={}, per_core_M={}, per_core_N={}, allowed_worker_cores={})",
             config.compute_with_storage_grid_size,
             config.in0_block_w,
             config.out_subblock_h,
             config.out_subblock_w,
             config.per_core_M,
-            config.per_core_N);
+            config.per_core_N,
+            config.allowed_worker_cores.has_value() ? fmt::format("{}", config.allowed_worker_cores.value()) : "None");
     });
 
     auto matmul_multi_core_reuse_multicast_program_config =
@@ -143,12 +161,12 @@ void py_module(nb::module_& mod) {
            std::size_t per_core_N,
            bool transpose_mcast,
            std::optional<UnaryWithParam> fused_activation,
-           bool fuse_batch) {
-            // Set out_block_h and out_block_w to defaults if they are not provided
+           bool fuse_batch,
+           std::optional<CoreRangeSet> allowed_worker_cores) {
             std::size_t actual_out_block_h = out_block_h.value_or(per_core_M);
             std::size_t actual_out_block_w = out_block_w.value_or(per_core_N);
 
-            new (t) MatmulMultiCoreReuseMultiCastProgramConfig(
+            new (t) MatmulMultiCoreReuseMultiCastProgramConfig{
                 compute_with_storage_grid_size,
                 in0_block_w,
                 out_subblock_h,
@@ -159,7 +177,8 @@ void py_module(nb::module_& mod) {
                 per_core_N,
                 transpose_mcast,
                 std::move(fused_activation),
-                fuse_batch);
+                fuse_batch,
+                std::move(allowed_worker_cores)};
         },
         nb::kw_only(),
         nb::arg("compute_with_storage_grid_size"),
@@ -172,7 +191,8 @@ void py_module(nb::module_& mod) {
         nb::arg("per_core_N").noconvert(),
         nb::arg("transpose_mcast").noconvert(),
         nb::arg("fused_activation") = nb::none(),
-        nb::arg("fuse_batch").noconvert() = true);
+        nb::arg("fuse_batch").noconvert() = true,
+        nb::arg("allowed_worker_cores") = nb::none());
 
     matmul_multi_core_reuse_multicast_program_config.def_rw(
         "compute_with_storage_grid_size",
@@ -183,6 +203,8 @@ void py_module(nb::module_& mod) {
         Specifies the 2D grid of cores (x, y) that will be used for computation and have
         access to storage. This determines how the computation is distributed across cores
         and affects multicast communication patterns.
+
+        **DEPRECATED**: Use ``allowed_worker_cores`` instead for finer control over the compute grid.
     )doc");
 
     matmul_multi_core_reuse_multicast_program_config.def_rw(
@@ -275,12 +297,21 @@ void py_module(nb::module_& mod) {
 
         Note: the batch dimensions need to all be 1 for the second input tensor when fuse_batch is true.
     )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_rw(
+        "allowed_worker_cores",
+        &MatmulMultiCoreReuseMultiCastProgramConfig::allowed_worker_cores,
+        R"doc(
+        Optional set of worker cores to restrict the matmul computation to.
+
+        When set, overrides ``compute_with_storage_grid_size`` for determining the active
+        compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
+    )doc");
     matmul_multi_core_reuse_multicast_program_config.def(
         "__repr__", [](const MatmulMultiCoreReuseMultiCastProgramConfig& config) {
             return fmt::format(
                 "MatmulMultiCoreReuseMultiCastProgramConfig(compute_with_storage_grid_size={}, in0_block_w={}, "
                 "out_subblock_h={}, out_subblock_w={}, out_block_h={}, out_block_w={}, per_core_M={}, "
-                "per_core_N={}, transpose_mcast={}, fused_activation={}, fuse_batch={})",
+                "per_core_N={}, transpose_mcast={}, fused_activation={}, fuse_batch={}, allowed_worker_cores={})",
                 config.compute_with_storage_grid_size,
                 config.in0_block_w,
                 config.out_subblock_h,
@@ -291,7 +322,9 @@ void py_module(nb::module_& mod) {
                 config.per_core_N,
                 config.transpose_mcast,
                 config.fused_activation,
-                config.fuse_batch);
+                config.fuse_batch,
+                config.allowed_worker_cores.has_value() ? fmt::format("{}", config.allowed_worker_cores.value())
+                                                        : "None");
         });
 
     auto matmul_multi_core_reuse_multicast_1d_program_config =
@@ -328,12 +361,12 @@ void py_module(nb::module_& mod) {
                bool gather_in0,
                CoreRangeSet hop_cores,
                std::size_t num_global_cb_receivers,
-               bool untilize_out) {
-                // Set out_block_h and out_block_w to defaults if they are not provided
+               bool untilize_out,
+               std::optional<CoreRangeSet> allowed_worker_cores) {
                 std::size_t actual_out_block_h = out_block_h.value_or(per_core_M);
                 std::size_t actual_out_block_w = out_block_w.value_or(per_core_N);
 
-                new (t) MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                new (t) MatmulMultiCoreReuseMultiCast1DProgramConfig{
                     compute_with_storage_grid_size,
                     in0_block_w,
                     out_subblock_h,
@@ -348,7 +381,8 @@ void py_module(nb::module_& mod) {
                     gather_in0,
                     std::move(hop_cores),
                     num_global_cb_receivers,
-                    untilize_out);
+                    untilize_out,
+                    std::move(allowed_worker_cores)};
             },
             nb::kw_only(),
             nb::arg("compute_with_storage_grid_size"),
@@ -365,7 +399,8 @@ void py_module(nb::module_& mod) {
             nb::arg("gather_in0").noconvert() = false,
             nb::arg("hop_cores").noconvert() = nb::cast(CoreRangeSet()),
             nb::arg("num_global_cb_receivers").noconvert() = 1,
-            nb::arg("untilize_out").noconvert() = false)
+            nb::arg("untilize_out").noconvert() = false,
+            nb::arg("allowed_worker_cores") = nb::none())
         .def_rw(
             "compute_with_storage_grid_size",
             &MatmulMultiCoreReuseMultiCast1DProgramConfig::compute_with_storage_grid_size,
@@ -379,6 +414,8 @@ void py_module(nb::module_& mod) {
             When the matmul op is invoked with a ``sub_device_id`` (and ``gather_in0`` is False),
             this rectangle is anchored at the sub-device's worker bounding-box start (instead of
             ``(0, 0)``) and must fit inside that bounding box. Ignored when ``gather_in0`` is True.
+
+            **DEPRECATED**: Use ``allowed_worker_cores`` instead for finer control over the compute grid.
         )doc")
         .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::in0_block_w, R"doc(
             Block width for both input tensors along the K dimension (shared inner dimension).
@@ -472,12 +509,21 @@ void py_module(nb::module_& mod) {
             the operation. This can be useful when the subsequent operation expects row-major
             data and can eliminate a separate untilization pass. Defaults to false.
         )doc")
+        .def_rw(
+            "allowed_worker_cores",
+            &MatmulMultiCoreReuseMultiCast1DProgramConfig::allowed_worker_cores,
+            R"doc(
+            Optional set of worker cores to restrict the matmul computation to.
+
+            When set, overrides ``compute_with_storage_grid_size`` for determining the active
+            compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
+        )doc")
         .def("__repr__", [](const MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
             return fmt::format(
                 "MatmulMultiCoreReuseMultiCast1DProgramConfig(compute_with_storage_grid_size={}, in0_block_w={}, "
                 "out_block_h={}, out_block_w={}, out_subblock_h={}, out_subblock_w={}, per_core_M={}, per_core_N={}, "
                 "fuse_batch={}, fused_activation={}, mcast_in0={}, gather_in0={}, hop_cores={}, "
-                "num_global_cb_receivers={}, untilize_out={})",
+                "num_global_cb_receivers={}, untilize_out={}, allowed_worker_cores={})",
                 config.compute_with_storage_grid_size,
                 config.in0_block_w,
                 config.out_block_h,
@@ -492,7 +538,9 @@ void py_module(nb::module_& mod) {
                 config.gather_in0,
                 config.hop_cores,
                 config.num_global_cb_receivers,
-                config.untilize_out);
+                config.untilize_out,
+                config.allowed_worker_cores.has_value() ? fmt::format("{}", config.allowed_worker_cores.value())
+                                                        : "None");
         });
 
     auto matmul_multi_core_reuse_multicast_dram_sharded_program_config =


### PR DESCRIPTION
## Summary
- Adds a new optional `CoreRangeSet` field `allowed_worker_cores` to all matmul program configs (`MatmulMultiCoreReuseProgramConfig`, `MatmulMultiCoreReuseMultiCastProgramConfig`, `MatmulMultiCoreReuseMultiCast1DProgramConfig`, `MatmulMultiCoreProgramConfig`). When set, it takes precedence over `compute_with_storage_grid_size` for grid resolution in all matmul factories.
- This is a **backward-compatible, backend-only change** — no existing call sites are modified. All existing Python and C++ code continues to work unchanged.
- Adds `get_allowed_worker_cores()` translation helpers, updates all matmul and sparse matmul factories to use the new field, and updates validation in `matmul_device_operation.cpp`.
- Exposes `allowed_worker_cores` in Python bindings (nanobind) and adds deprecation notices to `compute_with_storage_grid_size` (program config field) and `core_grid` (function parameter).
- Adds `test_custom_grids.py` with 28 tests exercising all factory paths (Reuse, Mcast1D, Mcast2D) with default grids, custom grids at origin, and sub-device offset grids.

## Test plan
- [x] Build passes (`build_metal.sh`)
- [x] `test_custom_grids.py` — 28/28 passed (new tests for `allowed_worker_cores`)
- [x] `test_matmul.py` — 609 passed, 104 skipped, 0 failures (existing regression suite)
- [x] Full `tests/ttnn/unit_tests/operations/matmul/` — 1180 passed, 140 skipped, 0 failures (all matmul/linear/sparse/addmm tests)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/matmul_allowed_worker_cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/matmul_allowed_worker_cores)