### PR TITLE
[Feature] Quasar - Assert on valid Buffer Descriptor programming (#1424)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -94,10 +94,17 @@ inline bool _divisible_by_pow_two_(const std::uint32_t value, const std::uint32_
 }
 
 /**
- * @brief Helper function to ensure valid tile sizes are programmed into the buffer descriptor
+ * @brief Helper function to ensure valid tile sizes are programmed into the buffer descriptor.
+ * valid tile sizes:
+    1x16: x=16, y=1, z=1
+    2x16: x=16, y=2, z=1
+    4x16: x=16, y=4, z=1
+    8x16: x=16, y=8, z=1
+    16x16: x=16, y=16, z=1
+    32x32: x=16, y=16, z=4
  * @param buf_desc: Contains L1 buffer descriptor information
  */
-void validate_buffer_desc(const buffer_descriptor_u& buf_desc)
+inline void validate_buffer_desc(const buffer_descriptor_u& buf_desc)
 {
     LLK_ASSERT(buf_desc.f.x_dim == 16, "x_dim must be 16");
     LLK_ASSERT(

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -11,6 +11,7 @@
 #include "ckernel_instr_params.h"
 #include "ckernel_proj_params.h"
 #include "ckernel_template.h"
+#include "llk_assert.h"
 #include "llk_defs.h"
 #include "tensix_types.h"
 
@@ -93,12 +94,30 @@ inline bool _divisible_by_pow_two_(const std::uint32_t value, const std::uint32_
 }
 
 /**
+ * @brief Helper function to ensure valid tile sizes are programmed into the buffer descriptor
+ * @param buf_desc: Contains L1 buffer descriptor information
+ */
+void validate_buffer_desc(const buffer_descriptor_u& buf_desc)
+{
+    LLK_ASSERT(buf_desc.f.x_dim == 16, "x_dim must be 16");
+    LLK_ASSERT(
+        buf_desc.f.y_dim == 16 || buf_desc.f.y_dim == 8 || buf_desc.f.y_dim == 4 || buf_desc.f.y_dim == 2 || buf_desc.f.y_dim == 1,
+        "y_dim must be powers of 2 <= 16");
+    LLK_ASSERT(buf_desc.f.z_dim == 1 || buf_desc.f.z_dim == 4, "z_dim must be 1 or 4");
+    if (buf_desc.f.z_dim == 4)
+    {
+        LLK_ASSERT(buf_desc.f.y_dim == 16, "y_dim must be 16 when z_dim is 4");
+    }
+}
+
+/**
  * @brief Populates buffer table entry for TDMA engines
  * @param buf_desc_id: Buffer descriptor id into the buffer descriptor table
  * @param buf_desc: Contains L1 buffer descriptor information
  */
 inline void _configure_buf_desc_table_(const std::uint32_t buf_desc_id, const buffer_descriptor_u& buf_desc)
 {
+    validate_buffer_desc(buf_desc);
     for (std::uint32_t i = 0; i < BD_NUM_WORDS; i++)
     {
         bd_table[buf_desc_id].words[i] = buf_desc.words[i];


### PR DESCRIPTION
### Feature
#1424

### Summary
https://github.com/tenstorrent/tt-llk/issues/1424

### Notes for reviewers
Running `pytest -x --run-simulator --port=5556 test_reduce_quasar.py` at `/proj_sw/user_dev/$USER/tt-metal/tt_metal/tt-llk/tests/python_tests/quasar` with invalid buffer descriptor values yields no passed tests:
<img width="1390" height="303" alt="image" src="https://github.com/user-attachments/assets/b810a419-c7dd-4b95-b72d-c48844574180" />

For comparison, if there are any tests that pass, the number of passed tests will be outputted:
<img width="1399" height="210" alt="image" src="https://github.com/user-attachments/assets/6b23f132-99a7-47e5-9353-9504a8e3ee11" />

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jihoonyou/assert-buffer-desc-programming)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jihoonyou/assert-buffer-desc-programming)