### PR TITLE
[tt-triage] Add llm-friendly output

### DIFF
--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import csv
 import io
+import os
 import textwrap
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields, is_dataclass
@@ -90,7 +91,9 @@ def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
 
 
 class OutputSerializer(ABC):
-    """Sink for one script's serialized result. Subclasses must implement `emit`."""
+    """Turns one script's result into output. Subclasses pick the format
+    (Rich tables, CSV, future JSON, …). The *destination* is handled by a
+    `Sink` instance the serializer holds."""
 
     @abstractmethod
     def emit(
@@ -106,12 +109,63 @@ class OutputSerializer(ABC):
     ) -> None:
         pass
 
+    def close(self) -> None:
+        """Release any owned resources (e.g. file handles). Default is a no-op."""
+        pass
+
+
+class Sink(ABC):
+    """Where rendered text goes. Decouples *format* (Serializer) from
+    *destination* (Sink) so each can vary independently."""
+
+    @abstractmethod
+    def write_line(self, line: str) -> None:
+        pass
+
+    def close(self) -> None:
+        """Release any owned resources (e.g. file handles). Default is a no-op."""
+        pass
+
+
+class ConsoleSink(Sink):
+    """`Sink` backed by a Rich console. Supports plain lines and Rich
+    renderables (tables, panels) — the latter is needed by `RichSerializer`."""
+
+    def __init__(self, console: Any):
+        self._console = console
+
+    def write_line(self, line: str) -> None:
+        self._console.print(line, markup=False, highlight=False)
+
+    def write_rich(self, renderable: Any) -> None:
+        self._console.print(renderable)
+
+
+class FileSink(Sink):
+    """`Sink` backed by a file on disk. Closes the file in `close()`."""
+
+    def __init__(self, path: str):
+        path = os.path.abspath(path)
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        self._file = open(path, "w", encoding="utf-8")
+
+    def write_line(self, line: str) -> None:
+        self._file.write(line)
+        self._file.write("\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        if not self._file.closed:
+            self._file.close()
+
 
 class RichSerializer(OutputSerializer):
-    """Renders results as Rich tables to the console."""
+    """Renders results as Rich tables."""
 
-    def __init__(self, console: Any, utils_module: Any, verbose_level_getter: Callable[[], int]):
-        self._console = console
+    def __init__(self, sink: ConsoleSink, utils_module: Any, verbose_level_getter: Callable[[], int]):
+        self._sink = sink
         self._utils = utils_module
         self._verbose_getter = verbose_level_getter
 
@@ -168,7 +222,14 @@ class RichSerializer(OutputSerializer):
             table.add_column(col, justify="left")
         for row in table_data.rows:
             table.add_row(*row)
-        self._console.print(table)
+        self._sink.write_rich(table)
+
+    def close(self) -> None:
+        self._sink.close()
+
+
+def _one_line(s: str) -> str:
+    return s.replace("\n", "\\n").replace("\r", "\\r")
 
 
 def _strip_rich_markup(s: str) -> str:
@@ -189,19 +250,17 @@ def _strip_rich_markup(s: str) -> str:
 
 
 class CsvSerializer(OutputSerializer):
-    """
-    Writes a report with one section per script to the Rich console.
+    """Renders results as CSV-formatted tables."""
 
-    Each section mirrors the console layout (`<script>:`, then `pass`/`fail`
-    and any warnings/failures), then emits tabular data as a CSV block.
-    """
-
-    def __init__(self, console: Any, verbose_level_getter: Callable[[], int]):
-        self._console = console
+    def __init__(self, sink: Sink, verbose_level_getter: Callable[[], int]):
+        self._sink = sink
         self._verbose_getter = verbose_level_getter
 
     def _print(self, line: str = "") -> None:
-        self._console.print(_strip_rich_markup(line), markup=False, highlight=False)
+        # Strip Rich markup (colour tags like `[blue]0x...[/]` embedded in cell
+        # values), then escape embedded newlines so each record is exactly one
+        # physical line.
+        self._sink.write_line(_one_line(_strip_rich_markup(line)))
 
     def _print_csv_row(self, row: list[str]) -> None:
         buf = io.StringIO()
@@ -253,3 +312,40 @@ class CsvSerializer(OutputSerializer):
         self._print_csv_row(table_data.columns)
         for row in table_data.rows:
             self._print_csv_row(row)
+
+    def close(self) -> None:
+        self._sink.close()
+
+
+class MultiSerializer(OutputSerializer):
+    """Fans `emit` / `close` out to several serializers (e.g. Rich + CSV file)."""
+
+    def __init__(self, serializers: Iterable[OutputSerializer]):
+        self._serializers = list(serializers)
+
+    def emit(
+        self,
+        script_name: str | None,
+        execution_time: str,
+        result: Any,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+        documentation: str | None,
+    ) -> None:
+        for s in self._serializers:
+            s.emit(
+                script_name=script_name,
+                execution_time=execution_time,
+                result=result,
+                failures=failures,
+                warnings=warnings,
+                script_failed=script_failed,
+                failure_message=failure_message,
+                documentation=documentation,
+            )
+
+    def close(self) -> None:
+        for s in self._serializers:
+            s.close()

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -7,16 +7,15 @@
 Output serializers for tt-triage script results.
 
 Each script's result flows through `serialize_result()` in `triage.py`, which
-delegates to an `OutputSerializer`. The default `RichSerializer` renders Rich
-tables to the console. The `CsvSerializer` writes a single text report
-file whose tables are emitted as CSV — easier and cheaper to consume for
-machine readers (LLMs, grep, diff) than the Rich box-drawing format.
+delegates to an `OutputSerializer`. `RichSerializer` renders Rich tables;
+`CsvSerializer` renders the same data as CSV-formatted tables,
+which is cheaper for machine readers (LLMs, grep, diff) than the box-drawing format.
 """
 
 from __future__ import annotations
 
 import csv
-import os
+import io
 import textwrap
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields, is_dataclass
@@ -91,7 +90,7 @@ def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
 
 
 class OutputSerializer(ABC):
-    """Sink for one script's serialized result. Subclasses must implement `emit` and `close`."""
+    """Sink for one script's serialized result. Subclasses must implement `emit`."""
 
     @abstractmethod
     def emit(
@@ -105,11 +104,7 @@ class OutputSerializer(ABC):
         failure_message: str | None,
         documentation: str | None,
     ) -> None:
-        ...
-
-    @abstractmethod
-    def close(self) -> None:
-        ...
+        pass
 
 
 class RichSerializer(OutputSerializer):
@@ -161,6 +156,7 @@ class RichSerializer(OutputSerializer):
 
         if isinstance(result, list) and len(result) == 0:
             utils.ERROR("  No results found.")
+            return
 
         table_data = extract_table_data(result, self._verbose_getter())
         if table_data is None:
@@ -174,38 +170,43 @@ class RichSerializer(OutputSerializer):
             table.add_row(*row)
         self._console.print(table)
 
-    def close(self) -> None:
-        pass
-
 
 def _strip_rich_markup(s: str) -> str:
     """Strip Rich markup tags (e.g. `[warning]...[/]`) from a string.
 
-    Log helpers in utils.py wrap messages in Rich tags for console rendering,
-    and some scripts embed inline markup in their messages. The Rich console
-    renders these away; a plain-text file must do the equivalent stripping.
+    Some script messages contain bracketed text that looks like markup but
+    isn't (e.g. `[!] core`, `[0x...]`, coordinate strings like `[1-1 (0,0)]`).
+    Rich raises `MarkupError` on those — fall back to the original string in
+    that case so we never crash on otherwise valid triage output.
     """
+    from rich.errors import MarkupError
     from rich.text import Text
 
-    return Text.from_markup(s).plain
+    try:
+        return Text.from_markup(s).plain
+    except MarkupError:
+        return s
 
 
 class CsvSerializer(OutputSerializer):
     """
-    Writes a report with one section per script.
+    Writes a report with one section per script to the Rich console.
 
     Each section mirrors the console layout (`<script>:`, then `pass`/`fail`
     and any warnings/failures), then emits tabular data as a CSV block.
     """
 
-    def __init__(self, path: str, verbose_level_getter: Callable[[], int]):
-        self._path = path
+    def __init__(self, console: Any, verbose_level_getter: Callable[[], int]):
+        self._console = console
         self._verbose_getter = verbose_level_getter
-        parent = os.path.dirname(os.path.abspath(path))
-        if parent:
-            os.makedirs(parent, exist_ok=True)
-        self._file = open(path, "w", encoding="utf-8")
-        self._writer = csv.writer(self._file, lineterminator="\n")
+
+    def _print(self, line: str = "") -> None:
+        self._console.print(_strip_rich_markup(line), markup=False, highlight=False)
+
+    def _print_csv_row(self, row: list[str]) -> None:
+        buf = io.StringIO()
+        csv.writer(buf, lineterminator="").writerow(row)
+        self._print(buf.getvalue())
 
     def emit(
         self,
@@ -218,80 +219,37 @@ class CsvSerializer(OutputSerializer):
         failure_message: str | None,
         documentation: str | None,
     ) -> None:
-        f = self._file
         if script_name is not None:
-            f.write("\n")
-            f.write(f"{script_name}{execution_time}:\n")
+            self._print()
+            self._print(f"{script_name}{execution_time}:")
 
         if result is None:
             if len(failures) > 0 or script_failed:
-                f.write("  fail\n")
+                self._print("  fail")
                 for failure in failures:
-                    f.write(f"    {_strip_rich_markup(failure)}\n")
+                    self._print(f"    {failure}")
                 if script_failed and failure_message:
-                    f.write(f"    {_strip_rich_markup(failure_message)}\n")
+                    self._print(f"    {failure_message}")
             else:
-                f.write("  pass\n")
+                self._print("  pass")
                 for warning in warnings:
-                    f.write(f"    {_strip_rich_markup(warning)}\n")
-            f.flush()
+                    self._print(f"    {warning}")
             return
 
         for failure in failures:
-            f.write(f"  {_strip_rich_markup(failure)}\n")
+            self._print(f"  {failure}")
         for warning in warnings:
-            f.write(f"  {_strip_rich_markup(warning)}\n")
+            self._print(f"  {warning}")
 
         if isinstance(result, list) and len(result) == 0:
-            f.write("  No results found.\n")
-            f.flush()
+            self._print("  No results found.")
             return
 
         table_data = extract_table_data(result, self._verbose_getter())
         if table_data is None:
-            f.write(f"  {result}\n")
-            f.flush()
+            self._print(f"  {result}")
             return
 
-        self._writer.writerow(table_data.columns)
+        self._print_csv_row(table_data.columns)
         for row in table_data.rows:
-            self._writer.writerow(row)
-        f.flush()
-
-    def close(self) -> None:
-        if not self._file.closed:
-            self._file.close()
-
-
-class MultiSerializer(OutputSerializer):
-    """Fans a single emit out to several serializers (e.g. Rich + CSV)."""
-
-    def __init__(self, serializers: Iterable[OutputSerializer]):
-        self._serializers = list(serializers)
-
-    def emit(
-        self,
-        script_name: str | None,
-        execution_time: str,
-        result: Any,
-        failures: list[str],
-        warnings: list[str],
-        script_failed: bool,
-        failure_message: str | None,
-        documentation: str | None,
-    ) -> None:
-        for s in self._serializers:
-            s.emit(
-                script_name=script_name,
-                execution_time=execution_time,
-                result=result,
-                failures=failures,
-                warnings=warnings,
-                script_failed=script_failed,
-                failure_message=failure_message,
-                documentation=documentation,
-            )
-
-    def close(self) -> None:
-        for s in self._serializers:
-            s.close()
+            self._print_csv_row(row)

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Output serializers for tt-triage script results.
+
+Each script's result flows through `serialize_result()` in `triage.py`, which
+delegates to an `OutputSerializer`. The default `RichSerializer` renders Rich
+tables to the console. The `CsvSerializer` writes a single text report
+file whose tables are emitted as CSV — easier and cheaper to consume for
+machine readers (LLMs, grep, diff) than the Rich box-drawing format.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import textwrap
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, fields, is_dataclass
+from typing import Any, Callable, Iterable
+
+
+@dataclass
+class TableData:
+    columns: list[str]
+    rows: list[list[str]]
+
+
+def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
+    """
+    Convert a dataclass or list-of-dataclasses to a `TableData`.
+
+    Returns `None` for results that aren't a dataclass or non-empty list of
+    dataclasses — those are emitted as plain strings by serializers.
+    """
+    if not (
+        is_dataclass(result)
+        or (isinstance(result, list) and len(result) > 0 and all(is_dataclass(item) for item in result))
+    ):
+        return None
+
+    if not isinstance(result, list):
+        result = [result]
+
+    columns: list[str] = []
+
+    def collect_header(obj: Any, flds: Iterable[Any]) -> None:
+        for fld in flds:
+            metadata = fld.metadata
+            if metadata.get("verbose", 0) > verbose_level:
+                continue
+            if metadata.get("dont_serialize"):
+                continue
+            if metadata.get("recurse"):
+                value = getattr(obj, fld.name)
+                assert is_dataclass(value)
+                collect_header(value, fields(value))
+            elif "serialized_name" in metadata:
+                columns.append(metadata.get("serialized_name") or fld.name)
+
+    def collect_row(row: list[str], obj: Any, flds: Iterable[Any]) -> None:
+        for fld in flds:
+            metadata = fld.metadata
+            if metadata.get("verbose", 0) > verbose_level:
+                continue
+            if metadata.get("dont_serialize"):
+                continue
+            if metadata.get("recurse"):
+                value = getattr(obj, fld.name)
+                assert is_dataclass(value)
+                collect_row(row, value, fields(value))
+            elif "additional_fields" in metadata:
+                assert all(hasattr(obj, af) for af in metadata["additional_fields"])
+                all_values = [getattr(obj, fld.name)]
+                all_values.extend(getattr(obj, af) for af in metadata["additional_fields"])
+                assert "serializer" in metadata, "Serializer must be provided for combined field."
+                row.append(metadata["serializer"](all_values))
+            elif "serializer" in metadata:
+                row.append(metadata["serializer"](getattr(obj, fld.name)))
+
+    collect_header(result[0], fields(result[0]))
+    rows: list[list[str]] = []
+    for item in result:
+        row: list[str] = []
+        collect_row(row, item, fields(item))
+        rows.append(row)
+    return TableData(columns=columns, rows=rows)
+
+
+class OutputSerializer(ABC):
+    """Sink for one script's serialized result. Subclasses must implement `emit` and `close`."""
+
+    @abstractmethod
+    def emit(
+        self,
+        script_name: str | None,
+        execution_time: str,
+        result: Any,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+        documentation: str | None,
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        ...
+
+
+class RichSerializer(OutputSerializer):
+    """Renders results as Rich tables to the console."""
+
+    def __init__(self, console: Any, utils_module: Any, verbose_level_getter: Callable[[], int]):
+        self._console = console
+        self._utils = utils_module
+        self._verbose_getter = verbose_level_getter
+
+    def emit(
+        self,
+        script_name: str | None,
+        execution_time: str,
+        result: Any,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+        documentation: str | None,
+    ) -> None:
+        from rich.table import Table
+
+        utils = self._utils
+        if script_name is not None:
+            print()
+            utils.INFO(f"{script_name}{execution_time}:")
+
+        if result is None:
+            if len(failures) > 0 or script_failed:
+                utils.ERROR("  fail")
+                for failure in failures:
+                    utils.ERROR(f"    {failure}")
+                if script_failed:
+                    utils.ERROR(f"    {failure_message}")
+                    if documentation:
+                        docstring_indented = textwrap.indent(documentation.strip(), "    ")
+                        utils.ERROR(f"  Script help:\n{docstring_indented}")
+            else:
+                utils.INFO("  pass")
+                for warning in warnings:
+                    utils.WARN(f"    {warning}")
+            return
+
+        for failure in failures:
+            utils.ERROR(f"  {failure}")
+        for warning in warnings:
+            utils.WARN(f"  {warning}")
+
+        if isinstance(result, list) and len(result) == 0:
+            utils.ERROR("  No results found.")
+
+        table_data = extract_table_data(result, self._verbose_getter())
+        if table_data is None:
+            utils.INFO(f"  {result}")
+            return
+
+        table = Table()
+        for col in table_data.columns:
+            table.add_column(col, justify="left")
+        for row in table_data.rows:
+            table.add_row(*row)
+        self._console.print(table)
+
+    def close(self) -> None:
+        pass
+
+
+class CsvSerializer(OutputSerializer):
+    """
+    Writes a report with one section per script.
+
+    Each section mirrors the console layout (`<script>:`, then `pass`/`fail`
+    and any warnings/failures), then emits tabular data as a CSV block.
+    """
+
+    def __init__(self, path: str, verbose_level_getter: Callable[[], int]):
+        self._path = path
+        self._verbose_getter = verbose_level_getter
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        self._file = open(path, "w", encoding="utf-8")
+        self._writer = csv.writer(self._file, lineterminator="\n")
+
+    def emit(
+        self,
+        script_name: str | None,
+        execution_time: str,
+        result: Any,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+        documentation: str | None,
+    ) -> None:
+        f = self._file
+        if script_name is not None:
+            f.write("\n")
+            f.write(f"{script_name}{execution_time}:\n")
+
+        if result is None:
+            if len(failures) > 0 or script_failed:
+                f.write("  fail\n")
+                for failure in failures:
+                    f.write(f"    {failure}\n")
+                if script_failed and failure_message:
+                    f.write(f"    {failure_message}\n")
+            else:
+                f.write("  pass\n")
+                for warning in warnings:
+                    f.write(f"    {warning}\n")
+            f.flush()
+            return
+
+        for failure in failures:
+            f.write(f"  {failure}\n")
+        for warning in warnings:
+            f.write(f"  {warning}\n")
+
+        if isinstance(result, list) and len(result) == 0:
+            f.write("  No results found.\n")
+            f.flush()
+            return
+
+        table_data = extract_table_data(result, self._verbose_getter())
+        if table_data is None:
+            f.write(f"  {result}\n")
+            f.flush()
+            return
+
+        self._writer.writerow(table_data.columns)
+        for row in table_data.rows:
+            self._writer.writerow(row)
+        f.flush()
+
+    def close(self) -> None:
+        if not self._file.closed:
+            self._file.close()
+
+
+class MultiSerializer(OutputSerializer):
+    """Fans a single emit out to several serializers (e.g. Rich + CSV)."""
+
+    def __init__(self, serializers: Iterable[OutputSerializer]):
+        self._serializers = list(serializers)
+
+    def emit(
+        self,
+        script_name: str | None,
+        execution_time: str,
+        result: Any,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+        documentation: str | None,
+    ) -> None:
+        for s in self._serializers:
+            s.emit(
+                script_name=script_name,
+                execution_time=execution_time,
+                result=result,
+                failures=failures,
+                warnings=warnings,
+                script_failed=script_failed,
+                failure_message=failure_message,
+                documentation=documentation,
+            )
+
+    def close(self) -> None:
+        for s in self._serializers:
+            s.close()

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -178,6 +178,18 @@ class RichSerializer(OutputSerializer):
         pass
 
 
+def _strip_rich_markup(s: str) -> str:
+    """Strip Rich markup tags (e.g. `[warning]...[/]`) from a string.
+
+    Log helpers in utils.py wrap messages in Rich tags for console rendering,
+    and some scripts embed inline markup in their messages. The Rich console
+    renders these away; a plain-text file must do the equivalent stripping.
+    """
+    from rich.text import Text
+
+    return Text.from_markup(s).plain
+
+
 class CsvSerializer(OutputSerializer):
     """
     Writes a report with one section per script.
@@ -215,20 +227,20 @@ class CsvSerializer(OutputSerializer):
             if len(failures) > 0 or script_failed:
                 f.write("  fail\n")
                 for failure in failures:
-                    f.write(f"    {failure}\n")
+                    f.write(f"    {_strip_rich_markup(failure)}\n")
                 if script_failed and failure_message:
-                    f.write(f"    {failure_message}\n")
+                    f.write(f"    {_strip_rich_markup(failure_message)}\n")
             else:
                 f.write("  pass\n")
                 for warning in warnings:
-                    f.write(f"    {warning}\n")
+                    f.write(f"    {_strip_rich_markup(warning)}\n")
             f.flush()
             return
 
         for failure in failures:
-            f.write(f"  {failure}\n")
+            f.write(f"  {_strip_rich_markup(failure)}\n")
         for warning in warnings:
-            f.write(f"  {warning}\n")
+            f.write(f"  {_strip_rich_markup(warning)}\n")
 
         if isinstance(result, list) and len(result) == 0:
             f.write("  No results found.\n")

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,7 +5,7 @@
 
 """
 Usage:
-    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>]
+    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output=<path>]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
@@ -25,6 +25,7 @@ Options:
     --disable-progress               Disable progress bars. [default: False]
     --disable-elf-cache              Re-parse ELF files on every access instead of caching. [default: False]
     --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
+    --llm-output=<path>              Write a compact text report with CSV-formatted tables to <path>. Easier and cheaper for LLMs (and grep/CI) to consume than the Rich-table console output.
 
 Description:
     Diagnoses Tenstorrent AI hardware by performing comprehensive health checks on ARC processors, NOC connectivity, L1 memory, and RISC-V cores.
@@ -76,7 +77,6 @@ import importlib
 import importlib.metadata as importlib_metadata
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TimeRemainingColumn, BarColumn, TextColumn
-from rich.table import Table
 import sys
 from ttexalens.context import Context
 from ttexalens.device import Device
@@ -617,13 +617,42 @@ def log_warning_risc(risc_name: str, location: OnChipCoordinate, message: str) -
     log_warning_location(location, f"{risc_name}: {message}")
 
 
+_output_serializer: Any = None
+
+
+def get_output_serializer() -> Any:
+    """Return the active serializer, defaulting to a Rich-console one on first use."""
+    global _output_serializer
+    if _output_serializer is None:
+        from serializers import RichSerializer
+
+        _output_serializer = RichSerializer(console, utils, get_verbose_level)
+    return _output_serializer
+
+
+def set_output_serializer(serializer: Any) -> None:
+    global _output_serializer
+    _output_serializer = serializer
+
+
+def init_output_serializer(args: ScriptArguments) -> None:
+    """Build the active serializer based on CLI args.
+
+    Default: `RichSerializer`. If `--llm-output=<path>` is set, fan out to both
+    Rich and `CsvSerializer` so the console view is preserved while a
+    machine-readable file is also written.
+    """
+    from serializers import CsvSerializer, MultiSerializer, RichSerializer
+
+    rich = RichSerializer(console, utils, get_verbose_level)
+    llm_output_path = args["--llm-output"]
+    if llm_output_path:
+        set_output_serializer(MultiSerializer([rich, CsvSerializer(llm_output_path, get_verbose_level)]))
+    else:
+        set_output_serializer(rich)
+
+
 def serialize_result(script: TriageScript | None, result, execution_time: str = ""):
-    from dataclasses import fields, is_dataclass
-
-    if script is not None:
-        print()
-        utils.INFO(f"{script.name}{execution_time}:")
-
     global FAILURE_CHECKS, FAILURE_CHECKS_LOCK, WARNING_CHECKS, WARNING_CHECKS_LOCK
     with FAILURE_CHECKS_LOCK:
         failures = FAILURE_CHECKS
@@ -631,87 +660,17 @@ def serialize_result(script: TriageScript | None, result, execution_time: str = 
     with WARNING_CHECKS_LOCK:
         warnings = WARNING_CHECKS
         WARNING_CHECKS = []
-    if result is None:
-        if len(failures) > 0 or script.failed:
-            utils.ERROR("  fail")
-            for failure in failures:
-                utils.ERROR(f"    {failure}")
-            if script.failed:
-                utils.ERROR(f"    {script.failure_message}")
 
-                import textwrap
-
-                docstring_indented = textwrap.indent(script.documentation.strip(), "    ")
-                utils.ERROR(f"  Script help:\n{docstring_indented}")
-        else:
-            utils.INFO("  pass")
-            for warning in warnings:
-                utils.WARN(f"    {warning}")
-        return
-
-    for failure in failures:
-        utils.ERROR(f"  {failure}")
-
-    for warning in warnings:
-        utils.WARN(f"  {warning}")
-
-    if isinstance(result, list) and len(result) == 0:
-        utils.ERROR("  No results found.")
-
-    if not (is_dataclass(result) or (isinstance(result, list) and all(is_dataclass(item) for item in result))):
-        utils.INFO(f"  {result}")
-    else:
-        if not isinstance(result, list):
-            result = [result]
-
-        def generate_header(table: Table, obj, flds):
-            for field in flds:
-                metadata = field.metadata
-                # Skip field if it requires higher verbosity level
-                if metadata.get("verbose", 0) > _verbose_level:
-                    continue
-                if "dont_serialize" in metadata and metadata["dont_serialize"]:
-                    continue
-                elif "recurse" in metadata and metadata["recurse"]:
-                    value = getattr(obj, field.name)
-                    assert is_dataclass(value)
-                    generate_header(table, value, fields(value))
-                elif "serialized_name" in metadata:
-                    justify = metadata.get("justify", "left")
-                    table.add_column(metadata.get("serialized_name", field.name), justify=justify)
-
-        def generate_row(row: list[str], obj, flds):
-            for field in flds:
-                metadata = field.metadata
-                # Skip field if it requires higher verbosity level
-                if metadata.get("verbose", 0) > _verbose_level:
-                    continue
-                if "dont_serialize" in metadata and metadata["dont_serialize"]:
-                    continue
-                elif "recurse" in metadata and metadata["recurse"]:
-                    value = getattr(obj, field.name)
-                    assert is_dataclass(value)
-                    generate_row(row, value, fields(value))
-                elif "additional_fields" in metadata:
-                    assert all(hasattr(obj, additional_field) for additional_field in metadata["additional_fields"])
-                    all_values = [getattr(obj, field.name)]
-                    all_values.extend(
-                        [getattr(obj, additional_field) for additional_field in metadata["additional_fields"]]
-                    )
-                    assert "serializer" in metadata, "Serializer must be provided for combined field."
-                    row.append(metadata["serializer"](all_values))
-                elif "serializer" in metadata:
-                    row.append(metadata["serializer"](getattr(obj, field.name)))
-
-        table = Table()
-
-        # Create table header
-        generate_header(table, result[0], fields(result[0]))
-        for item in result:
-            row: list[str] = []
-            generate_row(row, item, fields(item))
-            table.add_row(*row)
-        console.print(table)
+    get_output_serializer().emit(
+        script_name=script.name if script is not None else None,
+        execution_time=execution_time,
+        result=result,
+        failures=failures,
+        warnings=warnings,
+        script_failed=script.failed if script is not None else False,
+        failure_message=script.failure_message if script is not None else None,
+        documentation=script.documentation if script is not None else None,
+    )
 
 
 def _enforce_dependencies(args: ScriptArguments) -> None:
@@ -887,6 +846,8 @@ def run_script(
             all_scripts.setdefault(path, script)
         args = parse_arguments(all_scripts, script_path, argv)
 
+    init_output_serializer(args)
+
     # Initialize context if not provided
     if context is None:
         _enforce_dependencies(args)
@@ -907,6 +868,7 @@ def run_script(
     serialize_result(script, result)
 
     if force_exit:
+        get_output_serializer().close()
         # Remove nanobind leak check to avoid false positives on exit
         os._exit(0)
 
@@ -960,6 +922,8 @@ def main():
 
     # Parse common command line arguments
     args = parse_arguments(scripts)
+
+    init_output_serializer(args)
 
     # Enforce debugger dependencies, then initialize
     _enforce_dependencies(args)
@@ -1035,6 +999,8 @@ def main():
     from elfs_cache import run as get_elfs_cache
 
     get_elfs_cache(args, context).log_stats()
+
+    get_output_serializer().close()
 
     # Remove nanobind leak check to avoid false positives on exit
     os._exit(0)

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,7 +5,7 @@
 
 """
 Usage:
-    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output=<path>]
+    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
@@ -25,7 +25,7 @@ Options:
     --disable-progress               Disable progress bars. [default: False]
     --disable-elf-cache              Re-parse ELF files on every access instead of caching. [default: False]
     --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
-    --llm-output=<path>              Write a compact text report with CSV-formatted tables to <path>. Easier and cheaper for LLMs (and grep/CI) to consume than the Rich-table console output.
+    --llm-output                     Print machine-readable report (CSV-formatted tables) to stdout instead of Rich tables. Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
 
 Description:
     Diagnoses Tenstorrent AI hardware by performing comprehensive health checks on ARC processors, NOC connectivity, L1 memory, and RISC-V cores.
@@ -435,8 +435,11 @@ def init_console_and_verbosity(args: ScriptArguments) -> None:
     # When in a terminal, let Rich auto-detect the terminal width.
     # Similarly, if verbosity is increased, use larger width to avoid wrapping.
     width = None if sys.stdout.isatty() and _verbose_level == 0 else 10000
-    console = Console(theme=utils.create_console_theme(args["--disable-colors"]), highlight=False, width=width)
-    progress_disabled = bool(args["--disable-progress"])
+    # --llm-output implies no colors: non-table console output (status lines,
+    # warnings) needs to stay plain text for cheap LLM consumption.
+    disable_colors = bool(args["--disable-colors"]) or bool(args["--llm-output"])
+    console = Console(theme=utils.create_console_theme(disable_colors), highlight=False, width=width)
+    progress_disabled = bool(args["--disable-progress"]) or bool(args["--llm-output"])
 
     # Set verbose level from -v count (controls which columns are displayed)
     verbose_level = args["-v"] or 0
@@ -638,18 +641,16 @@ def set_output_serializer(serializer: Any) -> None:
 def init_output_serializer(args: ScriptArguments) -> None:
     """Build the active serializer based on CLI args.
 
-    Default: `RichSerializer`. If `--llm-output=<path>` is set, fan out to both
-    Rich and `CsvSerializer` so the console view is preserved while a
-    machine-readable file is also written.
+    Default: `RichSerializer`. If `--llm-output` is set,
+    swap in `CsvSerializer` — replacing Rich tables with CSV-formatted
+    ones for cheaper LLM/grep consumption.
     """
-    from serializers import CsvSerializer, MultiSerializer, RichSerializer
+    from serializers import CsvSerializer, RichSerializer
 
-    rich = RichSerializer(console, utils, get_verbose_level)
-    llm_output_path = args["--llm-output"]
-    if llm_output_path:
-        set_output_serializer(MultiSerializer([rich, CsvSerializer(llm_output_path, get_verbose_level)]))
+    if args["--llm-output"]:
+        set_output_serializer(CsvSerializer(console, get_verbose_level))
     else:
-        set_output_serializer(rich)
+        set_output_serializer(RichSerializer(console, utils, get_verbose_level))
 
 
 def serialize_result(script: TriageScript | None, result, execution_time: str = ""):
@@ -846,8 +847,6 @@ def run_script(
             all_scripts.setdefault(path, script)
         args = parse_arguments(all_scripts, script_path, argv)
 
-    init_output_serializer(args)
-
     # Initialize context if not provided
     if context is None:
         _enforce_dependencies(args)
@@ -865,10 +864,10 @@ def run_script(
     script = scripts[script_path] if script_path in scripts else None
     if return_result:
         return result
+    init_output_serializer(args)
     serialize_result(script, result)
 
     if force_exit:
-        get_output_serializer().close()
         # Remove nanobind leak check to avoid false positives on exit
         os._exit(0)
 
@@ -999,8 +998,6 @@ def main():
     from elfs_cache import run as get_elfs_cache
 
     get_elfs_cache(args, context).log_stats()
-
-    get_output_serializer().close()
 
     # Remove nanobind leak check to avoid false positives on exit
     os._exit(0)

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,7 +5,7 @@
 
 """
 Usage:
-    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output]
+    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
@@ -25,7 +25,8 @@ Options:
     --disable-progress               Disable progress bars. [default: False]
     --disable-elf-cache              Re-parse ELF files on every access instead of caching. [default: False]
     --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
-    --llm-output                     Print machine-readable report (CSV-formatted tables) to stdout instead of Rich tables. Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
+    --llm-output                     Replace Rich tables on the console with a machine-readable report (CSV-formatted tables). Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
+    --llm-output-path=<path>         Additionally write the machine-readable report to <path>. Can be combined with --llm-output; without it, Rich output still goes to the console.
 
 Description:
     Diagnoses Tenstorrent AI hardware by performing comprehensive health checks on ARC processors, NOC connectivity, L1 memory, and RISC-V cores.
@@ -639,18 +640,33 @@ def set_output_serializer(serializer: Any) -> None:
 
 
 def init_output_serializer(args: ScriptArguments) -> None:
-    """Build the active serializer based on CLI args.
+    """Build the active serializer(s) based on CLI args.
 
-    Default: `RichSerializer`. If `--llm-output` is set,
-    swap in `CsvSerializer` — replacing Rich tables with CSV-formatted
-    ones for cheaper LLM/grep consumption.
+    Combinations:
+      neither flag                      -> RichSerializer on the console
+      --llm-output                      -> CsvSerializer on the console (replaces Rich)
+      --llm-output-path=<path>          -> Rich on console + CsvSerializer to file
+      --llm-output --llm-output-path=.. -> CsvSerializer on console + CsvSerializer to file
     """
-    from serializers import CsvSerializer, RichSerializer
+    from serializers import ConsoleSink, CsvSerializer, FileSink, MultiSerializer, RichSerializer
+
+    console_sink = ConsoleSink(console)
+    serializers: list[Any] = []
 
     if args["--llm-output"]:
-        set_output_serializer(CsvSerializer(console, get_verbose_level))
+        serializers.append(CsvSerializer(console_sink, get_verbose_level))
     else:
-        set_output_serializer(RichSerializer(console, utils, get_verbose_level))
+        serializers.append(RichSerializer(console_sink, utils, get_verbose_level))
+
+    csv_path = args["--llm-output-path"]
+    if csv_path:
+        try:
+            file_sink = FileSink(csv_path)
+            serializers.append(CsvSerializer(file_sink, get_verbose_level))
+        except OSError as e:
+            utils.WARN(f"Failed to open --llm-output-path={csv_path!r}: {e}. File output will be skipped.")
+
+    set_output_serializer(serializers[0] if len(serializers) == 1 else MultiSerializer(serializers))
 
 
 def serialize_result(script: TriageScript | None, result, execution_time: str = ""):
@@ -868,6 +884,7 @@ def run_script(
     serialize_result(script, result)
 
     if force_exit:
+        get_output_serializer().close()
         # Remove nanobind leak check to avoid false positives on exit
         os._exit(0)
 
@@ -998,6 +1015,8 @@ def main():
     from elfs_cache import run as get_elfs_cache
 
     get_elfs_cache(args, context).log_stats()
+
+    get_output_serializer().close()
 
     # Remove nanobind leak check to avoid false positives on exit
     os._exit(0)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

#### What changed
Two new CLI flags for LLM-/grep-friendly triage output:
- `--llm-output` — replace Rich tables on the console with CSV-formatted output.
- `--llm-output-path=<path>` — additionally write the same CSV-formatted output to a file (can be combined with `--llm-output`).

Cell content is preserved; only the table framing changes. Default behavior is unchanged when neither flag is set. Closes https://github.com/tenstorrent/tt-exalens/issues/1022

#### How it changed
- New `tools/triage/serializers.py` with two orthogonal hierarchies:
  - **Format** (`OutputSerializer` ABC): `RichSerializer`, `CsvSerializer`, `MultiSerializer` (fan-out).
  - **Destination** (`Sink` ABC): `ConsoleSink` (writes through Rich, exposes `write_rich` for `Table` renderables), `FileSink` (opens/closes a file, normalizes the path, auto-creates parent dirs).
- One `CsvSerializer(sink, …)` covers any destination; future formats (e.g. JSON) plug in by accepting a `Sink`.
- Cell content is normalized for grep-friendly output:
  - Rich markup (`[blue]…[/]`, `[error]…[/]`) stripped via `Text.from_markup(...).plain`, with `MarkupError` fallback so coordinate strings like `[1-1 (0,0)]` and op_mesh straggler markers like `[!] core` pass through unchanged.
  - Embedded newlines in cell values (`dump_op_mesh` chip labels, `dump_running_operations` tensor args, callstack frames) are escaped to literal `\n` so each record is exactly one physical line.
- `--llm-output` implies `--disable-colors` and disables progress bars so non-table console output stays plain text.

## Token comparison: Rich console vs `--llm-output` (measured on a simple single-device hang)
Measured with Anthropic's `messages.count_tokens` API on `claude-opus-4-7`.

| File | Chars | Claude tokens (`count_tokens`) |
|---|---:|---:|
| Rich console | 88,444 | **41,092** |
| `--llm-output` | 48,125 | **30,606** |
| **Savings** | 46% | **25.5% (10,486 tokens)** |

Savings come from removing column padding, box-drawing characters, and per-cell ANSI overhead; they scale with table size (rows × columns × content width).

### Usage
```bash
# CSV on console (replaces Rich)
python tools/tt-triage.py --llm-output

# Rich on console + CSV in a file (CI use case)
python tools/tt-triage.py --llm-output-path=/tmp/report.txt

# CSV on console AND in a file
python tools/tt-triage.py --llm-output --llm-output-path=/tmp/report.txt
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-llm-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-llm-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/triage-llm-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-llm-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-llm-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-llm-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-llm-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-llm-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-llm-output)
