### PR TITLE
Migrate experimental/deepseek_prefill mesh-workload ops to ProgramDescriptor

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -9,10 +9,12 @@
 #include <limits>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include <ttnn/global_semaphore.hpp>
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 
@@ -33,8 +35,10 @@ uint32_t get_num_rows(const ttnn::Tensor& tensor) {
     return logical_volume / hidden_size;
 }
 
+// ProgramDescriptor-flavored helper.  Mirrors the legacy create_tensor_cb but
+// pushes a CBDescriptor onto the desc instead of calling CreateCircularBuffer.
 void create_tensor_cb(
-    tt::tt_metal::Program& program,
+    tt::tt_metal::ProgramDescriptor& desc,
     const CoreRangeSet& core_range_set,
     const ttnn::Tensor& tensor,
     uint32_t buffering_factor,
@@ -61,55 +65,34 @@ void create_tensor_cb(
         cb_size,
         data_format);
 
-    tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(cb_size, {{cb_id, data_format}}).set_page_size(cb_id, aligned_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = cb_size,
+        .core_ranges = core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = data_format,
+            .page_size = aligned_page_size,
+        }}},
+    });
 }
 
 }  // namespace detail
 
-CombineProgramFactory::cached_mesh_workload_t CombineProgramFactory::create_mesh_workload(
+namespace {
+
+// Per-coord ProgramDescriptor builder.  The cross-device GlobalSemaphores are
+// allocated once at workload scope in create_workload_descriptor() and passed
+// down by const-reference so every per-coord program references the same
+// device-side allocation (writer runtime args bake in `init_semaphore.address()`
+// / `exit_semaphore.address()` as absolute addresses).
+tt::tt_metal::ProgramDescriptor build_program_for_coord(
     const CombineParams& operation_attributes,
-    const MeshCoordinateRangeSet& tensor_coords,
-    const CombineInputs& tensor_args,
-    ttnn::Tensor& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, CombineSharedVariables> shared_variables;
-
-    auto* mesh_device = tensor_args.dispatched_buffer.device();
-
-    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
-                                                                            : tt::tt_metal::BufferType::L1;
-    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
-        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
-    auto exit_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
-        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
-    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(
-            operation_attributes,
-            coord,
-            tensor_args,
-            tensor_return_value,
-            tensor_coords,
-            init_barrier_semaphore,
-            exit_barrier_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
-
-ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFactory::create_at(
-    const CombineParams& operation_attributes,
-    const MeshCoordinate& mesh_coordinate,
     const CombineInputs& tensor_args,
     ttnn::Tensor& tensor_return_value,
-    const MeshCoordinateRangeSet& tensor_coords,
+    const ttnn::MeshCoordinate& mesh_coordinate,
     const GlobalSemaphore& init_semaphore,
     const GlobalSemaphore& exit_semaphore) {
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     const auto& dispatched_buffer = tensor_args.dispatched_buffer;
     const auto& dispatched_metadata = tensor_args.dispatched_metadata;
@@ -264,14 +247,31 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         idle_cores_per_sender,
         senders_with_extra_idle);
 
-    auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
-    auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
+    // ProgramDescriptor semaphores carry an explicit `.id` field — legacy
+    // CreateSemaphore() auto-assigned the next available ID per core, so we
+    // mirror that by maintaining a manual counter.  All semaphore ranges in
+    // this function nest (sender_core_grid ⊆ sender_and_idle_grid ⊆
+    // worker_core_range_set), so a single monotonic counter is sufficient to
+    // guarantee per-core uniqueness across every allocation site.
+    uint32_t next_sema_id = 0;
+    uint32_t zero_init_semaphore_id = next_sema_id++;
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = zero_init_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = sender_core_grid,
+        .initial_value = 0});
+    uint32_t zero_init_barrier_semaphore_id = next_sema_id++;
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = zero_init_barrier_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = sender_core_grid,
+        .initial_value = 0});
 
     const uint32_t read_batch_size = is_tile_layout ? dispatched_buffer.tensor_spec().tile().get_height() : 8;
 
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         dispatched_metadata,
         /*buffering_factor=*/read_batch_size,
@@ -290,14 +290,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         // One extra page holds the single receive_buf_addr (uint32) appended after counter data.
         uint32_t extra_pages = 1;
         uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
-        tt::tt_metal::CircularBufferConfig c2_config =
-            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
-                .set_page_size(tt::CBIndex::c_2, counter_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, c2_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = cb_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_2),
+                .data_format = data_format,
+                .page_size = counter_page_size,
+            }}},
+        });
     }
     // c_8: expert_region_offsets (reader-only, full tensor)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         expert_region_offsets,
         /*buffering_factor=*/detail::get_num_pages(expert_region_offsets),
@@ -309,7 +314,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         // dtype/page-size inherited from output_tensor: BFLOAT16 in the bf16 path,
         // FP8_E4M3 (auto-resolves to tt::DataFormat::Fp8_e4m3) in the fp8 path.
         detail::create_tensor_cb(
-            program,
+            desc,
             sender_core_grid,
             output_tensor,
             /*buffering_factor=*/read_batch_size,
@@ -328,15 +333,20 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             }
             uint32_t needed_bytes = std::max(max_idle_group_size * (uint32_t)sizeof(uint32_t), l1_alignment);
             uint32_t idle_c9_scratch_size = ((needed_bytes + l1_alignment - 1) / l1_alignment) * l1_alignment;
-            tt::tt_metal::CircularBufferConfig idle_c9_scratch_cfg =
-                tt::tt_metal::CircularBufferConfig(idle_c9_scratch_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt8}})
-                    .set_page_size(tt::CBIndex::c_10, idle_c9_scratch_size);
-            tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, idle_c9_scratch_cfg);
+            desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+                .total_size = idle_c9_scratch_size,
+                .core_ranges = sender_core_grid,
+                .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_10),
+                    .data_format = tt::DataFormat::UInt8,
+                    .page_size = idle_c9_scratch_size,
+                }}},
+            });
         }
     } else {
         // c_0 on sender cores: dispatched_buffer rows for ROW_MAJOR DMA reads
         detail::create_tensor_cb(
-            program,
+            desc,
             sender_core_grid,
             dispatched_buffer,
             /*buffering_factor=*/read_batch_size,
@@ -349,14 +359,18 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         constexpr uint32_t rw_buffering = 2;
 
         uint32_t route_info_page_size = l1_alignment;
-        tt::tt_metal::CircularBufferConfig route_info_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                rw_buffering * route_info_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_3, route_info_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = rw_buffering * route_info_page_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = route_info_page_size,
+            }}},
+        });
 
         detail::create_tensor_cb(
-            program,
+            desc,
             sender_core_grid,
             output_tensor,  // dispatched_buffer and output_tensor have same page size
             /*buffering_factor=*/rw_buffering,
@@ -370,14 +384,24 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
         uint32_t packet_header_cb_size = num_packet_headers * packet_header_size_bytes;
 
-        tt::tt_metal::CircularBufferConfig packet_header_cb_config =
-            tt::tt_metal::CircularBufferConfig(packet_header_cb_size, {{tt::CBIndex::c_5, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_5, packet_header_size_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, packet_header_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = packet_header_cb_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_5),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = packet_header_size_bytes,
+            }}},
+        });
     }
 
+    // Iterate over every coordinate in the mesh (full coord range derived from the
+    // mesh shape) — replaces the legacy `tensor_coords` parameter, which the new
+    // descriptor-style entry point no longer threads through.  The fabric defines
+    // baked into kernel compile-time args list every device on the mesh, so this
+    // must remain a full enumeration.
     std::vector<uint32_t> dest_mesh_id, dest_chip_id;
-    for (const auto& coord : tensor_coords.coords()) {
+    for (const auto& coord : ttnn::MeshCoordinateRange(mesh_view.shape())) {
         auto dest_fabric_node_id = mesh_device->get_fabric_node_id(coord);
         dest_mesh_id.push_back(*dest_fabric_node_id.mesh_id);
         dest_chip_id.push_back((uint32_t)dest_fabric_node_id.chip_id);
@@ -559,12 +583,29 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             sender_and_idle_ranges.insert(cr);
         }
         CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
-        counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+        counter_ready_semaphore_id = next_sema_id++;
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = counter_ready_semaphore_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = sender_and_idle_grid,
+            .initial_value = 0});
         // One data_ready and one start semaphore per sender so each sender's handshake with idle
         // cores is independent — idle core routes to the correct pair via sender_idx = expert / experts_per_sender.
         for (uint32_t s = 0; s < num_cores; s++) {
-            data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
-            start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+            uint32_t data_ready_id = next_sema_id++;
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+                .id = data_ready_id,
+                .core_type = tt::CoreType::WORKER,
+                .core_ranges = sender_and_idle_grid,
+                .initial_value = 0});
+            data_ready_semaphore_ids.push_back(data_ready_id);
+            uint32_t start_id = next_sema_id++;
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+                .id = start_id,
+                .core_type = tt::CoreType::WORKER,
+                .core_ranges = sender_and_idle_grid,
+                .initial_value = 0});
+            start_semaphore_ids.push_back(start_id);
         }
     }
 
@@ -588,14 +629,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
             uint32_t extra_pages = 1;
             uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
-            tt::tt_metal::CircularBufferConfig c1_idle_config =
-                tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
-                    .set_page_size(tt::CBIndex::c_1, counter_page_size);
-            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
+            desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+                .total_size = cb_size,
+                .core_ranges = idle_core_grid,
+                .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+                    .data_format = data_format,
+                    .page_size = counter_page_size,
+                }}},
+            });
         }
         // c_0 on idle cores: dispatched_buffer tiles
         detail::create_tensor_cb(
-            program,
+            desc,
             idle_core_grid,
             dispatched_buffer,
             /*buffering_factor=*/hidden_size / (32 * cb_factor),
@@ -606,7 +652,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         // FP8_E4M3 (auto-resolves to tt::DataFormat::Fp8_e4m3) in the fp8 path. The packer
         // selects the correct pack format based on the destination CB's DataFormat.
         detail::create_tensor_cb(
-            program,
+            desc,
             idle_core_grid,
             output_tensor,
             /*buffering_factor=*/read_batch_size,
@@ -615,20 +661,30 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         // c_3 on idle cores: 1-page signal CB (reader->compute, mirrors c_17 on sender cores)
         {
             uint32_t signal_page_size = l1_alignment;
-            tt::tt_metal::CircularBufferConfig signal_cb_config =
-                tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
-                    .set_page_size(tt::CBIndex::c_3, signal_page_size);
-            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+            desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+                .total_size = signal_page_size,
+                .core_ranges = idle_core_grid,
+                .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+                    .data_format = tt::DataFormat::UInt8,
+                    .page_size = signal_page_size,
+                }}},
+            });
         }
         // c_8 on idle cores: 1-page stop-signal CB (compute -> zero_init_writer).
         // Compute pushes 0 per batch (meaning "a batch is ready on c_2") and ROUTE_INFO_SENTINEL
         // when it exits its own loop, so zero_init_writer knows when to stop its send loop.
         {
             uint32_t stop_signal_page_size = l1_alignment;
-            tt::tt_metal::CircularBufferConfig stop_signal_cb_config =
-                tt::tt_metal::CircularBufferConfig(stop_signal_page_size, {{tt::CBIndex::c_8, tt::DataFormat::UInt8}})
-                    .set_page_size(tt::CBIndex::c_8, stop_signal_page_size);
-            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, stop_signal_cb_config);
+            desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+                .total_size = stop_signal_page_size,
+                .core_ranges = idle_core_grid,
+                .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_8),
+                    .data_format = tt::DataFormat::UInt8,
+                    .page_size = stop_signal_page_size,
+                }}},
+            });
         }
         // c_9 on idle cores: metadata-batch CB. The owning sender unicasts one read_batch_size
         // worth of metadata here per iteration. Idle cores report this CB's L1 address to their
@@ -640,10 +696,15 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t metadata_batch_page_size = detail::get_aligned_page_size(dispatched_metadata);
             auto metadata_fmt = tt::tt_metal::datatype_to_dataformat_converter(dispatched_metadata.dtype());
             uint32_t metadata_batch_cb_size = read_batch_size * metadata_batch_page_size;
-            tt::tt_metal::CircularBufferConfig metadata_batch_idle_config =
-                tt::tt_metal::CircularBufferConfig(metadata_batch_cb_size, {{tt::CBIndex::c_9, metadata_fmt}})
-                    .set_page_size(tt::CBIndex::c_9, metadata_batch_page_size);
-            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, metadata_batch_idle_config);
+            desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+                .total_size = metadata_batch_cb_size,
+                .core_ranges = idle_core_grid,
+                .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_9),
+                    .data_format = metadata_fmt,
+                    .page_size = metadata_batch_page_size,
+                }}},
+            });
         }
     }
 
@@ -702,15 +763,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
 
                 CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
-                reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-                    program,
+                tt::tt_metal::KernelDescriptor reader_untilize_kd;
+                reader_untilize_kd.kernel_source =
                     "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
-                    "reader_untilize.cpp",
-                    single_idle_core,
-                    tt::tt_metal::DataMovementConfig{
-                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                        .compile_args = per_core_args}));
+                    "reader_untilize.cpp";
+                reader_untilize_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+                reader_untilize_kd.core_ranges = single_idle_core;
+                reader_untilize_kd.compile_time_args = std::move(per_core_args);
+                reader_untilize_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+                    .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                };
+                reader_untilize_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
+                desc.kernels.push_back(std::move(reader_untilize_kd));
             }
         }
     }
@@ -737,22 +802,37 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             TT_THROW("Unsupported architecture for zero-init: {}", arch);
         }
 
-        tt::tt_metal::CircularBufferConfig zi_inline_cb_config =
-            tt::tt_metal::CircularBufferConfig(noc_max_burst_size, {{tt::CBIndex::c_7, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_7, noc_max_burst_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, zi_inline_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = noc_max_burst_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_7),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = noc_max_burst_size,
+            }}},
+        });
 
         uint32_t total_zero_init_cores = num_cores + num_idle_cores;
         uint32_t total_output_pages = detail::get_num_pages(output_tensor);
         pages_per_core = total_output_pages / total_zero_init_cores;
         remainder_pages = total_output_pages % total_zero_init_cores;
 
-        tt::tt_metal::CircularBufferConfig zi_idle_cb_config =
-            tt::tt_metal::CircularBufferConfig(noc_max_burst_size, {{tt::CBIndex::c_6, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_6, noc_max_burst_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, zi_idle_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = noc_max_burst_size,
+            .core_ranges = idle_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_6),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = noc_max_burst_size,
+            }}},
+        });
 
-        zi_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range_set, 0);
+        zi_done_semaphore_id = next_sema_id++;
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = zi_done_semaphore_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = worker_core_range_set,
+            .initial_value = 0});
     }
 
     if (create_zi_kernel) {
@@ -785,16 +865,20 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         zi_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
         zi_defines["INIT_ZEROS"] = init_zeros ? "1" : "0";
 
-        zero_init_kernel_id = tt::tt_metal::CreateKernel(
-            program,
+        tt::tt_metal::KernelDescriptor zero_init_kd;
+        zero_init_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
-            "zero_init_writer.cpp",
-            idle_core_grid,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-                .compile_args = zi_compile_time_args,
-                .defines = zi_defines});
+            "zero_init_writer.cpp";
+        zero_init_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        zero_init_kd.core_ranges = idle_core_grid;
+        zero_init_kd.compile_time_args = std::move(zi_compile_time_args);
+        zero_init_kd.defines = {zi_defines.begin(), zi_defines.end()};
+        zero_init_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
+        };
+        zero_init_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+        desc.kernels.push_back(std::move(zero_init_kd));
 
         zero_init_cores_vec = idle_row_cores;
     }
@@ -822,26 +906,34 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_10));  // cb_idle_c9_addr_scratch_id
         }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
-        reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp",
-            single_sender_core,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                .compile_args = per_sender_compile_args,
-                .defines = reader_defines}));
+        tt::tt_metal::KernelDescriptor reader_kd;
+        reader_kd.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp";
+        reader_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        reader_kd.core_ranges = single_sender_core;
+        reader_kd.compile_time_args = std::move(per_sender_compile_args);
+        reader_kd.defines = {reader_defines.begin(), reader_defines.end()};
+        reader_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+        };
+        reader_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
+        desc.kernels.push_back(std::move(reader_kd));
     }
 
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-            .compile_args = compile_time_args,
-            .defines = writer_defines});
+    tt::tt_metal::KernelDescriptor writer_kd;
+    writer_kd.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp";
+    writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kd.core_ranges = sender_core_grid;
+    writer_kd.compile_time_args = compile_time_args;
+    writer_kd.defines = {writer_defines.begin(), writer_defines.end()};
+    writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
+    };
+    tt::tt_metal::KernelHandle writer_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(writer_kd));
 
     // Compute kernel on idle cores that untilizes dispatched_buffer data (TILE_LAYOUT only)
     if (is_tile_layout) {
@@ -851,24 +943,25 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             --block_ct_dim;
         }
 
-        tt::tt_metal::CreateKernel(
-            program,
+        tt::tt_metal::KernelDescriptor compute_kd;
+        compute_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
-            "untilize_combine.cpp",
-            idle_core_grid,
-            tt::tt_metal::ComputeConfig{
-                .compile_args = {
-                    static_cast<uint32_t>(
-                        tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
-                                            //    data is loaded and ready to be untilized)
-                    static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
-                    static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
-                    read_batch_size,                          // 3: read_batch_size
-                    full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
-                    block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
-                    static_cast<uint32_t>(
-                        tt::CBIndex::c_8),  // 6: cb_stop_signal_id (compute -> zero_init_writer per-batch/stop)
-                }});
+            "untilize_combine.cpp";
+        compute_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        compute_kd.core_ranges = idle_core_grid;
+        compute_kd.compile_time_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
+                                                      //    data is loaded and ready to be untilized)
+            static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
+            static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
+            read_batch_size,                          // 3: read_batch_size
+            full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
+            block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
+            static_cast<uint32_t>(
+                tt::CBIndex::c_8),  // 6: cb_stop_signal_id (compute -> zero_init_writer per-batch/stop)
+        };
+        compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{};
+        desc.kernels.push_back(std::move(compute_kd));
     }
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
@@ -890,7 +983,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     // The kernel guards the zero-init reads with #if INIT_ZEROS so the indices match.
     if (create_zi_kernel) {
         for (uint32_t idle_idx = 0; idle_idx < num_idle_cores; idle_idx++) {
-            std::vector<uint32_t> zi_runtime_args = {output_tensor.buffer()->address()};
+            // Push output_tensor's buffer first as Buffer* so the framework records
+            // a BufferBinding for the cache-hit fast path.
+            tt::tt_metal::KernelDescriptor::RTArgList zi_runtime_args;
+            zi_runtime_args.push_back(output_tensor.buffer());
 
             if (init_zeros) {
                 uint32_t row_idx = num_cores + idle_idx;
@@ -923,7 +1019,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 zi_runtime_args.push_back(local_core_id);
             }
 
-            tt::tt_metal::SetRuntimeArgs(program, zero_init_kernel_id, zero_init_cores_vec[idle_idx], zi_runtime_args);
+            desc.kernels[zero_init_kernel_id].emplace_runtime_args(zero_init_cores_vec[idle_idx], zi_runtime_args);
         }
     }
 
@@ -932,18 +1028,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t expert_start = core_idx * experts_per_core_range;
         uint32_t expert_end = std::min((core_idx + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
 
-        std::vector<uint32_t> reader_runtime_args = {
-            dispatched_buffer.buffer()->address(),
-            dispatched_metadata.buffer()->address(),
-            expert_token_counts.buffer()->address(),
-            expert_region_offsets.buffer()->address(),
-            output_tensor.buffer()->address(),
-            zero_init_semaphore_id,
-            zero_init_barrier_semaphore_id,
-            num_cores,
-            expert_start,
-            expert_end,
-        };
+        // Reader RT args.  Tensor buffer addresses are pushed as Buffer* so the
+        // framework records BufferBindings for the O(1) cache-hit fast path.
+        tt::tt_metal::KernelDescriptor::RTArgList reader_runtime_args;
+        reader_runtime_args.push_back(dispatched_buffer.buffer());
+        reader_runtime_args.push_back(dispatched_metadata.buffer());
+        reader_runtime_args.push_back(expert_token_counts.buffer());
+        reader_runtime_args.push_back(expert_region_offsets.buffer());
+        reader_runtime_args.push_back(output_tensor.buffer());
+        reader_runtime_args.push_back(zero_init_semaphore_id);
+        reader_runtime_args.push_back(zero_init_barrier_semaphore_id);
+        reader_runtime_args.push_back(num_cores);
+        reader_runtime_args.push_back(expert_start);
+        reader_runtime_args.push_back(expert_end);
         if (init_zeros) {
             uint32_t sender_page_start = (core_idx * pages_per_core) + std::min(core_idx, remainder_pages);
             uint32_t sender_page_end = sender_page_start + pages_per_core + (core_idx < remainder_pages ? 1 : 0);
@@ -968,7 +1065,11 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             }
         }
 
-        std::vector<uint32_t> writer_runtime_args = {
+        // Writer RT args: build into a plain std::vector<uint32_t> first because
+        // append_fabric_connection_rt_args appends raw uint32_t values to a
+        // std::vector — then promote to the RTArgList builder (replacing the
+        // buffer-address slots with Buffer* entries) before emplace.
+        std::vector<uint32_t> writer_runtime_args_raw = {
             dispatched_buffer.buffer()->address(),
             dispatched_metadata.buffer()->address(),
             expert_token_counts.buffer()->address(),
@@ -985,8 +1086,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
         // Append NOC coordinates of all cores for inter-core barrier signaling
         for (const auto& [noc_x, noc_y] : sender_noc_coords) {
-            writer_runtime_args.push_back(noc_x);
-            writer_runtime_args.push_back(noc_y);
+            writer_runtime_args_raw.push_back(noc_x);
+            writer_runtime_args_raw.push_back(noc_y);
         }
 
         if (num_links > 0) {
@@ -1008,18 +1109,36 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                     expert_start,
                     expert_end);
 
-                tt::tt_fabric::append_fabric_connection_rt_args(
+                // ProgramDescriptor specialization: appends fabric-routing args
+                // onto writer_runtime_args_raw and patches desc-side bookkeeping.
+                tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
                     src_fabric_node_id,
                     mesh_device->get_fabric_node_id(neighbor_coordinate),
                     core_link,
-                    program,
+                    desc,
                     sender_core,
-                    writer_runtime_args);
+                    writer_runtime_args_raw);
             }
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[core_idx], sender_core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
+        // Promote the writer RT args to the kernel-descriptor builder, replacing
+        // the first five positions with Buffer* entries so the framework records
+        // BufferBindings for the cache-hit fast path.  All other positions
+        // (semaphore IDs, NOC coords, fabric-appended trailers) remain plain
+        // uint32_t.
+        tt::tt_metal::KernelDescriptor::RTArgList writer_runtime_args;
+        writer_runtime_args.reserve(writer_runtime_args_raw.size());
+        writer_runtime_args.push_back(dispatched_buffer.buffer());
+        writer_runtime_args.push_back(dispatched_metadata.buffer());
+        writer_runtime_args.push_back(expert_token_counts.buffer());
+        writer_runtime_args.push_back(expert_region_offsets.buffer());
+        writer_runtime_args.push_back(output_tensor.buffer());
+        for (size_t i = 5; i < writer_runtime_args_raw.size(); ++i) {
+            writer_runtime_args.push_back(writer_runtime_args_raw[i]);
+        }
+        desc.kernels[writer_kernel_id].emplace_runtime_args(sender_core, writer_runtime_args);
+
+        desc.kernels[reader_kernel_ids[core_idx]].emplace_runtime_args(sender_core, reader_runtime_args);
         core_idx++;
     }
 
@@ -1032,78 +1151,62 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t s = idle_sender_map[j];
             uint32_t expert_start = s * experts_per_core_range;
             uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
-            std::vector<uint32_t> idle_rt_args = {
-                counter_ready_semaphore_id,
-                dispatched_buffer.buffer()->address(),
-                expert_start,
-                expert_end,
-            };
-            tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
+            tt::tt_metal::KernelDescriptor::RTArgList idle_rt_args;
+            idle_rt_args.push_back(counter_ready_semaphore_id);
+            // dispatched_buffer is pushed as Buffer* so the framework records a
+            // BufferBinding for this RT slot (RT layout: [0:counter_ready_sem,
+            // 1:dispatched_buffer_addr, 2:expert_start, 3:expert_end]).
+            idle_rt_args.push_back(dispatched_buffer.buffer());
+            idle_rt_args.push_back(expert_start);
+            idle_rt_args.push_back(expert_end);
+            desc.kernels[reader_untilize_kernel_ids[j]].emplace_runtime_args(idle_row_cores[j], idle_rt_args);
         }
     }
 
-    return {
-        std::move(program),
-        {.reader_kernel_ids = std::move(reader_kernel_ids),
-         .writer_kernel_id = writer_kernel_id,
-         .zero_init_kernel_id = zero_init_kernel_id,
-         .reader_untilize_kernel_ids = std::move(reader_untilize_kernel_ids),
-         .cores = sender_cores,
-         .zero_init_cores = zero_init_cores_vec,
-         .idle_cores = idle_row_cores,
-         .init_semaphore = init_semaphore,
-         .exit_semaphore = exit_semaphore,
-         .zero_init_semaphore_id = zero_init_semaphore_id,
-         .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id,
-         .counter_ready_semaphore_id = counter_ready_semaphore_id,
-         .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
-         .start_semaphore_ids = std::move(start_semaphore_ids)}};
+    return desc;
 }
 
-void CombineProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const CombineParams& /*operation_attributes*/,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor CombineProgramFactory::create_workload_descriptor(
+    const CombineParams& operation_attributes,
     const CombineInputs& tensor_args,
-    ttnn::Tensor& tensor_return_value) {
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
+    ttnn::Tensor& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    auto* mesh_device = tensor_args.dispatched_buffer.device();
 
-        for (size_t s = 0; s < shared_variables.cores.size(); s++) {
-            const auto& core = shared_variables.cores[s];
-            auto& reader_runtime_args =
-                tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_ids[s], core);
-            auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.writer_kernel_id, core);
+    // Allocate the two cross-device GlobalSemaphores once per workload (cache miss).
+    // They live on WorkloadDescriptor.semaphores so the device-side allocations
+    // outlive the cached MeshWorkload via the program cache — writer runtime args
+    // reference them as absolute addresses.
+    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
+                                                                            : tt::tt_metal::BufferType::L1;
+    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
+        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
+    auto exit_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
+        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
+    // Cross-device barrier: ensure every device's GlobalSemaphores have been allocated
+    // before any kernel reads them.  Mirrors the previous prepare_resources hook.
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
 
-            reader_runtime_args.at(0) = tensor_args.dispatched_buffer.buffer()->address();
-            reader_runtime_args.at(1) = tensor_args.dispatched_metadata.buffer()->address();
-            reader_runtime_args.at(2) = tensor_args.expert_token_counts.buffer()->address();
-            reader_runtime_args.at(3) = tensor_args.expert_region_offsets.buffer()->address();
-            reader_runtime_args.at(4) = tensor_return_value.buffer()->address();
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+    workload_descriptor.semaphores.push_back(init_barrier_semaphore);
+    workload_descriptor.semaphores.push_back(exit_barrier_semaphore);
 
-            writer_runtime_args.at(0) = tensor_args.dispatched_buffer.buffer()->address();
-            writer_runtime_args.at(1) = tensor_args.dispatched_metadata.buffer()->address();
-            writer_runtime_args.at(2) = tensor_args.expert_token_counts.buffer()->address();
-            writer_runtime_args.at(3) = tensor_args.expert_region_offsets.buffer()->address();
-            writer_runtime_args.at(4) = tensor_return_value.buffer()->address();
-            writer_runtime_args.at(6) = (uint32_t)shared_variables.init_semaphore.address();
-            writer_runtime_args.at(7) = (uint32_t)shared_variables.exit_semaphore.address();
-        }
-
-        for (const auto& core : shared_variables.zero_init_cores) {
-            auto& zi_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.zero_init_kernel_id, core);
-            zi_runtime_args.at(0) = tensor_return_value.buffer()->address();
-        }
-
-        // Update idle core runtime args only when reader_untilize kernels exist (TILE_LAYOUT)
-        if (!shared_variables.reader_untilize_kernel_ids.empty()) {
-            for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
-                auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
-                    program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-                // RT layout: [0:counter_ready_sem, 1:dispatched_buffer_addr, 2:expert_start, 3:expert_end]
-                idle_rt_args.at(1) = tensor_args.dispatched_buffer.buffer()->address();
-            }
-        }
+    // Combine is mesh-coord-dependent (fabric routing + linearized counter offset
+    // are baked into kernel compile-time args), so we cannot replicate one
+    // ProgramDescriptor across the whole mesh — every coord gets its own build.
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = build_program_for_coord(
+            operation_attributes,
+            tensor_args,
+            tensor_return_value,
+            coord,
+            init_barrier_semaphore,
+            exit_barrier_semaphore);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
@@ -5,55 +5,28 @@
 #pragma once
 
 #include <vector>
+
 #include "combine_types.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 #include <ttnn/global_semaphore.hpp>
+#include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::combine {
 
-struct CombineSharedVariables {
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;  // one per sender core
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    tt::tt_metal::KernelHandle zero_init_kernel_id = 0;
-    std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;  // one per idle core
-    std::vector<CoreCoord> cores;
-    std::vector<CoreCoord> zero_init_cores;
-    std::vector<CoreCoord> idle_cores;
-    GlobalSemaphore init_semaphore;       // Initialized in create_at()
-    GlobalSemaphore exit_semaphore;       // Separate sem for the exit handshake (avoids
-                                          // init/exit race on combine_devices==2 pairs)
-    uint32_t zero_init_semaphore_id = 0;  // Local semaphore ID for reader->writer sync
-    uint32_t zero_init_barrier_semaphore_id = 0;     // Barrier: writer signals reader after global init
-    uint32_t counter_ready_semaphore_id = 0;         // Sender signals idle cores after token count multicast
-    std::vector<uint32_t> data_ready_semaphore_ids;  // One per sender: idle core signals sender data is ready
-    std::vector<uint32_t> start_semaphore_ids;       // One per sender: sender signals idle core to start
-};
-
 struct CombineProgramFactory {
-    using shared_variables_t = CombineSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
+    // Declarative WorkloadDescriptor entry point (Contract 2).  Allocates the two
+    // GlobalSemaphores once per cache miss (parked in `WorkloadDescriptor::semaphores`
+    // so their device-side allocations outlive the cached workload), runs the
+    // cross-device Synchronize barrier, then builds one ProgramDescriptor per
+    // mesh coordinate.  The framework realises this into the cached MeshWorkload.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const CombineParams& operation_attributes,
-        const MeshCoordinateRangeSet& tensor_coords,
-        const CombineInputs& tensor_args,
-        ttnn::Tensor& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const CombineParams& operation_attributes,
-        const MeshCoordinate& mesh_coordinate,
         const CombineInputs& tensor_args,
         ttnn::Tensor& tensor_return_value,
-        const MeshCoordinateRangeSet& tensor_coords,
-        const GlobalSemaphore& init_semaphore,
-        const GlobalSemaphore& exit_semaphore);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
-        const CombineParams& operation_attributes,
-        const CombineInputs& tensor_args,
-        ttnn::Tensor& tensor_return_value);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -9,11 +9,13 @@
 #include <limits>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include <ttnn/global_semaphore.hpp>
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
@@ -33,8 +35,12 @@ uint32_t get_num_rows(const ttnn::Tensor& tensor) {
     return logical_volume / hidden_size;
 }
 
+// ProgramDescriptor-flavored helper.  Pushes a CBDescriptor onto the desc
+// instead of calling CreateCircularBuffer.  Mirrors the legacy data_format
+// rewrite for the FP8 dispatch path (UINT8 dispatch buffers reinterpret as
+// Fp8_e4m3 in the CB until FP8 gets a dedicated dtype).
 void create_tensor_cb(
-    tt::tt_metal::Program& program,
+    tt::tt_metal::ProgramDescriptor& desc,
     const CoreRangeSet& core_range_set,
     const ttnn::Tensor& tensor,
     uint32_t buffering_factor,
@@ -66,9 +72,15 @@ void create_tensor_cb(
         cb_size,
         data_format);
 
-    tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(cb_size, {{cb_id, data_format}}).set_page_size(cb_id, aligned_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = cb_size,
+        .core_ranges = core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = data_format,
+            .page_size = aligned_page_size,
+        }}},
+    });
 }
 
 }  // namespace detail
@@ -76,16 +88,15 @@ void create_tensor_cb(
 namespace {
 
 // Tile-layout path: TILE inputs, fused untilize across sender + idle cores.
-ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_layout(
+tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     const DispatchParams& operation_attributes,
     const MeshCoordinate& mesh_coordinate,
     const DispatchInputs& tensor_args,
     DispatchProgramFactory::tensor_return_value_t& tensor_return_value,
-    const MeshCoordinateRangeSet& tensor_coords,
     const GlobalSemaphore& init_semaphore,
     const GlobalSemaphore& exit_semaphore,
     const GlobalSemaphore& cross_device_semaphore) {
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     auto input_tensor = tensor_args.input_tensor;
     auto indices_tensor = tensor_args.indices_tensor;
@@ -232,35 +243,47 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     uint32_t total_batches = (tokens_per_device + read_batch_size - 1) / read_batch_size;
 
     // ==================== Semaphores for inter-core sync ====================
+    // ProgramDescriptor semaphores carry an explicit `.id` field — legacy
+    // CreateSemaphore() auto-assigned the next available ID per core, so we
+    // mirror that with a monotonic counter.  Every semaphore here is created on
+    // the same sender_and_idle_grid, so a single counter trivially guarantees
+    // per-core uniqueness.
+    uint32_t next_sema_id = 0;
+    auto add_sema = [&](const CoreRangeSet& crs) -> uint32_t {
+        uint32_t id = next_sema_id++;
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = id, .core_type = tt::CoreType::WORKER, .core_ranges = crs, .initial_value = 0});
+        return id;
+    };
     // One data_ready + one start semaphore per sender (created on sender+idle grid)
     std::vector<uint32_t> data_ready_semaphore_ids;
     std::vector<uint32_t> start_semaphore_ids;
     data_ready_semaphore_ids.reserve(num_cores);
     start_semaphore_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
-        start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        data_ready_semaphore_ids.push_back(add_sema(sender_and_idle_grid));
+        start_semaphore_ids.push_back(add_sema(sender_and_idle_grid));
     }
     // addr_ready semaphore: sender signals idle cores after writing receive buffer address
-    auto addr_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto addr_ready_semaphore_id = add_sema(sender_and_idle_grid);
     // addr_value semaphore: holds the sender's c_18 L1 address (written via noc_async_write)
-    auto addr_value_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto addr_value_semaphore_id = add_sema(sender_and_idle_grid);
     // mbox_ready semaphore (per sender): idle cores signal this after NOC-writing their mailbox address.
     // Sender waits for count == num_idle_cores_in_group before reading its own scratch buffer.
     std::vector<uint32_t> mbox_ready_semaphore_ids;
     mbox_ready_semaphore_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        mbox_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        mbox_ready_semaphore_ids.push_back(add_sema(sender_and_idle_grid));
     }
     // mbox_scratch_addr semaphore: sender writes its route-table scratch base address here and
     // multicasts it to idle cores alongside addr_ready.  Idle cores read it after addr_ready fires,
     // then NOC-write their mailbox L1 address into the sender's scratch slot (core_id * 4 offset).
-    auto mbox_scratch_addr_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto mbox_scratch_addr_semaphore_id = add_sema(sender_and_idle_grid);
 
     // ==================== Circular Buffers for IDLE cores ====================
     // c_0: tiled input stripe (reader → compute)
     detail::create_tensor_cb(
-        program,
+        desc,
         idle_core_grid,
         input_tensor,
         /*buffering_factor=*/16,
@@ -270,16 +293,20 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     {
         uint32_t signal_page_size = l1_alignment;
         constexpr uint32_t signal_buffering = 2;
-        tt::tt_metal::CircularBufferConfig signal_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                signal_buffering * signal_page_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt32}})
-                .set_page_size(tt::CBIndex::c_10, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = signal_buffering * signal_page_size,
+            .core_ranges = idle_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_10),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = signal_page_size,
+            }}},
+        });
     }
     // c_11: untilize output (compute → writer)
     // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
     detail::create_tensor_cb(
-        program,
+        desc,
         idle_core_grid,
         output_tensor,
         /*buffering_factor=*/read_batch_size,
@@ -292,14 +319,19 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         uint32_t mailbox_page_size = tt::round_up(
             static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
             l1_alignment);
-        tt::tt_metal::CircularBufferConfig mailbox_cb_config =
-            tt::tt_metal::CircularBufferConfig(mailbox_page_size, {{tt::CBIndex::c_12, tt::DataFormat::UInt32}})
-                .set_page_size(tt::CBIndex::c_12, mailbox_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, mailbox_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = mailbox_page_size,
+            .core_ranges = idle_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_12),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = mailbox_page_size,
+            }}},
+        });
     }
     // c_13: metadata scratch (idle writer builds metadata here before NOC-writing to DRAM)
     detail::create_tensor_cb(
-        program,
+        desc,
         idle_core_grid,
         metadata_tensor,
         /*buffering_factor=*/1,
@@ -310,7 +342,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     // c_0: tiled input stripe for self-untilize (reader → compute on sender)
     // Double-buffered blocks of 8 tiles (compute processes 8 at a time)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         input_tensor,
         /*buffering_factor=*/16,
@@ -320,15 +352,19 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     {
         uint32_t signal_page_size = l1_alignment;
         constexpr uint32_t signal_buffering = 2;
-        tt::tt_metal::CircularBufferConfig sender_signal_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                signal_buffering * signal_page_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt32}})
-                .set_page_size(tt::CBIndex::c_10, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, sender_signal_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = signal_buffering * signal_page_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_10),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = signal_page_size,
+            }}},
+        });
     }
     // c_1: indices scratch
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         indices_tensor,
         /*buffering_factor=*/read_batch_size,
@@ -336,7 +372,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         "indices_scratch");
     // c_2: weights scratch
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         weights_tensor,
         /*buffering_factor=*/read_batch_size,
@@ -344,7 +380,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         "weights_scratch");
     // c_3: offsets (full tensor)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         offsets_tensor,
         /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
@@ -358,15 +394,18 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         constexpr uint32_t rw_buffering = 2;
 
         uint32_t route_info_page_size = l1_alignment;
-
-        tt::tt_metal::CircularBufferConfig route_info_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                rw_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_4, route_info_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = rw_buffering * route_info_page_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_4),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = route_info_page_size,
+            }}},
+        });
 
         detail::create_tensor_cb(
-            program,
+            desc,
             sender_core_grid,
             output_tensor,
             /*buffering_factor=*/rw_buffering,
@@ -374,7 +413,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
             "payload_for_writer");
 
         detail::create_tensor_cb(
-            program,
+            desc,
             sender_core_grid,
             metadata_tensor,
             /*buffering_factor=*/rw_buffering,
@@ -384,7 +423,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
 
     // c_7: metadata_temp (reader-only, for constructing metadata locally)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         metadata_tensor,
         /*buffering_factor=*/1,
@@ -392,7 +431,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         "metadata_temp_buffer");
     // c_9: dispatch_table (full tensor)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         dispatch_table_tensor,
         /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
@@ -401,7 +440,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     // c_18: receive buffer for untilized data from idle cores (also sender self-untilize output)
     // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         output_tensor,
         /*buffering_factor=*/read_batch_size,
@@ -413,10 +452,15 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         uint32_t mailbox_page_size = tt::round_up(
             static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
             l1_alignment);
-        tt::tt_metal::CircularBufferConfig route_table_cb_config =
-            tt::tt_metal::CircularBufferConfig(mailbox_page_size, {{tt::CBIndex::c_19, tt::DataFormat::UInt32}})
-                .set_page_size(tt::CBIndex::c_19, mailbox_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_table_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = mailbox_page_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_19),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = mailbox_page_size,
+            }}},
+        });
     }
 
     const auto [neighbors, directions] =
@@ -428,14 +472,23 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
         uint32_t packet_header_cb_size = num_packet_headers * packet_header_size_bytes;
 
-        tt::tt_metal::CircularBufferConfig packet_header_cb_config =
-            tt::tt_metal::CircularBufferConfig(packet_header_cb_size, {{tt::CBIndex::c_8, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_8, packet_header_size_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, packet_header_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = packet_header_cb_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_8),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = packet_header_size_bytes,
+            }}},
+        });
     }
 
+    // Iterate over every coordinate in the mesh (full coord range derived from
+    // the mesh shape) — replaces the legacy `tensor_coords` parameter, which the
+    // new descriptor-style entry point no longer threads through.  The fabric
+    // defines baked into kernel compile-time args list every device on the mesh.
     std::vector<uint32_t> dest_mesh_id, dest_chip_id;
-    for (const auto& coord : tensor_coords.coords()) {
+    for (const auto& coord : ttnn::MeshCoordinateRange(mesh_view.shape())) {
         auto dest_fabric_node_id = mesh_device->get_fabric_node_id(coord);
         dest_mesh_id.push_back(*dest_fabric_node_id.mesh_id);
         dest_chip_id.push_back((uint32_t)dest_fabric_node_id.chip_id);
@@ -557,29 +610,37 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_19));  // cb_route_table_scratch_id
 
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
-        reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-            program,
+        tt::tt_metal::KernelDescriptor reader_kd;
+        reader_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-            "reader_dispatch.cpp",
-            single_sender_core,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                .compile_args = per_sender_compile_args,
-                .defines = reader_defines}));
+            "reader_dispatch.cpp";
+        reader_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        reader_kd.core_ranges = single_sender_core;
+        reader_kd.compile_time_args = std::move(per_sender_compile_args);
+        reader_kd.defines = {reader_defines.begin(), reader_defines.end()};
+        reader_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+        };
+        reader_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
+        desc.kernels.push_back(std::move(reader_kd));
     }
 
     // ==================== Sender writer kernel (shared across all senders) ====================
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    tt::tt_metal::KernelDescriptor writer_kd;
+    writer_kd.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-        "writer_dispatch.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-            .compile_args = compile_time_args,
-            .defines = fabric_defines});
+        "writer_dispatch.cpp";
+    writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kd.core_ranges = sender_core_grid;
+    writer_kd.compile_time_args = compile_time_args;
+    writer_kd.defines = {fabric_defines.begin(), fabric_defines.end()};
+    writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
+    };
+    tt::tt_metal::KernelHandle writer_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(writer_kd));
 
     // ==================== Idle core kernels ====================
     // Reader and writer kernels run on the two data-movement RISCs of each idle core
@@ -635,58 +696,72 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(idle_writer_compile_args);
 
         CoreRangeSet single_idle_core({CoreRange(all_idle_cores[j])});
-        reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-            program,
+        tt::tt_metal::KernelDescriptor idle_reader_kd;
+        idle_reader_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-            "reader_untilize_dispatch.cpp",
-            single_idle_core,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                .compile_args = idle_reader_compile_args}));
+            "reader_untilize_dispatch.cpp";
+        idle_reader_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        idle_reader_kd.core_ranges = single_idle_core;
+        idle_reader_kd.compile_time_args = std::move(idle_reader_compile_args);
+        idle_reader_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+        };
+        reader_untilize_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
+        desc.kernels.push_back(std::move(idle_reader_kd));
 
-        writer_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-            program,
+        tt::tt_metal::KernelDescriptor idle_writer_kd;
+        idle_writer_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-            "writer_untilize_dispatch.cpp",
-            single_idle_core,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-                .compile_args = idle_writer_compile_args}));
+            "writer_untilize_dispatch.cpp";
+        idle_writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        idle_writer_kd.core_ranges = single_idle_core;
+        idle_writer_kd.compile_time_args = std::move(idle_writer_compile_args);
+        idle_writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
+        };
+        writer_untilize_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
+        desc.kernels.push_back(std::move(idle_writer_kd));
     }
 
     // Compute kernel on idle cores
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
-        "untilize_dispatch.cpp",
-        idle_core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
-            .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
-                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                (uint32_t)hidden_size,
-                read_batch_size,
-            }});
+    {
+        tt::tt_metal::KernelDescriptor idle_compute_kd;
+        idle_compute_kd.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
+            "untilize_dispatch.cpp";
+        idle_compute_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        idle_compute_kd.core_ranges = idle_core_grid;
+        idle_compute_kd.compile_time_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+            static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
+            static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+            (uint32_t)hidden_size,
+            read_batch_size,
+        };
+        idle_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{.math_fidelity = MathFidelity::HiFi4};
+        desc.kernels.push_back(std::move(idle_compute_kd));
+    }
 
     // Compute kernel on sender cores for self-untilize (output goes to c_18)
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
-        "untilize_dispatch.cpp",
-        sender_core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
-            .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
-                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                (uint32_t)hidden_size,
-                read_batch_size,
-            }});
+    {
+        tt::tt_metal::KernelDescriptor sender_compute_kd;
+        sender_compute_kd.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
+            "untilize_dispatch.cpp";
+        sender_compute_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        sender_compute_kd.core_ranges = sender_core_grid;
+        sender_compute_kd.compile_time_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+            static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
+            static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+            (uint32_t)hidden_size,
+            read_batch_size,
+        };
+        sender_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{.math_fidelity = MathFidelity::HiFi4};
+        desc.kernels.push_back(std::move(sender_compute_kd));
+    }
 
     // ==================== Pre-compute NOC coordinates ====================
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;
@@ -721,6 +796,11 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     }
 
     // ==================== Runtime args for sender cores ====================
+    // Build the base RT arg block as plain uint32_t so the fabric helper (which
+    // appends raw uint32_t values) can extend it.  Buffer-address slots are
+    // re-pushed below as Buffer* entries when promoting to the
+    // KernelDescriptor::RTArgList builder so the framework records
+    // BufferBindings for the cache-hit fast path.
     std::vector<uint32_t> base_runtime_args = {
         input_tensor.buffer()->address(),
         indices_tensor.buffer()->address(),
@@ -735,6 +815,25 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         (uint32_t)tokens_per_device,  // token_end_idx
         0,                            // dispatch_core_idx (set per core)
         num_cores,                    // num_dispatch_cores
+    };
+
+    // Helper: promote a flat uint32_t RT arg vector into an RTArgList with the
+    // first 7 positions converted to Buffer* (so BufferBindings are auto-
+    // registered for those slots), preserving all other positions verbatim.
+    auto promote_rt_args_with_buffer_bindings = [&](const std::vector<uint32_t>& raw_args) {
+        tt::tt_metal::KernelDescriptor::RTArgList args;
+        args.reserve(raw_args.size());
+        args.push_back(input_tensor.buffer());
+        args.push_back(indices_tensor.buffer());
+        args.push_back(weights_tensor.buffer());
+        args.push_back(offsets_tensor.buffer());
+        args.push_back(output_tensor.buffer());
+        args.push_back(metadata_tensor.buffer());
+        args.push_back(dispatch_table_tensor.buffer());
+        for (size_t i = 7; i < raw_args.size(); ++i) {
+            args.push_back(raw_args[i]);
+        }
+        return args;
     };
 
     uint32_t core_idx = 0;
@@ -785,18 +884,22 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
                     neighbor_coordinate[1],
                     sender_core,
                     core_link);
-                tt::tt_fabric::append_fabric_connection_rt_args(
+                // ProgramDescriptor specialization: appends fabric-routing args
+                // onto writer_runtime_args and patches desc-side bookkeeping.
+                tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
                     src_fabric_node_id,
                     mesh_device->get_fabric_node_id(neighbor_coordinate),
                     core_link,
-                    program,
+                    desc,
                     sender_core,
                     writer_runtime_args);
             }
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[core_idx], sender_core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
+        desc.kernels[reader_kernel_ids[core_idx]].emplace_runtime_args(
+            sender_core, promote_rt_args_with_buffer_bindings(reader_runtime_args));
+        desc.kernels[writer_kernel_id].emplace_runtime_args(
+            sender_core, promote_rt_args_with_buffer_bindings(writer_runtime_args));
         core_idx++;
     }
 
@@ -808,53 +911,41 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     for (uint32_t j = 0; j < num_idle_cores; j++) {
         uint32_t s = idle_sender_map[j];
 
-        std::vector<uint32_t> idle_reader_rt_args = {
-            input_tensor.buffer()->address(),
-        };
-        tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], all_idle_cores[j], idle_reader_rt_args);
+        // Idle reader: only RT arg is the input tensor base address — pushed as
+        // Buffer* so the framework records a BufferBinding.
+        tt::tt_metal::KernelDescriptor::RTArgList idle_reader_rt_args;
+        idle_reader_rt_args.push_back(input_tensor.buffer());
+        desc.kernels[reader_untilize_kernel_ids[j]].emplace_runtime_args(all_idle_cores[j], idle_reader_rt_args);
 
-        std::vector<uint32_t> idle_writer_rt_args = {
-            data_ready_semaphore_ids[s],
-            start_semaphore_ids[s],
-            sender_noc_coords[s].first,
-            sender_noc_coords[s].second,
-            addr_ready_semaphore_id,
-            addr_value_semaphore_id,
-            // New:
-            output_tensor.buffer()->address(),
-            metadata_tensor.buffer()->address(),
-            mbox_ready_semaphore_ids[s],
-            mbox_scratch_addr_semaphore_id,
-        };
-        tt::tt_metal::SetRuntimeArgs(program, writer_untilize_kernel_ids[j], all_idle_cores[j], idle_writer_rt_args);
+        // Idle writer: output_tensor (slot 6) and metadata_tensor (slot 7) are
+        // pushed as Buffer*; all other slots are plain uint32_t.
+        tt::tt_metal::KernelDescriptor::RTArgList idle_writer_rt_args;
+        idle_writer_rt_args.push_back(data_ready_semaphore_ids[s]);
+        idle_writer_rt_args.push_back(start_semaphore_ids[s]);
+        idle_writer_rt_args.push_back(sender_noc_coords[s].first);
+        idle_writer_rt_args.push_back(sender_noc_coords[s].second);
+        idle_writer_rt_args.push_back(addr_ready_semaphore_id);
+        idle_writer_rt_args.push_back(addr_value_semaphore_id);
+        idle_writer_rt_args.push_back(output_tensor.buffer());
+        idle_writer_rt_args.push_back(metadata_tensor.buffer());
+        idle_writer_rt_args.push_back(mbox_ready_semaphore_ids[s]);
+        idle_writer_rt_args.push_back(mbox_scratch_addr_semaphore_id);
+        desc.kernels[writer_untilize_kernel_ids[j]].emplace_runtime_args(all_idle_cores[j], idle_writer_rt_args);
     }
 
-    return {
-        std::move(program),
-        {.reader_kernel_ids = std::move(reader_kernel_ids),
-         .writer_kernel_id = writer_kernel_id,
-         .reader_untilize_kernel_ids = std::move(reader_untilize_kernel_ids),
-         .writer_untilize_kernel_ids = std::move(writer_untilize_kernel_ids),
-         .cores = sender_cores,
-         .idle_cores = all_idle_cores,
-         .init_semaphore = init_semaphore,
-         .exit_semaphore = exit_semaphore,
-         .cross_device_semaphore = cross_device_semaphore,
-         .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
-         .start_semaphore_ids = std::move(start_semaphore_ids)}};
+    return desc;
 }
 
 // Row-major path: ROW_MAJOR inputs, single reader kernel per sender, no idle cores.
-ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_major(
+tt::tt_metal::ProgramDescriptor create_at_row_major(
     const DispatchParams& operation_attributes,
     const MeshCoordinate& mesh_coordinate,
     const DispatchInputs& tensor_args,
     DispatchProgramFactory::tensor_return_value_t& tensor_return_value,
-    const MeshCoordinateRangeSet& tensor_coords,
     const GlobalSemaphore& init_semaphore,
     const GlobalSemaphore& exit_semaphore,
     const GlobalSemaphore& cross_device_semaphore) {
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     auto input_tensor = tensor_args.input_tensor;
     auto indices_tensor = tensor_args.indices_tensor;
@@ -931,7 +1022,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
 
     // c_0: input scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         input_tensor,
         /*buffering_factor=*/read_batch_size,
@@ -939,7 +1030,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
         "input_scratch");
     // c_1: indices scratch (reader-only)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         indices_tensor,
         /*buffering_factor=*/read_batch_size,
@@ -947,7 +1038,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
         "indices_scratch");
     // c_2: weights scratch (reader-only)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         weights_tensor,
         /*buffering_factor=*/read_batch_size,
@@ -955,7 +1046,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
         "weights_scratch");
     // c_3: offsets (reader-only, full tensor)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         offsets_tensor,
         /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
@@ -969,14 +1060,18 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
         constexpr uint32_t rw_buffering = 2;
 
         uint32_t route_info_page_size = l1_alignment;
-        tt::tt_metal::CircularBufferConfig route_info_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                rw_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_4, route_info_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = rw_buffering * route_info_page_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_4),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = route_info_page_size,
+            }}},
+        });
 
         detail::create_tensor_cb(
-            program,
+            desc,
             sender_core_grid,
             input_tensor,
             /*buffering_factor=*/rw_buffering,
@@ -984,7 +1079,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
             "payload_for_writer");
 
         detail::create_tensor_cb(
-            program,
+            desc,
             sender_core_grid,
             metadata_tensor,
             /*buffering_factor=*/rw_buffering,
@@ -994,7 +1089,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
 
     // c_7: metadata_temp (reader-only, for constructing metadata locally)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         metadata_tensor,
         /*buffering_factor=*/1,
@@ -1010,23 +1105,30 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
         auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
         uint32_t packet_header_cb_size = num_packet_headers * packet_header_size_bytes;
 
-        tt::tt_metal::CircularBufferConfig packet_header_cb_config =
-            tt::tt_metal::CircularBufferConfig(packet_header_cb_size, {{tt::CBIndex::c_8, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_8, packet_header_size_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, packet_header_cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = packet_header_cb_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_8),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = packet_header_size_bytes,
+            }}},
+        });
     }
 
     // c_9: dispatch_table (reader-only, full tensor)
     detail::create_tensor_cb(
-        program,
+        desc,
         sender_core_grid,
         dispatch_table_tensor,
         /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
         /*cb_id=*/tt::CBIndex::c_9,
         "dispatch_table_tensor");
 
+    // Iterate over every coordinate in the mesh (full coord range derived from
+    // the mesh shape) — replaces the legacy `tensor_coords` parameter.
     std::vector<uint32_t> dest_mesh_id, dest_chip_id;
-    for (const auto& coord : tensor_coords.coords()) {
+    for (const auto& coord : ttnn::MeshCoordinateRange(mesh_view.shape())) {
         auto dest_fabric_node_id = mesh_device->get_fabric_node_id(coord);
         dest_mesh_id.push_back(*dest_fabric_node_id.mesh_id);
         dest_chip_id.push_back((uint32_t)dest_fabric_node_id.chip_id);
@@ -1130,32 +1232,43 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
         fabric_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
     }
 
-    // Single reader kernel shared across all senders; store one handle per sender for
-    // uniform override_runtime_arguments iteration between tile and row-major paths.
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    // Single reader kernel shared across all senders.  (Legacy code stored one
+    // handle per sender for uniform override_runtime_arguments iteration; the
+    // descriptor framework uses BufferBindings on cache hit so the duplication
+    // is no longer needed.)
+    tt::tt_metal::KernelDescriptor reader_kd;
+    reader_kd.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-        "reader_dispatch.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-            .compile_args = compile_time_args,
-            .defines = fabric_defines});
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids(num_cores, reader_kernel_id);
+        "reader_dispatch.cpp";
+    reader_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kd.core_ranges = sender_core_grid;
+    reader_kd.compile_time_args = compile_time_args;
+    reader_kd.defines = {fabric_defines.begin(), fabric_defines.end()};
+    reader_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+    };
+    tt::tt_metal::KernelHandle reader_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(reader_kd));
 
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    tt::tt_metal::KernelDescriptor writer_kd;
+    writer_kd.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-        "writer_dispatch.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-            .compile_args = compile_time_args,
-            .defines = fabric_defines});
+        "writer_dispatch.cpp";
+    writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kd.core_ranges = sender_core_grid;
+    writer_kd.compile_time_args = compile_time_args;
+    writer_kd.defines = {fabric_defines.begin(), fabric_defines.end()};
+    writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
+    };
+    tt::tt_metal::KernelHandle writer_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(writer_kd));
 
-    // Runtime args: all cores process all tokens, experts split round-robin
+    // Runtime args: all cores process all tokens, experts split round-robin.
+    // Build as a flat uint32_t vector so the fabric helper can extend it, then
+    // promote to an RTArgList with Buffer* in the first seven slots.
     std::vector<uint32_t> base_runtime_args = {
         input_tensor.buffer()->address(),
         indices_tensor.buffer()->address(),
@@ -1170,6 +1283,22 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
         (uint32_t)tokens_per_device,  // token_end_idx (all tokens)
         0,                            // dispatch_core_idx (set per core)
         num_cores,                    // num_dispatch_cores
+    };
+
+    auto promote_rt_args_with_buffer_bindings = [&](const std::vector<uint32_t>& raw_args) {
+        tt::tt_metal::KernelDescriptor::RTArgList args;
+        args.reserve(raw_args.size());
+        args.push_back(input_tensor.buffer());
+        args.push_back(indices_tensor.buffer());
+        args.push_back(weights_tensor.buffer());
+        args.push_back(offsets_tensor.buffer());
+        args.push_back(output_tensor.buffer());
+        args.push_back(metadata_tensor.buffer());
+        args.push_back(dispatch_table_tensor.buffer());
+        for (size_t i = 7; i < raw_args.size(); ++i) {
+            args.push_back(raw_args[i]);
+        }
+        return args;
     };
 
     uint32_t core_idx = 0;
@@ -1200,48 +1329,40 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
                     neighbor_coordinate[1],
                     sender_core,
                     core_link);
-                tt::tt_fabric::append_fabric_connection_rt_args(
+                tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
                     src_fabric_node_id,
                     mesh_device->get_fabric_node_id(neighbor_coordinate),
                     core_link,
-                    program,
+                    desc,
                     sender_core,
                     writer_runtime_args);
             }
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, sender_core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
+        desc.kernels[reader_kernel_id].emplace_runtime_args(
+            sender_core, promote_rt_args_with_buffer_bindings(reader_runtime_args));
+        desc.kernels[writer_kernel_id].emplace_runtime_args(
+            sender_core, promote_rt_args_with_buffer_bindings(writer_runtime_args));
         core_idx++;
     }
 
-    return {
-        std::move(program),
-        {.reader_kernel_ids = std::move(reader_kernel_ids),
-         .writer_kernel_id = writer_kernel_id,
-         .reader_untilize_kernel_ids = {},
-         .writer_untilize_kernel_ids = {},
-         .cores = sender_cores,
-         .idle_cores = {},
-         .init_semaphore = init_semaphore,
-         .exit_semaphore = exit_semaphore,
-         .cross_device_semaphore = cross_device_semaphore,
-         .data_ready_semaphore_ids = {},
-         .start_semaphore_ids = {}}};
+    return desc;
 }
 
 }  // namespace
 
-DispatchProgramFactory::cached_mesh_workload_t DispatchProgramFactory::create_mesh_workload(
+tt::tt_metal::WorkloadDescriptor DispatchProgramFactory::create_workload_descriptor(
     const DispatchParams& operation_attributes,
-    const MeshCoordinateRangeSet& tensor_coords,
     const DispatchInputs& tensor_args,
-    DispatchProgramFactory::tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, DispatchSharedVariables> shared_variables;
-
+    DispatchProgramFactory::tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     auto* mesh_device = tensor_args.input_tensor.device();
 
+    // Allocate the three cross-device GlobalSemaphores once per workload (cache miss).
+    // They live on WorkloadDescriptor.semaphores so the device-side allocations
+    // outlive the cached MeshWorkload via the program cache — kernel runtime args
+    // bake in their absolute addresses, so per-coord program builds must see the
+    // same allocation as every other coord.
     auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
                                                                             : tt::tt_metal::BufferType::L1;
     auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
@@ -1250,33 +1371,15 @@ DispatchProgramFactory::cached_mesh_workload_t DispatchProgramFactory::create_me
         mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
     auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
         mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
+    // Cross-device barrier: ensure every device has allocated its GlobalSemaphores
+    // before any kernel reads them.  Mirrors the previous prepare_resources hook.
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
 
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(
-            operation_attributes,
-            coord,
-            tensor_args,
-            tensor_return_value,
-            tensor_coords,
-            init_barrier_semaphore,
-            exit_barrier_semaphore,
-            final_barrier_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+    workload_descriptor.semaphores.push_back(init_barrier_semaphore);
+    workload_descriptor.semaphores.push_back(exit_barrier_semaphore);
+    workload_descriptor.semaphores.push_back(final_barrier_semaphore);
 
-ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFactory::create_at(
-    const DispatchParams& operation_attributes,
-    const MeshCoordinate& mesh_coordinate,
-    const DispatchInputs& tensor_args,
-    DispatchProgramFactory::tensor_return_value_t& tensor_return_value,
-    const MeshCoordinateRangeSet& tensor_coords,
-    const GlobalSemaphore& init_semaphore,
-    const GlobalSemaphore& exit_semaphore,
-    const GlobalSemaphore& cross_device_semaphore) {
     const bool is_tile_layout = tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE;
     log_info(tt::LogOp, "Prefill dispatch: input tensor is {} layout", is_tile_layout ? "TILE" : "ROW_MAJOR");
     if (operation_attributes.use_fp8_dispatch) {
@@ -1285,86 +1388,31 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
             "Prefill dispatch: FP8 path — output buffer is allocated as UINT8 but content is Fp8_e4m3. "
             "CBs reinterpret UINT8 tensors as Fp8_e4m3 (temporary, until FP8 has a dedicated dtype).");
     }
-    if (is_tile_layout) {
-        return create_at_tile_layout(
-            operation_attributes,
-            mesh_coordinate,
-            tensor_args,
-            tensor_return_value,
-            tensor_coords,
-            init_semaphore,
-            exit_semaphore,
-            cross_device_semaphore);
+
+    // Dispatch is mesh-coord-dependent (fabric routing + linearized mesh
+    // coordinate are baked into kernel compile-time args), so we cannot
+    // replicate one ProgramDescriptor across the whole mesh — every coord
+    // gets its own build.
+    for (const auto& coord : tensor_coords.coords()) {
+        tt::tt_metal::ProgramDescriptor desc = is_tile_layout ? create_at_tile_layout(
+                                                                    operation_attributes,
+                                                                    coord,
+                                                                    tensor_args,
+                                                                    tensor_return_value,
+                                                                    init_barrier_semaphore,
+                                                                    exit_barrier_semaphore,
+                                                                    final_barrier_semaphore)
+                                                              : create_at_row_major(
+                                                                    operation_attributes,
+                                                                    coord,
+                                                                    tensor_args,
+                                                                    tensor_return_value,
+                                                                    init_barrier_semaphore,
+                                                                    exit_barrier_semaphore,
+                                                                    final_barrier_semaphore);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
-    return create_at_row_major(
-        operation_attributes,
-        mesh_coordinate,
-        tensor_args,
-        tensor_return_value,
-        tensor_coords,
-        init_semaphore,
-        exit_semaphore,
-        cross_device_semaphore);
-}
-
-void DispatchProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const DispatchParams& /*operation_attributes*/,
-    const DispatchInputs& tensor_args,
-    DispatchProgramFactory::tensor_return_value_t& tensor_return_value) {
-    const bool is_tile_layout = tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE;
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-        const auto& writer_kernel_id = shared_variables.writer_kernel_id;
-        const auto& cores = shared_variables.cores;
-
-        const auto& output_tensor = tensor_return_value.at(0);
-        const auto& metadata_tensor = tensor_return_value.at(1);
-
-        for (size_t s = 0; s < cores.size(); s++) {
-            const auto& core = cores[s];
-            auto& reader_runtime_args =
-                tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_ids[s], core);
-            auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
-
-            reader_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
-            reader_runtime_args.at(1) = tensor_args.indices_tensor.buffer()->address();
-            reader_runtime_args.at(2) = tensor_args.weights_tensor.buffer()->address();
-            reader_runtime_args.at(3) = tensor_args.expert_offsets_tensor.buffer()->address();
-            reader_runtime_args.at(4) = output_tensor.buffer()->address();
-            reader_runtime_args.at(5) = metadata_tensor.buffer()->address();
-            reader_runtime_args.at(6) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
-            reader_runtime_args.at(7) = (uint32_t)shared_variables.cross_device_semaphore.address();
-            reader_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore.address();
-
-            writer_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
-            writer_runtime_args.at(1) = tensor_args.indices_tensor.buffer()->address();
-            writer_runtime_args.at(2) = tensor_args.weights_tensor.buffer()->address();
-            writer_runtime_args.at(3) = tensor_args.expert_offsets_tensor.buffer()->address();
-            writer_runtime_args.at(4) = output_tensor.buffer()->address();
-            writer_runtime_args.at(5) = metadata_tensor.buffer()->address();
-            writer_runtime_args.at(6) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
-            writer_runtime_args.at(7) = (uint32_t)shared_variables.cross_device_semaphore.address();
-            writer_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore.address();
-            // Index 13 is the writer-only exit_semaphore.address() pushed in create_at_*.
-            // base_runtime_args has 13 entries (0..12), then writer push_back's exit_semaphore at 13.
-            writer_runtime_args.at(13) = (uint32_t)shared_variables.exit_semaphore.address();
-        }
-
-        // Idle cores only exist on the tile-layout path.
-        if (is_tile_layout) {
-            for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
-                auto& idle_reader_rt_args = tt::tt_metal::GetRuntimeArgs(
-                    program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-                idle_reader_rt_args.at(0) = tensor_args.input_tensor.buffer()->address();
-
-                auto& idle_writer_rt_args = tt::tt_metal::GetRuntimeArgs(
-                    program, shared_variables.writer_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-                idle_writer_rt_args.at(6) = output_tensor.buffer()->address();
-                idle_writer_rt_args.at(7) = metadata_tensor.buffer()->address();
-            }
-        }
-    }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.hpp
@@ -11,50 +11,26 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 #include <ttnn/global_semaphore.hpp>
+#include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 
-struct DispatchSharedVariables {
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
-    std::vector<tt::tt_metal::KernelHandle> writer_untilize_kernel_ids;
-    std::vector<CoreCoord> cores;
-    std::vector<CoreCoord> idle_cores;
-    GlobalSemaphore init_semaphore;          // Initialized in create_at()
-    GlobalSemaphore exit_semaphore;          // Separate sem for the exit handshake (avoids
-                                             // init/exit reuse race; mirrors combine fix)
-    GlobalSemaphore cross_device_semaphore;  // Initialized in create_at()
-    std::vector<uint32_t> data_ready_semaphore_ids;
-    std::vector<uint32_t> start_semaphore_ids;
-};
-
 struct DispatchProgramFactory {
-    using shared_variables_t = DispatchSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
     using tensor_return_value_t = std::array<Tensor, 2>;
 
-    static cached_mesh_workload_t create_mesh_workload(
+    // Declarative WorkloadDescriptor entry point (Contract 2).  Allocates the
+    // three GlobalSemaphores once per cache miss (parked in
+    // `WorkloadDescriptor::semaphores` so their device-side allocations outlive
+    // the cached workload), runs the cross-device Synchronize barrier, then
+    // builds one ProgramDescriptor per mesh coordinate.  The framework
+    // realises this into the cached MeshWorkload.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const DispatchParams& operation_attributes,
-        const MeshCoordinateRangeSet& tensor_coords,
-        const DispatchInputs& tensor_args,
-        tensor_return_value_t& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const DispatchParams& operation_attributes,
-        const MeshCoordinate& mesh_coordinate,
         const DispatchInputs& tensor_args,
         tensor_return_value_t& tensor_return_value,
-        const MeshCoordinateRangeSet& tensor_coords,
-        const GlobalSemaphore& init_semaphore,
-        const GlobalSemaphore& exit_semaphore,
-        const GlobalSemaphore& cross_device_semaphore);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
-        const DispatchParams& operation_attributes,
-        const DispatchInputs& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
@@ -12,19 +12,23 @@
 #include "ttnn/operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-namespace {
+tt::tt_metal::ProgramDescriptor OffsetCumsumProgramFactory::create_descriptor(
+    const OffsetCumsumParams& operation_attributes,
+    const Tensor& input,
+    tensor_return_value_t& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    TT_FATAL(
+        mesh_dispatch_coordinate.has_value(),
+        "OffsetCumsumProgramFactory::create_descriptor requires a mesh dispatch coordinate");
+    const ttnn::MeshCoordinate coord = mesh_dispatch_coordinate.value();
+    const uint32_t row_idx = coord[operation_attributes.cluster_axis];
+    const uint32_t experts_per_chip = operation_attributes.experts_per_chip;
 
-struct CreatedProgram {
-    tt::tt_metal::Program program;
-    OffsetCumsumSharedVariables shared_variables;
-};
-
-CreatedProgram create_program(
-    const Tensor& input, std::array<Tensor, 3>& tensor_return_value, uint32_t row_idx, uint32_t experts_per_chip) {
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(tt::tt_metal::DataType::UINT32);
 
@@ -50,22 +54,37 @@ CreatedProgram create_program(
     uint32_t expert_region_page_size = dst_expert_region_buffer->aligned_page_size();
 
     uint32_t cb_in0_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_in0_config =
-        tt::tt_metal::CircularBufferConfig(input_page_size, {{cb_in0_index, cb_data_format}})
-            .set_page_size(cb_in0_index, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_set, cb_in0_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = input_page_size,
+        .core_ranges = core_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_in0_index),
+            .data_format = cb_data_format,
+            .page_size = input_page_size,
+        }}},
+    });
 
     uint32_t cb_out0_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_out0_config =
-        tt::tt_metal::CircularBufferConfig(offsets_page_size, {{cb_out0_index, cb_data_format}})
-            .set_page_size(cb_out0_index, offsets_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_set, cb_out0_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = offsets_page_size,
+        .core_ranges = core_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_out0_index),
+            .data_format = cb_data_format,
+            .page_size = offsets_page_size,
+        }}},
+    });
 
     uint32_t cb_local_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_local_config =
-        tt::tt_metal::CircularBufferConfig(offsets_page_size, {{cb_local_index, cb_data_format}})
-            .set_page_size(cb_local_index, offsets_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_set, cb_local_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = offsets_page_size,
+        .core_ranges = core_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_local_index),
+            .data_format = cb_data_format,
+            .page_size = offsets_page_size,
+        }}},
+    });
 
     std::vector<uint32_t> compile_time_args = {
         cb_in0_index,
@@ -88,69 +107,29 @@ CreatedProgram create_program(
     tt::tt_metal::TensorAccessorArgs(dst_totals_buffer).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(dst_expert_region_buffer).append_to(compile_time_args);
 
-    std::map<std::string, std::string> kernel_defines;
-    tt::tt_metal::KernelHandle kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/kernels/"
-        "reader_offset_cumsum_interleaved.cpp",
-        core_set,
-        tt::tt_metal::ReaderDataMovementConfig(compile_time_args, kernel_defines));
+        "reader_offset_cumsum_interleaved.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = core_set;
+    reader_kernel_desc.compile_time_args = std::move(compile_time_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
-    tt::tt_metal::SetRuntimeArgs(
-        program,
-        kernel_id,
-        core,
-        {src_buffer->address(),
-         dst_offsets_buffer->address(),
-         dst_totals_buffer->address(),
-         dst_expert_region_buffer->address(),
-         row_idx});
+    // Buffer* in the first four positions so the framework records BufferBindings
+    // for the cache-hit fast path; row_idx is plain uint32_t (no override needed —
+    // it is invariant for a given coord, baked into the cached program for that coord).
+    tt::tt_metal::KernelDescriptor::RTArgList reader_rt_args;
+    reader_rt_args.push_back(src_buffer);
+    reader_rt_args.push_back(dst_offsets_buffer);
+    reader_rt_args.push_back(dst_totals_buffer);
+    reader_rt_args.push_back(dst_expert_region_buffer);
+    reader_rt_args.push_back(row_idx);
+    reader_kernel_desc.emplace_runtime_args(core, reader_rt_args);
 
-    return CreatedProgram{
-        std::move(program),
-        {/* kernel_id = */ kernel_id,
-         /* core      = */ core}};
-}
+    desc.kernels.push_back(std::move(reader_kernel_desc));
 
-}  // namespace
-
-OffsetCumsumProgramFactory::cached_mesh_workload_t OffsetCumsumProgramFactory::create_mesh_workload(
-    const OffsetCumsumParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const Tensor& input,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    for (const auto& coord : tensor_coords.coords()) {
-        uint32_t row_idx = coord[operation_attributes.cluster_axis];
-
-        auto result = create_program(input, tensor_return_value, row_idx, operation_attributes.experts_per_chip);
-        auto coord_range = ttnn::MeshCoordinateRange(coord);
-        mesh_workload.add_program(coord_range, std::move(result.program));
-        shared_variables.emplace(coord_range, result.shared_variables);
-    }
-
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
-}
-
-void OffsetCumsumProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const OffsetCumsumParams& operation_attributes,
-    const Tensor& input,
-    tensor_return_value_t& tensor_return_value) {
-    for (auto& [coord_range, program] : cached_workload.workload.get_programs()) {
-        auto coord = *(coord_range.begin());
-        uint32_t row_idx = coord[operation_attributes.cluster_axis];
-
-        auto& shared_vars = cached_workload.shared_variables.at(coord_range);
-        auto& runtime_args = GetRuntimeArgs(program, shared_vars.kernel_id, shared_vars.core);
-        runtime_args[0] = input.buffer()->address();
-        runtime_args[1] = tensor_return_value.at(0).buffer()->address();
-        runtime_args[2] = tensor_return_value.at(1).buffer()->address();
-        runtime_args[3] = tensor_return_value.at(2).buffer()->address();
-        runtime_args[4] = row_idx;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
@@ -24,7 +24,7 @@ tt::tt_metal::ProgramDescriptor OffsetCumsumProgramFactory::create_descriptor(
     TT_FATAL(
         mesh_dispatch_coordinate.has_value(),
         "OffsetCumsumProgramFactory::create_descriptor requires a mesh dispatch coordinate");
-    const ttnn::MeshCoordinate coord = mesh_dispatch_coordinate.value();
+    const ttnn::MeshCoordinate& coord = mesh_dispatch_coordinate.value();
     const uint32_t row_idx = coord[operation_attributes.cluster_axis];
     const uint32_t experts_per_chip = operation_attributes.experts_per_chip;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.hpp
@@ -5,35 +5,26 @@
 #pragma once
 
 #include <array>
-#include <unordered_map>
+#include <optional>
 
 #include "offset_cumsum_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct OffsetCumsumSharedVariables {
-    tt::tt_metal::KernelHandle kernel_id = 0;
-    CoreCoord core;
-};
-
 struct OffsetCumsumProgramFactory {
-    using shared_variables_t = OffsetCumsumSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
     using tensor_return_value_t = std::array<Tensor, 3>;
 
-    static cached_mesh_workload_t create_mesh_workload(
-        const OffsetCumsumParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const Tensor& input,
-        tensor_return_value_t& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Per-coord program build.  `mesh_dispatch_coordinate` is required: this op
+    // bakes a per-device `row_idx` (derived from cluster_axis) into the reader's
+    // runtime args, so each device gets a different program.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const OffsetCumsumParams& operation_attributes,
         const Tensor& input,
-        tensor_return_value_t& tensor_return_value);
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::post_combine_reduce {
 
@@ -18,17 +18,13 @@ uint32_t get_num_pages(const ttnn::Tensor& tensor) { return (uint32_t)tensor.buf
 uint32_t get_page_size(const ttnn::Tensor& tensor) { return (uint32_t)tensor.buffer()->page_size(); }
 uint32_t get_aligned_page_size(const ttnn::Tensor& tensor) { return (uint32_t)tensor.buffer()->aligned_page_size(); }
 
-struct CreatedProgram {
-    tt::tt_metal::Program program;
-    PostCombineReduceProgramFactory::shared_variables_t shared_variables;
-};
+}  // namespace
 
-CreatedProgram create_at(
+tt::tt_metal::ProgramDescriptor PostCombineReduceProgramFactory::create_descriptor(
     const PostCombineReduceParams& operation_attributes,
-    [[maybe_unused]] const ttnn::MeshCoordinate& mesh_coordinate,
     const PostCombineReduceInputs& tensor_args,
     ttnn::Tensor& tensor_return_value) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    tt::tt_metal::ProgramDescriptor desc;
 
     const auto& combine_output = tensor_args.combine_output;
     const auto& weights = tensor_args.weights;
@@ -105,17 +101,27 @@ CreatedProgram create_at(
 
     // c_0: Stream one expert at a time through c_0 to minimize L1 footprint.
     uint32_t combine_cb_size = emb_dim_cb_tiles * tile_size;
-    tt::tt_metal::CircularBufferConfig cb_combine_config =
-        tt::tt_metal::CircularBufferConfig(combine_cb_size, {{tt::CBIndex::c_0, input_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_0, tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_combine_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = combine_cb_size,
+        .core_ranges = core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = tile_size,
+        }}},
+    });
 
     // c_1: Stream one weight at a time (matching expert-by-expert input streaming).
     uint32_t weight_cb_size = tile_size;
-    tt::tt_metal::CircularBufferConfig cb_weight_config =
-        tt::tt_metal::CircularBufferConfig(weight_cb_size, {{tt::CBIndex::c_1, weight_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_1, tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_weight_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = weight_cb_size,
+        .core_ranges = core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+            .data_format = weight_cb_data_format,
+            .page_size = tile_size,
+        }}},
+    });
 
     // c_2 / c_3 CBs (dispatch table, indices) are only allocated when the
     // DeepSeek skip path is in use; the GPT-OSS path does not touch them.
@@ -139,36 +145,55 @@ CreatedProgram create_at(
         dispatch_table_page_size_val = get_page_size(expert_dispatch_table);
         dispatch_table_aligned_page_size = get_aligned_page_size(expert_dispatch_table);
         uint32_t dispatch_table_cb_size = dispatch_table_num_pages * dispatch_table_aligned_page_size;
-        tt::tt_metal::CircularBufferConfig cb_dispatch_table_config =
-            tt::tt_metal::CircularBufferConfig(
-                dispatch_table_cb_size, {{tt::CBIndex::c_2, dispatch_table_cb_data_format}})
-                .set_page_size(tt::CBIndex::c_2, dispatch_table_aligned_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_dispatch_table_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = dispatch_table_cb_size,
+            .core_ranges = core_range_set,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_2),
+                .data_format = dispatch_table_cb_data_format,
+                .page_size = dispatch_table_aligned_page_size,
+            }}},
+        });
 
         // c_3: Indices scratch — loaded one chunk at a time (reused per chunk).
         indices_page_size_val = get_page_size(indices);
         indices_aligned_page_size = get_aligned_page_size(indices);
         indices_pages_per_core = TOKENS_PER_CHUNK;
         uint32_t indices_cb_size = indices_pages_per_core * indices_aligned_page_size;
-        tt::tt_metal::CircularBufferConfig cb_indices_config =
-            tt::tt_metal::CircularBufferConfig(indices_cb_size, {{tt::CBIndex::c_3, indices_cb_data_format}})
-                .set_page_size(tt::CBIndex::c_3, indices_aligned_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_indices_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = indices_cb_size,
+            .core_ranges = core_range_set,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+                .data_format = indices_cb_data_format,
+                .page_size = indices_aligned_page_size,
+            }}},
+        });
     }
 
     // c_16: Output — one chunk at a time (compute produces TOKENS_PER_CHUNK tiles per iteration)
     uint32_t output_cb_size = TOKENS_PER_CHUNK * emb_dim_cb_tiles * tile_size;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(output_cb_size, {{tt::CBIndex::c_16, output_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_16, tile_size);
-    auto cb_output_handle = tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_output_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = output_cb_size,
+        .core_ranges = core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = tile_size,
+        }}},
+    });
 
     // c_17: Row-major scratch for tilize — one chunk at a time
     uint32_t rowmajor_cb_size = TOKENS_PER_CHUNK * emb_dim_cb_tiles * tile_size;
-    tt::tt_metal::CircularBufferConfig cb_rowmajor_config =
-        tt::tt_metal::CircularBufferConfig(rowmajor_cb_size, {{tt::CBIndex::c_17, output_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_17, tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_rowmajor_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = rowmajor_cb_size,
+        .core_ranges = core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_17),
+            .data_format = output_cb_data_format,
+            .page_size = tile_size,
+        }}},
+    });
 
     auto* combine_buffer = combine_output.buffer();
     auto* weight_buffer = weights.buffer();
@@ -218,31 +243,39 @@ CreatedProgram create_at(
         .append_to(writer_compile_time_args);
     writer_compile_time_args.push_back(static_cast<uint32_t>(use_dispatch_table_skip ? 1 : 0));
 
-    auto reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    // Build kernel descriptors and push them onto desc.kernels.  Stable indices
+    // (0=reader, 1=compute, 2=writer) below let emplace_runtime_args identify
+    // each kernel.
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/"
-        "deepseek_moe_post_combine_reduce_reader.cpp",
-        core_range_set,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "deepseek_moe_post_combine_reduce_reader.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = core_range_set;
+    reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
-    auto compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    tt::tt_metal::KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/"
-        "deepseek_moe_post_combine_reduce_compute.cpp",
-        core_range_set,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
-            .fp32_dest_acc_en = false,
-            .dst_full_sync_en = false,
-            .compile_args = compute_compile_time_args,
-        });
+        "deepseek_moe_post_combine_reduce_compute.cpp";
+    compute_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = core_range_set;
+    compute_kernel_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_kernel_desc.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = MathFidelity::HiFi4,
+        .fp32_dest_acc_en = false,
+        .dst_full_sync_en = false,
+    };
 
-    auto writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/"
-        "deepseek_moe_post_combine_reduce_writer.cpp",
-        core_range_set,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "deepseek_moe_post_combine_reduce_writer.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = core_range_set;
+    writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
 
     // Distribute chunks of 32 tokens across cores. The first `extra_chunks` cores
     // get (base_chunks_per_core + 1) chunks; the remaining get base_chunks_per_core.
@@ -251,98 +284,44 @@ CreatedProgram create_at(
         const CoreCoord& core = cores[i];
         const uint32_t chunks_this_core = base_chunks_per_core + (i < extra_chunks ? 1 : 0);
 
-        std::vector<uint32_t> reader_runtime_args = {
-            combine_buffer->address(),
-            token_start,
-            chunks_this_core,
-        };
+        // Reader RT args: [combine_buffer*, token_start, chunks_this_core].
+        // Push the buffer pointer first so the framework records a BufferBinding
+        // for the cache-hit fast path.
+        tt::tt_metal::KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(combine_buffer);
+        reader_rt_args.push_back(token_start);
+        reader_rt_args.push_back(chunks_this_core);
+        reader_kernel_desc.emplace_runtime_args(core, reader_rt_args);
 
-        std::vector<uint32_t> compute_runtime_args = {
-            token_start,
-            chunks_this_core,
-        };
+        // Compute RT args (no Buffer*).
+        tt::tt_metal::KernelDescriptor::RTArgList compute_rt_args;
+        compute_rt_args.push_back(token_start);
+        compute_rt_args.push_back(chunks_this_core);
+        compute_kernel_desc.emplace_runtime_args(core, compute_rt_args);
 
         // Writer runtime args: weight_addr, output_addr,
         //   (deepseek only: dispatch_table_addr, indices_addr),
-        //   token_start, chunks_this_core. override_runtime_arguments mirrors this layout.
-        std::vector<uint32_t> writer_runtime_args = {
-            weight_buffer->address(),
-            output_buffer->address(),
-        };
+        //   token_start, chunks_this_core.  All buffer addresses are pushed as
+        //   Buffer* so the framework records bindings for the fast path.
+        tt::tt_metal::KernelDescriptor::RTArgList writer_rt_args;
+        writer_rt_args.push_back(weight_buffer);
+        writer_rt_args.push_back(output_buffer);
         if (use_dispatch_table_skip) {
-            writer_runtime_args.push_back(dispatch_table_buffer->address());
-            writer_runtime_args.push_back(indices_buffer->address());
+            writer_rt_args.push_back(dispatch_table_buffer);
+            writer_rt_args.push_back(indices_buffer);
         }
-        writer_runtime_args.push_back(token_start);
-        writer_runtime_args.push_back(chunks_this_core);
-
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        writer_rt_args.push_back(token_start);
+        writer_rt_args.push_back(chunks_this_core);
+        writer_kernel_desc.emplace_runtime_args(core, writer_rt_args);
 
         token_start += chunks_this_core * TOKENS_PER_CHUNK;
     }
 
-    return CreatedProgram{
-        std::move(program),
-        {
-            .reader_kernel_id = reader_kernel_id,
-            .compute_kernel_id = compute_kernel_id,
-            .writer_kernel_id = writer_kernel_id,
-            .output_cb_handle = cb_output_handle,
-            .cores = cores,
-            .use_dispatch_table_skip = use_dispatch_table_skip,
-        }};
-}
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+    desc.kernels.push_back(std::move(writer_kernel_desc));
 
-}  // namespace
-
-PostCombineReduceProgramFactory::cached_mesh_workload_t PostCombineReduceProgramFactory::create_mesh_workload(
-    const PostCombineReduceParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const PostCombineReduceInputs& tensor_args,
-    ttnn::Tensor& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto result = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        auto coord_range = ttnn::MeshCoordinateRange(coord);
-        mesh_workload.add_program(coord_range, std::move(result.program));
-        shared_variables.emplace(coord_range, std::move(result.shared_variables));
-    }
-
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
-}
-
-void PostCombineReduceProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    [[maybe_unused]] const PostCombineReduceParams& operation_attributes,
-    const PostCombineReduceInputs& tensor_args,
-    ttnn::Tensor& tensor_return_value) {
-    auto* combine_buffer = tensor_args.combine_output.buffer();
-    auto* weight_buffer = tensor_args.weights.buffer();
-    auto* output_buffer = tensor_return_value.buffer();
-    auto* indices_buffer = tensor_args.indices.has_value() ? tensor_args.indices->buffer() : nullptr;
-    auto* dispatch_table_buffer =
-        tensor_args.expert_dispatch_table.has_value() ? tensor_args.expert_dispatch_table->buffer() : nullptr;
-
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& svars = cached_workload.shared_variables.at(range);
-
-        for (const auto& core : svars.cores) {
-            auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, svars.reader_kernel_id, core);
-            reader_runtime_args[0] = combine_buffer->address();
-
-            auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, svars.writer_kernel_id, core);
-            writer_runtime_args[0] = weight_buffer->address();
-            writer_runtime_args[1] = output_buffer->address();
-            if (svars.use_dispatch_table_skip) {
-                writer_runtime_args[2] = dispatch_table_buffer->address();
-                writer_runtime_args[3] = indices_buffer->address();
-            }
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::post_combine_reduce

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.hpp
@@ -7,33 +7,15 @@
 #include "post_combine_reduce_types.hpp"
 
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::post_combine_reduce {
 
 struct PostCombineReduceProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id;
-        tt::tt_metal::KernelHandle compute_kernel_id;
-        tt::tt_metal::KernelHandle writer_kernel_id;
-        tt::tt_metal::CBHandle output_cb_handle;
-        std::vector<tt::tt_metal::CoreCoord> cores;
-        // Tracks whether this program was built with the DeepSeek (dispatch
-        // table) skip path so override_runtime_arguments can thread the
-        // dispatch_table / indices addresses only when they exist.
-        bool use_dispatch_table_skip;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const PostCombineReduceParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const PostCombineReduceInputs& tensor_args,
-        ttnn::Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Per-coord program build.  The post_combine_reduce kernels are coord-invariant
+    // (no fabric, no per-device row index), so this factory uses the no-coord
+    // overload and the framework replicates the same descriptor across the mesh.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PostCombineReduceParams& operation_attributes,
         const PostCombineReduceInputs& tensor_args,
         ttnn::Tensor& tensor_return_value);


### PR DESCRIPTION
Four ops in the deepseek_prefill family:

- `dispatch`
- `combine`
- `post_combine_reduce`
- `offset_cumsum` (helper factory)

Each factory exposes `static create_descriptor(...)` returning `ProgramDescriptor` with `mesh_dispatch_coordinate`. Uses the workload-level `prepare_resources` hook from #44397 for GlobalSemaphore allocation.

Depends on: #44397.

Contributes to #42193, #42207.

## Performance

deepseek_prefill mesh-workload ops (combine, dispatch, offset_cumsum, post_combine_reduce) require multi-device meshes; single-device bench is not meaningful. Per-op host dispatch perf delta from main: pending CI/multi-device runner.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=dgomez/migrate-deepseek-prefill-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:dgomez/migrate-deepseek-prefill-mesh)