### PR TITLE
Migrate experimental/transformer leftover ops (6) to ProgramDescriptor

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -14,9 +14,10 @@
 #include "ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
 #include "ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.hpp"
 
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/constants.hpp>
@@ -30,6 +31,7 @@
 namespace ttnn::experimental::prim {
 
 using namespace ttnn::ccl;
+using namespace tt::tt_metal;
 
 namespace {
 
@@ -93,36 +95,19 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores_fuse(
 
 }  // namespace
 
-AllReduceCreateQkvHeadsMeshWorkloadFactory::cached_mesh_workload_t
-AllReduceCreateQkvHeadsMeshWorkloadFactory::create_mesh_workload(
+ProgramDescriptor AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor(
     const AllReduceCreateQkvHeadsParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const AllReduceCreateQkvHeadsInputs& tensor_args,
-    AllReduceCreateQkvHeadsResult& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    AllReduceCreateQkvHeadsResult& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    TT_FATAL(
+        mesh_dispatch_coordinate.has_value(),
+        "AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor requires a mesh dispatch coordinate");
+    const ttnn::MeshCoordinate mesh_coord = mesh_dispatch_coordinate.value();
 
-    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-        for (const auto& mesh_coord : mesh_coord_range) {
-            const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-            auto cached_program = create_at(operation_attributes, mesh_coord, tensor_args, tensor_return_value);
-            shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-            mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-        }
-    }
+    log_debug(tt::LogOp, "AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor called");
 
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
-}
-
-ttnn::device_operation::CachedProgram<AllReduceCreateQkvHeadsSharedVariables>
-AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
-    const AllReduceCreateQkvHeadsParams& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coord,
-    const AllReduceCreateQkvHeadsInputs& tensor_args,
-    AllReduceCreateQkvHeadsResult& tensor_return_value) {
-    log_debug(tt::LogOp, "AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at called");
-
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& buffer_tensor = tensor_args.buffer_tensor;
@@ -227,12 +212,15 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
     uint32_t single_batch_offset_tile_size = tt::tile_size(cb_batch_offset_data_format);
     batch_offset_index_stick_size = batch_offset_tensor.buffer()->aligned_page_size();
 
-    tt::tt_metal::CircularBufferConfig cb_batch_offset_config_reader =
-        tt::tt_metal::CircularBufferConfig(
-            single_batch_offset_tile_size, {{batch_offset_cb_index_reader, cb_batch_offset_data_format}})
-            .set_page_size(batch_offset_cb_index_reader, 1);
-    tt::tt_metal::CreateCircularBuffer(
-        program, output_tensor.memory_config().shard_spec()->grid, cb_batch_offset_config_reader);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = single_batch_offset_tile_size,
+        .core_ranges = output_tensor.memory_config().shard_spec()->grid,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_reader),
+            .data_format = cb_batch_offset_data_format,
+            .page_size = 1,
+        }}},
+    });
 
     uint32_t q_base_addr = q_output_tensor.buffer()->address();
     uint32_t k_base_addr = k_output_tensor.buffer()->address();
@@ -361,21 +349,29 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     tt::DataFormat output_df = tt::tt_metal::datatype_to_dataformat_converter(operation_attributes.dtype);
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
-            .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_num_pages * l1_scratch_cb_page_size_bytes,
+        .core_ranges = sender_worker_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = df,
+            .page_size = l1_scratch_cb_page_size_bytes,
+        }}},
+    });
 
     // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
     const auto reserved_packet_header_CB_index = tt::CBIndex::c_3;
     static constexpr auto num_packet_headers_storable = 8;
     auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
-    tt::tt_metal::CircularBufferConfig cb_reserved_packet_header_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_packet_headers_storable * packet_header_size_bytes * 2,
-            {{reserved_packet_header_CB_index, tt::DataFormat::RawUInt32}})
-            .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_packet_headers_storable * packet_header_size_bytes * 2,
+        .core_ranges = sender_worker_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(reserved_packet_header_CB_index),
+            .data_format = tt::DataFormat::RawUInt32,
+            .page_size = packet_header_size_bytes,
+        }}},
+    });
 
     // Reduction kernel setup
     auto all_cores = output_tensor_cores.merge(sender_worker_core_range);
@@ -464,11 +460,20 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
         }
     }
 
-    // Create reduction semaphores for each link
+    // Create reduction semaphores for each link.  Translate CreateSemaphore(program, all_cores, 0)
+    // calls to SemaphoreDescriptor entries with sequential ids; the descriptor framework
+    // allocates real semaphore ids from these on cache miss.
     std::vector<uint32_t> reduction_semaphore_ids;
     reduction_semaphore_ids.reserve(operation_attributes.num_links);
     for (uint32_t link = 0; link < operation_attributes.num_links; link++) {
-        reduction_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, all_cores, 0));
+        uint32_t sem_id = static_cast<uint32_t>(desc.semaphores.size());
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = sem_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = all_cores,
+            .initial_value = 0,
+        });
+        reduction_semaphore_ids.push_back(sem_id);
     }
 
     /* reduction cb */
@@ -477,11 +482,18 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
     uint32_t reduction_CB_size = reduction_CB_tiles * reduction_CB_single_tile_size;
 
     uint32_t reduction_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig reduction_cb_config =
-        tt::tt_metal::CircularBufferConfig(reduction_CB_size, {{reduction_cb_index, df}})
-            .set_page_size(reduction_cb_index, reduction_CB_single_tile_size)
-            .set_globally_allocated_address(*buffer_tensor.buffer());
-    auto cb_reduction = tt::tt_metal::CreateCircularBuffer(program, all_cores, reduction_cb_config);
+    // Globally-allocated CB backed by buffer_tensor.buffer(); the descriptor framework
+    // patches the address automatically on every dispatch when .buffer is set.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = reduction_CB_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(reduction_cb_index),
+            .data_format = df,
+            .page_size = reduction_CB_single_tile_size,
+        }}},
+        .buffer = buffer_tensor.buffer(),
+    });
 
     /* out cb */
     uint32_t out_CB_single_tile_size = output_tensor.tensor_spec().tile().get_tile_size(output_df);
@@ -489,12 +501,16 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
     uint32_t out_CB_size = out_CB_tiles * out_CB_single_tile_size;
 
     uint32_t out_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig out_cb_config =
-        tt::tt_metal::CircularBufferConfig(out_CB_size, {{out_cb_index, output_df}})
-            .set_page_size(out_cb_index, out_CB_single_tile_size)
-            .set_globally_allocated_address(*output_tensor.buffer());  // TODO: Remove once new cb attached for output
-    auto cb_out = tt::tt_metal::CreateCircularBuffer(
-        program, output_tensor_cores, out_cb_config);  // TODO: This should be the output cores instead
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out_CB_size,
+        .core_ranges = output_tensor_cores,  // TODO: This should be the output cores instead
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(out_cb_index),
+            .data_format = output_df,
+            .page_size = out_CB_single_tile_size,
+        }}},
+        .buffer = output_tensor.buffer(),  // TODO: Remove once new cb attached for output
+    });
 
     // Create reduction dataflow kernel
     std::vector<uint32_t> reader_compile_time_args = {
@@ -534,51 +550,61 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
     };
     tt::tt_metal::TensorAccessorArgs(batch_offset_tensor.buffer()).append_to(writer_compile_time_args);
 
-    auto reduction_reader_kernel_config = tt::tt_metal::DataMovementConfig{
+    KernelDescriptor reduction_reader_kernel_desc;
+    reduction_reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/"
+        "reduction_receiver.cpp";
+    reduction_reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reduction_reader_kernel_desc.core_ranges = output_tensor_cores;
+    reduction_reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
+    reduction_reader_kernel_desc.config = DataMovementConfigDescriptor{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
         .noc = operation_attributes.use_noc1_only ? tt::tt_metal::NOC::NOC_1 : reader_noc,
         .noc_mode = operation_attributes.use_noc1_only ? tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC
                                                        : tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
-        .compile_args = std::move(reader_compile_time_args)};
+    };
+    desc.kernels.push_back(std::move(reduction_reader_kernel_desc));
+    KernelHandle reduction_reader_kernel_id = desc.kernels.size() - 1;
 
-    auto reduction_writer_kernel_config = tt::tt_metal::DataMovementConfig{
+    KernelDescriptor reduction_writer_kernel_desc;
+    reduction_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/"
+        "reduction_receiver.cpp";
+    reduction_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reduction_writer_kernel_desc.core_ranges = output_tensor_cores;
+    reduction_writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
+    reduction_writer_kernel_desc.config = DataMovementConfigDescriptor{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
         .noc = operation_attributes.use_noc1_only ? tt::tt_metal::NOC::NOC_1 : writer_noc,
         .noc_mode = operation_attributes.use_noc1_only ? tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC
                                                        : tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
-        .compile_args = std::move(writer_compile_time_args)};
-
-    auto reduction_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/"
-        "reduction_receiver.cpp",
-        output_tensor_cores,
-        reduction_reader_kernel_config);
-
-    auto reduction_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/"
-        "reduction_receiver.cpp",
-        output_tensor_cores,
-        reduction_writer_kernel_config);
+    };
+    desc.kernels.push_back(std::move(reduction_writer_kernel_desc));
+    KernelHandle reduction_writer_kernel_id = desc.kernels.size() - 1;
 
     // Create reduction compute kernel
-    auto reduction_kernel_config = tt::tt_metal::ComputeConfig{};
-    reduction_kernel_config.compile_args = {
+    KernelDescriptor reduction_compute_kernel_desc;
+    reduction_compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/compute/"
+        "reduction.cpp";
+    reduction_compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reduction_compute_kernel_desc.core_ranges = output_tensor_cores;
+    reduction_compute_kernel_desc.compile_time_args = {
         reduction_cb_index,
         out_cb_index,
     };
-    auto reduction_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/compute/"
-        "reduction.cpp",
-        output_tensor_cores,
-        reduction_kernel_config);
+    reduction_compute_kernel_desc.config = ComputeConfigDescriptor{};
+    // Runtime args for the reduction compute kernel are the same for every core in
+    // output_tensor_cores.  Mirror SetRuntimeArgs(program, kernel, cores, args) by
+    // emplacing per-core copies for every logical core in the range set.
     std::vector<uint32_t> reduction_kernel_rt_args = {
         operation_attributes.ring_size,  // num_blocks
         output_tensor_shard_num_pages,   // block_num_tiles
     };
-    tt::tt_metal::SetRuntimeArgs(program, reduction_kernel_id, output_tensor_cores, reduction_kernel_rt_args);
+    for (const auto& core : output_cores_vec) {
+        reduction_compute_kernel_desc.runtime_args.emplace_back(core, reduction_kernel_rt_args);
+    }
+    desc.kernels.push_back(std::move(reduction_compute_kernel_desc));
 
     // Now prepare rt args for the reader and writer kernels
 
@@ -613,17 +639,21 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
         op_config.get_page_size(),  // tensor0_page_size
     };
     log_trace(tt::LogOp, "Reader Compile Args:");
-    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor worker_sender_reader_kernel_desc;
+    worker_sender_reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/"
-        "worker_reader.cpp",
-        sender_worker_core_range,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = reader_noc,
-            .noc_mode = operation_attributes.use_noc1_only ? tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC
-                                                           : tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
-            .compile_args = reader_compile_args});
+        "worker_reader.cpp";
+    worker_sender_reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    worker_sender_reader_kernel_desc.core_ranges = sender_worker_core_range;
+    worker_sender_reader_kernel_desc.compile_time_args = std::move(reader_compile_args);
+    worker_sender_reader_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = reader_noc,
+        .noc_mode = operation_attributes.use_noc1_only ? tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC
+                                                       : tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+    };
+    desc.kernels.push_back(std::move(worker_sender_reader_kernel_desc));
+    KernelHandle worker_sender_reader_kernel_id = desc.kernels.size() - 1;
 
     // Writer
     std::vector<uint32_t> writer_compile_args = {
@@ -637,17 +667,21 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
         num_targets_backward,             // num_targets_backward_direction
     };
     log_trace(tt::LogOp, "Writer Compile Args:");
-    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor worker_sender_writer_kernel_desc;
+    worker_sender_writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/"
-        "worker_writer.cpp",
-        sender_worker_core_range,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = writer_noc,
-            .noc_mode = operation_attributes.use_noc1_only ? tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC
-                                                           : tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
-            .compile_args = writer_compile_args});
+        "worker_writer.cpp";
+    worker_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    worker_sender_writer_kernel_desc.core_ranges = sender_worker_core_range;
+    worker_sender_writer_kernel_desc.compile_time_args = std::move(writer_compile_args);
+    worker_sender_writer_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = writer_noc,
+        .noc_mode = operation_attributes.use_noc1_only ? tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC
+                                                       : tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+    };
+    desc.kernels.push_back(std::move(worker_sender_writer_kernel_desc));
+    KernelHandle worker_sender_writer_kernel_id = desc.kernels.size() - 1;
 
     // Kernel Runtime Args
     for (uint32_t link = 0; link < operation_attributes.num_links; link++) {
@@ -675,21 +709,23 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
             output_tensor_cores_y.push_back(this_core.y);
         }
 
-        // Set reader runtime args
-        std::vector<uint32_t> reader_rt_args = {
-            input_tensor.buffer()->address(),    // tensor_address0
-            input_tensor_shard_num_pages,        // num_tiles_per_core
-            worker_num_tiles_to_read,            // num_tiles_to_read
-            input_first_core_tile_start_offset,  // first_core_tile_start_offset
-            input_tensor_cores_x.size(),         // num_cores
-        };
-        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_x.begin(), input_tensor_cores_x.end());
-        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_y.begin(), input_tensor_cores_y.end());
-        log_trace(tt::LogOp, "Reader Runtime Args:");
-        for ([[maybe_unused]] const auto& arg : reader_rt_args) {
-            log_trace(tt::LogOp, "\t{}", arg);
+        // Set reader runtime args.  Index 0 (input tensor buffer base address) is
+        // pushed as Buffer* so the framework records a BufferBinding for the
+        // cache-hit fast path.
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(input_tensor.buffer());                               // tensor_address0
+        reader_rt_args.push_back(input_tensor_shard_num_pages);                        // num_tiles_per_core
+        reader_rt_args.push_back(worker_num_tiles_to_read);                            // num_tiles_to_read
+        reader_rt_args.push_back(input_first_core_tile_start_offset);                  // first_core_tile_start_offset
+        reader_rt_args.push_back(static_cast<uint32_t>(input_tensor_cores_x.size()));  // num_cores
+        for (uint32_t v : input_tensor_cores_x) {
+            reader_rt_args.push_back(v);
         }
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+        for (uint32_t v : input_tensor_cores_y) {
+            reader_rt_args.push_back(v);
+        }
+        log_trace(tt::LogOp, "Reader Runtime Args appended");
+        desc.kernels[worker_sender_reader_kernel_id].emplace_runtime_args(core, reader_rt_args);
 
         // Set writer runtime args
         std::vector<uint32_t> mcast_start_x;
@@ -717,20 +753,22 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
         }
 
         uint32_t out_ready_sem_wait_value = operation_attributes.ring_size;
+        // Writer RT args: build into a plain std::vector<uint32_t> first because the
+        // fabric helper appends into a vector.
         std::vector<uint32_t> writer_rt_args = {
-            reduction_cb_index,                        // tensor_address0
-            operation_attributes.semaphore.address(),  // out_ready_sem_bank_addr (absolute address)
-            output_tensor_shard_num_pages,             // num_tiles_per_core
-            worker_num_tiles_to_read,                  // num_tiles_to_read
-            output_first_core_tile_start_offset,       // first_core_tile_start_offset
-            output_tensor_cores_x.size(),              // num_cores
-            num_mcast_cores,                           // num_mcast_cores
-            drain_sync_core.x,                         // out_ready_sem_noc0_x
-            drain_sync_core.y,                         // out_ready_sem_noc0_y
-            out_ready_sem_wait_value,                  // out_ready_sem_wait_value
-            reduction_semaphore_ids[link],             // reduction_semaphore_id
-            mcast_start_x.size(),                      // num_mcast_ranges
-            link,                                      // link
+            reduction_cb_index,                                   // tensor_address0
+            operation_attributes.semaphore.address(),             // out_ready_sem_bank_addr (absolute address)
+            output_tensor_shard_num_pages,                        // num_tiles_per_core
+            worker_num_tiles_to_read,                             // num_tiles_to_read
+            output_first_core_tile_start_offset,                  // first_core_tile_start_offset
+            static_cast<uint32_t>(output_tensor_cores_x.size()),  // num_cores
+            num_mcast_cores,                                      // num_mcast_cores
+            drain_sync_core.x,                                    // out_ready_sem_noc0_x
+            drain_sync_core.y,                                    // out_ready_sem_noc0_y
+            out_ready_sem_wait_value,                             // out_ready_sem_wait_value
+            reduction_semaphore_ids[link],                        // reduction_semaphore_id
+            static_cast<uint32_t>(mcast_start_x.size()),          // num_mcast_ranges
+            link,                                                 // link
         };
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_x.begin(), output_tensor_cores_x.end());
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_y.begin(), output_tensor_cores_y.end());
@@ -740,114 +778,94 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
         writer_rt_args.insert(writer_rt_args.end(), mcast_end_x.begin(), mcast_end_x.end());
         writer_rt_args.insert(writer_rt_args.end(), mcast_end_y.begin(), mcast_end_y.end());
 
-        log_trace(tt::LogOp, "Writer Runtime Args:");
-        for ([[maybe_unused]] const auto& arg : writer_rt_args) {
-            log_trace(tt::LogOp, "\t{}", arg);
-        }
+        log_trace(tt::LogOp, "Writer Runtime Args appended");
 
         writer_rt_args.push_back(forward_fabric_node_id.has_value());
         if (forward_fabric_node_id.has_value()) {
             const auto target_device_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coord);
-            tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device_fabric_node_id, forward_fabric_node_id.value(), link, program, {core}, writer_rt_args);
+            tt::tt_fabric::append_fabric_connection_rt_args<ProgramDescriptor>(
+                target_device_fabric_node_id, forward_fabric_node_id.value(), link, desc, core, writer_rt_args);
         }
 
         writer_rt_args.push_back(backward_fabric_node_id.has_value());
         if (backward_fabric_node_id.has_value()) {
             const auto target_device_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coord);
-            tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device_fabric_node_id, backward_fabric_node_id.value(), link, program, {core}, writer_rt_args);
+            tt::tt_fabric::append_fabric_connection_rt_args<ProgramDescriptor>(
+                target_device_fabric_node_id, backward_fabric_node_id.value(), link, desc, core, writer_rt_args);
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+        // Promote writer RT args to the descriptor.  None of the indices in this
+        // op's worker_writer kernel correspond to tensor buffer addresses
+        // (semaphore.address() and CB indices only), so all entries stay as
+        // plain uint32_t -- but we still need an RTArgList wrapper because
+        // emplace_runtime_args has no std::vector<uint32_t> overload.
+        KernelDescriptor::RTArgList worker_writer_rt_args_builder;
+        worker_writer_rt_args_builder.reserve(writer_rt_args.size());
+        for (uint32_t v : writer_rt_args) {
+            worker_writer_rt_args_builder.push_back(v);
+        }
+        desc.kernels[worker_sender_writer_kernel_id].emplace_runtime_args(core, worker_writer_rt_args_builder);
 
-        // Set reduction worker runtime args
+        // Set reduction worker runtime args.  Each output core in this link's range
+        // gets the shared template plus this link's semaphore id appended, and
+        // index 4 (in_core_idx) is patched per output core below to match the
+        // logic in the original SetRuntimeArgs + GetRuntimeArgs override pass.
+        // Indices 0..3 are q/k/v/batch_offset buffer base addresses; push them
+        // as Buffer* so the framework records BufferBindings for the cache-hit
+        // fast path.
         std::vector<uint32_t> reduction_reader_rt_args(reader_writer_runtime_args_template);
         std::vector<uint32_t> reduction_writer_rt_args(reader_writer_runtime_args_template);
         reduction_reader_rt_args.push_back(reduction_semaphore_ids[link]);
         reduction_writer_rt_args.push_back(reduction_semaphore_ids[link]);
-        tt::tt_metal::SetRuntimeArgs(
-            program, reduction_reader_kernel_id, output_corerangeset_per_link[link], reduction_reader_rt_args);
-        tt::tt_metal::SetRuntimeArgs(
-            program, reduction_writer_kernel_id, output_corerangeset_per_link[link], reduction_writer_rt_args);
+
+        auto build_reduction_rt_args = [&](const std::vector<uint32_t>& src) {
+            KernelDescriptor::RTArgList out;
+            out.reserve(src.size());
+            // Index 0: q buffer addr -- Buffer*
+            out.push_back(q_output_tensor.buffer());
+            // Index 1: k buffer addr -- Buffer*
+            out.push_back(k_output_tensor.buffer());
+            // Index 2: v buffer addr -- Buffer*
+            out.push_back(v_output_tensor.buffer());
+            // Index 3: batch_offset buffer addr -- Buffer*
+            out.push_back(batch_offset_tensor.buffer());
+            // Remaining indices stay as uint32_t.
+            for (size_t i = 4; i < src.size(); ++i) {
+                out.push_back(src[i]);
+            }
+            return out;
+        };
+
+        for (const auto& output_core_range : output_corerangeset_per_link[link].ranges()) {
+            for (const auto& output_core : corerange_to_cores(output_core_range, std::nullopt, true)) {
+                desc.kernels[reduction_reader_kernel_id].emplace_runtime_args(
+                    output_core, build_reduction_rt_args(reduction_reader_rt_args));
+                desc.kernels[reduction_writer_kernel_id].emplace_runtime_args(
+                    output_core, build_reduction_rt_args(reduction_writer_rt_args));
+            }
+        }
     }
 
-    auto& reduction_reader_args_by_core = GetRuntimeArgs(program, reduction_reader_kernel_id);
-    auto& reduction_writer_args_by_core = GetRuntimeArgs(program, reduction_writer_kernel_id);
-
+    // Patch reduction reader/writer rt arg index 4 (in_core_idx) per output core, matching
+    // the post-loop GetRuntimeArgs fixup in the original program factory: for each input
+    // core i, the corresponding output core (by logical coord) gets reader_args[4] =
+    // writer_args[4] = i.  We do this by walking input cores and updating the runtime args
+    // already attached to that core in the reader/writer reduction kernel descriptors.
+    auto patch_arg_at_index_4 = [](KernelDescriptor& kd, const CoreCoord& core, uint32_t value) {
+        for (auto& [c, args] : kd.runtime_args) {
+            if (c == core) {
+                args[4] = value;
+                return;
+            }
+        }
+    };
     for (uint32_t i = 0; i < in_num_cores; i++) {
         const auto& core = in_cores_vec[i];
-        auto& reader_args = reduction_reader_args_by_core[core.x][core.y];
-        reader_args[4] = i;
-        auto& writer_args = reduction_writer_args_by_core[core.x][core.y];
-        writer_args[4] = i;
+        patch_arg_at_index_4(desc.kernels[reduction_reader_kernel_id], core, i);
+        patch_arg_at_index_4(desc.kernels[reduction_writer_kernel_id], core, i);
     }
 
-    return ttnn::device_operation::CachedProgram<shared_variables_t>{
-        std::move(program),
-        {.worker_sender_reader_kernel_id = worker_sender_reader_kernel_id,
-         .worker_sender_writer_kernel_id = worker_sender_writer_kernel_id,
-         .sender_worker_cores = sender_worker_cores,
-         .cb_out = cb_out,
-         .cb_reduction = cb_reduction,
-         .output_cores_vec = output_cores_vec,
-         .reduction_reader_kernel_id = reduction_reader_kernel_id,
-         .reduction_writer_kernel_id = reduction_writer_kernel_id}};
-}
-
-void AllReduceCreateQkvHeadsMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const AllReduceCreateQkvHeadsParams& operation_attributes,
-    const AllReduceCreateQkvHeadsInputs& tensor_args,
-    AllReduceCreateQkvHeadsResult& tensor_return_value) {
-    const auto& input = tensor_args.input_tensor;
-    const auto& buffer_tensor = tensor_args.buffer_tensor;
-    const auto& batch_tensor = tensor_args.batch_offset_tensor;
-    const auto& output = tensor_return_value.all_reduce;
-    const auto& q_output = tensor_return_value.q;
-    const auto& k_output = tensor_return_value.k;
-    const auto& v_output = tensor_return_value.v;
-
-    auto q_base_addr = q_output.buffer()->address();
-    auto k_base_addr = k_output.buffer()->address();
-    auto v_base_addr = v_output.buffer()->address();
-    auto batch_base_addr = batch_tensor.buffer()->address();
-
-    for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(mesh_coord_range);
-
-        // Update senders
-        auto& worker_reader_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_reader_kernel_id);
-        auto& worker_writer_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_writer_kernel_id);
-        for (const auto& core : shared_vars.sender_worker_cores) {
-            // reader
-            auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
-            worker_reader_sender_runtime_args[0] = input.buffer()->address();
-            // writer
-            auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
-            worker_writer_sender_runtime_args[1] = operation_attributes.semaphore.address();
-        }
-
-        auto& reduction_reader_args_by_core = GetRuntimeArgs(program, shared_vars.reduction_reader_kernel_id);
-        auto& reduction_writer_args_by_core = GetRuntimeArgs(program, shared_vars.reduction_writer_kernel_id);
-
-        for (const auto& core : shared_vars.output_cores_vec) {
-            auto& reader_args = reduction_reader_args_by_core[core.x][core.y];
-            reader_args[0] = q_base_addr;
-            reader_args[1] = k_base_addr;
-            reader_args[2] = v_base_addr;
-            reader_args[3] = batch_base_addr;
-            auto& writer_args = reduction_writer_args_by_core[core.x][core.y];
-            writer_args[0] = q_base_addr;
-            writer_args[1] = k_base_addr;
-            writer_args[2] = v_base_addr;
-            writer_args[3] = batch_base_addr;
-        }
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_out, *output.buffer());
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_reduction, *buffer_tensor.buffer());
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -103,7 +103,7 @@ ProgramDescriptor AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor(
     TT_FATAL(
         mesh_dispatch_coordinate.has_value(),
         "AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor requires a mesh dispatch coordinate");
-    const ttnn::MeshCoordinate mesh_coord = mesh_dispatch_coordinate.value();
+    const ttnn::MeshCoordinate& mesh_coord = mesh_dispatch_coordinate.value();
 
     log_debug(tt::LogOp, "AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor called");
 
@@ -852,12 +852,12 @@ ProgramDescriptor AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor(
     // writer_args[4] = i.  We do this by walking input cores and updating the runtime args
     // already attached to that core in the reader/writer reduction kernel descriptors.
     auto patch_arg_at_index_4 = [](KernelDescriptor& kd, const CoreCoord& core, uint32_t value) {
-        for (auto& [c, args] : kd.runtime_args) {
-            if (c == core) {
-                args[4] = value;
-                return;
-            }
-        }
+        auto it = std::find_if(
+            kd.runtime_args.begin(), kd.runtime_args.end(), [&core](const auto& entry) { return entry.first == core; });
+        TT_FATAL(it != kd.runtime_args.end(), "patch_arg_at_index_4: core {} not found", core);
+        auto& args = it->second;
+        TT_FATAL(args.size() > 4, "patch_arg_at_index_4: args.size() = {} < 5", args.size());
+        args[4] = value;
     };
     for (uint32_t i = 0; i < in_num_cores; i++) {
         const auto& core = in_cores_vec[i];

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.hpp
@@ -5,47 +5,25 @@
 
 #include "all_reduce_create_qkv_heads_device_operation_types.hpp"
 
-#include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 
-#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
-#include <vector>
+#include <optional>
 
 namespace ttnn::experimental::prim {
 
-struct AllReduceCreateQkvHeadsSharedVariables {
-    tt::tt_metal::KernelHandle worker_sender_reader_kernel_id{};
-    tt::tt_metal::KernelHandle worker_sender_writer_kernel_id{};
-    std::vector<CoreCoord> sender_worker_cores;
-    tt::tt_metal::CBHandle cb_out{};
-    tt::tt_metal::CBHandle cb_reduction{};
-    std::vector<CoreCoord> output_cores_vec;
-    tt::tt_metal::KernelHandle reduction_reader_kernel_id{};
-    tt::tt_metal::KernelHandle reduction_writer_kernel_id{};
-};
-
 struct AllReduceCreateQkvHeadsMeshWorkloadFactory {
-    using shared_variables_t = AllReduceCreateQkvHeadsSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const AllReduceCreateQkvHeadsParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const AllReduceCreateQkvHeadsInputs& tensor_args,
-        AllReduceCreateQkvHeadsResult& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const AllReduceCreateQkvHeadsParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const AllReduceCreateQkvHeadsInputs& tensor_args,
-        AllReduceCreateQkvHeadsResult& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Per-coord program build.  The GlobalSemaphore lives on
+    // AllReduceCreateQkvHeadsParams (allocated by the caller), so no
+    // prepare_resources hook is required -- the semaphore is passed through and
+    // its address is written into runtime args every dispatch via the normal
+    // apply_descriptor_runtime_args path.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const AllReduceCreateQkvHeadsParams& operation_attributes,
         const AllReduceCreateQkvHeadsInputs& tensor_args,
-        AllReduceCreateQkvHeadsResult& tensor_return_value);
+        AllReduceCreateQkvHeadsResult& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
@@ -6,15 +6,17 @@
 
 #include "create_qkv_heads_program_factory.hpp"
 #include "create_qkv_heads_device_operation.hpp"
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 using namespace tt::constants;
 using namespace tt;
+using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {
 
-CreateQKVHeadsProgramFactory::cached_program_t CreateQKVHeadsProgramFactory::create(
+ProgramDescriptor CreateQKVHeadsProgramFactory::create_descriptor(
     const CreateQKVHeadsParams& operation_attributes,
     const CreateQKVHeadsInputs& tensor_args,
     CreateQKVHeadsResult& output) {
@@ -114,7 +116,8 @@ CreateQKVHeadsProgramFactory::cached_program_t CreateQKVHeadsProgramFactory::cre
         num_tiles_per_group.push_back(heads * head_dim / TILE_WIDTH);
     }
 
-    Program program = tt::tt_metal::CreateProgram();
+    ProgramDescriptor desc;
+
     std::vector<uint32_t> reader_compile_time_args = {
 
         (std::uint32_t)heads_per_group[0],  // q heads in group
@@ -139,21 +142,20 @@ CreateQKVHeadsProgramFactory::cached_program_t CreateQKVHeadsProgramFactory::cre
         (std::uint32_t)num_tiles_per_group[2] * single_tile_size,  // size of V tiles in each group, in bytes
     };
 
-    std::map<std::string, std::string> reader_defines;
-    if (transpose_k) {
-        reader_defines["TRANSPOSE_K_HEADS"] = "1";
-    }
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/kernels/"
-        "reader_create_qkv_heads_sharded.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
-
-    tt_metal::KernelHandle compute_kernel_id = 0;
-    bool has_compute_kernel = false;
+        "reader_create_qkv_heads_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
     if (transpose_k) {
-        has_compute_kernel = true;
+        reader_desc.defines = {{"TRANSPOSE_K_HEADS", "1"}};
+    }
+    desc.kernels.push_back(std::move(reader_desc));
+
+    if (transpose_k) {
         std::vector<uint32_t> compute_args = {
             (std::uint32_t)block_ht * num_tiles_per_group[1] * groups_per_block,  // number of K tiles
         };
@@ -161,12 +163,15 @@ CreateQKVHeadsProgramFactory::cached_program_t CreateQKVHeadsProgramFactory::cre
         // resolves the unpack-dst CB to Tf32 (10-bit mantissa) instead of Float16_b (7-bit
         // mantissa). Mirrors the per-dtype promotion in eltwise unary/binary primitives.
         const bool fp32_dest_acc_en = input_tensor.dtype() == tt_metal::DataType::FLOAT32;
-        compute_kernel_id = tt_metal::CreateKernel(
-            program,
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/"
-            "compute/transpose_wh_sharded.cpp",
-            all_cores,
-            tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args});
+            "compute/transpose_wh_sharded.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = all_cores;
+        compute_desc.compile_time_args = std::move(compute_args);
+        compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+        desc.kernels.push_back(std::move(compute_desc));
     }
 
     uint32_t input_size = block_ht * block_wt * single_tile_size;
@@ -175,70 +180,64 @@ CreateQKVHeadsProgramFactory::cached_program_t CreateQKVHeadsProgramFactory::cre
     uint32_t v_size = block_ht * num_tiles_per_group[2] * single_tile_size * groups_per_block;
 
     // qkv tensor
-    auto c_in0_config = tt::tt_metal::CircularBufferConfig(input_size, {{CBIndex::c_0, data_format}})
-                            .set_page_size(CBIndex::c_0, single_tile_size)
-                            .set_globally_allocated_address(*input_tensor.buffer());
-    auto cb_in0_id = CreateCircularBuffer(program, all_cores, c_in0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = CBIndex::c_0,
+            .data_format = data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = input_tensor.buffer(),
+    });
 
     // q sharded
-    auto c_out0_config = tt::tt_metal::CircularBufferConfig(q_size, {{CBIndex::c_16, data_format}})
-                             .set_page_size(CBIndex::c_16, single_tile_size)
-                             .set_globally_allocated_address(*output_q.buffer());
-    auto cb_out0_id = CreateCircularBuffer(program, all_cores, c_out0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = CBIndex::c_16,
+            .data_format = data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output_q.buffer(),
+    });
     // k sharded
-    auto c_out1_config = tt::tt_metal::CircularBufferConfig(k_size, {{CBIndex::c_17, data_format}})
-                             .set_page_size(CBIndex::c_17, single_tile_size)
-                             .set_globally_allocated_address(*output_k.buffer());
-    auto cb_out1_id = CreateCircularBuffer(program, all_cores, c_out1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = k_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = CBIndex::c_17,
+            .data_format = data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output_k.buffer(),
+    });
     // v sharded
-    auto c_out2_config = tt::tt_metal::CircularBufferConfig(v_size, {{CBIndex::c_18, data_format}})
-                             .set_page_size(CBIndex::c_18, single_tile_size)
-                             .set_globally_allocated_address(*output_v.buffer());
-    auto cb_out2_id = CreateCircularBuffer(program, all_cores, c_out2_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = v_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = CBIndex::c_18,
+            .data_format = data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output_v.buffer(),
+    });
 
     if (transpose_k) {
-        auto c_im0_config = tt::tt_metal::CircularBufferConfig(k_size, {{CBIndex::c_24, data_format}})
-                                .set_page_size(CBIndex::c_24, single_tile_size);
-        CreateCircularBuffer(program, all_cores, c_im0_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = k_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = CBIndex::c_24,
+                .data_format = data_format,
+                .page_size = single_tile_size,
+            }}},
+        });
     }
 
-    return cached_program_t{
-        std::move(program),
-        CreateQKVHeadsSharedVariables{
-            .reader_kernel_id = reader_kernel_id,
-            .compute_kernel_id = compute_kernel_id,
-            .cb_in0_id = cb_in0_id,
-            .cb_out0_id = cb_out0_id,
-            .cb_out1_id = cb_out1_id,
-            .cb_out2_id = cb_out2_id,
-            .all_cores = all_cores,
-            .has_compute_kernel = has_compute_kernel,
-        }};
-}
-
-void CreateQKVHeadsProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const CreateQKVHeadsParams& /*operation_attributes*/,
-    const CreateQKVHeadsInputs& tensor_args,
-    CreateQKVHeadsResult& output) {
-    const auto& input_tensor = tensor_args.input;
-    auto& [output_q, output_k, output_v] = output;
-
-    auto& program = cached_program.program;
-    auto& cb_in0_id = cached_program.shared_variables.cb_in0_id;
-    auto& cb_out0_id = cached_program.shared_variables.cb_out0_id;
-    auto& cb_out1_id = cached_program.shared_variables.cb_out1_id;
-    auto& cb_out2_id = cached_program.shared_variables.cb_out2_id;
-
-    auto* in0_buffer = input_tensor.buffer();
-    auto* out0_buffer = output_q.buffer();
-    auto* out1_buffer = output_k.buffer();
-    auto* out2_buffer = output_v.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, cb_in0_id, *in0_buffer);
-    UpdateDynamicCircularBufferAddress(program, cb_out0_id, *out0_buffer);
-    UpdateDynamicCircularBufferAddress(program, cb_out1_id, *out1_buffer);
-    UpdateDynamicCircularBufferAddress(program, cb_out2_id, *out2_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.hpp
@@ -5,32 +5,14 @@
 #pragma once
 
 #include "create_qkv_heads_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct CreateQKVHeadsSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle compute_kernel_id = 0;
-    tt::tt_metal::CBHandle cb_in0_id = 0;
-    tt::tt_metal::CBHandle cb_out0_id = 0;
-    tt::tt_metal::CBHandle cb_out1_id = 0;
-    tt::tt_metal::CBHandle cb_out2_id = 0;
-    CoreRangeSet all_cores;
-    bool has_compute_kernel = false;
-};
-
 struct CreateQKVHeadsProgramFactory {
-    using shared_variables_t = CreateQKVHeadsSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const CreateQKVHeadsParams& operation_attributes,
-        const CreateQKVHeadsInputs& tensor_args,
-        CreateQKVHeadsResult& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const CreateQKVHeadsParams& operation_attributes,
         const CreateQKVHeadsInputs& tensor_args,
         CreateQKVHeadsResult& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/dit_layernorm_post_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/dit_layernorm_post_all_gather_welford_program_factory.cpp
@@ -4,27 +4,28 @@
 
 #include "dit_layernorm_post_all_gather_welford_program_factory.hpp"
 
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/math.hpp"
 
 #include <optional>
 #include <string>
-#include <variant>
 
 using uint32_t = std::uint32_t;
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {
 
-PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgramFactory::create(
+ProgramDescriptor PostAllGatherWelfordProgramFactory::create_descriptor(
     const DitLayernormPostAllGatherParams& operation_attributes,
     const DitLayernormPostAllGatherInputs& tensor_args,
     Tensor& output) {
-    using tt::tt_metal::CircularBufferConfig;
-
     const auto& a = tensor_args.input;
     const auto& stats = tensor_args.stats;
     const auto& gamma = tensor_args.gamma;
@@ -54,16 +55,14 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
     const uint32_t dst_reg_count = get_dest_reg_count(operation_attributes.compute_kernel_config);
     uint32_t block_size = dst_reg_count;  // stride by dest regs, like fused rmsnorm
 
-    tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::DataFormat stats_data_format = tt::tt_metal::datatype_to_dataformat_converter(stats.dtype());
-    tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat in_data_format = datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat stats_data_format = datatype_to_dataformat_converter(stats.dtype());
+    tt::DataFormat out_data_format = datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    tt::DataFormat gamma_cb_data_format = gamma.has_value()
-                                              ? tt::tt_metal::datatype_to_dataformat_converter(gamma.value().dtype())
-                                              : tt::DataFormat::Float16_b;
-    tt::DataFormat beta_cb_data_format = beta.has_value()
-                                             ? tt::tt_metal::datatype_to_dataformat_converter(beta.value().dtype())
-                                             : tt::DataFormat::Float16_b;
+    tt::DataFormat gamma_cb_data_format =
+        gamma.has_value() ? datatype_to_dataformat_converter(gamma.value().dtype()) : tt::DataFormat::Float16_b;
+    tt::DataFormat beta_cb_data_format =
+        beta.has_value() ? datatype_to_dataformat_converter(beta.value().dtype()) : tt::DataFormat::Float16_b;
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
     uint32_t stats_single_tile_size = tt::tile_size(stats_data_format);
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
@@ -72,11 +71,11 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
     uint32_t gamma_single_tile_size = tt::tile_size(gamma_cb_data_format);
     uint32_t beta_single_tile_size = tt::tile_size(beta_cb_data_format);
 
-    auto a_addr = a.buffer()->address();
-    auto stats_addr = stats.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto dst_addr = output.buffer()->address();
+    Buffer* a_buffer = a.buffer();
+    Buffer* stats_buffer = stats.buffer();
+    Buffer* gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    Buffer* beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
+    Buffer* dst_buffer = output.buffer();
 
     uint32_t Wt_round_up_block_size = tt::round_up(Wt, block_size);
 
@@ -104,7 +103,7 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
 
     auto cores = corerange_to_cores(all_cores, std::nullopt);
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)block_size,
@@ -171,15 +170,13 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
     reader_compile_time_args.push_back((std::uint32_t)beta_batch_stride_tiles);
     reader_compile_time_args.push_back((std::uint32_t)Ht);
 
-    tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(stats.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(gamma.has_value() ? gamma.value().buffer() : nullptr)
-        .append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(beta.has_value() ? beta.value().buffer() : nullptr)
-        .append_to(reader_compile_time_args);
+    TensorAccessorArgs(a_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(stats_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(gamma_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(beta_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)Wt, (std::uint32_t)block_size};
-    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> compute_defines;
@@ -190,19 +187,24 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
         reader_defines["FUSE_BETA"] = "1";
     }
 
-    auto reader_kernels_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/"
-        "reader_layernorm_postallgather_dit.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+        "reader_layernorm_postallgather_dit.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = {reader_defines.begin(), reader_defines.end()};
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    auto writer_kernels_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/"
-        "writer_layernorm_postallgather_dit.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "writer_layernorm_postallgather_dit.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<uint32_t> compute_args = {
         Wt,
@@ -216,16 +218,19 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
         Ht,
         Wt_round_up_block_size};
 
-    const auto* compute_kernel_file =
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/compute/"
         "layernorm_post_allgather_welford.cpp";
-    auto compute_config = tt::tt_metal::ComputeConfig{
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.defines = {compute_defines.begin(), compute_defines.end()};
+    compute_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .math_approx_mode = math_approx_mode,
-        .compile_args = compute_args,
-        .defines = compute_defines};
-    auto compute_kernels_id = tt::tt_metal::CreateKernel(program, compute_kernel_file, all_cores, compute_config);
+    };
 
     /**
      * c_0 -> a
@@ -240,54 +245,99 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
      */
 
     // A input
-    CircularBufferConfig cb_inp_config =
-        CircularBufferConfig(in0_tiles * in_single_tile_size, {{tt::CBIndex::c_0, in_data_format}})
-            .set_page_size(tt::CBIndex::c_0, in_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_inp_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_tiles * in_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = in_data_format,
+            .page_size = in_single_tile_size,
+        }}},
+    });
     // Stats input
-    CircularBufferConfig cb_stats_config =
-        CircularBufferConfig(in1_tiles * stats_single_tile_size, {{tt::CBIndex::c_1, stats_data_format}})
-            .set_page_size(tt::CBIndex::c_1, stats_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_stats_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_tiles * stats_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+            .data_format = stats_data_format,
+            .page_size = stats_single_tile_size,
+        }}},
+    });
     if (gamma.has_value()) {
         // Gamma input
-        CircularBufferConfig cb_gamma_config =
-            CircularBufferConfig(in2_tiles * gamma_single_tile_size, {{tt::CBIndex::c_2, gamma_cb_data_format}})
-                .set_page_size(tt::CBIndex::c_2, gamma_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_gamma_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = in2_tiles * gamma_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_2),
+                .data_format = gamma_cb_data_format,
+                .page_size = gamma_single_tile_size,
+            }}},
+        });
     }
     if (beta.has_value()) {
         // Beta input
-        CircularBufferConfig cb_beta_config =
-            CircularBufferConfig(in3_tiles * beta_single_tile_size, {{tt::CBIndex::c_3, beta_cb_data_format}})
-                .set_page_size(tt::CBIndex::c_3, beta_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_beta_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = in3_tiles * beta_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+                .data_format = beta_cb_data_format,
+                .page_size = beta_single_tile_size,
+            }}},
+        });
     }
     // Epsilon input
-    CircularBufferConfig cb_eps_config =
-        CircularBufferConfig(in4_tiles * bfloat16_tile_size, {{tt::CBIndex::c_4, tt::DataFormat::Float16_b}})
-            .set_page_size(tt::CBIndex::c_4, bfloat16_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_eps_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in4_tiles * bfloat16_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_4),
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = bfloat16_tile_size,
+        }}},
+    });
     // stats reduced
-    CircularBufferConfig cb_intermed0_config =
-        CircularBufferConfig(intermed0_tiles * single_tile_size, {{tt::CBIndex::c_5, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_5, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed0_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_5),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
     // recip_sqrt_var
-    CircularBufferConfig cb_intermed4_config =
-        CircularBufferConfig(intermed1_tiles * single_tile_size, {{tt::CBIndex::c_6, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_6, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed4_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed1_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_6),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
     // a intermediate
-    CircularBufferConfig cb_intermed5_config =
-        CircularBufferConfig(intermed2_tiles * single_tile_size, {{tt::CBIndex::c_7, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_7, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed5_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed2_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_7),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
     // output
-    CircularBufferConfig cb_out0_config =
-        CircularBufferConfig(out0_tiles * out_single_tile_size, {{tt::CBIndex::c_8, out_data_format}})
-            .set_page_size(tt::CBIndex::c_8, out_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_out0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_tiles * out_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_8),
+            .data_format = out_data_format,
+            .page_size = out_single_tile_size,
+        }}},
+    });
 
     union {
         float f;
@@ -312,67 +362,34 @@ PostAllGatherWelfordProgramFactory::cached_program_t PostAllGatherWelfordProgram
         TT_FATAL(tile_row_start < tile_row_end, "Tile row start must be less than tile row end");
         TT_FATAL(tile_row_end <= num_tile_rows, "Tile row end must be less than or equal to number of tile rows");
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            reader_kernels_id,
-            core,
-            {
-                a_addr,
-                stats_addr,
-                gamma_dram_addr,
-                beta_dram_addr,
-                tile_row_start,
-                tile_row_end,
-                e.u,
-            });
-        tt::tt_metal::SetRuntimeArgs(program, compute_kernels_id, core, {num_tile_rows_per_core, tile_row_start});
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernels_id, core, {dst_addr, tile_row_start, tile_row_end});
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.reserve(7);
+        reader_args.push_back(a_buffer);
+        reader_args.push_back(stats_buffer);
+        if (gamma_buffer != nullptr) {
+            reader_args.push_back(gamma_buffer);
+        } else {
+            reader_args.push_back(uint32_t{0});
+        }
+        if (beta_buffer != nullptr) {
+            reader_args.push_back(beta_buffer);
+        } else {
+            reader_args.push_back(uint32_t{0});
+        }
+        reader_args.push_back(tile_row_start);
+        reader_args.push_back(tile_row_end);
+        reader_args.push_back(e.u);
+        reader_desc.emplace_runtime_args(core, reader_args);
+        compute_desc.emplace_runtime_args(core, {num_tile_rows_per_core, tile_row_start});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, tile_row_start, tile_row_end});
         curr_row += num_tile_rows_per_core;
     }
 
-    return cached_program_t{
-        std::move(program),
-        {.reader_kernel_id = reader_kernels_id, .writer_kernel_id = writer_kernels_id, .cores = cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void PostAllGatherWelfordProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const DitLayernormPostAllGatherParams&,
-    const DitLayernormPostAllGatherInputs& tensor_args,
-    Tensor& output) {
-    auto& shared_vars = cached_program.shared_variables;
-    auto& program = cached_program.program;
-
-    const auto input_addr = tensor_args.input.buffer()->address();
-    const auto stats_addr = tensor_args.stats.buffer()->address();
-    const bool has_gamma = tensor_args.gamma.has_value();
-    const bool has_beta = tensor_args.beta.has_value();
-    const auto gamma_addr = has_gamma ? tensor_args.gamma.value().buffer()->address() : 0;
-    const auto beta_addr = has_beta ? tensor_args.beta.value().buffer()->address() : 0;
-    const auto output_addr = output.buffer()->address();
-
-    auto& reader_runtime_args_by_core = tt::tt_metal::GetRuntimeArgs(program, shared_vars.reader_kernel_id);
-    auto& writer_runtime_args_by_core = tt::tt_metal::GetRuntimeArgs(program, shared_vars.writer_kernel_id);
-
-    for (const auto& core : shared_vars.cores) {
-        {
-            auto& reader_args = reader_runtime_args_by_core.at(core.x).at(core.y);
-
-            reader_args[0] = input_addr;
-            reader_args[1] = stats_addr;
-            if (has_gamma) {
-                reader_args[2] = gamma_addr;
-            }
-            if (has_beta) {
-                reader_args[3] = beta_addr;
-            }
-        }
-
-        {
-            auto& writer_args = writer_runtime_args_by_core.at(core.x).at(core.y);
-            writer_args[0] = output_addr;
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/dit_layernorm_post_all_gather_welford_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/dit_layernorm_post_all_gather_welford_program_factory.hpp
@@ -5,27 +5,14 @@
 #pragma once
 
 #include "dit_layernorm_post_all_gather_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct PostAllGatherWelfordSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    std::vector<CoreCoord> cores;
-};
-
 struct PostAllGatherWelfordProgramFactory {
-    using shared_variables_t = PostAllGatherWelfordSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const DitLayernormPostAllGatherParams& operation_attributes,
-        const DitLayernormPostAllGatherInputs& tensor_args,
-        Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const DitLayernormPostAllGatherParams& operation_attributes,
         const DitLayernormPostAllGatherInputs& tensor_args,
         Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_program_factory.cpp
@@ -118,6 +118,14 @@ tt::tt_metal::ProgramDescriptor FusedRMSNormPostAllGatherProgramFactory::create_
     log_debug(tt::LogOp, "rope_cos_data_format: {}", rope_cos_data_format);
     log_debug(tt::LogOp, "rope_sin_data_format: {}", rope_sin_data_format);
 
+    // Optional tensor buffers passed as Buffer* so the framework patches their
+    // addresses on cache hits (BufferBinding). Plain uint32_t goes stale when
+    // the allocator moves the buffer on a subsequent dispatch (cf. #44565).
+    Buffer* const weight_buffer = has_weight ? weight_tensor.value().buffer() : nullptr;
+    Buffer* const transformation_mat_buffer = fuse_rope ? transformation_mat.value().buffer() : nullptr;
+    Buffer* const rope_cos_buffer = fuse_rope ? rope_cos.value().buffer() : nullptr;
+    Buffer* const rope_sin_buffer = fuse_rope ? rope_sin.value().buffer() : nullptr;
+
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     //////////////////////////////////////////////////////////////////////////
@@ -288,26 +296,16 @@ tt::tt_metal::ProgramDescriptor FusedRMSNormPostAllGatherProgramFactory::create_
         const uint32_t tile_row_end = std::min(tile_row_start + num_tile_rows_per_core, num_tile_rows);
         const uint32_t num_tile_rows_to_process = tile_row_end - tile_row_start;
 
-        KernelDescriptor::RTArgList reader_args;
-        reader_args.push_back(input_tensor.buffer());
-        reader_args.push_back(stats_tensor.buffer());
-        if (has_weight) {
-            reader_args.push_back(weight_tensor.value().buffer());
-        } else {
-            reader_args.push_back(0u);
-        }
-        if (fuse_rope) {
-            reader_args.push_back(transformation_mat.value().buffer());
-            reader_args.push_back(rope_cos.value().buffer());
-            reader_args.push_back(rope_sin.value().buffer());
-        } else {
-            reader_args.push_back(0u);
-            reader_args.push_back(0u);
-            reader_args.push_back(0u);
-        }
-        reader_args.push_back(tile_row_start);
-        reader_args.push_back(tile_row_end);
-        reader_kernel_desc.emplace_runtime_args(core, reader_args);
+        reader_kernel_desc.emplace_runtime_args(
+            core,
+            {input_tensor.buffer(),
+             stats_tensor.buffer(),
+             weight_buffer,
+             transformation_mat_buffer,
+             rope_cos_buffer,
+             rope_sin_buffer,
+             tile_row_start,
+             tile_row_end});
 
         compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_to_process});
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -10,7 +10,8 @@
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::experimental::transformer {
 
@@ -33,59 +34,14 @@ struct NlpCreateHeadsDeviceOperation {
     using tensor_return_value_t = std::tuple<Tensor, Tensor, Tensor>;
 
     struct Interleaved {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernel_id;
-            tt::tt_metal::KernelHandle writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-            bool read_from_input_tensor_kv;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
     };
 
     struct Sharded {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernel_id{};
-            tt::tt_metal::KernelHandle writer_kernel_id{};
-            std::size_t num_cores{};
-            std::size_t num_cores_y{};
-            bool read_from_input_tensor_kv{};
-            tt::tt_metal::CBHandle cb_q_output{};
-            tt::tt_metal::CBHandle cb_k_output{};
-            tt::tt_metal::CBHandle cb_v_output{};
-            std::vector<CoreCoord> cores;
-            uint32_t head_size{};
-            uint32_t per_risc0_out_q_heads{};
-            uint32_t per_risc1_out_q_heads{};
-            uint32_t per_core_in_q_heads{};
-            uint32_t per_core_out_kv_heads{};
-            uint32_t per_core_in_kv_heads{};
-            uint32_t head_tiles{};
-            uint32_t num_kv_cores{};
-            uint32_t single_tile_size{};
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -10,6 +10,7 @@
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/memory_config/memory_config.hpp"
 
 #include <tt-metalium/program_descriptors.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -10,7 +10,7 @@
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/tensor/memory_config/memory_config.hpp"
+#include "ttnn/types.hpp"  // exposes ttnn::MemoryConfig alias used in member/signature declarations
 
 #include <tt-metalium/program_descriptors.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -2,18 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
-#include "nlp_create_qkv_heads_device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "nlp_create_qkv_heads_device_operation.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 
 using namespace tt::constants;
 using namespace tt;
+using namespace tt::tt_metal;
 
-NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDeviceOperation::Interleaved::create(
+ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -37,11 +40,9 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
 
     tt_metal::Buffer* in1_buffer = nullptr;
-    uint32_t in1_buffer_addr = 0;
     if (read_from_input_tensor_kv) {
         in1_buffer = input_tensor_kv.value().buffer();
         TT_ASSERT(in1_buffer->size() % single_tile_size == 0);
-        in1_buffer_addr = in1_buffer->address();
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -89,7 +90,7 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Program program = tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)q_num_tiles,
@@ -112,8 +113,8 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     tt::tt_metal::TensorAccessorArgs(k_buffer).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(v_buffer).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
     if (transpose_k_heads) {
         // For FLOAT32 input, enable fp32 dest accumulation so the JIT data-format selection
         // resolves the unpack-dst CB to Tf32 (10-bit mantissa) instead of Float16_b (7-bit
@@ -121,41 +122,51 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
         const bool fp32_dest_acc_en = input_tensor.dtype() == tt_metal::DataType::FLOAT32;
 
         std::vector<uint32_t> compute_args_core_group_1 = {num_blocks_per_core_group_1 * kv_num_tiles};
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp",
-            core_group_1,
-            tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args_core_group_1});
+        KernelDescriptor compute_desc_1;
+        compute_desc_1.kernel_source = "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp";
+        compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_1.core_ranges = core_group_1;
+        compute_desc_1.compile_time_args = std::move(compute_args_core_group_1);
+        compute_desc_1.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+        desc.kernels.push_back(std::move(compute_desc_1));
 
         if (core_group_2.num_cores() > 0) {
             std::vector<uint32_t> compute_args_core_group_2 = {num_blocks_per_core_group_2 * kv_num_tiles};
-            tt_metal::CreateKernel(
-                program,
-                "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp",
-                core_group_2,
-                tt_metal::ComputeConfig{
-                    .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args_core_group_2});
+            KernelDescriptor compute_desc_2;
+            compute_desc_2.kernel_source = "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp";
+            compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            compute_desc_2.core_ranges = core_group_2;
+            compute_desc_2.compile_time_args = std::move(compute_args_core_group_2);
+            compute_desc_2.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+            desc.kernels.push_back(std::move(compute_desc_2));
         }
 
-        reader_defines["TRANSPOSE_K_HEADS"] = "1";
-        writer_defines["TRANSPOSE_K_HEADS"] = "1";
+        reader_defines.emplace_back("TRANSPOSE_K_HEADS", "1");
+        writer_defines.emplace_back("TRANSPOSE_K_HEADS", "1");
     }
     if (read_from_input_tensor_kv) {
-        reader_defines["READ_FROM_INPUT_TENSOR_KV"] = "1";
+        reader_defines.emplace_back("READ_FROM_INPUT_TENSOR_KV", "1");
     }
 
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
+        "reader_tm_tile_layout_nlp_create_qkv_heads.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "writer_tm_tile_layout_nlp_create_qkv_heads.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
+        "writer_tm_tile_layout_nlp_create_qkv_heads.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // Create circular buffers
     uint32_t micro_block_size = 1;                 // Num tiles to read/wait for in reader and writer
@@ -165,10 +176,15 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     // uint32_t cb1_num_tiles = in0_w_tiles * 2; // double buffer; this runs out of space for generic shapes
     uint32_t src1_cb_index = 1;  // cb0 is needed for compute if we want to use generic transpose_wh compute kernel
     uint32_t cb1_num_tiles = cb_num_tiles;
-    tt_metal::CircularBufferConfig cb_src1_config =
-        tt_metal::CircularBufferConfig(cb1_num_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb1_num_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
 
     // If we transpose_k_heads:
     // - reader will write to cb0, instead of cb1
@@ -177,17 +193,27 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     if (transpose_k_heads) {
         uint32_t src0_cb_index = 0;
         uint32_t cb0_num_tiles = cb_num_tiles;
-        tt_metal::CircularBufferConfig cb_src0_config =
-            tt_metal::CircularBufferConfig(cb0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-                .set_page_size(src0_cb_index, single_tile_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = cb0_num_tiles * single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src0_cb_index),
+                .data_format = cb_data_format,
+                .page_size = single_tile_size,
+            }}},
+        });
 
         uint32_t out_cb_index = 16;
         uint32_t out_cb_num_tiles = cb_num_tiles;
-        tt_metal::CircularBufferConfig cb_out_config =
-            tt_metal::CircularBufferConfig(out_cb_num_tiles * single_tile_size, {{out_cb_index, cb_data_format}})
-                .set_page_size(out_cb_index, single_tile_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = out_cb_num_tiles * single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(out_cb_index),
+                .data_format = cb_data_format,
+                .page_size = single_tile_size,
+            }}},
+        });
     }
 
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
@@ -201,14 +227,6 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
             TT_ASSERT(false, "Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_runtime_args = {
-            (std::uint32_t)in0_buffer->address(),
-            (std::uint32_t)in1_buffer_addr,
-            num_blocks_per_core,
-            num_blocks_written * in0_w_tiles,
-            num_blocks_written * in1_w_tiles,
-        };
-
         uint32_t q_out_h_dim = num_blocks_written % q_out_h_tiles;
         uint32_t q_out_tensor_tile_id =
             (num_blocks_written / q_out_h_tiles * q_out_CHtWt) + (q_out_h_dim * q_out_w_tiles);
@@ -218,110 +236,42 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
                                             ? (num_blocks_written / q_out_h_tiles * kv_out_CHtWt) + q_out_h_dim
                                             : v_out_tensor_tile_id;
 
-        std::vector<uint32_t> writer_runtime_args = {
-            (std::uint32_t)q_buffer->address(),  // q_tensor_addr
-            (std::uint32_t)k_buffer->address(),  // k_tensor_addr
-            (std::uint32_t)v_buffer->address(),  // v_tensor_addr
-            num_blocks_per_core,                 // num_blocks
-            q_out_h_dim,                         // q_out_h_dim
-            q_out_tensor_tile_id,                // q_out_tensor_tile_id
-            k_out_tensor_tile_id,                // k_out_tensor_tile_id
-            v_out_tensor_tile_id,                // v_out_tensor_tile_id
-        };
+        KernelDescriptor::RTArgList reader_rt;
+        reader_rt.reserve(5);
+        reader_rt.push_back(in0_buffer);
+        if (in1_buffer != nullptr) {
+            reader_rt.push_back(in1_buffer);
+        } else {
+            reader_rt.push_back(uint32_t{0});
+        }
+        reader_rt.push_back(num_blocks_per_core);
+        reader_rt.push_back(num_blocks_written * in0_w_tiles);
+        reader_rt.push_back(num_blocks_written * in1_w_tiles);
+        reader_desc.emplace_runtime_args(core, reader_rt);
 
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                q_buffer,              // q_tensor_addr
+                k_buffer,              // k_tensor_addr
+                v_buffer,              // v_tensor_addr
+                num_blocks_per_core,   // num_blocks
+                q_out_h_dim,           // q_out_h_dim
+                q_out_tensor_tile_id,  // q_out_tensor_tile_id
+                k_out_tensor_tile_id,  // k_out_tensor_tile_id
+                v_out_tensor_tile_id,  // v_out_tensor_tile_id
+            });
+
         num_blocks_written += num_blocks_per_core;
     }
 
-    [[maybe_unused]] auto override_runtime_arguments_callback =
-        [reader_kernel_id,
-         writer_kernel_id,
-         num_cores,
-         num_cores_y,
-         read_from_input_tensor_kv = read_from_input_tensor_kv](
-            const void* /*operation*/,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<Tensor>& output_tensors) {
-            auto* src_buffer = input_tensors.at(0).buffer();
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-            uint32_t src_kv_buffer_addr = 0;
-            if (read_from_input_tensor_kv) {
-                src_kv_buffer_addr = optional_input_tensors.at(0).value().buffer()->address();
-            }
-
-            auto* dst_buffer_query = output_tensors.at(0).buffer();
-            auto* dst_buffer_key = output_tensors.at(1).buffer();
-            auto* dst_buffer_value = output_tensors.at(2).buffer();
-
-            for (uint32_t i = 0; i < num_cores; i++) {
-                CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-                {
-                    auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                    runtime_args[0] = src_buffer->address();
-
-                    if (read_from_input_tensor_kv) {
-                        runtime_args[1] = src_kv_buffer_addr;
-                    }
-                }
-
-                {
-                    auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                    runtime_args[0] = dst_buffer_query->address();
-                    runtime_args[1] = dst_buffer_key->address();
-                    runtime_args[2] = dst_buffer_value->address();
-                }
-            }
-        };
-
-    return {
-        std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y, read_from_input_tensor_kv}};
+    return desc;
 }
 
-void NlpCreateHeadsDeviceOperation::Interleaved::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto* src_buffer = tensor_args.input_tensor_q.buffer();
-
-    uint32_t src_kv_buffer_addr = 0;
-    if (cached_program.shared_variables.read_from_input_tensor_kv) {
-        src_kv_buffer_addr = tensor_args.input_tensor_kv.value().buffer()->address();
-    }
-
-    auto* dst_buffer_query = std::get<0>(tensor_return_value).buffer();
-    auto* dst_buffer_key = std::get<1>(tensor_return_value).buffer();
-    auto* dst_buffer_value = std::get<2>(tensor_return_value).buffer();
-
-    for (uint32_t i = 0; i < cached_program.shared_variables.num_cores; i++) {
-        CoreCoord core = {
-            i / cached_program.shared_variables.num_cores_y, i % cached_program.shared_variables.num_cores_y};
-
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-
-            if (cached_program.shared_variables.read_from_input_tensor_kv) {
-                runtime_args[1] = src_kv_buffer_addr;
-            }
-        }
-
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-            runtime_args[0] = dst_buffer_query->address();
-            runtime_args[1] = dst_buffer_key->address();
-            runtime_args[2] = dst_buffer_value->address();
-        }
-    }
-}
-
-NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOperation::Sharded::create(
+ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -332,7 +282,7 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
     auto num_q_heads = operation_attributes.num_q_heads;
     auto num_kv_heads = operation_attributes.num_kv_heads;
 
-    tt_metal::Program program = tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     tt_metal::IDevice* device = input_tensor.device();
 
@@ -355,33 +305,48 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
     uint32_t per_core_in_q_heads = num_q_heads / input_tensor.shard_spec().value().num_cores();
 
     uint32_t q_output_cb_index = CBIndex::c_16;
-    tt_metal::CircularBufferConfig cb_q_output_config =
-        tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
-            .set_page_size(q_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*std::get<0>(output).buffer());
-    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_num_tiles * single_tile_size,
+        .core_ranges = q_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = std::get<0>(output).buffer(),
+    });
 
     auto k_shard_spec = std::get<1>(output).shard_spec().value();
     auto k_cores = k_shard_spec.grid;
     auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
 
     uint32_t k_output_cb_index = CBIndex::c_17;
-    tt_metal::CircularBufferConfig cb_k_output_config =
-        tt_metal::CircularBufferConfig(k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
-            .set_page_size(k_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*std::get<1>(output).buffer());
-    auto cb_k_output = tt_metal::CreateCircularBuffer(program, k_cores, cb_k_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = k_num_tiles * single_tile_size,
+        .core_ranges = k_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(k_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = std::get<1>(output).buffer(),
+    });
 
     auto v_shard_spec = std::get<0>(output).shard_spec().value();
     auto v_cores = q_shard_spec.grid;
     auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
     uint32_t v_output_cb_index = CBIndex::c_18;
-    tt_metal::CircularBufferConfig cb_v_output_config =
-        tt_metal::CircularBufferConfig(v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
-            .set_page_size(v_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*std::get<2>(output).buffer());
-    auto cb_v_output = tt_metal::CreateCircularBuffer(program, v_cores, cb_v_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = v_num_tiles * single_tile_size,
+        .core_ranges = v_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(v_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = std::get<2>(output).buffer(),
+    });
 
     uint32_t per_core_out_kv_heads = num_kv_heads / k_cores.num_cores();
     uint32_t per_core_in_kv_heads =
@@ -399,24 +364,29 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
 
     std::vector<uint32_t> reader_compile_time_args = {q_output_cb_index, k_output_cb_index};
     std::vector<uint32_t> writer_compile_time_args = {q_output_cb_index, v_output_cb_index};
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp",
-        q_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
+        "reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = q_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp",
-        q_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = q_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t num_cores = std::max(q_cores.num_cores(), k_cores.num_cores());
 
     auto core_grid = q_cores.bounding_box();
     uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
-    uint32_t num_kv_cores = k_cores.num_cores();
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
@@ -475,7 +445,7 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
         remote_q_head_start_idx = (remote_q_head_start_idx + per_risc0_out_q_heads) % per_core_in_q_heads;
         q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
 
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
 
         reader_runtime_args[1] = per_risc1_out_q_heads;
         reader_runtime_args[3] = remote_q_head_start_idx;
@@ -503,192 +473,13 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
             v_start_addr = v_base_addr + remote_kv_head_start_idx * head_size;
         }
 
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+        writer_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
     }
 
-    // auto override_runtime_arguments_callback = [
-    //         reader_kernel_id,
-    //         writer_kernel_id,
-    //         num_cores,
-    //         num_cores_y,
-    //         read_from_input_tensor_kv=read_from_input_tensor_kv,
-    //         cb_q_output,
-    //         cb_k_output,
-    //         cb_v_output,
-    //         cores,
-    //         head_size,
-    //         per_risc0_out_q_heads,
-    //         per_risc1_out_q_heads,
-    //         per_core_in_q_heads,
-    //         per_core_out_kv_heads,
-    //         per_core_in_kv_heads,
-    //         head_tiles,
-    //         num_kv_cores,
-    //         single_tile_size
-    //     ]
-    // (
-    //     const void* operation,
-    //     Program &program,
-    //     const std::vector<Tensor>& input_tensors,
-    //     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    //     const std::vector<Tensor>& output_tensors
-    // ) {
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-    //     auto src_buffer = input_tensors.at(0).buffer();
-
-    //     uint32_t src_kv_buffer_addr = 0;
-    //     if (read_from_input_tensor_kv) {
-    //         src_kv_buffer_addr = optional_input_tensors.at(0).value().buffer()->address();
-    //     }
-
-    //     auto dst_buffer_query = output_tensors.at(0).buffer();
-    //     auto dst_buffer_key = output_tensors.at(1).buffer();
-    //     auto dst_buffer_value = output_tensors.at(2).buffer();
-
-    //     UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
-    //     UpdateDynamicCircularBufferAddress(program, cb_k_output, *dst_buffer_key);
-    //     UpdateDynamicCircularBufferAddress(program, cb_v_output, *dst_buffer_value);
-
-    //     uint32_t q_base_addr = input_tensors[0].buffer()->address();
-    //     uint32_t k_base_addr = 0;
-    //     if (read_from_input_tensor_kv) {
-    //         k_base_addr = input_tensor_kv.value().buffer()->address();
-    //     } else {
-    //         k_base_addr = q_base_addr + per_core_in_q_heads * head_tiles * single_tile_size;
-    //     }
-    //     uint32_t v_base_addr = k_base_addr + per_core_in_kv_heads * head_tiles * single_tile_size;
-
-    //     uint32_t remote_q_head_start_idx = 0;
-    //     uint32_t remote_kv_head_start_idx = 0;
-    //     uint32_t q_start_addr = q_base_addr;
-    //     uint32_t k_start_addr = k_base_addr;
-    //     uint32_t v_start_addr = v_base_addr;
-
-    //     for (uint32_t i = 0; i < num_cores; ++i) {
-    //         const auto& core = cores[i];
-    //         bool read_kv_heads = i < num_kv_cores;
-    //         {
-    //             auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-    //             runtime_args[6] = q_base_addr;
-    //             runtime_args[7] = q_start_addr;
-    //             runtime_args[15] = k_base_addr;
-    //             runtime_args[16] = k_start_addr;
-    //             remote_q_head_start_idx = (remote_q_head_start_idx + per_risc0_out_q_heads) % per_core_in_q_heads;
-    //             q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
-    //         }
-    //         {
-    //             auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-    //             runtime_args[6] = q_base_addr;
-    //             runtime_args[15] = v_base_addr;
-    //             if (per_risc1_out_q_heads > 0) {
-    //                 runtime_args[7] = q_start_addr;
-    //                 remote_q_head_start_idx = (remote_q_head_start_idx + per_risc1_out_q_heads) %
-    //                 per_core_in_q_heads; q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
-    //             }
-    //             if (read_kv_heads) {
-    //                 runtime_args[16] = v_start_addr;
-    //                 remote_kv_head_start_idx = (remote_kv_head_start_idx + per_core_out_kv_heads) %
-    //                 per_core_in_kv_heads; k_start_addr = k_base_addr + remote_kv_head_start_idx * head_size;
-    //                 v_start_addr = v_base_addr + remote_kv_head_start_idx * head_size;
-    //             }
-    //         }
-    //     }
-    // };
-
-    return {
-        std::move(program),
-        {reader_kernel_id,
-         writer_kernel_id,
-         num_cores,
-         num_cores_y,
-         read_from_input_tensor_kv,
-         cb_q_output,
-         cb_k_output,
-         cb_v_output,
-         cores,
-         head_size,
-         per_risc0_out_q_heads,
-         per_risc1_out_q_heads,
-         per_core_in_q_heads,
-         per_core_out_kv_heads,
-         per_core_in_kv_heads,
-         head_tiles,
-         num_kv_cores,
-         single_tile_size}};
-}
-
-void NlpCreateHeadsDeviceOperation::Sharded::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto* dst_buffer_query = std::get<0>(tensor_return_value).buffer();
-    auto* dst_buffer_key = std::get<1>(tensor_return_value).buffer();
-    auto* dst_buffer_value = std::get<2>(tensor_return_value).buffer();
-
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_q_output, *dst_buffer_query);
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_k_output, *dst_buffer_key);
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_v_output, *dst_buffer_value);
-
-    uint32_t q_base_addr = tensor_args.input_tensor_q.buffer()->address();
-    uint32_t k_base_addr = 0;
-    if (cached_program.shared_variables.read_from_input_tensor_kv) {
-        k_base_addr = tensor_args.input_tensor_kv.value().buffer()->address();
-    } else {
-        k_base_addr = q_base_addr + cached_program.shared_variables.per_core_in_q_heads *
-                                        cached_program.shared_variables.head_tiles *
-                                        cached_program.shared_variables.single_tile_size;
-    }
-    uint32_t v_base_addr =
-        k_base_addr + (cached_program.shared_variables.per_core_in_kv_heads *
-                       cached_program.shared_variables.head_tiles * cached_program.shared_variables.single_tile_size);
-
-    uint32_t remote_q_head_start_idx = 0;
-    uint32_t remote_kv_head_start_idx = 0;
-    uint32_t q_start_addr = q_base_addr;
-    uint32_t k_start_addr = k_base_addr;
-    uint32_t v_start_addr = v_base_addr;
-
-    for (uint32_t i = 0; i < cached_program.shared_variables.num_cores; ++i) {
-        const auto& core = cached_program.shared_variables.cores[i];
-        bool read_kv_heads = i < cached_program.shared_variables.num_kv_cores;
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-            runtime_args[6] = q_base_addr;
-            runtime_args[7] = q_start_addr;
-            runtime_args[15] = k_base_addr;
-            runtime_args[16] = k_start_addr;
-            remote_q_head_start_idx =
-                (remote_q_head_start_idx + cached_program.shared_variables.per_risc0_out_q_heads) %
-                cached_program.shared_variables.per_core_in_q_heads;
-            q_start_addr = q_base_addr + remote_q_head_start_idx * cached_program.shared_variables.head_size;
-        }
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-            runtime_args[6] = q_base_addr;
-            runtime_args[15] = v_base_addr;
-            if (cached_program.shared_variables.per_risc1_out_q_heads > 0) {
-                runtime_args[7] = q_start_addr;
-                remote_q_head_start_idx =
-                    (remote_q_head_start_idx + cached_program.shared_variables.per_risc1_out_q_heads) %
-                    cached_program.shared_variables.per_core_in_q_heads;
-                q_start_addr = q_base_addr + remote_q_head_start_idx * cached_program.shared_variables.head_size;
-            }
-            if (read_kv_heads) {
-                runtime_args[16] = v_start_addr;
-                remote_kv_head_start_idx =
-                    (remote_kv_head_start_idx + cached_program.shared_variables.per_core_out_kv_heads) %
-                    cached_program.shared_variables.per_core_in_kv_heads;
-                k_start_addr = k_base_addr + remote_kv_head_start_idx * cached_program.shared_variables.head_size;
-                v_start_addr = v_base_addr + remote_kv_head_start_idx * cached_program.shared_variables.head_size;
-            }
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -410,6 +410,17 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
 
     uint32_t remote_q_read = 0;
     uint32_t remote_kv_read = 0;
+    // TODO: convert to emplace_runtime_args(Buffer*) for fast cache-hit patching once the
+    // reader/writer kernel ABI is updated to accept (base_buffer, offset) pairs and compute
+    // q_start_addr = get_arg_val(base_pos) + get_arg_val(offset_pos) in-kernel.  Today both
+    // q_base_addr and q_start_addr are baked as raw uint32_t (q_start_addr = q_base_addr +
+    // remote_q_head_start_idx * head_size), and similarly for K/V whose base addresses are
+    // themselves computed offsets into the input (or kv) buffer rather than standalone
+    // buffers, which makes a clean BufferBinding registration non-trivial.  No BufferBinding
+    // is registered for this op, so the contract-1 adapter falls back to the slow-path
+    // rebuild via apply_descriptor_runtime_args on cache hits (see
+    // mesh_device_operation_adapter.hpp apply_descriptor — Contract-1 branch with empty
+    // resolved_bindings.rt_args), which correctly refreshes the addresses, just not as fast.
     for (uint32_t i = 0; i < num_cores; ++i) {
         const auto& core = cores[i];
         bool read_kv_heads = i < k_cores.num_cores();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
@@ -9,7 +9,8 @@
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::experimental::transformer {
 
@@ -32,59 +33,14 @@ struct NlpCreateHeadsBoltzDeviceOperation {
     using tensor_return_value_t = std::tuple<Tensor, Tensor, Tensor>;
 
     struct Interleaved {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernel_id;
-            tt::tt_metal::KernelHandle writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-            bool read_from_input_tensor_kv;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
     };
 
     struct Sharded {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernel_id{};
-            tt::tt_metal::KernelHandle writer_kernel_id{};
-            std::size_t num_cores{};
-            std::size_t num_cores_y{};
-            bool read_from_input_tensor_kv{};
-            tt::tt_metal::CBHandle cb_q_output{};
-            tt::tt_metal::CBHandle cb_k_output{};
-            tt::tt_metal::CBHandle cb_v_output{};
-            std::vector<CoreCoord> cores;
-            uint32_t head_size{};
-            uint32_t per_risc0_out_q_heads{};
-            uint32_t per_risc1_out_q_heads{};
-            uint32_t per_core_in_q_heads{};
-            uint32_t per_core_out_kv_heads{};
-            uint32_t per_core_in_kv_heads{};
-            uint32_t head_tiles{};
-            uint32_t num_kv_cores{};
-            uint32_t single_tile_size{};
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
@@ -9,7 +9,7 @@
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/tensor/memory_config/memory_config.hpp"
+#include "ttnn/types.hpp"  // exposes ttnn::MemoryConfig alias used in member/signature declarations
 
 #include <tt-metalium/program_descriptors.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
@@ -9,6 +9,7 @@
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/memory_config/memory_config.hpp"
 
 #include <tt-metalium/program_descriptors.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
@@ -2,19 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
-#include "nlp_create_qkv_heads_boltz_device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>
 
+#include "nlp_create_qkv_heads_boltz_device_operation.hpp"
+
 namespace ttnn::operations::experimental::transformer {
 using namespace tt::constants;
 using namespace tt;
+using namespace tt::tt_metal;
 
-NlpCreateHeadsBoltzDeviceOperation::Interleaved::cached_program_t
-NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
+ProgramDescriptor NlpCreateHeadsBoltzDeviceOperation::Interleaved::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -38,11 +40,9 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
     TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
 
     tt_metal::Buffer* in1_buffer = nullptr;
-    uint32_t in1_buffer_addr = 0;
     if (read_from_input_tensor_kv) {
         in1_buffer = input_tensor_kv.value().buffer();
         TT_ASSERT(in1_buffer->size() % single_tile_size == 0);
-        in1_buffer_addr = in1_buffer->address();
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -90,7 +90,7 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Program program = tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     // Compile-time args must match kernel expectations exactly.
     std::vector<uint32_t> reader_compile_time_args = {
@@ -112,44 +112,55 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
     tt::tt_metal::TensorAccessorArgs(k_buffer).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(v_buffer).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
     if (transpose_k_heads) {
         std::vector<uint32_t> compute_args_core_group_1 = {num_blocks_per_core_group_1 * kv_num_tiles};
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp",
-            core_group_1,
-            tt_metal::ComputeConfig{.compile_args = compute_args_core_group_1});
+        KernelDescriptor compute_desc_1;
+        compute_desc_1.kernel_source = "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp";
+        compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_1.core_ranges = core_group_1;
+        compute_desc_1.compile_time_args = std::move(compute_args_core_group_1);
+        compute_desc_1.config = ComputeConfigDescriptor{};
+        desc.kernels.push_back(std::move(compute_desc_1));
 
         if (core_group_2.num_cores() > 0) {
             std::vector<uint32_t> compute_args_core_group_2 = {num_blocks_per_core_group_2 * kv_num_tiles};
-            tt_metal::CreateKernel(
-                program,
-                "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp",
-                core_group_2,
-                tt_metal::ComputeConfig{.compile_args = compute_args_core_group_2});
+            KernelDescriptor compute_desc_2;
+            compute_desc_2.kernel_source = "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp";
+            compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            compute_desc_2.core_ranges = core_group_2;
+            compute_desc_2.compile_time_args = std::move(compute_args_core_group_2);
+            compute_desc_2.config = ComputeConfigDescriptor{};
+            desc.kernels.push_back(std::move(compute_desc_2));
         }
 
-        reader_defines["TRANSPOSE_K_HEADS"] = "1";
-        writer_defines["TRANSPOSE_K_HEADS"] = "1";
+        reader_defines.emplace_back("TRANSPOSE_K_HEADS", "1");
+        writer_defines.emplace_back("TRANSPOSE_K_HEADS", "1");
     }
     if (read_from_input_tensor_kv) {
-        reader_defines["READ_FROM_INPUT_TENSOR_KV"] = "1";
+        reader_defines.emplace_back("READ_FROM_INPUT_TENSOR_KV", "1");
     }
 
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
+        "reader_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/"
-        "writer_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
+        "writer_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // Create circular buffers
     uint32_t micro_block_size = 1;                 // Num tiles to read/wait for in reader and writer
@@ -159,10 +170,15 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
     // uint32_t cb1_num_tiles = in0_w_tiles * 2; // double buffer; this runs out of space for generic shapes
     uint32_t src1_cb_index = 1;  // cb0 is needed for compute if we want to use generic transpose_wh compute kernel
     uint32_t cb1_num_tiles = cb_num_tiles;
-    tt_metal::CircularBufferConfig cb_src1_config =
-        tt_metal::CircularBufferConfig(cb1_num_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb1_num_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
 
     // If we transpose_k_heads:
     // - reader will write to cb0, instead of cb1
@@ -171,17 +187,27 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
     if (transpose_k_heads) {
         uint32_t src0_cb_index = 0;
         uint32_t cb0_num_tiles = cb_num_tiles;
-        tt_metal::CircularBufferConfig cb_src0_config =
-            tt_metal::CircularBufferConfig(cb0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-                .set_page_size(src0_cb_index, single_tile_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = cb0_num_tiles * single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src0_cb_index),
+                .data_format = cb_data_format,
+                .page_size = single_tile_size,
+            }}},
+        });
 
         uint32_t out_cb_index = 16;
         uint32_t out_cb_num_tiles = cb_num_tiles;
-        tt_metal::CircularBufferConfig cb_out_config =
-            tt_metal::CircularBufferConfig(out_cb_num_tiles * single_tile_size, {{out_cb_index, cb_data_format}})
-                .set_page_size(out_cb_index, single_tile_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = out_cb_num_tiles * single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(out_cb_index),
+                .data_format = cb_data_format,
+                .page_size = single_tile_size,
+            }}},
+        });
     }
 
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
@@ -195,14 +221,6 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
             TT_ASSERT(false, "Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_runtime_args = {
-            (std::uint32_t)in0_buffer->address(),
-            (std::uint32_t)in1_buffer_addr,
-            num_blocks_per_core,
-            num_blocks_written * in0_w_tiles,
-            num_blocks_written * in1_w_tiles,
-        };
-
         uint32_t q_out_h_dim = num_blocks_written % q_out_h_tiles;
         uint32_t q_out_tensor_tile_id =
             (num_blocks_written / q_out_h_tiles * q_out_CHtWt) + (q_out_h_dim * q_out_w_tiles);
@@ -212,67 +230,42 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
                                             ? (num_blocks_written / q_out_h_tiles * kv_out_CHtWt) + q_out_h_dim
                                             : v_out_tensor_tile_id;
 
-        std::vector<uint32_t> writer_runtime_args = {
-            (std::uint32_t)q_buffer->address(),  // q_tensor_addr
-            (std::uint32_t)k_buffer->address(),  // k_tensor_addr
-            (std::uint32_t)v_buffer->address(),  // v_tensor_addr
-            num_blocks_per_core,                 // num_blocks
-            q_out_h_dim,                         // q_out_h_dim
-            q_out_tensor_tile_id,                // q_out_tensor_tile_id
-            k_out_tensor_tile_id,                // k_out_tensor_tile_id
-            v_out_tensor_tile_id,                // v_out_tensor_tile_id
-        };
+        KernelDescriptor::RTArgList reader_rt;
+        reader_rt.reserve(5);
+        reader_rt.push_back(in0_buffer);
+        if (in1_buffer != nullptr) {
+            reader_rt.push_back(in1_buffer);
+        } else {
+            reader_rt.push_back(uint32_t{0});
+        }
+        reader_rt.push_back(num_blocks_per_core);
+        reader_rt.push_back(num_blocks_written * in0_w_tiles);
+        reader_rt.push_back(num_blocks_written * in1_w_tiles);
+        reader_desc.emplace_runtime_args(core, reader_rt);
 
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                q_buffer,              // q_tensor_addr
+                k_buffer,              // k_tensor_addr
+                v_buffer,              // v_tensor_addr
+                num_blocks_per_core,   // num_blocks
+                q_out_h_dim,           // q_out_h_dim
+                q_out_tensor_tile_id,  // q_out_tensor_tile_id
+                k_out_tensor_tile_id,  // k_out_tensor_tile_id
+                v_out_tensor_tile_id,  // v_out_tensor_tile_id
+            });
+
         num_blocks_written += num_blocks_per_core;
     }
 
-    return {
-        std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y, read_from_input_tensor_kv}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void NlpCreateHeadsBoltzDeviceOperation::Interleaved::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto* src_buffer = tensor_args.input_tensor_q.buffer();
-
-    uint32_t src_kv_buffer_addr = 0;
-    if (cached_program.shared_variables.read_from_input_tensor_kv) {
-        src_kv_buffer_addr = tensor_args.input_tensor_kv.value().buffer()->address();
-    }
-
-    auto* dst_buffer_query = std::get<0>(tensor_return_value).buffer();
-    auto* dst_buffer_key = std::get<1>(tensor_return_value).buffer();
-    auto* dst_buffer_value = std::get<2>(tensor_return_value).buffer();
-
-    for (uint32_t i = 0; i < cached_program.shared_variables.num_cores; i++) {
-        CoreCoord core = {
-            i / cached_program.shared_variables.num_cores_y, i % cached_program.shared_variables.num_cores_y};
-
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-
-            if (cached_program.shared_variables.read_from_input_tensor_kv) {
-                runtime_args[1] = src_kv_buffer_addr;
-            }
-        }
-
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-            runtime_args[0] = dst_buffer_query->address();
-            runtime_args[1] = dst_buffer_key->address();
-            runtime_args[2] = dst_buffer_value->address();
-        }
-    }
-}
-
-NlpCreateHeadsBoltzDeviceOperation::Sharded::cached_program_t NlpCreateHeadsBoltzDeviceOperation::Sharded::create(
+ProgramDescriptor NlpCreateHeadsBoltzDeviceOperation::Sharded::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -283,7 +276,7 @@ NlpCreateHeadsBoltzDeviceOperation::Sharded::cached_program_t NlpCreateHeadsBolt
     auto num_q_heads = operation_attributes.num_q_heads;
     auto num_kv_heads = operation_attributes.num_kv_heads;
 
-    tt_metal::Program program = tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     tt_metal::IDevice* device = input_tensor.device();
 
@@ -306,33 +299,48 @@ NlpCreateHeadsBoltzDeviceOperation::Sharded::cached_program_t NlpCreateHeadsBolt
     uint32_t per_core_in_q_heads = num_q_heads / input_tensor.shard_spec().value().num_cores();
 
     uint32_t q_output_cb_index = CBIndex::c_16;
-    tt_metal::CircularBufferConfig cb_q_output_config =
-        tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
-            .set_page_size(q_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*std::get<0>(output).buffer());
-    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_num_tiles * single_tile_size,
+        .core_ranges = q_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = std::get<0>(output).buffer(),
+    });
 
     auto k_shard_spec = std::get<1>(output).shard_spec().value();
     auto k_cores = k_shard_spec.grid;
     auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
 
     uint32_t k_output_cb_index = CBIndex::c_17;
-    tt_metal::CircularBufferConfig cb_k_output_config =
-        tt_metal::CircularBufferConfig(k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
-            .set_page_size(k_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*std::get<1>(output).buffer());
-    auto cb_k_output = tt_metal::CreateCircularBuffer(program, k_cores, cb_k_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = k_num_tiles * single_tile_size,
+        .core_ranges = k_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(k_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = std::get<1>(output).buffer(),
+    });
 
     auto v_shard_spec = std::get<0>(output).shard_spec().value();
     auto v_cores = q_shard_spec.grid;
     auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
     uint32_t v_output_cb_index = CBIndex::c_18;
-    tt_metal::CircularBufferConfig cb_v_output_config =
-        tt_metal::CircularBufferConfig(v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
-            .set_page_size(v_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*std::get<2>(output).buffer());
-    auto cb_v_output = tt_metal::CreateCircularBuffer(program, v_cores, cb_v_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = v_num_tiles * single_tile_size,
+        .core_ranges = v_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(v_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = std::get<2>(output).buffer(),
+    });
 
     uint32_t per_core_out_kv_heads = num_kv_heads / k_cores.num_cores();
     uint32_t per_core_in_kv_heads =
@@ -350,24 +358,29 @@ NlpCreateHeadsBoltzDeviceOperation::Sharded::cached_program_t NlpCreateHeadsBolt
 
     std::vector<uint32_t> reader_compile_time_args = {q_output_cb_index, k_output_cb_index};
     std::vector<uint32_t> writer_compile_time_args = {q_output_cb_index, v_output_cb_index};
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_boltz_sharded.cpp",
-        q_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
+        "reader_tm_tile_layout_nlp_create_qkv_heads_boltz_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = q_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_boltz_sharded.cpp",
-        q_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "reader_tm_tile_layout_nlp_create_qkv_heads_boltz_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = q_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t num_cores = std::max(q_cores.num_cores(), k_cores.num_cores());
 
     auto core_grid = q_cores.bounding_box();
     uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
-    uint32_t num_kv_cores = k_cores.num_cores();
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
@@ -426,7 +439,7 @@ NlpCreateHeadsBoltzDeviceOperation::Sharded::cached_program_t NlpCreateHeadsBolt
         remote_q_head_start_idx = (remote_q_head_start_idx + per_risc0_out_q_heads) % per_core_in_q_heads;
         q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
 
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
 
         reader_runtime_args[1] = per_risc1_out_q_heads;
         reader_runtime_args[3] = remote_q_head_start_idx;
@@ -454,103 +467,13 @@ NlpCreateHeadsBoltzDeviceOperation::Sharded::cached_program_t NlpCreateHeadsBolt
             v_start_addr = v_base_addr + remote_kv_head_start_idx * head_size;
         }
 
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+        writer_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
     }
 
-    return {
-        std::move(program),
-        {reader_kernel_id,
-         writer_kernel_id,
-         num_cores,
-         num_cores_y,
-         read_from_input_tensor_kv,
-         cb_q_output,
-         cb_k_output,
-         cb_v_output,
-         cores,
-         head_size,
-         per_risc0_out_q_heads,
-         per_risc1_out_q_heads,
-         per_core_in_q_heads,
-         per_core_out_kv_heads,
-         per_core_in_kv_heads,
-         head_tiles,
-         num_kv_cores,
-         single_tile_size}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void NlpCreateHeadsBoltzDeviceOperation::Sharded::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto* dst_buffer_query = std::get<0>(tensor_return_value).buffer();
-    auto* dst_buffer_key = std::get<1>(tensor_return_value).buffer();
-    auto* dst_buffer_value = std::get<2>(tensor_return_value).buffer();
-
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_q_output, *dst_buffer_query);
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_k_output, *dst_buffer_key);
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_v_output, *dst_buffer_value);
-
-    uint32_t q_base_addr = tensor_args.input_tensor_q.buffer()->address();
-    uint32_t k_base_addr = 0;
-    if (cached_program.shared_variables.read_from_input_tensor_kv) {
-        k_base_addr = tensor_args.input_tensor_kv.value().buffer()->address();
-    } else {
-        k_base_addr = q_base_addr + cached_program.shared_variables.per_core_in_q_heads *
-                                        cached_program.shared_variables.head_tiles *
-                                        cached_program.shared_variables.single_tile_size;
-    }
-    uint32_t v_base_addr =
-        k_base_addr + (cached_program.shared_variables.per_core_in_kv_heads *
-                       cached_program.shared_variables.head_tiles * cached_program.shared_variables.single_tile_size);
-
-    uint32_t remote_q_head_start_idx = 0;
-    uint32_t remote_kv_head_start_idx = 0;
-    uint32_t q_start_addr = q_base_addr;
-    uint32_t k_start_addr = k_base_addr;
-    uint32_t v_start_addr = v_base_addr;
-
-    for (uint32_t i = 0; i < cached_program.shared_variables.num_cores; ++i) {
-        const auto& core = cached_program.shared_variables.cores[i];
-        bool read_kv_heads = i < cached_program.shared_variables.num_kv_cores;
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-            runtime_args[6] = q_base_addr;
-            runtime_args[7] = q_start_addr;
-            runtime_args[15] = k_base_addr;
-            runtime_args[16] = k_start_addr;
-            remote_q_head_start_idx =
-                (remote_q_head_start_idx + cached_program.shared_variables.per_risc0_out_q_heads) %
-                cached_program.shared_variables.per_core_in_q_heads;
-            q_start_addr = q_base_addr + remote_q_head_start_idx * cached_program.shared_variables.head_size;
-        }
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-            runtime_args[6] = q_base_addr;
-            runtime_args[15] = v_base_addr;
-            if (cached_program.shared_variables.per_risc1_out_q_heads > 0) {
-                runtime_args[7] = q_start_addr;
-                remote_q_head_start_idx =
-                    (remote_q_head_start_idx + cached_program.shared_variables.per_risc1_out_q_heads) %
-                    cached_program.shared_variables.per_core_in_q_heads;
-                q_start_addr = q_base_addr + remote_q_head_start_idx * cached_program.shared_variables.head_size;
-            }
-            if (read_kv_heads) {
-                runtime_args[16] = v_start_addr;
-                remote_kv_head_start_idx =
-                    (remote_kv_head_start_idx + cached_program.shared_variables.per_core_out_kv_heads) %
-                    cached_program.shared_variables.per_core_in_kv_heads;
-                k_start_addr = k_base_addr + remote_kv_head_start_idx * cached_program.shared_variables.head_size;
-                v_start_addr = v_base_addr + remote_kv_head_start_idx * cached_program.shared_variables.head_size;
-            }
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
@@ -404,6 +404,17 @@ ProgramDescriptor NlpCreateHeadsBoltzDeviceOperation::Sharded::create_descriptor
 
     uint32_t remote_q_read = 0;
     uint32_t remote_kv_read = 0;
+    // TODO: convert to emplace_runtime_args(Buffer*) for fast cache-hit patching once the
+    // reader/writer kernel ABI is updated to accept (base_buffer, offset) pairs and compute
+    // q_start_addr = get_arg_val(base_pos) + get_arg_val(offset_pos) in-kernel.  Today both
+    // q_base_addr and q_start_addr are baked as raw uint32_t (q_start_addr = q_base_addr +
+    // remote_q_head_start_idx * head_size), and similarly for K/V whose base addresses are
+    // themselves computed offsets into the input (or kv) buffer rather than standalone
+    // buffers, which makes a clean BufferBinding registration non-trivial.  No BufferBinding
+    // is registered for this op, so the contract-1 adapter falls back to the slow-path
+    // rebuild via apply_descriptor_runtime_args on cache hits (see
+    // mesh_device_operation_adapter.hpp apply_descriptor — Contract-1 branch with empty
+    // resolved_bindings.rt_args), which correctly refreshes the addresses, just not as fast.
     for (uint32_t i = 0; i < num_cores; ++i) {
         const auto& core = cores[i];
         bool read_kv_heads = i < k_cores.num_cores();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.cpp
@@ -3,19 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "nlp_create_qkv_heads_decode_interleaved_program_factory.hpp"
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
+
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt;
 
 namespace ttnn::experimental::prim {
 
-NLPCreateQKVHeadsDecodeInterleavedProgramFactory::cached_program_t
-NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
@@ -26,7 +27,7 @@ NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create(
     const auto& num_kv_heads = operation_attributes.num_kv_heads;
     const auto& head_dim = operation_attributes.head_dim;
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
@@ -42,35 +43,50 @@ NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create(
     auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
 
     uint32_t q_output_cb_index = CBIndex::c_16;
-    CircularBufferConfig cb_q_output_config =
-        CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
-            .set_page_size(q_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[0].buffer());
-    auto cb_q_output = CreateCircularBuffer(program, q_cores, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_num_tiles * single_tile_size,
+        .core_ranges = q_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[0].buffer(),
+    });
 
     auto k_shard_spec = output[1].shard_spec().value();
     auto k_cores = k_shard_spec.grid;
     auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
 
     uint32_t k_output_cb_index = CBIndex::c_17;
-    CircularBufferConfig cb_k_output_config =
-        CircularBufferConfig(k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
-            .set_page_size(k_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[1].buffer());
-    auto cb_k_output = CreateCircularBuffer(program, k_cores, cb_k_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = k_num_tiles * single_tile_size,
+        .core_ranges = k_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(k_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[1].buffer(),
+    });
 
     auto v_shard_spec = output[2].shard_spec().value();
     auto v_cores = q_shard_spec.grid;
     auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
     uint32_t v_output_cb_index = CBIndex::c_18;
-    CircularBufferConfig cb_v_output_config =
-        CircularBufferConfig(v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
-            .set_page_size(v_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[2].buffer());
-    auto cb_v_output = CreateCircularBuffer(program, v_cores, cb_v_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = v_num_tiles * single_tile_size,
+        .core_ranges = v_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(v_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[2].buffer(),
+    });
 
-    uint32_t q_base_addr = input_tensor.buffer()->address();
+    Buffer* in_buffer = input_tensor.buffer();
 
     // The reader kernel reads each face row as a single 16-element noc_async_read transaction
     // (`16 * element_size` bytes). When the input is DRAM-interleaved and that read size is below
@@ -79,7 +95,7 @@ NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create(
     // parities and the read silently returns wrong data (issue #43270). When that condition
     // holds, switch the kernel to a DRAM-aligned scratch+memcpy path; otherwise the original
     // direct-read fast path runs unchanged. Sharded inputs do not go through this factory.
-    const bool is_dram = input_tensor.buffer()->buffer_type() == BufferType::DRAM;
+    const bool is_dram = in_buffer->buffer_type() == BufferType::DRAM;
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
     const bool use_aligned_path = is_dram && (sub_tile_line_bytes < dram_alignment);
 
@@ -96,14 +112,24 @@ NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create(
         const uint32_t scratch_size_bytes = (head_tiles + 1) * dram_alignment;
         // Float16_b is just a placeholder DataFormat for this scratch CB — the kernel only treats
         // it as raw L1 storage and copies bytes via memcpy.
-        CircularBufferConfig cb_reader_scratch_config =
-            CircularBufferConfig(scratch_size_bytes, {{reader_scratch_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(reader_scratch_cb_index, dram_alignment);
-        CreateCircularBuffer(program, q_cores, cb_reader_scratch_config);
-        CircularBufferConfig cb_writer_scratch_config =
-            CircularBufferConfig(scratch_size_bytes, {{writer_scratch_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(writer_scratch_cb_index, dram_alignment);
-        CreateCircularBuffer(program, q_cores, cb_writer_scratch_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = scratch_size_bytes,
+            .core_ranges = q_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(reader_scratch_cb_index),
+                .data_format = tt::DataFormat::Float16_b,
+                .page_size = dram_alignment,
+            }}},
+        });
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = scratch_size_bytes,
+            .core_ranges = q_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(writer_scratch_cb_index),
+                .data_format = tt::DataFormat::Float16_b,
+                .page_size = dram_alignment,
+            }}},
+        });
     }
 
     // We parallelize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2
@@ -123,21 +149,29 @@ NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create(
         dram_alignment,
         reader_scratch_cb_index,
     };
-    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_time_args);
-    auto reader_kernel_id = CreateKernel(
-        program,
+    tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-        q_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
-    reader_compile_time_args[9] = 2;  // read the second phase
-    reader_compile_time_args[12] = writer_scratch_cb_index;
-    auto writer_kernel_id = CreateKernel(
-        program,
+        "reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = q_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    std::vector<uint32_t> writer_compile_time_args = reader_compile_time_args;
+    writer_compile_time_args[9] = 2;  // read the second phase
+    writer_compile_time_args[12] = writer_scratch_cb_index;
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-        q_cores,
-        WriterDataMovementConfig(reader_compile_time_args));
+        "reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = q_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
     auto core_grid = q_cores.bounding_box();
@@ -149,67 +183,14 @@ NLPCreateQKVHeadsDecodeInterleavedProgramFactory::create(
             i < 16 ? i * sub_tile_line_bytes : ((i - 16) * sub_tile_line_bytes) + (512 * element_size);
 
         const auto& core = cores[i];
-        std::vector<uint32_t> reader_runtime_args = {in_tile_offset_by_batch, q_base_addr};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(core, {in_tile_offset_by_batch, in_buffer});
+        writer_desc.emplace_runtime_args(core, {in_tile_offset_by_batch, in_buffer});
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = reader_kernel_id,
-            .writer_kernel_id = writer_kernel_id,
-            .num_cores = num_cores,
-            .cb_q_output = cb_q_output,
-            .cb_k_output = cb_k_output,
-            .cb_v_output = cb_v_output,
-            .cores = cores,
-            .element_size = element_size,
-            .sub_tile_line_bytes = sub_tile_line_bytes}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void NLPCreateQKVHeadsDecodeInterleavedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensors) {
-    using namespace tt::tt_metal;
-
-    auto& program = cached_program.program;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& num_cores = cached_program.shared_variables.num_cores;
-    const auto& cb_q_output = cached_program.shared_variables.cb_q_output;
-    const auto& cb_k_output = cached_program.shared_variables.cb_k_output;
-    const auto& cb_v_output = cached_program.shared_variables.cb_v_output;
-    const auto& cores = cached_program.shared_variables.cores;
-    const auto& element_size = cached_program.shared_variables.element_size;
-    const auto& sub_tile_line_bytes = cached_program.shared_variables.sub_tile_line_bytes;
-
-    auto *dst_buffer_query = output_tensors.at(0).buffer();
-    auto *dst_buffer_key = output_tensors.at(1).buffer();
-    auto *dst_buffer_value = output_tensors.at(2).buffer();
-
-    UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
-    UpdateDynamicCircularBufferAddress(program, cb_k_output, *dst_buffer_key);
-    UpdateDynamicCircularBufferAddress(program, cb_v_output, *dst_buffer_value);
-
-    uint32_t q_base_addr = tensor_args.input_tensor.buffer()->address();
-    uint32_t q_start_addr = q_base_addr;
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        uint32_t in_tile_offset_by_batch =
-            i < 16 ? i * sub_tile_line_bytes : ((i - 16) * sub_tile_line_bytes) + (512 * element_size);
-        const auto& core = cores[i];
-        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-        runtime_args[0] = in_tile_offset_by_batch;
-        runtime_args[1] = q_start_addr;
-
-        auto& runtime_args_writer = GetRuntimeArgs(program, writer_kernel_id, core);
-        runtime_args_writer[0] = in_tile_offset_by_batch;
-        runtime_args_writer[1] = q_start_addr;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.hpp
@@ -5,8 +5,9 @@
 #pragma once
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/device_operation.hpp"
 #include "nlp_create_qkv_heads_decode_device_operation_types.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -15,30 +16,10 @@ struct NLPCreateQKVHeadsDecodeInterleavedProgramFactory {
     using tensor_args_t = NlpCreateQkvHeadsDecodeInputs;
     using tensor_return_value_t = std::vector<Tensor>;
 
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        uint32_t num_cores{};
-        tt::tt_metal::CBHandle cb_q_output{};
-        tt::tt_metal::CBHandle cb_k_output{};
-        tt::tt_metal::CBHandle cb_v_output{};
-        std::vector<CoreCoord> cores;
-        uint32_t element_size{};
-        uint32_t sub_tile_line_bytes{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensors);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
@@ -3,17 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "nlp_create_qkv_heads_decode_sharded_program_factory.hpp"
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
+
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt;
 
 namespace ttnn::experimental::prim {
 
-NLPCreateQKVHeadsDecodeShardedProgramFactory::cached_program_t NLPCreateQKVHeadsDecodeShardedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
@@ -26,7 +28,7 @@ NLPCreateQKVHeadsDecodeShardedProgramFactory::cached_program_t NLPCreateQKVHeads
     const auto& head_dim = operation_attributes.head_dim;
     const auto& overlap_qk_coregrid = operation_attributes.overlap_qk_coregrid;
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     IDevice* device = input_tensor.device();
     // Create CBs for reader/writer for batch_offset
@@ -64,45 +66,69 @@ NLPCreateQKVHeadsDecodeShardedProgramFactory::cached_program_t NLPCreateQKVHeads
         uint32_t single_batch_offset_tile_size = tt::tile_size(cb_batch_offset_data_format);
         batch_offset_index_stick_size = batch_offset.value().buffer()->aligned_page_size();
 
-        CircularBufferConfig cb_batch_offset_config_reader =
-            CircularBufferConfig(
-                single_batch_offset_tile_size, {{batch_offset_cb_index_reader, cb_batch_offset_data_format}})
-                .set_page_size(batch_offset_cb_index_reader, 1);
-        CreateCircularBuffer(program, qk_cores, cb_batch_offset_config_reader);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = single_batch_offset_tile_size,
+            .core_ranges = qk_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_reader),
+                .data_format = cb_batch_offset_data_format,
+                .page_size = 1,
+            }}},
+        });
 
-        CircularBufferConfig cb_batch_offset_config_writer =
-            CircularBufferConfig(
-                single_batch_offset_tile_size, {{batch_offset_cb_index_writer, cb_batch_offset_data_format}})
-                .set_page_size(batch_offset_cb_index_writer, 1);
-        CreateCircularBuffer(program, qk_cores, cb_batch_offset_config_writer);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = single_batch_offset_tile_size,
+            .core_ranges = qk_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_writer),
+                .data_format = cb_batch_offset_data_format,
+                .page_size = 1,
+            }}},
+        });
     }
 
     uint32_t q_output_cb_index = CBIndex::c_16;
-    CircularBufferConfig cb_q_output_config =
-        CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
-            .set_page_size(q_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[0].buffer());
-    auto cb_q_output = CreateCircularBuffer(program, q_cores, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_num_tiles * single_tile_size,
+        .core_ranges = q_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[0].buffer(),
+    });
 
     uint32_t k_output_cb_index = CBIndex::c_17;
-    CircularBufferConfig cb_k_output_config =
-        CircularBufferConfig(k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
-            .set_page_size(k_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[1].buffer());
-    auto cb_k_output = CreateCircularBuffer(program, k_cores, cb_k_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = k_num_tiles * single_tile_size,
+        .core_ranges = k_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(k_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[1].buffer(),
+    });
 
     auto v_shard_spec = output[2].shard_spec().value();
     auto v_cores = v_shard_spec.grid;
     auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
     uint32_t v_output_cb_index = CBIndex::c_18;
-    CircularBufferConfig cb_v_output_config =
-        CircularBufferConfig(v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
-            .set_page_size(v_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[2].buffer());
-    auto cb_v_output = CreateCircularBuffer(program, v_cores, cb_v_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = v_num_tiles * single_tile_size,
+        .core_ranges = v_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(v_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[2].buffer(),
+    });
 
-    uint32_t q_base_addr = input_tensor.buffer()->address();
+    Buffer* in_buffer = input_tensor.buffer();
+    Buffer* batch_offset_buffer = batch_offset.has_value() ? batch_offset.value().buffer() : nullptr;
 
     // cores for q
     uint32_t q_num_cores = q_cores.num_cores();  // number of cores of the output
@@ -160,24 +186,31 @@ NLPCreateQKVHeadsDecodeShardedProgramFactory::cached_program_t NLPCreateQKVHeads
         batch_offset.has_value() ? 1 : 0,  // use_batch_offset
         batch_offset_index_stick_size,
         batch_offset_cb_index_reader};
-    tt::tt_metal::TensorAccessorArgs(batch_offset.has_value() ? batch_offset.value().buffer() : nullptr)
-        .append_to(q_reader_compile_time_args);
-    auto q_reader_kernel_id = CreateKernel(
-        program,
+    tt::tt_metal::TensorAccessorArgs(batch_offset_buffer).append_to(q_reader_compile_time_args);
+
+    KernelDescriptor q_reader_desc;
+    q_reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-        q_cores,
-        ReaderDataMovementConfig(q_reader_compile_time_args));
+        "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
+    q_reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    q_reader_desc.core_ranges = q_cores;
+    q_reader_desc.compile_time_args = q_reader_compile_time_args;
+    q_reader_desc.config = ReaderConfigDescriptor{};
+
     std::vector<uint32_t> q_writer_compile_time_args = q_reader_compile_time_args;
     q_writer_compile_time_args[9] = 2;  // read the second phase
-    auto q_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-        q_cores,
-        WriterDataMovementConfig(q_writer_compile_time_args));
 
-    tt::tt_metal::KernelHandle k_reader_kernel_id = 0, k_writer_kernel_id = 0;
+    KernelDescriptor q_writer_desc;
+    q_writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
+        "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
+    q_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    q_writer_desc.core_ranges = q_cores;
+    q_writer_desc.compile_time_args = std::move(q_writer_compile_time_args);
+    q_writer_desc.config = WriterConfigDescriptor{};
+
+    KernelDescriptor k_reader_desc;
+    KernelDescriptor k_writer_desc;
     if (!overlap_qk_coregrid) {
         // Switch process_qv and process_k for k kernels
         process_qv = 0;
@@ -185,132 +218,73 @@ NLPCreateQKVHeadsDecodeShardedProgramFactory::cached_program_t NLPCreateQKVHeads
         std::vector<uint32_t> k_reader_compile_time_args = q_reader_compile_time_args;
         k_reader_compile_time_args[12] = process_qv;
         k_reader_compile_time_args[13] = process_k;
-        k_reader_kernel_id = CreateKernel(
-            program,
+
+        k_reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-            "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-            k_cores,
-            ReaderDataMovementConfig(k_reader_compile_time_args));
+            "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
+        k_reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        k_reader_desc.core_ranges = k_cores;
+        k_reader_desc.compile_time_args = k_reader_compile_time_args;
+        k_reader_desc.config = ReaderConfigDescriptor{};
 
         std::vector<uint32_t> k_writer_compile_time_args = k_reader_compile_time_args;
         k_writer_compile_time_args[9] = 2;  // read the second phase
-        k_writer_kernel_id = CreateKernel(
-            program,
+
+        k_writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-            "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-            k_cores,
-            WriterDataMovementConfig(k_writer_compile_time_args));
+            "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
+        k_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        k_writer_desc.core_ranges = k_cores;
+        k_writer_desc.compile_time_args = std::move(k_writer_compile_time_args);
+        k_writer_desc.config = WriterConfigDescriptor{};
     }
 
-    uint32_t q_start_addr = q_base_addr;
-    bool use_batch_offset = batch_offset.has_value();
+    auto push_batch_offset = [&](KernelDescriptor::RTArgList& rt) {
+        if (batch_offset_buffer != nullptr) {
+            rt.push_back(batch_offset_buffer);
+        } else {
+            rt.push_back(uint32_t{0});
+        }
+    };
 
     for (uint32_t i = 0; i < q_num_cores; ++i) {
         const auto& core = q_cores_vector[i];
-        std::vector<uint32_t> q_reader_runtime_args;
-        q_reader_runtime_args.reserve(3 + in_num_cores_x + in_num_cores_y);
-        q_reader_runtime_args = {q_start_addr, use_batch_offset ? batch_offset.value().buffer()->address() : 0, i};
-        q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-        q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+        KernelDescriptor::RTArgList rt;
+        rt.reserve(3 + in_num_cores_x + in_num_cores_y);
+        rt.push_back(in_buffer);  // q_start_addr (= input_tensor base)
+        push_batch_offset(rt);
+        rt.push_back(i);
+        rt.append(noc_x_coords);
+        rt.append(noc_y_coords);
 
-        SetRuntimeArgs(program, q_reader_kernel_id, core, q_reader_runtime_args);
-        SetRuntimeArgs(program, q_writer_kernel_id, core, q_reader_runtime_args);
+        q_reader_desc.emplace_runtime_args(core, rt);
+        q_writer_desc.emplace_runtime_args(core, rt);
     }
 
     if (!overlap_qk_coregrid) {
         for (uint32_t i = 0; i < k_num_cores; ++i) {
             const auto& core = k_cores_vector[i];
-            std::vector<uint32_t> k_reader_runtime_args;
-            k_reader_runtime_args.reserve(3 + in_num_cores_x + in_num_cores_y);
-            k_reader_runtime_args = {q_start_addr, use_batch_offset ? batch_offset.value().buffer()->address() : 0, i};
-            k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-            k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+            KernelDescriptor::RTArgList rt;
+            rt.reserve(3 + in_num_cores_x + in_num_cores_y);
+            rt.push_back(in_buffer);
+            push_batch_offset(rt);
+            rt.push_back(i);
+            rt.append(noc_x_coords);
+            rt.append(noc_y_coords);
 
-            SetRuntimeArgs(program, k_reader_kernel_id, core, k_reader_runtime_args);
-            SetRuntimeArgs(program, k_writer_kernel_id, core, k_reader_runtime_args);
+            k_reader_desc.emplace_runtime_args(core, rt);
+            k_writer_desc.emplace_runtime_args(core, rt);
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .q_reader_kernel_id = q_reader_kernel_id,
-            .q_writer_kernel_id = q_writer_kernel_id,
-            .k_reader_kernel_id = k_reader_kernel_id,
-            .k_writer_kernel_id = k_writer_kernel_id,
-            .q_num_cores = q_num_cores,
-            .k_num_cores = k_num_cores,
-            .cb_q_output = cb_q_output,
-            .cb_k_output = cb_k_output,
-            .cb_v_output = cb_v_output,
-            .q_cores_vector = q_cores_vector,
-            .k_cores_vector = k_cores_vector,
-            .element_size = element_size,
-            .sub_tile_line_bytes = sub_tile_line_bytes,
-            .overlap_qk_coregrid = overlap_qk_coregrid,
-            .use_batch_offset = use_batch_offset}};
-}
-
-void NLPCreateQKVHeadsDecodeShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensors) {
-    using namespace tt::tt_metal;
-
-    auto& program = cached_program.program;
-    const auto& q_reader_kernel_id = cached_program.shared_variables.q_reader_kernel_id;
-    const auto& q_writer_kernel_id = cached_program.shared_variables.q_writer_kernel_id;
-    const auto& k_reader_kernel_id = cached_program.shared_variables.k_reader_kernel_id;
-    const auto& k_writer_kernel_id = cached_program.shared_variables.k_writer_kernel_id;
-    const auto& q_num_cores = cached_program.shared_variables.q_num_cores;
-    const auto& k_num_cores = cached_program.shared_variables.k_num_cores;
-    const auto& cb_q_output = cached_program.shared_variables.cb_q_output;
-    const auto& cb_k_output = cached_program.shared_variables.cb_k_output;
-    const auto& cb_v_output = cached_program.shared_variables.cb_v_output;
-    const auto& q_cores_vector = cached_program.shared_variables.q_cores_vector;
-    const auto& k_cores_vector = cached_program.shared_variables.k_cores_vector;
-    const auto& overlap_qk_coregrid = cached_program.shared_variables.overlap_qk_coregrid;
-    const auto& use_batch_offset = cached_program.shared_variables.use_batch_offset;
-
-    auto *dst_buffer_query = output_tensors.at(0).buffer();
-    auto *dst_buffer_key = output_tensors.at(1).buffer();
-    auto *dst_buffer_value = output_tensors.at(2).buffer();
-
-    UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
-    UpdateDynamicCircularBufferAddress(program, cb_k_output, *dst_buffer_key);
-    UpdateDynamicCircularBufferAddress(program, cb_v_output, *dst_buffer_value);
-
-    uint32_t q_base_addr = tensor_args.input_tensor.buffer()->address();
-    uint32_t q_start_addr = q_base_addr;
-
-    for (uint32_t i = 0; i < q_num_cores; ++i) {
-        const auto& core = q_cores_vector[i];
-        auto& runtime_args = GetRuntimeArgs(program, q_reader_kernel_id, core);
-        runtime_args[0] = q_start_addr;
-        runtime_args[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-        runtime_args[2] = i;
-
-        auto& runtime_args_writer = GetRuntimeArgs(program, q_writer_kernel_id, core);
-        runtime_args_writer[0] = q_start_addr;
-        runtime_args_writer[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-        runtime_args_writer[2] = i;
-    }
-
+    desc.kernels.push_back(std::move(q_reader_desc));
+    desc.kernels.push_back(std::move(q_writer_desc));
     if (!overlap_qk_coregrid) {
-        for (uint32_t i = 0; i < k_num_cores; ++i) {
-            const auto& core = k_cores_vector[i];
-            auto& runtime_args = GetRuntimeArgs(program, k_reader_kernel_id, core);
-            runtime_args[0] = q_start_addr;
-            runtime_args[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-            runtime_args[2] = i;
-
-            auto& runtime_args_writer = GetRuntimeArgs(program, k_writer_kernel_id, core);
-            runtime_args_writer[0] = q_start_addr;
-            runtime_args_writer[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-            runtime_args_writer[2] = i;
-        }
+        desc.kernels.push_back(std::move(k_reader_desc));
+        desc.kernels.push_back(std::move(k_writer_desc));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.hpp
@@ -5,8 +5,9 @@
 #pragma once
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/device_operation.hpp"
 #include "nlp_create_qkv_heads_decode_device_operation_types.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -15,36 +16,10 @@ struct NLPCreateQKVHeadsDecodeShardedProgramFactory {
     using tensor_args_t = NlpCreateQkvHeadsDecodeInputs;
     using tensor_return_value_t = std::vector<Tensor>;
 
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle q_reader_kernel_id{};
-        tt::tt_metal::KernelHandle q_writer_kernel_id{};
-        tt::tt_metal::KernelHandle k_reader_kernel_id{};
-        tt::tt_metal::KernelHandle k_writer_kernel_id{};
-        uint32_t q_num_cores{};
-        uint32_t k_num_cores{};
-        tt::tt_metal::CBHandle cb_q_output{};
-        tt::tt_metal::CBHandle cb_k_output{};
-        tt::tt_metal::CBHandle cb_v_output{};
-        std::vector<CoreCoord> q_cores_vector;
-        std::vector<CoreCoord> k_cores_vector;
-        uint32_t element_size{};
-        uint32_t sub_tile_line_bytes{};
-        bool overlap_qk_coregrid{};
-        bool use_batch_offset{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensors);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.cpp
@@ -3,18 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.hpp"
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
+
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt;
 
 namespace ttnn::experimental::prim {
 
-NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::cached_program_t
-NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create(
+tt::tt_metal::ProgramDescriptor NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
@@ -27,7 +28,7 @@ NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create(
     const auto& head_dim = operation_attributes.head_dim;
     const auto& overlap_qk_coregrid = operation_attributes.overlap_qk_coregrid;
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     IDevice* device = input_tensor.device();
     // Create CBs for reader/writer for batch_offset
@@ -65,45 +66,69 @@ NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create(
         uint32_t single_batch_offset_tile_size = tt::tile_size(cb_batch_offset_data_format);
         batch_offset_index_stick_size = batch_offset.value().buffer()->aligned_page_size();
 
-        CircularBufferConfig cb_batch_offset_config_reader =
-            CircularBufferConfig(
-                single_batch_offset_tile_size, {{batch_offset_cb_index_reader, cb_batch_offset_data_format}})
-                .set_page_size(batch_offset_cb_index_reader, 1);
-        CreateCircularBuffer(program, qk_cores, cb_batch_offset_config_reader);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = single_batch_offset_tile_size,
+            .core_ranges = qk_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_reader),
+                .data_format = cb_batch_offset_data_format,
+                .page_size = 1,
+            }}},
+        });
 
-        CircularBufferConfig cb_batch_offset_config_writer =
-            CircularBufferConfig(
-                single_batch_offset_tile_size, {{batch_offset_cb_index_writer, cb_batch_offset_data_format}})
-                .set_page_size(batch_offset_cb_index_writer, 1);
-        CreateCircularBuffer(program, qk_cores, cb_batch_offset_config_writer);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = single_batch_offset_tile_size,
+            .core_ranges = qk_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(batch_offset_cb_index_writer),
+                .data_format = cb_batch_offset_data_format,
+                .page_size = 1,
+            }}},
+        });
     }
 
     uint32_t q_output_cb_index = CBIndex::c_16;
-    CircularBufferConfig cb_q_output_config =
-        CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
-            .set_page_size(q_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[0].buffer());
-    auto cb_q_output = CreateCircularBuffer(program, q_cores, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_num_tiles * single_tile_size,
+        .core_ranges = q_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[0].buffer(),
+    });
 
     uint32_t k_output_cb_index = CBIndex::c_17;
-    CircularBufferConfig cb_k_output_config =
-        CircularBufferConfig(k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
-            .set_page_size(k_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[1].buffer());
-    auto cb_k_output = CreateCircularBuffer(program, k_cores, cb_k_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = k_num_tiles * single_tile_size,
+        .core_ranges = k_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(k_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[1].buffer(),
+    });
 
     const auto v_shard_spec = output[0].shard_spec().value();
     const auto v_cores = q_shard_spec.grid;
     const auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
     uint32_t v_output_cb_index = CBIndex::c_18;
-    CircularBufferConfig cb_v_output_config =
-        CircularBufferConfig(v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
-            .set_page_size(v_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output[2].buffer());
-    auto cb_v_output = CreateCircularBuffer(program, v_cores, cb_v_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = v_num_tiles * single_tile_size,
+        .core_ranges = v_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(v_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output[2].buffer(),
+    });
 
-    uint32_t q_base_addr = input_tensor.buffer()->address();
+    Buffer* in_buffer = input_tensor.buffer();
+    Buffer* batch_offset_buffer = batch_offset.has_value() ? batch_offset.value().buffer() : nullptr;
 
     // cores for q
     const uint32_t q_num_cores = q_cores.num_cores();  // number of cores of the output
@@ -157,26 +182,32 @@ NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create(
         batch_offset_index_stick_size,
         batch_offset_cb_index_reader};
 
-    tt::tt_metal::TensorAccessorArgs(batch_offset.has_value() ? batch_offset.value().buffer() : nullptr)
-        .append_to(q_reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(batch_offset_buffer).append_to(q_reader_compile_time_args);
 
-    auto q_reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor q_reader_desc;
+    q_reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
-        q_cores,
-        ReaderDataMovementConfig(q_reader_compile_time_args));
+        "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp";
+    q_reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    q_reader_desc.core_ranges = q_cores;
+    q_reader_desc.compile_time_args = q_reader_compile_time_args;
+    q_reader_desc.config = ReaderConfigDescriptor{};
+
     std::vector<uint32_t> q_writer_compile_time_args = q_reader_compile_time_args;
     q_writer_compile_time_args[9] = 2;  // read the second phase
     q_writer_compile_time_args[15] = batch_offset_cb_index_writer;
-    auto q_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
-        q_cores,
-        WriterDataMovementConfig(q_writer_compile_time_args));
 
-    tt::tt_metal::KernelHandle k_reader_kernel_id = 0, k_writer_kernel_id = 0;
+    KernelDescriptor q_writer_desc;
+    q_writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
+        "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp";
+    q_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    q_writer_desc.core_ranges = q_cores;
+    q_writer_desc.compile_time_args = std::move(q_writer_compile_time_args);
+    q_writer_desc.config = WriterConfigDescriptor{};
+
+    KernelDescriptor k_reader_desc;
+    KernelDescriptor k_writer_desc;
     if (!overlap_qk_coregrid) {
         // Switch process_qv and process_k for k kernels
         process_qv = 0;
@@ -184,137 +215,72 @@ NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create(
         std::vector<uint32_t> k_reader_compile_time_args = q_reader_compile_time_args;
         k_reader_compile_time_args[11] = process_qv;
         k_reader_compile_time_args[12] = process_k;
-        k_reader_kernel_id = CreateKernel(
-            program,
+
+        k_reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-            "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
-            k_cores,
-            ReaderDataMovementConfig(k_reader_compile_time_args));
+            "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp";
+        k_reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        k_reader_desc.core_ranges = k_cores;
+        k_reader_desc.compile_time_args = k_reader_compile_time_args;
+        k_reader_desc.config = ReaderConfigDescriptor{};
 
         std::vector<uint32_t> k_writer_compile_time_args = k_reader_compile_time_args;
         k_writer_compile_time_args[9] = 2;  // read the second phase
         k_writer_compile_time_args[15] = batch_offset_cb_index_writer;
-        k_writer_kernel_id = CreateKernel(
-            program,
+
+        k_writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-            "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
-            k_cores,
-            WriterDataMovementConfig(k_writer_compile_time_args));
+            "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp";
+        k_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        k_writer_desc.core_ranges = k_cores;
+        k_writer_desc.compile_time_args = std::move(k_writer_compile_time_args);
+        k_writer_desc.config = WriterConfigDescriptor{};
     }
 
-    uint32_t q_start_addr = q_base_addr;
-    bool use_batch_offset = batch_offset.has_value();
+    auto push_batch_offset = [&](KernelDescriptor::RTArgList& rt) {
+        if (batch_offset_buffer != nullptr) {
+            rt.push_back(batch_offset_buffer);
+        } else {
+            rt.push_back(uint32_t{0});
+        }
+    };
 
     for (uint32_t i = 0; i < q_num_cores; ++i) {
         const auto& core = q_cores_vector[i];
-        std::vector<uint32_t> q_reader_runtime_args;
-        q_reader_runtime_args.reserve(3 + (2 * in_num_cores));
-        q_reader_runtime_args = {q_start_addr, use_batch_offset ? batch_offset.value().buffer()->address() : 0, i};
-        q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-        q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
-        SetRuntimeArgs(program, q_reader_kernel_id, core, q_reader_runtime_args);
-        SetRuntimeArgs(program, q_writer_kernel_id, core, q_reader_runtime_args);
+        KernelDescriptor::RTArgList rt;
+        rt.reserve(3 + 2 * in_num_cores);
+        rt.push_back(in_buffer);
+        push_batch_offset(rt);
+        rt.push_back(i);
+        rt.append(noc_x_coords);
+        rt.append(noc_y_coords);
+        q_reader_desc.emplace_runtime_args(core, rt);
+        q_writer_desc.emplace_runtime_args(core, rt);
     }
 
     if (!overlap_qk_coregrid) {
         for (uint32_t i = 0; i < k_num_cores; ++i) {
             const auto& core = k_cores_vector[i];
-            std::vector<uint32_t> k_reader_runtime_args;
-            k_reader_runtime_args.reserve(3 + (2 * in_num_cores));
-            k_reader_runtime_args = {q_start_addr, use_batch_offset ? batch_offset.value().buffer()->address() : 0, i};
-            k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-            k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
-            SetRuntimeArgs(program, k_reader_kernel_id, core, k_reader_runtime_args);
-            SetRuntimeArgs(program, k_writer_kernel_id, core, k_reader_runtime_args);
+            KernelDescriptor::RTArgList rt;
+            rt.reserve(3 + 2 * in_num_cores);
+            rt.push_back(in_buffer);
+            push_batch_offset(rt);
+            rt.push_back(i);
+            rt.append(noc_x_coords);
+            rt.append(noc_y_coords);
+            k_reader_desc.emplace_runtime_args(core, rt);
+            k_writer_desc.emplace_runtime_args(core, rt);
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .q_reader_kernel_id = q_reader_kernel_id,
-            .q_writer_kernel_id = q_writer_kernel_id,
-            .k_reader_kernel_id = k_reader_kernel_id,
-            .k_writer_kernel_id = k_writer_kernel_id,
-            .q_num_cores = q_num_cores,
-            .k_num_cores = k_num_cores,
-            .cb_q_output = cb_q_output,
-            .cb_k_output = cb_k_output,
-            .cb_v_output = cb_v_output,
-            .q_cores_vector = q_cores_vector,
-            .k_cores_vector = k_cores_vector,
-            .element_size = element_size,
-            .sub_tile_line_bytes = sub_tile_line_bytes,
-            .overlap_qk_coregrid = overlap_qk_coregrid,
-            .use_batch_offset = use_batch_offset}};
-}
-
-void NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensors) {
-    using namespace tt::tt_metal;
-
-    auto& program = cached_program.program;
-    const auto& q_reader_kernel_id = cached_program.shared_variables.q_reader_kernel_id;
-    const auto& q_writer_kernel_id = cached_program.shared_variables.q_writer_kernel_id;
-    const auto& k_reader_kernel_id = cached_program.shared_variables.k_reader_kernel_id;
-    const auto& k_writer_kernel_id = cached_program.shared_variables.k_writer_kernel_id;
-    const auto& q_num_cores = cached_program.shared_variables.q_num_cores;
-    const auto& k_num_cores = cached_program.shared_variables.k_num_cores;
-    const auto& cb_q_output = cached_program.shared_variables.cb_q_output;
-    const auto& cb_k_output = cached_program.shared_variables.cb_k_output;
-    const auto& cb_v_output = cached_program.shared_variables.cb_v_output;
-    const auto& q_cores_vector = cached_program.shared_variables.q_cores_vector;
-    const auto& k_cores_vector = cached_program.shared_variables.k_cores_vector;
-    const auto& overlap_qk_coregrid = cached_program.shared_variables.overlap_qk_coregrid;
-    const auto& use_batch_offset = cached_program.shared_variables.use_batch_offset;
-
-    auto *dst_buffer_query = output_tensors.at(0).buffer();
-    auto *dst_buffer_key = output_tensors.at(1).buffer();
-    auto *dst_buffer_value = output_tensors.at(2).buffer();
-
-    UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
-    UpdateDynamicCircularBufferAddress(program, cb_k_output, *dst_buffer_key);
-    UpdateDynamicCircularBufferAddress(program, cb_v_output, *dst_buffer_value);
-
-    uint32_t q_base_addr = tensor_args.input_tensor.buffer()->address();
-    uint32_t q_start_addr = q_base_addr;
-
-    auto& q_reader_args_by_core = GetRuntimeArgs(program, q_reader_kernel_id);
-    auto& q_writer_args_by_core = GetRuntimeArgs(program, q_writer_kernel_id);
-
-    for (uint32_t i = 0; i < q_num_cores; ++i) {
-        const auto& core = q_cores_vector[i];
-        auto& runtime_args = q_reader_args_by_core[core.x][core.y];
-        runtime_args[0] = q_start_addr;
-        runtime_args[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-        runtime_args[2] = i;
-
-        auto& runtime_args_writer = q_writer_args_by_core[core.x][core.y];
-        runtime_args_writer[0] = q_start_addr;
-        runtime_args_writer[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-        runtime_args_writer[2] = i;
-    }
-
+    desc.kernels.push_back(std::move(q_reader_desc));
+    desc.kernels.push_back(std::move(q_writer_desc));
     if (!overlap_qk_coregrid) {
-        auto& k_reader_args_by_core = GetRuntimeArgs(program, k_reader_kernel_id);
-        auto& k_writer_args_by_core = GetRuntimeArgs(program, k_writer_kernel_id);
-
-        for (uint32_t i = 0; i < k_num_cores; ++i) {
-            const auto& core = k_cores_vector[i];
-            auto& runtime_args = k_reader_args_by_core[core.x][core.y];
-            runtime_args[0] = q_start_addr;
-            runtime_args[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-            runtime_args[2] = i;
-
-            auto& runtime_args_writer = k_writer_args_by_core[core.x][core.y];
-            runtime_args_writer[0] = q_start_addr;
-            runtime_args_writer[1] = use_batch_offset ? tensor_args.batch_offset.value().buffer()->address() : 0;
-            runtime_args_writer[2] = i;
-        }
+        desc.kernels.push_back(std::move(k_reader_desc));
+        desc.kernels.push_back(std::move(k_writer_desc));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.hpp
@@ -5,8 +5,9 @@
 #pragma once
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/device_operation.hpp"
 #include "nlp_create_qkv_heads_decode_device_operation_types.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -15,36 +16,10 @@ struct NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory {
     using tensor_args_t = NlpCreateQkvHeadsDecodeInputs;
     using tensor_return_value_t = std::vector<Tensor>;
 
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle q_reader_kernel_id{};
-        tt::tt_metal::KernelHandle q_writer_kernel_id{};
-        tt::tt_metal::KernelHandle k_reader_kernel_id{};
-        tt::tt_metal::KernelHandle k_writer_kernel_id{};
-        uint32_t q_num_cores{};
-        uint32_t k_num_cores{};
-        tt::tt_metal::CBHandle cb_q_output{};
-        tt::tt_metal::CBHandle cb_k_output{};
-        tt::tt_metal::CBHandle cb_v_output{};
-        std::vector<CoreCoord> q_cores_vector;
-        std::vector<CoreCoord> k_cores_vector;
-        uint32_t element_size{};
-        uint32_t sub_tile_line_bytes{};
-        bool overlap_qk_coregrid{};
-        bool use_batch_offset{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensors);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
Migrates the experimental/transformer ops not covered by the earlier exp-transformer / exp-transformer2 batches, completing the family:

- `all_reduce_create_qkv_heads` (mesh-workload, 4-arg per-coord factory)
- `create_qkv_heads` (sharded, optional transpose_k compute kernel)
- `dit_layernorm_post_all_gather` (Welford, optional gamma/beta)
- `nlp_create_qkv_heads` (Interleaved + Sharded)
- `nlp_create_qkv_heads_boltz` (Interleaved + Sharded)
- `nlp_create_qkv_heads_decode` (Interleaved + Sharded + ShardedSubcoregrid)

Tests (Wormhole B0):
- test_create_qkv_heads: 58/58 passed
- test_nlp_create_qkv_heads: 111/111 passed
- test_nlp_create_qkv_heads_boltz: 9/9 passed
- test_nlp_create_qkv_heads_decode: 205 passed / 39 skipped

Multi-device ops (`all_reduce_create_qkv_heads`, `dit_layernorm_post_all_gather`) build clean but require t3000/blackhole for end-to-end validation.

Contributes to #42193, #42202.

## Performance

transformer leftovers (6 ops, 9 factory types): create_qkv_heads / nlp_create_qkv_heads / nlp_create_qkv_heads_decode / nlp_create_qkv_heads_boltz / dit_layernorm_post_all_gather / all_reduce_create_qkv_heads. Per-op host-dispatch bench TBD (op signatures need rework for the bench harness); migration validated structurally and via CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-transformer-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-transformer-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-transformer-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-transformer-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-transformer-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-transformer-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-transformer-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-transformer-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-transformer-leftovers)
