### PR TITLE
Avoid unsafe pack untilize HW configure

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
@@ -90,6 +90,22 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         false);  // partial_face
 }
 
+template <bool is_fp32_dest_acc_en>
+inline void llk_pack_reconfig_data_format_disaggregated(
+    const std::uint32_t new_output, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
+    const std::uint32_t output_id = get_output_id(new_output);
+    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
+
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        get_local_cb_interface(output_id).fifo_page_size,
+        face_r_dim,
+        tile_c_dim,
+        num_faces,
+        false);  // partial_face
+}
+
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
@@ -116,6 +116,23 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         narrow_tile);
 }
 
+template <bool is_fp32_dest_acc_en>
+inline void llk_pack_reconfig_data_format_disaggregated(
+    const std::uint32_t new_output, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
+    const std::uint32_t output_id = get_output_id(new_output);
+    const bool partial_face = get_output_partial_face(output_id);
+    const bool narrow_tile = get_output_narrow_tile(output_id);
+
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        get_local_cb_interface(output_id).fifo_page_size,
+        face_r_dim,
+        num_faces,
+        partial_face,
+        narrow_tile);
+}
+
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {

--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -38,12 +38,9 @@ namespace ckernel {
  * - full-sync mode (16-bit mode): 16 tiles
  * - full-sync mode (32-bit mode): 8 tiles
  *
- * NOTE: This function allows the user to specify `face_r_dim` and `num_faces` through function parameters. Setting these
- * parameters results in an expensive MMIO write and cannot be avoided currently.
- * This should be addressed more systematically within the issue tt-metal#22820, since these two values can be inferred
- * from the circular buffer description, the same way as it is done in `llk_pack_hw_configure`. This
- * would remove the need for `llk_pack_untilize_hw_configure_disaggregated` altogether and we would pay the price
- * of the MMIO write only once, in `compute_kernel_hw_startup`.
+ * NOTE: This function allows the user to specify `face_r_dim` and `num_faces` through function parameters. PACK
+ * reconfiguration must use these explicit values, since they can differ from the output circular buffer metadata for
+ * non-default untilize blocks.
  *
  * Return value: None
  *
@@ -73,8 +70,7 @@ ALWI void pack_untilize_dest_init(
     // Needed for setting swizzle_32b:
     MATH((llk_math_reconfig_remap(true)));
 #endif  // TODO NC: A workaround for tt-metal#17132. Should be addressed more systematically in tt-llk#989
-    PACK(
-        (llk_pack_untilize_hw_configure_disaggregated<DST_ACCUM_MODE, false /*untilize*/>(ocb, face_r_dim, num_faces)));
+    PACK((llk_pack_reconfig_data_format_disaggregated<DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
     PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, false, narrow_row, row_num_datums, dense>(
         ocb, face_r_dim, num_faces)));
     PACK((llk_init_packer_dest_offset_registers<true, false>()));
@@ -99,12 +95,7 @@ ALWI void pack_untilize_dest_init(
  * - full-sync mode (16-bit mode): 16 tiles
  * - full-sync mode (32-bit mode): 8 tiles
  *
- * NOTE: This function uses default `face_r_dim` and `num_faces` values (16 and 4, respectively). Setting these
- * parameters results in an expensive MMIO write and cannot be avoided currently.
- * This should be addressed more systematically within the issue tt-metal#22820, since these two values can be inferred
- * from the circular buffer description, the same way as it is done in `llk_pack_hw_configure`. This
- * would remove the need for `llk_pack_untilize_hw_configure_disaggregated` altogether and we would pay the price
- * of the MMIO write only once, in `compute_kernel_hw_startup`.
+ * NOTE: This function uses default `face_r_dim` and `num_faces` values (16 and 4, respectively).
  *
  * Return value: None
  *


### PR DESCRIPTION
Refs #17641.

Partial resolution for #17641: this fixes the stale packer-geometry failure exposed by pack-untilize callers that pass non-default `face_r_dim` / `num_faces`. The broader `llk_pack_untilize_hw_configure_disaggregated` API contract cleanup remains open.

## Summary
- avoid calling `llk_pack_untilize_hw_configure_disaggregated` from `pack_untilize_dest_init`
- add WH/BH explicit-geometry wrappers around the lightweight pack data-format reconfig path
- preserve caller-provided `face_r_dim` / `num_faces` so pack-untilize can refresh the needed packer counters without running the full HW configure path

## Why
`llk_pack_untilize_hw_configure_disaggregated` runs the broader pack hardware configure path. That path is not thread-safe and is not safe to call in the middle of a kernel while compute threads may already be active.

This patch keeps `pack_untilize_dest_init` on the lightweight reconfig path, but extends that path so it can use the explicit untilize geometry supplied by the caller instead of deriving geometry from output CB metadata.

## Testing
- `pytest -q -x tests/ttnn/unit_tests/operations/pool/test_adaptive_pool2d.py` (76 passed, 16 skipped)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/pack-untilize-reconfig-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/pack-untilize-reconfig-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/pack-untilize-reconfig-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/pack-untilize-reconfig-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/pack-untilize-reconfig-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/pack-untilize-reconfig-only)

## Downstream Dependency

Blocks #44079. The conv3d fix in #44079 depends on this PR because otherwise some conv3d cases hang on BH.