### PR TITLE
Migrate experimental/ssm leftovers to ProgramDescriptor

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -61,16 +61,6 @@ Tensor PrefixScanDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.a.device());
 }
 
-ttsl::hash::hash_t PrefixScanDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& a = tensor_args.a;
-    const auto& a_shape = a.padded_shape();
-    operation::Hash hash = operation::hash_operation<PrefixScanDeviceOperation>(
-        args.math_fidelity, a.dtype(), a.memory_config(), a_shape.volume());
-
-    return hash;
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "prefix_scan_device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
+#include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
@@ -4,9 +4,10 @@
 
 #pragma once
 
-#include <functional>
 #include <optional>
+#include <variant>
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "prefix_scan_program_factory.hpp"
 
@@ -20,7 +21,6 @@ struct PrefixScanDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<PrefixScanProgramFactory>;
-    using shared_variables_t = PrefixScanProgramFactory::shared_variables_t;
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
@@ -28,8 +28,6 @@ struct PrefixScanDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
@@ -7,8 +7,11 @@
 #include <optional>
 #include <variant>
 
+#include <tt-metalium/base_types.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/memory_config/memory_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
 #include "prefix_scan_program_factory.hpp"
 
 #include "prefix_scan_device_operation_types.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
@@ -41,8 +41,8 @@ ttnn::experimental::prim::PrefixScanDeviceOperation::tensor_return_value_t prefi
     const Tensor& a,
     const Tensor& bx,
     const Tensor& h_prev,
-    const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    std::optional<DataType> dtype = std::nullopt,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    std::optional<tt::tt_metal::DataType> dtype = std::nullopt,
     std::optional<tt::tt_metal::MathFidelity> math_fidelity = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -5,9 +5,10 @@
 #include "prefix_scan_program_factory.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::tt_metal;
 
@@ -15,14 +16,17 @@ namespace ttnn::experimental::prim {
 
 using namespace tt::constants;
 
-PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
+tt::tt_metal::ProgramDescriptor PrefixScanProgramFactory::create_descriptor(
     const PrefixScanParams& operation_attributes, const PrefixScanInputs& tensor_args, Tensor& tensor_return_value) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
     const auto& a = tensor_args.a;
+    const auto& bx = tensor_args.bx;
+    const auto& h_prev = tensor_args.h_prev;
     auto& output = tensor_return_value;
 
-    auto* output_buffer = output.buffer();
+    Buffer* a_buffer = a.buffer();
+    Buffer* bx_buffer = bx.buffer();
+    Buffer* h_buffer = h_prev.buffer();
+    Buffer* output_buffer = output.buffer();
     TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device");
 
     const tt::DataFormat input_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
@@ -33,18 +37,6 @@ PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
     const uint32_t intermediary_tile_size = tt::tile_size(intermediary_format);
 
     const auto all_cores = a.shard_spec()->grid;
-    const auto create_circular_buffer = [&program, &all_cores](
-                                            uint32_t index,
-                                            uint32_t num_tiles,
-                                            uint32_t tile_size,
-                                            const tt::DataFormat& format,
-                                            Buffer* buffer = nullptr) -> tt::tt_metal::CBHandle {
-        auto config = CircularBufferConfig(num_tiles * tile_size, {{index, format}}).set_page_size(index, tile_size);
-        if (buffer != nullptr) {
-            config = config.set_globally_allocated_address(*buffer);
-        }
-        return tt::tt_metal::CreateCircularBuffer(program, all_cores, config);
-    };
 
     const uint32_t sharded_sequence_length = a.shard_spec()->shape[0];
     const uint32_t sharded_hidden_state_length = a.shard_spec()->shape[1];
@@ -68,43 +60,25 @@ PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
     // The reader kernel copies data from the shard to this staging CB chunk by chunk via NOC read,
     // alternating between a and bx data. The compute kernel consumes each in sequence.
     const uint32_t cb_a_in_id = tt::CBIndex::c_0;
-    create_circular_buffer(cb_a_in_id, num_tiles_in_chunk, input_tile_size, input_format);
-
     const uint32_t cb_bx_in_id = cb_a_in_id;  // shared staging CB
 
     const uint32_t num_tiles_in_row_to_tile_cb = 32;  // Tilizing 32 tiles will pack tensor rows into separate tiles
     const uint32_t cb_a_tilize_in_id = tt::CBIndex::c_24;
-    create_circular_buffer(cb_a_tilize_in_id, num_tiles_in_row_to_tile_cb, intermediary_tile_size, intermediary_format);
-
     const uint32_t cb_bx_tilize_in_id = tt::CBIndex::c_25;
-    create_circular_buffer(
-        cb_bx_tilize_in_id, num_tiles_in_row_to_tile_cb, intermediary_tile_size, intermediary_format);
-
     const uint32_t cb_tilize_out_id = tt::CBIndex::c_26;
-    create_circular_buffer(cb_tilize_out_id, num_tiles_in_row_to_tile_cb, intermediary_tile_size, intermediary_format);
-
     const uint32_t cb_h_prev_id = tt::CBIndex::c_27;
-    create_circular_buffer(cb_h_prev_id, 2, intermediary_tile_size, intermediary_format);
-
     const uint32_t cb_ah_id = tt::CBIndex::c_28;
-    create_circular_buffer(cb_ah_id, 2, intermediary_tile_size, intermediary_format);
-
     const uint32_t cb_h_id = tt::CBIndex::c_29;
-    create_circular_buffer(cb_h_id, 2, intermediary_tile_size, intermediary_format);
-
     const uint32_t cb_h_acc_id = tt::CBIndex::c_31;
-    create_circular_buffer(cb_h_acc_id, num_chunks_per_row, intermediary_tile_size, intermediary_format);
 
     // Non-shard-backed staging CB for h_in. The h_prev shard uses intermediary_row_size pages
     // (64 bytes) but Float16_b format. The unpacker reads full-format tiles (~2KB) which overshoot
     // the 64-byte page boundary. If the shard is near the L1 limit this causes OOB.
     // Using a non-shard-backed CB at a low L1 address avoids this.
     const uint32_t cb_h_in_id = tt::CBIndex::c_2;
-    create_circular_buffer(cb_h_in_id, total_tiles_per_row, intermediary_row_size, intermediary_format);
 
     // Shard-backed output CB last - buffer address may be high in L1
     const uint32_t cb_out_id = tt::CBIndex::c_16;
-    const auto cb_out = create_circular_buffer(cb_out_id, total_tiles, input_tile_size, input_format, output_buffer);
 
     std::vector<uint32_t> reader_compile_time_args = {
         cb_a_in_id, cb_bx_in_id, cb_h_in_id, input_tile_size, intermediary_row_size};
@@ -123,107 +97,146 @@ PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
         cb_out_id,
         cb_h_acc_id};
 
-    auto reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-
-    auto writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    auto compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = operation_attributes.math_fidelity,
-            .fp32_dest_acc_en = false,
-            .math_approx_mode = false,
-            .compile_args = compute_compile_time_args});
-
     auto device_compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
     std::vector<CoreCoord> cores = grid_to_cores(
         all_cores.num_cores(), device_compute_with_storage_grid_size.x, device_compute_with_storage_grid_size.y, true);
 
-    // Store shared variables
-    PrefixScanSharedVariables shared_variables;
-    shared_variables.reader_kernel_id = reader_kernel_id;
-    shared_variables.writer_kernel_id = writer_kernel_id;
-    shared_variables.compute_kernel_id = compute_kernel_id;
-    shared_variables.cores = cores;
-    shared_variables.cb_out = cb_out;
-    shared_variables.total_tiles = total_tiles;
-    shared_variables.total_tiles_per_row = total_tiles_per_row;
-    shared_variables.total_tiles_per_col = total_tiles_per_col;
-    shared_variables.num_chunks_per_row = num_chunks_per_row;
-    shared_variables.sharded_hidden_state_length = sharded_hidden_state_length;
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build ProgramDescriptor
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
 
-    cached_program_t cached_program{std::move(program), std::move(shared_variables)};
+    // Non-shard-backed staging CB shared between a and bx inputs (see above).
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_in_chunk * input_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_a_in_id),
+            .data_format = input_format,
+            .page_size = input_tile_size}}}});
 
-    // Set initial runtime args
-    override_runtime_arguments(cached_program, operation_attributes, tensor_args, tensor_return_value);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_in_row_to_tile_cb * intermediary_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_a_tilize_in_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_tile_size}}}});
 
-    return cached_program;
-}
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_in_row_to_tile_cb * intermediary_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_bx_tilize_in_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_tile_size}}}});
 
-void PrefixScanProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PrefixScanParams& /*operation_attributes*/,
-    const PrefixScanInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    const auto& a = tensor_args.a;
-    const auto& bx = tensor_args.bx;
-    const auto& h_prev = tensor_args.h_prev;
-    auto& output = tensor_return_value;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_in_row_to_tile_cb * intermediary_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_tilize_out_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_tile_size}}}});
 
-    tt::tt_metal::Buffer* a_buffer = a.buffer();
-    tt::tt_metal::Buffer* bx_buffer = bx.buffer();
-    tt::tt_metal::Buffer* h_buffer = h_prev.buffer();
-    tt::tt_metal::Buffer* output_buffer = output.buffer();
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * intermediary_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_h_prev_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_tile_size}}}});
 
-    TT_FATAL(a_buffer != nullptr, "Input a buffer should be allocated on device");
-    TT_FATAL(bx_buffer != nullptr, "Input bx buffer should be allocated on device");
-    TT_FATAL(h_buffer != nullptr, "Input h_prev buffer should be allocated on device");
-    TT_FATAL(output_buffer != nullptr, "Output buffer should be allocated on device");
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * intermediary_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_ah_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_tile_size}}}});
 
-    auto& program = cached_program.program;
-    const auto& shared_vars = cached_program.shared_variables;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * intermediary_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_h_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_tile_size}}}});
 
-    // Only update shard-backed output CB; a_in/bx_in and h_in are non-shard-backed staging CBs
-    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_out, *output_buffer);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_chunks_per_row * intermediary_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_h_acc_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_tile_size}}}});
 
-    std::vector<std::vector<uint32_t>> reader_runtime_args = {
-        shared_vars.cores.size(),
-        {0, 0, 0, 0, 0}};  // (total_tiles_per_row, total_tiles_per_col, a_shard_addr, bx_shard_addr, h_shard_addr)
-    std::vector<std::vector<uint32_t>> writer_runtime_args = {
-        shared_vars.cores.size(), {0, 0, 0}};  // (num_tiles_per_core, hidden_state_len, h_shard_addr)
-    std::vector<std::vector<uint32_t>> compute_runtime_args = {
-        shared_vars.cores.size(),
-        {0, 0, 0, 0}};  // (total_tiles, total_tiles_per_row, total_tiles_per_col, num_chunks_per_row)
+    // Non-shard-backed staging CB for h_in (see above).
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = total_tiles_per_row * intermediary_row_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_h_in_id),
+            .data_format = intermediary_format,
+            .page_size = intermediary_row_size}}}});
 
-    for (uint32_t i = 0; i < shared_vars.cores.size(); i++) {
-        reader_runtime_args[i][0] = shared_vars.total_tiles_per_row;
-        reader_runtime_args[i][1] = shared_vars.total_tiles_per_col;
-        reader_runtime_args[i][2] = static_cast<uint32_t>(a_buffer->address());
-        reader_runtime_args[i][3] = static_cast<uint32_t>(bx_buffer->address());
-        reader_runtime_args[i][4] = static_cast<uint32_t>(h_buffer->address());
+    // Shard-backed output CB last - buffer address may be high in L1.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = total_tiles * input_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_out_id),
+            .data_format = input_format,
+            .page_size = input_tile_size}}},
+        .buffer = output_buffer});
 
-        writer_runtime_args[i][0] = shared_vars.total_tiles;
-        writer_runtime_args[i][1] = shared_vars.sharded_hidden_state_length;
-        writer_runtime_args[i][2] = static_cast<uint32_t>(h_buffer->address());
+    // Build kernels with per-core runtime args.
+    KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp";
+    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_kernel_desc.config = ReaderConfigDescriptor{};
+    reader_kernel_desc.runtime_args.reserve(cores.size());
 
-        compute_runtime_args[i][0] = shared_vars.total_tiles;
-        compute_runtime_args[i][1] = shared_vars.total_tiles_per_row;
-        compute_runtime_args[i][2] = shared_vars.total_tiles_per_col;
-        compute_runtime_args[i][3] = shared_vars.num_chunks_per_row;
+    KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp";
+    writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_kernel_desc.config = WriterConfigDescriptor{};
+    writer_kernel_desc.runtime_args.reserve(cores.size());
+
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = operation_attributes.math_fidelity, .fp32_dest_acc_en = false, .math_approx_mode = false};
+    compute_kernel_desc.runtime_args.reserve(cores.size());
+
+    for (const auto& core : cores) {
+        // (total_tiles_per_row, total_tiles_per_col, a_shard_addr, bx_shard_addr, h_shard_addr)
+        reader_kernel_desc.emplace_runtime_args(
+            core, {total_tiles_per_row, total_tiles_per_col, a_buffer, bx_buffer, h_buffer});
+
+        // (num_tiles_per_core, hidden_state_len, h_shard_addr)
+        writer_kernel_desc.emplace_runtime_args(core, {total_tiles, sharded_hidden_state_length, h_buffer});
+
+        // (total_tiles, total_tiles_per_row, total_tiles_per_col, num_chunks_per_row)
+        compute_kernel_desc.emplace_runtime_args(
+            core, {total_tiles, total_tiles_per_row, total_tiles_per_col, num_chunks_per_row});
     }
-    SetRuntimeArgs(program, shared_vars.reader_kernel_id, shared_vars.cores, reader_runtime_args);
-    SetRuntimeArgs(program, shared_vars.writer_kernel_id, shared_vars.cores, writer_runtime_args);
-    SetRuntimeArgs(program, shared_vars.compute_kernel_id, shared_vars.cores, compute_runtime_args);
+
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+    desc.kernels.push_back(std::move(writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -27,7 +27,10 @@ tt::tt_metal::ProgramDescriptor PrefixScanProgramFactory::create_descriptor(
     Buffer* bx_buffer = bx.buffer();
     Buffer* h_buffer = h_prev.buffer();
     Buffer* output_buffer = output.buffer();
-    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device");
+    TT_FATAL(a_buffer != nullptr, "Input a buffer should be allocated on device");
+    TT_FATAL(bx_buffer != nullptr, "Input bx buffer should be allocated on device");
+    TT_FATAL(h_buffer != nullptr, "Input h_prev buffer should be allocated on device");
+    TT_FATAL(output_buffer != nullptr, "Output buffer should be allocated on device");
 
     const tt::DataFormat input_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     const uint32_t input_tile_size = tt::tile_size(input_format);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.hpp
@@ -4,36 +4,16 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "prefix_scan_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim {
 
-struct PrefixScanSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    tt::tt_metal::KernelHandle compute_kernel_id = 0;
-    std::vector<tt::tt_metal::CoreCoord> cores;
-    tt::tt_metal::CBHandle cb_out{};
-    uint32_t total_tiles = 0;
-    uint32_t total_tiles_per_row = 0;
-    uint32_t total_tiles_per_col = 0;
-    uint32_t num_chunks_per_row = 0;
-    uint32_t sharded_hidden_state_length = 0;
-};
-
 struct PrefixScanProgramFactory {
-    using shared_variables_t = PrefixScanSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PrefixScanParams& operation_attributes, const PrefixScanInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PrefixScanParams& operation_attributes,
-        const PrefixScanInputs& tensor_args,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
@@ -110,32 +110,6 @@ Tensor RepeatAndInterleaveEltwiseMulDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.a.device());
 }
 
-ttsl::hash::hash_t RepeatAndInterleaveEltwiseMulDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor_a = tensor_args.a;
-    const auto& input_tensor_b = tensor_args.b;
-    const auto& input_shape_a = input_tensor_a.padded_shape();
-    const auto& input_shape_b = input_tensor_b.padded_shape();
-    // Determine compile-time defines based on shapes
-    bool repeat_in0 = (input_shape_a[-1] == TILE_WIDTH);
-    bool repeat_interleave_in1 = (input_shape_b[-1] == HIDDEN_SIZE);
-
-    operation::Hash hash = operation::hash_operation<RepeatAndInterleaveEltwiseMulDeviceOperation>(
-        args,
-        input_tensor_a.dtype(),
-        input_tensor_b.dtype(),
-        input_tensor_a.memory_config(),
-        input_tensor_b.memory_config(),
-        args.memory_config,
-        args.math_fidelity,
-        input_shape_a.volume(),
-        input_shape_b.volume(),
-        repeat_in0,
-        repeat_interleave_in1);
-
-    return hash;
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "repeat_and_interleave_eltwise_mul_device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
+#include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <variant>
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "repeat_and_interleave_eltwise_mul_program_factory.hpp"
 
@@ -26,8 +27,6 @@ struct RepeatAndInterleaveEltwiseMulDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
@@ -39,8 +39,8 @@ namespace ttnn::prim {
 Tensor repeat_and_interleave_eltwise_mul(
     const Tensor& a,
     const Tensor& b,
-    const std::optional<MemoryConfig>& memory_config,
-    std::optional<DataType> dtype,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
+    std::optional<tt::tt_metal::DataType> dtype,
     std::optional<tt::tt_metal::MathFidelity> math_fidelity,
     const std::optional<Tensor>& preallocated_output = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
@@ -7,8 +7,11 @@
 #include <optional>
 #include <variant>
 
+#include <tt-metalium/base_types.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/memory_config/memory_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
 #include "repeat_and_interleave_eltwise_mul_program_factory.hpp"
 
 #include "repeat_and_interleave_eltwise_mul_device_operation_types.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -2,12 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <string>
-
 #include "repeat_and_interleave_eltwise_mul_program_factory.hpp"
 
-#include <tt-metalium/work_split.hpp>
+#include <map>
+#include <string>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -18,7 +21,7 @@ namespace {
 constexpr uint32_t ONE_TILE = 1;
 }  // namespace
 
-RepeatAndInterleaveEltwiseMulProgramFactory::cached_program_t RepeatAndInterleaveEltwiseMulProgramFactory::create(
+tt::tt_metal::ProgramDescriptor RepeatAndInterleaveEltwiseMulProgramFactory::create_descriptor(
     const RepeatMulParams& operation_attributes, const RepeatMulInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
@@ -27,10 +30,10 @@ RepeatAndInterleaveEltwiseMulProgramFactory::cached_program_t RepeatAndInterleav
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* src1_buffer = b.buffer();
+    Buffer* src0_buffer = a.buffer();
+    Buffer* src1_buffer = b.buffer();
 
-    tt::tt_metal::Buffer* out_buffer = output.buffer();
+    Buffer* out_buffer = output.buffer();
     TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
@@ -43,8 +46,6 @@ RepeatAndInterleaveEltwiseMulProgramFactory::cached_program_t RepeatAndInterleav
     uint32_t interm_single_tile_size = tt::tile_size(interm_data_format);
     uint32_t output_single_tile_size = tt::tile_size(output_data_format);
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
     // Parallelize on bshape[-1]
     auto num_output_blocks_total = bshape[-1] / TILE_WIDTH;
     const bool row_major = false;
@@ -53,80 +54,47 @@ RepeatAndInterleaveEltwiseMulProgramFactory::cached_program_t RepeatAndInterleav
         tt::tt_metal::split_work_to_cores(device_compute_with_storage_grid_size, num_output_blocks_total, row_major);
 
     uint32_t g1_numcores = core_group_1.num_cores();
-    uint32_t g2_numcores = core_group_2.num_cores();
     std::vector<CoreCoord> cores = grid_to_cores(
         num_cores, device_compute_with_storage_grid_size.x, device_compute_with_storage_grid_size.y, row_major);
 
-    // Create circular buffers
+    // Circular buffer indices
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t cb0_tiles = ONE_TILE * 2;  // double buffer
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb0_tiles * in0_single_tile_size, {{src0_cb_index, in0_data_format}})
-            .set_page_size(src0_cb_index, in0_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
     uint32_t cb1_tiles = ONE_TILE * 2;  // double buffer
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(cb1_tiles * in1_single_tile_size, {{src1_cb_index, in1_data_format}})
-            .set_page_size(src1_cb_index, in1_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
     uint32_t output_cb_index = 16;
     uint32_t output_cb_tiles = ONE_TILE * 2;  // double buffer
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            output_cb_tiles * output_single_tile_size, {{output_cb_index, output_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
     uint32_t interm_num_tiles = ONE_TILE * 2;  // double buffer
     uint32_t interm_cb_size = interm_num_tiles * interm_single_tile_size;
     uint32_t cb_intermed0_index = tt::CBIndex::c_24;  // cb_in0_transposed
-    tt::tt_metal::CircularBufferConfig cb_intermed0_config =
-        tt::tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed0_index, interm_data_format}})
-            .set_page_size(cb_intermed0_index, interm_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
-
     uint32_t cb_intermed1_index = tt::CBIndex::c_25;  // cb_in1_transposed
-    tt::tt_metal::CircularBufferConfig cb_intermed1_config =
-        tt::tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed1_index, interm_data_format}})
-            .set_page_size(cb_intermed1_index, interm_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
-
     uint32_t cb_intermed2_index = tt::CBIndex::c_26;  // cb_in1_bcast_row
-    tt::tt_metal::CircularBufferConfig cb_intermed2_config =
-        tt::tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed2_index, interm_data_format}})
-            .set_page_size(cb_intermed2_index, interm_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed2_config);
-
     uint32_t cb_intermed3_index = tt::CBIndex::c_27;  // cb_out_transposed
-    tt::tt_metal::CircularBufferConfig cb_intermed3_config =
-        tt::tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed3_index, interm_data_format}})
-            .set_page_size(cb_intermed3_index, interm_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed3_config);
 
     // Compile time args
     std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)src1_cb_index,
-        (std::uint32_t)cb_intermed1_index,
-        (std::uint32_t)cb_intermed2_index,
+        static_cast<uint32_t>(src0_cb_index),
+        static_cast<uint32_t>(src1_cb_index),
+        static_cast<uint32_t>(cb_intermed1_index),
+        static_cast<uint32_t>(cb_intermed2_index),
     };
     tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(src1_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)output_cb_index,
+        static_cast<uint32_t>(output_cb_index),
     };
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)src1_cb_index,
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)cb_intermed0_index,
-        (std::uint32_t)cb_intermed1_index,
-        (std::uint32_t)cb_intermed2_index,
-        (std::uint32_t)cb_intermed3_index,
+        static_cast<uint32_t>(src0_cb_index),
+        static_cast<uint32_t>(src1_cb_index),
+        static_cast<uint32_t>(output_cb_index),
+        static_cast<uint32_t>(cb_intermed0_index),
+        static_cast<uint32_t>(cb_intermed1_index),
+        static_cast<uint32_t>(cb_intermed2_index),
+        static_cast<uint32_t>(cb_intermed3_index),
     };
 
     std::map<std::string, std::string> ssm_eltwise_defines;
@@ -137,116 +105,111 @@ RepeatAndInterleaveEltwiseMulProgramFactory::cached_program_t RepeatAndInterleav
         ssm_eltwise_defines["REPEAT_INTERLEAVE_IN1"] = "1";
     }
 
+    // Convert std::map to KernelDescriptor::Defines (vector of pairs, deterministic order from map).
+    KernelDescriptor::Defines descriptor_defines;
+    descriptor_defines.reserve(ssm_eltwise_defines.size());
+    for (const auto& [k, v] : ssm_eltwise_defines) {
+        descriptor_defines.emplace_back(k, v);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build ProgramDescriptor
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    // Create circular buffers
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb0_tiles * in0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size}}}});
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb1_tiles * in1_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = in1_data_format,
+            .page_size = in1_single_tile_size}}}});
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size}}}});
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = interm_cb_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_intermed0_index),
+            .data_format = interm_data_format,
+            .page_size = interm_single_tile_size}}}});
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = interm_cb_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_intermed1_index),
+            .data_format = interm_data_format,
+            .page_size = interm_single_tile_size}}}});
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = interm_cb_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_intermed2_index),
+            .data_format = interm_data_format,
+            .page_size = interm_single_tile_size}}}});
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = interm_cb_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_intermed3_index),
+            .data_format = interm_data_format,
+            .page_size = interm_single_tile_size}}}});
+
     // Load kernels
-    auto reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/"
-        "reader_ssm_eltwise_mul.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, ssm_eltwise_defines));
+        "reader_ssm_eltwise_mul.cpp";
+    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_kernel_desc.defines = descriptor_defines;
+    reader_kernel_desc.config = ReaderConfigDescriptor{};
+    reader_kernel_desc.runtime_args.reserve(cores.size());
 
-    auto writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/"
-        "writer_ssm_eltwise_mul.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "writer_ssm_eltwise_mul.cpp";
+    writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_kernel_desc.config = WriterConfigDescriptor{};
+    writer_kernel_desc.runtime_args.reserve(cores.size());
 
-    auto compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/"
-        "ssm_eltwise_mul.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = operation_attributes.math_fidelity,
-            .fp32_dest_acc_en = false,
-            .math_approx_mode = false,
-            .compile_args = compute_args,
-            .defines = ssm_eltwise_defines});
+        "ssm_eltwise_mul.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_args);
+    compute_kernel_desc.defines = std::move(descriptor_defines);
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = operation_attributes.math_fidelity, .fp32_dest_acc_en = false, .math_approx_mode = false};
+    compute_kernel_desc.runtime_args.reserve(cores.size());
 
-    // Store shared variables
-    shared_variables_t shared_variables;
-    shared_variables.reader_kernel_id = reader_kernel_id;
-    shared_variables.writer_kernel_id = writer_kernel_id;
-    shared_variables.compute_kernel_id = compute_kernel_id;
-    shared_variables.compute_with_storage_grid_size = device_compute_with_storage_grid_size;
-    shared_variables.all_cores = all_cores;
-    shared_variables.cores = cores;
-    shared_variables.num_cores = num_cores;
-    shared_variables.g1_numcores = g1_numcores;
-    shared_variables.g2_numcores = g2_numcores;
-    shared_variables.num_blocks_per_core_group_1 = num_blocks_per_core_group_1;
-    shared_variables.num_blocks_per_core_group_2 = num_blocks_per_core_group_2;
-    shared_variables.ashape = ashape;
-    shared_variables.bshape = bshape;
-    shared_variables.hidden_size = HIDDEN_SIZE;
-
-    cached_program_t cached_program{std::move(program), std::move(shared_variables)};
-
-    // Set initial runtime args
-    override_runtime_arguments(cached_program, operation_attributes, tensor_args, tensor_return_value);
-
-    return cached_program;
-}
-
-void RepeatAndInterleaveEltwiseMulProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RepeatMulParams&,
-    const RepeatMulInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    const auto& a = tensor_args.a;
-    const auto& b = tensor_args.b;
-    const auto& output = tensor_return_value;
-
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* src1_buffer = b.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-
-    auto& program = cached_program.program;
-    const auto& cores = cached_program.shared_variables.cores;
-    const auto& num_cores = cached_program.shared_variables.num_cores;
-    const auto& g1_numcores = cached_program.shared_variables.g1_numcores;
-    const auto& num_blocks_per_core_group_1 = cached_program.shared_variables.num_blocks_per_core_group_1;
-    const auto& num_blocks_per_core_group_2 = cached_program.shared_variables.num_blocks_per_core_group_2;
-    const auto& bshape = cached_program.shared_variables.bshape;
-    const auto& ashape = cached_program.shared_variables.ashape;
-    const auto& hidden_size = cached_program.shared_variables.hidden_size;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& compute_kernel_id = cached_program.shared_variables.compute_kernel_id;
-
-    // Default reader runtime args
-    std::vector<uint32_t> reader_runtime_args = {
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    };
-
-    // Default writer runtime args
-    std::vector<uint32_t> writer_runtime_args = {
-        0,
-        0,
-        0,
-        0,
-        0,
-    };
-
-    // Default compute runtime args
-    std::vector<uint32_t> compute_runtime_args = {
-        0,
-        0,
-    };
-
-    std::vector<std::vector<uint32_t>> all_reader_runtime_args = {cores.size(), reader_runtime_args};
-    std::vector<std::vector<uint32_t>> all_writer_runtime_args = {cores.size(), writer_runtime_args};
-    std::vector<std::vector<uint32_t>> all_compute_runtime_args = {cores.size(), compute_runtime_args};
-
-    // Set runtime args
-    uint32_t num_blocks_per_core;
+    // Set runtime args per core
+    uint32_t num_blocks_per_core = 0;
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
         if (i < g1_numcores) {
             num_blocks_per_core = num_blocks_per_core_group_1;
@@ -254,38 +217,46 @@ void RepeatAndInterleaveEltwiseMulProgramFactory::override_runtime_arguments(
             num_blocks_per_core = num_blocks_per_core_group_2;
         }
 
-        // Update core dependent runtime args
-        all_reader_runtime_args[i][0] = src0_buffer->address();
-        all_reader_runtime_args[i][1] = src1_buffer->address();
-        all_reader_runtime_args[i][2] = num_blocks_per_core;
-        all_reader_runtime_args[i][3] = num_blocks_written;
-        all_reader_runtime_args[i][4] = bshape[2] / TILE_HEIGHT;
-        all_reader_runtime_args[i][5] = bshape[-1] / TILE_WIDTH;
-        all_reader_runtime_args[i][6] = ashape[-1] / TILE_WIDTH;
+        // reader: (src0_addr, src1_addr, num_blocks_per_core, num_blocks_written,
+        //          bshape[2]/TILE_HEIGHT, bshape[-1]/TILE_WIDTH, ashape[-1]/TILE_WIDTH)
+        reader_kernel_desc.emplace_runtime_args(
+            cores[i],
+            {src0_buffer,
+             src1_buffer,
+             num_blocks_per_core,
+             num_blocks_written,
+             static_cast<uint32_t>(bshape[2] / TILE_HEIGHT),
+             static_cast<uint32_t>(bshape[-1] / TILE_WIDTH),
+             static_cast<uint32_t>(ashape[-1] / TILE_WIDTH)});
 
-        all_writer_runtime_args[i][0] = dst_buffer->address();
-
+        // writer: (dst_addr, num_tiles, start_id, bshape[2]/TILE_HEIGHT, hidden_size)
         // update writer's num_tiles based on input_b already repeat_interleaved or not
-        if (bshape[-1] == hidden_size) {
-            all_writer_runtime_args[i][1] = num_blocks_per_core * TILE_WIDTH;
-            all_writer_runtime_args[i][2] = num_blocks_written * TILE_WIDTH;
-        } else {
-            all_writer_runtime_args[i][1] = num_blocks_per_core;
-            all_writer_runtime_args[i][2] = num_blocks_written;
+        uint32_t writer_num_tiles = num_blocks_per_core;
+        uint32_t writer_start_id = num_blocks_written;
+        if (bshape[-1] == HIDDEN_SIZE) {
+            writer_num_tiles = num_blocks_per_core * TILE_WIDTH;
+            writer_start_id = num_blocks_written * TILE_WIDTH;
         }
+        writer_kernel_desc.emplace_runtime_args(
+            cores[i],
+            {out_buffer,
+             writer_num_tiles,
+             writer_start_id,
+             static_cast<uint32_t>(bshape[2] / TILE_HEIGHT),
+             HIDDEN_SIZE});
 
-        all_writer_runtime_args[i][3] = bshape[2] / TILE_HEIGHT;
-        all_writer_runtime_args[i][4] = hidden_size;
-
-        all_compute_runtime_args[i][0] = num_blocks_per_core;
-        all_compute_runtime_args[i][1] = bshape[2] / TILE_HEIGHT;
+        // compute: (num_blocks_per_core, bshape[2]/TILE_HEIGHT)
+        compute_kernel_desc.emplace_runtime_args(
+            cores[i], {num_blocks_per_core, static_cast<uint32_t>(bshape[2] / TILE_HEIGHT)});
 
         num_blocks_written += num_blocks_per_core;
     }
 
-    SetRuntimeArgs(program, reader_kernel_id, cores, all_reader_runtime_args);
-    SetRuntimeArgs(program, writer_kernel_id, cores, all_writer_runtime_args);
-    SetRuntimeArgs(program, compute_kernel_id, cores, all_compute_runtime_args);
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+    desc.kernels.push_back(std::move(writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -34,7 +34,7 @@ tt::tt_metal::ProgramDescriptor RepeatAndInterleaveEltwiseMulProgramFactory::cre
     Buffer* src1_buffer = b.buffer();
 
     Buffer* out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.dtype());

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.hpp
@@ -4,40 +4,16 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "repeat_and_interleave_eltwise_mul_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim {
 
-struct RepeatAndInterleaveEltwiseMulSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    tt::tt_metal::KernelHandle compute_kernel_id = 0;
-    CoreCoord compute_with_storage_grid_size;
-    CoreRangeSet all_cores;
-    std::vector<CoreCoord> cores;
-    uint32_t num_cores = 0;
-    uint32_t g1_numcores = 0;
-    uint32_t g2_numcores = 0;
-    uint32_t num_blocks_per_core_group_1 = 0;
-    uint32_t num_blocks_per_core_group_2 = 0;
-    Shape ashape;
-    Shape bshape;
-    uint32_t hidden_size = 0;
-};
-
 struct RepeatAndInterleaveEltwiseMulProgramFactory {
-    using shared_variables_t = RepeatAndInterleaveEltwiseMulSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RepeatMulParams& operation_attributes, const RepeatMulInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const RepeatMulParams& operation_attributes,
-        const RepeatMulInputs& tensor_args,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
Two SSM ops not covered by `hc_sum_reduce`:

- `experimental/ssm/prefix_scan`
- `experimental/ssm/repeat_and_interleave_eltwise_mul`

Each factory exposes `static create_descriptor(...)` returning `ProgramDescriptor`; legacy bookkeeping dropped. Output CB on prefix_scan rebinds via `CBDescriptor::buffer`; tensor buffer runtime args use `Buffer*` via `emplace_runtime_args` for the BufferBinding fast cache-hit path. Both ops had identical custom `compute_program_hash` overrides that mirrored the default hash (boilerplate); removed.

Tests (Wormhole B0): test_ssm_prefix_scan + test_ssm_repeat_and_interleave_eltwise_mul validated in reduction+ssm bucket — 186/186 passed.

Contributes to #42193, #42386.

## Performance

Host dispatch (cache hit, WH B0 single device, N=20, 5 trials, warm cache):
- repeat_and_interleave_eltwise_mul 1x1x32x32 × 1x1x32x5120: 19617 ns ± 462 ns vs main 31315 ns ± 1956 ns (−37.4%) — fast cache-hit patching via emplace_runtime_args(Buffer*)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-exp-ssm-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-exp-ssm-leftovers)
