### PR TITLE
PCC test now asserts correctly (bug fix)

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1067,13 +1067,16 @@ def test_demo_text(
         if pcc_check:
             torch_output_logits = torch_output[0]
             logits = tt_out_logits_all_users[0, 0, :vocab_size]
-            does_pass, pcc_message = comp_pcc(
-                logits, torch_output_logits, 0.90 if not apc_test else demo_targets["prefill_pcc"]
-            )
+            expected_prefill_pcc = 0.90 if not apc_test else demo_targets["prefill_pcc"]
+            does_pass, pcc_message = comp_pcc(logits, torch_output_logits, expected_prefill_pcc)
             logger.info(f"PCC: {pcc_message}")
             logger.info(
                 f"Teacher forced token at prefill {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
             )
+            if not apc_test:
+                assert does_pass, (
+                    f"Prefill PCC check failed: {pcc_message}, while expected >= {expected_prefill_pcc}."
+                )
         if apc_test:
             assert_message = (
                 f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"
@@ -1211,14 +1214,18 @@ def test_demo_text(
                         torch_output_logits = torch_output[1]
                     else:
                         torch_output_logits = torch_output[iteration + 1]
-                    does_pass, pcc_message = comp_pcc(
-                        tt_out_logits_saved, torch_output_logits, 0.91 if not apc_test else demo_targets["decode_pcc"]
-                    )
+                    expected_decode_pcc = 0.91 if not apc_test else demo_targets["decode_pcc"]
+                    does_pass, pcc_message = comp_pcc(tt_out_logits_saved, torch_output_logits, expected_decode_pcc)
                     logger.info(f"PCC: {pcc_message}")
                     logger.info(
                         f"Teacher forced token at decode iteration {iteration} "
                         f"{'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
                     )
+                    if not apc_test:
+                        assert does_pass, (
+                            f"Decode PCC check failed at iteration {iteration}: {pcc_message}, "
+                            f"while expected >= {expected_decode_pcc}."
+                        )
 
                 if apc_test:
                     assert_message = (

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1074,9 +1074,7 @@ def test_demo_text(
                 f"Teacher forced token at prefill {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
             )
             if not apc_test:
-                assert does_pass, (
-                    f"Prefill PCC check failed: {pcc_message}, while expected >= {expected_prefill_pcc}."
-                )
+                assert does_pass, f"Prefill PCC check failed: {pcc_message}, while expected >= {expected_prefill_pcc}."
         if apc_test:
             assert_message = (
                 f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -709,13 +709,16 @@ def test_qwen_demo_text(
         if pcc_check:
             torch_output_logits = torch_output[0]
             logits = tt_out_logits_all_users[0, 0, :vocab_size]
-            does_pass, pcc_message = comp_pcc(
-                logits, torch_output_logits, 0.91 if not apc_test else demo_targets["prefill_pcc"]
-            )
+            expected_prefill_pcc = 0.91 if not apc_test else demo_targets["prefill_pcc"]
+            does_pass, pcc_message = comp_pcc(logits, torch_output_logits, expected_prefill_pcc)
             logger.info(f"PCC: {pcc_message}")
             logger.info(
                 f"Teacher forced token at prefill {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
             )
+            if not apc_test:
+                assert does_pass, (
+                    f"Prefill PCC check failed: {pcc_message}, while expected >= {expected_prefill_pcc}."
+                )
         if apc_test:
             assert_message = (
                 f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"
@@ -847,13 +850,17 @@ def test_qwen_demo_text(
                         torch_output_logits = torch_output[1]  # 0 is prefill logits
                     else:
                         torch_output_logits = torch_output[iteration + 1]
-                    does_pass, pcc_message = comp_pcc(
-                        tt_out_logits_saved, torch_output_logits, 0.91 if not apc_test else demo_targets["decode_pcc"]
-                    )
+                    expected_decode_pcc = 0.91 if not apc_test else demo_targets["decode_pcc"]
+                    does_pass, pcc_message = comp_pcc(tt_out_logits_saved, torch_output_logits, expected_decode_pcc)
                     logger.info(f"PCC: {pcc_message}")
                     logger.info(
                         f"Teacher forced token at decode iteration {iteration} {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
                     )
+                    if not apc_test:
+                        assert does_pass, (
+                            f"Decode PCC check failed at iteration {iteration}: {pcc_message}, "
+                            f"while expected >= {expected_decode_pcc}."
+                        )
                 if apc_test:
                     assert_message = (
                         f"Decode PCC check failed: {pcc_message}, while expected {demo_targets['decode_pcc']}.\n"

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -716,9 +716,7 @@ def test_qwen_demo_text(
                 f"Teacher forced token at prefill {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
             )
             if not apc_test:
-                assert does_pass, (
-                    f"Prefill PCC check failed: {pcc_message}, while expected >= {expected_prefill_pcc}."
-                )
+                assert does_pass, f"Prefill PCC check failed: {pcc_message}, while expected >= {expected_prefill_pcc}."
         if apc_test:
             assert_message = (
                 f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"


### PR DESCRIPTION
###Bug fix

### Summary
The problem was that the Galaxy Llama/Qwen PCC demo paths called comp_pcc(...) and logged FAILED PCC check when PCC was below threshold, but the regular PCC modes never asserted on the returned does_pass boolean. Pytest then reported status PASSED even after a PCC failure.

### Notes for reviewers
The fix stores the expected PCC threshold, checks does_pass, and asserts when it is false for non-APC PCC runs. APC keeps its existing exact target checks. I applied this to both prefill and decode PCC checks in text_demo.py, and mirrored the same pattern in text_qwen_demo.py because it had the same issue.

CI tests:
Llama 3.3 70B pcc80L test in the CI: https://github.com/tenstorrent/tt-metal/actions/runs/25860296842

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fixed_assert_on_pcc_80l)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fixed_assert_on_pcc_80l)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fixed_assert_on_pcc_80l)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fixed_assert_on_pcc_80l)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fixed_assert_on_pcc_80l)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fixed_assert_on_pcc_80l)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fixed_assert_on_pcc_80l)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fixed_assert_on_pcc_80l)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fixed_assert_on_pcc_80l)