### PR TITLE
Migrate experimental/paged_cache to ProgramDescriptor + re-patch update_idxs/batch_idx on cache hit

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
@@ -257,6 +257,88 @@ def test_update_cache_decode_program_cache(
     assert device.num_program_cache_entries() == 1
 
 
+def run_update_cache_decode_attr_idxs(
+    cache_idx, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+):
+    """Drives the NON-index-tensor path: update positions are passed via the `update_idxs` list
+    (operation_attributes.update_idxs), which the C++ factory bakes into runtime args. This is the
+    path exercised by the DynamicRuntimeArg re-patching — the index-tensor path is already covered by
+    run_test_update_cache_decode and is correct on cache hits for a different reason (buffer re-patch)."""
+    input_shape = [1, num_users, num_heads, head_dim]
+    cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+    cache = torch.randn(cache_shape).bfloat16().float()
+    cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+    x = torch.randn(input_shape).bfloat16().float()
+    x_pad = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_heads), "constant", 0)
+
+    xt = ttnn.Tensor(x_pad, input_dtype).to(ttnn.TILE_LAYOUT)
+    xt = ttnn.reshape(xt, ttnn.Shape(input_shape))
+    compute_grid_size = device.compute_with_storage_grid_size()
+    num_cores = num_users
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+    input_shard_spec = ttnn.ShardSpec(
+        shard_grid,
+        [xt.volume() // xt.padded_shape[-1] // num_cores, xt.padded_shape[-1]],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    xt = xt.to(device, input_mem_config)
+
+    # Distinct per-user positions; varying cache_idx between cached calls must move where the cache is
+    # written. update_idxs is passed as a plain list (NO update_idxs_tensor) -> attribute path.
+    cache_idxs = [cache_idx + i * 17 for i in range(num_users)]
+    cachett = ttnn.experimental.paged_update_cache(cachett, xt, update_idxs=cache_idxs, share_cache=False)
+
+    for i in range(num_users):
+        update_idx = cache_idxs[i]
+        x_view = x.permute(1, 2, 0, 3)[i, ...]
+        cache[i, 0:num_heads, update_idx : update_idx + 1, 0 : x.shape[-1]] = x_view
+
+    tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+
+    tt_updated_slice = []
+    for i in range(num_users):
+        update_idx = cache_idxs[i]
+        tt_slice = tt_got_back[i, 0:num_heads, update_idx : update_idx + 1, 0 : x.shape[-1]]
+        tt_updated_slice.append(tt_slice)
+    tt_updated_slice = torch.stack(tt_updated_slice, dim=0).permute(2, 0, 1, 3)
+
+    if input_dtype == ttnn.bfloat16 and cache_dtype == input_dtype:
+        eq_cache, _ = comp_equal(cache, tt_got_back)
+        eq_update, _ = comp_equal(x, tt_updated_slice)
+    else:
+        eq_cache, _ = comp_pcc(cache, tt_got_back, pcc=0.99)
+        eq_update, _ = comp_pcc(x, tt_updated_slice, pcc=0.99)
+    assert eq_cache and eq_update
+
+
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("max_seq_len", [2048])
+@pytest.mark.parametrize("num_users", [32])
+@pytest.mark.parametrize("num_heads", [1])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("cache_dtype", [ttnn.bfloat16])
+def test_update_cache_decode_attr_idxs_program_cache(
+    head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+):
+    """Regression for the DynamicRuntimeArg fix on the NON-index-tensor path. update_idxs is excluded
+    from the program hash, so the two calls below must share ONE cache entry; and because the cache
+    write offset (cache_start_id / tile_update_offset_B) is re-patched on the cache hit, the second
+    call must write at its OWN positions (not the first call's frozen ones). Pins both halves:
+      - num_program_cache_entries() == 1  guards the hash exclusion (no re-hashing on differing idxs)
+      - the in-process correctness check on the 2nd call guards the frozen-arg bug."""
+    # First call: cache miss, builds + caches the program at one set of positions.
+    run_update_cache_decode_attr_idxs(
+        127, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+    )
+    # Second call: DIFFERENT positions, same shapes -> program-cache HIT. Output must reflect the new
+    # positions (would fail with frozen cache_start_id before the get_dynamic_runtime_args fix).
+    run_update_cache_decode_attr_idxs(
+        1057, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+    )
+    assert device.num_program_cache_entries() == 1
+
+
 def run_test_tensor_index_update_cache_decode(
     cache_idx, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
 ):

--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_fused_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_fused_update_cache.py
@@ -25,6 +25,7 @@ def run_test_paged_fused_update_cache_decode(
     row_major=False,
     is_cur_pos_sharded=False,
     is_page_table_sharded=False,
+    use_attr_idxs=False,
 ):
     max_num_blocks_per_seq = max_seq_len // block_size
     assert max_num_blocks_per_seq * block_size == max_seq_len
@@ -154,7 +155,9 @@ def run_test_paged_fused_update_cache_decode(
 
     # Update indices
     cache_idxs = [cache_idx + i * 17 for i in range(num_users)]
-    if num_heads == 1:
+    # The -1 "skip this user" sentinel is an index-tensor feature; the attribute (update_idxs list)
+    # path takes uint32 positions, so don't inject it there.
+    if num_heads == 1 and not use_attr_idxs:
         cache_idxs[num_users // 2] = -1
     cache_idxs_memory_config = None
     if is_cur_pos_sharded:
@@ -173,10 +176,17 @@ def run_test_paged_fused_update_cache_decode(
     else:
         cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
 
-    # Perform fused update cache operation
-    cachett1, cachett2 = ttnn.experimental.paged_fused_update_cache(
-        cachett1, xt1, cachett2, xt2, update_idxs_tensor=cache_idxs_tt, page_table=page_table_tt
-    )
+    # Perform fused update cache operation. use_attr_idxs drives the NON-index-tensor path
+    # (update_idxs list -> operation_attributes.update_idxs), where cache_start_id / tile_update_offset_B
+    # are baked into runtime args and must be re-patched on cache hits via get_dynamic_runtime_args.
+    if use_attr_idxs:
+        cachett1, cachett2 = ttnn.experimental.paged_fused_update_cache(
+            cachett1, xt1, cachett2, xt2, update_idxs=cache_idxs, page_table=page_table_tt
+        )
+    else:
+        cachett1, cachett2 = ttnn.experimental.paged_fused_update_cache(
+            cachett1, xt1, cachett2, xt2, update_idxs_tensor=cache_idxs_tt, page_table=page_table_tt
+        )
 
     # Verification for cache1 and cache2
     for cache_idx, cache, cachett, x in [(1, cache1, cachett1, x1), (2, cache2, cachett2, x2)]:
@@ -346,4 +356,55 @@ def test_paged_fused_update_cache_decode_program_caching(
             pcc,
         )
 
+    assert device.num_program_cache_entries() == 1
+
+
+@pytest.mark.timeout(1200)
+# Non-paged only: the paged fused-update path validates that update positions arrive via an index
+# TENSOR (which is Buffer-bound and re-patched anyway), so the frozen-attr bug only applies here.
+@pytest.mark.parametrize("paged_update", [False])
+@pytest.mark.parametrize("block_size", [128], ids=["block128"])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("max_seq_len", [2048])
+@pytest.mark.parametrize("num_users", [8])
+@pytest.mark.parametrize("num_heads", [1])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("cache_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("pcc", [0.9995])
+def test_paged_fused_update_cache_decode_attr_idxs_program_caching(
+    paged_update, block_size, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device, pcc
+):
+    """Regression for the DynamicRuntimeArg fix on the NON-index-tensor (update_idxs list) path. The two
+    cached calls below differ only in their positions, which are excluded from the program hash — so they
+    must share ONE cache entry, and the second call must write at its OWN positions (cache_start_id /
+    tile_update_offset_B re-patched on the cache hit, not frozen at the first call's values)."""
+    # Cache miss, then a HIT at different positions, same shapes.
+    run_test_paged_fused_update_cache_decode(
+        paged_update,
+        127,
+        block_size,
+        head_dim,
+        max_seq_len,
+        num_users,
+        num_heads,
+        input_dtype,
+        cache_dtype,
+        device,
+        pcc,
+        use_attr_idxs=True,
+    )
+    run_test_paged_fused_update_cache_decode(
+        paged_update,
+        1057,
+        block_size,
+        head_dim,
+        max_seq_len,
+        num_users,
+        num_heads,
+        input_dtype,
+        cache_dtype,
+        device,
+        pcc,
+        use_attr_idxs=True,
+    )
     assert device.num_program_cache_entries() == 1

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -6,6 +6,8 @@
 
 #include <tt-metalium/constants.hpp>
 
+#include "ttnn/device_operation.hpp"
+#include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::tt_metal;
@@ -141,6 +143,27 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
             "Batch idx tensor must be DRAM-resident");
+    }
+
+    // When mesh_coords is provided, validate it is a subset of the tensor's mesh
+    // coordinates. The descriptor framework dispatches a (noop) program for every
+    // tensor_coord regardless of mesh_coords membership, so a stray coord in mesh_coords
+    // that doesn't exist in tensor_coords would silently never run — matches the legacy
+    // create_mesh_workload's TT_FATAL check.
+    if (args.mesh_coords.has_value()) {
+        const auto tensor_coords_vec =
+            ttnn::device_operation::mesh_device_operation_utils::extract_tensor_coordinates(tensor_args);
+        const std::set<ttnn::MeshCoordinate> tensor_coords_set(tensor_coords_vec.begin(), tensor_coords_vec.end());
+        for (const auto& mesh_coord : args.mesh_coords.value()) {
+            TT_FATAL(
+                tensor_coords_set.contains(mesh_coord),
+                "Mesh coordinate ({}, {}) is in mesh_coords but not found in tensor_coords. "
+                "mesh_coords size: {}, tensor_coords size: {}",
+                mesh_coord[0],
+                mesh_coord[1],
+                args.mesh_coords->size(),
+                tensor_coords_set.size());
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
@@ -6,11 +6,16 @@
 
 #include <functional>
 #include <optional>
+#include <vector>
+
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "paged_fill_cache_program_factory.hpp"
 
 #include "paged_fill_cache_device_operation_types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::experimental::prim {
 
@@ -20,7 +25,6 @@ struct PagedFillCacheDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<PagedFillCacheProgramFactory, PagedFillCacheMeshWorkloadFactory>;
-    using shared_variables_t = PagedFillCacheProgramFactory::shared_variables_t;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
@@ -32,6 +36,19 @@ struct PagedFillCacheDeviceOperation {
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // batch_idx_fallback and noop are excluded from the program hash (so calls differing only in
+    // them cache-hit). Of these only batch_idx_fallback is genuinely dynamic: in the scalar-fallback
+    // path (no batch_idx_tensor) it is baked into a writer runtime arg, so it must be re-applied to
+    // the cached program on every dispatch. Returns empty in batch-idx-tensor mode (the writer pushes
+    // a Buffer* the framework already re-patches) and for coords excluded from a mesh dispatch. noop
+    // is derived from the hashed mesh_coords and is therefore stable across cache hits, so it is not
+    // re-patched.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -2,15 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "paged_fill_cache_device_operation_types.hpp"
-#include <tt-metalium/work_split.hpp>
 #include "paged_fill_cache_program_factory.hpp"
+
+#include "paged_fill_cache_device_operation.hpp"
+#include "paged_fill_cache_device_operation_types.hpp"
+
+#include <cmath>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/mesh_device_operation_utils.hpp"
-#include <unordered_map>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::tt_metal;
 
@@ -19,11 +22,45 @@ namespace ttnn::experimental::prim {
 using namespace tt::constants;
 using namespace tt;
 
-PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::create(
-    const PagedFillCacheParams& operation_attributes,
-    const PagedFillCacheInputs& tensor_args,
-    Tensor& /*tensor_return_value*/) {
-    Program program{};
+namespace {
+
+// Worker-core list for the fill_cache work-split. batch_idx_fallback (excluded from the program
+// hash, baked into writer runtime args) is the SAME value on every core, so re-patching it on a
+// cache hit only needs the core *ordering* — not the per-core block counts. This helper is the
+// single source of truth for that ordering: both build_paged_fill_cache_descriptor (cache miss)
+// and PagedFillCacheDeviceOperation::get_dynamic_runtime_args (cache hit) call it, so the two
+// paths cannot drift in which cores they touch or in what order.
+std::vector<tt_metal::CoreCoord> compute_paged_fill_cache_cores(
+    const PagedFillCacheParams& /*operation_attributes*/, const PagedFillCacheInputs& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+
+    // num_blocks_of_work mirrors build_paged_fill_cache_descriptor: input_batch * num_heads *
+    // input_seq_len_t. block_size / cache geometry does not influence the work-split, so it is
+    // intentionally omitted here.
+    const uint32_t input_batch = input_tensor.padded_shape()[0];
+    const uint32_t num_heads = input_tensor.padded_shape()[1];
+    const uint32_t input_seq_len = input_tensor.padded_shape()[2];
+    const uint32_t input_seq_len_t = input_seq_len / TILE_HEIGHT;
+    const uint32_t num_blocks_of_work = input_batch * num_heads * input_seq_len_t;
+
+    tt_metal::IDevice* device = input_tensor.device();
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    const bool row_major = true;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks_of_work, row_major);
+
+    return grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+}
+
+// Build the per-coord descriptor.  Shared by the single-device and mesh-workload
+// factories; the mesh path passes a possibly-overridden `noop` (true for
+// coordinates excluded from operation_attributes.mesh_coords).
+ProgramDescriptor build_paged_fill_cache_descriptor(
+    const PagedFillCacheParams& operation_attributes, const PagedFillCacheInputs& tensor_args, bool noop) {
+    ProgramDescriptor desc;
 
     const auto& cache_tensor = tensor_args.cache_tensor;
     const auto& input_tensor = tensor_args.input_tensor;
@@ -73,14 +110,12 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     // row. The legacy single-batch case (input_batch == 1, tensor.shape ==
     // [1]) falls out naturally.
     const bool use_batch_idx_tensor = batch_idx_tensor.has_value();
-    uint32_t batch_idx_buffer_addr = 0;
     tt::DataFormat batch_idx_data_format = tt::DataFormat::UInt32;
     uint32_t batch_idx_stick_size_B = 4;  // per-element size, e.g. 4 for uint32
     uint32_t batch_idx_num_elements = 1;
 
     if (use_batch_idx_tensor) {
         const auto& tensor = batch_idx_tensor.value();
-        batch_idx_buffer_addr = tensor.buffer()->address();
         batch_idx_data_format = tt_metal::datatype_to_dataformat_converter(tensor.dtype());
         batch_idx_stick_size_B = tensor.element_size();
         batch_idx_num_elements = tensor.physical_volume();
@@ -103,8 +138,6 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     tt_metal::IDevice* device = input_tensor.device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     bool row_major;
     uint32_t num_cores, num_blocks_per_core_group_1, num_blocks_per_core_group_2;
@@ -121,18 +154,36 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     tt::CBIndex page_table_cb_index = tt::CBIndex::c_1;
     tt::CBIndex cb_batch_idx_id = tt::CBIndex::c_2;  // New CB for batch_idx_tensor
 
-    create_cb(src0_cb_index, program, all_cores, single_tile_size, num_input_tiles, cb_data_format);
-    create_cb(page_table_cb_index, program, all_cores, page_table_stick_size_B, 1, page_table_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_table_stick_size_B,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(page_table_cb_index),
+            .data_format = page_table_data_format,
+            .page_size = page_table_stick_size_B,
+        }}},
+    });
     if (use_batch_idx_tensor) {
         // CB holds all `batch_idx_num_elements` entries so the writer kernel
         // can pick the right entry per batch row in the batched case.
-        create_cb(
-            cb_batch_idx_id,
-            program,
-            all_cores,
-            batch_idx_stick_size_B * batch_idx_num_elements,
-            1,
-            batch_idx_data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = batch_idx_stick_size_B * batch_idx_num_elements,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_batch_idx_id),
+                .data_format = batch_idx_data_format,
+                .page_size = batch_idx_stick_size_B,
+            }}},
+        });
     }
 
     auto* src_buffer = input_tensor.buffer();
@@ -170,22 +221,27 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     TensorAccessorArgs(batch_idx_tensor.has_value() ? batch_idx_tensor->buffer() : nullptr)
         .append_to(writer_compile_time_args);
 
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();
 
-    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+    // Core list shared with get_dynamic_runtime_args (single source of truth for ordering).
+    const auto cores = compute_paged_fill_cache_cores(operation_attributes, tensor_args);
 
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
         const CoreCoord& core = cores.at(i);
@@ -198,211 +254,108 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
             num_blocks_per_core = 0;
         }
 
-        tt_metal::SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
             {
-                src_buffer->address(),
-                num_blocks_written * Wt,              // start_tile_id
-                num_blocks_per_core,                  // num_rows
-                (uint32_t)operation_attributes.noop,  // noop flag
+                src_buffer,
+                num_blocks_written * Wt,  // start_tile_id
+                num_blocks_per_core,      // num_rows
+                (uint32_t)noop,           // noop flag
             });
 
-        uint32_t writer_batch_arg =
-            use_batch_idx_tensor ? batch_idx_buffer_addr : operation_attributes.batch_idx_fallback;
-
-        tt_metal::SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
-            core,
-            {
-                dst_buffer->address(),
-                page_table_buffer->address(),
-                num_blocks_written,                   // start_row_num
-                num_blocks_per_core,                  // num_rows
-                writer_batch_arg,                     // batch_idx_tensor_addr or batch_idx_fallback
-                (uint32_t)operation_attributes.noop,  // noop flag
-            });
+        // batch_idx_tensor_addr (Buffer*) or batch_idx_fallback (uint32_t).  Use
+        // emplace_runtime_args so the buffer base address is patched on cache hits.
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.push_back(dst_buffer);
+        writer_args.push_back(page_table_buffer);
+        writer_args.push_back(num_blocks_written);   // start_row_num
+        writer_args.push_back(num_blocks_per_core);  // num_rows
+        if (use_batch_idx_tensor) {
+            writer_args.push_back(batch_idx_tensor->buffer());  // batch_idx_tensor_addr
+        } else {
+            writer_args.push_back(operation_attributes.batch_idx_fallback);  // batch_idx_fallback
+        }
+        writer_args.push_back(static_cast<uint32_t>(noop));  // noop flag
+        writer_desc.emplace_runtime_args(core, writer_args);
         num_blocks_written += num_blocks_per_core;
     }
 
-    // Store shared variables
-    shared_variables_t shared_variables{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cores = cores,
-        .g1_numcores = g1_numcores,
-        .g2_numcores = g2_numcores,
-        .num_blocks_per_core_group_1 = num_blocks_per_core_group_1,
-        .num_blocks_per_core_group_2 = num_blocks_per_core_group_2,
-        .Wt = Wt,
-        .use_batch_idx_tensor = use_batch_idx_tensor};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-    return cached_program_t(std::move(program), std::move(shared_variables));
+    return desc;
 }
 
-void PagedFillCacheProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
+}  // namespace
+
+ProgramDescriptor PagedFillCacheProgramFactory::create_descriptor(
     const PagedFillCacheParams& operation_attributes,
     const PagedFillCacheInputs& tensor_args,
     Tensor& /*tensor_return_value*/) {
-    auto& program = cached_program.program;
-    const auto& shared_vars = cached_program.shared_variables;
-
-    auto dst_addr = tensor_args.cache_tensor.buffer()->address();
-    auto src_addr = tensor_args.input_tensor.buffer()->address();
-    auto page_table_addr = tensor_args.page_table.buffer()->address();
-
-    uint32_t current_kernel_batch_arg;
-    if (shared_vars.use_batch_idx_tensor) {
-        TT_FATAL(
-            tensor_args.batch_idx_tensor_opt.has_value(),
-            "batch_idx_tensor_opt is expected but not provided when use_batch_idx_tensor is true.");
-        current_kernel_batch_arg = tensor_args.batch_idx_tensor_opt.value().buffer()->address();
-    } else {
-        current_kernel_batch_arg = operation_attributes.batch_idx_fallback;
-    }
-
-    auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.unary_reader_kernel_id);
-    auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.unary_writer_kernel_id);
-
-    for (uint32_t i = 0, num_blocks_written = 0; i < shared_vars.cores.size(); i++) {
-        const CoreCoord& core = shared_vars.cores.at(i);
-        uint32_t num_blocks_per_core = 0;
-        if (i < shared_vars.g1_numcores) {
-            num_blocks_per_core = shared_vars.num_blocks_per_core_group_1;
-        } else if (i < shared_vars.g1_numcores + shared_vars.g2_numcores) {
-            num_blocks_per_core = shared_vars.num_blocks_per_core_group_2;
-        } else {
-            num_blocks_per_core = 0;
-        }
-
-        auto& reader_args = reader_args_by_core.at(core.x).at(core.y);
-        reader_args[0] = src_addr;
-        reader_args[1] = num_blocks_written * shared_vars.Wt;  // start_tile_id
-        reader_args[2] = num_blocks_per_core;                  // num_rows
-        reader_args[3] = (uint32_t)operation_attributes.noop;  // noop flag
-
-        auto& writer_args = writer_args_by_core.at(core.x).at(core.y);
-        writer_args[0] = dst_addr;
-        writer_args[1] = page_table_addr;
-        writer_args[2] = num_blocks_written;        // start_row_num
-        writer_args[3] = num_blocks_per_core;       // num_rows
-        writer_args[4] = current_kernel_batch_arg;  // batch_idx_tensor_addr or batch_idx_fallback
-        writer_args[5] = (uint32_t)operation_attributes.noop;  // noop flag
-
-        num_blocks_written += num_blocks_per_core;
-    }
+    return build_paged_fill_cache_descriptor(operation_attributes, tensor_args, operation_attributes.noop);
 }
 
-PagedFillCacheMeshWorkloadFactory::cached_mesh_workload_t PagedFillCacheMeshWorkloadFactory::create_mesh_workload(
+ProgramDescriptor PagedFillCacheMeshWorkloadFactory::create_descriptor(
     const PagedFillCacheParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const PagedFillCacheInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    // Filter coordinates based on mesh_coords if provided
-    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords_opt = operation_attributes.mesh_coords;
-
-    if (mesh_coords_opt.has_value()) {
-        // Validate that all mesh_coords are present in tensor_coords BEFORE creating programs
-        const auto& mesh_coords_set = mesh_coords_opt.value();
-        const auto tensor_coords_vector = tensor_coords.coords();
-        std::set<ttnn::MeshCoordinate> tensor_coords_set(tensor_coords_vector.begin(), tensor_coords_vector.end());
-
-        for (const auto& mesh_coord : mesh_coords_set) {
-            TT_FATAL(
-                tensor_coords_set.contains(mesh_coord),
-                "Mesh coordinate ({}, {}) is in mesh_coords but not found in tensor_coords. "
-                "mesh_coords size: {}, tensor_coords size: {}",
-                mesh_coord[0],
-                mesh_coord[1],
-                mesh_coords_set.size(),
-                tensor_coords_set.size());
-        }
-        for (const auto& mesh_coord : mesh_coords_set) {
-            const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-            auto cached_program =
-                PagedFillCacheProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
-            shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-            mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-        }
-
-        // Create dummy programs for excluded coordinates
-        std::vector<ttnn::MeshCoordinate> dummy_coords;
-        for (const auto& coord : tensor_coords_set) {
-            if (!mesh_coords_set.contains(coord)) {
-                dummy_coords.push_back(coord);
-            }
-        }
-
-        if (!dummy_coords.empty()) {
-            for (const auto& mesh_coord : dummy_coords) {
-                const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-                // Create operation attributes with noop=true for dummy programs
-                PagedFillCacheParams dummy_attrs{
-                    .batch_idx_fallback = operation_attributes.batch_idx_fallback,
-                    .mesh_coords = operation_attributes.mesh_coords,
-                    .noop = true,
-                    .block_size_override = operation_attributes.block_size_override,
-                    .cache_position_modulo = operation_attributes.cache_position_modulo};
-                auto cached_program =
-                    PagedFillCacheProgramFactory::create(dummy_attrs, tensor_args, tensor_return_value);
-                shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-                mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-            }
-        }
-    } else {
-        // When mesh_coords is not provided, iterate over all tensor_coords
-        for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-            for (const auto& mesh_coord : mesh_coord_range) {
-                const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-                auto cached_program =
-                    PagedFillCacheProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
-                shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-                mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-            }
+    Tensor& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    // When mesh_coords is provided, coordinates outside that set get a noop
+    // program (kernels early-exit).  This preserves the legacy behavior of
+    // dispatching a "dummy" program to every device in the mesh range so the
+    // cached workload covers all coords.
+    bool noop = operation_attributes.noop;
+    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value()) {
+        const auto& mesh_coords_set = operation_attributes.mesh_coords.value();
+        if (!mesh_coords_set.contains(mesh_dispatch_coordinate.value())) {
+            noop = true;
         }
     }
-
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+    return build_paged_fill_cache_descriptor(operation_attributes, tensor_args, noop);
 }
 
-void PagedFillCacheMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const PagedFillCacheParams& operation_attributes,
-    const PagedFillCacheInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    PagedFillCacheProgramFactory program_factory;
-
-    // Determine which coordinates should have noop=true (excluded from mesh_coords)
-    std::set<ttnn::MeshCoordinate> mesh_coords_set;
-    if (operation_attributes.mesh_coords.has_value()) {
-        mesh_coords_set = operation_attributes.mesh_coords.value();
+std::vector<tt::tt_metal::DynamicRuntimeArg> PagedFillCacheDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    // Coords excluded from a mesh dispatch build a noop program (kernels early-exit), so there is
+    // nothing meaningful to re-patch there.
+    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value() &&
+        !operation_attributes.mesh_coords.value().contains(mesh_dispatch_coordinate.value())) {
+        return {};
     }
 
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
-        const ttnn::MeshCoordinate coord = *(coordinate_range.begin());
-
-        // Determine if this coordinate should be a noop (dummy program)
-        // If mesh_coords is provided and this coord is not in it, it's a dummy program
-        bool is_dummy = operation_attributes.mesh_coords.has_value() && !mesh_coords_set.contains(coord);
-
-        // Create modified operation_attributes with correct noop value for this coordinate
-        PagedFillCacheParams coord_attrs{
-            .batch_idx_fallback = operation_attributes.batch_idx_fallback,
-            .mesh_coords = operation_attributes.mesh_coords,
-            .noop = is_dummy,
-            .block_size_override = operation_attributes.block_size_override,
-            .cache_position_modulo = operation_attributes.cache_position_modulo};
-
-        ttnn::device_operation::mesh_device_operation_utils::apply_override_runtime_arguments(
-            program_factory, program, shared_variables, coord_attrs, coord, tensor_args, tensor_return_value);
+    // batch-idx-tensor mode: the writer pushes the batch_idx tensor's Buffer* (writer arg 4), which
+    // the framework already re-patches by buffer base address. Nothing op-specific to re-apply.
+    if (tensor_args.batch_idx_tensor_opt.has_value()) {
+        return {};
     }
+
+    // Scalar-fallback mode: batch_idx_fallback is excluded from the program hash (so two calls
+    // differing only in it cache-hit) yet baked into writer runtime arg index 4 — re-patch it on
+    // every dispatch or it freezes at the first cache-miss value. It is the SAME value on every
+    // core (operation_attributes.batch_idx_fallback, not per-core), so we emit one arg per core
+    // using the shared core-list helper (single source of truth for core ordering).
+    //
+    // noop is intentionally NOT re-patched: it is derived from the hashed mesh_coords (the mesh
+    // factory sets it per coord from coord-membership), so it is stable across cache hits for a
+    // fixed coord and is already correct in the cached program.
+    //
+    // Kernel push order in build_paged_fill_cache_descriptor: reader(0), writer(1).
+    // Writer rt args: [0]=dst, [1]=page_table, [2]=start_row_num, [3]=num_rows,
+    //                 [4]=batch_idx_fallback (scalar-fallback mode), [5]=noop.
+    constexpr uint32_t kWriterKernelIdx = 1;
+    constexpr uint32_t kBatchIdxFallbackArgIdx = 4;
+
+    const auto cores = compute_paged_fill_cache_cores(operation_attributes, tensor_args);
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size());
+    for (const auto& core : cores) {
+        dynamic_args.push_back(
+            {kWriterKernelIdx, core, kBatchIdxFallbackArgIdx, operation_attributes.batch_idx_fallback});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.hpp
@@ -5,53 +5,29 @@
 #pragma once
 
 #include "paged_fill_cache_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include <optional>
 
 namespace ttnn::experimental::prim {
 
-struct PagedFillCacheSharedVariables {
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = 0;
-    std::vector<tt::tt_metal::CoreCoord> cores;
-    uint32_t g1_numcores = 0;
-    uint32_t g2_numcores = 0;
-    uint32_t num_blocks_per_core_group_1 = 0;
-    uint32_t num_blocks_per_core_group_2 = 0;
-    uint32_t Wt = 0;
-    bool use_batch_idx_tensor = false;
-};
-
 struct PagedFillCacheProgramFactory {
-    using shared_variables_t = PagedFillCacheSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const PagedFillCacheParams& operation_attributes,
-        const PagedFillCacheInputs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedFillCacheParams& operation_attributes,
         const PagedFillCacheInputs& tensor_args,
         Tensor& tensor_return_value);
 };
 
 struct PagedFillCacheMeshWorkloadFactory {
-    using shared_variables_t = PagedFillCacheSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const PagedFillCacheParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const PagedFillCacheInputs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Per-coord program build.  When mesh_coords is provided and the dispatch
+    // coordinate is not in it, the resulting program is a noop (early-exits in
+    // kernels) so the cache slot is still populated for that coord.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedFillCacheParams& operation_attributes,
         const PagedFillCacheInputs& tensor_args,
-        Tensor& tensor_return_value);
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "paged_fused_update_cache_device_operation.hpp"
 #include "paged_fused_update_cache_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 using namespace tt::tt_metal;
@@ -261,6 +262,56 @@ ttsl::hash::hash_t PagedFusedUpdateCacheDeviceOperation::compute_program_hash(
         operation_attributes.mesh_coords,
         tensor_args,
         program_factory.index());
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> PagedFusedUpdateCacheDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    // Coords excluded from a mesh dispatch get an empty ProgramDescriptor (see the mesh factories) — no
+    // kernels, nothing to patch.
+    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value() &&
+        !operation_attributes.mesh_coords.value().contains(mesh_dispatch_coordinate.value())) {
+        return {};
+    }
+
+    // Per-index offsets come from the factory matching the input layout — the same tiled-vs-row-major
+    // condition select_program_factory uses. Index-tensor mode bakes no per-call offsets (positions are
+    // read on-device from the re-patched index tensor), so the helper returns empty and there is nothing
+    // dynamic to re-apply.
+    const auto& input_tensor1 = tensor_args.input_tensor1;
+    const bool is_tiled = input_tensor1.layout() == tt::tt_metal::Layout::TILE;
+
+    // Kernel push order in both factories' create_descriptor: reader(0), writer(1), compute(2).
+    // Reader rt args:  [0]=has_work, [1]=is_input1, [2]=dst, [3]=cache_start_id, ...
+    // Writer rt args:  [0]=has_work, [1]=dst, [2]=cache_start_id, [3]=tile_update_offset_B, ...
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    const auto emit = [&](const auto& offsets) {
+        if (offsets.empty()) {
+            return;
+        }
+        // Each index i handles input1 on core1 and input2 on core2, both using the same offsets.
+        dynamic_args.reserve(offsets.size() * 6);
+        for (const auto& off : offsets) {
+            for (const auto& core : {off.core1, off.core2}) {
+                dynamic_args.push_back({kReaderKernelIdx, core, /*arg_idx=*/3, off.cache_start_id});
+                dynamic_args.push_back({kWriterKernelIdx, core, /*arg_idx=*/2, off.cache_start_id});
+                dynamic_args.push_back({kWriterKernelIdx, core, /*arg_idx=*/3, off.tile_update_offset_B});
+            }
+        }
+    };
+
+    if (is_tiled) {
+        emit(PagedTiledFusedUpdateCacheProgramFactory::compute_tiled_fused_offsets(operation_attributes, tensor_args));
+    } else {
+        emit(PagedRowMajorFusedUpdateCacheProgramFactory::compute_row_major_fused_offsets(
+            operation_attributes, tensor_args));
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.hpp
@@ -6,11 +6,16 @@
 
 #include <optional>
 #include <variant>
+#include <vector>
+
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "paged_fused_update_cache_device_operation_types.hpp"
 #include "paged_tiled_fused_update_cache_program_factory.hpp"
 #include "paged_row_major_fused_update_cache_program_factory.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::experimental::prim {
 
@@ -39,6 +44,16 @@ struct PagedFusedUpdateCacheDeviceOperation {
 
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    // update_idxs is excluded from the program hash (so decode steps that differ only in position
+    // cache-hit). The cache-write offsets it determines (cache_start_id, tile_update_offset_B) are
+    // DYNAMIC and re-applied to the cached program on every dispatch. Returns empty in index-tensor
+    // mode (positions read on-device) and for coords excluded from a mesh dispatch.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_row_major_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_row_major_fused_update_cache_program_factory.cpp
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "paged_fused_update_cache_device_operation_types.hpp"
-#include <tt-metalium/work_split.hpp>
 #include "paged_row_major_fused_update_cache_program_factory.hpp"
+
+#include "paged_fused_update_cache_device_operation_types.hpp"
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/mesh_device_operation_utils.hpp"
-#include <unordered_map>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::tt_metal;
 
@@ -31,11 +31,57 @@ bool enable_fp32_dest_acc(
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE_ROW_MAJOR
 
-PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFusedUpdateCacheProgramFactory::create(
+std::vector<PagedRowMajorFusedUpdateCacheProgramFactory::PerIndexOffsets>
+PagedRowMajorFusedUpdateCacheProgramFactory::compute_row_major_fused_offsets(
+    const PagedFusedUpdateCacheParams& operation_attributes, const PagedFusedUpdateCacheInputs& tensor_args) {
+    // cache_start_id / tile_update_offset_B are derived from update_idxs, which is excluded from the
+    // program hash (see PagedFusedUpdateCacheDeviceOperation::compute_program_hash) yet baked into runtime
+    // args, so they must be re-patched on every cache hit via get_dynamic_runtime_args. This helper is the
+    // single source of truth for the formulas — both create_descriptor (cache miss) and
+    // get_dynamic_runtime_args (cache hit) call it, so the two paths cannot drift. Returns empty when an
+    // index tensor is used: in that mode the offsets are 0 here and the real positions are read on-device
+    // from the (Buffer-bound, re-patched) index tensor.
+    if (tensor_args.update_idxs_tensor.has_value()) {
+        return {};
+    }
+
+    const auto& cache_tensor1 = tensor_args.cache_tensor1;
+    const auto& input_tensor1 = tensor_args.input_tensor1;
+    const auto& input_tensor2 = tensor_args.input_tensor2;
+    const bool fp32_dest_acc_en = CMAKE_UNIQUE_NAMESPACE_ROW_MAJOR::enable_fp32_dest_acc(
+        input_tensor1.device(), operation_attributes.compute_kernel_config);
+
+    const uint32_t Wt = cache_tensor1.padded_shape()[-1] / TILE_WIDTH;
+    const uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor1.padded_shape()[-1] * sizeof(float)
+                                             : cache_tensor1.padded_shape()[-1] * 2;  // 2 bytes for bfloat16
+    const uint32_t cache_total_num_tiles = cache_tensor1.physical_volume() / TILE_HW;
+    // share_cache => batch offset is 0 (one shared cache buffer); mirror create_descriptor exactly.
+    const uint32_t cache_batch_num_tiles =
+        operation_attributes.share_cache ? 0 : cache_total_num_tiles / cache_tensor1.padded_shape()[0];
+
+    const bool row_major = input_tensor1.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+    const CoreRangeSet input1_cores = input_tensor1.shard_spec().value().grid;
+    const CoreRangeSet input2_cores = input_tensor2.shard_spec().value().grid;
+    const auto& cores1 = corerange_to_cores(input1_cores, input1_cores.num_cores(), row_major);
+    const auto& cores2 = corerange_to_cores(input2_cores, input2_cores.num_cores(), row_major);
+
+    std::vector<PerIndexOffsets> offsets;
+    offsets.reserve(cores1.size());
+    for (uint32_t i = 0; i < cores1.size(); ++i) {
+        const uint32_t update_idx = operation_attributes.update_idxs.at(i);
+        const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
+        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * Wt);
+        const uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+        offsets.push_back({cores1.at(i), cores2.at(i), cache_start_id, tile_update_offset_B});
+    }
+    return offsets;
+}
+
+ProgramDescriptor PagedRowMajorFusedUpdateCacheProgramFactory::create_descriptor(
     const PagedFusedUpdateCacheParams& operation_attributes,
     const PagedFusedUpdateCacheInputs& tensor_args,
     PagedFusedUpdateCacheResult& /*tensor_return_value*/) {
-    Program program{};
+    ProgramDescriptor desc;
 
     const auto& cache_tensor1 = tensor_args.cache_tensor1;
     const auto& input_tensor1 = tensor_args.input_tensor1;
@@ -63,7 +109,6 @@ PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFused
 
     // Index tensor-specific parameters
     const bool use_index_tensor = update_idxs_tensor.has_value();
-    uint32_t index_buffer_addr = 0;
     const uint32_t log2_page_size = 0;
     uint32_t index_stick_size = 0;
     tt::DataFormat index_data_format = tt::DataFormat::Int32;
@@ -71,7 +116,6 @@ PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFused
     bool index_is_dram = true;
     if (use_index_tensor) {
         index_buffer_ptr = update_idxs_tensor.value().is_sharded() ? update_idxs_tensor.value().buffer() : nullptr;
-        index_buffer_addr = use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
         index_data_format = tt_metal::datatype_to_dataformat_converter(update_idxs_tensor.value().dtype());
         index_is_dram = update_idxs_tensor.value().buffer()->buffer_type() == tt_metal::BufferType::DRAM;
         index_stick_size = update_idxs_tensor.value().buffer()->aligned_page_size();
@@ -137,8 +181,8 @@ PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFused
 
     const uint32_t num_input_tiles = input1_shard_spec.shape[0] * input1_shard_spec.shape[1] / TILE_HW;
 
-    auto* const in1_buffer_address = input_tensor1.buffer();
-    auto* const in2_buffer_address = input_tensor2.buffer();
+    auto* const in1_buffer = input_tensor1.buffer();
+    auto* const in2_buffer = input_tensor2.buffer();
 
     const uint32_t num_cache_tiles = 2 * Wt;   // double buffered
     const uint32_t num_interm_tiles = 2 * Wt;  // double buffered
@@ -153,54 +197,94 @@ PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFused
     const tt::CBIndex intermed1_cb_index = CBIndex::c_6;
     const tt::CBIndex output_cb_index = CBIndex::c_7;
 
-    create_cb(cache_cb_index, program, all_cores_bb, cache_single_tile_size, num_cache_tiles, cache_cb_data_format);
-    auto [_1, cb_src1] = create_cb(
-        src1_cb_index,
-        program,
-        input1_cores,
-        input_single_tile_size,
-        num_input_tiles,
-        input_cb_data_format,
-        in1_buffer_address);
-    auto [_2, cb_src3] = create_cb(
-        src2_cb_index,
-        program,
-        input2_cores,
-        input_single_tile_size,
-        num_input_tiles,
-        input_cb_data_format,
-        in2_buffer_address);
-    create_cb(
-        {intermed0_cb_index, intermed1_cb_index},
-        program,
-        all_cores_bb,
-        interm_single_tile_size,
-        num_interm_tiles,
-        interm_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cache_tiles * cache_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cache_cb_index),
+            .data_format = cache_cb_data_format,
+            .page_size = cache_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = input1_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in1_buffer,
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = input2_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src2_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in2_buffer,
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * interm_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{
+            CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(intermed0_cb_index),
+                .data_format = interm_cb_data_format,
+                .page_size = interm_single_tile_size,
+            },
+            CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(intermed1_cb_index),
+                .data_format = interm_cb_data_format,
+                .page_size = interm_single_tile_size,
+            },
+        }},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * cache_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = cache_cb_data_format,
+            .page_size = cache_single_tile_size,
+        }}},
+    });
 
-    create_cb(output_cb_index, program, all_cores_bb, cache_single_tile_size, num_output_tiles, cache_cb_data_format);
+    // used for share cache for signaling when the cache is ready to be read
+    const uint32_t in0_sequential_mode_semaphore_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = in0_sequential_mode_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_cores_bb,
+        .initial_value = 0,
+    });
 
-    const auto in0_sequential_mode_semaphore_id = tt_metal::CreateSemaphore(
-        program, all_cores_bb, 0);  // used for share cache for signaling when the cache is ready to be read
-
-    CBHandle cb_cur_pos_id = 0;
     if (use_index_tensor) {
-        auto [_3, cb_src5] =
-            create_cb(cb_index_id, program, all_cores_bb, index_stick_size, 1, index_data_format, index_buffer_ptr);
-        cb_cur_pos_id = cb_src5;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = index_stick_size,
+            .core_ranges = all_cores_bb,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_index_id),
+                .data_format = index_data_format,
+                .page_size = index_stick_size,
+            }}},
+            .buffer = index_buffer_ptr,
+        });
     }
 
-    CBHandle cb_page_table_id = 0;
     if (is_paged_cache) {
-        auto [_4, cb_src7] = create_cb(
-            cb_pagetable_id,
-            program,
-            all_cores_bb,
-            page_table_stick_size,
-            num_pages_page_table,
-            page_table_data_format,
-            page_table_buffer_ptr);
-        cb_page_table_id = cb_src7;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_pages_page_table * page_table_stick_size,
+            .core_ranges = all_cores_bb,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_pagetable_id),
+                .data_format = page_table_data_format,
+                .page_size = page_table_stick_size,
+            }}},
+            .buffer = page_table_buffer_ptr,
+        });
     }
 
     auto* const dst1_buffer = cache_tensor1.buffer();
@@ -275,28 +359,34 @@ PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFused
     };
 
     // Create reader kernel
-    const auto unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/"
-        "reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp",
-        all_cores_bb,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_bb;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Create writer kernel
-    const auto unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/"
-        "writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp",
-        all_cores_bb,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores_bb;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // Create compute kernel
-    const auto compute_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/"
-        "paged_row_major_fused_update_cache.cpp",
-        all_cores_bb,
-        tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+        "paged_row_major_fused_update_cache.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores_bb;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
 
     constexpr bool has_work = true;
     constexpr bool is_input1 = true;
@@ -304,16 +394,20 @@ PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFused
     const auto& cores1 = corerange_to_cores(input1_cores, input1_cores.num_cores(), row_major);
     const auto& cores2 = corerange_to_cores(input2_cores, input2_cores.num_cores(), row_major);
 
+    Buffer* const index_buffer_for_rt = use_index_tensor ? update_idxs_tensor.value().buffer() : nullptr;
+    Buffer* const page_table_buffer_for_rt = is_paged_cache ? page_table.value().buffer() : nullptr;
+
+    // cache_start_id / tile_update_offset_B are derived from update_idxs (excluded from the program hash)
+    // — computed via the shared helper so get_dynamic_runtime_args re-patches identical values on cache
+    // hits. Empty in index-tensor mode (offsets read on-device from the re-patched index tensor).
+    const auto offsets = compute_row_major_fused_offsets(operation_attributes, tensor_args);
     for (uint32_t i = 0; i < cores1.size(); ++i) {
         const CoreCoord& core1 = cores1.at(i);
         const CoreCoord& core2 = cores2.at(i);
 
-        const uint32_t update_idx = use_index_tensor ? 0 : operation_attributes.update_idxs.at(i);
-
         // Cache tile info
-        const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
-        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * Wt);
-        const uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+        const uint32_t cache_start_id = use_index_tensor ? 0u : offsets.at(i).cache_start_id;
+        const uint32_t tile_update_offset_B = use_index_tensor ? 0u : offsets.at(i).tile_update_offset_B;
 
         // Calculate synchronization parameters
         const bool wait_to_start = operation_attributes.share_cache and (i != 0);
@@ -335,268 +429,130 @@ PagedRowMajorFusedUpdateCacheProgramFactory::cached_program_t PagedRowMajorFused
 
         // Input1 args
         // Set runtime args for reader
-        SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core1,
-            {
-                has_work,
-                is_input1,
-                dst1_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                index_buffer_addr,
-                i,
-                is_paged_cache ? page_table.value().buffer()->address() : 0,
-                wait_to_start,
-            });
+        {
+            KernelDescriptor::RTArgList rargs;
+            rargs.push_back(static_cast<uint32_t>(has_work));
+            rargs.push_back(static_cast<uint32_t>(is_input1));
+            rargs.push_back(dst1_buffer);
+            rargs.push_back(use_index_tensor ? 0u : cache_start_id);
+            if (use_index_tensor) {
+                rargs.push_back(index_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(i);
+            if (is_paged_cache) {
+                rargs.push_back(page_table_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(static_cast<uint32_t>(wait_to_start));
+            reader_desc.emplace_runtime_args(core1, rargs);
+        }
 
         // Set runtime args for writer
-        SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core1,
             {
-                has_work,
-                dst1_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                use_index_tensor ? 0 : tile_update_offset_B,
+                static_cast<uint32_t>(has_work),
+                dst1_buffer,
+                use_index_tensor ? 0u : cache_start_id,
+                use_index_tensor ? 0u : tile_update_offset_B,
                 i,
-                send_signal,
+                static_cast<uint32_t>(send_signal),
                 send_core1_x,
                 send_core1_y,
-                is_input1,
+                static_cast<uint32_t>(is_input1),
             });
 
         // Set runtime args for compute
-        SetRuntimeArgs(
-            program,
-            compute_kernel_id,
+        compute_desc.emplace_runtime_args(
             core1,
             {
-                has_work,
-                is_input1,
+                static_cast<uint32_t>(has_work),
+                static_cast<uint32_t>(is_input1),
             });
 
         // Input2 args
         // Set runtime args for reader
-        SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core2,
-            {
-                has_work,
-                !is_input1,
-                dst2_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                index_buffer_addr,
-                i,
-                is_paged_cache ? page_table.value().buffer()->address() : 0,
-                wait_to_start,
-            });
+        {
+            KernelDescriptor::RTArgList rargs;
+            rargs.push_back(static_cast<uint32_t>(has_work));
+            rargs.push_back(static_cast<uint32_t>(!is_input1));
+            rargs.push_back(dst2_buffer);
+            rargs.push_back(use_index_tensor ? 0u : cache_start_id);
+            if (use_index_tensor) {
+                rargs.push_back(index_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(i);
+            if (is_paged_cache) {
+                rargs.push_back(page_table_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(static_cast<uint32_t>(wait_to_start));
+            reader_desc.emplace_runtime_args(core2, rargs);
+        }
 
         // Set runtime args for writer
-        SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core2,
             {
-                has_work,
-                dst2_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                use_index_tensor ? 0 : tile_update_offset_B,
+                static_cast<uint32_t>(has_work),
+                dst2_buffer,
+                use_index_tensor ? 0u : cache_start_id,
+                use_index_tensor ? 0u : tile_update_offset_B,
                 i,
-                send_signal,
+                static_cast<uint32_t>(send_signal),
                 send_core2_x,
                 send_core2_y,
-                !is_input1,
+                static_cast<uint32_t>(!is_input1),
             });
 
         // Set runtime args for compute
-        SetRuntimeArgs(
-            program,
-            compute_kernel_id,
+        compute_desc.emplace_runtime_args(
             core2,
             {
-                has_work,
-                !is_input1,
+                static_cast<uint32_t>(has_work),
+                static_cast<uint32_t>(!is_input1),
             });
     }
 
     // Set runtime args for unused cores
-    SetRuntimeArgs(program, unary_reader_kernel_id, unused_cores, {!has_work});
-    SetRuntimeArgs(program, unary_writer_kernel_id, unused_cores, {!has_work});
-    SetRuntimeArgs(program, compute_kernel_id, unused_cores, {!has_work});
+    for (const auto& core_range : unused_cores.ranges()) {
+        for (const auto& core : core_range) {
+            reader_desc.emplace_runtime_args(core, {uint32_t{!has_work}});
+            writer_desc.emplace_runtime_args(core, {uint32_t{!has_work}});
+            compute_desc.emplace_runtime_args(core, {uint32_t{!has_work}});
+        }
+    }
 
-    // Store shared variables
-    shared_variables_t shared_vars{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cores1 = cores1,
-        .cores2 = cores2,
-        .Wbytes = Wbytes,
-        .Wt = Wt,
-        .cb_src1 = cb_src1,
-        .cb_src3 = cb_src3,
-        .cb_cur_pos_id = cb_cur_pos_id,
-        .cb_page_table_id = cb_page_table_id,
-        .cache_batch_num_tiles = cache_batch_num_tiles,
-        .use_index_tensor = use_index_tensor,
-        .is_paged_cache = is_paged_cache};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    return cached_program_t{std::move(program), std::move(shared_vars)};
+    return desc;
 }
 
-void PagedRowMajorFusedUpdateCacheProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
+ProgramDescriptor PagedRowMajorFusedUpdateCacheMeshWorkloadFactory::create_descriptor(
     const PagedFusedUpdateCacheParams& operation_attributes,
     const PagedFusedUpdateCacheInputs& tensor_args,
-    PagedFusedUpdateCacheResult& /*tensor_return_value*/) {
-    auto& shared_vars = cached_program.shared_variables;
-    auto& program = cached_program.program;
-
-    const auto& input_tensor1 = tensor_args.input_tensor1;
-    const auto& input_tensor2 = tensor_args.input_tensor2;
-    const auto& update_idxs_tensor = tensor_args.update_idxs_tensor;
-    const auto& page_table = tensor_args.page_table;
-
-    auto* const src1_buffer = input_tensor1.buffer();
-    auto* const src2_buffer = input_tensor2.buffer();
-
-    auto* const dst1_buffer = tensor_args.cache_tensor1.buffer();
-    auto* const dst2_buffer = tensor_args.cache_tensor2.buffer();
-
-    auto* index_tensor_buffer = shared_vars.use_index_tensor ? update_idxs_tensor.value().buffer() : nullptr;
-    auto* page_table_buffer = shared_vars.is_paged_cache ? page_table.value().buffer() : nullptr;
-    const auto index_tensor_addr = shared_vars.use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
-    const auto page_table_tensor_addr = shared_vars.is_paged_cache ? page_table.value().buffer()->address() : 0;
-
-    if (input_tensor1.is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_src1, *src1_buffer);
-    }
-    if (input_tensor2.is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_src3, *src2_buffer);
-    }
-    auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.unary_reader_kernel_id);
-    auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.unary_writer_kernel_id);
-
-    for (uint32_t i = 0; i < shared_vars.cores1.size(); ++i) {
-        const uint32_t update_idx = shared_vars.use_index_tensor ? 0 : operation_attributes.update_idxs.at(i);
-        // Cache tile info
-        const uint32_t cache_batch_tile_offset = i * shared_vars.cache_batch_num_tiles;
-        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * shared_vars.Wt);
-        // Offset to write into untilized cache
-        const uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * shared_vars.Wbytes;
-
-        const CoreCoord& core1 = shared_vars.cores1.at(i);
-        const CoreCoord& core2 = shared_vars.cores2.at(i);
-
-        // Input1 args
-        {
-            auto& runtime_args = reader_args_by_core.at(core1.x).at(core1.y);
-            runtime_args[2] = dst1_buffer->address();
-            runtime_args[3] = cache_start_id;
-            runtime_args[4] = index_tensor_addr;
-            runtime_args[6] = page_table_tensor_addr;
-        }
-
-        {
-            auto& runtime_args = writer_args_by_core.at(core1.x).at(core1.y);
-            runtime_args[1] = dst1_buffer->address();
-            runtime_args[2] = cache_start_id;
-            runtime_args[3] = tile_update_offset_B;
-        }
-
-        // Input2 args
-        {
-            auto& runtime_args = reader_args_by_core.at(core2.x).at(core2.y);
-            runtime_args[2] = dst2_buffer->address();
-            runtime_args[3] = cache_start_id;
-            runtime_args[4] = index_tensor_addr;
-            runtime_args[6] = page_table_tensor_addr;
-        }
-
-        {
-            auto& runtime_args = writer_args_by_core.at(core2.x).at(core2.y);
-            runtime_args[1] = dst2_buffer->address();
-            runtime_args[2] = cache_start_id;
-            runtime_args[3] = tile_update_offset_B;
+    PagedFusedUpdateCacheResult& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    // When mesh_coords is provided, coords outside that set get an empty program
+    // (the legacy mesh path skipped them entirely; with the descriptor framework
+    // every dispatched coord receives a descriptor, so an empty one is the
+    // closest equivalent).
+    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value()) {
+        const auto& mesh_coords_set = operation_attributes.mesh_coords.value();
+        if (!mesh_coords_set.contains(mesh_dispatch_coordinate.value())) {
+            return ProgramDescriptor{};
         }
     }
-    if (shared_vars.use_index_tensor and update_idxs_tensor.has_value() and update_idxs_tensor.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_cur_pos_id, *index_tensor_buffer);
-    }
-    if (shared_vars.is_paged_cache and page_table.has_value() and page_table.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_page_table_id, *page_table_buffer);
-    }
-}
-
-PagedRowMajorFusedUpdateCacheMeshWorkloadFactory::cached_mesh_workload_t
-PagedRowMajorFusedUpdateCacheMeshWorkloadFactory::create_mesh_workload(
-    const PagedFusedUpdateCacheParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const PagedFusedUpdateCacheInputs& tensor_args,
-    PagedFusedUpdateCacheResult& tensor_return_value) {
-    log_debug(tt::LogOp, "PagedRowMajorFusedUpdateCacheMeshWorkloadFactory::create_mesh_workload called");
-    log_debug(tt::LogOp, "tensor_coords has {} ranges", tensor_coords.ranges().size());
-
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    // Filter coordinates based on mesh_coords if provided
-    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords_opt = operation_attributes.mesh_coords;
-
-    if (mesh_coords_opt.has_value()) {
-        log_debug(tt::LogOp, "mesh_coords provided with {} coordinates", mesh_coords_opt.value().size());
-    } else {
-        log_debug(tt::LogOp, "mesh_coords not provided, using all tensor_coords");
-    }
-
-    // Create programs for each coordinate in tensor_coords (filtered by mesh_coords if provided)
-    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-        for (const auto& mesh_coord : mesh_coord_range) {
-            // Skip this coordinate if mesh_coords is provided and this coordinate is not in the set
-            if (mesh_coords_opt.has_value()) {
-                const auto& mesh_coords_set = mesh_coords_opt.value();
-                if (!mesh_coords_set.contains(mesh_coord)) {
-                    log_debug(
-                        tt::LogOp, "Skipping coordinate ({}, {}) - not in mesh_coords", mesh_coord[0], mesh_coord[1]);
-                    continue;  // Skip this coordinate
-                }
-            }
-
-            // Create a program for this specific coordinate using the base factory
-            log_debug(tt::LogOp, "Creating program for coordinate ({}, {})", mesh_coord[0], mesh_coord[1]);
-            const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-            auto cached_program = PagedRowMajorFusedUpdateCacheProgramFactory::create(
-                operation_attributes, tensor_args, tensor_return_value);
-            shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-            mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-        }
-    }
-
-    log_debug(tt::LogOp, "Created mesh workload with {} programs", mesh_workload.get_programs().size());
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
-}
-
-void PagedRowMajorFusedUpdateCacheMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const PagedFusedUpdateCacheParams& operation_attributes,
-    const PagedFusedUpdateCacheInputs& tensor_args,
-    PagedFusedUpdateCacheResult& tensor_return_value) {
-    PagedRowMajorFusedUpdateCacheProgramFactory program_factory;
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
-
-        ttnn::device_operation::mesh_device_operation_utils::apply_override_runtime_arguments(
-            program_factory,
-            program,
-            shared_variables,
-            operation_attributes,
-            *(coordinate_range.begin()),
-            tensor_args,
-            tensor_return_value);
-    }
+    return PagedRowMajorFusedUpdateCacheProgramFactory::create_descriptor(
+        operation_attributes, tensor_args, tensor_return_value);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_row_major_fused_update_cache_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_row_major_fused_update_cache_program_factory.hpp
@@ -5,59 +5,48 @@
 #pragma once
 
 #include "paged_fused_update_cache_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include <cstdint>
+#include <optional>
 #include <vector>
-#include <tt-metalium/host_api.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct PagedRowMajorFusedUpdateCacheSharedVariables {
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = 0;
-    std::vector<tt::tt_metal::CoreCoord> cores1;
-    std::vector<tt::tt_metal::CoreCoord> cores2;
-    uint32_t Wbytes = 0;
-    uint32_t Wt = 0;
-    tt::tt_metal::CBHandle cb_src1 = 0;
-    tt::tt_metal::CBHandle cb_src3 = 0;
-    tt::tt_metal::CBHandle cb_cur_pos_id = 0;
-    tt::tt_metal::CBHandle cb_page_table_id = 0;
-    uint32_t cache_batch_num_tiles = 0;
-    bool use_index_tensor = false;
-    bool is_paged_cache = false;
-};
-
 struct PagedRowMajorFusedUpdateCacheProgramFactory {
-    using shared_variables_t = PagedRowMajorFusedUpdateCacheSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    // Per-index cache-write offsets derived from update_idxs. One entry per index i over cores1.size();
+    // each handles input1 on core1 and input2 on core2, both sharing the same offsets.
+    struct PerIndexOffsets {
+        tt::tt_metal::CoreCoord core1;
+        tt::tt_metal::CoreCoord core2;
+        uint32_t cache_start_id = 0;
+        uint32_t tile_update_offset_B = 0;
+    };
 
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedFusedUpdateCacheParams& operation_attributes,
         const PagedFusedUpdateCacheInputs& tensor_args,
         PagedFusedUpdateCacheResult& tensor_return_value);
 
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PagedFusedUpdateCacheParams& operation_attributes,
-        const PagedFusedUpdateCacheInputs& tensor_args,
-        PagedFusedUpdateCacheResult& tensor_return_value);
+    // Single source of truth for the cache_start_id / tile_update_offset_B formulas (shared by
+    // create_descriptor on a cache miss and get_dynamic_runtime_args on a cache hit). Returns empty in
+    // index-tensor mode (positions read on-device).
+    static std::vector<PerIndexOffsets> compute_row_major_fused_offsets(
+        const PagedFusedUpdateCacheParams& operation_attributes, const PagedFusedUpdateCacheInputs& tensor_args);
 };
 
 struct PagedRowMajorFusedUpdateCacheMeshWorkloadFactory {
-    using shared_variables_t = PagedRowMajorFusedUpdateCacheSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const PagedFusedUpdateCacheParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const PagedFusedUpdateCacheInputs& tensor_args,
-        PagedFusedUpdateCacheResult& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Per-coord program build.  Coordinates outside operation_attributes.mesh_coords
+    // (when provided) get an empty program — the legacy mesh path skipped them
+    // entirely; with the descriptor framework we still must hand back a descriptor
+    // for every dispatched coord, so we return an empty one for excluded coords.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedFusedUpdateCacheParams& operation_attributes,
         const PagedFusedUpdateCacheInputs& tensor_args,
-        PagedFusedUpdateCacheResult& tensor_return_value);
+        PagedFusedUpdateCacheResult& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_tiled_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_tiled_fused_update_cache_program_factory.cpp
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "paged_fused_update_cache_device_operation_types.hpp"
-#include <tt-metalium/work_split.hpp>
 #include "paged_tiled_fused_update_cache_program_factory.hpp"
+
+#include "paged_fused_update_cache_device_operation_types.hpp"
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/mesh_device_operation_utils.hpp"
-#include <unordered_map>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::tt_metal;
 
@@ -31,11 +31,57 @@ bool enable_fp32_dest_acc(
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE_TILED
 
-PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdateCacheProgramFactory::create(
+std::vector<PagedTiledFusedUpdateCacheProgramFactory::PerIndexOffsets>
+PagedTiledFusedUpdateCacheProgramFactory::compute_tiled_fused_offsets(
+    const PagedFusedUpdateCacheParams& operation_attributes, const PagedFusedUpdateCacheInputs& tensor_args) {
+    // cache_start_id / tile_update_offset_B are derived from update_idxs, which is excluded from the
+    // program hash (see PagedFusedUpdateCacheDeviceOperation::compute_program_hash) yet baked into runtime
+    // args, so they must be re-patched on every cache hit via get_dynamic_runtime_args. This helper is the
+    // single source of truth for the formulas — both create_descriptor (cache miss) and
+    // get_dynamic_runtime_args (cache hit) call it, so the two paths cannot drift. Returns empty when an
+    // index tensor is used: in that mode the offsets are 0 here and the real positions are read on-device
+    // from the (Buffer-bound, re-patched) index tensor.
+    if (tensor_args.update_idxs_tensor.has_value()) {
+        return {};
+    }
+
+    const auto& cache_tensor1 = tensor_args.cache_tensor1;
+    const auto& input_tensor1 = tensor_args.input_tensor1;
+    const auto& input_tensor2 = tensor_args.input_tensor2;
+    const bool fp32_dest_acc_en = CMAKE_UNIQUE_NAMESPACE_TILED::enable_fp32_dest_acc(
+        input_tensor1.device(), operation_attributes.compute_kernel_config);
+
+    const uint32_t Wt = cache_tensor1.padded_shape()[-1] / TILE_WIDTH;
+    const uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor1.padded_shape()[-1] * sizeof(float)
+                                             : cache_tensor1.padded_shape()[-1] * 2;  // 2 bytes for bfloat16
+    const uint32_t cache_total_num_tiles = cache_tensor1.physical_volume() / TILE_HW;
+    // share_cache => batch offset is 0 (one shared cache buffer); mirror create_descriptor exactly.
+    const uint32_t cache_batch_num_tiles =
+        operation_attributes.share_cache ? 0 : cache_total_num_tiles / cache_tensor1.padded_shape()[0];
+
+    const bool row_major = input_tensor1.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+    const CoreRangeSet input1_cores = input_tensor1.shard_spec().value().grid;
+    const CoreRangeSet input2_cores = input_tensor2.shard_spec().value().grid;
+    const auto& cores1 = corerange_to_cores(input1_cores, input1_cores.num_cores(), row_major);
+    const auto& cores2 = corerange_to_cores(input2_cores, input2_cores.num_cores(), row_major);
+
+    std::vector<PerIndexOffsets> offsets;
+    offsets.reserve(cores1.size());
+    for (uint32_t i = 0; i < cores1.size(); ++i) {
+        const uint32_t update_idx = operation_attributes.update_idxs.at(i);
+        const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
+        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * Wt);
+        const uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+        offsets.push_back({cores1.at(i), cores2.at(i), cache_start_id, tile_update_offset_B});
+    }
+    return offsets;
+}
+
+ProgramDescriptor PagedTiledFusedUpdateCacheProgramFactory::create_descriptor(
     const PagedFusedUpdateCacheParams& operation_attributes,
     const PagedFusedUpdateCacheInputs& tensor_args,
     PagedFusedUpdateCacheResult& /*tensor_return_value*/) {
-    Program program{};
+    ProgramDescriptor desc;
 
     const auto& cache_tensor1 = tensor_args.cache_tensor1;
     const auto& input_tensor1 = tensor_args.input_tensor1;
@@ -63,7 +109,6 @@ PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdate
 
     // Index tensor-specific parameters
     bool use_index_tensor = update_idxs_tensor.has_value();
-    uint32_t index_buffer_addr = 0;
     uint32_t log2_page_size = 0;
     uint32_t index_stick_size = 0;
     tt::DataFormat index_data_format = tt::DataFormat::Int32;
@@ -71,7 +116,6 @@ PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdate
     Buffer* index_buffer_ptr = nullptr;
     if (use_index_tensor) {
         index_buffer_ptr = update_idxs_tensor.value().is_sharded() ? update_idxs_tensor.value().buffer() : nullptr;
-        index_buffer_addr = use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
         index_data_format = tt_metal::datatype_to_dataformat_converter(update_idxs_tensor.value().dtype());
         index_is_dram = update_idxs_tensor.value().buffer()->buffer_type() == tt_metal::BufferType::DRAM;
         index_stick_size = update_idxs_tensor.value().buffer()->aligned_page_size();
@@ -130,9 +174,9 @@ PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdate
 
     uint32_t num_input_tiles = input1_shard_spec.value().shape[0] * input1_shard_spec.value().shape[1] / TILE_HW;
 
-    auto* in1_buffer_address = input1_shard_spec.has_value() ? input_tensor1.buffer() : nullptr;
+    auto* in1_buffer = input1_shard_spec.has_value() ? input_tensor1.buffer() : nullptr;
 
-    auto* in2_buffer_address = input2_shard_spec.has_value() ? input_tensor2.buffer() : nullptr;
+    auto* in2_buffer = input2_shard_spec.has_value() ? input_tensor2.buffer() : nullptr;
 
     uint32_t num_cache_tiles = 2 * Wt;   // double buffered
     uint32_t num_interm_tiles = 2 * Wt;  // double buffered
@@ -148,55 +192,103 @@ PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdate
     const tt::CBIndex intermed2_cb_index = CBIndex::c_26;
     const tt::CBIndex output_cb_index = CBIndex::c_16;
 
-    create_cb(cache_cb_index, program, all_cores_bb, cache_single_tile_size, num_cache_tiles, cache_cb_data_format);
-    auto [_1, cb_src1] = create_cb(
-        src1_cb_index,
-        program,
-        input1_cores,
-        input_single_tile_size,
-        num_input_tiles,
-        input_cb_data_format,
-        in1_buffer_address);
-    auto [_2, cb_src3] = create_cb(
-        src2_cb_index,
-        program,
-        input2_cores,
-        input_single_tile_size,
-        num_input_tiles,
-        input_cb_data_format,
-        in2_buffer_address);
-    create_cb(
-        {intermed0_cb_index, intermed1_cb_index},
-        program,
-        all_cores_bb,
-        interm_single_tile_size,
-        num_interm_tiles,
-        interm_cb_data_format);
-    create_cb(
-        intermed2_cb_index, program, all_cores_bb, interm_single_tile_size, num_interm_tiles, interm_cb_data_format);
-    create_cb(output_cb_index, program, all_cores_bb, cache_single_tile_size, num_output_tiles, cache_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cache_tiles * cache_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cache_cb_index),
+            .data_format = cache_cb_data_format,
+            .page_size = cache_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = input1_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in1_buffer,
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = input2_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src2_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in2_buffer,
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * interm_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{
+            CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(intermed0_cb_index),
+                .data_format = interm_cb_data_format,
+                .page_size = interm_single_tile_size,
+            },
+            CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(intermed1_cb_index),
+                .data_format = interm_cb_data_format,
+                .page_size = interm_single_tile_size,
+            },
+        }},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * interm_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(intermed2_cb_index),
+            .data_format = interm_cb_data_format,
+            .page_size = interm_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * cache_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = cache_cb_data_format,
+            .page_size = cache_single_tile_size,
+        }}},
+    });
 
-    auto in0_sequential_mode_semaphore_id = tt_metal::CreateSemaphore(
-        program, all_cores_bb, 0);  // used for share cache for signaling when the cache is ready to be read
+    // used for share cache for signaling when the cache is ready to be read
+    const uint32_t in0_sequential_mode_semaphore_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = in0_sequential_mode_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_cores_bb,
+        .initial_value = 0,
+    });
 
-    CBHandle cb_cur_pos_id = 0;
     if (use_index_tensor) {
-        auto [_3, cb_src5] =
-            create_cb(cb_index_id, program, all_cores_bb, index_stick_size, 1, index_data_format, index_buffer_ptr);
-        cb_cur_pos_id = cb_src5;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = index_stick_size,
+            .core_ranges = all_cores_bb,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_index_id),
+                .data_format = index_data_format,
+                .page_size = index_stick_size,
+            }}},
+            .buffer = index_buffer_ptr,
+        });
     }
 
-    CBHandle cb_page_table_id = 0;
     if (is_paged_cache) {
-        auto [_4, cb_src7] = create_cb(
-            cb_pagetable_id,
-            program,
-            all_cores_bb,
-            page_table_stick_size,
-            num_pages_page_table,
-            page_table_data_format,
-            page_table_buffer_ptr);
-        cb_page_table_id = cb_src7;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_pages_page_table * page_table_stick_size,
+            .core_ranges = all_cores_bb,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_pagetable_id),
+                .data_format = page_table_data_format,
+                .page_size = page_table_stick_size,
+            }}},
+            .buffer = page_table_buffer_ptr,
+        });
     }
 
     auto* dst1_buffer = cache_tensor1.buffer();
@@ -271,27 +363,33 @@ PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdate
     };
 
     // Create reader kernel
-    auto unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/"
-        "reader_paged_fused_update_cache_interleaved_start_id.cpp",
-        all_cores_bb,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_paged_fused_update_cache_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_bb;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Create writer kernel
-    auto unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/"
-        "writer_paged_fused_update_cache_interleaved_start_id.cpp",
-        all_cores_bb,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "writer_paged_fused_update_cache_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores_bb;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // Create compute kernel
-    auto compute_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp",
-        all_cores_bb,
-        tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores_bb;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
 
     constexpr bool has_work = true;
     constexpr bool is_input1 = true;
@@ -299,16 +397,20 @@ PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdate
     const auto& cores1 = corerange_to_cores(input1_cores, input1_cores.num_cores(), row_major);
     const auto& cores2 = corerange_to_cores(input2_cores, input2_cores.num_cores(), row_major);
 
+    Buffer* const index_buffer_for_rt = use_index_tensor ? update_idxs_tensor.value().buffer() : nullptr;
+    Buffer* const page_table_buffer_for_rt = is_paged_cache ? page_table.value().buffer() : nullptr;
+
+    // cache_start_id / tile_update_offset_B are derived from update_idxs (excluded from the program hash)
+    // — computed via the shared helper so get_dynamic_runtime_args re-patches identical values on cache
+    // hits. Empty in index-tensor mode (offsets read on-device from the re-patched index tensor).
+    const auto offsets = compute_tiled_fused_offsets(operation_attributes, tensor_args);
     for (uint32_t i = 0; i < cores1.size(); ++i) {
         const CoreCoord& core1 = cores1.at(i);
         const CoreCoord& core2 = cores2.at(i);
 
-        const uint32_t update_idx = use_index_tensor ? 0 : operation_attributes.update_idxs.at(i);
-
         // Cache tile info
-        const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
-        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * Wt);
-        uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+        const uint32_t cache_start_id = use_index_tensor ? 0u : offsets.at(i).cache_start_id;
+        const uint32_t tile_update_offset_B = use_index_tensor ? 0u : offsets.at(i).tile_update_offset_B;
 
         // Calculate synchronization parameters
         bool wait_to_start = operation_attributes.share_cache and (i != 0);
@@ -330,266 +432,124 @@ PagedTiledFusedUpdateCacheProgramFactory::cached_program_t PagedTiledFusedUpdate
 
         // Input1 args
         // Set runtime args for reader
-        SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core1,
-            {
-                has_work,
-                is_input1,
-                dst1_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                index_buffer_addr,
-                i,
-                is_paged_cache ? page_table.value().buffer()->address() : 0,
-                wait_to_start,
-            });
+        {
+            KernelDescriptor::RTArgList rargs;
+            rargs.push_back(static_cast<uint32_t>(has_work));
+            rargs.push_back(static_cast<uint32_t>(is_input1));
+            rargs.push_back(dst1_buffer);
+            rargs.push_back(use_index_tensor ? 0u : cache_start_id);
+            if (use_index_tensor) {
+                rargs.push_back(index_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(i);
+            if (is_paged_cache) {
+                rargs.push_back(page_table_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(static_cast<uint32_t>(wait_to_start));
+            reader_desc.emplace_runtime_args(core1, rargs);
+        }
 
         // Set runtime args for writer
-        SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core1,
             {
-                has_work,
-                dst1_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                use_index_tensor ? 0 : tile_update_offset_B,
+                static_cast<uint32_t>(has_work),
+                dst1_buffer,
+                use_index_tensor ? 0u : cache_start_id,
+                use_index_tensor ? 0u : tile_update_offset_B,
                 i,
-                send_signal,
+                static_cast<uint32_t>(send_signal),
                 send_core1_x,
                 send_core1_y,
             });
 
         // Set runtime args for compute
-        SetRuntimeArgs(
-            program,
-            compute_kernel_id,
+        compute_desc.emplace_runtime_args(
             core1,
             {
-                has_work,
-                is_input1,
+                static_cast<uint32_t>(has_work),
+                static_cast<uint32_t>(is_input1),
             });
 
         // Input2 args
         // Set runtime args for reader
-        SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core2,
-            {
-                has_work,
-                !is_input1,
-                dst2_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                index_buffer_addr,
-                i,
-                is_paged_cache ? page_table.value().buffer()->address() : 0,
-                wait_to_start,
-            });
+        {
+            KernelDescriptor::RTArgList rargs;
+            rargs.push_back(static_cast<uint32_t>(has_work));
+            rargs.push_back(static_cast<uint32_t>(!is_input1));
+            rargs.push_back(dst2_buffer);
+            rargs.push_back(use_index_tensor ? 0u : cache_start_id);
+            if (use_index_tensor) {
+                rargs.push_back(index_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(i);
+            if (is_paged_cache) {
+                rargs.push_back(page_table_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(static_cast<uint32_t>(wait_to_start));
+            reader_desc.emplace_runtime_args(core2, rargs);
+        }
 
         // Set runtime args for writer
-        SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core2,
             {
-                has_work,
-                dst2_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                use_index_tensor ? 0 : tile_update_offset_B,
+                static_cast<uint32_t>(has_work),
+                dst2_buffer,
+                use_index_tensor ? 0u : cache_start_id,
+                use_index_tensor ? 0u : tile_update_offset_B,
                 i,
-                send_signal,
+                static_cast<uint32_t>(send_signal),
                 send_core2_x,
                 send_core2_y,
             });
 
         // Set runtime args for compute
-        SetRuntimeArgs(
-            program,
-            compute_kernel_id,
+        compute_desc.emplace_runtime_args(
             core2,
             {
-                has_work,
-                !is_input1,
+                static_cast<uint32_t>(has_work),
+                static_cast<uint32_t>(!is_input1),
             });
     }
 
     // Set runtime args for unused cores
-    SetRuntimeArgs(program, unary_reader_kernel_id, unused_cores, {!has_work});
-    SetRuntimeArgs(program, unary_writer_kernel_id, unused_cores, {!has_work});
-    SetRuntimeArgs(program, compute_kernel_id, unused_cores, {!has_work});
+    for (const auto& core_range : unused_cores.ranges()) {
+        for (const auto& core : core_range) {
+            reader_desc.emplace_runtime_args(core, {uint32_t{!has_work}});
+            writer_desc.emplace_runtime_args(core, {uint32_t{!has_work}});
+            compute_desc.emplace_runtime_args(core, {uint32_t{!has_work}});
+        }
+    }
 
-    // Store shared variables
-    shared_variables_t shared_vars{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cores1 = cores1,
-        .cores2 = cores2,
-        .Wbytes = Wbytes,
-        .Wt = Wt,
-        .cb_src1 = cb_src1,
-        .cb_src3 = cb_src3,
-        .cb_cur_pos_id = cb_cur_pos_id,
-        .cb_page_table_id = cb_page_table_id,
-        .cache_batch_num_tiles = cache_batch_num_tiles,
-        .use_index_tensor = use_index_tensor,
-        .is_paged_cache = is_paged_cache};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    return cached_program_t{std::move(program), std::move(shared_vars)};
+    return desc;
 }
 
-void PagedTiledFusedUpdateCacheProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
+ProgramDescriptor PagedTiledFusedUpdateCacheMeshWorkloadFactory::create_descriptor(
     const PagedFusedUpdateCacheParams& operation_attributes,
     const PagedFusedUpdateCacheInputs& tensor_args,
-    PagedFusedUpdateCacheResult& /*tensor_return_value*/) {
-    auto& shared_vars = cached_program.shared_variables;
-    auto& program = cached_program.program;
-
-    const auto& input_tensor1 = tensor_args.input_tensor1;
-    const auto& input_tensor2 = tensor_args.input_tensor2;
-    const auto& update_idxs_tensor = tensor_args.update_idxs_tensor;
-    const auto& page_table = tensor_args.page_table;
-
-    auto* src1_buffer = input_tensor1.buffer();
-    auto* src2_buffer = input_tensor2.buffer();
-
-    auto* dst1_buffer = tensor_args.cache_tensor1.buffer();
-    auto* dst2_buffer = tensor_args.cache_tensor2.buffer();
-
-    auto* index_tensor_buffer = shared_vars.use_index_tensor ? update_idxs_tensor.value().buffer() : nullptr;
-    auto* page_table_buffer = shared_vars.is_paged_cache ? page_table.value().buffer() : nullptr;
-    auto index_tensor_addr = shared_vars.use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
-    auto page_table_tensor_addr = shared_vars.is_paged_cache ? page_table.value().buffer()->address() : 0;
-
-    if (input_tensor1.is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_src1, *src1_buffer);
-    }
-    if (input_tensor2.is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_src3, *src2_buffer);
-    }
-    auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.unary_reader_kernel_id);
-    auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.unary_writer_kernel_id);
-
-    for (uint32_t i = 0; i < shared_vars.cores1.size(); ++i) {
-        const uint32_t update_idx = shared_vars.use_index_tensor ? 0 : operation_attributes.update_idxs.at(i);
-        // Cache tile info
-        const uint32_t cache_batch_tile_offset = i * shared_vars.cache_batch_num_tiles;
-        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * shared_vars.Wt);
-        // Offset to write into untilized cache
-        uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * shared_vars.Wbytes;
-
-        const CoreCoord& core1 = shared_vars.cores1.at(i);
-        const CoreCoord& core2 = shared_vars.cores2.at(i);
-
-        // Input1 args
-        {
-            auto& runtime_args = reader_args_by_core.at(core1.x).at(core1.y);
-            runtime_args[2] = dst1_buffer->address();
-            runtime_args[3] = cache_start_id;
-            runtime_args[4] = index_tensor_addr;
-            runtime_args[6] = page_table_tensor_addr;
-        }
-
-        {
-            auto& runtime_args = writer_args_by_core.at(core1.x).at(core1.y);
-            runtime_args[1] = dst1_buffer->address();
-            runtime_args[2] = cache_start_id;
-            runtime_args[3] = tile_update_offset_B;
-        }
-
-        // Input2 args
-        {
-            auto& runtime_args = reader_args_by_core.at(core2.x).at(core2.y);
-            runtime_args[2] = dst2_buffer->address();
-            runtime_args[3] = cache_start_id;
-            runtime_args[4] = index_tensor_addr;
-            runtime_args[6] = page_table_tensor_addr;
-        }
-
-        {
-            auto& runtime_args = writer_args_by_core.at(core2.x).at(core2.y);
-            runtime_args[1] = dst2_buffer->address();
-            runtime_args[2] = cache_start_id;
-            runtime_args[3] = tile_update_offset_B;
+    PagedFusedUpdateCacheResult& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value()) {
+        const auto& mesh_coords_set = operation_attributes.mesh_coords.value();
+        if (!mesh_coords_set.contains(mesh_dispatch_coordinate.value())) {
+            return ProgramDescriptor{};
         }
     }
-    if (shared_vars.use_index_tensor and update_idxs_tensor.has_value() and update_idxs_tensor.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_cur_pos_id, *index_tensor_buffer);
-    }
-    if (shared_vars.is_paged_cache and page_table.has_value() and page_table.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_page_table_id, *page_table_buffer);
-    }
-}
-
-PagedTiledFusedUpdateCacheMeshWorkloadFactory::cached_mesh_workload_t
-PagedTiledFusedUpdateCacheMeshWorkloadFactory::create_mesh_workload(
-    const PagedFusedUpdateCacheParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const PagedFusedUpdateCacheInputs& tensor_args,
-    PagedFusedUpdateCacheResult& tensor_return_value) {
-    log_debug(tt::LogOp, "PagedTiledFusedUpdateCacheMeshWorkloadFactory::create_mesh_workload called");
-    log_debug(tt::LogOp, "tensor_coords has {} ranges", tensor_coords.ranges().size());
-
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    // Filter coordinates based on mesh_coords if provided
-    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords_opt = operation_attributes.mesh_coords;
-
-    if (mesh_coords_opt.has_value()) {
-        log_debug(tt::LogOp, "mesh_coords provided with {} coordinates", mesh_coords_opt.value().size());
-    } else {
-        log_debug(tt::LogOp, "mesh_coords not provided, using all tensor_coords");
-    }
-
-    // Create programs for each coordinate in tensor_coords (filtered by mesh_coords if provided)
-    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-        for (const auto& mesh_coord : mesh_coord_range) {
-            // Skip this coordinate if mesh_coords is provided and this coordinate is not in the set
-            if (mesh_coords_opt.has_value()) {
-                const auto& mesh_coords_set = mesh_coords_opt.value();
-                if (!mesh_coords_set.contains(mesh_coord)) {
-                    log_debug(
-                        tt::LogOp, "Skipping coordinate ({}, {}) - not in mesh_coords", mesh_coord[0], mesh_coord[1]);
-                    continue;  // Skip this coordinate
-                }
-            }
-
-            // Create a program for this specific coordinate using the base factory
-            log_debug(tt::LogOp, "Creating program for coordinate ({}, {})", mesh_coord[0], mesh_coord[1]);
-            const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-            auto cached_program = PagedTiledFusedUpdateCacheProgramFactory::create(
-                operation_attributes, tensor_args, tensor_return_value);
-            shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-            mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-        }
-    }
-
-    log_debug(tt::LogOp, "Created mesh workload with {} programs", mesh_workload.get_programs().size());
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
-}
-
-void PagedTiledFusedUpdateCacheMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const PagedFusedUpdateCacheParams& operation_attributes,
-    const PagedFusedUpdateCacheInputs& tensor_args,
-    PagedFusedUpdateCacheResult& tensor_return_value) {
-    PagedTiledFusedUpdateCacheProgramFactory program_factory;
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
-
-        ttnn::device_operation::mesh_device_operation_utils::apply_override_runtime_arguments(
-            program_factory,
-            program,
-            shared_variables,
-            operation_attributes,
-            *(coordinate_range.begin()),
-            tensor_args,
-            tensor_return_value);
-    }
+    return PagedTiledFusedUpdateCacheProgramFactory::create_descriptor(
+        operation_attributes, tensor_args, tensor_return_value);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_tiled_fused_update_cache_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_tiled_fused_update_cache_program_factory.hpp
@@ -5,59 +5,48 @@
 #pragma once
 
 #include "paged_fused_update_cache_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include <cstdint>
+#include <optional>
 #include <vector>
-#include <tt-metalium/host_api.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct PagedTiledFusedUpdateCacheSharedVariables {
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = 0;
-    std::vector<tt::tt_metal::CoreCoord> cores1;
-    std::vector<tt::tt_metal::CoreCoord> cores2;
-    uint32_t Wbytes = 0;
-    uint32_t Wt = 0;
-    tt::tt_metal::CBHandle cb_src1 = 0;
-    tt::tt_metal::CBHandle cb_src3 = 0;
-    tt::tt_metal::CBHandle cb_cur_pos_id = 0;
-    tt::tt_metal::CBHandle cb_page_table_id = 0;
-    uint32_t cache_batch_num_tiles = 0;
-    bool use_index_tensor = false;
-    bool is_paged_cache = false;
-};
-
 struct PagedTiledFusedUpdateCacheProgramFactory {
-    using shared_variables_t = PagedTiledFusedUpdateCacheSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    // Per-index cache-write offsets derived from update_idxs. One entry per index i over cores1.size();
+    // each handles input1 on core1 and input2 on core2, both sharing the same offsets.
+    struct PerIndexOffsets {
+        tt::tt_metal::CoreCoord core1;
+        tt::tt_metal::CoreCoord core2;
+        uint32_t cache_start_id = 0;
+        uint32_t tile_update_offset_B = 0;
+    };
 
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedFusedUpdateCacheParams& operation_attributes,
         const PagedFusedUpdateCacheInputs& tensor_args,
         PagedFusedUpdateCacheResult& tensor_return_value);
 
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PagedFusedUpdateCacheParams& operation_attributes,
-        const PagedFusedUpdateCacheInputs& tensor_args,
-        PagedFusedUpdateCacheResult& tensor_return_value);
+    // Single source of truth for the cache_start_id / tile_update_offset_B formulas (shared by
+    // create_descriptor on a cache miss and get_dynamic_runtime_args on a cache hit). Returns empty in
+    // index-tensor mode (positions read on-device).
+    static std::vector<PerIndexOffsets> compute_tiled_fused_offsets(
+        const PagedFusedUpdateCacheParams& operation_attributes, const PagedFusedUpdateCacheInputs& tensor_args);
 };
 
 struct PagedTiledFusedUpdateCacheMeshWorkloadFactory {
-    using shared_variables_t = PagedTiledFusedUpdateCacheSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const PagedFusedUpdateCacheParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const PagedFusedUpdateCacheInputs& tensor_args,
-        PagedFusedUpdateCacheResult& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Per-coord program build.  Coordinates outside operation_attributes.mesh_coords
+    // (when provided) get an empty program — the legacy mesh path skipped them
+    // entirely; with the descriptor framework we still must hand back a descriptor
+    // for every dispatched coord, so we return an empty one for excluded coords.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedFusedUpdateCacheParams& operation_attributes,
         const PagedFusedUpdateCacheInputs& tensor_args,
-        PagedFusedUpdateCacheResult& tensor_return_value);
+        PagedFusedUpdateCacheResult& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "paged_update_cache_device_operation.hpp"
 #include "paged_update_cache_device_operation_types.hpp"
 #include "paged_update_cache_program_factory.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include <tt-metalium/constants.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
@@ -6,10 +6,15 @@
 
 #include <optional>
 #include <variant>
+#include <vector>
+
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "paged_update_cache_device_operation_types.hpp"
 #include "paged_update_cache_program_factory.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::experimental::prim {
 
@@ -34,6 +39,16 @@ struct PagedUpdateCacheDeviceOperation {
 
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
+
+    // update_idxs is excluded from the program hash (so decode steps that differ only in position
+    // cache-hit). The cache-write offsets it determines (cache_start_id, tile_update_offset_B) are
+    // DYNAMIC and re-applied to the cached program on every dispatch. Returns empty in index-tensor
+    // mode (positions read on-device) and for coords excluded from a mesh dispatch.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "paged_update_cache_device_operation_types.hpp"
-#include <tt-metalium/work_split.hpp>
 #include "paged_update_cache_program_factory.hpp"
+
+#include "paged_update_cache_device_operation.hpp"
+#include "paged_update_cache_device_operation_types.hpp"
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/mesh_device_operation_utils.hpp"
-#include <unordered_map>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::tt_metal;
 
@@ -19,19 +20,71 @@ namespace ttnn::experimental::prim {
 using namespace tt::constants;
 using namespace tt;
 
-static bool enable_fp32_dest(
-    const tt_metal::IDevice* device, const ttnn::DeviceComputeKernelConfig& compute_kernel_config) {
+namespace {
+
+bool enable_fp32_dest(const tt_metal::IDevice* device, const ttnn::DeviceComputeKernelConfig& compute_kernel_config) {
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     return fp32_dest_acc_en;
 }
 
-PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory::create(
+// Per-worker-core cache-write offsets derived from `update_idxs`. These values are excluded from the
+// program hash (PagedUpdateCacheDeviceOperation::compute_program_hash) yet baked into runtime args, so
+// they must be re-patched on every cache hit via get_dynamic_runtime_args. This helper is the single
+// source of truth for the formulas — both create_descriptor (cache miss) and get_dynamic_runtime_args
+// (cache hit) call it, so the two paths cannot drift. Returns empty when an index tensor is used: in
+// that mode the offsets are 0 here and the real positions are read on-device from the (Buffer-bound,
+// re-patched) index tensor.
+struct UpdateCachePerCoreOffsets {
+    tt_metal::CoreCoord core;
+    uint32_t cache_start_id = 0;
+    uint32_t tile_update_offset_B = 0;
+};
+
+std::vector<UpdateCachePerCoreOffsets> compute_update_cache_offsets(
+    const PagedUpdateCacheParams& operation_attributes, const PagedUpdateCacheInputs& tensor_args) {
+    if (tensor_args.update_idxs_tensor.has_value()) {
+        return {};
+    }
+
+    const auto& cache_tensor = tensor_args.cache_tensor;
+    const auto& input_tensor = tensor_args.input_tensor;
+    const bool fp32_dest_acc_en = enable_fp32_dest(input_tensor.device(), operation_attributes.compute_kernel_config);
+
+    const uint32_t Wt = input_tensor.padded_shape()[-1] / TILE_WIDTH;
+    const uint32_t Wbytes = fp32_dest_acc_en ? input_tensor.padded_shape()[-1] * sizeof(float)
+                                             : input_tensor.padded_shape()[-1] * 2;  // 2 bytes for bfloat16
+    const uint32_t cache_total_num_tiles = cache_tensor.physical_volume() / TILE_HW;
+    // share_cache => batch offset is 0 (one shared cache buffer); mirror create_descriptor exactly.
+    const uint32_t cache_batch_num_tiles =
+        operation_attributes.share_cache ? 0 : cache_total_num_tiles / cache_tensor.padded_shape()[0];
+
+    const std::optional<ShardSpec>& shard_spec = input_tensor.shard_spec();
+    const bool row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+    const CoreRangeSet all_cores = shard_spec.value().grid;
+    const uint32_t num_cores = all_cores.num_cores();
+    const auto& cores = corerange_to_cores(all_cores, num_cores, row_major);
+
+    std::vector<UpdateCachePerCoreOffsets> offsets;
+    offsets.reserve(cores.size());
+    for (uint32_t i = 0; i < cores.size(); ++i) {
+        const uint32_t update_idx = operation_attributes.update_idxs.at(i);
+        const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
+        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * Wt);
+        const uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+        offsets.push_back({cores.at(i), cache_start_id, tile_update_offset_B});
+    }
+    return offsets;
+}
+
+}  // namespace
+
+ProgramDescriptor PagedUpdateCacheProgramFactory::create_descriptor(
     const PagedUpdateCacheParams& operation_attributes,
     const PagedUpdateCacheInputs& tensor_args,
     Tensor& /*tensor_return_value*/) {
-    Program program{};
+    ProgramDescriptor desc;
 
     const auto& cache_tensor = tensor_args.cache_tensor;
     const auto& input_tensor = tensor_args.input_tensor;
@@ -54,12 +107,10 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
     // Index tensor-specific parameters
     bool use_index_tensor = update_idxs_tensor.has_value();
     uint32_t index_tensor_tile_size = 0;
-    uint32_t index_buffer_addr = 0;
     uint32_t log2_page_size = 0;
     uint32_t index_stick_size = 0;
     tt::DataFormat index_data_format = tt::DataFormat::Int32;
     if (use_index_tensor) {
-        index_buffer_addr = update_idxs_tensor.value().buffer()->address();
         index_data_format = tt_metal::datatype_to_dataformat_converter(update_idxs_tensor.value().dtype());
         index_tensor_tile_size = tt::tile_size(index_data_format);
         index_stick_size = update_idxs_tensor.value().buffer()->aligned_page_size();
@@ -115,7 +166,7 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
     CoreRangeSet all_cores = shard_spec.value().grid;
     uint32_t num_cores = all_cores.num_cores();
     uint32_t num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
-    auto* in1_buffer_address = shard_spec.has_value() ? input_tensor.buffer() : nullptr;
+    auto* in1_buffer = shard_spec.has_value() ? input_tensor.buffer() : nullptr;
 
     uint32_t num_cache_tiles = 2 * Wt;   // double buffered
     uint32_t num_interm_tiles = 2 * Wt;  // double buffered
@@ -130,34 +181,91 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
     const tt::CBIndex intermed2_cb_index = CBIndex::c_26;
     const tt::CBIndex output_cb_index = CBIndex::c_16;
 
-    create_cb(src0_cb_index, program, all_cores, cache_single_tile_size, num_cache_tiles, cache_cb_data_format);
-    auto [_, cb_src1] = create_cb(
-        src1_cb_index,
-        program,
-        all_cores,
-        input_single_tile_size,
-        num_input_tiles,
-        input_cb_data_format,
-        in1_buffer_address);
-    create_cb(
-        {intermed0_cb_index, intermed1_cb_index},
-        program,
-        all_cores,
-        interm_single_tile_size,
-        num_interm_tiles,
-        interm_cb_data_format);
-    create_cb(intermed2_cb_index, program, all_cores, interm_single_tile_size, num_interm_tiles, interm_cb_data_format);
-    create_cb(output_cb_index, program, all_cores, cache_single_tile_size, num_output_tiles, cache_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cache_tiles * cache_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cache_cb_data_format,
+            .page_size = cache_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in1_buffer,
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * interm_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{
+            CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(intermed0_cb_index),
+                .data_format = interm_cb_data_format,
+                .page_size = interm_single_tile_size,
+            },
+            CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(intermed1_cb_index),
+                .data_format = interm_cb_data_format,
+                .page_size = interm_single_tile_size,
+            },
+        }},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * interm_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(intermed2_cb_index),
+            .data_format = interm_cb_data_format,
+            .page_size = interm_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * cache_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = cache_cb_data_format,
+            .page_size = cache_single_tile_size,
+        }}},
+    });
 
-    auto in0_sequential_mode_semaphore_id = tt_metal::CreateSemaphore(
-        program, all_cores, 0);  // used for share cache for signaling when the cache is ready to be read
+    // used for share cache for signaling when the cache is ready to be read
+    const uint32_t in0_sequential_mode_semaphore_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = in0_sequential_mode_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_cores,
+        .initial_value = 0,
+    });
 
     if (use_index_tensor) {
-        create_cb(cb_index_id, program, all_cores, index_tensor_tile_size, 1, index_data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = index_tensor_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_index_id),
+                .data_format = index_data_format,
+                .page_size = index_tensor_tile_size,
+            }}},
+        });
     }
 
     if (is_paged_cache) {
-        create_cb(cb_pagetable_id, program, all_cores, page_table_stick_size, 1, page_table_data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = page_table_stick_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_pagetable_id),
+                .data_format = page_table_data_format,
+                .page_size = page_table_stick_size,
+            }}},
+        });
     }
 
     auto* dst_buffer = cache_tensor.buffer();
@@ -230,35 +338,44 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
         num_heads,
     };
 
-    auto unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/"
-        "reader_update_cache_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_update_cache_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    auto unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/"
-        "writer_update_cache_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "writer_update_cache_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+
+    Buffer* const index_buffer_for_rt = use_index_tensor ? update_idxs_tensor.value().buffer() : nullptr;
+    Buffer* const page_table_buffer_for_rt = is_paged_cache ? page_table.value().buffer() : nullptr;
 
     const auto& cores = corerange_to_cores(all_cores, num_cores, row_major);
+    // cache_start_id / tile_update_offset_B are derived from update_idxs (excluded from the program
+    // hash) — computed via the shared helper so get_dynamic_runtime_args re-patches identical values on
+    // cache hits. Empty in index-tensor mode (offsets read on-device from the re-patched index tensor).
+    const auto offsets = compute_update_cache_offsets(operation_attributes, tensor_args);
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores.at(i);
-        const uint32_t update_idx = use_index_tensor ? 0 : operation_attributes.update_idxs.at(i);
-        // Cache tile info
-        const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
-        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * Wt);
-        // Offset to write into untilized cache
-        uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+        const uint32_t cache_start_id = use_index_tensor ? 0u : offsets.at(i).cache_start_id;
+        const uint32_t tile_update_offset_B = use_index_tensor ? 0u : offsets.at(i).tile_update_offset_B;
 
         bool wait_to_start, send_signal;
         uint32_t send_core_x, send_core_y;
@@ -277,164 +394,91 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
             send_core_y = 0;
         }
 
-        SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core,
-            {
-                dst_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                index_buffer_addr,
-                i,
-                is_paged_cache ? page_table.value().buffer()->address() : 0,
-                wait_to_start,
-            });
+        {
+            KernelDescriptor::RTArgList rargs;
+            rargs.push_back(dst_buffer);
+            rargs.push_back(use_index_tensor ? 0u : cache_start_id);
+            if (use_index_tensor) {
+                rargs.push_back(index_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(i);
+            if (is_paged_cache) {
+                rargs.push_back(page_table_buffer_for_rt);
+            } else {
+                rargs.push_back(uint32_t{0});
+            }
+            rargs.push_back(static_cast<uint32_t>(wait_to_start));
+            reader_desc.emplace_runtime_args(core, rargs);
+        }
 
-        SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core,
             {
-                dst_buffer->address(),
-                use_index_tensor ? 0 : cache_start_id,
-                use_index_tensor ? 0 : tile_update_offset_B,
+                dst_buffer,
+                use_index_tensor ? 0u : cache_start_id,
+                use_index_tensor ? 0u : tile_update_offset_B,
                 i,
-                send_signal,
+                static_cast<uint32_t>(send_signal),
                 send_core_x,
                 send_core_y,
             });
     }
 
-    // Store shared variables
-    shared_variables_t shared_variables{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cores = cores,
-        .Wbytes = Wbytes,
-        .Wt = Wt,
-        .cb_src1 = cb_src1,
-        .cache_batch_num_tiles = cache_batch_num_tiles,
-        .use_index_tensor = use_index_tensor,
-        .is_paged_cache = is_paged_cache};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    return cached_program_t(std::move(program), std::move(shared_variables));
+    return desc;
 }
 
-PagedUpdateCacheMeshWorkloadFactory::cached_mesh_workload_t PagedUpdateCacheMeshWorkloadFactory::create_mesh_workload(
+ProgramDescriptor PagedUpdateCacheMeshWorkloadFactory::create_descriptor(
     const PagedUpdateCacheParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const PagedUpdateCacheInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    log_debug(tt::LogOp, "PagedUpdateCacheMeshWorkloadFactory::create_mesh_workload called");
-    log_debug(tt::LogOp, "tensor_coords has {} ranges", tensor_coords.ranges().size());
-
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    // Filter coordinates based on mesh_coords if provided
-    const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords_opt = operation_attributes.mesh_coords;
-
-    if (mesh_coords_opt.has_value()) {
-        log_debug(tt::LogOp, "mesh_coords provided with {} coordinates", mesh_coords_opt.value().size());
-    } else {
-        log_debug(tt::LogOp, "mesh_coords not provided, using all tensor_coords");
-    }
-
-    // Create programs for each coordinate in tensor_coords (filtered by mesh_coords if provided)
-    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-        for (const auto& mesh_coord : mesh_coord_range) {
-            // Skip this coordinate if mesh_coords is provided and this coordinate is not in the set
-            if (mesh_coords_opt.has_value()) {
-                const auto& mesh_coords_set = mesh_coords_opt.value();
-                if (!mesh_coords_set.contains(mesh_coord)) {
-                    log_debug(
-                        tt::LogOp, "Skipping coordinate ({}, {}) - not in mesh_coords", mesh_coord[0], mesh_coord[1]);
-                    continue;  // Skip this coordinate
-                }
-            }
-
-            // Create a program for this specific coordinate using the base factory
-            log_debug(tt::LogOp, "Creating program for coordinate ({}, {})", mesh_coord[0], mesh_coord[1]);
-            const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-            auto cached_program =
-                PagedUpdateCacheProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
-            shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-            mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
+    Tensor& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value()) {
+        const auto& mesh_coords_set = operation_attributes.mesh_coords.value();
+        if (!mesh_coords_set.contains(mesh_dispatch_coordinate.value())) {
+            return ProgramDescriptor{};
         }
     }
-
-    log_debug(tt::LogOp, "Created mesh workload with {} programs", mesh_workload.get_programs().size());
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+    return PagedUpdateCacheProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
 }
 
-void PagedUpdateCacheProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PagedUpdateCacheParams& operation_attributes,
-    const PagedUpdateCacheInputs& tensor_args,
-    Tensor& /*tensor_return_value*/) {
-    auto& program = cached_program.program;
-    const auto& shared_vars = cached_program.shared_variables;
-
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = tensor_args.cache_tensor.buffer();
-
-    auto index_tensor_addr =
-        shared_vars.use_index_tensor ? tensor_args.update_idxs_tensor.value().buffer()->address() : 0;
-    auto page_table_tensor_addr = shared_vars.is_paged_cache ? tensor_args.page_table.value().buffer()->address() : 0;
-
-    if (tensor_args.input_tensor.is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_src1, *src_buffer);
+std::vector<tt::tt_metal::DynamicRuntimeArg> PagedUpdateCacheDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    // Coords excluded from a mesh dispatch get an empty ProgramDescriptor (see the mesh factory) — no
+    // kernels, nothing to patch.
+    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value() &&
+        !operation_attributes.mesh_coords.value().contains(mesh_dispatch_coordinate.value())) {
+        return {};
     }
 
-    auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.unary_reader_kernel_id);
-    auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.unary_writer_kernel_id);
-
-    for (uint32_t i = 0; i < shared_vars.cores.size(); ++i) {
-        const uint32_t update_idx = shared_vars.use_index_tensor ? 0 : operation_attributes.update_idxs.at(i);
-        // Cache tile info
-        const uint32_t cache_batch_tile_offset = i * shared_vars.cache_batch_num_tiles;
-        const uint32_t cache_start_id = cache_batch_tile_offset + ((update_idx / TILE_HEIGHT) * shared_vars.Wt);
-        // Offset to write into untilized cache
-        uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * shared_vars.Wbytes;
-
-        const CoreCoord& core = shared_vars.cores.at(i);
-
-        {
-            auto& runtime_args = reader_args_by_core.at(core.x).at(core.y);
-            runtime_args[0] = dst_buffer->address();
-            runtime_args[1] = cache_start_id;
-            runtime_args[2] = index_tensor_addr;
-            runtime_args[4] = page_table_tensor_addr;
-        }
-
-        {
-            auto& runtime_args = writer_args_by_core.at(core.x).at(core.y);
-            runtime_args[0] = dst_buffer->address();
-            runtime_args[1] = cache_start_id;
-            runtime_args[2] = tile_update_offset_B;
-        }
+    // Index-tensor mode bakes no per-call offsets (positions are read on-device from the re-patched
+    // index tensor), so there is nothing dynamic to re-apply.
+    const auto offsets = compute_update_cache_offsets(operation_attributes, tensor_args);
+    if (offsets.empty()) {
+        return {};
     }
-}
 
-void PagedUpdateCacheMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const PagedUpdateCacheParams& operation_attributes,
-    const PagedUpdateCacheInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    PagedUpdateCacheProgramFactory program_factory;
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
-
-        ttnn::device_operation::mesh_device_operation_utils::apply_override_runtime_arguments(
-            program_factory,
-            program,
-            shared_variables,
-            operation_attributes,
-            *(coordinate_range.begin()),
-            tensor_args,
-            tensor_return_value);
+    // Kernel push order in create_descriptor: reader(0), writer(1), compute(2).
+    // Reader rt args:  [0]=dst, [1]=cache_start_id, ...
+    // Writer rt args:  [0]=dst, [1]=cache_start_id, [2]=tile_update_offset_B, ...
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(offsets.size() * 3);
+    for (const auto& off : offsets) {
+        dynamic_args.push_back({kReaderKernelIdx, off.core, /*arg_idx=*/1, off.cache_start_id});
+        dynamic_args.push_back({kWriterKernelIdx, off.core, /*arg_idx=*/1, off.cache_start_id});
+        dynamic_args.push_back({kWriterKernelIdx, off.core, /*arg_idx=*/2, off.tile_update_offset_B});
     }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.hpp
@@ -5,54 +5,27 @@
 #pragma once
 
 #include "paged_update_cache_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
-#include <vector>
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include <optional>
 
 namespace ttnn::experimental::prim {
 
-struct PagedUpdateCacheSharedVariables {
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = 0;
-    std::vector<tt::tt_metal::CoreCoord> cores;
-    uint32_t Wbytes = 0;
-    uint32_t Wt = 0;
-    tt::tt_metal::CBHandle cb_src1 = 0;
-    uint32_t cache_batch_num_tiles = 0;
-    bool use_index_tensor = false;
-    bool is_paged_cache = false;
-};
-
 struct PagedUpdateCacheProgramFactory {
-    using shared_variables_t = PagedUpdateCacheSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const PagedUpdateCacheParams& operation_attributes,
-        const PagedUpdateCacheInputs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedUpdateCacheParams& operation_attributes,
         const PagedUpdateCacheInputs& tensor_args,
         Tensor& tensor_return_value);
 };
 
 struct PagedUpdateCacheMeshWorkloadFactory {
-    using shared_variables_t = PagedUpdateCacheSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const PagedUpdateCacheParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const PagedUpdateCacheInputs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Per-coord program build.  See PagedRowMajorFusedUpdateCacheMeshWorkloadFactory.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PagedUpdateCacheParams& operation_attributes,
         const PagedUpdateCacheInputs& tensor_args,
-        Tensor& tensor_return_value);
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
## Summary
Migrates **fill_cache**, **fused_update_cache** (tiled + row-major), and **update_cache** to the descriptor framework.

Each sub-op's `compute_program_hash` deliberately excludes per-call scalars that are baked into runtime args:
- update_cache / fused_update_cache (non-index-tensor mode): `update_idxs` → `cache_start_id`, `tile_update_offset_B`
- fill_cache (scalar-fallback mode): `batch_idx_fallback`

On the BufferBinding **fast cache-hit path** those args would **freeze at the first cache-miss value** — a silent wrong KV-cache whenever a decode step reuses a cached program at a new position. Each device operation now implements **`get_dynamic_runtime_args`** to re-patch them on every dispatch. A shared per-core helper single-sources the offset formulas between `create_descriptor` (miss) and `get_dynamic_runtime_args` (hit) so the two paths cannot drift.

- Index-tensor mode emits nothing (positions read on-device from the re-patched index tensor).
- Mesh-excluded coords emit nothing (empty program).
- `noop` is left alone: it is determined by the hashed `mesh_coords`, so it is stable across cache hits.
- Paged fused-update validates that positions arrive via an index tensor, so the frozen-attr bug only affects the non-paged path there.

Part of #42193, #42382.

## Status: rebased onto main (#45762 merged)
The `DynamicRuntimeArg` mechanism this fix relies on landed on main via #45762. This branch has been rebased onto main and now contains **only the paged_cache files** (#45762's commits dropped out). Standalone and ready for review.

## Validation
- New regression tests pin **both halves** (a differing position must NOT add a cache entry **and** must change the output):
  - `test_update_cache_decode_attr_idxs_program_cache` (update_cache, non-index-tensor path)
  - `test_paged_fused_update_cache_decode_attr_idxs_program_caching` (non-paged fused)
- Existing tensor-path tests green: `test_paged_fused_update_cache` **84 passed**, `test_paged_cache_flexible_geometry` **20 passed** (the latter already exercises fill_cache's varying-`batch_idx` cache-hit path).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-paged-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-paged-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-paged-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-paged-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-paged-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-paged-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-paged-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-paged-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-paged-cache)
