### PR TITLE
Bug fix: Assert NoC write packet tags are cleared between kernels

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -339,6 +339,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         WatcherTestParams{"Brisc", {TENSIX, DM, 0}, dev_msgs::DebugAssertTripped},
         WatcherTestParams{"NCrisc", {TENSIX, DM, 1}, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
+        WatcherTestParams{"NCriscPacketTag", {TENSIX, DM, 1}, dev_msgs::DebugAssertNCriscNOCPacketTagClearedTripped},
         // DM2 to DM7 only run on Quasar
         WatcherTestParams{"DM2", {TENSIX, DM, 2}, dev_msgs::DebugAssertTripped},
         WatcherTestParams{"DM3", {TENSIX, DM, 3}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped},

--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -232,6 +232,7 @@ int __attribute__((noinline)) main(void) {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
         noc_local_state_init(n);
     }
+    noc_clear_all_packet_tags();
     uint8_t prev_noc_mode = DM_DEDICATED_NOC;
     ncrisc_noc_full_sync();
 

--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisck.cc
@@ -48,6 +48,7 @@ void _start() {
             ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
             ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
+            ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
             WAYPOINT("NKFD");
         }
 

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -382,6 +382,7 @@ int main() {
     // ex. Immediately after starting, we send a RUN_MSG_RESET_READ_PTR signal
     noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
     noc_local_state_init(noc_index);
+    noc_clear_all_packet_tags();
     trigger_sync_register_init();
 
     DeviceProfilerInit();
@@ -557,6 +558,7 @@ int main() {
                         ASSERT(ncrisc_dynamic_noc_nonposted_writes_flushed(noc));
                         ASSERT(ncrisc_dynamic_noc_nonposted_atomics_flushed(noc));
                         ASSERT(ncrisc_dynamic_noc_posted_writes_sent(noc));
+                        ASSERT(ncrisc_noc_packet_tags_cleared(noc), DebugAssertNCriscNOCPacketTagClearedTripped);
                     }
                     WAYPOINT("NKFD");
                 }

--- a/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
@@ -88,6 +88,7 @@ uint32_t _start() {
             ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
             ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
+            ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
             WAYPOINT("NKFD");
         }
     }

--- a/tt_metal/hw/firmware/src/tt-1xx/drisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/drisc.cc
@@ -67,6 +67,7 @@ int main() {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
         noc_local_state_init(n);
     }
+    noc_clear_all_packet_tags();
 
     DEVICE_PRINT_INITIALIZE_LOCK();
 

--- a/tt_metal/hw/firmware/src/tt-1xx/drisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/drisck.cc
@@ -34,6 +34,7 @@ uint32_t _start() {
         ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
         ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
         ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
+        ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
         WAYPOINT("NKFD");
     }
     return measure_stack_usage();

--- a/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
@@ -100,6 +100,7 @@ void __attribute__((noinline)) Application(void) {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
         noc_local_state_init(n);
     }
+    noc_clear_all_packet_tags();
     ncrisc_noc_full_sync();
     WAYPOINT("REW");
     uint32_t count = 0;

--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisck.cc
@@ -45,6 +45,7 @@ uint32_t _start() {
             ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
             ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
+            ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
             WAYPOINT("NKFD");
         }
     }

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisck.cc
@@ -82,6 +82,7 @@ uint32_t _start() {
         ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
         ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
         ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
+        ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
         WAYPOINT("NKFD");
     }
 #endif

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -274,6 +274,7 @@ enum debug_assert_type_t {
     DebugAssertRtaOutOfBounds = 8,
     DebugAssertCrtaOutOfBounds = 9,
     DebugAssertHwFault = 10,
+    DebugAssertNCriscNOCPacketTagClearedTripped = 11,
 };
 
 enum debug_transaction_type_t { TransactionRead = 0, TransactionWrite = 1, TransactionAtomic = 2, TransactionNumTypes };

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -68,6 +68,7 @@ constexpr uint32_t BRISC_WR_CMD_BUF = 0;      // for large writes
 constexpr uint32_t BRISC_RD_CMD_BUF = 1;      // for all reads
 constexpr uint32_t BRISC_WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
 constexpr uint32_t BRISC_AT_CMD_BUF = 3;      // for atomics
+constexpr uint32_t NUM_NOC_CMD_BUFS = 4;
 
 // BH has 64 bit address space but pipegen was not updated to support this so WH scheme of encoding addresses is used
 // (36 bits of address followed by coordinates) This means that lo and mid registers need to have the address portion
@@ -237,6 +238,28 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
 // Clears NOC_PACKET_TAG register for the specified cmd_buf.
 inline __attribute__((always_inline)) void noc_clear_packet_tag(uint32_t noc, uint32_t cmd_buf) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
+}
+
+inline __attribute__((always_inline)) void noc_clear_packet_tags(uint32_t noc) {
+    for (uint32_t cmd_buf = 0; cmd_buf < NUM_NOC_CMD_BUFS; cmd_buf++) {
+        noc_clear_packet_tag(noc, cmd_buf);
+    }
+}
+
+inline __attribute__((always_inline)) void noc_clear_all_packet_tags() {
+    for (uint32_t noc = 0; noc < NUM_NOCS; noc++) {
+        noc_clear_packet_tags(noc);
+    }
+}
+
+// Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 after kernel handoff.
+inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32_t noc) {
+    for (uint32_t cmd_buf = 0; cmd_buf < NUM_NOC_CMD_BUFS; cmd_buf++) {
+        if (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG) != 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -252,14 +252,11 @@ inline __attribute__((always_inline)) void noc_clear_all_packet_tags() {
     }
 }
 
-// Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 after kernel handoff.
+// Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 for multicast writes after
+// kernel handoff. Only write-capable command buffers matter for this assert.
 inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32_t noc) {
-    for (uint32_t cmd_buf = 0; cmd_buf < NUM_NOC_CMD_BUFS; cmd_buf++) {
-        if (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG) != 0) {
-            return false;
-        }
-    }
-    return true;
+    return NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_CMD_BUF, NOC_PACKET_TAG) == 0 &&
+           NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_PACKET_TAG) == 0;
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -253,10 +253,11 @@ inline __attribute__((always_inline)) void noc_clear_all_packet_tags() {
 }
 
 // Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 for multicast writes after
-// kernel handoff. Only write-capable command buffers matter for this assert.
+// kernel handoff. Only write/atomic-capable command buffers matter for this assert.
 inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32_t noc) {
     return NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_CMD_BUF, NOC_PACKET_TAG) == 0 &&
-           NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_PACKET_TAG) == 0;
+           NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_PACKET_TAG) == 0 &&
+           NOC_CMD_BUF_READ_REG(noc, NCRISC_AT_CMD_BUF, NOC_PACKET_TAG) == 0;
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -215,14 +215,11 @@ inline __attribute__((always_inline)) void noc_clear_all_packet_tags() {
     }
 }
 
-// Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 after kernel handoff.
+// Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 for multicast writes after
+// kernel handoff. Only write-capable command buffers matter for this assert.
 inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32_t noc) {
-    for (uint32_t cmd_buf = 0; cmd_buf < NUM_NOC_CMD_BUFS; cmd_buf++) {
-        if (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG) != 0) {
-            return false;
-        }
-    }
-    return true;
+    return NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_CMD_BUF, NOC_PACKET_TAG) == 0 &&
+           NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_PACKET_TAG) == 0;
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -216,10 +216,11 @@ inline __attribute__((always_inline)) void noc_clear_all_packet_tags() {
 }
 
 // Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 for multicast writes after
-// kernel handoff. Only write-capable command buffers matter for this assert.
+// kernel handoff. Only write/atomic-capable command buffers matter for this assert.
 inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32_t noc) {
     return NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_CMD_BUF, NOC_PACKET_TAG) == 0 &&
-           NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_PACKET_TAG) == 0;
+           NOC_CMD_BUF_READ_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_PACKET_TAG) == 0 &&
+           NOC_CMD_BUF_READ_REG(noc, NCRISC_AT_CMD_BUF, NOC_PACKET_TAG) == 0;
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -50,6 +50,7 @@ constexpr uint32_t BRISC_WR_CMD_BUF = 0;      // for large writes
 constexpr uint32_t BRISC_RD_CMD_BUF = 1;      // for all reads
 constexpr uint32_t BRISC_WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
 constexpr uint32_t BRISC_AT_CMD_BUF = 3;      // for atomics
+constexpr uint32_t NUM_NOC_CMD_BUFS = 4;
 
 // 36 bits of address followed by coordinate. First 32 bits of address go into lo register, remaining address bits and
 // coordinates are in the mid register
@@ -200,6 +201,28 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
 // Clears NOC_PACKET_TAG register for the specified cmd_buf.
 inline __attribute__((always_inline)) void noc_clear_packet_tag(uint32_t noc, uint32_t cmd_buf) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
+}
+
+inline __attribute__((always_inline)) void noc_clear_packet_tags(uint32_t noc) {
+    for (uint32_t cmd_buf = 0; cmd_buf < NUM_NOC_CMD_BUFS; cmd_buf++) {
+        noc_clear_packet_tag(noc, cmd_buf);
+    }
+}
+
+inline __attribute__((always_inline)) void noc_clear_all_packet_tags() {
+    for (uint32_t noc = 0; noc < NUM_NOCS; noc++) {
+        noc_clear_packet_tags(noc);
+    }
+}
+
+// Kernels that do not explicitly set transaction IDs should naturally use transaction ID 0 after kernel handoff.
+inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32_t noc) {
+    for (uint32_t cmd_buf = 0; cmd_buf < NUM_NOC_CMD_BUFS; cmd_buf++) {
+        if (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG) != 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -130,6 +130,9 @@ inline std::string get_debug_assert_message(
         case dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped:
             return "detected an inter-kernel data race due to kernel completing with pending NOC "
                    "transactions (missing NOC posted writes sent barrier).";
+        case dev_msgs::DebugAssertNCriscNOCPacketTagClearedTripped:
+            return "detected invalid NOC command buffer state before starting the next kernel "
+                   "(NOC packet tags must be zero so implicit transaction ID users start with transaction ID 0).";
         case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds.";
         case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds.";
         case dev_msgs::DebugAssertHwFault:

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -132,7 +132,8 @@ inline std::string get_debug_assert_message(
                    "transactions (missing NOC posted writes sent barrier).";
         case dev_msgs::DebugAssertNCriscNOCPacketTagClearedTripped:
             return "detected invalid NOC command buffer state before starting the next kernel "
-                   "(NOC packet tags must be zero so implicit transaction ID users start with transaction ID 0).";
+                   "(write-capable NOC packet tags must be zero so implicit transaction ID users start with "
+                   "transaction ID 0).";
         case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds.";
         case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds.";
         case dev_msgs::DebugAssertHwFault:

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/kernels/dm1.cpp
@@ -109,4 +109,5 @@ void kernel_main() {
 
     // Ensure write and semaphore have left the core before continuing
     noc_async_write_flushed_with_trid(semaphore_trid, /*noc=*/1);
+    noc_async_write_set_trid(0, /*noc=*/1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
@@ -297,6 +297,7 @@ void kernel_main() {
         noc_async_write_set_trid(semaphore_trid, /*noc=*/1);
         noc_semaphore_inc</*posted=*/true>(collector_semaphore_noc_addr, /*incr=*/1, /*noc_id=*/1, /*vc=*/vchannel);
         noc_async_write_flushed_with_trid(semaphore_trid, /*noc=*/1);
+        noc_async_write_set_trid(0, /*noc=*/1);
 
         // We are done with the group scores
         cb_pop_front(cb_c2w_rdy, 1);
@@ -323,6 +324,7 @@ void kernel_main() {
         noc_async_write_set_trid(semaphore_trid, /*noc=*/1);
         noc_semaphore_inc</*posted=*/true>(collector_semaphore_noc_addr, /*incr=*/1, /*noc_id=*/1, /*vc=*/vchannel);
         noc_async_write_flushed_with_trid(semaphore_trid, /*noc=*/1);
+        noc_async_write_set_trid(0, /*noc=*/1);
 
         cb_pop_front(cb_w2c_in8, 1);
     }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Add firmware startup clearing and between-kernel assertions for NoC packet tags so write-capable tt-1xx command buffers do not carry a stale transaction ID into the next kernel. The assert is scoped to write-capable command buffers because the failure mode is specific to multicast writes.

The problematic sequence is:
1. One kernel explicitly uses a nonzero transaction ID and leaves that packet tag programmed in a write command buffer.
2. The next kernel does a multicast write without intending to use that transaction ID, but the stale packet tag causes the multicast to be issued with it.
3. A later kernel explicitly uses the same transaction ID and waits on it, but the outstanding counter can already be in a bad wrapped state and the barrier observes transactions that never complete.

Per `tt-isa-documentation/WormholeB0/NoC/Counters.md`, `NIU_MST_REQS_OUTSTANDING_ID(i)` is an 8-bit counter that is incremented and decremented by transaction ID. For a request with both broadcast and response-marked behavior, hardware increments the counter once when the request is initiated but decrements it for every response received. That can leave the counter nonzero by unsigned underflow/wrap even when there are no real outstanding transactions. Clearing packet tags at startup and asserting write-capable packet tags are zero at kernel handoff prevents one kernel's transaction ID state from accidentally tagging a later multicast.

### Notes for reviewers
Review the tt-1xx NoC helper changes and the placement of asserts beside the existing NoC counter checks. Dedicated-NoC kernel wrappers check only their assigned `NOC_INDEX`; dynamic-NoC firmware checks each NoC in its existing loop. Read and atomic command buffers are intentionally ignored by the packet-tag assert because this invariant is targeted at multicast write transaction accounting.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/packet-tag-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/packet-tag-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/packet-tag-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/packet-tag-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/packet-tag-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/packet-tag-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/packet-tag-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/packet-tag-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/packet-tag-asserts)
