### PR TITLE
Fix conv3d DRAM read alignment staging

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -238,6 +238,24 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         input_tensor.buffer()->is_dram() &&
         input_tensor.buffer()->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
         !input_tensor.buffer()->buffer_distribution_spec().has_value();
+    const uint32_t dram_read_alignment = tt::tt_metal::hal::get_dram_alignment();
+    const bool input_pages_are_dram_read_aligned = in_row_size_bytes % dram_read_alignment == 0;
+    const bool c_in_slice_is_dram_read_aligned = C_in_block_bytes % dram_read_alignment == 0;
+    const bool enable_dram_read_staging =
+        input_is_dram_interleaved && input_pages_are_dram_read_aligned && !c_in_slice_is_dram_read_aligned;
+    // The staged reader rounds the DRAM source down by at most alignment - 1 bytes and reads
+    // a full aligned window.  The scratch CB itself may only be L1-aligned, so reserve one
+    // extra alignment chunk to let the kernel round its scratch base up safely.
+    const uint32_t max_staged_dram_window_bytes =
+        tt::round_up(C_in_block_bytes + dram_read_alignment - 1, dram_read_alignment);
+    const uint32_t dram_read_scratch_page_bytes =
+        enable_dram_read_staging ? max_staged_dram_window_bytes + dram_read_alignment : 0;
+    uint32_t cb_dram_read_scratch_id = 32;  // Invalid; set below if DRAM read staging is needed
+    if (enable_dram_read_staging) {
+        cb_dram_read_scratch_id = next_cb_index++;
+        tt::tt_metal::create_cb(
+            cb_dram_read_scratch_id, program, core_grid, dram_read_scratch_page_bytes, 1, data_format);
+    }
 
     // L1 pre-fetch buffer for kernels > 1x1x1 with no dilation.
     // Gathers the spatial receptive field from DRAM once per spatial block, then vol2col reads from L1.
@@ -253,6 +271,9 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
                                (tile_size * matmul_K_t * matmul_N_t) +          // weight_tiled
                                (partial_tile_size * matmul_M_t * matmul_N_t) +  // matmul_interm (may be fp32)
                                (tile_size * matmul_M_t * matmul_N_t);           // matmul_result_rm
+    if (enable_dram_read_staging) {
+        other_cbs_bytes += dram_read_scratch_page_bytes;
+    }
     if (C_in_num_blocks > 1) {
         other_cbs_bytes += partial_tile_size * matmul_M_t * matmul_N_t;  // reduction (same format as partials)
         other_cbs_bytes += tile_size;                                    // worker_ack
@@ -397,6 +418,13 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         enable_streaming_output,
         out_subblock_h,
         out_subblock_w);
+    log_debug(
+        tt::LogOp,
+        "DRAM read staging: enable={}, alignment={}, scratch_page_bytes={}, cb_id={}",
+        enable_dram_read_staging,
+        dram_read_alignment,
+        dram_read_scratch_page_bytes,
+        cb_dram_read_scratch_id);
 
     /**
      * Compute parallelism for multi-core.
@@ -548,8 +576,11 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     // a finer granularity). Below the lower cutoff or below the intensity floor,
     // ring is fully off.
     const bool intensity_pass = bytes_per_tile >= conv3d_gather_tuning::kGatherIntensityCutoffBytes;
+    // Scratch-backed reader modes already issue larger or serialized reads; the trid ring
+    // only affects fallback edge gathers there and measured as overhead.
+    const bool gather_trid_ring_allowed = !enable_coalesced_shard_reads && !enable_dram_read_staging;
     uint32_t gather_trids = 0;
-    if (intensity_pass) {
+    if (gather_trid_ring_allowed && intensity_pass) {
         if (inner_gather_burst >= conv3d_gather_tuning::kGatherTridDepthHigh) {
             gather_trids = conv3d_gather_tuning::kGatherTridDepthHigh;
         } else if (inner_gather_burst >= conv3d_gather_tuning::kGatherInnerBurstCutoff) {
@@ -557,11 +588,6 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         }
     }
 
-    // Coalesced shard reads already issue larger DRAM transactions through the scratch window.
-    // Keeping the trid ring enabled only affects fallback edge gathers and measured as overhead.
-    if (enable_coalesced_shard_reads) {
-        gather_trids = 0;
-    }
     log_debug(
         tt::LogOp,
         "gather trid ring: bytes_per_tile={}, inner_burst={}, gather_trids={}",
@@ -608,7 +634,10 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         patch_pad_bytes,
         gather_trids,
         static_cast<uint32_t>(enable_coalesced_shard_reads),
-        coalesced_scratch_rows};
+        coalesced_scratch_rows,
+        cb_dram_read_scratch_id,
+        static_cast<uint32_t>(enable_dram_read_staging),
+        dram_read_alignment};
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
 
     auto reader_kernels_id = CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp
@@ -11,9 +11,9 @@
 //
 // Two cooperating gates select whether gather_rows_to_shard runs the trid ring:
 //
-//   1. Host per-shape classifier (program_factory): if the shape is compute-bound,
-//      `gather_trids` is set to 0 and all ring code is constexpr-elided in the
-//      kernel.  See conv3d_program_factory.cpp.
+//   1. Host per-shape classifier (program_factory): if the shape is compute-bound
+//      or uses a scratch-backed reader mode, `gather_trids` is set to 0 and all
+//      ring code is constexpr-elided in the kernel.  See conv3d_program_factory.cpp.
 //
 //   2. Kernel per-call fast-path (reader_vol2col): even when the host enables the
 //      ring, an individual gather call with too few reads to fill at least two ring

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -58,14 +58,14 @@ inline void zeroPad(Noc noc, const Dst& dst, uint32_t offset) {
     }
 }
 
-template <typename Reader, typename Dst>
+template <typename Reader>
 FORCE_INLINE void read_input_row(
     Noc noc,
     const Reader& reader,
     uint32_t page_idx,
     uint32_t c_in_offset_bytes,
     uint32_t in_row_size_bytes,
-    const Dst& dst,
+    const experimental::CB& dst,
     uint32_t dst_offset,
     uint32_t size_bytes) {
     if constexpr (Reader::DSpec::tensor_shape_static) {
@@ -93,6 +93,70 @@ FORCE_INLINE void read_input_row(
         size_bytes,
         {.page_id = page_idx, .offset_bytes = c_in_offset_bytes},
         {.offset_bytes = dst_offset});
+}
+
+template <uint32_t dram_read_alignment, typename Reader>
+FORCE_INLINE void read_input_row_staged_from_dram(
+    Noc noc,
+    const Reader& reader,
+    uint32_t page_idx,
+    uint32_t c_in_offset_bytes,
+    const experimental::CB& dst,
+    uint32_t dst_offset,
+    uint32_t size_bytes,
+    const experimental::CB& scratch_cb) {
+    static_assert(Reader::DSpec::is_interleaved && Reader::DSpec::is_dram);
+    static_assert(dram_read_alignment > 0);
+    static_assert((dram_read_alignment & (dram_read_alignment - 1)) == 0);
+    constexpr uint32_t alignment_mask = dram_read_alignment - 1;
+
+    // The factory enables this helper only when DRAM pages are aligned but the split
+    // C-in slice is smaller than the DRAM read alignment.  Always stage through an
+    // aligned scratch window so every read follows the same alignment-safe path.
+    const uint64_t src_noc_addr = reader.get_noc_addr(page_idx, c_in_offset_bytes, noc.get_noc_id());
+    const uint32_t src_align_offset = static_cast<uint32_t>(src_noc_addr) & alignment_mask;
+    const uint64_t aligned_src_noc_addr = src_noc_addr - src_align_offset;
+    const uint32_t aligned_read_size = (src_align_offset + size_bytes + alignment_mask) & ~alignment_mask;
+
+    const uint32_t scratch_unaligned = scratch_cb.get_write_ptr();
+    const uint32_t scratch_l1_addr = (scratch_unaligned + alignment_mask) & ~alignment_mask;
+
+    // Aligning backward gives us a raw full NOC address rather than a reader page/offset pair.
+    noc_async_read<NOC_MAX_BURST_SIZE + 1, true>(
+        aligned_src_noc_addr, scratch_l1_addr, aligned_read_size, noc.get_noc_id());
+    // Scratch must be populated before it is used as the source for the local L1 copy.
+    noc.async_read_barrier();
+
+    // The scratch CB is a single staging page reused by each call.  After issuing the
+    // local copy, drain it before returning so the next staged read cannot overwrite
+    // scratch while it is still the source for an in-flight L1->L1 read.
+    UnicastEndpoint self_ep;
+    noc.async_read(
+        self_ep,
+        dst,
+        size_bytes,
+        experimental::local_addr(scratch_l1_addr + src_align_offset, noc.get_noc_id()),
+        {.offset_bytes = dst_offset});
+    noc.async_read_barrier();
+}
+
+template <bool EnableDramReadStaging, uint32_t dram_read_alignment, typename Reader>
+FORCE_INLINE void read_input_row_maybe_staged(
+    Noc noc,
+    const Reader& reader,
+    uint32_t page_idx,
+    uint32_t c_in_offset_bytes,
+    uint32_t in_row_size_bytes,
+    const experimental::CB& dst,
+    uint32_t dst_offset,
+    uint32_t size_bytes,
+    const experimental::CB& scratch_cb) {
+    if constexpr (EnableDramReadStaging && Reader::DSpec::is_interleaved && Reader::DSpec::is_dram) {
+        read_input_row_staged_from_dram<dram_read_alignment>(
+            noc, reader, page_idx, c_in_offset_bytes, dst, dst_offset, size_bytes, scratch_cb);
+    } else {
+        read_input_row(noc, reader, page_idx, c_in_offset_bytes, in_row_size_bytes, dst, dst_offset, size_bytes);
+    }
 }
 
 // Manages chunked CB writes: reserves TILE_HEIGHT pages, tracks patches written,
@@ -235,10 +299,9 @@ template <
     uint32_t H_shard_max_W_shard_max,
     uint32_t W_shard_max,
     uint32_t kW,
-    uint32_t stride_w,
-    typename ShardCB>
+    uint32_t stride_w>
 void shift_retained_w_columns(
-    Noc noc, const ShardCB& shard_cb, uint32_t T_shard_cur, uint32_t h_rows_gathered) {
+    Noc noc, const experimental::CB& shard_cb, uint32_t T_shard_cur, uint32_t h_rows_gathered) {
     constexpr uint32_t overlap_w = kW > stride_w ? kW - stride_w : 0;
     constexpr uint32_t shift_bytes = overlap_w * C_in_block_bytes;
     constexpr uint32_t src_off = (W_shard_max - overlap_w) * C_in_block_bytes;
@@ -287,12 +350,14 @@ template <
     uint32_t in_row_size_bytes,
     bool check_padding,
     uint32_t N_TRIDS,
-    typename Reader,
-    typename ShardCB>
+    bool EnableDramReadStaging,
+    uint32_t dram_read_alignment,
+    typename Reader>
 void gather_rows_to_shard(
     Noc noc,
     const Reader& in_reader,
-    const ShardCB& shard_cb,
+    const experimental::CB& shard_cb,
+    const experimental::CB& dram_read_scratch_cb,
     uint32_t batch_page_base,
     uint32_t c_in_offset_bytes,
     int32_t t_shard_start,
@@ -304,11 +369,11 @@ void gather_rows_to_shard(
     uint32_t w_col_start,
     uint32_t w_count) {
     // N_TRIDS == 0 is a compile-time sentinel: the host-side classifier disabled the trid
-    // ring for this shape (compute-bound regime — see conv3d_program_factory.cpp).  In that
-    // case all ring code is constexpr-elided and the function reduces to issue-all + single
-    // trailing barrier.  When non-zero, N_TRIDS is always conv3d_gather_tuning::
-    // kGatherTridDepth (the host wires this in); the upper bound matches the underlying NoC
-    // trid-id range.
+    // ring for this shape (compute-bound or scratch-backed reader mode — see
+    // conv3d_program_factory.cpp).  In that case all ring code is constexpr-elided and the
+    // function reduces to issue-all + single trailing barrier.  When non-zero, N_TRIDS is
+    // always one of the conv3d_gather_tuning depths; the upper bound matches the underlying
+    // NoC trid-id range.
     static_assert(
         N_TRIDS == 0 || N_TRIDS == conv3d_gather_tuning::kGatherTridDepthLow ||
         N_TRIDS == conv3d_gather_tuning::kGatherTridDepthHigh);
@@ -363,7 +428,7 @@ void gather_rows_to_shard(
                             const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_clamped) * H_in_W_in +
                                                       static_cast<uint32_t>(h_clamped) * W_in +
                                                       static_cast<uint32_t>(w_clamped);
-                            read_input_row(
+                            read_input_row_maybe_staged<EnableDramReadStaging, dram_read_alignment>(
                                 noc,
                                 in_reader,
                                 page_idx,
@@ -371,12 +436,13 @@ void gather_rows_to_shard(
                                 in_row_size_bytes,
                                 shard_cb,
                                 shard_offset,
-                                C_in_block_bytes);
+                                C_in_block_bytes,
+                                dram_read_scratch_cb);
                         }
                     } else {
                         const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
                                                   static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_in);
-                        read_input_row(
+                        read_input_row_maybe_staged<EnableDramReadStaging, dram_read_alignment>(
                             noc,
                             in_reader,
                             page_idx,
@@ -384,13 +450,14 @@ void gather_rows_to_shard(
                             in_row_size_bytes,
                             shard_cb,
                             shard_offset,
-                            C_in_block_bytes);
+                            C_in_block_bytes,
+                            dram_read_scratch_cb);
                     }
                 } else {
                     // Fast path: no padding checks
                     const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
                                               static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_in);
-                    read_input_row(
+                    read_input_row_maybe_staged<EnableDramReadStaging, dram_read_alignment>(
                         noc,
                         in_reader,
                         page_idx,
@@ -398,7 +465,8 @@ void gather_rows_to_shard(
                         in_row_size_bytes,
                         shard_cb,
                         shard_offset,
-                        C_in_block_bytes);
+                        C_in_block_bytes,
+                        dram_read_scratch_cb);
                 }
                 if constexpr (N_TRIDS != 0) {
                     if (use_ring) {
@@ -442,12 +510,11 @@ template <
     uint32_t W_in,
     uint32_t H_in_W_in,
     uint32_t GatherTrids,
-    typename Reader,
-    typename ShardCB>
+    typename Reader>
 void gather_rows_to_shard_coalesced(
     Noc noc,
     const Reader& in_reader,
-    const ShardCB& shard_cb,
+    const experimental::CB& shard_cb,
     uint32_t shard_l1_base,
     uint32_t scratch_row_offset,
     uint32_t batch_page_base,
@@ -547,12 +614,14 @@ template <
     uint32_t in_row_size_bytes,
     uint32_t GatherTrids,
     bool EnableCoalescedShardReads,
-    typename Reader,
-    typename ShardCB>
+    bool EnableDramReadStaging,
+    uint32_t dram_read_alignment,
+    typename Reader>
 void gather_rows_to_shard_selected(
     Noc noc,
     const Reader& in_reader,
-    const ShardCB& shard_cb,
+    const experimental::CB& shard_cb,
+    const experimental::CB& dram_read_scratch_cb,
     [[maybe_unused]] uint32_t shard_l1_base,
     [[maybe_unused]] uint32_t coalesced_scratch_offset,
     bool all_in_bounds,
@@ -614,10 +683,13 @@ void gather_rows_to_shard_selected(
             H_in_W_in,
             in_row_size_bytes,
             decltype(check_padding_v)::value,
-            GatherTrids>(
+            GatherTrids,
+            EnableDramReadStaging,
+            dram_read_alignment>(
             noc,
             in_reader,
             shard_cb,
+            dram_read_scratch_cb,
             batch_page_base,
             c_in_offset_bytes,
             t_shard_start,
@@ -680,6 +752,9 @@ void kernel_main() {
     constexpr uint32_t gather_trids = get_compile_time_arg_val(36);
     constexpr bool enable_coalesced_shard_reads = get_compile_time_arg_val(37) == 1;
     constexpr uint32_t coalesced_scratch_rows = get_compile_time_arg_val(38);
+    constexpr uint32_t cb_dram_read_scratch = get_compile_time_arg_val(39);
+    constexpr bool enable_dram_read_staging = get_compile_time_arg_val(40) == 1;
+    constexpr uint32_t dram_read_alignment = get_compile_time_arg_val(41);
     constexpr uint32_t padded_page_bytes = kT * kH * kW * C_in_block_bytes + patch_pad_bytes;
 
     // Load input/output addresses and range parameters
@@ -697,7 +772,7 @@ void kernel_main() {
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
 
     // Tensor accessor for input tensor
-    constexpr auto in_args = TensorAccessorArgs<39>();
+    constexpr auto in_args = TensorAccessorArgs<42>();
     const auto in_reader = TensorAccessor(in_args, in_addr);
 
     Noc noc;
@@ -713,6 +788,10 @@ void kernel_main() {
 
     // Reserve shard buffer once (used as scratch space, not streaming CB)
     experimental::CB shard_cb(cb_input_shard);
+    experimental::CB dram_read_scratch_cb(cb_dram_read_scratch);
+    if constexpr (enable_dram_read_staging) {
+        dram_read_scratch_cb.reserve_back(1);
+    }
     uint32_t shard_l1_base = 0;
     if constexpr (use_l1_prefetch) {
         constexpr uint32_t shard_total = T_shard_max * H_shard_max_W_shard_max;
@@ -804,10 +883,13 @@ void kernel_main() {
                                         H_in_W_in,
                                         in_row_size_bytes,
                                         gather_trids,
-                                        enable_coalesced_shard_reads>(
+                                        enable_coalesced_shard_reads,
+                                        enable_dram_read_staging,
+                                        dram_read_alignment>(
                                         noc,
                                         in_reader,
                                         shard_cb,
+                                        dram_read_scratch_cb,
                                         shard_l1_base,
                                         coalesced_scratch_offset,
                                         shard_all_in_bounds,
@@ -847,10 +929,13 @@ void kernel_main() {
                                                 H_in_W_in,
                                                 in_row_size_bytes,
                                                 gather_trids,
-                                                enable_coalesced_shard_reads>(
+                                                enable_coalesced_shard_reads,
+                                                enable_dram_read_staging,
+                                                dram_read_alignment>(
                                                 noc,
                                                 in_reader,
                                                 shard_cb,
+                                                dram_read_scratch_cb,
                                                 shard_l1_base,
                                                 coalesced_scratch_offset,
                                                 shard_all_in_bounds,
@@ -940,7 +1025,9 @@ void kernel_main() {
                                                             batch_page_base + static_cast<uint32_t>(t_idx) * H_in_W_in +
                                                             static_cast<uint32_t>(h_idx) * W_in +
                                                             static_cast<uint32_t>(w_idx);
-                                                        read_input_row(
+                                                        read_input_row_maybe_staged<
+                                                            enable_dram_read_staging,
+                                                            dram_read_alignment>(
                                                             noc,
                                                             in_reader,
                                                             page_idx,
@@ -948,7 +1035,8 @@ void kernel_main() {
                                                             in_row_size_bytes,
                                                             chunk.cb,
                                                             chunk.write_offset,
-                                                            C_in_block_bytes);
+                                                            C_in_block_bytes,
+                                                            dram_read_scratch_cb);
                                                         chunk.write_offset += C_in_block_bytes;
                                                     }
                                                 }


### PR DESCRIPTION
## Summary
- Add a compile-time gated DRAM read staging path in Conv3d `reader_vol2col` for DRAM-interleaved inputs where the full input row is DRAM-aligned but the active `C_in_block` slice is not.
- Host enables staging only when:
  `input_is_dram_interleaved && in_row_size_bytes % dram_alignment == 0 && C_in_block_bytes % dram_alignment != 0`.
- Affected reads issue an aligned DRAM read into a one-page scratch CB, then copy the exact unaligned slice locally in L1 into the real destination.
- Include the scratch CB in L1 budgeting and thread it through direct reads and `gather_rows_to_shard*`.
- Disable the gather TRID ring while staging is active because the scratch bounce path serializes reads through the single staging page.

This is not a general Conv3d data-path change; it is compile-time disabled for aligned cases and only applies to the DRAM-interleaved transition case above.

## Root Cause / Regression
- `6f74790a539` / #43715 lowered the default `C_in_block` for `kernel=(2, 14, 14)` from `32` to `16` to fix L1 overflow.
- Before #43715, the new large-kernel no-config case failed program validation with L1 overflow (`1747968 B > 1572864 B`) and did not reach execution.
- With `C_in_block = 32`, the minimum row-major row slice for bf16/fp16 was `32 * 2 = 64B`, matching BH DRAM alignment. Direct DRAM reads therefore stayed naturally aligned.
- With `C_in_block = 16`, the row slice is `16 * 2 = 32B`. The DRAM row page remains `64B`-aligned, but the packed vol2col destination advances in `32B` increments, so direct reads can have different `64B` alignment offsets between the DRAM source and L1 destination.
- The program then fits and runs, but gathers corrupted input data. On `6f74790a539`, the large-kernel test fails with PCC `0.7069771446067014`.

## Why This Fix
Conv3d now needs smaller `C_in_block` values for large-kernel L1 fit. For the transition case where the full DRAM row is aligned but the copied slice is not, the reader stages through aligned scratch L1 before copying the exact slice locally. This preserves the smaller block size without relying on unsafe direct DRAM read alignment behavior.

## Test Plan
- [x] `./build_metal.sh --release`
- [x] `scripts/run_safe_pytest.sh "tests/ttnn/unit_tests/operations/conv/test_conv3d.py::test_conv3d_no_config[auto_block_large_kernel]"`
- [ ] Broader Blackhole post-commit Conv3d coverage
- [ ] Wormhole Conv3d coverage to verify unaffected aligned paths remain clean
- [ ] Verify perf neutral when staging path is not taken because it is compile-time disabled

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/conv3d-dram-read-staging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/conv3d-dram-read-staging)