### PR TITLE
[cleanup] separate out const vs mutable accessor for MeshTensor

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -116,7 +116,17 @@ public:
      *
      * pre-condition: The device tensor must not be in a default constructed state.
      */
-    distributed::MeshDevice& device() const;
+    const distributed::MeshDevice& device() const;
+
+    /**
+     * Get the mutable device the allocated device memory is on.
+     *
+     * This function is meant to be compatible with existing code and may be removed in the future,
+     * please consider this an internal function and use device() whenever possible.
+     *
+     * pre-condition: The device tensor must not be in a default constructed state.
+     */
+    distributed::MeshDevice& device_mut() const;
 
     // Getters:
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -36,7 +36,9 @@ std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_break
     return impl().raw_mesh_buffer();
 }
 
-distributed::MeshDevice& MeshTensor::device() const { return *mesh_buffer().device(); }
+const distributed::MeshDevice& MeshTensor::device() const { return device_mut(); }
+
+distributed::MeshDevice& MeshTensor::device_mut() const { return *mesh_buffer().device(); }
 
 bool MeshTensor::is_initialized() const { return impl_ != nullptr; }
 

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -62,7 +62,7 @@ bool should_use_pinned_write_path(distributed::MeshDevice& mesh_device, size_t s
 
 HostTensor enqueue_read_tensor(distributed::MeshCommandQueue& cq, const MeshTensor& device_tensor, bool blocking) {
     auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
-    auto& device = device_tensor.device();
+    const auto& device = device_tensor.device();
 
     auto distributed_host_buffer = DistributedHostBuffer::create(device.get_view());
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -218,8 +218,12 @@ bool DeviceStorage::is_allocated() const { return mesh_tensor_holder_->is_alloca
 distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {
     return std::visit(
         ttsl::overloaded{
-            [](const MeshTensorHolder::Allocated& allocated) { return &allocated.mesh_tensor_.device(); },
-            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) { return tombstone.mesh_buffer_->device(); },
+            [](const MeshTensorHolder::Allocated& allocated) -> distributed::MeshDevice* {
+                return &allocated.mesh_tensor_.device_mut();
+            },
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> distributed::MeshDevice* {
+                return tombstone.mesh_buffer_->device();
+            },
             [](const auto&) -> distributed::MeshDevice* { TT_THROW("Tensor is not allocated"); }},
         mesh_tensor_holder_->state_);
 }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -292,7 +292,7 @@ std::string to_string_impl(const Tensor& tensor) {
         return to_string_impl<T>(cpu_tensor);
     }
 
-    auto& mesh_device = storage.get_mesh_tensor().device();
+    const auto& mesh_device = storage.get_mesh_tensor().device();
     // TODO: Uncomment after the distributed tensors migration to tt-metal is complete.
     // if (mesh_device->num_devices() == 1) {
     //     return to_string<T>(ttnn::distributed::get_device_tensors(cpu_tensor).at(0));


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

MeshTensor has a device getter that returns a mutable reference to it's associated MeshDevice by default.

Which allows the user to assign a new MeshDevice into a const MeshTensor.
This is not desirable.
You can also break the core invariant of MeshTensor (object lifetime = device memory lifetime) by getting the allocator from the MeshDevice and call `deallocate_buffers` on it.

However, the const correctness of MeshDevice is not looked over and there maybe mutable functions of MeshDevice would be of use from a const MeshTensor. Thus an escape hatch is left as `device_mut`, we should clean this up after MeshTensor usage migration.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mesh-tensor-device-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mesh-tensor-device-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mesh-tensor-device-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mesh-tensor-device-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mesh-tensor-device-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mesh-tensor-device-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mesh-tensor-device-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mesh-tensor-device-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mesh-tensor-device-const)