### PR TITLE
Adds INT32 MUL and COMP Binary SFPU kernels for Quasar

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2271,6 +2271,18 @@ class EltwiseBinaryGolden(FidelityMasking):
         # Compute in float32 for better fidelity, then cast back to original dtype.
         return (t1.to(torch.float32) * t2.to(torch.float32)).to(t1.dtype)
 
+    def _gt_int(self, t1, t2):
+        return (t1 > t2).to(torch.int32)
+
+    def _lt_int(self, t1, t2):
+        return (t1 < t2).to(torch.int32)
+
+    def _le_int(self, t1, t2):
+        return (t1 <= t2).to(torch.int32)
+
+    def _ge_int(self, t1, t2):
+        return (t1 >= t2).to(torch.int32)
+
 
 @register_golden
 class BinarySFPUGolden(EltwiseBinaryGolden):
@@ -2281,6 +2293,11 @@ class BinarySFPUGolden(EltwiseBinaryGolden):
                 MathOperation.SfpuElwadd: self._add,
                 MathOperation.SfpuElwsub: self._sub,
                 MathOperation.SfpuElwmul: self._mul,
+                MathOperation.SfpuElwmulInt: self._mul,
+                MathOperation.SfpuGtInt: self._gt_int,
+                MathOperation.SfpuLtInt: self._lt_int,
+                MathOperation.SfpuLeInt: self._le_int,
+                MathOperation.SfpuGeInt: self._ge_int,
                 MathOperation.SfpuXlogy: self._xlogy,
                 MathOperation.SfpuElwRightShift: self._right_shift,
                 MathOperation.SfpuElwLeftShift: self._left_shift,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -32,6 +32,7 @@ class MathOpType(Enum):
 
     SFPU_UNARY = auto()
     SFPU_BINARY = auto()
+    SFPU_BINARY_INT = auto()
     SFPU_TERNARY = auto()
 
     FPU_BINARY = auto()
@@ -118,6 +119,11 @@ class MathOperation(Enum):
     SfpuElwdiv = OpSpec("DIV", MathOpType.SFPU_BINARY)
     SfpuElwrsub = OpSpec("RSUB", MathOpType.SFPU_BINARY)
     SfpuElwpow = OpSpec("POW", MathOpType.SFPU_BINARY)
+    SfpuElwmulInt = OpSpec("MUL", MathOpType.SFPU_BINARY_INT)
+    SfpuGtInt = OpSpec("GT_INT", MathOpType.SFPU_BINARY_INT)
+    SfpuLtInt = OpSpec("LT_INT", MathOpType.SFPU_BINARY_INT)
+    SfpuLeInt = OpSpec("LE_INT", MathOpType.SFPU_BINARY_INT)
+    SfpuGeInt = OpSpec("GE_INT", MathOpType.SFPU_BINARY_INT)
 
     # =============================================================================
     # SFPU TERNARY OPERATIONS

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -123,6 +123,22 @@ class EN_DEST_REUSE(TemplateParameter):
         return "#define EN_DEST_REUSE"
 
 
+@dataclass
+class SFPU_INT_OP(TemplateParameter):
+    """Emit a #define to select the integer SFPU operation in a shared C++ test source.
+
+    Supported values: "MUL", "GT", "LT", "LE", "GE".  When omitted the C++ source
+    falls through to its default (add_int) path.
+    """
+
+    op: str = ""
+
+    def convert_to_cpp(self) -> str:
+        if self.op:
+            return f"#define SFPU_INT_OP_{self.op.upper()}"
+        return ""
+
+
 def _generate_operation_constants(mathop: MathOperation) -> list[str]:
     """Generate the appropriate operation constants based on the math operation type."""
     constants = []

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
@@ -21,6 +21,7 @@ from helpers.test_variant_parameters import (
     IMPLIED_MATH_FORMAT,
     MATH_OP,
     NUM_FACES,
+    SFPU_INT_OP,
     SFPU_TILE_INDICES,
     TEST_FACE_DIMS,
     TILE_COUNT,
@@ -28,33 +29,26 @@ from helpers.test_variant_parameters import (
 )
 from helpers.utils import passed_test
 
+_SRC0_IDX, _SRC1_IDX, _DST_IDX = 0, 1, 0
 
-@pytest.mark.quasar
-@pytest.mark.parametrize(
-    "data_format, dest_acc",
-    [
-        (DataFormat.Int32, DestAccumulation.Yes),
-        (DataFormat.Float16_b, DestAccumulation.Yes),
-        (DataFormat.Float16_b, DestAccumulation.No),
-    ],
-)
-@pytest.mark.parametrize(
-    "src0_idx, src1_idx, dst_idx",
-    [
-        (0, 1, 0),
-        (1, 0, 0),
-        (0, 1, 1),
-        (0, 2, 1),
-        (2, 3, 0),
-    ],
-)
-def test_sfpu_binary_add_quasar(data_format, dest_acc, src0_idx, src1_idx, dst_idx):
-    """
-    Test binary SFPU ADD on Quasar architecture.
 
-    Loads tiles directly into DEST via unpack-to-dest,
-    performs elementwise add via SFPU using programmable
-    tile indices, and verifies the result against a golden reference.
+def _run_sfpu_binary_quasar(
+    data_format,
+    dest_acc,
+    src0_idx,
+    src1_idx,
+    dst_idx,
+    mathop,
+    sfpu_int_op="",
+    clamp_inputs=None,
+):
+    """Shared driver for all binary SFPU tests on Quasar.
+
+    Args:
+        sfpu_int_op: passed to SFPU_INT_OP template parameter ("MUL", "GT",
+                     "LT", "LE", "GE", or "" for the default add path).
+        clamp_inputs: if set, clamp src_A to (-clamp_inputs, clamp_inputs) to
+                      avoid overflow.
     """
     num_tiles_needed = max(src0_idx, src1_idx, dst_idx) + 1
     formats = InputOutputFormat(input_format=data_format, output_format=data_format)
@@ -70,8 +64,10 @@ def test_sfpu_binary_add_quasar(data_format, dest_acc, src0_idx, src1_idx, dst_i
         full_2sc_int_range=True,
     )
 
+    if clamp_inputs is not None:
+        src_A = torch.clamp(src_A, -clamp_inputs, clamp_inputs)
+
     num_faces = 4
-    mathop = MathOperation.SfpuElwadd
 
     elements_per_tile = 1024  # 4 faces * 16 rows * 16 cols
     generate_golden = get_golden_generator(BinarySFPUGolden)
@@ -88,17 +84,21 @@ def test_sfpu_binary_add_quasar(data_format, dest_acc, src0_idx, src1_idx, dst_i
     dst_start = dst_idx * elements_per_tile
     golden_tensor = golden_full[dst_start : dst_start + elements_per_tile]
 
-    tile_count_res = 1  # we only pack the single output tile
+    tile_count_res = 1
+
+    templates = [
+        MATH_OP(mathop=mathop),
+        IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
+        UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
+        DEST_SYNC(),
+    ]
+    if sfpu_int_op:
+        templates.insert(1, SFPU_INT_OP(sfpu_int_op))
 
     configuration = TestConfig(
         "sources/quasar/sfpu_binary_quasar_test.cpp",
         formats,
-        templates=[
-            MATH_OP(mathop=mathop),
-            IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
-            UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
-            DEST_SYNC(),
-        ],
+        templates=templates,
         runtimes=[
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(num_faces),
@@ -133,3 +133,83 @@ def test_sfpu_binary_add_quasar(data_format, dest_acc, src0_idx, src1_idx, dst_i
     assert passed_test(
         golden_tensor, res_tensor, data_format
     ), "Assert against golden failed"
+
+
+# ---------------------------------------------------------------------------
+# ADD (Int32 + Float16_b)
+# ---------------------------------------------------------------------------
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "data_format, dest_acc",
+    [
+        (DataFormat.Int32, DestAccumulation.Yes),
+        (DataFormat.Float16_b, DestAccumulation.Yes),
+        (DataFormat.Float16_b, DestAccumulation.No),
+    ],
+)
+def test_sfpu_binary_add_quasar(data_format, dest_acc):
+    """Test binary SFPU ADD on Quasar architecture."""
+    _run_sfpu_binary_quasar(
+        data_format,
+        dest_acc,
+        _SRC0_IDX,
+        _SRC1_IDX,
+        _DST_IDX,
+        mathop=MathOperation.SfpuElwadd,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MUL_INT (Int32 only — Float16_b requires bf16 SFPU mul kernel from PR2)
+# ---------------------------------------------------------------------------
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "data_format, dest_acc",
+    [
+        (DataFormat.Int32, DestAccumulation.Yes),
+    ],
+)
+def test_sfpu_binary_mul_quasar(data_format, dest_acc):
+    """Test binary SFPU MUL_INT on Quasar architecture."""
+    _run_sfpu_binary_quasar(
+        data_format,
+        dest_acc,
+        _SRC0_IDX,
+        _SRC1_IDX,
+        _DST_IDX,
+        mathop=MathOperation.SfpuElwmulInt,
+        sfpu_int_op="MUL",
+        clamp_inputs=1000,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integer comparisons (GT, LT, LE, GE) — parametrized over comp_op
+# ---------------------------------------------------------------------------
+_COMP_OPS = [
+    ("GT", MathOperation.SfpuGtInt),
+    ("LT", MathOperation.SfpuLtInt),
+    ("LE", MathOperation.SfpuLeInt),
+    ("GE", MathOperation.SfpuGeInt),
+]
+
+
+@pytest.mark.quasar
+@pytest.mark.parametrize("comp_op, mathop", _COMP_OPS, ids=[op for op, _ in _COMP_OPS])
+@pytest.mark.parametrize(
+    "data_format, dest_acc",
+    [
+        (DataFormat.Int32, DestAccumulation.Yes),
+    ],
+)
+def test_sfpu_binary_comp_int_quasar(comp_op, mathop, data_format, dest_acc):
+    """Test binary SFPU integer comparison (GT/LT/LE/GE) on Quasar."""
+    _run_sfpu_binary_quasar(
+        data_format,
+        dest_acc,
+        _SRC0_IDX,
+        _SRC1_IDX,
+        _DST_IDX,
+        mathop=mathop,
+        sfpu_int_op=comp_op,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
@@ -143,8 +143,8 @@ def _run_sfpu_binary_quasar(
     "data_format, dest_acc",
     [
         (DataFormat.Int32, DestAccumulation.Yes),
-        (DataFormat.Float16_b, DestAccumulation.Yes),
-        (DataFormat.Float16_b, DestAccumulation.No),
+        # (DataFormat.Float16_b, DestAccumulation.Yes), // TODO pgardner: Add back through ckernel_sfpu_add.h
+        # (DataFormat.Float16_b, DestAccumulation.No),
     ],
 )
 def test_sfpu_binary_add_quasar(data_format, dest_acc):
@@ -167,6 +167,8 @@ def test_sfpu_binary_add_quasar(data_format, dest_acc):
     "data_format, dest_acc",
     [
         (DataFormat.Int32, DestAccumulation.Yes),
+        # (DataFormat.Float16_b, DestAccumulation.Yes), // TODO pgardner: Add back through ckernel_sfpu_add.h THIS MAY HAVE A BUG??
+        # (DataFormat.Float16_b, DestAccumulation.No),
     ],
 )
 def test_sfpu_binary_mul_quasar(data_format, dest_acc):

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
@@ -59,6 +59,7 @@ def _run_sfpu_binary_quasar(
         stimuli_format_A=data_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=data_format,
+        negative_values=True,
         input_dimensions_B=input_dimensions,
         sfpu=False,
         full_2sc_int_range=True,
@@ -66,6 +67,7 @@ def _run_sfpu_binary_quasar(
 
     if clamp_inputs is not None:
         src_A = torch.clamp(src_A, -clamp_inputs, clamp_inputs)
+        src_B = torch.clamp(src_B, -clamp_inputs, clamp_inputs)
 
     num_faces = 4
 

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
@@ -89,28 +89,25 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int in1_offset      = params.SRC1_TILE_IDX * tile_stride;
     const int out_offset      = params.DST_TILE_IDX * tile_stride;
 
-    _llk_math_eltwise_sfpu_start_(0);
-
-    for (std::uint32_t face = 0; face < NUM_FACES; face++)
-    {
 #if defined(SFPU_INT_OP_MUL)
-        _mul_int32_<false>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+    _llk_math_eltwise_binary_sfpu_params_<false>(
+        _mul_int32_<false, 8>, 0, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
 #elif defined(SFPU_INT_OP_GT)
-        calculate_binary_comp_int32<false, 8, SfpuType::gt>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+    _llk_math_eltwise_binary_sfpu_params_<false>(
+        calculate_binary_comp_int32<false, 8, SfpuType::gt>, 0, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
 #elif defined(SFPU_INT_OP_LT)
-        calculate_binary_comp_int32<false, 8, SfpuType::lt>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+    _llk_math_eltwise_binary_sfpu_params_<false>(
+        calculate_binary_comp_int32<false, 8, SfpuType::lt>, 0, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
 #elif defined(SFPU_INT_OP_LE)
-        calculate_binary_comp_int32<false, 8, SfpuType::le>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+    _llk_math_eltwise_binary_sfpu_params_<false>(
+        calculate_binary_comp_int32<false, 8, SfpuType::le>, 0, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
 #elif defined(SFPU_INT_OP_GE)
-        calculate_binary_comp_int32<false, 8, SfpuType::ge>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+    _llk_math_eltwise_binary_sfpu_params_<false>(
+        calculate_binary_comp_int32<false, 8, SfpuType::ge>, 0, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
 #else
-        _calculate_add_(src_format, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+    _llk_math_eltwise_binary_sfpu_params_<false>(
+        _add_int_<false, 8, 0, false>, 0, src_format, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
 #endif
-        _llk_math_eltwise_sfpu_inc_dst_face_addr_();
-    }
-
-
-    _llk_math_eltwise_sfpu_done_();
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
@@ -59,6 +59,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "llk_math_eltwise_binary_sfpu.h"
 #include "params.h"
 #include "sfpu/ckernel_sfpu_add.h"
+#if defined(SFPU_INT_OP_MUL)
+#include "sfpu/ckernel_sfpu_mul_int32.h"
+#endif
+#if defined(SFPU_INT_OP_GT) || defined(SFPU_INT_OP_LT) || defined(SFPU_INT_OP_LE) || defined(SFPU_INT_OP_GE)
+#include "sfpu/ckernel_sfpu_binary_comp.h"
+#endif
 
 using namespace ckernel;
 using namespace ckernel::math;
@@ -78,7 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_eltwise_sfpu_init_();
 
-    constexpr int tile_stride = NUM_FACES * FACE_R_DIM; // 4 faces * 16 rows per tile
+    constexpr int tile_stride = NUM_FACES * FACE_R_DIM;
     const int in0_offset      = params.SRC0_TILE_IDX * tile_stride;
     const int in1_offset      = params.SRC1_TILE_IDX * tile_stride;
     const int out_offset      = params.DST_TILE_IDX * tile_stride;
@@ -87,9 +93,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     for (std::uint32_t face = 0; face < NUM_FACES; face++)
     {
+#if defined(SFPU_INT_OP_MUL)
+        _mul_int32_<false>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+#elif defined(SFPU_INT_OP_GT)
+        calculate_binary_comp_int32<false, 8, SfpuType::gt>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+#elif defined(SFPU_INT_OP_LT)
+        calculate_binary_comp_int32<false, 8, SfpuType::lt>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+#elif defined(SFPU_INT_OP_LE)
+        calculate_binary_comp_int32<false, 8, SfpuType::le>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+#elif defined(SFPU_INT_OP_GE)
+        calculate_binary_comp_int32<false, 8, SfpuType::ge>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+#else
         _calculate_add_(src_format, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+#endif
         _llk_math_eltwise_sfpu_inc_dst_face_addr_();
     }
+
 
     _llk_math_eltwise_sfpu_done_();
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -14,7 +14,8 @@ namespace ckernel
 {
 namespace sfpu
 {
-inline void _calculate_add_(const DataFormat fmt, const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, int INSTRUCTION_MODE = 0, bool SIGN_MAGNITUDE_FORMAT = false>
+inline void _add_int_(const DataFormat fmt, const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
 {
     LLK_ASSERT(fmt == DataFormat::Int32 || fmt == DataFormat::Float16_b, "Only Int32 and Float16_b are currently supported for SFPU add on Quasar");
 
@@ -27,36 +28,20 @@ inline void _calculate_add_(const DataFormat fmt, const int iterations, const in
         TT_SFPLOAD(p_sfpu::LREG0, instr_mod, ADDR_MOD_7, 0, in0_offset_idx + (d << 1));
         TT_SFPLOAD(p_sfpu::LREG1, instr_mod, ADDR_MOD_7, 0, in1_offset_idx + (d << 1));
 
-        if (is_int)
-        {
-            // On Quasar, SFPU kernels should assume that integer inputs are in 2's complement format
-            // TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag -> 2SC
-            // TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag-> 2SC
+        // On Quasar, SFPU kernels should assume that integer inputs are in 2's complement format
+        // TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag -> 2SC
+        // TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag-> 2SC
 
-            TTI_SFPIADD(
-                0x0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG1,
-                p_sfpu::sfp_binary_mod::SFPIADD_DISABLE_CC); // SFPIADD needs to explicitly disable CC output since CC exu is enabled by default
+        TTI_SFPIADD(
+            0x0,
+            p_sfpu::LREG0,
+            p_sfpu::LREG1,
+            p_sfpu::sfp_binary_mod::SFPIADD_DISABLE_CC); // SFPIADD needs to explicitly disable CC output since CC exu is enabled by default
 
-            // TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::TWO_SC_TO_SM); // 2SC -> Sing+Mag
+        // TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::TWO_SC_TO_SM); // 2SC -> Sing+Mag
 
-            TT_SFPSTORE(p_sfpu::LREG1, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
-        }
-        else
-        {
-            TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, 0x0);
-
-            TT_SFPSTORE(p_sfpu::LREG2, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
-        }
+        TT_SFPSTORE(p_sfpu::LREG1, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
     }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, int INSTRUCTION_MODE = 0, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void _add_int_(const int iterations, const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
-{
-    static_assert(!SIGN_MAGNITUDE_FORMAT, "Quasar uses 2's complement natively; sign-magnitude not supported");
-    _calculate_add_(DataFormat::Int32, iterations, dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -17,7 +17,7 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, int INSTRUCTION_MODE = 0, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void _add_int_(const DataFormat fmt, const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
 {
-    LLK_ASSERT(fmt == DataFormat::Int32 || fmt == DataFormat::Float16_b, "Only Int32 and Float16_b are currently supported for SFPU add on Quasar");
+    LLK_ASSERT(fmt == DataFormat::Int32, "Only Int32 currently supported for SFPU integer add on Quasar");
 
     const bool is_int    = (fmt == DataFormat::Int32);
     const auto instr_mod = is_int ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT; // There is a quasar bug with implied fmts + upk to dest, so we need use

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -18,7 +18,7 @@ inline void _calculate_add_(const DataFormat fmt, const int iterations, const in
 {
     LLK_ASSERT(fmt == DataFormat::Int32 || fmt == DataFormat::Float16_b, "Only Int32 and Float16_b are currently supported for SFPU add on Quasar");
 
-    const bool is_int = (fmt == DataFormat::Int32);
+    const bool is_int    = (fmt == DataFormat::Int32);
     const auto instr_mod = is_int ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT; // There is a quasar bug with implied fmts + upk to dest, so we need use
                                                                                      // use explicit types for int SFPULOAD/STORE TEN-4674
 
@@ -50,6 +50,13 @@ inline void _calculate_add_(const DataFormat fmt, const int iterations, const in
             TT_SFPSTORE(p_sfpu::LREG2, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
         }
     }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, int INSTRUCTION_MODE = 0, bool SIGN_MAGNITUDE_FORMAT = false>
+inline void _add_int_(const int iterations, const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
+{
+    static_assert(!SIGN_MAGNITUDE_FORMAT, "Quasar uses 2's complement natively; sign-magnitude not supported");
+    _calculate_add_(DataFormat::Int32, iterations, dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_binary_comp.h
@@ -34,7 +34,7 @@ inline void calculate_binary_comp_int32(
 
     if constexpr (invert_result)
     {
-        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_LOWER, 0x01);
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
     }
 
     const std::uint32_t idx_x = swap_operands ? dst_index_in1 : dst_index_in0;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_binary_comp.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_instr_params.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "llk_defs.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// Int32 binary comparison for relational ops (signed), ported from BH.
+// All ops reduce to computing LT(X, Y) with optional operand swap and result
+// inversion:
+//   lt(A,B) = LT(A,B)           gt(A,B) = LT(B,A)
+//   ge(A,B) = NOT LT(A,B)       le(A,B) = NOT LT(B,A)
+template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
+inline void calculate_binary_comp_int32(
+    const int iterations, const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
+{
+    static_assert(
+        RELATIONAL_OP == SfpuType::lt || RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge,
+        "Supported operation types: lt, gt, le, ge");
+
+    constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
+    constexpr bool invert_result = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
+
+    if constexpr (invert_result)
+    {
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_LOWER, 0x01);
+    }
+
+    const std::uint32_t idx_x = swap_operands ? dst_index_in1 : dst_index_in0;
+    const std::uint32_t idx_y = swap_operands ? dst_index_in0 : dst_index_in1;
+
+    for (int d = 0; d < iterations; d++)
+    {
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, idx_x + (d << 1));
+        TT_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, idx_y + (d << 1));
+
+        TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG2, 0);
+        TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG3, 0);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
+
+        TTI_SFPXOR(p_sfpu::LREG2, p_sfpu::LREG3);
+
+        // Same-sign path: subtract and extract sign bit.
+        TTI_SFPSETCC(0, p_sfpu::LREG3, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+        // imod 6 = subtract (lreg_c - lreg_dest) with CC output disabled
+        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+
+        // Different-sign path: result = sign bit of X.
+        TTI_SFPCOMPC;
+        TTI_SFPMOV(p_sfpu::LREG2, p_sfpu::LREG1, 0);
+        TTI_SFPENCC(0, 0);
+
+        if constexpr (invert_result)
+        {
+            TTI_SFPXOR(p_sfpu::LREG7, p_sfpu::LREG1);
+        }
+
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, dst_index_out + (d << 1));
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_mul_int32.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_instr_params.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// Int32 multiply ported from the BH DISABLE_SFPLOADMACRO path.
+// Uses SFPMUL24 (24-bit partial products) + shifts to produce a full 32-bit
+// result. Quasar uses 2's complement natively so no sign-magnitude conversion
+// is needed.
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void _mul_int32_(const int iterations, const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
+{
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, dst_index_in0 + (d << 1));
+        TTI_SFPSHFT((-23) & 0xFFF, p_sfpu::LREG0, p_sfpu::LREG1, 5); // lreg1 = lreg0 >> 23
+        TT_SFPLOAD(p_sfpu::LREG2, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, dst_index_in1 + (d << 1));
+        TTI_SFPSHFT((-23) & 0xFFF, p_sfpu::LREG2, p_sfpu::LREG3, 5); // lreg3 = lreg2 >> 23
+
+        TTI_SFPMUL24(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LREG4, 0); // low(a_lo * b_lo)
+        TTI_SFPMUL24(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG5, 1); // high(a_lo * b_lo)
+        TTI_SFPMUL24(p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG6, 0); // low(a_hi * b_lo)
+        TTI_SFPMUL24(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LREG7, 0); // low(a_lo * b_hi)
+
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG5, p_sfpu::sfp_binary_mod::SFPIADD_DISABLE_CC); // lreg5 += lreg6
+        TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG5, p_sfpu::sfp_binary_mod::SFPIADD_DISABLE_CC); // lreg5 += lreg7
+        TTI_SFPSHFT(23, p_sfpu::LREG5, p_sfpu::LREG5, 5);                                         // lreg5 <<= 23
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, p_sfpu::sfp_binary_mod::SFPIADD_DISABLE_CC); // lreg4 += lreg5
+
+        TT_SFPSTORE(p_sfpu::LREG4, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, dst_index_out + (d << 1));
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -102,7 +102,7 @@ enum class SfpuType : std::uint32_t
     gt_int,
     le_int,
     ge_int,
-    mul_int32,
+    mul_int,
 };
 
 enum class BinaryOp : std::uint8_t

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -10,7 +10,7 @@ namespace ckernel
 {
 
 // Currently unused but kept for backwards compatibility
-enum VectorMode
+enum class VectorMode
 {
     None      = 0,
     R         = 1,
@@ -92,7 +92,17 @@ enum class SfpuType : std::uint32_t
     abs,
     fill,
     swiglu,
-    where
+    where,
+    unused,
+    lt,
+    gt,
+    le,
+    ge,
+    lt_int,
+    gt_int,
+    le_int,
+    ge_int,
+    mul_int32,
 };
 
 enum class BinaryOp : std::uint8_t
@@ -100,6 +110,7 @@ enum class BinaryOp : std::uint8_t
     ADD,
     SUB,
     MUL,
+    DIV,
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
### PR Category
Test
Feature

### Summary
Ports Int32 MUL and COMP kernels to QS from BH directly
Extends LLK test infra test

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pgardner/QS-BinarySFPU-int-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pgardner/QS-BinarySFPU-int-ops)