### PR TITLE
[tt-triage] Reset device after test_hang_report.py

### DIFF
--- a/tools/tests/triage/test_hang_report.py
+++ b/tools/tests/triage/test_hang_report.py
@@ -27,10 +27,23 @@ REPORT_DIR = METAL_HOME / "generated/test_reports"
 FAKE_TEST_ID = "fake/test_hang.py::test_hung_operation[device0]"
 
 
+@pytest.fixture
+def reset_device_after_hang():
+    """Always reset the card after the test.
+
+    This test intentionally hangs the device and has no opt-out — there's no
+    failure mode where a caller wants to keep the broken state. Without a
+    reset here, subsequent test files (e.g. test_triage.py's manual-hang
+    fixture) start on a broken device and fail with "Inspector data unavailable".
+    """
+    yield
+    subprocess.run(["tt-smi", "-r"], check=True)
+
+
 @pytest.mark.skipif(not HANG_APP.exists(), reason="Hang app binary not built")
 @pytest.mark.skipif(not TRIAGE_SCRIPT.exists(), reason="tt-triage.py not found")
 @pytest.mark.skipif(not HANG_REPORT_SCRIPT.exists(), reason="hang_report.py not found")
-def test_hang_generates_junit_xml():
+def test_hang_generates_junit_xml(reset_device_after_hang):
     existing = set(REPORT_DIR.glob("hang_report_*.xml")) if REPORT_DIR.exists() else set()
 
     triage_output_path = METAL_HOME / "generated/triage_output.txt"


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Adds reset device after `test_hang_report.py`. The device was left in a hung state after that test and the next first triage test will hit an inspector error due to metal not being able to initialize onto a hung device and hanging but no inspector is online.

Causing metal L2 nightly to fail, but not merge gate, as this test is enabled only in that group.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-nightly-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-nightly-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/triage-nightly-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-nightly-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-nightly-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-nightly-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-nightly-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-nightly-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-nightly-fix)