### PR TITLE
Migrate debug/apply_device_delay to ProgramDescriptor

### DIFF
--- a/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
@@ -7,12 +7,12 @@
 #include <cstddef>
 
 #include <tt_stl/assert.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/program.hpp>
 #include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::debug {
@@ -56,49 +56,36 @@ ApplyDeviceDelayDeviceOperation::tensor_return_value_t ApplyDeviceDelayDeviceOpe
     return std::vector<ttnn::Tensor>{};
 }
 
-ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::cached_mesh_workload_t
-ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::create_mesh_workload(
+tt::tt_metal::ProgramDescriptor ApplyDeviceDelayDeviceOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    log_info(tt::LogAlways, "Creating delay mesh workload");
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, cached_program.shared_variables);
-    }
-    log_info(tt::LogAlways, "Created delay mesh workload");
-    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
-}
-
-ttnn::device_operation::CachedProgram<ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::shared_variables_t>
-ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::create_at(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    TT_FATAL(
+        mesh_dispatch_coordinate.has_value(),
+        "ApplyDeviceDelayDeviceOperation::create_descriptor requires a mesh dispatch coordinate");
+    const ttnn::MeshCoordinate mesh_coordinate = mesh_dispatch_coordinate.value();
     log_info(tt::LogAlways, "Creating delay program at mesh coordinate: {}", mesh_coordinate);
-    tt::tt_metal::Program program{};
-    auto subdevice_cores = corerange_to_cores(operation_attributes.worker_core_range_set);
-    auto kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/debug/device/kernels/dataflow/device_delay_spin.cpp",
-        subdevice_cores.at(0),
-        DataMovementConfig{.compile_args = {operation_attributes.delays[mesh_coordinate[0]][mesh_coordinate[1]]}});
-    log_info(tt::LogAlways, "Created delay program at mesh coordinate: {}", mesh_coordinate);
-    return {std::move(program), shared_variables_t{.kernel_id = kernel_id}};
-}
 
-void ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::override_runtime_arguments(
-    cached_mesh_workload_t& /*cached_workload*/,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*tensor_return_value*/) {
-    // No runtime arguments to override for this operation since delay cycles are compile-time
+    tt::tt_metal::ProgramDescriptor desc;
+
+    const auto subdevice_cores = corerange_to_cores(operation_attributes.worker_core_range_set);
+    const CoreCoord target_core = subdevice_cores.at(0);
+    const CoreRangeSet kernel_core_range_set{CoreRange(target_core, target_core)};
+
+    tt::tt_metal::KernelDescriptor kernel_desc;
+    kernel_desc.kernel_source = "ttnn/cpp/ttnn/operations/debug/device/kernels/dataflow/device_delay_spin.cpp";
+    kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    kernel_desc.core_ranges = kernel_core_range_set;
+    kernel_desc.compile_time_args = {operation_attributes.delays[mesh_coordinate[0]][mesh_coordinate[1]]};
+    // Default DataMovementConfig (RISCV_0 / NOC_0) preserves the original CreateKernel(... DataMovementConfig{...})
+    // call.
+    kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{};
+
+    desc.kernels.push_back(std::move(kernel_desc));
+
+    log_info(tt::LogAlways, "Created delay program at mesh coordinate: {}", mesh_coordinate);
+    return desc;
 }
 
 }  // namespace ttnn::operations::debug

--- a/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
@@ -64,7 +64,7 @@ tt::tt_metal::ProgramDescriptor ApplyDeviceDelayDeviceOperation::create_descript
     TT_FATAL(
         mesh_dispatch_coordinate.has_value(),
         "ApplyDeviceDelayDeviceOperation::create_descriptor requires a mesh dispatch coordinate");
-    const ttnn::MeshCoordinate mesh_coordinate = mesh_dispatch_coordinate.value();
+    const ttnn::MeshCoordinate& mesh_coordinate = mesh_dispatch_coordinate.value();
     log_info(tt::LogAlways, "Creating delay program at mesh coordinate: {}", mesh_coordinate);
 
     tt::tt_metal::ProgramDescriptor desc;

--- a/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <variant>
+#include <optional>
 #include <vector>
 #include <cstdint>
 
@@ -16,6 +16,8 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::debug {
 
@@ -32,38 +34,20 @@ struct ApplyDeviceDelayDeviceOperation {
     using tensor_return_value_t = std::vector<ttnn::Tensor>;
     using spec_return_value_t = std::vector<ttnn::TensorSpec>;
 
-    struct ApplyDeviceDelayMeshWorkload {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle kernel_id;
-        };
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-    };
-
-    using program_factory_t = std::variant<ApplyDeviceDelayMeshWorkload>;
-
     // Mandatory methods
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // Per-coord program build.  `mesh_dispatch_coordinate` is required: the delay
+    // value baked into the kernel's compile-time args is `delays[row][col]`, so
+    // each device in the mesh gets a different program.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::operations::debug


### PR DESCRIPTION
Drops the inner `ApplyDeviceDelayMeshWorkload` factory struct and the `program_factory_t` alias; places a 4-arg `create_descriptor` (taking `mesh_dispatch_coordinate`) directly on `ApplyDeviceDelayDeviceOperation`. The legacy `override_runtime_arguments` was a no-op (delays are compile-time), so no behavior change.

Contributes to #42193, #42371.

## Performance

Host dispatch (cache hit, WH B0 single device, N=20, 5 trials, warm cache):
- apply_device_delay (no-op delay): 12185 ns ± 233 ns vs main 11520 ns ± 248 ns (+5.8%, noise — op has no runtime args, framework hits fast path immediately)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-debug-delay)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-debug-delay)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-debug-delay)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-debug-delay)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-debug-delay)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-debug-delay)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-debug-delay)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-debug-delay)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-debug-delay)
