### PR TITLE
[tt-triage] Add operation id to callstack aggregation

### DIFF
--- a/tools/triage/dump_aggregated_callstacks.py
+++ b/tools/triage/dump_aggregated_callstacks.py
@@ -215,8 +215,8 @@ def _collect_aggregated(
     if not results:
         return None
 
-    # Aggregate by (kernel_id, normalized_pc, risc_name)
-    buckets: dict[tuple[int | None, int | None, str], AggregationBucket] = {}
+    # Aggregate by (kernel_id, normalized_pc, risc_name, op_id)
+    buckets: dict[tuple[int | None, int | None, str, int | None], AggregationBucket] = {}
 
     for check_result in results:
         if check_result.result is None:
@@ -229,7 +229,7 @@ def _collect_aggregated(
         # Normalize PC into kernel space when kernel_offset is available
         normalized_pc = pc - d.kernel_offset if d.kernel_offset is not None and pc is not None else pc
 
-        key = (d.watcher_kernel_id, normalized_pc, check_result.risc_name)
+        key = (d.watcher_kernel_id, normalized_pc, check_result.risc_name, d.host_assigned_id)
         bucket = buckets.get(key)
         if bucket is None:
             bucket = AggregationBucket(cs_data, check_result.risc_name)
@@ -243,7 +243,7 @@ def _collect_aggregated(
         )
 
     # Sort ascending by op_id
-    sorted_buckets = sorted(buckets.values(), key=lambda b: b.op_id)
+    sorted_buckets = sorted(buckets.values(), key=lambda b: (b.op_id is None, b.op_id))
     return [b.to_row(visualize_devices, verbose, context) for b in sorted_buckets]
 
 

--- a/tools/triage/dump_aggregated_callstacks.py
+++ b/tools/triage/dump_aggregated_callstacks.py
@@ -12,7 +12,7 @@ Options:
     --device-visualization           Show device visualizations instead of plain coordinate lists in the Locations column.
 
 Description:
-    Aggregates callstacks by (Kernel Id, normalized PC, RISC Name) and shows:
+    Aggregates callstacks by (Kernel Id, normalized PC, RISC Name and Operation Id) and shows:
       - Kernel Id / Kernel Name
       - Op Id (host_assigned_id, for correlation with dump_running_operations.py)
       - Callstack


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Callstacks in `dump_aggregated_callstacks.py` are aggregated by normalized PC + kernel id, there is a chance that different ops can be stuck at the same point in the same kernel (id) so we swallow those other ops and only show the first one. Closes https://github.com/tenstorrent/tt-exalens/issues/1018

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/agg-callstacks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/agg-callstacks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/agg-callstacks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/agg-callstacks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/agg-callstacks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/agg-callstacks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/agg-callstacks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/agg-callstacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/agg-callstacks)