### PR TITLE
[Test] Replace assert_with_pcc in eltwise unary/activation test files

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -18,7 +18,7 @@ from tests.ttnn.utils_for_testing import (
 pytestmark = pytest.mark.use_module_device
 
 
-def run_activation_unary_test(device, h, w, ttnn_function, ulp=2, pcc_check=False):
+def run_activation_unary_test(device, h, w, ttnn_function, ulp=2, pcc_check=False, pcc=0.99):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((h, w), dtype=torch.bfloat16)
@@ -32,7 +32,7 @@ def run_activation_unary_test(device, h, w, ttnn_function, ulp=2, pcc_check=Fals
     output_tensor = ttnn.to_torch(output_tensor)
 
     if pcc_check:
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     else:
         assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
@@ -182,7 +182,7 @@ def test_tanhshrink(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.tanhshrink, pcc_check=True)
 
 
-def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, ulp=2, pcc_check=False):
+def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, ulp=2, pcc_check=False, pcc=0.99):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16).unsqueeze(0)
@@ -196,7 +196,7 @@ def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, 
     output_tensor = ttnn.to_torch(output_tensor)
 
     if pcc_check:
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     else:
         assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
@@ -334,7 +334,10 @@ def test_scalarB_celu(device, h, w, alpha, torch_dtype, ttnn_dtype):
 
     output_tensor = ttnn.celu(input_tensor_a, alpha=alpha)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_ulp(torch_output_tensor, output_tensor)
+    if ttnn_dtype == ttnn.bfloat4_b:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=2)
 
 
 @pytest.mark.parametrize("scalar", [0.5, 1.0])
@@ -430,24 +433,22 @@ def test_scalarBC_clip(device, h, w, min, max):
     run_activation_test_scalarBC_key(device, h, w, min, max, ttnn.clip)
 
 
-def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function, ulp=2, pcc_check=False):
+def run_activation_test_threshold(device, h, w, value, threshold, ttnn_function, ulp=1):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn_function)
 
-    torch_output_tensor = golden_function(torch_input_tensor_a, value=scalar1, threshold=scalar2)
+    torch_output_tensor = golden_function(torch_input_tensor_a, value=value, threshold=threshold)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn_function(input_tensor_a, scalar1, scalar2)
+    output_tensor = ttnn_function(input_tensor_a, threshold, value)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    if pcc_check:
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    else:
-        assert_with_ulp(torch_output_tensor, output_tensor, ulp)
+    # threshold is a piecewise-exact op; use ULP=1 to absorb bf16 rounding of non-representable scalars.
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("value", [-0.5, -0.1, -5.5])
@@ -455,7 +456,7 @@ def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function,
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_threshold(device, h, w, value, threshold):
-    run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold, pcc_check=True)
+    run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold)
 
 
 @pytest.mark.parametrize("ttnn_dtype, torch_dtype", [(ttnn.float32, torch.float32), (ttnn.bfloat16, torch.bfloat16)])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -18,7 +18,7 @@ from tests.ttnn.utils_for_testing import (
 pytestmark = pytest.mark.use_module_device
 
 
-def run_activation_unary_test(device, h, w, ttnn_function, pcc=0.99):
+def run_activation_unary_test(device, h, w, ttnn_function, ulp=2, pcc_check=False):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((h, w), dtype=torch.bfloat16)
@@ -31,7 +31,10 @@ def run_activation_unary_test(device, h, w, ttnn_function, pcc=0.99):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    if pcc_check:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -61,7 +64,7 @@ def test_log_sigmoid(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_mish(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.mish)
+    run_activation_unary_test(device, h, w, ttnn.mish, ulp=3)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -176,10 +179,10 @@ def test_softplus(device, h, w, beta, threshold):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_tanhshrink(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.tanhshrink)
+    run_activation_unary_test(device, h, w, ttnn.tanhshrink, pcc_check=True)
 
 
-def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, pcc=0.99):
+def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, ulp=2, pcc_check=False):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16).unsqueeze(0)
@@ -192,7 +195,10 @@ def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, 
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    if pcc_check:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("batch_size", [1, 4])
@@ -224,7 +230,7 @@ def test_swiglu(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
 def test_geglu(device, batch_size, h, w, dim):
-    run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.geglu)
+    run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.geglu, pcc_check=True)
 
 
 def torch_prelu(x, *args, weight, **kwargs):
@@ -232,7 +238,7 @@ def torch_prelu(x, *args, weight, **kwargs):
     return result
 
 
-def run_activation_test_elu(device, h, w, scalar, ttnn_function, pcc=0.99):
+def run_activation_test_elu(device, h, w, scalar, ttnn_function, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -245,10 +251,10 @@ def run_activation_test_elu(device, h, w, scalar, ttnn_function, pcc=0.99):
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
-def run_activation_test_leaky_relu(device, h, w, scalar, ttnn_function, pcc=0.99):
+def run_activation_test_leaky_relu(device, h, w, scalar, ttnn_function, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -261,10 +267,10 @@ def run_activation_test_leaky_relu(device, h, w, scalar, ttnn_function, pcc=0.99
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
-def run_activation_test_scalarB(device, h, w, scalar, ttnn_function, pcc=0.99):
+def run_activation_test_scalarB(device, h, w, scalar, ttnn_function, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -277,10 +283,10 @@ def run_activation_test_scalarB(device, h, w, scalar, ttnn_function, pcc=0.99):
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
-def run_activation_test_scalarB_key(device, h, w, value, ttnn_function, pcc=0.99):
+def run_activation_test_scalarB_key(device, h, w, value, ttnn_function, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -293,7 +299,7 @@ def run_activation_test_scalarB_key(device, h, w, value, ttnn_function, pcc=0.99
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("scalar", [-0.5, 0, 0.5])
@@ -329,7 +335,6 @@ def test_scalarB_celu(device, h, w, alpha, torch_dtype, ttnn_dtype):
     output_tensor = ttnn.celu(input_tensor_a, alpha=alpha)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_ulp(torch_output_tensor, output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
 @pytest.mark.parametrize("scalar", [0.5, 1.0])
@@ -347,7 +352,7 @@ def test_scalarB_hardshrink(device, h, w, scalar):
 
     output_tensor = ttnn.hardshrink(input_tensor_a, lambd=scalar)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_with_ulp(torch_output_tensor, output_tensor, 2)
 
 
 @pytest.mark.parametrize("value", [0.88])
@@ -379,7 +384,7 @@ def test_scalarB_prelu(device, h, w, weight):
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_with_ulp(torch_output_tensor, output_tensor, 2)
 
 
 @pytest.mark.parametrize("scalar", [0.5])
@@ -397,10 +402,10 @@ def test_scalarB_softshrink(device, h, w, scalar):
 
     output_tensor = ttnn.softshrink(input_tensor_a, lambd=scalar)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_with_ulp(torch_output_tensor, output_tensor, 2)
 
 
-def run_activation_test_scalarBC_key(device, h, w, scalar1, scalar2, ttnn_function, pcc=0.99):
+def run_activation_test_scalarBC_key(device, h, w, scalar1, scalar2, ttnn_function, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -414,7 +419,7 @@ def run_activation_test_scalarBC_key(device, h, w, scalar1, scalar2, ttnn_functi
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("min", [-0.5, -0.1, -5.5])
@@ -425,7 +430,7 @@ def test_scalarBC_clip(device, h, w, min, max):
     run_activation_test_scalarBC_key(device, h, w, min, max, ttnn.clip)
 
 
-def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function, pcc=0.99):
+def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function, ulp=2, pcc_check=False):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -439,7 +444,10 @@ def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function,
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    if pcc_check:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("value", [-0.5, -0.1, -5.5])
@@ -447,7 +455,7 @@ def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function,
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_threshold(device, h, w, value, threshold):
-    run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold)
+    run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold, pcc_check=True)
 
 
 @pytest.mark.parametrize("ttnn_dtype, torch_dtype", [(ttnn.float32, torch.float32), (ttnn.bfloat16, torch.bfloat16)])
@@ -468,7 +476,7 @@ def test_mish_golden_verification(ttnn_dtype, torch_dtype, device):
     )
     output_tensor = ttnn.mish(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(golden_output, output_tensor, pcc=0.99)
+    assert_with_ulp(golden_output, output_tensor, 2)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -19,6 +19,12 @@ pytestmark = pytest.mark.use_module_device
 
 
 def run_activation_unary_test(device, h, w, ttnn_function, ulp=2, pcc_check=False, pcc=0.99):
+    """Run a single-input activation on a torch-random bf16 tensor in [-1, 1) and assert vs golden.
+
+    Default ``ulp=2`` covers kernels with up to ~1 ULP error plus the additional ULP from bf16
+    input quantization. Callers override ``ulp`` when the kernel has a different expected error,
+    or set ``pcc_check=True`` with an op-specific ``pcc`` when ULP is not the appropriate tolerance.
+    """
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((h, w), dtype=torch.bfloat16)
@@ -477,7 +483,7 @@ def test_mish_golden_verification(ttnn_dtype, torch_dtype, device):
     )
     output_tensor = ttnn.mish(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_ulp(golden_output, output_tensor, 2)
+    assert_with_pcc(golden_output, output_tensor, pcc=0.99)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 pytestmark = pytest.mark.use_module_device
 
@@ -31,7 +31,7 @@ def test_hardtanh_default(device, shapes):
     output_tensor = ttnn.hardtanh(input_tensor_a)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.9999
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -40,11 +40,11 @@ def test_hardtanh_default(device, shapes):
 )
 @pytest.mark.parametrize(
     "min",
-    [0.25, 0.5, 0.66, -1],
+    [0.25, 0.5, 0.66015625, -1],
 )
 @pytest.mark.parametrize(
     "max",
-    [1, 2.5, 3, 6.6],
+    [1, 2.5, 3, 6.59375],
 )
 def test_hardtanh_args(device, shapes, min, max):
     torch.manual_seed(0)
@@ -61,4 +61,4 @@ def test_hardtanh_args(device, shapes, min, max):
     output_tensor = ttnn.hardtanh(input_tensor_a, min_val=min, max_val=max)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.9999
+    assert_equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_equal
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_ulp
 
 pytestmark = pytest.mark.use_module_device
 
@@ -40,11 +40,11 @@ def test_hardtanh_default(device, shapes):
 )
 @pytest.mark.parametrize(
     "min",
-    [0.25, 0.5, 0.66015625, -1],
+    [0.25, 0.5, 0.66, -1],
 )
 @pytest.mark.parametrize(
     "max",
-    [1, 2.5, 3, 6.59375],
+    [1, 2.5, 3, 6.6],
 )
 def test_hardtanh_args(device, shapes, min, max):
     torch.manual_seed(0)
@@ -61,4 +61,4 @@ def test_hardtanh_args(device, shapes, min, max):
     output_tensor = ttnn.hardtanh(input_tensor_a, min_val=min, max_val=max)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -27,6 +27,12 @@ def run_math_unary_test(
     pcc_check=False,
     pcc=0.9999,
 ):
+    """Run a single-input math op on a random bf16 tensor in [0, 1) and assert vs the torch golden.
+
+    Default ``ulp=1`` covers kernels that are bit-exact in bf16 or accurate to one bf16 ULP over
+    [0, 1). Callers override ``ulp`` when the kernel has a larger expected error, or set
+    ``pcc_check=True`` with an op-specific ``pcc`` when ULP is not the appropriate tolerance.
+    """
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -229,6 +235,14 @@ def test_triu(device, h, w):
 
 
 def run_math_unary_test_recip(device, h, w, ttnn_function, ulp=1):
+    """Reciprocal on random bf16 inputs in ``[-100, 100] + 0.0001`` (non-zero).
+
+    Default ``ulp=1``; ``test_recip`` overrides to 2 to cover an additional bf16 ULP of error from
+    the reciprocal hardware approximation near the tails of this range. The ``1/+0 = +inf`` edge
+    case is covered separately by ``test_recip_fixed[fill_value=0.0]`` so the test can assert the
+    sign of the resulting infinity, which a generic ``allow_nonfinite=True`` ULP check on a random
+    tensor cannot do.
+    """
     torch.manual_seed(0)
 
     low = -100

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc, assert_with_ulp, assert_allclose
 from models.common.utility_functions import torch_random
 
 from loguru import logger
@@ -16,13 +16,13 @@ from loguru import logger
 pytestmark = pytest.mark.use_module_device
 
 
-def run_math_unary_test(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, pcc=0.9999):
+def run_math_unary_test(
+    device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=1, allow_nonfinite=False, pcc_check=False
+):
     torch.manual_seed(0)
 
-    # Generate random [0; 1] tensor
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     if "digamma" in str(ttnn_function):
-        # Scale and shift range to [2; 102] for digamma
         torch_input_tensor = torch_input_tensor * 100.0 + 2.0
 
     golden_function = ttnn.get_golden_function(ttnn_function)
@@ -30,25 +30,27 @@ def run_math_unary_test(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, pc
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
     output_tensor = ttnn_function(input_tensor)
-    # Verify output layout matches input layout
     assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    if pcc_check:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_i0(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.i0, layout=layout, pcc=0.998)
+    run_math_unary_test(device, h, w, ttnn.i0, layout=layout, ulp=1)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_lgamma(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.lgamma, layout=layout, pcc=0.99)
+    run_math_unary_test(device, h, w, ttnn.lgamma, layout=layout, pcc_check=True)
 
 
 @pytest.mark.parametrize("h", [32])
@@ -83,14 +85,13 @@ def test_eq(device, h, w, output_dtype):
     assert output_tensor.get_dtype() == output_dtype
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages(device)) - 1
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert_equal(torch_output_tensor.float(), output_tensor.float())
 
     # EQ with a preallocated output tensor
     output_tensor_preallocated_bfloat16 = ttnn.ones(
         [h, w], ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG
     )
     output_tensor_preallocated = output_tensor_preallocated_bfloat16
-    # There is no good way to create uint16 tensor in ttnn/torch, so we create bfloat16 and typecast to target
     if output_dtype != ttnn.bfloat16:
         output_tensor_preallocated = ttnn.typecast(
             output_tensor_preallocated_bfloat16, output_dtype, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -100,125 +101,125 @@ def test_eq(device, h, w, output_dtype):
     ttnn.eq(input_tensor_a, input_tensor_b, dtype=output_dtype, output_tensor=output_tensor_preallocated)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages(device))
     torch_output_tensor_preallocated = ttnn.to_torch(output_tensor_preallocated)
-    assert_with_pcc(torch_output_tensor, torch_output_tensor_preallocated, 0.999)
+    assert_equal(torch_output_tensor.float(), torch_output_tensor_preallocated.float())
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_log10(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.log10, layout=layout)
+    run_math_unary_test(device, h, w, ttnn.log10, layout=layout, ulp=2, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_log1p(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.log1p, layout=layout, pcc=0.999)
+    run_math_unary_test(device, h, w, ttnn.log1p, layout=layout, ulp=1)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_log2(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.log2, layout=layout, pcc=0.999)
+    run_math_unary_test(device, h, w, ttnn.log2, layout=layout, ulp=1, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_neg(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.neg, layout=layout)
+    run_math_unary_test(device, h, w, ttnn.neg, layout=layout, ulp=0)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_abs(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.abs, layout=layout)
+    run_math_unary_test(device, h, w, ttnn.abs, layout=layout, ulp=0)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_rad2deg(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.rad2deg)
+    run_math_unary_test(device, h, w, ttnn.rad2deg, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_cbrt(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.cbrt, pcc=0.999)
+    run_math_unary_test(device, h, w, ttnn.cbrt, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_tril(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.tril)
+    run_math_unary_test(device, h, w, ttnn.tril, ulp=0)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_deg2rad(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.deg2rad)
+    run_math_unary_test(device, h, w, ttnn.deg2rad, ulp=2)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_sqrt(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.sqrt, layout=layout)
+    run_math_unary_test(device, h, w, ttnn.sqrt, layout=layout, ulp=0)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_digamma(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.digamma)
+    run_math_unary_test(device, h, w, ttnn.digamma, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_erf(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.erf)
+    run_math_unary_test(device, h, w, ttnn.erf, ulp=1)
 
 
 @pytest.mark.parametrize("h", [2])
 @pytest.mark.parametrize("w", [3])
 def test_erfc(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.erfc)
+    run_math_unary_test(device, h, w, ttnn.erfc, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_erfinv(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.erfinv, pcc=0.999)
+    run_math_unary_test(device, h, w, ttnn.erfinv, pcc_check=True)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_square(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.square, layout=layout)
+    run_math_unary_test(device, h, w, ttnn.square, layout=layout, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_exp2(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.exp2, pcc=0.98)
+    run_math_unary_test(device, h, w, ttnn.exp2, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_expm1(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.expm1, pcc=0.99)
+    run_math_unary_test(device, h, w, ttnn.expm1, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_triu(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.triu)
+    run_math_unary_test(device, h, w, ttnn.triu, ulp=0)
 
 
-def run_math_unary_test_recip(device, h, w, ttnn_function, pcc=0.9999):
+def run_math_unary_test_recip(device, h, w, ttnn_function, ulp=1):
     torch.manual_seed(0)
 
     low = -100
@@ -231,10 +232,12 @@ def run_math_unary_test_recip(device, h, w, ttnn_function, pcc=0.9999):
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn_function(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
-def run_math_unary_test_fixed_val(device, h, w, fill_value, ttnn_function, pcc=0.9999):
+def run_math_unary_test_fixed_val(
+    device, h, w, fill_value, ttnn_function, ulp=1, allow_nonfinite=False, pcc_check=False
+):
     torch.manual_seed(0)
     torch_input_tensor = torch.full((h, w), fill_value, dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn_function)
@@ -243,7 +246,10 @@ def run_math_unary_test_fixed_val(device, h, w, fill_value, ttnn_function, pcc=0
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn_function(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    if pcc_check:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -260,10 +266,10 @@ def test_recip(device, h, w):
         def __call__(self, input_tensor):
             return ttnn.reciprocal(input_tensor)
 
-    run_math_unary_test_recip(device, h, w, reciprocal_wrapper(), pcc=0.999)
+    run_math_unary_test_recip(device, h, w, reciprocal_wrapper(), ulp=2)
 
 
-def run_math_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
+def run_math_unary_test_range(device, h, w, ttnn_function, ulp=1):
     torch.manual_seed(0)
     low = 1.6
     high = 100
@@ -276,13 +282,13 @@ def run_math_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
     output_tensor = ttnn_function(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("h", [5])
 @pytest.mark.parametrize("w", [5])
 def test_multigammaln(device, h, w):
-    run_math_unary_test_range(device, h, w, ttnn.multigammaln, pcc=0.999)
+    run_math_unary_test_range(device, h, w, ttnn.multigammaln, ulp=2)
 
 
 def run_math_test_polygamma(device, h, w, scalar, ttnn_function, ulp=1):
@@ -311,5 +317,14 @@ def test_polygamma(device, h, w, scalar):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_recip_fixed(device, h, w):
-    run_math_unary_test_fixed_val(device, h, w, 0, ttnn.reciprocal, pcc=0.999)
+@pytest.mark.parametrize("fill_value", [0.001, -0.001, 1.0, -1.0])
+def test_recip_fixed(device, h, w, fill_value):
+    torch.manual_seed(0)
+    torch_input_tensor = torch.full((h, w), fill_value, dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.reciprocal)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.reciprocal(input_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)
+    assert_allclose(torch_output_tensor, output_tensor, atol=1e-2, rtol=1e-2)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -17,7 +17,15 @@ pytestmark = pytest.mark.use_module_device
 
 
 def run_math_unary_test(
-    device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=1, allow_nonfinite=False, pcc_check=False
+    device,
+    h,
+    w,
+    ttnn_function,
+    layout=ttnn.TILE_LAYOUT,
+    ulp=1,
+    allow_nonfinite=False,
+    pcc_check=False,
+    pcc=0.9999,
 ):
     torch.manual_seed(0)
 
@@ -34,7 +42,7 @@ def run_math_unary_test(
     output_tensor = ttnn.to_torch(output_tensor)
 
     if pcc_check:
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     else:
         assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
@@ -50,7 +58,7 @@ def test_i0(device, h, w, layout):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_lgamma(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.lgamma, layout=layout, pcc_check=True)
+    run_math_unary_test(device, h, w, ttnn.lgamma, layout=layout, pcc_check=True, pcc=0.99)
 
 
 @pytest.mark.parametrize("h", [32])
@@ -167,7 +175,7 @@ def test_deg2rad(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_sqrt(device, h, w, layout):
-    run_math_unary_test(device, h, w, ttnn.sqrt, layout=layout, ulp=0)
+    run_math_unary_test(device, h, w, ttnn.sqrt, layout=layout, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -191,7 +199,8 @@ def test_erfc(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_erfinv(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.erfinv, pcc_check=True)
+    # ULP=227 exceeds the ULP ≤ 5 policy; fall back to PCC with the original per-test threshold.
+    run_math_unary_test(device, h, w, ttnn.erfinv, pcc_check=True, pcc=0.999)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -233,23 +242,6 @@ def run_math_unary_test_recip(device, h, w, ttnn_function, ulp=1):
     output_tensor = ttnn_function(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_ulp(torch_output_tensor, output_tensor, ulp)
-
-
-def run_math_unary_test_fixed_val(
-    device, h, w, fill_value, ttnn_function, ulp=1, allow_nonfinite=False, pcc_check=False
-):
-    torch.manual_seed(0)
-    torch_input_tensor = torch.full((h, w), fill_value, dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn_function)
-    torch_output_tensor = golden_function(torch_input_tensor, device=device)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn_function(input_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
-    if pcc_check:
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    else:
-        assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -317,14 +309,22 @@ def test_polygamma(device, h, w, scalar):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("fill_value", [0.001, -0.001, 1.0, -1.0])
+@pytest.mark.parametrize("fill_value", [0.0, 0.001, -0.001, 1.0, -1.0])
 def test_recip_fixed(device, h, w, fill_value):
     torch.manual_seed(0)
     torch_input_tensor = torch.full((h, w), fill_value, dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn.reciprocal)
-    torch_output_tensor = golden_function(torch_input_tensor, device=device)
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.reciprocal(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)
-    assert_allclose(torch_output_tensor, output_tensor, atol=1e-2, rtol=1e-2)
+    if fill_value == 0.0:
+        # 1/+0 must be +inf on device (the bf16 golden clamps to +max-bf16, which is incorrect).
+        # Compare against an exact +inf tensor so that a -inf or +max-bf16 regression is caught.
+        expected = torch.full_like(output_tensor, float("inf"))
+        assert torch.equal(
+            output_tensor, expected
+        ), f"reciprocal(+0) should produce +inf, got unique values {output_tensor.unique()}"
+    else:
+        golden_function = ttnn.get_golden_function(ttnn.reciprocal)
+        torch_output_tensor = golden_function(torch_input_tensor, device=device)
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)
+        assert_allclose(torch_output_tensor, output_tensor, atol=1e-2, rtol=1e-2)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
@@ -9,10 +9,10 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 
 
-def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, ttnn_function, ulp=2):
+def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, ttnn_function, ulp=2, approx_pcc=0.999):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hw, out_channels), dtype=torch.bfloat16)
@@ -24,7 +24,10 @@ def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, t
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
+    if approx_mode == ttnn.SigmoidMode.FastApproximate:
+        assert_with_pcc(torch_output_tensor, output_tensor, approx_pcc)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("h", [2048])
@@ -34,4 +37,5 @@ def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, t
 @pytest.mark.parametrize("approx_mode", [ttnn.SigmoidMode.Accurate, ttnn.SigmoidMode.FastApproximate])
 def test_sigmoid_two_out_channels(device, h, w, out_channels, vector_mode, approx_mode):
     torch.manual_seed(0)
-    run_unary_test_sharded(device, h * w, out_channels, vector_mode, approx_mode, ttnn.sigmoid, ulp=4)
+    # FastApproximate path is intentionally looser; preserve the original 0.991 PCC threshold.
+    run_unary_test_sharded(device, h * w, out_channels, vector_mode, approx_mode, ttnn.sigmoid, ulp=1, approx_pcc=0.991)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
@@ -13,6 +13,12 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 
 
 def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, ttnn_function, ulp=2, approx_pcc=0.999):
+    """Sharded unary op on random bf16 inputs in [-1, 1).
+
+    Default ``ulp=2`` covers up to ~1 ULP kernel error plus the additional ULP from bf16 input
+    rounding. The ``FastApproximate`` path is intentionally not ULP-equivalent to the accurate
+    kernel; for that mode this helper falls back to ``assert_with_pcc(approx_pcc)`` instead.
+    """
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hw, out_channels), dtype=torch.bfloat16)
@@ -37,5 +43,4 @@ def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, t
 @pytest.mark.parametrize("approx_mode", [ttnn.SigmoidMode.Accurate, ttnn.SigmoidMode.FastApproximate])
 def test_sigmoid_two_out_channels(device, h, w, out_channels, vector_mode, approx_mode):
     torch.manual_seed(0)
-    # FastApproximate path is intentionally looser; preserve the original 0.991 PCC threshold.
     run_unary_test_sharded(device, h * w, out_channels, vector_mode, approx_mode, ttnn.sigmoid, ulp=1, approx_pcc=0.991)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
@@ -9,10 +9,10 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, ttnn_function, pcc=0.9999):
+def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, ttnn_function, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hw, out_channels), dtype=torch.bfloat16)
@@ -24,7 +24,7 @@ def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, t
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("h", [2048])
@@ -34,4 +34,4 @@ def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, t
 @pytest.mark.parametrize("approx_mode", [ttnn.SigmoidMode.Accurate, ttnn.SigmoidMode.FastApproximate])
 def test_sigmoid_two_out_channels(device, h, w, out_channels, vector_mode, approx_mode):
     torch.manual_seed(0)
-    run_unary_test_sharded(device, h * w, out_channels, vector_mode, approx_mode, ttnn.sigmoid, pcc=0.991)
+    run_unary_test_sharded(device, h * w, out_channels, vector_mode, approx_mode, ttnn.sigmoid, ulp=4)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose, assert_with_ulp
 
 pytestmark = pytest.mark.use_module_device
 
@@ -192,8 +192,7 @@ def test_tanh_height_sharded(device, input_shapes, high, low, torch_dtype, ttnn_
     golden_tensor = golden_function(in_data)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    pcc, pcc_msg = assert_with_pcc(golden_tensor, output_tensor, 0.999)
-    assert pcc
+    assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=4)
 
 
 def return_mem_config(mem_config_string):
@@ -289,5 +288,4 @@ def test_tanh_sharded(device, high, low, input_mem_config, torch_dtype, ttnn_dty
     golden_tensor = golden_function(in_data)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    pcc, pcc_msg = assert_with_pcc(golden_tensor, output_tensor, 0.999)
-    assert pcc
+    assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=4)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -192,7 +192,7 @@ def test_tanh_height_sharded(device, input_shapes, high, low, torch_dtype, ttnn_
     golden_tensor = golden_function(in_data)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=4)
+    assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=1)
 
 
 def return_mem_config(mem_config_string):
@@ -287,5 +287,5 @@ def test_tanh_sharded(device, high, low, input_mem_config, torch_dtype, ttnn_dty
     golden_function = ttnn.get_golden_function(ttnn.tanh)
     golden_tensor = golden_function(in_data)
 
-    assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=4)
+    pcc, pcc_msg = assert_with_pcc(golden_tensor, output_tensor, 0.999)
+    assert pcc

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -14,7 +14,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_w
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import (
     data_gen_with_range,
     data_gen_with_range_dtype,
-    compare_pcc,
 )
 from models.common.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 
@@ -41,7 +40,7 @@ def create_full_range_tensor(input_shapes, dtype):
     return in_data
 
 
-def run_unary_test(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, pcc=0.9999):
+def run_unary_test(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2, allow_nonfinite=False, pcc_check=False):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -50,15 +49,17 @@ def run_unary_test(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, pcc=0.9
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
     output_tensor = ttnn_function(input_tensor)
-    # Verify output layout matches input layout
     assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    if pcc_check:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
 
 def run_unary_with_approx_mode_test(
-    device, h, w, ttnn_function, vector_mode, approx_mode, layout=ttnn.TILE_LAYOUT, pcc=0.9999
+    device, h, w, ttnn_function, vector_mode, approx_mode, layout=ttnn.TILE_LAYOUT, ulp=2
 ):
     torch.manual_seed(0)
 
@@ -72,10 +73,12 @@ def run_unary_with_approx_mode_test(
     assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
-def run_unary_test_fixed(device, h, w, fill_value, ttnn_function, layout=ttnn.TILE_LAYOUT, pcc=0.9999):
+def run_unary_test_fixed(
+    device, h, w, fill_value, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2, allow_nonfinite=False
+):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.full((h, w), fill_value, dtype=torch.bfloat16)
@@ -85,11 +88,10 @@ def run_unary_test_fixed(device, h, w, fill_value, ttnn_function, layout=ttnn.TI
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
     output_tensor = ttnn_function(input_tensor)
-    # Verify output layout matches input layout
     assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
 
 def run_identity_test(device, h, w, data_type):
@@ -212,21 +214,21 @@ def test_fp32_uint32(device, h, w, dtype):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_exp(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.exp, layout=layout, pcc=0.9998)
+    run_unary_test(device, h, w, ttnn.exp, layout=layout, ulp=2)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_gelu(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.gelu, layout=layout, pcc=0.9996)
+    run_unary_test(device, h, w, ttnn.gelu, layout=layout, ulp=2)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_relu(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.relu, layout=layout)
+    run_unary_test(device, h, w, ttnn.relu, layout=layout, ulp=0)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -240,7 +242,7 @@ def test_silu(device, h, w, layout):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_log(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.log, layout=layout)
+    run_unary_test(device, h, w, ttnn.log, layout=layout, allow_nonfinite=True)
 
 
 def test_log_edge_cases(device):
@@ -311,8 +313,11 @@ def test_unary_log_operations_ttnn(
     golden_tensor = golden_function(input_torch_converted, device=device)
     tt_result = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(tt_result, golden_tensor, pcc=0.99)
-    assert torch.allclose(tt_result, golden_tensor, rtol=4e-2, atol=4e-2)
+    if ttnn_dtype == ttnn.bfloat8_b:
+        assert_with_pcc(tt_result, golden_tensor, pcc=0.99)
+        assert torch.allclose(tt_result, golden_tensor, rtol=4e-2, atol=4e-2)
+    else:
+        assert_with_ulp(tt_result, golden_tensor)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -332,21 +337,21 @@ def test_01_volume_sin(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_asin(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.asin, layout=layout, pcc=0.999)
+    run_unary_test(device, h, w, ttnn.asin, layout=layout, ulp=2)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_cos(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.cos, layout=layout, pcc=0.999)
+    run_unary_test(device, h, w, ttnn.cos, layout=layout, ulp=2)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_acos(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.acos, layout=layout, pcc=0.999)
+    run_unary_test(device, h, w, ttnn.acos, layout=layout, ulp=2)
 
 
 def run_unary_inverse_trig_bf16_test(device, h, w, ttnn_function, ulp_threshold, layout=ttnn.TILE_LAYOUT):
@@ -396,7 +401,7 @@ def test_atan(device, h, w, layout):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_sinh(device, h, w, layout):
-    run_unary_test(device, h, w, ttnn.sinh, layout=layout)
+    run_unary_test(device, h, w, ttnn.sinh, layout=layout, pcc_check=True)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -417,11 +422,11 @@ def test_sigmoid(device, h, w, vector_mode, approx_mode, layout):
             )
 
     run_unary_with_approx_mode_test(
-        device, h, w, sigmoid_wrap(), vector_mode=vector_mode, approx_mode=approx_mode, layout=layout, pcc=0.999
+        device, h, w, sigmoid_wrap(), vector_mode=vector_mode, approx_mode=approx_mode, layout=layout, ulp=3
     )
 
 
-def run_unary_test_range(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, pcc=0.9999):
+def run_unary_test_range(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2):
     torch.manual_seed(0)
     low = -100
     high = 100
@@ -437,24 +442,24 @@ def run_unary_test_range(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, p
     assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_floor(device, h, w, layout):
-    run_unary_test_range(device, h, w, ttnn.floor, layout=layout, pcc=0.99)
+    run_unary_test_range(device, h, w, ttnn.floor, layout=layout, ulp=1)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_ceil(device, h, w, layout):
-    run_unary_test_range(device, h, w, ttnn.ceil, layout=layout, pcc=0.99)
+    run_unary_test_range(device, h, w, ttnn.ceil, layout=layout, ulp=1)
 
 
-def run_unary_test_with_float(device, h, w, scalar, ttnn_function, layout=ttnn.TILE_LAYOUT, pcc=0.9999):
+def run_unary_test_with_float(device, h, w, scalar, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -467,10 +472,10 @@ def run_unary_test_with_float(device, h, w, scalar, ttnn_function, layout=ttnn.T
     assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
-def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, pcc=0.9999):
+def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, ulp=2):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -483,7 +488,7 @@ def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, pcc
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -491,7 +496,7 @@ def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, pcc
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_pow(device, h, w, scalar, layout):
-    run_unary_test_with_float(device, h, w, scalar, ttnn.pow, layout=layout, pcc=0.999)
+    run_unary_test_with_float(device, h, w, scalar, ttnn.pow, layout=layout, ulp=2)
 
 
 @pytest.mark.parametrize("lower_limit", [0, 1.0, 2, -5.5])
@@ -561,13 +566,13 @@ def test_fmod(device, h, w, scalar):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_asin_fixed(device, h, w):
-    run_unary_test_fixed(device, h, w, 90, ttnn.asin, pcc=0.999)
+    run_unary_test_fixed(device, h, w, 90, ttnn.asin, ulp=2, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_acos_fixed(device, h, w):
-    run_unary_test_fixed(device, h, w, 90, ttnn.acos, pcc=0.999)
+    run_unary_test_fixed(device, h, w, 90, ttnn.acos, ulp=2, allow_nonfinite=True)
 
 
 def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function):
@@ -608,7 +613,7 @@ def test_unary_floor(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.floor)
     golden_tensor = golden_function(in_data1)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(golden_tensor, output_tensor, 0.999)
+    assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -626,7 +631,7 @@ def test_unary_ceil(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.ceil)
     golden_tensor = golden_function(in_data1)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(golden_tensor, output_tensor, 0.999)
+    assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -827,7 +832,6 @@ def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, devi
     golden_tensor = golden_function(in_data1)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -864,9 +868,8 @@ def test_unary_angle_conversion_ttnn(input_shapes, device, ttnn_dtype, ttnn_func
     output_tensor = ttnn_function(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data1)
-    output = ttnn.to_torch(output_tensor)
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass and assert_with_ulp(golden_tensor, output)
+
+    assert_with_ulp(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -886,7 +889,6 @@ def test_unary_trunc_ttnn(input_shapes, device):
     golden_tensor = golden_function(in_data)
 
     assert_with_ulp(output_tensor, golden_tensor)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -904,7 +906,6 @@ def test_unary_trunc_ttnn_opt(input_shapes, device):
     golden_tensor = golden_function(in_data)
 
     assert_with_ulp(output_tensor, golden_tensor)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -948,7 +949,6 @@ def test_unary_silu_swish_threshold(ttnn_function, device):
     golden_tensor = golden_function(in_data1, device=device)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=0.032)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
 
 
 @pytest.mark.parametrize(
@@ -981,7 +981,10 @@ def test_unary_inverse_hyperbolic_edge_case_ttnn(
     golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data1, device=device)
 
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+    if ttnn_dtype == ttnn.bfloat16:
+        assert_with_ulp(output_tensor, golden_tensor, allow_nonfinite=True)
+    else:
+        assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -998,10 +1001,7 @@ def test_unary_acosh_ttnn(input_shapes, device):
     output_tensor = ttnn.acosh(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn.acosh)
     golden_tensor = golden_function(in_data1, device=device)
-    output = ttnn.to_torch(output_tensor)
-
     assert_with_ulp(output_tensor, golden_tensor)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -1027,7 +1027,10 @@ def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     golden_function = ttnn.get_golden_function(ttnn.asinh)
     golden_tensor = golden_function(in_data1, device=device)
 
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
+    if ttnn_dtype == ttnn.bfloat16:
+        assert_with_ulp(output_tensor, golden_tensor)
+    else:
+        assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
 
 
 @pytest.mark.parametrize(
@@ -1095,7 +1098,6 @@ def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtyp
     golden_tensor = golden_function(in_data, lambd=param)
 
     assert_with_ulp(output_tensor, golden_tensor)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -1126,7 +1128,6 @@ def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, de
     golden_tensor = golden_function(in_data, lambd=param)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=0.02)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -1153,7 +1154,6 @@ def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_functio
     golden_tensor = golden_function(in_data, lambd=param)
 
     assert_with_ulp(output_tensor, golden_tensor)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -1173,7 +1173,6 @@ def test_unary_frac_ttnn(input_shapes, device):
     golden_tensor = golden_function(in_data)
 
     assert_with_ulp(output_tensor, golden_tensor)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -1191,7 +1190,6 @@ def test_unary_frac_ttnn_opt(input_shapes, device):
     golden_tensor = golden_function(in_data)
 
     assert_with_ulp(output_tensor, golden_tensor)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -1220,7 +1218,6 @@ def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device
     golden_tensor = golden_function(in_data1, device=device)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
 
 
 @pytest.mark.parametrize(
@@ -1249,7 +1246,6 @@ def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, dev
     golden_tensor = golden_function(in_data1, device=device)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
 
 
 @pytest.mark.parametrize(
@@ -1276,7 +1272,6 @@ def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, 
     golden_tensor = golden_function(in_data1, device=device)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
 
 
 @pytest.mark.parametrize(
@@ -1298,7 +1293,6 @@ def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device):
     golden_tensor = golden_function(in_data1, device=device)
 
     assert_allclose(output_tensor, golden_tensor, atol=0.025)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
 
 
 @pytest.mark.parametrize(
@@ -1462,7 +1456,6 @@ def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype,
         golden_function = ttnn.get_golden_function(ttnn.clamp)
         golden_tensor = golden_function(in_data1, min, max)
         assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
-        assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -1490,7 +1483,6 @@ def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
     golden_tensor = golden_function(in_data1)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -1519,7 +1511,6 @@ def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     golden_tensor = golden_function(in_data1)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=0.15)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -1638,8 +1629,7 @@ def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     golden_tensor = golden_function(in_data)
 
     if ttnn_dtype == ttnn.bfloat16:
-        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=5.0)
-
+        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=5)
     else:
         assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
@@ -1659,8 +1649,8 @@ def test_unary_rpow_ttnn(input_shapes, exponent, device):
     golden_function = ttnn.get_golden_function(ttnn.rpow)
     golden_tensor = golden_function(in_data1, exponent)
 
-    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=8)  # ULP<=1 for exponents less than 5
     assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.99)
+    assert_allclose(ttnn.to_torch(output_tensor), golden_tensor, atol=1e-2, rtol=0.1)
 
 
 @pytest.mark.parametrize(
@@ -1812,7 +1802,7 @@ def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device):
     golden_tensor = golden_function(in_data1, device=device)
     tt_res = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(tt_res, golden_tensor, pcc=0.9999)
+    assert_with_ulp(tt_res, golden_tensor, ulp_threshold=2, allow_nonfinite=True)
 
 
 def test_hardmish_bfloat16_ulp(device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -40,7 +40,9 @@ def create_full_range_tensor(input_shapes, dtype):
     return in_data
 
 
-def run_unary_test(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2, allow_nonfinite=False, pcc_check=False):
+def run_unary_test(
+    device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2, allow_nonfinite=False, pcc_check=False, pcc=0.9999
+):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -53,13 +55,13 @@ def run_unary_test(device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2, 
     output_tensor = ttnn.to_torch(output_tensor)
 
     if pcc_check:
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     else:
         assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
 
 def run_unary_with_approx_mode_test(
-    device, h, w, ttnn_function, vector_mode, approx_mode, layout=ttnn.TILE_LAYOUT, ulp=2
+    device, h, w, ttnn_function, vector_mode, approx_mode, layout=ttnn.TILE_LAYOUT, ulp=2, approx_pcc=0.999
 ):
     torch.manual_seed(0)
 
@@ -69,11 +71,14 @@ def run_unary_with_approx_mode_test(
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
     output_tensor = ttnn_function(input_tensor, vector_mode=vector_mode, fast_and_approximate_mode=approx_mode)
-    # Verify output layout matches input layout
     assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_ulp(torch_output_tensor, output_tensor, ulp)
+    if approx_mode:
+        # Fast-approximate path is intentionally looser than the ULP ≤ 5 cap; verify with PCC instead.
+        assert_with_pcc(torch_output_tensor, output_tensor, approx_pcc)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp)
 
 
 def run_unary_test_fixed(
@@ -317,7 +322,7 @@ def test_unary_log_operations_ttnn(
         assert_with_pcc(tt_result, golden_tensor, pcc=0.99)
         assert torch.allclose(tt_result, golden_tensor, rtol=4e-2, atol=4e-2)
     else:
-        assert_with_ulp(tt_result, golden_tensor)
+        assert_with_ulp(tt_result, golden_tensor, ulp_threshold=2)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -422,7 +427,7 @@ def test_sigmoid(device, h, w, vector_mode, approx_mode, layout):
             )
 
     run_unary_with_approx_mode_test(
-        device, h, w, sigmoid_wrap(), vector_mode=vector_mode, approx_mode=approx_mode, layout=layout, ulp=3
+        device, h, w, sigmoid_wrap(), vector_mode=vector_mode, approx_mode=approx_mode, layout=layout, ulp=1
     )
 
 
@@ -869,7 +874,7 @@ def test_unary_angle_conversion_ttnn(input_shapes, device, ttnn_dtype, ttnn_func
     golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data1)
 
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2)
 
 
 @pytest.mark.parametrize(
@@ -888,7 +893,7 @@ def test_unary_trunc_ttnn(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.trunc)
     golden_tensor = golden_function(in_data)
 
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -905,7 +910,7 @@ def test_unary_trunc_ttnn_opt(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.trunc)
     golden_tensor = golden_function(in_data)
 
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -982,9 +987,34 @@ def test_unary_inverse_hyperbolic_edge_case_ttnn(
     golden_tensor = golden_function(in_data1, device=device)
 
     if ttnn_dtype == ttnn.bfloat16:
-        assert_with_ulp(output_tensor, golden_tensor, allow_nonfinite=True)
+        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2, allow_nonfinite=True)
     else:
-        assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+        # PCC masks non-finite entries, so check the non-finite layout before PCC on the finite slice.
+        output_torch = ttnn.to_torch(output_tensor)
+        g_isnan, d_isnan = torch.isnan(golden_tensor), torch.isnan(output_torch)
+        g_isinf, d_isinf = torch.isinf(golden_tensor), torch.isinf(output_torch)
+        if ttnn_dtype == ttnn.float32:
+            # float32 preserves IEEE semantics; require exact NaN/Inf mask + Inf-sign equivalence.
+            torch.testing.assert_close(g_isnan, d_isnan, msg="NaN positions differ between golden and device")
+            torch.testing.assert_close(g_isinf, d_isinf, msg="Inf positions differ between golden and device")
+            inf_both = g_isinf & d_isinf
+            if inf_both.any():
+                torch.testing.assert_close(
+                    torch.signbit(golden_tensor[inf_both]),
+                    torch.signbit(output_torch[inf_both]),
+                    msg="Inf signs differ between golden and device",
+                )
+        else:
+            # bfloat8_b acosh of out-of-domain inputs returns ±Inf on device where the golden returns
+            # NaN — a pre-existing semantic gap. Still require that the non-finite *positions* match
+            # so a regression that returns finite values for out-of-domain inputs is caught.
+            g_nonfinite = ~torch.isfinite(golden_tensor)
+            d_nonfinite = ~torch.isfinite(output_torch)
+            torch.testing.assert_close(
+                g_nonfinite, d_nonfinite, msg="Non-finite positions differ between golden and device"
+            )
+        finite_mask = torch.isfinite(golden_tensor) & torch.isfinite(output_torch)
+        assert_with_pcc(output_torch[finite_mask], golden_tensor[finite_mask], pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -1001,7 +1031,7 @@ def test_unary_acosh_ttnn(input_shapes, device):
     output_tensor = ttnn.acosh(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn.acosh)
     golden_tensor = golden_function(in_data1, device=device)
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2)
 
 
 @pytest.mark.parametrize(
@@ -1028,7 +1058,7 @@ def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     golden_tensor = golden_function(in_data1, device=device)
 
     if ttnn_dtype == ttnn.bfloat16:
-        assert_with_ulp(output_tensor, golden_tensor)
+        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2)
     else:
         assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.9999)
 
@@ -1097,7 +1127,7 @@ def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtyp
     golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data, lambd=param)
 
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -1153,7 +1183,7 @@ def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_functio
     golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data, lambd=param)
 
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -1172,7 +1202,7 @@ def test_unary_frac_ttnn(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.frac)
     golden_tensor = golden_function(in_data)
 
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -1189,7 +1219,7 @@ def test_unary_frac_ttnn_opt(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.frac)
     golden_tensor = golden_function(in_data)
 
-    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -43,6 +43,13 @@ def create_full_range_tensor(input_shapes, dtype):
 def run_unary_test(
     device, h, w, ttnn_function, layout=ttnn.TILE_LAYOUT, ulp=2, allow_nonfinite=False, pcc_check=False, pcc=0.9999
 ):
+    """Run a single-input unary op on a random bf16 tensor in [0, 1) and assert vs the torch golden.
+
+    Default ``ulp=2`` covers kernels with up to ~1 ULP error plus the additional ULP that bf16
+    round-to-nearest of intermediate values can introduce. Callers override ``ulp`` when the kernel
+    has a different expected error, or set ``pcc_check=True`` with an op-specific ``pcc`` when ULP
+    is not the appropriate tolerance.
+    """
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -75,7 +82,7 @@ def run_unary_with_approx_mode_test(
     output_tensor = ttnn.to_torch(output_tensor)
 
     if approx_mode:
-        # Fast-approximate path is intentionally looser than the ULP ≤ 5 cap; verify with PCC instead.
+        # Fast-approximate path has a wider expected error than the ULP ≤ 5 cap; verify with PCC instead.
         assert_with_pcc(torch_output_tensor, output_tensor, approx_pcc)
     else:
         assert_with_ulp(torch_output_tensor, output_tensor, ulp)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_ulp
 
 pytestmark = pytest.mark.use_module_device
 
@@ -56,5 +56,11 @@ def test_add_and_apply_activations(device, shape, activations, torch_dtype):
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.add(input_tensor_a, input_tensor_b, activations=activations)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.99988)
+    if activations:
+        # Cast bool→float because comp_equal uses subtraction which doesn't support bool tensors
+        assert_equal(torch_output_tensor.float(), output_tensor.float())
+    elif torch_dtype == torch.bfloat16:
+        assert_with_ulp(torch_output_tensor, output_tensor, 1)
+    else:
+        assert_equal(torch_output_tensor, output_tensor)
     assert output_tensor.shape == shape

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -164,6 +164,12 @@ def test_acos_fp32(device):
 
 
 def run_unary_test(device, h, w, ttnn_function, ulp=1, allow_nonfinite=False, pcc_check=False, pcc=0.9999):
+    """Run a single-input fp32 unary op on a random tensor in [0, 1) and assert vs the torch golden.
+
+    Default ``ulp=1`` covers kernels accurate to one float32 ULP. Callers override ``ulp`` when the
+    kernel has a larger expected error, or set ``pcc_check=True`` with an op-specific ``pcc`` when
+    ULP is not the appropriate tolerance.
+    """
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.float32)
@@ -190,7 +196,7 @@ def test_exp(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_tanh(device, h, w):
-    run_unary_test(device, h, w, ttnn.tanh, ulp=3)
+    run_unary_test(device, h, w, ttnn.tanh, pcc_check=True, pcc=0.993)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -208,7 +214,7 @@ def test_rsqrt(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_silu(device, h, w):
-    run_unary_test(device, h, w, ttnn.silu, ulp=2)
+    run_unary_test(device, h, w, ttnn.silu, ulp=3)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -146,7 +146,7 @@ def test_acos_fp32(device):
     run_unary_fp32_test_with_ulp(device, ttnn.acos, torch.acos, max_ulp=100)
 
 
-def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
+def run_unary_test(device, h, w, ttnn_function, ulp=1, allow_nonfinite=False, pcc_check=False):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.float32)
@@ -158,65 +158,68 @@ def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    if pcc_check:
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_exp(device, h, w):
-    run_unary_test(device, h, w, ttnn.exp, pcc=0.9998)
+    run_unary_test(device, h, w, ttnn.exp, ulp=1)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_tanh(device, h, w):
-    run_unary_test(device, h, w, ttnn.tanh, pcc=0.993)
+    run_unary_test(device, h, w, ttnn.tanh, ulp=3)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_gelu(device, h, w):
-    run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
+    run_unary_test(device, h, w, ttnn.gelu, pcc_check=True)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_rsqrt(device, h, w):
-    run_unary_test(device, h, w, ttnn.rsqrt)
+    run_unary_test(device, h, w, ttnn.rsqrt, ulp=2)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_silu(device, h, w):
-    run_unary_test(device, h, w, ttnn.silu)
+    run_unary_test(device, h, w, ttnn.silu, ulp=2)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_log(device, h, w):
-    run_unary_test(device, h, w, ttnn.log)
+    run_unary_test(device, h, w, ttnn.log, ulp=3)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_sinh(device, h, w):
-    run_unary_test(device, h, w, ttnn.sinh)
+    run_unary_test(device, h, w, ttnn.sinh, pcc_check=True)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_cosh(device, h, w):
-    run_unary_test(device, h, w, ttnn.cosh, pcc=0.999)
+    run_unary_test(device, h, w, ttnn.cosh, pcc_check=True)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_acosh(device, h, w):
-    run_unary_test(device, h, w, ttnn.acosh)
+    run_unary_test(device, h, w, ttnn.acosh, ulp=1, allow_nonfinite=True)
 
 
 @pytest.mark.skip("The current version doesn’t work with float32, but this will be fixed in issue #231689.")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_atanh(device, h, w):
-    run_unary_test(device, h, w, ttnn.atanh, pcc=0.997)
+    run_unary_test(device, h, w, ttnn.atanh, ulp=2)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -111,7 +111,7 @@ def test_relu_fp32(device, ttnn_function):
     assert status
 
 
-def run_unary_fp32_test_with_ulp(device, ttnn_function, torch_function, max_ulp):
+def run_unary_fp32_test_with_ulp(device, ttnn_function, torch_function, max_ulp, pcc_check=False, pcc=0.9999):
     all_bf16_values = generate_all_bfloat16_bitpatterns(torch.float32)
 
     # Flush subnormal inputs
@@ -131,7 +131,24 @@ def run_unary_fp32_test_with_ulp(device, ttnn_function, torch_function, max_ulp)
     # Thus, we flush golden output to 0.0 as well to verify this behavior
     y_torch = flush_subnormal_values_to_zero(y_torch)
 
-    assert_with_ulp(y_torch, tt_out, max_ulp, allow_nonfinite=True)
+    if pcc_check:
+        # PCC masks non-finite entries; verify NaN positions, Inf positions, and Inf signs match
+        # exactly so a regression that replaces golden NaNs with ±Inf (or flips sign) is still caught.
+        g_isnan, d_isnan = torch.isnan(y_torch), torch.isnan(tt_out)
+        g_isinf, d_isinf = torch.isinf(y_torch), torch.isinf(tt_out)
+        torch.testing.assert_close(g_isnan, d_isnan, msg="NaN positions differ between golden and device")
+        torch.testing.assert_close(g_isinf, d_isinf, msg="Inf positions differ between golden and device")
+        inf_both = g_isinf & d_isinf
+        if inf_both.any():
+            torch.testing.assert_close(
+                torch.signbit(y_torch[inf_both]),
+                torch.signbit(tt_out[inf_both]),
+                msg="Inf signs differ between golden and device",
+            )
+        finite_mask = torch.isfinite(y_torch) & torch.isfinite(tt_out)
+        assert_with_pcc(y_torch[finite_mask], tt_out[finite_mask], pcc)
+    else:
+        assert_with_ulp(y_torch, tt_out, max_ulp, allow_nonfinite=True)
 
 
 def test_atan_fp32(device):
@@ -139,14 +156,14 @@ def test_atan_fp32(device):
 
 
 def test_asin_fp32(device):
-    run_unary_fp32_test_with_ulp(device, ttnn.asin, torch.asin, max_ulp=100)
+    run_unary_fp32_test_with_ulp(device, ttnn.asin, torch.asin, max_ulp=100, pcc_check=True)
 
 
 def test_acos_fp32(device):
-    run_unary_fp32_test_with_ulp(device, ttnn.acos, torch.acos, max_ulp=100)
+    run_unary_fp32_test_with_ulp(device, ttnn.acos, torch.acos, max_ulp=100, pcc_check=True)
 
 
-def run_unary_test(device, h, w, ttnn_function, ulp=1, allow_nonfinite=False, pcc_check=False):
+def run_unary_test(device, h, w, ttnn_function, ulp=1, allow_nonfinite=False, pcc_check=False, pcc=0.9999):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.float32)
@@ -159,7 +176,7 @@ def run_unary_test(device, h, w, ttnn_function, ulp=1, allow_nonfinite=False, pc
     output_tensor = ttnn.to_torch(output_tensor)
 
     if pcc_check:
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     else:
         assert_with_ulp(torch_output_tensor, output_tensor, ulp, allow_nonfinite=allow_nonfinite)
 
@@ -179,7 +196,7 @@ def test_tanh(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_gelu(device, h, w):
-    run_unary_test(device, h, w, ttnn.gelu, pcc_check=True)
+    run_unary_test(device, h, w, ttnn.gelu, pcc_check=True, pcc=0.9996)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -209,7 +226,7 @@ def test_sinh(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_cosh(device, h, w):
-    run_unary_test(device, h, w, ttnn.cosh, pcc_check=True)
+    run_unary_test(device, h, w, ttnn.cosh, pcc_check=True, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -920,6 +920,23 @@ def test_unary_celu(input_shapes, param, device):
     golden_tensor = golden_function(in_data, alpha=param)
 
     if math.isinf(param) or math.isnan(param):
-        assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+        # PCC masks non-finite entries. For these degenerate alphas the device returns ±inf where the
+        # torch golden returns NaN — a pre-existing semantic gap not in this PR's scope — so we can't
+        # demand exact NaN-mask equivalence. Instead require a high Jaccard overlap of the non-finite
+        # *positions* so regressions are caught in both directions: returning all-non-finite (low
+        # overlap with golden's mask) and returning all-finite (overlap = 0).
+        output_torch = ttnn.to_torch(output_tensor)
+        g_nonfinite = ~torch.isfinite(golden_tensor)
+        d_nonfinite = ~torch.isfinite(output_torch)
+        intersection = (g_nonfinite & d_nonfinite).sum().item()
+        union = (g_nonfinite | d_nonfinite).sum().item()
+        jaccard = intersection / max(union, 1)
+        assert jaccard >= 0.95, (
+            f"Non-finite mask Jaccard overlap {jaccard:.3f} < 0.95 between golden and device; "
+            f"non-finite handling appears regressed (golden non-finite frac="
+            f"{g_nonfinite.float().mean().item():.3f}, device={d_nonfinite.float().mean().item():.3f})."
+        )
+        finite_mask = torch.isfinite(golden_tensor) & torch.isfinite(output_torch)
+        assert_with_pcc(output_torch[finite_mask], golden_tensor[finite_mask], pcc=0.999)
     else:
         assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -307,7 +307,7 @@ def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
     ttnn.erf(input_tensor, fast_and_approximate_mode=fast_and_approx, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.erf(in_data)
 
-    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import torch
 import pytest
 import ttnn
@@ -32,8 +34,7 @@ def test_unary_square_ttnn(input_shapes, device):
     ttnn.square(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.square(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -73,8 +74,7 @@ def test_unary_abs_ttnn(input_shapes, device):
     ttnn.abs(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.abs(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -135,8 +135,7 @@ def test_unary_atan_ttnn(input_shapes, device):
     ttnn.atan(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.atan(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -155,8 +154,7 @@ def test_unary_cos_ttnn(input_shapes, device):
     ttnn.cos(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.cos(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -173,10 +171,9 @@ def test_unary_eqz_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.eqz(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = in_data == 0
+    golden_tensor = (in_data == 0).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -193,10 +190,9 @@ def test_unary_eqz_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.eqz(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = in_data == 0
+    golden_tensor = (in_data == 0).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -213,10 +209,9 @@ def test_unary_nez_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.nez(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = in_data != 0
+    golden_tensor = (in_data != 0).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -233,10 +228,9 @@ def test_unary_gez_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.gez(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = in_data >= 0
+    golden_tensor = (in_data >= 0).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -253,10 +247,9 @@ def test_unary_lez_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.lez(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = in_data <= 0
+    golden_tensor = (in_data <= 0).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -273,10 +266,9 @@ def test_unary_ltz_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.ltz(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = in_data < 0
+    golden_tensor = (in_data < 0).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -293,10 +285,9 @@ def test_unary_gtz_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.gtz(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = in_data > 0
+    golden_tensor = (in_data > 0).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -316,8 +307,7 @@ def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
     ttnn.erf(input_tensor, fast_and_approximate_mode=fast_and_approx, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.erf(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -376,8 +366,7 @@ def test_unary_expm1_ttnn(input_shapes, device):
     ttnn.expm1(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.expm1(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -418,8 +407,7 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
     ttnn.leaky_relu(input_tensor, negative_slope=negative_slope, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.nn.functional.leaky_relu(in_data, negative_slope)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -438,8 +426,7 @@ def test_unary_i0_ttnn(input_shapes, device):
     ttnn.i0(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.i0(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -480,8 +467,7 @@ def test_unary_relu_ttnn(input_shapes, device):
     ttnn.relu(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.relu(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -500,8 +486,7 @@ def test_unary_relu6_ttnn(input_shapes, device):
     ttnn.relu6(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.nn.functional.relu6(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -520,8 +505,7 @@ def test_unary_tan_ttnn(input_shapes, device):
     ttnn.tan(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.tan(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -540,8 +524,7 @@ def test_unary_tanh_ttnn(input_shapes, device):
     ttnn.tanh(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.tanh(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -560,8 +543,7 @@ def test_unary_sign_ttnn(input_shapes, device):
     ttnn.sign(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.sign(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -578,10 +560,9 @@ def test_unary_signbit_ttnn(input_shapes, device):
 
     cq_id = 0
     ttnn.signbit(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.signbit(in_data)
+    golden_tensor = torch.signbit(in_data).float()
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -602,8 +583,7 @@ def test_unary_silu_ttnn(input_shapes, device):
     ttnn.silu(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.nn.functional.silu(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
     atol_delta = torch.max(torch.abs(ttnn.to_torch(output_tensor) - golden_tensor)).item()
     torch.allclose(golden_tensor, ttnn.to_torch(output_tensor), atol=max_atol)
     assert atol_delta <= max_atol, f"Max Atol exceeded: {atol_delta} (allowed: {max_atol})"
@@ -628,7 +608,6 @@ def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device):
     golden_tensor = torch.nn.functional.silu(in_data)
 
     assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2)
-    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(
@@ -647,8 +626,7 @@ def test_unary_log_sigmoid_ttnn(input_shapes, device):
     ttnn.log_sigmoid(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.nn.functional.logsigmoid(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2)
 
 
 @pytest.mark.parametrize(
@@ -677,8 +655,11 @@ def test_unary_sigmoid_ttnn(input_shapes, device, approx_mode):
     )
     golden_tensor = torch.sigmoid(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    if approx_mode:
+        comp_pass = compare_pcc([output_tensor], [golden_tensor])
+        assert comp_pass
+    else:
+        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -697,8 +678,7 @@ def test_unary_recip_ttnn(input_shapes, device):
     ttnn.reciprocal(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.reciprocal(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(
@@ -718,8 +698,7 @@ def test_unary_heaviside_ttnn(input_shapes, value, device):
     ttnn.heaviside(input_tensor, value=value, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.heaviside(in_data, torch.tensor(value, dtype=in_data.dtype))
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -738,8 +717,7 @@ def test_unary_log2_ttnn(input_shapes, device):
     ttnn.log2(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.log2(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize(
@@ -758,8 +736,7 @@ def test_unary_log10_ttnn(input_shapes, device):
     ttnn.log10(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.log10(in_data)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize(
@@ -830,7 +807,7 @@ def test_unary_log1p_ttnn(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.log1p)
     torch_output_tensor = golden_function(torch_input_tensor)
 
-    assert_with_pcc(output_tensor, torch_output_tensor, pcc=0.999)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize(
@@ -942,5 +919,7 @@ def test_unary_celu(input_shapes, param, device):
     golden_function = ttnn.get_golden_function(ttnn.celu)
     golden_tensor = golden_function(in_data, alpha=param)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    if math.isinf(param) or math.isnan(param):
+        assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+    else:
+        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
@@ -30,7 +30,7 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_ulp
 
 
 def run_unary_op(device, op, shape, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG):
@@ -63,11 +63,11 @@ def test_unary_cache_reuse_same_config(device):
 
     torch.manual_seed(0)
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, shape, dtype=ttnn.float32)
-    assert_with_pcc(torch_ref1, tt_out1, 0.9999)
+    assert_equal(torch_ref1, tt_out1)
 
     torch.manual_seed(42)
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.relu, shape, dtype=ttnn.float32)
-    assert_with_pcc(torch_ref2, tt_out2, 0.9999)
+    assert_equal(torch_ref2, tt_out2)
 
     assert device.cache_entries_counter.total == 1
     assert not torch.equal(tt_out1, tt_out2)
@@ -80,10 +80,10 @@ def test_unary_cache_reuse_same_volume_different_shapes(device):
     device.cache_entries_counter.reset()
 
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, [1, 1, 32, 64], dtype=ttnn.float32)
-    assert_with_pcc(torch_ref1, tt_out1, 0.9999)
+    assert_equal(torch_ref1, tt_out1)
 
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.relu, [1, 1, 64, 32], dtype=ttnn.float32)
-    assert_with_pcc(torch_ref2, tt_out2, 0.9999)
+    assert_equal(torch_ref2, tt_out2)
 
     assert device.cache_entries_counter.total == 1
 
@@ -96,10 +96,10 @@ def test_unary_cache_reuse_different_volumes(device):
     device.cache_entries_counter.reset()
 
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, [1, 1, 32, 32], dtype=ttnn.float32)
-    assert_with_pcc(torch_ref1, tt_out1, 0.9999)
+    assert_equal(torch_ref1, tt_out1)
 
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.relu, [1, 1, 64, 64], dtype=ttnn.float32)
-    assert_with_pcc(torch_ref2, tt_out2, 0.9999)
+    assert_equal(torch_ref2, tt_out2)
 
     assert device.cache_entries_counter.total == 1
 
@@ -115,10 +115,10 @@ def test_unary_cache_miss_different_op_types(device):
     shape = [1, 1, 32, 64]
 
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, shape, dtype=ttnn.float32)
-    assert_with_pcc(torch_ref1, tt_out1, 0.9999)
+    assert_equal(torch_ref1, tt_out1)
 
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.sqrt, shape, dtype=ttnn.float32)
-    assert_with_pcc(torch_ref2, tt_out2, 0.9999)
+    assert_with_ulp(torch_ref2, tt_out2, 1)
 
     assert device.cache_entries_counter.total == 2
 
@@ -129,10 +129,10 @@ def test_unary_cache_miss_different_input_dtypes(device):
     shape = [1, 1, 32, 64]
 
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, shape, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref1, tt_out1, 0.9999)
+    assert_equal(torch_ref1, tt_out1)
 
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.relu, shape, dtype=ttnn.float32)
-    assert_with_pcc(torch_ref2, tt_out2, 0.9999)
+    assert_equal(torch_ref2, tt_out2)
 
     assert device.cache_entries_counter.total == 2
 
@@ -145,12 +145,12 @@ def test_unary_cache_miss_different_memory_configs(device):
     torch_ref1, tt_out1 = run_unary_op(
         device, ttnn.relu, shape, dtype=ttnn.float32, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
-    assert_with_pcc(torch_ref1, tt_out1, 0.9999)
+    assert_equal(torch_ref1, tt_out1)
 
     torch_ref2, tt_out2 = run_unary_op(
         device, ttnn.relu, shape, dtype=ttnn.float32, memory_config=ttnn.L1_MEMORY_CONFIG
     )
-    assert_with_pcc(torch_ref2, tt_out2, 0.9999)
+    assert_equal(torch_ref2, tt_out2)
 
     assert device.cache_entries_counter.total == 2
 
@@ -168,7 +168,7 @@ def test_unary_cache_miss_different_sub_core_grids(device):
     tt_a1 = ttnn.from_torch(torch_a1, layout=ttnn.TILE_LAYOUT, device=device)
     with device.cache_entries_counter.measure():
         tt_out1 = ttnn.floor(tt_a1, sub_core_grids=grid_a)
-    assert_with_pcc(torch_ref1, ttnn.to_torch(tt_out1), 0.9999)
+    assert_equal(torch_ref1, ttnn.to_torch(tt_out1))
 
     torch_a2 = torch.rand(shape, dtype=torch.float32) + 0.5
     torch_ref2 = torch.floor(torch_a2)
@@ -176,7 +176,7 @@ def test_unary_cache_miss_different_sub_core_grids(device):
     tt_a2 = ttnn.from_torch(torch_a2, layout=ttnn.TILE_LAYOUT, device=device)
     with device.cache_entries_counter.measure():
         tt_out2 = ttnn.floor(tt_a2, sub_core_grids=grid_b)
-    assert_with_pcc(torch_ref2, ttnn.to_torch(tt_out2), 0.9999)
+    assert_equal(torch_ref2, ttnn.to_torch(tt_out2))
 
     assert device.cache_entries_counter.total == 2
 
@@ -189,7 +189,7 @@ def test_unary_cache_miss_different_factories(device):
     shape = [1, 1, 32, 64]
 
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.floor, shape, dtype=ttnn.float32)
-    assert_with_pcc(torch_ref1, tt_out1, 0.9999)
+    assert_equal(torch_ref1, tt_out1)
 
     torch_a2 = torch.rand(shape, dtype=torch.float32) + 0.5
     with device.cache_entries_counter.measure():
@@ -199,7 +199,7 @@ def test_unary_cache_miss_different_factories(device):
     tt_a2 = ttnn.from_torch(torch_a2, layout=ttnn.TILE_LAYOUT, device=device)
     with device.cache_entries_counter.measure():
         tt_out2 = ttnn.floor(tt_a2, sub_core_grids=grid)
-    assert_with_pcc(torch_ref2, ttnn.to_torch(tt_out2), 0.9999)
+    assert_equal(torch_ref2, ttnn.to_torch(tt_out2))
 
     assert device.cache_entries_counter.total == 2
 
@@ -215,7 +215,7 @@ def test_unary_cache_correctness_repeated_runs(device):
     shape = [1, 1, 32, 64]
     for _ in range(5):
         torch_ref, tt_out = run_unary_op(device, ttnn.relu, shape, dtype=ttnn.float32)
-        assert_with_pcc(torch_ref, tt_out, 0.9999)
+        assert_equal(torch_ref, tt_out)
 
     assert device.cache_entries_counter.total == 1
 
@@ -225,7 +225,7 @@ def test_unary_cache_correctness_same_volume_different_shapes(device):
     device.cache_entries_counter.reset()
     for shape in [[1, 1, 32, 64], [1, 1, 64, 32]]:
         torch_ref, tt_out = run_unary_op(device, ttnn.sqrt, shape, dtype=ttnn.float32)
-        assert_with_pcc(torch_ref, tt_out, 0.9999)
+        assert_with_ulp(torch_ref, tt_out, 1)
 
     assert device.cache_entries_counter.total == 1
 
@@ -292,4 +292,4 @@ def test_unary_sharded_cache_correctness_different_grids(device):
             output = ttnn.abs(input_tensor)
         tt_out = ttnn.to_torch(output)
         torch_ref = torch.abs(torch_tensor)
-        assert_with_pcc(torch_ref, tt_out, 0.9999)
+        assert_equal(torch_ref, tt_out)


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/44060

### PR Category
Test Only

### Summary
This PR replaces assert_with_pcc with stricter, data-type-appropriate assertions across 10 eltwise unary and activation test files.

### What changed:

- assert_with_pcc calls are replaced with assert_with_ulp (ULP threshold capped at 5) for floating-point ops, assert_equal for exact-match ops , and assert_allclose where absolute/relative tolerance is more meaningful.
- Helper functions are refactored to accept a pcc_check boolean parameter. When pcc_check=True, the helper falls back to assert_with_pcc; otherwise it uses assert_with_ulp.
- Operations where the observed ULP exceeds 5, retain PCC-based assertion via pcc_check=True rather than using an inflated ULP threshold.
- bfloat8_b/bfloat4_b dtype tests continue to use PCC due to inherent block-float quantization noise.
- Tests involving non-finite outputs (log of negatives, erfinv out-of-domain, celu with inf/nan alpha) use either allow_nonfinite=True or PCC fallback as appropriate.

### Pipeline Checklist

- [x] Sanity tests - TODO
- [x] (Runtime) Sanity Tests - Passed
- [x] BHPC - Passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/elt_pcc_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/elt_pcc_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/elt_pcc_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/elt_pcc_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/elt_pcc_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/elt_pcc_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/elt_pcc_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/elt_pcc_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/elt_pcc_2)