### PR TITLE
[LLK] Fix num_tiles == 1 handling in unpack_tilize wormhole

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -15,9 +15,10 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
     _llk_unpack_tilize_init_(
-        unpack_src_format[operand_id], unpack_dst_format[operand_id], ct_dim, face_r_dim, narrow_tile);
+        unpack_src_format[operand_id], unpack_dst_format[operand_id], ct_dim, face_r_dim, narrow_tile, num_faces);
 }
 
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -15,14 +15,14 @@
 #ifdef ARCH_WORMHOLE // ARCH_WORMHOLE version of the wrappers
 
 inline void _llk_unpack_tilize_init_wrapper_(
-    const std::uint32_t unpack_src_format          = 0,
-    const std::uint32_t unpack_dst_format          = 0,
-    const std::uint32_t ct_dim                     = 0,
-    const std::uint32_t face_r_dim                 = ckernel::FACE_R_DIM,
-    const bool narrow_tile                         = false,
-    [[maybe_unused]] const std::uint32_t num_faces = 4)
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t ct_dim            = 0,
+    const std::uint32_t face_r_dim        = ckernel::FACE_R_DIM,
+    const bool narrow_tile                = false,
+    const std::uint32_t num_faces         = 4)
 {
-    _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile);
+    _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile, num_faces);
 }
 
 inline std::uint32_t _llk_unpack_tilize_block_ct_dim_wrapper_(const std::uint32_t block_ct_dim)

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -64,16 +64,6 @@ def test_unpack_tilize_comprehensive(
     # Get architecture for architecture-specific skips
     arch = get_chip_architecture()
 
-    # Wormhole unpack_tilize has 0-loop for num_faces=1
-    # File: tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h:220
-    # num_loops = num_faces / 2 → when num_faces=1, this is 1/2=0 (integer division)
-    # Result: for (n=0; n<0; n++) never executes, no data unpacked, packer timeout
-    if arch == ChipArchitecture.WORMHOLE and num_faces == 1:
-        pytest.skip(
-            "Wormhole LLK: num_loops = num_faces/2 = 0 when num_faces=1 "
-            "(tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h:220)"
-        )
-
     # BFP8_b input format not supported by tilize unpacker
     # Tilize unpacker cannot correctly read row-major BFP8_b data with shared exponents
     # Note: BFP8_b input works in regular unpack mode (test_eltwise_unary_datacopy with tilize_en=false)

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -31,7 +31,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
 
     // Initialize tilize unpacker
-    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, params.NARROW_TILE);
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, params.NARROW_TILE, params.num_faces);
 
     std::uint32_t read_offset = 0;
 

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -30,14 +30,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
 
+    const std::uint32_t num_faces = _llk_unpack_tilize_num_faces_wrapper_(params.num_faces);
+
     // Initialize tilize unpacker
-    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, params.NARROW_TILE, params.num_faces);
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, params.NARROW_TILE, num_faces);
 
     std::uint32_t read_offset = 0;
 
     const std::uint32_t block_ct_dim = _llk_unpack_tilize_block_ct_dim_wrapper_(params.BLOCK_CT_DIM);
-
-    const std::uint32_t num_faces = _llk_unpack_tilize_num_faces_wrapper_(params.num_faces);
 
     // Main tilize loop - handle different tile configurations
     for (std::uint32_t row = 0; row < params.BLOCK_RT_DIM; ++row)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -48,8 +48,10 @@ inline void _llk_unpack_tilize_init_(
     const std::uint32_t unpack_dst_format = 0,
     const std::uint32_t ct_dim            = 0,
     const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const bool narrow_tile                = false)
+    const bool narrow_tile                = false,
+    const std::uint32_t num_faces         = 4)
 {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
     // In case of 32-bit numbers, we have to unpack into dest register
@@ -61,6 +63,7 @@ inline void _llk_unpack_tilize_init_(
         "Unsupported unpacker format conversion.");
 
     const std::uint32_t block_c_dim = ct_dim * (narrow_tile ? FACE_C_DIM : TILE_C_DIM);
+    const bool narrow_layout        = narrow_tile || (num_faces == 1);
 
     // Set face dim
     TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
@@ -78,7 +81,7 @@ inline void _llk_unpack_tilize_init_(
     TTI_REG2FLOP(
         1, 0, 0, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::FACE_DIM_1x16); // GPR preloaded with  16 | (16 << 16)
 
-    _llk_unpack_tilize_mop_config_(narrow_tile, unpack_to_dest);
+    _llk_unpack_tilize_mop_config_(narrow_layout, unpack_to_dest);
 }
 
 // Internal function to implement unpacking to source register
@@ -197,6 +200,7 @@ inline void _llk_unpack_tilize_(
     std::uint32_t top_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, tile_index) << (narrow_tile ? 0 : 1);
     // Each iteration unpacks 2 face_r_dimx16 faces (1st 0,1 2nd 2,3 unless tile is <=16x32)
     // For narrow tile we unpack 1 face in each iteration
+    // For num_faces == 1 we unpack a single face per tile
     // Offset address is in 16B words
     // Datum count = tile_index*face_r_dim (/16 to get word count)
 
@@ -204,7 +208,7 @@ inline void _llk_unpack_tilize_(
     std::uint32_t bot_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, face_r_dim * block_c_dim_16B); //*N rows / 16 to get 16B word aligned address
 
     // Program srcA and srcB base addresses
-    std::uint32_t num_loops = narrow_tile ? 2 : num_faces / 2;
+    std::uint32_t num_loops = (num_faces == 1) ? 1 : (narrow_tile ? 2 : num_faces >> 1);
 
     if (!unpack_to_dest)
     {


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
https://github.com/tenstorrent/tt-llk/issues/732

Num faces == 1 was not being handled properly. This fix corrects the iterations of the loops for that case.
Removed the test skip condition as the test now passes.

### Notes for reviewers
- Seems like the naming conventions for narrow_tile, num_faces is all very confusing and somewhat overlap. So in this fix, if num_faces == 1 is detected, narrow_tile is pretty much ignored
- in _llk_unpack_tilize_mop_config_, should the argument name narrow_tile be changed? As it is now being set as true for num_faces == 1 as well.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:halgh/unpack_tilize_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:halgh/unpack_tilize_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:halgh/unpack_tilize_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:halgh/unpack_tilize_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:halgh/unpack_tilize_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:halgh/unpack_tilize_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:halgh/unpack_tilize_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=halgh/unpack_tilize_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:halgh/unpack_tilize_bug)