### PR TITLE
Fixing DEVICE_PRINT on Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
@@ -37,9 +37,8 @@ void UpdateGoldenOutput(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const std::string& risc) {
     // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
-    // by machine
-    const std::string& device_core_risc =
-        std::to_string(mesh_device->get_devices()[0]->id()) + ":(x=?,y=?):" + risc + ": ";
+    // by machine. CoreCoord::str() formats as "x-y".
+    const std::string& device_core_risc = std::to_string(mesh_device->get_devices()[0]->id()) + ":?-?:" + risc + ": ";
 
     const std::string& output_line_all_riscs = device_core_risc + "Printing on a RISC.";
     golden_output.push_back(output_line_all_riscs);

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -37,9 +37,8 @@ void UpdateGoldenOutput(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const std::string& risc) {
     // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
-    // by machine
-    const std::string& device_core_risc =
-        std::to_string(mesh_device->get_devices()[0]->id()) + ":(x=?,y=?):" + risc + ": ";
+    // by machine. CoreCoord::str() formats as "x-y".
+    const std::string& device_core_risc = std::to_string(mesh_device->get_devices()[0]->id()) + ":?-?:" + risc + ": ";
 
     const std::string& output_line_all_riscs = device_core_risc + "Printing on a RISC.";
     golden_output.push_back(output_line_all_riscs);

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -201,12 +201,8 @@ extern "C" uint32_t _start1() {
     extern uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
     WAYPOINT("I");
-    DEVICE_PRINT_UPDATE_PROCESSOR_INDEX();
-    if (hartid == 0) {
-        DEVICE_PRINT_INITIALIZE_LOCK();
-    }
-    // DPRINT << "DM0-FW: initialized" << ENDL();
-    // DEVICE_PRINT("DM0-FW: initialized\n");
+    DPRINT << "DM0-FW: initialized" << ENDL();
+    DEVICE_PRINT("DM0-FW: initialized\n");
 
     // handle noc_tobank ???
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -201,8 +201,8 @@ extern "C" uint32_t _start1() {
     extern uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
     WAYPOINT("I");
-    DPRINT << "DM0-FW: initialized" << ENDL();
-    DEVICE_PRINT("DM0-FW: initialized\n");
+    // DPRINT << "DM0-FW: initialized" << ENDL();
+    // DEVICE_PRINT("DM0-FW: initialized\n");
 
     // handle noc_tobank ???
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -201,6 +201,10 @@ extern "C" uint32_t _start1() {
     extern uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
     WAYPOINT("I");
+    DEVICE_PRINT_UPDATE_PROCESSOR_INDEX();
+    if (hartid == 0) {
+        DEVICE_PRINT_INITIALIZE_LOCK();
+    }
     // DPRINT << "DM0-FW: initialized" << ENDL();
     // DEVICE_PRINT("DM0-FW: initialized\n");
 
@@ -214,7 +218,6 @@ extern "C" uint32_t _start1() {
     if (hartid > 0) {
         signal_subordinate_completion();
     } else {  // This is DM0
-        DEVICE_PRINT_INITIALIZE_LOCK();
         risc_init();
         noc_bank_table_init(MEM_BANK_TO_NOC_SCRATCH);
         thread_sync_init();

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -117,6 +117,7 @@ extern "C" uint32_t _start1() {
     volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
                                                        ->subordinate_sync.map[hartid];  // first entry is for NCRISC
     WAYPOINT("I");
+    DEVICE_PRINT_UPDATE_PROCESSOR_INDEX();
 
     extern uint32_t __ldm_data_start[];
     do_crt1(__ldm_data_start);

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -117,7 +117,6 @@ extern "C" uint32_t _start1() {
     volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
                                                        ->subordinate_sync.map[hartid];  // first entry is for NCRISC
     WAYPOINT("I");
-    DEVICE_PRINT_UPDATE_PROCESSOR_INDEX();
 
     extern uint32_t __ldm_data_start[];
     do_crt1(__ldm_data_start);

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -24,8 +24,10 @@
 #endif
 
 #ifndef PROCESSOR_INDEX
-#define USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED 1
-#define PROCESSOR_INDEX device_print_detail::processor_index_saved
+#define PROCESSOR_INDEX_DEFINED 0
+#define PROCESSOR_INDEX internal_::get_hw_thread_idx()
+#else
+#define PROCESSOR_INDEX_DEFINED 1
 #endif
 
 #define DEVICE_PRINT_STRINGS_SECTION_NAME ".device_print_strings"
@@ -186,7 +188,9 @@ struct dp_typed_array_t {
                 constexpr auto message_size = device_print_detail::serialization::get_total_message_size(args...); \
                 device_print_detail::structures::DevicePrintHeader header = {};                                    \
                 header.is_kernel = DEVICE_PRINT_IS_KERNEL;                                                         \
-                header.risc_id = PROCESSOR_INDEX;                                                                  \
+                if constexpr (PROCESSOR_INDEX_DEFINED) {                                                           \
+                    header.risc_id = PROCESSOR_INDEX;                                                              \
+                }                                                                                                  \
                 header.message_payload =                                                                           \
                     message_size - sizeof(header); /* Payload size does not include header itself */               \
                 return header;                                                                                     \
@@ -213,17 +217,8 @@ struct dp_typed_array_t {
 
 #define DEVICE_PRINT_INITIALIZE_LOCK() device_print_detail::locking::initialize_lock()
 #define DEVICE_PRINT_KERNEL_FINISHED() device_print_detail::locking::update_kernel_finished()
-#ifdef USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED
-#define DEVICE_PRINT_UPDATE_PROCESSOR_INDEX() PROCESSOR_INDEX = internal_::get_hw_thread_idx()
-#else
-#define DEVICE_PRINT_UPDATE_PROCESSOR_INDEX()
-#endif
 
 namespace device_print_detail {
-
-#ifdef USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED
-static uint32_t processor_index_saved = 0;
-#endif
 
 // Helper to invoke a callable with arguments copied by value.
 // This allows DEVICE_PRINT to accept volatile packed struct fields,
@@ -1301,6 +1296,19 @@ namespace locking {
 uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer, uint32_t message_size);
 void release_lock();
 
+#if !defined(ARCH_WORMHOLE)
+volatile tt_l1_ptr std::atomic<uint32_t>& get_lock_atomic() {
+#if !defined(ARCH_QUASAR)
+    return get_device_print_buffer()->aux.lock;
+#else
+    std::uintptr_t buffer_address = reinterpret_cast<std::uintptr_t>(get_device_print_buffer());
+    auto uncached_address = buffer_address - MEM_L1_UNCACHED_BASE;
+    auto* print_buffer = reinterpret_cast<volatile tt_l1_ptr DevicePrintMemoryLayout*>(uncached_address);
+    return print_buffer->aux.lock;
+#endif
+}
+#endif
+
 // Takes lock unconditionally. Prints kernel id message if needed.
 void acquire_lock() {
     // We need to acquire lock only if we have more than 1 processor, otherwise there is no contention.
@@ -1336,7 +1344,7 @@ void acquire_lock() {
             }
         }
 #else
-        auto& lock_atomic = get_device_print_buffer()->aux.lock;
+        auto& lock_atomic = get_lock_atomic();
 
         while (lock_atomic.exchange(1) != 0) {
             // Failed to acquire lock, wait and try again
@@ -1355,15 +1363,20 @@ void acquire_lock() {
     // Check if we should print kernel id
     volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer = get_device_print_buffer();
     if (device_print_buffer->aux.wpos != DEBUG_PRINT_SERVER_DISABLED_MAGIC) {
-        auto risc_state = device_print_buffer->aux.risc_state[PROCESSOR_INDEX];
+#if PROCESSOR_INDEX_DEFINED
+        constexpr auto processor_index = PROCESSOR_INDEX;
+#else
+        auto processor_index = internal_::get_hw_thread_idx();
+#endif
+        auto risc_state = device_print_buffer->aux.risc_state[processor_index];
         if (risc_state != DevicePrintRiscCoreState::PrintingDisabled) {
             if (risc_state == DevicePrintRiscCoreState::KernelNotPrinted) {
                 uint32_t launch_idx = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
                 tt_l1_ptr launch_msg_t* const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_idx]);
-                auto kernel_id = launch_msg->kernel_config.watcher_kernel_ids[PROCESSOR_INDEX];
+                auto kernel_id = launch_msg->kernel_config.watcher_kernel_ids[processor_index];
                 structures::DevicePrintHeader new_kernel_message = {};
                 new_kernel_message.is_kernel = 1;
-                new_kernel_message.risc_id = PROCESSOR_INDEX;
+                new_kernel_message.risc_id = processor_index;
                 new_kernel_message.message_payload = structures::DevicePrintHeader::max_message_payload_size;
                 new_kernel_message.info_id = kernel_id;
                 auto header_value = new_kernel_message.value;
@@ -1373,7 +1386,7 @@ void acquire_lock() {
                 formatting::device_print_type<decltype(header_value)>::serialize(
                     device_print_buffer_ptr, 0, header_value);
                 device_print_buffer->aux.wpos += sizeof(new_kernel_message);
-                device_print_buffer->aux.risc_state[PROCESSOR_INDEX] = DevicePrintRiscCoreState::KernelPrinted;
+                device_print_buffer->aux.risc_state[processor_index] = DevicePrintRiscCoreState::KernelPrinted;
             }
         }
     }
@@ -1382,8 +1395,13 @@ void acquire_lock() {
 
 void update_kernel_finished() {
     volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer = get_device_print_buffer();
-    if (device_print_buffer->aux.risc_state[PROCESSOR_INDEX] != DevicePrintRiscCoreState::PrintingDisabled) {
-        device_print_buffer->aux.risc_state[PROCESSOR_INDEX] = DevicePrintRiscCoreState::KernelNotPrinted;
+#if PROCESSOR_INDEX_DEFINED
+    constexpr auto processor_index = PROCESSOR_INDEX;
+#else
+    auto processor_index = internal_::get_hw_thread_idx();
+#endif
+    if (device_print_buffer->aux.risc_state[processor_index] != DevicePrintRiscCoreState::PrintingDisabled) {
+        device_print_buffer->aux.risc_state[processor_index] = DevicePrintRiscCoreState::KernelNotPrinted;
     }
 }
 
@@ -1395,7 +1413,7 @@ void release_lock() {
     *lock_ptr = 0;  // Release lock by setting to 0
     asm volatile("" ::: "memory");
 #else
-    auto& lock_atomic = get_device_print_buffer()->aux.lock;
+    auto& lock_atomic = get_lock_atomic();
     lock_atomic = 0;
 #endif
 }
@@ -1407,7 +1425,7 @@ void initialize_lock() {
     *lock_ptr = 0;  // Ensure lock starts in free state
     asm volatile("" ::: "memory");
 #else
-    auto& lock_atomic = get_device_print_buffer()->aux.lock;
+    auto& lock_atomic = get_lock_atomic();
     lock_atomic = 0;
 #endif
 }
@@ -1628,6 +1646,10 @@ begin_message_write(structures::DevicePrintHeader header, std::uintptr_t string_
         header.info_id = static_cast<uint32_t>(string_info_index);
     }
 
+#if !PROCESSOR_INDEX_DEFINED
+    header.risc_id = internal_::get_hw_thread_idx();
+#endif
+
     // Serialize header
     auto device_print_buffer_ptr = &(device_print_buffer->data[0]) + write_position;
     formatting::device_print_type<decltype(header.value)>::serialize(device_print_buffer_ptr, 0, header.value);
@@ -1668,6 +1690,5 @@ __attribute__((noinline)) void end_message_write() {
 #define DEVICE_PRINT(format, ...)
 #define DEVICE_PRINT_INITIALIZE_LOCK()
 #define DEVICE_PRINT_KERNEL_FINISHED()
-#define DEVICE_PRINT_UPDATE_PROCESSOR_INDEX()
 
 #endif

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -1346,6 +1346,7 @@ void acquire_lock() {
     // After acquiring the lock, invalidate our L1 cache to ensure we see the most up-to-date data in the buffer
     invalidate_l1_cache();
 
+#if defined(KERNEL_BUILD)
     // Check if we should print kernel id
     volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer = get_device_print_buffer();
     if (device_print_buffer->aux.wpos != DEBUG_PRINT_SERVER_DISABLED_MAGIC) {
@@ -1371,6 +1372,7 @@ void acquire_lock() {
             }
         }
     }
+#endif
 }
 
 void update_kernel_finished() {

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -213,6 +213,11 @@ struct dp_typed_array_t {
 
 #define DEVICE_PRINT_INITIALIZE_LOCK() device_print_detail::locking::initialize_lock()
 #define DEVICE_PRINT_KERNEL_FINISHED() device_print_detail::locking::update_kernel_finished()
+#ifdef USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED
+#define DEVICE_PRINT_UPDATE_PROCESSOR_INDEX() PROCESSOR_INDEX = internal_::get_hw_thread_idx()
+#else
+#define DEVICE_PRINT_UPDATE_PROCESSOR_INDEX()
+#endif
 
 namespace device_print_detail {
 
@@ -1405,9 +1410,6 @@ void initialize_lock() {
     auto& lock_atomic = get_device_print_buffer()->aux.lock;
     lock_atomic = 0;
 #endif
-#ifdef USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED
-    PROCESSOR_INDEX = internal_::get_hw_thread_idx();
-#endif
 }
 
 uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer, uint32_t message_size) {
@@ -1666,5 +1668,6 @@ __attribute__((noinline)) void end_message_write() {
 #define DEVICE_PRINT(format, ...)
 #define DEVICE_PRINT_INITIALIZE_LOCK()
 #define DEVICE_PRINT_KERNEL_FINISHED()
+#define DEVICE_PRINT_UPDATE_PROCESSOR_INDEX()
 
 #endif

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -23,6 +23,11 @@
 #include "dprint_tile.h"
 #endif
 
+#ifndef PROCESSOR_INDEX
+#define USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED 1
+#define PROCESSOR_INDEX device_print_detail::processor_index_saved
+#endif
+
 #define DEVICE_PRINT_STRINGS_SECTION_NAME ".device_print_strings"
 #define DEVICE_PRINT_STRINGS_INFO_SECTION_NAME ".device_print_strings_info"
 
@@ -210,6 +215,10 @@ struct dp_typed_array_t {
 #define DEVICE_PRINT_KERNEL_FINISHED() device_print_detail::locking::update_kernel_finished()
 
 namespace device_print_detail {
+
+#ifdef USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED
+static uint32_t processor_index_saved = 0;
+#endif
 
 // Helper to invoke a callable with arguments copied by value.
 // This allows DEVICE_PRINT to accept volatile packed struct fields,
@@ -797,30 +806,16 @@ template <>
 struct device_print_type<char*> {
     static constexpr device_print_type_info value = {'s', sizeof(char*)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, char* argument) {
-        if constexpr (sizeof(char*) == 4) {
-            *reinterpret_cast<device_print_buffer_ptr<uint32_t>>(device_print_buffer + offset) =
-                reinterpret_cast<uint32_t>(argument);
-        } else if constexpr (sizeof(char*) == 8) {
-            *reinterpret_cast<device_print_buffer_ptr<uint64_t>>(device_print_buffer + offset) =
-                reinterpret_cast<uint64_t>(argument);
-        } else {
-            static_assert(sizeof(char*) == 4 || sizeof(char*) == 8, "Unsupported pointer size");
-        }
+        *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
+                reinterpret_cast<std::uintptr_t>(argument);
     }
 };
 template <>
 struct device_print_type<const char*> {
     static constexpr device_print_type_info value = {'s', sizeof(const char*)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, const char* argument) {
-        if constexpr (sizeof(const char*) == 4) {
-            *reinterpret_cast<device_print_buffer_ptr<uint32_t>>(device_print_buffer + offset) =
-                reinterpret_cast<uint32_t>(argument);
-        } else if constexpr (sizeof(const char*) == 8) {
-            *reinterpret_cast<device_print_buffer_ptr<uint64_t>>(device_print_buffer + offset) =
-                reinterpret_cast<uint64_t>(argument);
-        } else {
-            static_assert(sizeof(const char*) == 4 || sizeof(const char*) == 8, "Unsupported pointer size");
-        }
+        *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
+                reinterpret_cast<std::uintptr_t>(argument);
     }
 };
 
@@ -830,13 +825,8 @@ template <>
 struct device_print_type<ct_string> {
     static constexpr device_print_type_info value = {'s', sizeof(const char*)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, ct_string argument) {
-        if constexpr (sizeof(const char*) == 4) {
-            *reinterpret_cast<device_print_buffer_ptr<uint32_t>>(device_print_buffer + offset) =
-                reinterpret_cast<uint32_t>(argument.ptr);
-        } else if constexpr (sizeof(const char*) == 8) {
-            *reinterpret_cast<device_print_buffer_ptr<uint64_t>>(device_print_buffer + offset) =
-                reinterpret_cast<uint64_t>(argument.ptr);
-        }
+        *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
+                reinterpret_cast<std::uintptr_t>(argument.ptr);
     }
 };
 
@@ -1412,6 +1402,9 @@ void initialize_lock() {
 #else
     auto& lock_atomic = get_device_print_buffer()->aux.lock;
     lock_atomic = 0;
+#endif
+#ifdef USE_DEVICE_PRINT_PROCESSOR_INDEX_SAVED
+    PROCESSOR_INDEX = internal_::get_hw_thread_idx();
 #endif
 }
 

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -1302,8 +1302,8 @@ volatile tt_l1_ptr std::atomic<uint32_t>& get_lock_atomic() {
     return get_device_print_buffer()->aux.lock;
 #else
     std::uintptr_t buffer_address = reinterpret_cast<std::uintptr_t>(get_device_print_buffer());
-    auto uncached_address = buffer_address - MEM_L1_UNCACHED_BASE;
-    auto* print_buffer = reinterpret_cast<volatile tt_l1_ptr DevicePrintMemoryLayout*>(uncached_address);
+    auto cached_address = buffer_address - MEM_L1_UNCACHED_BASE;
+    auto* print_buffer = reinterpret_cast<volatile tt_l1_ptr DevicePrintMemoryLayout*>(cached_address);
     return print_buffer->aux.lock;
 #endif
 }

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -196,8 +196,17 @@ const DeviceBuildEnv& BuildEnvManager::get_device_build_env(ChipId device_id) {
 
 const JitBuildState& BuildEnvManager::get_firmware_build_state(
     ChipId device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id) {
-    const uint32_t state_idx =
-        get_firmware_build_index_and_state_count(programmable_core, processor_class).first + processor_id;
+    // `processor_id` is indexed in the per-processor-type space (0..get_processor_types_count-1),
+    // which on Quasar can span replicated NEOs (e.g. COMPUTE has 16 entries: 4 NEOs x 4 TRISCs).
+    // Firmware binaries are built per TRISC type only (num_fw_binaries == 4 for COMPUTE), and the
+    // processor layout is {NEO0 TR0..3, NEO1 TR0..3, ...}, so the type index is processor_id % num_fw_binaries.
+    const auto [base, num_fw_binaries] = get_firmware_build_index_and_state_count(programmable_core, processor_class);
+    TT_ASSERT(
+        num_fw_binaries > 0,
+        "No firmware binaries for programmable_core={} processor_class={}",
+        programmable_core,
+        processor_class);
+    const uint32_t state_idx = base + (static_cast<uint32_t>(processor_id) % num_fw_binaries);
     return get_device_build_env(device_id).firmware_build_states[state_idx];
 }
 


### PR DESCRIPTION
Fixing `DEVICE_PRINT` for Quasar.
Problems encountered:
- It is not single risc core that is being taken out of reset, so multiple could put lock to init value and make others pass lock gate. It is changed so that host initializes lock for them.
- `device_print.h` changes to support not having `PROCESSOR_INDEX` defined
- Getting atomic lock was problematic since it had address in 4MB range, instead of in cache range.
- Kernel start message was incorrectly sent for firmware
- `BuildEnvManager::get_firmware_build_state` didn't have incorporated changes for Quasar.

There are two more warnings that pollute kernel build output in `eth_fw_api.h` that should be fixed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/device_print_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/device_print_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/device_print_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/device_print_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/device_print_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/device_print_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/device_print_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/device_print_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/device_print_quasar)