### PR TITLE
Migrate point_to_point to ProgramDescriptor on mesh workload hook

### DIFF
--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
@@ -5,7 +5,6 @@
 #include <tt_stl/assert.hpp>
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
-#include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
@@ -99,8 +98,6 @@ Fabric1DRoute fabric_1d_routing(
 }
 }  // namespace detail
 
-using cached_workload_t = device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variables_t>;
-
 void PointToPointOp::validate(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     TT_FATAL(!input_tensor.is_sharded(), "Point to point does not yet support sharded configs");
@@ -184,17 +181,18 @@ PointToPointOp::tensor_return_value_t PointToPointOp::create_output_tensors(
     return {intermediate_output_tensor, final_output_tensor};
 }
 
-PointToPointOp::SendReceive::cached_mesh_workload_t PointToPointOp::SendReceive::create_mesh_workload(
+tt::tt_metal::WorkloadDescriptor PointToPointOp::SendReceive::create_workload_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    std::array<MeshCoordinate, 2> use_coords = {operation_attributes.send_coord, operation_attributes.receive_coord};
-
+    tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     auto* mesh_device = tensor_args.input_tensor.device();
+
+    // Allocate the shared GlobalSemaphore used by both endpoint programs and
+    // run the cross-device Synchronize barrier ONCE per workload (cache miss).
+    // The semaphore's device-side allocation must outlive every program that
+    // references its absolute address — park it in WorkloadDescriptor.semaphores
+    // so the framework keeps it alive for the cached workload's lifetime.
     auto sd_id = mesh_device->get_sub_device_ids().at(0);
     auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
     auto semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
@@ -202,89 +200,33 @@ PointToPointOp::SendReceive::cached_mesh_workload_t PointToPointOp::SendReceive:
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
     log_debug(tt::LogOp, "Synchronize devices in p2p op done");
 
+    const auto& send_coord = operation_attributes.send_coord;
+    const auto& receive_coord = operation_attributes.receive_coord;
+
     const auto& coords = tensor_coords.coords();
-    for (const auto& c : use_coords) {
+    for (const auto& c : {send_coord, receive_coord}) {
         auto it = std::find(coords.begin(), coords.end(), c);
         TT_FATAL(it != coords.end(), "Tensor not present on coordinate: {}", c);
     }
 
-    for (const auto& coord : use_coords) {
-        auto cached_workload = create_at(operation_attributes, coord, tensor_args, tensor_return_value, semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_workload.program));
-        shared_variables.emplace(coord, std::move(cached_workload.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+    workload_descriptor.semaphores.push_back(semaphore);
+
+    // Only the sender and receiver coords participate.  The original
+    // create_mesh_workload likewise added programs only for these two coords;
+    // we keep that behaviour by emitting per-coord PerCoordProgram entries.
+    tt::tt_metal::ProgramDescriptor send_desc = send_program_factory(
+        tensor_args, operation_attributes, send_coord, receive_coord, tensor_return_value, semaphore);
+    workload_descriptor.programs.push_back(
+        {tt::tt_metal::distributed::MeshCoordinateRange(send_coord), std::move(send_desc)});
+
+    tt::tt_metal::ProgramDescriptor receive_desc =
+        receive_program_factory(operation_attributes, tensor_return_value, semaphore);
+    workload_descriptor.programs.push_back(
+        {tt::tt_metal::distributed::MeshCoordinateRange(receive_coord), std::move(receive_desc)});
+
+    return workload_descriptor;
 }
-
-cached_workload_t PointToPointOp::SendReceive::create_at(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
-    const tt::tt_metal::GlobalSemaphore& semaphore) {
-    const auto& send_coordinate = operation_attributes.send_coord;
-    const auto& receive_coordinate = operation_attributes.receive_coord;
-
-    if (mesh_coordinate == send_coordinate) {
-        return send_program_factory(
-            tensor_args, operation_attributes, send_coordinate, receive_coordinate, tensor_return_value, semaphore);
-    }
-    if (mesh_coordinate == receive_coordinate) {
-        return receive_program_factory(operation_attributes, tensor_return_value, semaphore);
-    }
-
-    TT_THROW("Invalid coordinate in p2p");
-    return {Program{}, shared_variables_t{.semaphore = semaphore}};
-}
-
-void PointToPointOp::SendReceive::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    const auto send_coord = operation_attributes.send_coord;
-    const auto receive_coord = operation_attributes.receive_coord;
-
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& coord = range.start_coord();
-        TT_FATAL(
-            coord == range.end_coord(),
-            "Expected single coordinate per program but got range of {} to {}",
-            coord,
-            range.end_coord());
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-
-        if (coord == send_coord) {
-            const auto& send_unary_reader_kernel_id = shared_variables.send_unary_reader_kernel_id;
-            const auto& send_unary_writer_kernel_id = shared_variables.send_unary_writer_kernel_id;
-
-            // change this when we use more cores for multi-link
-            const auto& core = shared_variables.sender_cores.at(0);
-
-            auto& reader_runtime_args = GetRuntimeArgs(program, send_unary_reader_kernel_id, core);
-            reader_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
-
-            auto& writer_runtime_args = GetRuntimeArgs(program, send_unary_writer_kernel_id, core);
-            writer_runtime_args.at(0) = tensor_return_value.at(0).buffer()->address();
-            writer_runtime_args.at(8) = shared_variables.semaphore.address();
-        }
-
-        if (coord == receive_coord) {
-            const auto& receive_unary_reader_kernel_id = shared_variables.receive_unary_reader_kernel_id;
-            const auto& receive_unary_writer_kernel_id = shared_variables.receive_unary_writer_kernel_id;
-
-            // change this when we use more cores for multi-link
-            const auto& core = shared_variables.receiver_cores.at(0);
-
-            auto& reader_runtime_args = GetRuntimeArgs(program, receive_unary_reader_kernel_id, core);
-            reader_runtime_args.at(3) = tensor_return_value.at(0).buffer()->address();
-            reader_runtime_args.at(7) = shared_variables.semaphore.address();
-
-            auto& writer_runtime_args = GetRuntimeArgs(program, receive_unary_writer_kernel_id, core);
-            writer_runtime_args.at(0) = tensor_return_value.at(1).buffer()->address();
-        }
-    }
-};
 
 }  // namespace ttnn::operations::point_to_point
 

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
@@ -9,6 +9,8 @@
 #include <tt-metalium/global_semaphore.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/types.hpp"
 #include "ttnn/device_operation.hpp"
 
@@ -39,39 +41,22 @@ struct PointToPointOp {
     using tensor_return_value_t = std::array<ttnn::Tensor, 2>;
 
     struct SendReceive {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle send_unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle send_unary_writer_kernel_id;
-            std::vector<CoreCoord> sender_cores;
-
-            tt::tt_metal::KernelHandle receive_unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle receive_unary_writer_kernel_id;
-            std::vector<CoreCoord> receiver_cores;
-            const tt::tt_metal::GlobalSemaphore semaphore;
-        };
-
-        // AdaptedCachedMeshWorkload this maps device coordinates to sets of shared variables.
-        // CachedMeshWorkload has a common set for all devices.
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
+        // Builds the entire workload in one call (cache miss):
+        //   1. Allocates the shared GlobalSemaphore used by both endpoint
+        //      programs and runs the cross-device Synchronize barrier; the
+        //      semaphore is parked in `WorkloadDescriptor::semaphores` so it
+        //      outlives the cached workload.
+        //   2. Builds ProgramDescriptors for the send_coord (via
+        //      send_program_factory) and the receive_coord (via
+        //      receive_program_factory) and pushes them as single-coord
+        //      ranges into `programs`.  No program is emitted for any other
+        //      mesh coord — matches the legacy create_mesh_workload that only
+        //      added programs at the two endpoint coords.
+        static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
             const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value,
-            const tt::tt_metal::GlobalSemaphore& semaphore);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
+            const ttnn::MeshCoordinateRangeSet& tensor_coords);
     };
 
     using program_factory_t = std::variant<SendReceive>;
@@ -120,7 +105,7 @@ Fabric1DRoute fabric_1d_routing(
 
 }  // namespace detail
 
-device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variables_t> send_program_factory(
+tt::tt_metal::ProgramDescriptor send_program_factory(
     const PointToPointOp::tensor_args_t& tensor_args,
     const PointToPointOp::operation_attributes_t& operation_attributes,
     const MeshCoordinate& send_coord,
@@ -128,7 +113,7 @@ device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variables_t>
     PointToPointOp::tensor_return_value_t& output_tensor,
     const tt::tt_metal::GlobalSemaphore& semaphore);
 
-device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variables_t> receive_program_factory(
+tt::tt_metal::ProgramDescriptor receive_program_factory(
     const PointToPointOp::operation_attributes_t& operation_attributes,
     PointToPointOp::tensor_return_value_t& output_tensor,
     const tt::tt_metal::GlobalSemaphore& semaphore);

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/receive_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/receive_program_factory.cpp
@@ -4,6 +4,7 @@
 ///
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
@@ -11,7 +12,7 @@
 
 namespace ttnn::operations::point_to_point {
 
-ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variables_t> receive_program_factory(
+tt::tt_metal::ProgramDescriptor receive_program_factory(
     const PointToPointOp::operation_attributes_t& operation_attributes,
     PointToPointOp::tensor_return_value_t& output_tensors,
     const tt::tt_metal::GlobalSemaphore& semaphore) {
@@ -39,7 +40,7 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
             tt::tt_metal::split_work_to_cores(use_cores, total_packets);
 
     // program!
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     tt::DataFormat inter_dataformat = tt::tt_metal::datatype_to_dataformat_converter(intermediate_tensor.dtype());
 
@@ -48,27 +49,40 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
     constexpr auto buffering_factor = 2;  // this is in other fabric kernels
     constexpr auto num_packet_headers_storable = 2;
     const auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
-    tt::tt_metal::CircularBufferConfig cb_header_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_packet_headers_storable * packet_header_size_bytes * buffering_factor,
-            {{packet_header_cb_id, tt::DataFormat::RawUInt32}})
-            .set_page_size(packet_header_cb_id, packet_header_size_bytes);
-    CreateCircularBuffer(program, all_cores, cb_header_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_packet_headers_storable * packet_header_size_bytes * buffering_factor,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(packet_header_cb_id),
+            .data_format = tt::DataFormat::RawUInt32,
+            .page_size = packet_header_size_bytes,
+        }}},
+    });
 
     // Scratch CB for loading up pages that are collected into packets
     constexpr auto packet_cb_id = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_packet_config =
-        tt::tt_metal::CircularBufferConfig(packet_size_bytes, {{packet_cb_id, inter_dataformat}})
-            .set_page_size(packet_cb_id, packet_size_bytes);
-    CreateCircularBuffer(program, all_cores, cb_packet_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = packet_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(packet_cb_id),
+            .data_format = inter_dataformat,
+            .page_size = packet_size_bytes,
+        }}},
+    });
 
     // CB for sender reader->writer kernels
     constexpr auto receiver_cb_id = tt::CBIndex::c_2;
     const uint32_t cb_num_pages = 3 * num_pages_per_packet;
-    tt::tt_metal::CircularBufferConfig cb_receiver_config =
-        tt::tt_metal::CircularBufferConfig(cb_num_pages * output_page_size_bytes, {{receiver_cb_id, inter_dataformat}})
-            .set_page_size(receiver_cb_id, output_page_size_bytes);
-    CreateCircularBuffer(program, all_cores, cb_receiver_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = cb_num_pages * output_page_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(receiver_cb_id),
+            .data_format = inter_dataformat,
+            .page_size = output_page_size_bytes,
+        }}},
+    });
 
     const auto& topology = operation_attributes.topology;
     const auto this_fabric_id = mesh_device->get_fabric_node_id(receive_coord);
@@ -77,24 +91,37 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
 
     std::vector<uint32_t> reader_ct_args = {packet_header_cb_id, packet_cb_id, receiver_cb_id, l1_alignment};
     tt::tt_metal::TensorAccessorArgs(output_tensors.at(0).buffer()).append_to(reader_ct_args);
-    tt::tt_metal::KernelHandle receive_unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = std::move(reader_ct_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
     // And the writer
     std::vector<uint32_t> writer_ct_args = {receiver_cb_id};
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_ct_args);
-    tt::tt_metal::KernelHandle receive_unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_unary_interleaved_start_id_gen.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_unary_interleaved_start_id_gen.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = std::move(writer_ct_args);
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+
+    // Push kernels into desc.kernels first so we can refer to them by stable
+    // index — append_fabric_connection_rt_args() indexes desc.kernels via the
+    // KernelHandle for its ProgramDescriptor overload.
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+    desc.kernels.push_back(std::move(writer_kernel_desc));
+    tt::tt_metal::KernelHandle receive_unary_reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle receive_unary_writer_kernel_id = 1;
 
     constexpr auto link_idx = 0;  // for single link implementation
     uint32_t page_idx_start = 0, page_idx_end = 0;
-    std::vector<CoreCoord> receiver_cores;
     for (auto c : corerange_to_cores(all_cores, std::nullopt)) {
         uint32_t increment = 0;
         if (core_group_1.contains(c)) {
@@ -107,11 +134,15 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
         increment = std::min(increment, output_num_pages - page_idx_start);
         page_idx_end += increment;
 
+        // Build reader RT args via plain vector to interop with the fabric
+        // helper, then promote to the KernelDescriptor's RTArgList — index 3
+        // (intermediate buffer address) becomes a Buffer* binding, and index
+        // 7 stays as the GlobalSemaphore's absolute address.
         std::vector<uint32_t> reader_runtime_args = {
             page_idx_start,
             page_idx_end,
             num_pages_per_packet,
-            intermediate_tensor.buffer()->address(),
+            intermediate_tensor.buffer()->address(),  // placeholder, replaced via Buffer* below
             packet_size_bytes,
             output_page_size_bytes,
             num_page_segments,
@@ -121,31 +152,37 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
 
         if (sender_is_forward) {
             tt::tt_fabric::append_fabric_connection_rt_args(
-                this_fabric_id, next_fabric_id, link_idx, program, c, reader_runtime_args);
+                this_fabric_id, next_fabric_id, link_idx, desc, c, reader_runtime_args);
         }
         reader_runtime_args.emplace_back(!sender_is_forward);
         if (!sender_is_forward) {
             tt::tt_fabric::append_fabric_connection_rt_args(
-                this_fabric_id, next_fabric_id, link_idx, program, c, reader_runtime_args);
+                this_fabric_id, next_fabric_id, link_idx, desc, c, reader_runtime_args);
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, receive_unary_reader_kernel_id, c, reader_runtime_args);
+        tt::tt_metal::KernelDescriptor::RTArgList reader_rt_args_builder;
+        reader_rt_args_builder.reserve(reader_runtime_args.size());
+        for (size_t i = 0; i < reader_runtime_args.size(); ++i) {
+            if (i == 3) {
+                reader_rt_args_builder.push_back(intermediate_tensor.buffer());
+            } else {
+                reader_rt_args_builder.push_back(reader_runtime_args[i]);
+            }
+        }
+        desc.kernels[receive_unary_reader_kernel_id].emplace_runtime_args(c, reader_rt_args_builder);
 
-        const std::vector<uint32_t> writer_runtime_args = {
-            output_tensor.buffer()->address(), increment, page_idx_start, output_page_size_bytes};
-
-        tt::tt_metal::SetRuntimeArgs(program, receive_unary_writer_kernel_id, c, writer_runtime_args);
+        // Writer RT args.  Index 0 is the output buffer's base address —
+        // push as Buffer* so the framework records a BufferBinding.
+        tt::tt_metal::KernelDescriptor::RTArgList writer_rt_args;
+        writer_rt_args.push_back(output_tensor.buffer());
+        writer_rt_args.push_back(increment);
+        writer_rt_args.push_back(page_idx_start);
+        writer_rt_args.push_back(output_page_size_bytes);
+        desc.kernels[receive_unary_writer_kernel_id].emplace_runtime_args(c, writer_rt_args);
 
         page_idx_start += increment;
-        receiver_cores.push_back(c);
     }
 
-    return {
-        std::move(program),
-        PointToPointOp::SendReceive::shared_variables_t{
-            .receive_unary_reader_kernel_id = receive_unary_reader_kernel_id,
-            .receive_unary_writer_kernel_id = receive_unary_writer_kernel_id,
-            .receiver_cores = receiver_cores,
-            .semaphore = semaphore}};
+    return desc;
 }
 }  // namespace ttnn::operations::point_to_point

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
@@ -6,13 +6,14 @@
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "point_to_point_device_op.hpp"
 
 namespace ttnn::operations::point_to_point {
 
-ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variables_t> send_program_factory(
+tt::tt_metal::ProgramDescriptor send_program_factory(
     const PointToPointOp::tensor_args_t& tensor_args,
     const PointToPointOp::operation_attributes_t& operation_attributes,
     const MeshCoordinate& send_coord,
@@ -39,7 +40,7 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
             tt::tt_metal::split_work_to_cores(use_cores, total_packets);
 
     // program!
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     // CB for sender reader->writer kernels
     // Note this ID is hardcoded in the reader kernel
@@ -47,38 +48,54 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
     constexpr auto cb_num_pages = 2;
     const uint32_t aligned_input_page_size_bytes = tt::round_up(input_page_size_bytes, l1_alignment);
     tt::DataFormat input_dataformat = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    tt::tt_metal::CircularBufferConfig cb_sender_config =
-        tt::tt_metal::CircularBufferConfig(cb_num_pages * aligned_input_page_size_bytes, {{sender_cb_id, input_dataformat}})
-            .set_page_size(sender_cb_id, aligned_input_page_size_bytes);
-    CreateCircularBuffer(program, all_cores, cb_sender_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = cb_num_pages * aligned_input_page_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(sender_cb_id),
+            .data_format = input_dataformat,
+            .page_size = aligned_input_page_size_bytes,
+        }}},
+    });
 
     // allocate space for packet headers for payload semaphore
     constexpr auto packet_header_cb_id = tt::CBIndex::c_1;
     constexpr auto buffering_factor = 2;  // this is in other fabric kernels
     constexpr auto num_packet_headers_storable = 2;
     const auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
-    tt::tt_metal::CircularBufferConfig cb_header_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_packet_headers_storable * packet_header_size_bytes * buffering_factor,
-            {{packet_header_cb_id, tt::DataFormat::RawUInt32}})
-            .set_page_size(packet_header_cb_id, packet_header_size_bytes);
-    CreateCircularBuffer(program, all_cores, cb_header_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = num_packet_headers_storable * packet_header_size_bytes * buffering_factor,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(packet_header_cb_id),
+            .data_format = tt::DataFormat::RawUInt32,
+            .page_size = packet_header_size_bytes,
+        }}},
+    });
 
     // Scratch CB for coalescing pages into packets
     constexpr auto packet_cb_id = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_packet_config =
-        tt::tt_metal::CircularBufferConfig(packet_size_bytes, {{packet_cb_id, input_dataformat}})
-            .set_page_size(packet_cb_id, packet_size_bytes);
-    CreateCircularBuffer(program, all_cores, cb_packet_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = packet_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(packet_cb_id),
+            .data_format = input_dataformat,
+            .page_size = packet_size_bytes,
+        }}},
+    });
 
     // basic reader kernel set up
     std::vector<uint32_t> reader_ct_args;
     tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_ct_args);
-    tt::tt_metal::KernelHandle send_unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = std::move(reader_ct_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
     const auto this_fabric_id = mesh_device->get_fabric_node_id(send_coord);
 
@@ -88,16 +105,25 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
     std::vector<uint32_t> writer_ct_args = {sender_cb_id, packet_header_cb_id, packet_cb_id, l1_alignment};
     tt::tt_metal::TensorAccessorArgs(output_tensors.at(0).buffer()).append_to(writer_ct_args);
 
-    tt::tt_metal::KernelHandle send_unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = std::move(writer_ct_args);
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+
+    // Push kernels onto desc.kernels so we can refer to them by stable index;
+    // append_fabric_connection_rt_args() is templated on ProgramDescriptor and
+    // indexes into desc.kernels via the KernelHandle.
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+    desc.kernels.push_back(std::move(writer_kernel_desc));
+    tt::tt_metal::KernelHandle send_unary_reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle send_unary_writer_kernel_id = 1;
 
     constexpr auto link_idx = 0;  // for single link implementation
 
     uint32_t page_idx_start = 0, page_idx_end = 0;
-    std::vector<CoreCoord> sender_cores;
     for (auto c : corerange_to_cores(all_cores, std::nullopt)) {
         uint32_t increment = 0;
         if (core_group_1.contains(c)) {
@@ -110,12 +136,23 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
         increment = std::min(increment, input_num_pages - page_idx_start);
         page_idx_end += increment;
 
-        const std::vector<uint32_t> reader_runtime_args = {
-            input_tensor.buffer()->address(), increment, page_idx_start, input_page_size_bytes};
-        tt::tt_metal::SetRuntimeArgs(program, send_unary_reader_kernel_id, c, reader_runtime_args);
+        // Reader RT args.  arg[0] is the input tensor's buffer address; push
+        // it as Buffer* so the framework records a BufferBinding and patches
+        // it on cache hit (no override_runtime_arguments).
+        tt::tt_metal::KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(input_tensor.buffer());
+        reader_rt_args.push_back(increment);
+        reader_rt_args.push_back(page_idx_start);
+        reader_rt_args.push_back(input_page_size_bytes);
+        desc.kernels[send_unary_reader_kernel_id].emplace_runtime_args(c, reader_rt_args);
 
+        // Writer RT args.  Use a plain std::vector<uint32_t> first to interop
+        // with append_fabric_connection_rt_args(), then promote to the
+        // KernelDescriptor's RTArgList — index 0 (output buffer address) and
+        // index 8 (semaphore address) become a Buffer* binding and an
+        // absolute semaphore address, respectively.
         std::vector<uint32_t> writer_runtime_args = {
-            output_tensors.at(0).buffer()->address(),
+            output_tensors.at(0).buffer()->address(),  // placeholder, replaced via Buffer* below
             page_idx_start,
             page_idx_end,
             num_hops,
@@ -129,26 +166,25 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
 
         if (dst_is_forward) {
             tt::tt_fabric::append_fabric_connection_rt_args(
-                this_fabric_id, next_fabric_id, link_idx, program, c, writer_runtime_args);
+                this_fabric_id, next_fabric_id, link_idx, desc, c, writer_runtime_args);
         }
         writer_runtime_args.emplace_back(!dst_is_forward);
         if (!dst_is_forward) {
             tt::tt_fabric::append_fabric_connection_rt_args(
-                this_fabric_id, next_fabric_id, link_idx, program, c, writer_runtime_args);
+                this_fabric_id, next_fabric_id, link_idx, desc, c, writer_runtime_args);
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, send_unary_writer_kernel_id, c, writer_runtime_args);
+        tt::tt_metal::KernelDescriptor::RTArgList writer_rt_args_builder;
+        writer_rt_args_builder.reserve(writer_runtime_args.size());
+        writer_rt_args_builder.push_back(output_tensors.at(0).buffer());  // tensor_address0 as Buffer*
+        for (size_t i = 1; i < writer_runtime_args.size(); ++i) {
+            writer_rt_args_builder.push_back(writer_runtime_args[i]);
+        }
+        desc.kernels[send_unary_writer_kernel_id].emplace_runtime_args(c, writer_rt_args_builder);
 
         page_idx_start += increment;
-        sender_cores.push_back(c);
     }
 
-    return {
-        std::move(program),
-        PointToPointOp::SendReceive::shared_variables_t{
-            .send_unary_reader_kernel_id = send_unary_reader_kernel_id,
-            .send_unary_writer_kernel_id = send_unary_writer_kernel_id,
-            .sender_cores = sender_cores,
-            .semaphore = semaphore}};
+    return desc;
 }
 }  // namespace ttnn::operations::point_to_point


### PR DESCRIPTION
Migrates the `point_to_point` op (send + receive program factories) to `ProgramDescriptor` using the workload-level `prepare_resources` hook from #44397.

Depends on: #44397.

Contributes to #42193, #42393.

## Performance

point_to_point requires distinct sender/receiver mesh coords on a multi-device fabric; single-device bench is not meaningful. Per-op host dispatch perf delta from main: pending CI/multi-device runner.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-point-to-point)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-point-to-point)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-point-to-point)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-point-to-point)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-point-to-point)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-point-to-point)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-point-to-point)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-point-to-point)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-point-to-point)
