### PR TITLE
Add changes to llk test infra for stability/cleanup on emulation

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/exalens_server.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/exalens_server.py
@@ -35,6 +35,7 @@ class ExalensServer:
         self._started_before = False
 
     def start(self) -> None:
+        self._kill_stale_servers()
         self._emu_logs_baseline = set(glob.glob(self.EMU_LOG_PATTERN))
         if not os.path.isdir(self._simulator_path):
             logger.error(
@@ -276,3 +277,55 @@ class ExalensServer:
     @property
     def ever_started(self) -> bool:
         return self._started_before
+
+    def _kill_stale_servers(self) -> None:
+        """Kill any orphaned tt-exalens processes left over from previous runs on the same port.
+        These can be missed by a simple ps command because the tt-exalens process is in a new session.
+        In the normal case (no orphans) this is just a quick pgrep that returns empty.
+        """
+        try:
+            result = subprocess.run(
+                ["pgrep", "-f", f"tt-exalens.*--port={self._port}"],
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return
+
+        if result.returncode != 0 or not result.stdout.strip():
+            return
+
+        my_pid = os.getpid()
+        stale_pids = []
+        for line in result.stdout.strip().splitlines():
+            try:
+                pid = int(line.strip())
+            except ValueError:
+                continue
+            if pid == my_pid:
+                continue
+            stale_pids.append(pid)
+
+        if not stale_pids:
+            return
+
+        logger.warning(
+            "Found {} stale tt-exalens process(es) on port {}: {}. Killing...",
+            len(stale_pids),
+            self._port,
+            stale_pids,
+        )
+
+        for pid in stale_pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except (OSError, ProcessLookupError):
+                pass
+
+        time.sleep(0.5)
+
+        for pid in stale_pids:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (OSError, ProcessLookupError):
+                pass

--- a/tt_metal/tt-llk/tests/python_tests/helpers/exalens_server.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/exalens_server.py
@@ -7,6 +7,7 @@ import shutil
 import signal
 import subprocess
 import time
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -285,7 +286,7 @@ class ExalensServer:
         """
         try:
             result = subprocess.run(
-                ["pgrep", "-f", f"tt-exalens.*--port={self._port}"],
+                ["pgrep", "-f", "tt-exalens"],
                 capture_output=True,
                 text=True,
             )
@@ -296,6 +297,7 @@ class ExalensServer:
             return
 
         my_pid = os.getpid()
+        port_arg = f"--port={self._port}"
         stale_pids = []
         for line in result.stdout.strip().splitlines():
             try:
@@ -303,6 +305,12 @@ class ExalensServer:
             except ValueError:
                 continue
             if pid == my_pid:
+                continue
+            try:
+                cmdline_args = Path(f"/proc/{pid}/cmdline").read_bytes().split(b"\x00")
+                if port_arg.encode() not in cmdline_args:
+                    continue
+            except OSError:
                 continue
             stale_pids.append(pid)
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1241,7 +1241,7 @@ class TestConfig:
             if TestConfig.ARCH != ChipArchitecture.QUASAR:
                 commit_brisc_command(TestConfig.TENSIX_LOCATION, BriscCmd.RESET_TRISCS)
         else:
-            set_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
+            commit_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
 
         VARIANT_ELF_DIR = (
             TestConfig.ARTEFACTS_DIR / self.test_name / self.variant_id / "elf"


### PR DESCRIPTION
### PR Category
LLK emulation environment stability

### Summary
1. Use commit_tensix_soft_reset instead of set_tensix_soft_reset in the TRISC boot path so we poll the reset register until confirmed before loading ELFs. On the emulator the register write isn't instantaneous, so load_elf would see the core as not-in-reset and assert.
2. Kill stale tt-exalens processes on the same port at ExalensServer.start(). If a previous pytest run was force-killed, the tt-exalens subprocess (which runs in its own session) can survive as an orphan and block subsequent runs. This is a no-op in the normal case — just a quick pgrep that returns empty.

### Notes for reviewers
Both changes only affect the --run-simulator path and have no impact on silicon test runs.
<3

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pgardner/QS-llk-infra-pollReset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pgardner/QS-llk-infra-pollReset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pgardner/QS-llk-infra-pollReset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pgardner/QS-llk-infra-pollReset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pgardner/QS-llk-infra-pollReset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pgardner/QS-llk-infra-pollReset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pgardner/QS-llk-infra-pollReset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pgardner/QS-llk-infra-pollReset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pgardner/QS-llk-infra-pollReset)