### PR TITLE
Migrate ccl/all_broadcast to ProgramDescriptor (POC for workload-level prepare_resources)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -15,46 +15,19 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <algorithm>
 
 namespace ttnn::prim {
 
-AllBroadcastProgramFactory::cached_mesh_workload_t AllBroadcastProgramFactory::create_mesh_workload(
-    const AllBroadcastParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const Tensor& input,
-    std::vector<Tensor>& output_tensors) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+namespace {
 
-    auto* mesh_device = input.device();
-    auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
-
-    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
-                                                                            : tt::tt_metal::BufferType::L1;
-    auto init_barrier_semaphore =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
-    auto final_barrier_semaphore =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
-    log_debug(tt::LogOp, "Semaphores allocated and waiting for all devices to be ready");
-    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
-    log_debug(tt::LogOp, "All devices are ready, starting program execution");
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = AllBroadcastProgramFactory::create_at(
-            operation_attributes, coord, input, output_tensors, final_barrier_semaphore, init_barrier_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-
-    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
-}
-
-AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_at(
+// Build a per-coord ProgramDescriptor.  The kernel args depend on the sender
+// coordinate (ring_index + forward/backward fabric neighbor lookups), so this
+// runs once per coord inside create_workload_descriptor().
+tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     const AllBroadcastParams& operation_attributes,
     const ttnn::MeshCoordinate& sender_device_coord,
     const Tensor& input,
@@ -62,7 +35,7 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
     const tt::tt_metal::GlobalSemaphore& semaphore,
     const tt::tt_metal::GlobalSemaphore& barrier_semaphore) {
     const auto& input_tensor = input;
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     auto* mesh_device = input_tensor.device();
 
@@ -129,9 +102,9 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
     uint32_t cb_num_pages = 3 * num_pages_per_packet;  // triple buffering
     uint32_t src0_cb_index = tt::CB::c_in0;
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
-            .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
+
+    uint32_t cb_total_size = cb_num_pages * l1_scratch_cb_page_size_bytes;
+    uint32_t cb_page_size = l1_scratch_cb_page_size_bytes;
 
     uint32_t buffer_page_size = page_size;
     uint32_t num_packets_per_page =
@@ -142,11 +115,18 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
         }
 
         uint32_t num_rows_per_packet = (max_packet_size / buffer_page_size >= 2) ? 2 : 1;
-        cb_src0_config =
-            tt::tt_metal::CircularBufferConfig(3 * buffer_page_size * num_rows_per_packet, {{src0_cb_index, df}})
-                .set_page_size(src0_cb_index, buffer_page_size);
+        cb_total_size = 3 * buffer_page_size * num_rows_per_packet;
+        cb_page_size = buffer_page_size;
     }
-    CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = cb_total_size,
+        .core_ranges = sender_worker_core_range,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = df,
+            .page_size = cb_page_size,
+        }}},
+    });
 
     // Tensor Info
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
@@ -216,20 +196,36 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(writer_compile_args);
     }
-    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        tilized ? "ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_tile_reader.cpp"
-                : "ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_rm_reader.cpp",
-        sender_worker_core_range,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args, kernel_defines));
 
-    // Writer
-    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    // Build kernel descriptors.  Push them onto desc.kernels NOW (before the
+    // per-link runtime-args loop) so we can refer to them by stable index for
+    // both emplace_runtime_args() and the fabric helper, which expects a
+    // KernelHandle that indexes into desc.kernels for the ProgramDescriptor
+    // overload.
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        tilized ? "ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_tile_reader.cpp"
+                : "ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_rm_reader.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = sender_worker_core_range;
+    reader_kernel_desc.compile_time_args = std::move(reader_compile_args);
+    reader_kernel_desc.defines = {kernel_defines.begin(), kernel_defines.end()};
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
         tilized ? "ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_tile_writer.cpp"
-                : "ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_rm_writer.cpp",
-        sender_worker_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_args, kernel_defines));
+                : "ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_rm_writer.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = sender_worker_core_range;
+    writer_kernel_desc.compile_time_args = std::move(writer_compile_args);
+    writer_kernel_desc.defines = {kernel_defines.begin(), kernel_defines.end()};
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+    desc.kernels.push_back(std::move(writer_kernel_desc));
+    tt::tt_metal::KernelHandle worker_sender_reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle worker_sender_writer_kernel_id = 1;
 
     // Kernel Runtime Args
     CoreCoord drain_sync_core;  // the first worker of each chip is the drain sync core, which contains the output ready
@@ -252,16 +248,23 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
         uint32_t remainder = input_tensor_num_pages % operation_attributes.num_links;
         uint32_t input_tile_id_start = (link * base_pages_per_worker) + std::min(link, remainder);
         uint32_t input_tile_id_end = ((link + 1) * base_pages_per_worker) + std::min(link + 1, remainder);
-        std::vector<uint32_t> reader_rt_args = {
-            input_tensor.buffer()->address(),        // tensor_address0
-            input_tile_id_start * num_width_shards,  // tile_id_start
-            input_tile_id_end * num_width_shards,    // tile_id_end
-        };
+
+        // Build reader RT args.  The first arg is the input tensor buffer
+        // address; push it as Buffer* so the framework records a BufferBinding
+        // and patches it directly on cache hit (no override_runtime_arguments).
+        tt::tt_metal::KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(input_tensor.buffer());                   // tensor_address0
+        reader_rt_args.push_back(input_tile_id_start * num_width_shards);  // tile_id_start
+        reader_rt_args.push_back(input_tile_id_end * num_width_shards);    // tile_id_end
 
         if (sharded) {
-            shard_builder::extend_sharding_run_time_args(input_tensor, reader_rt_args);
+            // shard_builder still writes raw uint32_t into a std::vector; append
+            // those onto the RTArgList builder.
+            std::vector<uint32_t> sharding_rt_args;
+            shard_builder::extend_sharding_run_time_args(input_tensor, sharding_rt_args);
+            reader_rt_args.append(sharding_rt_args);
         }
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+        desc.kernels[worker_sender_reader_kernel_id].emplace_runtime_args(core, reader_rt_args);
 
         // Set writer runtime args
         bool wait_output_semaphore = (link == 0);
@@ -269,19 +272,26 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
         uint32_t out_ready_sem_wait_value = ring_size * operation_attributes.num_links;
         uint32_t output_tile_id_start = input_tile_id_start;
         uint32_t output_tile_id_end = input_tile_id_end;
+
+        // The fabric helper appends to a plain std::vector<uint32_t>; build the
+        // writer args there first, then push them into the kernel descriptor.
+        // Index 0 is a placeholder (output buffer base address) that is replaced
+        // with a Buffer* binding before emplace_runtime_args() below.
         std::vector<uint32_t> writer_rt_args = {
-            output_tensors[ring_index].buffer()->address(),  // tensor_address0  //HERE
-            semaphore.address(),                             // out_ready_sem_bank_addr (absolute address)
-            output_tile_id_start * num_width_shards,         // tile_id_start
-            output_tile_id_end * num_width_shards,           // tile_id_end
-            wait_output_semaphore,                           // wait_output_semaphore
-            reset_global_semaphore,                          // reset_global_semaphore
-            drain_sync_core.x,                               // out_ready_sem_noc0_x
-            drain_sync_core.y,                               // out_ready_sem_noc0_y
-            out_ready_sem_wait_value,                        // out_ready_sem_wait_value
-            barrier_semaphore.address(),                     // barrier_sem
-            barrier_core.x,                                  // barrier_sem_noc0_x
-            barrier_core.y                                   // barrier_sem_noc0_y
+            output_tensors[ring_index]
+                .buffer()
+                ->address(),                          // tensor_address0 (placeholder; replaced via Buffer* below)
+            semaphore.address(),                      // out_ready_sem_bank_addr (absolute address)
+            output_tile_id_start * num_width_shards,  // tile_id_start
+            output_tile_id_end * num_width_shards,    // tile_id_end
+            wait_output_semaphore,                    // wait_output_semaphore
+            reset_global_semaphore,                   // reset_global_semaphore
+            drain_sync_core.x,                        // out_ready_sem_noc0_x
+            drain_sync_core.y,                        // out_ready_sem_noc0_y
+            out_ready_sem_wait_value,                 // out_ready_sem_wait_value
+            barrier_semaphore.address(),              // barrier_sem
+            barrier_core.x,                           // barrier_sem_noc0_x
+            barrier_core.y                            // barrier_sem_noc0_y
         };
         auto num_connections = (int)forward_coord.has_value() + (int)backward_coord.has_value();
         writer_rt_args.push_back(num_connections);
@@ -301,51 +311,73 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
             dst_nodes.push_back(backward_coord_fabric_node_id);
         }
 
+        // The fabric helper's ProgramDescriptor specialization indexes into
+        // desc.kernels via the KernelHandle to add per-kernel defines.  It also
+        // appends additional fabric connection args (and, on 2D meshes, more
+        // header words) onto writer_rt_args.
         append_routing_plane_connection_manager_rt_args(
-            sender_fabric_node_id, dst_nodes, {link}, program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+            sender_fabric_node_id, dst_nodes, {link}, desc, worker_sender_writer_kernel_id, core, writer_rt_args);
+
+        // Promote the writer RT args to the kernel descriptor.  Index 0 is the
+        // output buffer's base address — push it as Buffer* so the framework
+        // records a BufferBinding for the cache-hit fast path.  All other
+        // positions remain plain uint32_t.
+        tt::tt_metal::KernelDescriptor::RTArgList writer_rt_args_builder;
+        writer_rt_args_builder.reserve(writer_rt_args.size());
+        writer_rt_args_builder.push_back(output_tensors[ring_index].buffer());
+        for (size_t i = 1; i < writer_rt_args.size(); ++i) {
+            writer_rt_args_builder.push_back(writer_rt_args[i]);
+        }
+        desc.kernels[worker_sender_writer_kernel_id].emplace_runtime_args(core, writer_rt_args_builder);
     }
 
-    shared_variables_t shared_variables{
-        .sender_worker_cores = sender_worker_cores,
-        .worker_sender_reader_kernel_id = worker_sender_reader_kernel_id,
-        .worker_sender_writer_kernel_id = worker_sender_writer_kernel_id,
-        .semaphore = semaphore,
-        .barrier_semaphore = barrier_semaphore,
-        .ring_index = ring_index,
-    };
-
-    return {std::move(program), std::move(shared_variables)};
+    return desc;
 }
 
-void AllBroadcastProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const AllBroadcastParams& /*operation_attributes*/,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor AllBroadcastProgramFactory::create_workload_descriptor(
+    const AllBroadcastParams& operation_attributes,
     const Tensor& input,
-    std::vector<Tensor>& output_tensors) {
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        // const auto& coord = coordinate_range.start_coord();
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
+    std::vector<Tensor>& output_tensors,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-        log_trace(tt::LogOp, "DEBUG: semaphore: {}", shared_vars.semaphore.address());
-        log_trace(tt::LogOp, "DEBUG: barrier_semaphore: {}", shared_vars.barrier_semaphore.address());
-        // update senders
-        auto& worker_reader_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_reader_kernel_id);
-        auto& worker_writer_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_writer_kernel_id);
+    auto* mesh_device = input.device();
+    auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
+    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
 
-        for (const auto& core : shared_vars.sender_worker_cores) {
-            // reader
-            auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
-            worker_reader_sender_runtime_args[0] = input.buffer()->address();
-            // writer
-            auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
-            worker_writer_sender_runtime_args[0] = output_tensors[shared_vars.ring_index].buffer()->address();
-            worker_writer_sender_runtime_args[1] = shared_vars.semaphore.address();
-            worker_writer_sender_runtime_args[9] = shared_vars.barrier_semaphore.address();
-        }
+    // Allocate the two workload-scoped GlobalSemaphores.  Park them on the
+    // descriptor's `semaphores` vector so their device-side allocations stay
+    // alive for the lifetime of the cached workload — both are referenced by
+    // writer runtime args as absolute addresses.  The init barrier is stored
+    // at index 0 and the out-ready drain semaphore at index 1; subscript
+    // access below mirrors the original argument ordering at the create_at
+    // call site (semaphore = final drain, barrier_semaphore = init barrier).
+    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
+                                                                            : tt::tt_metal::BufferType::L1;
+    workload_descriptor.semaphores.push_back(
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type));
+    workload_descriptor.semaphores.push_back(
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type));
+    const auto& init_barrier_semaphore = workload_descriptor.semaphores[0];
+    const auto& final_barrier_semaphore = workload_descriptor.semaphores[1];
+    log_debug(tt::LogOp, "Semaphores allocated and waiting for all devices to be ready");
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
+    log_debug(tt::LogOp, "All devices are ready, starting program execution");
+
+    // Build a per-coord ProgramDescriptor.  Unlike pool/upsample, all_broadcast's
+    // per-coord program depends on the sender coordinate (ring_index +
+    // forward/backward fabric neighbors), so we cannot share one descriptor
+    // across the mesh — emit one entry per coord.
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = build_program_descriptor_at(
+            operation_attributes, coord, input, output_tensors, final_barrier_semaphore, init_barrier_semaphore);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.hpp
@@ -5,41 +5,34 @@
 #pragma once
 #include "ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation_types.hpp"
 
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 namespace ttnn::prim {
 struct AllBroadcastProgramFactory {
-    struct shared_variables_t {
-        std::vector<tt::tt_metal::CoreCoord> sender_worker_cores;
-        tt::tt_metal::KernelHandle worker_sender_reader_kernel_id{};
-        tt::tt_metal::KernelHandle worker_sender_writer_kernel_id{};
-        tt::tt_metal::GlobalSemaphore semaphore;
-        tt::tt_metal::GlobalSemaphore barrier_semaphore;
-        uint32_t ring_index = 0;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
+    // Declarative workload-scoped factory (Contract 2).
+    //
+    // create_workload_descriptor() runs ONCE per workload (cache miss):
+    //   1. Allocates the two GlobalSemaphores used by writer runtime args
+    //      (out-ready drain semaphore + cross-device init barrier semaphore)
+    //      and parks them on WorkloadDescriptor::semaphores so they outlive
+    //      the cached workload via the program cache.
+    //   2. Runs the distributed Synchronize barrier so every device sees the
+    //      semaphores before any program is dispatched.
+    //   3. Loops `tensor_coords` and pushes a per-coord ProgramDescriptor
+    //      into WorkloadDescriptor::programs.  Each program depends on the
+    //      sender device coordinate (ring_index + forward/backward neighbor
+    //      fabric nodes), so we build one descriptor per coord rather than
+    //      sharing one across the mesh.
+    //
+    // Buffer base addresses are bound via emplace_runtime_args() so the
+    // framework patches them through the fast cache-hit path; no manual
+    // override_runtime_arguments() hook is required.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const AllBroadcastParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const Tensor& input,
-        std::vector<Tensor>& output_tensors);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
-        const AllBroadcastParams& operation_attributes,
-        const Tensor& input,
-        std::vector<Tensor>& output_tensors);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const AllBroadcastParams& operation_attributes,
-        const ttnn::MeshCoordinate& coord,
         const Tensor& input,
         std::vector<Tensor>& output_tensors,
-        const tt::tt_metal::GlobalSemaphore& semaphore,
-        const tt::tt_metal::GlobalSemaphore& barrier_semaphore);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
POC consumer for the workload-level `prepare_resources` hook in PR #44397. `all_broadcast` allocates 2 `GlobalSemaphore`s and calls `Synchronize` in `prepare_resources`; `create_descriptor` builds the per-coord program using `mesh_dispatch_coordinate` for ring index / neighbor lookups.

Depends on: #44397 (Hoist prepare_resources to workload-level)

Contributes to #42193, #42209.

## Performance

all_broadcast is a multi-device CCL op; single-device bench is not meaningful. Per-op host dispatch perf delta from main: pending CI/multi-device runner.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-ccl-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-ccl-all-broadcast)
