### PR TITLE
[tt-train][WIP] Split K Gram polynomial implementation

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -137,6 +137,10 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/subtract_at_target/subtract_at_target.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/subtract_at_target/device/subtract_at_target_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/subtract_at_target/device/subtract_at_target_program_factory.cpp
+    # Gram Polynomial (bG + cG^2)
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/gram_polynomial/gram_polynomial.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/gram_polynomial/device/gram_polynomial_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
     # CrossEntropy Backward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/cross_entropy_bw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp

--- a/tt-train/sources/ttml/metal/common/const_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/const_utils.hpp
@@ -28,4 +28,15 @@ enum class AttentionMaskType {
  */
 enum class StochasticRounding : bool { Disabled = false, Enabled = true };
 
+/**
+ * Specifies whether a symmetric output is written fully or only as the upper triangle.
+ *
+ * - UpperTriangle: Write G[i,j] for i<=j (lower triangle left untouched)
+ * - Full: Write upper triangle and also the transposed mirror to the lower triangle positions
+ */
+enum class OutputMode : uint32_t {
+    UpperTriangle = 0,
+    Full = 1,
+};
+
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -6,6 +6,7 @@
 
 #include "ops/cross_entropy_bw/cross_entropy_bw.hpp"
 #include "ops/cross_entropy_fw/cross_entropy_fw.hpp"
+#include "ops/gram_polynomial/gram_polynomial.hpp"
 #include "ops/layernorm_bw/layernorm_bw.hpp"
 #include "ops/layernorm_fw/layernorm_fw.hpp"
 #include "ops/polynorm_fw/polynorm_fw.hpp"

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gram_polynomial_device_operation.hpp"
+
+namespace ttml::metal::ops::gram_polynomial::device {
+
+GramPolynomialDeviceOperation::program_factory_t GramPolynomialDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return GramPolynomialProgramFactory{};
+}
+
+void GramPolynomialDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    TT_FATAL(input.storage_type() == tt::tt_metal::StorageType::DEVICE, "Input tensor must be on device");
+    TT_FATAL(input.buffer() != nullptr, "Input tensor must be allocated on device");
+    TT_FATAL(input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Input tensor must be in DRAM");
+    TT_FATAL(input.layout() == tt::tt_metal::Layout::TILE, "Input tensor must have TILE layout");
+    TT_FATAL(input.dtype() == ttnn::DataType::BFLOAT16, "Input tensor must be BFLOAT16");
+    TT_FATAL(
+        input.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+        "Input tensor must use INTERLEAVED memory layout");
+    const auto rank = input.logical_shape().rank();
+    TT_FATAL(rank == 2 || rank == 4, "Input tensor must be 2D [M, K] or 4D [1, 1, M, K]");
+    if (rank == 4) {
+        TT_FATAL(
+            input.logical_shape()[0] == 1 && input.logical_shape()[1] == 1,
+            "Batch dimensions must be 1, got [{}, {}]",
+            input.logical_shape()[0],
+            input.logical_shape()[1]);
+    }
+    const uint32_t K_tiles = input.logical_shape()[-1] / tt::constants::TILE_WIDTH;
+    TT_FATAL(K_tiles % 2 == 0, "K dimension ({} tiles) must be even for K-split", K_tiles);
+    const auto device_grid = input.device()->compute_with_storage_grid_size();
+    const uint32_t grid_dim = static_cast<uint32_t>(std::min(device_grid.x - 1, device_grid.y));
+    TT_FATAL(grid_dim >= 3, "Device grid too small for gram matmul (need at least 4x3 compute grid)");
+
+    if (tensor_args.preallocated_output.has_value()) {
+        const auto& output = tensor_args.preallocated_output.value();
+        const uint32_t M = input.logical_shape()[-2];
+        TT_FATAL(output.storage_type() == tt::tt_metal::StorageType::DEVICE, "Preallocated output must be on device");
+        TT_FATAL(output.buffer() != nullptr, "Preallocated output must be allocated on device");
+        TT_FATAL(
+            output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Preallocated output must be in DRAM");
+        TT_FATAL(output.layout() == tt::tt_metal::Layout::TILE, "Preallocated output must have TILE layout");
+        TT_FATAL(output.dtype() == ttnn::DataType::BFLOAT16, "Preallocated output must be BFLOAT16");
+        TT_FATAL(
+            output.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "Preallocated output must use INTERLEAVED memory layout");
+        TT_FATAL(
+            output.logical_shape()[-2] == M && output.logical_shape()[-1] == M,
+            "Preallocated output shape must be [{}, {}], got [{}, {}]",
+            M,
+            M,
+            output.logical_shape()[-2],
+            output.logical_shape()[-1]);
+    }
+}
+
+GramPolynomialDeviceOperation::spec_return_value_t GramPolynomialDeviceOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output->tensor_spec();
+    }
+    const uint32_t M = tensor_args.input_tensor.logical_shape()[-2];
+    auto shape = ttnn::Shape({1, 1, M, M});
+    return ttnn::TensorSpec(
+        shape,
+        tt::tt_metal::TensorLayout(ttnn::DataType::BFLOAT16, tt::tt_metal::Layout::TILE, ttnn::DRAM_MEMORY_CONFIG));
+}
+
+GramPolynomialDeviceOperation::tensor_return_value_t GramPolynomialDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
+    }
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
+}
+
+ttsl::hash::hash_t GramPolynomialDeviceOperation::compute_program_hash(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return tt::tt_metal::operation::hash_operation<GramPolynomialDeviceOperation>(
+        operation_attributes.output_mode, operation_attributes.math_fidelity, tensor_args.input_tensor.logical_shape());
+}
+
+}  // namespace ttml::metal::ops::gram_polynomial::device

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation.cpp
@@ -23,7 +23,7 @@ void GramPolynomialDeviceOperation::validate_on_program_cache_miss(
         input.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
         "Input tensor must use INTERLEAVED memory layout");
     const auto rank = input.logical_shape().rank();
-    TT_FATAL(rank == 2 || rank == 4, "Input tensor must be 2D [M, K] or 4D [1, 1, M, K]");
+    TT_FATAL(rank == 2 || rank == 4, "Input tensor must be 2D [M, M] or 4D [1, 1, M, M]");
     if (rank == 4) {
         TT_FATAL(
             input.logical_shape()[0] == 1 && input.logical_shape()[1] == 1,
@@ -31,11 +31,16 @@ void GramPolynomialDeviceOperation::validate_on_program_cache_miss(
             input.logical_shape()[0],
             input.logical_shape()[1]);
     }
-    const uint32_t K_tiles = input.logical_shape()[-1] / tt::constants::TILE_WIDTH;
-    TT_FATAL(K_tiles % 2 == 0, "K dimension ({} tiles) must be even for K-split", K_tiles);
+    TT_FATAL(
+        input.logical_shape()[-2] == input.logical_shape()[-1],
+        "Input G must be square, got [{}, {}]",
+        input.logical_shape()[-2],
+        input.logical_shape()[-1]);
+    const uint32_t M_tiles = input.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+    TT_FATAL(M_tiles % 2 == 0, "M dimension ({} tiles) must be even for K-split", M_tiles);
     const auto device_grid = input.device()->compute_with_storage_grid_size();
     const uint32_t grid_dim = static_cast<uint32_t>(std::min(device_grid.x - 1, device_grid.y));
-    TT_FATAL(grid_dim >= 3, "Device grid too small for gram matmul (need at least 4x3 compute grid)");
+    TT_FATAL(grid_dim >= 3, "Device grid too small for gram polynomial (need at least 4x3 compute grid)");
 
     if (tensor_args.preallocated_output.has_value()) {
         const auto& output = tensor_args.preallocated_output.value();
@@ -83,7 +88,11 @@ GramPolynomialDeviceOperation::tensor_return_value_t GramPolynomialDeviceOperati
 ttsl::hash::hash_t GramPolynomialDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::operation::hash_operation<GramPolynomialDeviceOperation>(
-        operation_attributes.output_mode, operation_attributes.math_fidelity, tensor_args.input_tensor.logical_shape());
+        operation_attributes.b,
+        operation_attributes.c,
+        operation_attributes.output_mode,
+        operation_attributes.math_fidelity,
+        tensor_args.input_tensor.logical_shape());
 }
 
 }  // namespace ttml::metal::ops::gram_polynomial::device

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ttnn/device_operation.hpp>
+
+#include "gram_polynomial_device_operation_types.hpp"
+#include "gram_polynomial_program_factory.hpp"
+
+namespace ttml::metal::ops::gram_polynomial::device {
+
+struct GramPolynomialDeviceOperation {
+    using operation_attributes_t = device::operation_attributes_t;
+    using tensor_args_t = device::tensor_args_t;
+    using spec_return_value_t = device::spec_return_value_t;
+    using tensor_return_value_t = device::tensor_return_value_t;
+    using program_factory_t = std::variant<GramPolynomialProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t &, const tensor_args_t &);
+    static void validate_on_program_cache_miss(const operation_attributes_t &, const tensor_args_t &);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t &, const tensor_args_t &);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t &, const tensor_args_t &);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t &, const tensor_args_t &);
+};
+
+}  // namespace ttml::metal::ops::gram_polynomial::device

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation_types.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ttnn/tensor/tensor.hpp>
+
+#include "metal/common/const_utils.hpp"
+
+namespace ttml::metal::ops::gram_polynomial::device {
+
+struct operation_attributes_t {
+    ttml::metal::OutputMode output_mode = ttml::metal::OutputMode::UpperTriangle;
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+};
+
+struct tensor_args_t {
+    ttnn::Tensor input_tensor;
+    std::optional<ttnn::Tensor> preallocated_output = std::nullopt;
+};
+
+using tensor_return_value_t = ttnn::Tensor;
+using spec_return_value_t = ttnn::TensorSpec;
+
+}  // namespace ttml::metal::ops::gram_polynomial::device

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_device_operation_types.hpp
@@ -11,6 +11,8 @@
 namespace ttml::metal::ops::gram_polynomial::device {
 
 struct operation_attributes_t {
+    float b = 0.0f;
+    float c = 1.0f;
     ttml::metal::OutputMode output_mode = ttml::metal::OutputMode::UpperTriangle;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 };

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "gram_polynomial_program_factory.hpp"
 
+#include <bit>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "metal/common/program_utils.hpp"
@@ -478,7 +479,17 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
         return ComputeConfig{
             .math_fidelity = attrs.math_fidelity,
             .fp32_dest_acc_en = true,
-            .compile_args = {K_half, K_block_tiles, Mpc, subblock_w, M_block, subblock_h, N_block, num_n_blocks},
+            .compile_args =
+                {K_half,
+                 K_block_tiles,
+                 Mpc,
+                 subblock_w,
+                 M_block,
+                 subblock_h,
+                 N_block,
+                 num_n_blocks,
+                 std::bit_cast<uint32_t>(attrs.b),
+                 std::bit_cast<uint32_t>(attrs.c)},
             .defines = defines};
     };
 

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
@@ -488,8 +488,7 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
                  subblock_h,
                  N_block,
                  num_n_blocks,
-                 std::bit_cast<uint32_t>(attrs.c != 0.0f ? attrs.b / attrs.c : 0.0f),
-                 std::bit_cast<uint32_t>(attrs.c)},
+                 std::bit_cast<uint32_t>(attrs.c != 0.0f ? attrs.b / attrs.c : 0.0f)},
             .defines = defines};
     };
 

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
@@ -133,6 +133,8 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
             // c_7: staging for transpose (mb tiles BF16, batched per-column)
             create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_7, out_tile_format, out_tile_sz, M_block);
         }
+        // c_3: 2-tile sync CB — compute signals both DM RISCs after reduce
+        create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_3, out_tile_format, out_tile_sz, 2);
         create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_5, out_tile_format, out_tile_sz, c5_tiles);
         create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_6, out_tile_format, out_tile_sz, M_block);
     };
@@ -364,7 +366,7 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
             .compile_args = make_recv_write_ct(row_sender_sem2, row_receiver_sem2),
             .defines = upper_recv_defines});
 
-    // Col lower receivers (interior, x>0, y≥x): plain receiver
+    // Col lower receivers (interior, x>0, y≥x): plain receiver, sync after reduce
     const KernelHandle col_lower_recv_kid = CreateKernel(
         program,
         receiver_path,
@@ -372,15 +374,16 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
         DataMovementConfig{
             .processor = risc_1,
             .noc = noc_1,
-            .compile_args = {
-                recv_tiles,
-                tile_sz,
-                col_sender_sem,
-                col_receiver_sem,
-                (uint32_t)tt::CBIndex::c_1,
-                block_sz,
-                num_m_blocks,
-                num_n_blocks}});
+            .compile_args =
+                {recv_tiles,
+                 tile_sz,
+                 col_sender_sem,
+                 col_receiver_sem,
+                 (uint32_t)tt::CBIndex::c_1,
+                 block_sz,
+                 num_m_blocks,
+                 num_n_blocks},
+        });
 
     // Col lower receivers (edge, x=0, y>0): REDUCE_SEND to upper core (y, 0)
     const KernelHandle col_lower_recv_edge_kid = CreateKernel(
@@ -407,7 +410,7 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
                  num_n_blocks},
             .defines = {{"REDUCE_SEND", "1"}}});
 
-    // Col upper receivers (y<x, y>0): plain receiver
+    // Col upper receivers (y<x, y>0): plain receiver, waits for compute reduce before next block
     const KernelHandle col_upper_recv_kid = CreateKernel(
         program,
         receiver_path,
@@ -415,15 +418,16 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
         DataMovementConfig{
             .processor = risc_1,
             .noc = noc_1,
-            .compile_args = {
-                recv_tiles,
-                tile_sz,
-                col_sender_sem2,
-                col_receiver_sem2,
-                (uint32_t)tt::CBIndex::c_1,
-                block_sz,
-                num_m_blocks,
-                num_n_blocks}});
+            .compile_args =
+                {recv_tiles,
+                 tile_sz,
+                 col_sender_sem2,
+                 col_receiver_sem2,
+                 (uint32_t)tt::CBIndex::c_1,
+                 block_sz,
+                 num_m_blocks,
+                 num_n_blocks},
+        });
 
     // === Diagonal helper kernels (x=grid_dim column) ===
     // Helper row receiver: REDUCE_RECV on RISCV_0 (receives diagonal's partial)
@@ -447,7 +451,7 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
                  num_m_blocks,
                  M_block,
                  num_n_blocks},
-            .defines = {{"REDUCE_RECV", "1"}}});
+            .defines = {{"REDUCE_RECV", "1"}, {"WAIT_REDUCE_DONE", "1"}}});
 
     // Helper DRAM reader: reads odd K-columns, writes combined output (c_6) to DRAM
     std::vector<uint32_t> ct_dram = {
@@ -488,7 +492,8 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
                  subblock_h,
                  N_block,
                  num_n_blocks,
-                 std::bit_cast<uint32_t>(attrs.c != 0.0f ? attrs.b / attrs.c : 0.0f)},
+                 std::bit_cast<uint32_t>(attrs.c != 0.0f ? attrs.b / attrs.c : 0.0f),
+                 std::bit_cast<uint32_t>(attrs.c)},
             .defines = defines};
     };
 

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
@@ -1,0 +1,768 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gram_polynomial_program_factory.hpp"
+
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "metal/common/program_utils.hpp"
+
+namespace ttml::metal::ops::gram_polynomial::device {
+
+namespace {
+tt::tt_metal::CoreRangeSet make_core_range_set(const std::vector<tt::tt_metal::CoreCoord>& cores) {
+    std::set<tt::tt_metal::CoreRange> ranges;
+    for (const auto& c : cores) {
+        ranges.insert(tt::tt_metal::CoreRange(c, c));
+    }
+    return tt::tt_metal::CoreRangeSet(ranges);
+}
+}  // namespace
+
+GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::create(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    using namespace tt::tt_metal;
+
+    Program program = CreateProgram();
+    const auto& input = tensor_args.input_tensor;
+    auto* const device = input.device();
+
+    const auto device_grid = device->compute_with_storage_grid_size();
+    // Largest square grid with room for a helper column at x=grid_dim
+    const uint32_t grid_dim = static_cast<uint32_t>(std::min(device_grid.x - 1, device_grid.y));
+
+    // Tile counts from padded_shape (always tile-aligned, matches DRAM layout)
+    const uint32_t M_tiles = input.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+    const uint32_t K_tiles = input.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+    const uint32_t K_half = K_tiles / 2;
+
+    const uint32_t padded_M_tiles = tt::round_up(M_tiles, grid_dim);
+    const uint32_t Mpc = padded_M_tiles / grid_dim;
+
+    const auto tile_format = tt::DataFormat::Float16_b;
+    const auto tile_sz = tt::tile_size(tile_format);
+
+    const auto full_grid = tt::tt_metal::CoreRange({0, 0}, {grid_dim - 1, grid_dim - 1});
+
+    // Diagonal helper column: x=grid_dim cores compute odd-K partial for diagonal blocks.
+    const tt::tt_metal::CoreRange helper_range({grid_dim, 0}, {grid_dim, grid_dim - 1});
+    const auto all_cores = tt::tt_metal::CoreRangeSet(std::set<tt::tt_metal::CoreRange>{full_grid, helper_range});
+    // Upper x-bound for row multicast (includes helper column)
+    const uint32_t upper_x_end = grid_dim;
+
+    const uint32_t subblock_h = 2;
+    const uint32_t subblock_w = std::min(Mpc, 2u);
+
+    const auto intermed_format = tt::DataFormat::Float32;
+    const auto intermed_tile_sz = tt::tile_size(intermed_format);
+    const auto out_tile_format = tt::DataFormat::Float16_b;
+    const auto out_tile_sz = tt::tile_size(out_tile_format);
+
+    const bool mirror_active = (attrs.output_mode == ttml::metal::OutputMode::Full);
+
+    // Find the largest M_block and K_block_tiles (kb) that fit all CBs in L1.
+    // Minimizes num_m_blocks (fewer subblock passes), then maximizes kb (fewer DRAM reads).
+    const uint32_t L1_BUDGET =
+        device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    const uint32_t mirror_out_overhead = mirror_active ? 2 * out_tile_sz : 0;  // per-mb extra for c_4 + c_7
+
+    // Find optimal (kb, mb) that minimizes num_m_blocks (= ceil(Mpc/mb)), then maximizes kb.
+    // Input CBs (c_0, c_1) hold 2 blocks each for double-buffered DRAM streaming.
+    constexpr uint32_t input_cb_num_blocks = 2;
+
+    auto find_max_mb = [&](uint32_t kb) -> uint32_t {
+        for (uint32_t mb = Mpc; mb >= 1; mb--) {
+            // c_0 + c_1: two input CBs, each holds input_cb_num_blocks × kb × mb tiles
+            uint32_t input_cbs = 2 * input_cb_num_blocks * kb * mb * tile_sz;
+            // c_2: matmul intermediate accumulator (FP32), mb × mb tiles
+            uint32_t intermed_cb = mb * mb * intermed_tile_sz;
+            // c_5: output/reduce CB, mb × mb tiles
+            uint32_t output_cb = mb * mb * out_tile_sz;
+            // c_6: combined output after reduction, mb tiles
+            uint32_t combined_cb = mb * out_tile_sz;
+            // c_4 + c_7: mirror output staging (only with OutputMode::Full)
+            uint32_t mirror_cbs = mb * mirror_out_overhead;
+
+            if (input_cbs + intermed_cb + output_cb + combined_cb + mirror_cbs <= L1_BUDGET)
+                return mb;
+        }
+        return 0;
+    };
+
+    uint32_t best_kb = 0, best_mb = 0, best_num_m_blocks = UINT32_MAX;
+    for (uint32_t kb = 1; kb <= std::min(K_half, 8u); kb++) {
+        if (K_half % kb != 0)
+            continue;
+        uint32_t mb = find_max_mb(kb);
+        if (mb == 0)
+            continue;
+        uint32_t n = (Mpc + mb - 1) / mb;
+        if (n > best_num_m_blocks)
+            break;
+        best_num_m_blocks = n;
+        best_kb = kb;
+        best_mb = mb;
+    }
+    TT_FATAL(best_mb > 0, "Cannot fit mcast gram matmul in L1");
+
+    const uint32_t K_block_tiles = best_kb;
+    const uint32_t M_block = best_mb;
+    const uint32_t N_block = M_block;
+    const uint32_t num_m_blocks = best_num_m_blocks;
+    const uint32_t num_n_blocks = (Mpc + N_block - 1) / N_block;
+    const uint32_t block_sz = K_block_tiles * M_block;
+    const uint32_t cb_size = input_cb_num_blocks * block_sz;
+    const uint32_t num_tiles = M_block * K_tiles;  // tiles per sender per (m_sub, n_sub) pass
+    // Output DRAM stride in tiles — use padded M (tile-aligned) to match DRAM layout
+    const uint32_t padded_out_tiles = M_tiles;
+    const uint32_t recv_tiles = K_half * M_block;  // tiles per receiver per (m_sub, n_sub) pass
+
+    const uint32_t send_out_cb = (uint32_t)tt::CBIndex::c_5;
+    const uint32_t c5_tiles = M_block * N_block;
+
+    auto create_all_cbs = [&](const tt::tt_metal::CoreRange& range) {
+        create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_0, tile_format, tile_sz, cb_size);
+        create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_1, tile_format, tile_sz, cb_size);
+        create_circular_buffer(
+            program, range, (uint32_t)tt::CBIndex::c_2, intermed_format, intermed_tile_sz, M_block * N_block);
+        if (mirror_active) {
+            // c_4: mirror buffer for transposed tiles (M_block tiles, streamed col by col)
+            create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_4, out_tile_format, out_tile_sz, M_block);
+            // c_7: staging for transpose (mb tiles BF16, batched per-column)
+            create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_7, out_tile_format, out_tile_sz, M_block);
+        }
+        create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_5, out_tile_format, out_tile_sz, c5_tiles);
+        create_circular_buffer(program, range, (uint32_t)tt::CBIndex::c_6, out_tile_format, out_tile_sz, M_block);
+    };
+    create_all_cbs(full_grid);
+    {  // helpers
+        create_all_cbs(helper_range);
+    }
+
+    // Semaphores on all cores (helpers need row sems for multicast reception)
+    auto row_sender_sem = CreateSemaphore(program, all_cores, INVALID);
+    auto row_receiver_sem = CreateSemaphore(program, all_cores, INVALID);
+    auto row_sender_sem2 = CreateSemaphore(program, all_cores, INVALID);
+    auto row_receiver_sem2 = CreateSemaphore(program, all_cores, INVALID);
+    auto col_sender_sem = CreateSemaphore(program, all_cores, INVALID);
+    auto col_receiver_sem = CreateSemaphore(program, all_cores, INVALID);
+    auto col_sender_sem2 = CreateSemaphore(program, all_cores, INVALID);
+    auto col_receiver_sem2 = CreateSemaphore(program, all_cores, INVALID);
+    auto reduce_sem = CreateSemaphore(program, all_cores, 0);
+
+    const auto noc_1 = detail::preferred_noc_for_dram_write(device->arch());
+    const auto noc_0 = detail::preferred_noc_for_dram_read(device->arch());
+    const auto risc_1 = DataMovementProcessor::RISCV_1;
+    const auto risc_0 = DataMovementProcessor::RISCV_0;
+
+    const uint32_t in_addr = input.buffer()->address();
+
+    const uint32_t out_addr = output.buffer()->address();
+
+    const std::string base = "tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/";
+    const std::string sender_path = base + "mcast_sender.cpp";
+    const std::string receiver_path = base + "mcast_receiver.cpp";
+    const std::string receiver_writer_path = base + "mcast_receiver_writer.cpp";
+    const std::string compute_matmul_path = base + "compute_matmul.cpp";
+    const std::string helper_dram_reader_path = base + "helper_dram_reader.cpp";
+
+    // === Core classification ===
+    // Row senders: x=0
+    std::vector<tt::tt_metal::CoreCoord> row_senders;  // (0, y>0) — regular sender
+    for (uint32_t y = 1; y < grid_dim; y++) row_senders.push_back({0, y});
+    // (0, 0) is sender_writer — handled separately
+
+    // Col senders: y=0 (all x)
+    std::vector<tt::tt_metal::CoreCoord> col_senders;
+    for (uint32_t x = 0; x < grid_dim; x++) col_senders.push_back({x, 0});
+
+    // Row receivers (RISCV_0, x>0): ALL use receiver_writer (including y=0 edge)
+    std::vector<tt::tt_metal::CoreCoord> row_lower_recv, row_upper_recv;
+    for (uint32_t y = 0; y < grid_dim; y++) {
+        for (uint32_t x = 1; x < grid_dim; x++) {
+            if (x <= y) {
+                row_lower_recv.push_back({x, y});
+            } else {
+                row_upper_recv.push_back({x, y});  // includes y=0 edge
+            }
+        }
+    }
+
+    // Col receivers (RISCV_1, y>0): interior = plain receiver, edge (x=0) = receiver_writer
+    std::vector<tt::tt_metal::CoreCoord> col_lower_recv_interior, col_lower_recv_edge, col_upper_recv;
+    for (uint32_t x = 0; x < grid_dim; x++) {
+        for (uint32_t y = 1; y < grid_dim; y++) {
+            if (x == 0) {
+                col_lower_recv_edge.push_back({0, y});  // receiver_writer for output
+            } else if (y >= x) {
+                col_lower_recv_interior.push_back({x, y});
+            } else {
+                col_upper_recv.push_back({x, y});
+            }
+        }
+    }
+
+    // === Sender kernels ===
+    // Row sender+reduce for (0,0): RISCV_0/NOC_0, sends partial to helper (grid_dim, 0)
+    KernelHandle row_sender_reduce_kid;
+    {
+        std::vector<uint32_t> ct = {
+            num_tiles,
+            tile_sz,
+            row_sender_sem,
+            row_receiver_sem,
+            row_sender_sem2,
+            row_receiver_sem2,
+            (uint32_t)tt::CBIndex::c_0,
+            block_sz,
+            cb_size,
+            send_out_cb,
+            out_tile_sz,
+            (uint32_t)tt::CBIndex::c_5,
+            reduce_sem,
+            num_m_blocks,
+            M_block,
+            num_n_blocks};
+        TensorAccessorArgs(*input.buffer()).append_to(ct);
+        row_sender_reduce_kid = CreateKernel(
+            program,
+            sender_path,
+            make_core_range_set({{0, 0}}),
+            DataMovementConfig{
+                .processor = risc_0, .noc = noc_0, .compile_args = ct, .defines = {{"SENDER_REDUCE_SEND", "1"}}});
+    }
+
+    // Row sender for (0, y>0): RISCV_0/NOC_0, CB c_0
+    std::vector<uint32_t> row_sender_ct = {
+        num_tiles,
+        tile_sz,
+        row_sender_sem,
+        row_receiver_sem,
+        row_sender_sem2,
+        row_receiver_sem2,
+        (uint32_t)tt::CBIndex::c_0,
+        block_sz,
+        cb_size,
+        num_m_blocks,
+        num_n_blocks};
+    TensorAccessorArgs(*input.buffer()).append_to(row_sender_ct);
+    const KernelHandle row_sender_kid = CreateKernel(
+        program,
+        sender_path,
+        make_core_range_set(row_senders),
+        DataMovementConfig{.processor = risc_0, .noc = noc_0, .compile_args = row_sender_ct});
+
+    // Col sender: RISCV_1/NOC_1, CB c_1
+    KernelHandle col_sender_kid;
+    {
+        std::vector<uint32_t> ct = {
+            num_tiles,
+            tile_sz,
+            col_sender_sem,
+            col_receiver_sem,
+            col_sender_sem2,
+            col_receiver_sem2,
+            (uint32_t)tt::CBIndex::c_1,
+            block_sz,
+            cb_size,
+            num_m_blocks,
+            num_n_blocks};
+        TensorAccessorArgs(*input.buffer()).append_to(ct);
+        col_sender_kid = CreateKernel(
+            program,
+            sender_path,
+            make_core_range_set(col_senders),
+            DataMovementConfig{.processor = risc_1, .noc = noc_1, .compile_args = ct});
+    }
+
+    // === Receiver kernels ===
+    // Row lower receivers split: off-diagonal (REDUCE_SEND) and diagonal (REDUCE_SEND to helper)
+    // Both have same CT args structure, but compute defines differ (set per core group below)
+    auto make_recv_send_ct = [&](uint32_t sender_sem_id, uint32_t receiver_sem_id) {
+        return std::vector<uint32_t>{
+            recv_tiles,
+            tile_sz,
+            sender_sem_id,
+            receiver_sem_id,
+            (uint32_t)tt::CBIndex::c_0,
+            block_sz,
+            send_out_cb,
+            out_tile_sz,
+            Mpc,
+            (uint32_t)tt::CBIndex::c_5,
+            reduce_sem,
+            num_m_blocks,
+            M_block,
+            num_n_blocks};
+    };
+
+    auto make_recv_write_ct = [&](uint32_t sender_sem_id, uint32_t receiver_sem_id) {
+        std::vector<uint32_t> ct = {
+            recv_tiles,
+            tile_sz,
+            sender_sem_id,
+            receiver_sem_id,
+            (uint32_t)tt::CBIndex::c_0,
+            block_sz,
+            (uint32_t)tt::CBIndex::c_6,
+            out_tile_sz,
+            Mpc,  // cb_out = c_6 (combined)
+            padded_out_tiles,
+            (uint32_t)tt::CBIndex::c_5,
+            reduce_sem,
+            num_m_blocks,
+            M_block,
+            num_n_blocks};
+        TensorAccessorArgs(*output.buffer()).append_to(ct);
+        return ct;
+    };
+
+    // Lower off-diagonal (x < y, x > 0): REDUCE_SEND — send transposed partial to upper
+    std::vector<tt::tt_metal::CoreCoord> row_lower_offdiag, row_lower_diag;
+    for (auto& c : row_lower_recv) {
+        if (c.x < c.y)
+            row_lower_offdiag.push_back(c);
+        else
+            row_lower_diag.push_back(c);  // x == y, diagonal
+    }
+
+    // Lower off-diagonal: REDUCE_SEND
+    const KernelHandle row_lower_offdiag_kid = CreateKernel(
+        program,
+        receiver_writer_path,
+        make_core_range_set(row_lower_offdiag),
+        DataMovementConfig{
+            .processor = risc_0,
+            .noc = noc_0,
+            .compile_args = make_recv_send_ct(row_sender_sem, row_receiver_sem),
+            .defines = {{"REDUCE_SEND", "1"}}});
+
+    // Lower diagonal (x == y, y > 0): REDUCE_SEND to helper
+    const KernelHandle row_lower_diag_kid = CreateKernel(
+        program,
+        receiver_writer_path,
+        make_core_range_set(row_lower_diag),
+        DataMovementConfig{
+            .processor = risc_0,
+            .noc = noc_0,
+            .compile_args = make_recv_send_ct(row_sender_sem, row_receiver_sem),
+            .defines = {{"REDUCE_SEND", "1"}}});
+
+    // Row upper receivers (x > y): REDUCE_RECV — receive partner's partial, write combined
+    auto upper_recv_defines = std::map<std::string, std::string>{{"REDUCE_RECV", "1"}};
+    if (mirror_active)
+        upper_recv_defines["MIRROR_OUTPUT"] = "1";
+    const KernelHandle row_upper_recv_kid = CreateKernel(
+        program,
+        receiver_writer_path,
+        make_core_range_set(row_upper_recv),
+        DataMovementConfig{
+            .processor = risc_0,
+            .noc = noc_0,
+            .compile_args = make_recv_write_ct(row_sender_sem2, row_receiver_sem2),
+            .defines = upper_recv_defines});
+
+    // Col lower receivers (interior, x>0, y≥x): plain receiver
+    const KernelHandle col_lower_recv_kid = CreateKernel(
+        program,
+        receiver_path,
+        make_core_range_set(col_lower_recv_interior),
+        DataMovementConfig{
+            .processor = risc_1,
+            .noc = noc_1,
+            .compile_args = {
+                recv_tiles,
+                tile_sz,
+                col_sender_sem,
+                col_receiver_sem,
+                (uint32_t)tt::CBIndex::c_1,
+                block_sz,
+                num_m_blocks,
+                num_n_blocks}});
+
+    // Col lower receivers (edge, x=0, y>0): REDUCE_SEND to upper core (y, 0)
+    const KernelHandle col_lower_recv_edge_kid = CreateKernel(
+        program,
+        receiver_writer_path,
+        make_core_range_set(col_lower_recv_edge),
+        DataMovementConfig{
+            .processor = risc_1,
+            .noc = noc_1,
+            .compile_args =
+                {recv_tiles,
+                 tile_sz,
+                 col_sender_sem,
+                 col_receiver_sem,
+                 (uint32_t)tt::CBIndex::c_1,
+                 block_sz,
+                 send_out_cb,
+                 out_tile_sz,
+                 Mpc,
+                 (uint32_t)tt::CBIndex::c_5,
+                 reduce_sem,
+                 num_m_blocks,
+                 M_block,
+                 num_n_blocks},
+            .defines = {{"REDUCE_SEND", "1"}}});
+
+    // Col upper receivers (y<x, y>0): plain receiver
+    const KernelHandle col_upper_recv_kid = CreateKernel(
+        program,
+        receiver_path,
+        make_core_range_set(col_upper_recv),
+        DataMovementConfig{
+            .processor = risc_1,
+            .noc = noc_1,
+            .compile_args = {
+                recv_tiles,
+                tile_sz,
+                col_sender_sem2,
+                col_receiver_sem2,
+                (uint32_t)tt::CBIndex::c_1,
+                block_sz,
+                num_m_blocks,
+                num_n_blocks}});
+
+    // === Diagonal helper kernels (x=grid_dim column) ===
+    // Helper row receiver: REDUCE_RECV on RISCV_0 (receives diagonal's partial)
+    const KernelHandle helper_recv_kid = CreateKernel(
+        program,
+        receiver_path,
+        helper_range,
+        DataMovementConfig{
+            .processor = risc_0,
+            .noc = noc_0,
+            .compile_args =
+                {recv_tiles,
+                 tile_sz,
+                 row_sender_sem2,
+                 row_receiver_sem2,
+                 (uint32_t)tt::CBIndex::c_0,
+                 block_sz,
+                 (uint32_t)tt::CBIndex::c_5,
+                 reduce_sem,
+                 Mpc,
+                 num_m_blocks,
+                 M_block,
+                 num_n_blocks},
+            .defines = {{"REDUCE_RECV", "1"}}});
+
+    // Helper DRAM reader: reads odd K-columns, writes combined output (c_6) to DRAM
+    std::vector<uint32_t> ct_dram = {
+        recv_tiles,
+        tile_sz,
+        (uint32_t)tt::CBIndex::c_1,
+        block_sz,
+        (uint32_t)tt::CBIndex::c_6,
+        out_tile_sz,
+        Mpc,
+        padded_out_tiles,
+        num_m_blocks,
+        M_block,
+        num_n_blocks};
+    TensorAccessorArgs(*input.buffer()).append_to(ct_dram);
+    TensorAccessorArgs(*output.buffer()).append_to(ct_dram);
+    auto dram_defines = std::map<std::string, std::string>{};
+    if (mirror_active)
+        dram_defines["MIRROR_OUTPUT"] = "1";
+    const KernelHandle helper_dram_reader_kid = CreateKernel(
+        program,
+        helper_dram_reader_path,
+        helper_range,
+        DataMovementConfig{.processor = risc_1, .noc = noc_1, .compile_args = ct_dram, .defines = dram_defines});
+
+    // === Compute ===
+    // Different defines per core group for reduction mode
+    auto compute_cfg = [&](std::map<std::string, std::string> defines = {}) {
+        return ComputeConfig{
+            .math_fidelity = attrs.math_fidelity,
+            .fp32_dest_acc_en = true,
+            .compile_args = {K_half, K_block_tiles, Mpc, subblock_w, M_block, subblock_h, N_block, num_n_blocks},
+            .defines = defines};
+    };
+
+    // Lower off-diagonal: REDUCE_SENDER_TRANSPOSE
+    std::vector<tt::tt_metal::CoreCoord> sender_transpose_cores;
+    for (uint32_t y = 1; y < grid_dim; y++)
+        for (uint32_t x = 0; x < y; x++) sender_transpose_cores.push_back({x, y});
+    CreateKernel(
+        program,
+        compute_matmul_path,
+        make_core_range_set(sender_transpose_cores),
+        compute_cfg({{"REDUCE_SENDER_TRANSPOSE", "1"}}));
+
+    // Diagonal: REDUCE_SENDER
+    std::vector<tt::tt_metal::CoreCoord> sender_diag_cores;
+    for (uint32_t d = 0; d < grid_dim; d++) sender_diag_cores.push_back({d, d});
+    CreateKernel(
+        program, compute_matmul_path, make_core_range_set(sender_diag_cores), compute_cfg({{"REDUCE_SENDER", "1"}}));
+
+    // Upper: REDUCE_ACCUMULATOR
+    std::vector<tt::tt_metal::CoreCoord> accum_cores;
+    for (uint32_t y = 0; y < grid_dim; y++)
+        for (uint32_t x = y + 1; x < grid_dim; x++) accum_cores.push_back({x, y});
+    auto accum_defines = std::map<std::string, std::string>{{"REDUCE_ACCUMULATOR", "1"}};
+    if (mirror_active)
+        accum_defines["MIRROR_OUTPUT"] = "1";
+    CreateKernel(program, compute_matmul_path, make_core_range_set(accum_cores), compute_cfg(accum_defines));
+
+    // Helpers: REDUCE_ACCUMULATOR (no mirror — diagonal blocks are self-symmetric)
+    CreateKernel(program, compute_matmul_path, helper_range, compute_cfg({{"REDUCE_ACCUMULATOR", "1"}}));
+
+    // === Runtime args ===
+
+    // --- Row sender+reduce at (0,0): sends partial to helper (grid_dim, 0) ---
+    {
+        auto row_lower_start_p = device->worker_core_from_logical_core({0, 0});
+        auto row_lower_end_p = row_lower_start_p;
+        auto row_upper_start_p = device->worker_core_from_logical_core({1, 0});
+        auto row_upper_end_p = device->worker_core_from_logical_core({upper_x_end, 0});
+        auto helper_p = device->worker_core_from_logical_core({grid_dim, 0});
+        SetRuntimeArgs(
+            program,
+            row_sender_reduce_kid,
+            tt::tt_metal::CoreCoord{0, 0},
+            {in_addr,
+             (uint32_t)row_lower_start_p.x,
+             (uint32_t)row_lower_start_p.y,
+             (uint32_t)row_lower_end_p.x,
+             (uint32_t)row_lower_end_p.y,
+             1u,  // lower_num_dests (diagonal only at row 0)
+             (uint32_t)row_upper_start_p.x,
+             (uint32_t)row_upper_start_p.y,
+             (uint32_t)row_upper_end_p.x,
+             (uint32_t)row_upper_end_p.y,
+             upper_x_end,  // upper_num_dests
+             0u,           // injector_keeps_odd (row 0 keeps even)
+             1u,           // lower_loopback (diagonal is self)
+             0u,           // tile_offset_row (grid row 0)
+             Mpc,
+             K_tiles,
+             M_tiles,
+             K_tiles,
+             (uint32_t)helper_p.x,    // partner_noc_x (helper core)
+             (uint32_t)helper_p.y});  // partner_noc_y
+    }
+
+    // --- Row sender at (0, y>0) ---
+    for (uint32_t y = 1; y < grid_dim; y++) {
+        tt::tt_metal::CoreCoord sender_core{0, y};
+        uint32_t row_lower_num = y + 1;
+        auto row_lower_start_p = device->worker_core_from_logical_core({0, y});
+        auto row_lower_end_p = device->worker_core_from_logical_core({y, y});
+        uint32_t row_upper_num = (upper_x_end > y) ? (upper_x_end - y) : 0;
+        tt::tt_metal::CoreCoord row_upper_start_log =
+            (row_upper_num > 0) ? tt::tt_metal::CoreCoord{y + 1, y} : tt::tt_metal::CoreCoord{0, y};
+        tt::tt_metal::CoreCoord row_upper_end_log =
+            (row_upper_num > 0) ? tt::tt_metal::CoreCoord{upper_x_end, y} : tt::tt_metal::CoreCoord{0, y};
+        auto row_upper_start_p = device->worker_core_from_logical_core(row_upper_start_log);
+        auto row_upper_end_p = device->worker_core_from_logical_core(row_upper_end_log);
+        SetRuntimeArgs(
+            program,
+            row_sender_kid,
+            sender_core,
+            {in_addr,
+             (uint32_t)row_lower_start_p.x,
+             (uint32_t)row_lower_start_p.y,
+             (uint32_t)row_lower_end_p.x,
+             (uint32_t)row_lower_end_p.y,
+             row_lower_num,  // lower_num_dests
+             (uint32_t)row_upper_start_p.x,
+             (uint32_t)row_upper_start_p.y,
+             (uint32_t)row_upper_end_p.x,
+             (uint32_t)row_upper_end_p.y,
+             row_upper_num,  // upper_num_dests
+             0u,             // injector_keeps_odd (row senders keep even)
+             1u,             // lower_loopback (sender is part of lower mcast)
+             y * Mpc,        // tile_offset_row
+             Mpc,
+             K_tiles,
+             M_tiles,
+             K_tiles});
+    }
+
+    // --- Col sender at (x, 0) ---
+    for (uint32_t x = 0; x < grid_dim; x++) {
+        tt::tt_metal::CoreCoord sender_core{x, 0};
+        uint32_t col_lower_num = grid_dim - x;
+        tt::tt_metal::CoreCoord col_lower_start_log{x, x}, col_lower_end_log{x, grid_dim - 1};
+        if (x == 0)
+            col_lower_start_log = {0, 0};
+        auto col_lower_start_p = device->worker_core_from_logical_core(col_lower_start_log);
+        auto col_lower_end_p = device->worker_core_from_logical_core(col_lower_end_log);
+        std::swap(col_lower_start_p, col_lower_end_p);  // NOC_1: swap
+        uint32_t col_upper_num = (x >= 2) ? (x - 1) : 0;
+        tt::tt_metal::CoreCoord col_upper_start_log =
+            (col_upper_num > 0) ? tt::tt_metal::CoreCoord{x, 1} : tt::tt_metal::CoreCoord{x, 0};
+        tt::tt_metal::CoreCoord col_upper_end_log =
+            (col_upper_num > 0) ? tt::tt_metal::CoreCoord{x, x - 1} : tt::tt_metal::CoreCoord{x, 0};
+        auto col_upper_start_p = device->worker_core_from_logical_core(col_upper_start_log);
+        auto col_upper_end_p = device->worker_core_from_logical_core(col_upper_end_log);
+        std::swap(col_upper_start_p, col_upper_end_p);  // NOC_1: swap
+        uint32_t keeps_odd = (x > 0) ? 1u : 0u;
+        uint32_t loopback = (x == 0) ? 1u : 0u;
+        SetRuntimeArgs(
+            program,
+            col_sender_kid,
+            sender_core,
+            {in_addr,
+             (uint32_t)col_lower_start_p.x,
+             (uint32_t)col_lower_start_p.y,
+             (uint32_t)col_lower_end_p.x,
+             (uint32_t)col_lower_end_p.y,
+             col_lower_num,
+             (uint32_t)col_upper_start_p.x,
+             (uint32_t)col_upper_start_p.y,
+             (uint32_t)col_upper_end_p.x,
+             (uint32_t)col_upper_end_p.y,
+             col_upper_num,
+             keeps_odd,
+             loopback,
+             x * Mpc,  // tile_offset_row
+             Mpc,
+             K_tiles,
+             M_tiles,
+             K_tiles});
+    }
+
+    // --- Row receiver runtime args (x>0, all y) ---
+    for (uint32_t y = 0; y < grid_dim; y++) {
+        auto row_sender_p = device->worker_core_from_logical_core({0, y});
+        for (uint32_t x = 1; x < grid_dim; x++) {
+            tt::tt_metal::CoreCoord core{x, y};
+            if (x < y) {
+                // Lower off-diagonal: REDUCE_SEND to upper core (y, x)
+                auto partner_p = device->worker_core_from_logical_core({y, x});
+                SetRuntimeArgs(
+                    program,
+                    row_lower_offdiag_kid,
+                    core,
+                    {(uint32_t)row_sender_p.x, (uint32_t)row_sender_p.y, (uint32_t)partner_p.x, (uint32_t)partner_p.y});
+            } else if (x == y) {
+                // Lower diagonal: REDUCE_SEND to helper (grid_dim, y)
+                auto partner_p = device->worker_core_from_logical_core({grid_dim, y});
+                SetRuntimeArgs(
+                    program,
+                    row_lower_diag_kid,
+                    core,
+                    {(uint32_t)row_sender_p.x, (uint32_t)row_sender_p.y, (uint32_t)partner_p.x, (uint32_t)partner_p.y});
+            } else {
+                // Upper: REDUCE_RECV, write combined output to DRAM
+                uint32_t M_start_tile = y * Mpc;
+                uint32_t N_start_tile = x * Mpc;
+                std::vector<uint32_t> rt = {
+                    (uint32_t)row_sender_p.x, (uint32_t)row_sender_p.y, out_addr, M_start_tile, N_start_tile, M_tiles};
+                if (mirror_active) {
+                    rt.push_back(N_start_tile);  // mirror_M_start = N_start (swapped)
+                    rt.push_back(M_start_tile);  // mirror_N_start = M_start (swapped)
+                }
+                SetRuntimeArgs(program, row_upper_recv_kid, core, rt);
+            }
+        }
+    }
+
+    // --- Col receiver runtime args (y>0) ---
+    for (uint32_t x = 0; x < grid_dim; x++) {
+        auto col_sender_p = device->worker_core_from_logical_core({x, 0});
+        for (uint32_t y = 1; y < grid_dim; y++) {
+            tt::tt_metal::CoreCoord core{x, y};
+            if (x == 0) {
+                // Edge lower (0, y>0): REDUCE_SEND to upper core (y, 0)
+                auto partner_p = device->worker_core_from_logical_core({y, 0});
+                SetRuntimeArgs(
+                    program,
+                    col_lower_recv_edge_kid,
+                    core,
+                    {(uint32_t)col_sender_p.x, (uint32_t)col_sender_p.y, (uint32_t)partner_p.x, (uint32_t)partner_p.y});
+            } else if (y >= x) {
+                SetRuntimeArgs(program, col_lower_recv_kid, core, {(uint32_t)col_sender_p.x, (uint32_t)col_sender_p.y});
+            } else {
+                SetRuntimeArgs(program, col_upper_recv_kid, core, {(uint32_t)col_sender_p.x, (uint32_t)col_sender_p.y});
+            }
+        }
+    }
+
+    // --- Helper runtime args ---
+    {  // helpers
+        for (uint32_t y = 0; y < grid_dim; y++) {
+            tt::tt_metal::CoreCoord helper_core{grid_dim, y};
+            auto row_sender_p = device->worker_core_from_logical_core({0, y});
+
+            // RISCV_0: row receiver + REDUCE_RECV (receives diagonal's partial)
+            SetRuntimeArgs(program, helper_recv_kid, helper_core, {(uint32_t)row_sender_p.x, (uint32_t)row_sender_p.y});
+
+            // RISCV_1: DRAM reader + output writer for diagonal block G[y,y]
+            SetRuntimeArgs(
+                program,
+                helper_dram_reader_kid,
+                helper_core,
+                {in_addr,
+                 y * Mpc,  // tile_offset_row
+                 K_tiles,
+                 out_addr,
+                 y * Mpc,  // M_start_tile (diagonal)
+                 y * Mpc,  // N_start_tile (diagonal)
+                 M_tiles,
+                 K_tiles});
+        }
+    }
+
+    // Build core lists for override_runtime_arguments
+    std::vector<tt::tt_metal::CoreCoord> row_sender_cores_list;
+    for (uint32_t y = 1; y < grid_dim; y++) row_sender_cores_list.push_back({0, y});
+
+    std::vector<tt::tt_metal::CoreCoord> col_sender_cores_list;
+    for (uint32_t x = 0; x < grid_dim; x++) col_sender_cores_list.push_back({x, 0});
+
+    std::vector<tt::tt_metal::CoreCoord> helper_cores_list;
+    for (uint32_t y = 0; y < grid_dim; y++) helper_cores_list.push_back({grid_dim, y});
+
+    return {
+        std::move(program),
+        shared_variables_t{
+            .row_sender_reduce_kid = row_sender_reduce_kid,
+            .row_sender_kid = row_sender_kid,
+            .col_sender_kid = col_sender_kid,
+            .helper_dram_reader_kid = helper_dram_reader_kid,
+            .row_upper_recv_kid = row_upper_recv_kid,
+            .row_sender_cores = std::move(row_sender_cores_list),
+            .col_sender_cores = std::move(col_sender_cores_list),
+            .row_upper_cores = std::move(row_upper_recv),
+            .helper_cores = std::move(helper_cores_list)}};
+}
+
+void GramPolynomialProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t&,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& program = cached_program.program;
+    auto& sv = cached_program.shared_variables;
+
+    const uint32_t in_addr = tensor_args.input_tensor.buffer()->address();
+    const uint32_t out_addr = output.buffer()->address();
+
+    // Update in_addr (runtime arg index 0) for all sender kernels
+    auto& rr_args = GetRuntimeArgs(program, sv.row_sender_reduce_kid);
+    rr_args[0][0][0] = in_addr;  // core (0,0)
+
+    auto& rs_args = GetRuntimeArgs(program, sv.row_sender_kid);
+    for (const auto& c : sv.row_sender_cores) rs_args[c.x][c.y][0] = in_addr;
+
+    auto& cs_args = GetRuntimeArgs(program, sv.col_sender_kid);
+    for (const auto& c : sv.col_sender_cores) cs_args[c.x][c.y][0] = in_addr;
+
+    // Update out_addr (runtime arg index 2) for upper recv writer kernels
+    auto& ur_args = GetRuntimeArgs(program, sv.row_upper_recv_kid);
+    for (const auto& c : sv.row_upper_cores) ur_args[c.x][c.y][2] = out_addr;
+
+    // Update in_addr (index 0) and out_addr (index 3) for helper DRAM readers
+    auto& hd_args = GetRuntimeArgs(program, sv.helper_dram_reader_kid);
+    for (const auto& c : sv.helper_cores) {
+        hd_args[c.x][c.y][0] = in_addr;
+        hd_args[c.x][c.y][3] = out_addr;
+    }
+}
+
+}  // namespace ttml::metal::ops::gram_polynomial::device

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.cpp
@@ -488,7 +488,7 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
                  subblock_h,
                  N_block,
                  num_n_blocks,
-                 std::bit_cast<uint32_t>(attrs.b),
+                 std::bit_cast<uint32_t>(attrs.c != 0.0f ? attrs.b / attrs.c : 0.0f),
                  std::bit_cast<uint32_t>(attrs.c)},
             .defines = defines};
     };
@@ -497,7 +497,7 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
     std::vector<tt::tt_metal::CoreCoord> sender_transpose_cores;
     for (uint32_t y = 1; y < grid_dim; y++)
         for (uint32_t x = 0; x < y; x++) sender_transpose_cores.push_back({x, y});
-    CreateKernel(
+    const auto compute_lower_kid = CreateKernel(
         program,
         compute_matmul_path,
         make_core_range_set(sender_transpose_cores),
@@ -506,7 +506,7 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
     // Diagonal: REDUCE_SENDER
     std::vector<tt::tt_metal::CoreCoord> sender_diag_cores;
     for (uint32_t d = 0; d < grid_dim; d++) sender_diag_cores.push_back({d, d});
-    CreateKernel(
+    const auto compute_diag_kid = CreateKernel(
         program, compute_matmul_path, make_core_range_set(sender_diag_cores), compute_cfg({{"REDUCE_SENDER", "1"}}));
 
     // Upper: REDUCE_ACCUMULATOR
@@ -516,10 +516,19 @@ GramPolynomialProgramFactory::cached_program_t GramPolynomialProgramFactory::cre
     auto accum_defines = std::map<std::string, std::string>{{"REDUCE_ACCUMULATOR", "1"}};
     if (mirror_active)
         accum_defines["MIRROR_OUTPUT"] = "1";
-    CreateKernel(program, compute_matmul_path, make_core_range_set(accum_cores), compute_cfg(accum_defines));
+    const auto compute_upper_kid =
+        CreateKernel(program, compute_matmul_path, make_core_range_set(accum_cores), compute_cfg(accum_defines));
 
     // Helpers: REDUCE_ACCUMULATOR (no mirror — diagonal blocks are self-symmetric)
-    CreateKernel(program, compute_matmul_path, helper_range, compute_cfg({{"REDUCE_ACCUMULATOR", "1"}}));
+    const auto compute_helper_kid =
+        CreateKernel(program, compute_matmul_path, helper_range, compute_cfg({{"REDUCE_ACCUMULATOR", "1"}}));
+
+    // Compute runtime args: N_global_offset = x * Mpc (column position of this core's output block)
+    for (auto& c : sender_transpose_cores) SetRuntimeArgs(program, compute_lower_kid, c, {c.x * Mpc});
+    for (auto& c : sender_diag_cores) SetRuntimeArgs(program, compute_diag_kid, c, {c.x * Mpc});
+    for (auto& c : accum_cores) SetRuntimeArgs(program, compute_upper_kid, c, {c.x * Mpc});
+    for (uint32_t y = 0; y < grid_dim; y++)
+        SetRuntimeArgs(program, compute_helper_kid, tt::tt_metal::CoreCoord{grid_dim, y}, {y * Mpc});
 
     // === Runtime args ===
 

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/gram_polynomial_program_factory.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ttnn/device_operation.hpp>
+
+#include "gram_polynomial_device_operation_types.hpp"
+
+namespace ttml::metal::ops::gram_polynomial::device {
+
+struct GramPolynomialProgramFactory {
+    struct shared_variables_t {
+        // Kernels with in_addr at runtime arg index 0
+        tt::tt_metal::KernelHandle row_sender_reduce_kid;
+        tt::tt_metal::KernelHandle row_sender_kid;
+        tt::tt_metal::KernelHandle col_sender_kid;
+        tt::tt_metal::KernelHandle helper_dram_reader_kid;
+        // Kernel with out_addr at runtime arg index 2
+        tt::tt_metal::KernelHandle row_upper_recv_kid;
+        // Core lists for iterating runtime args
+        std::vector<tt::tt_metal::CoreCoord> row_sender_cores;
+        std::vector<tt::tt_metal::CoreCoord> col_sender_cores;
+        std::vector<tt::tt_metal::CoreCoord> row_upper_cores;
+        std::vector<tt::tt_metal::CoreCoord> helper_cores;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+
+    static void override_runtime_arguments(
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+};
+
+}  // namespace ttml::metal::ops::gram_polynomial::device

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -144,9 +144,9 @@ void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, u
 }
 
 #ifdef REDUCE_ACCUMULATOR
-// Add own_partial + partner_partial, pack to output.
-void add_reduce_block(uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32_t M_rows, uint32_t N_cols) {
-    add_tiles_init(own_cb, recv_cb);
+// Add c * (own_partial + partner_partial), pack to output.
+void add_reduce_block(
+    uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32_t M_rows, uint32_t N_cols, uint32_t c_scalar) {
     reconfig_data_format(own_cb, recv_cb);
     pack_reconfig_data_format(out_cb);
 
@@ -155,7 +155,10 @@ void add_reduce_block(uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32
         cb_reserve_back(out_cb, N_cols);
         for (uint32_t n = 0; n < N_cols; n++) {
             acquire_dst();
+            add_tiles_init(own_cb, recv_cb);
             add_tiles(own_cb, recv_cb, tile_id, tile_id, 0);
+            binop_with_scalar_tile_init();
+            mul_unary_tile(0, c_scalar);
             pack_tile(0, out_cb);
             release_dst();
             tile_id++;
@@ -211,12 +214,12 @@ void kernel_main() {
     constexpr uint32_t N_block = get_compile_time_arg_val(6);
     constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
     constexpr uint32_t b_over_c_bits = get_compile_time_arg_val(8);
+    constexpr uint32_t c_bits = get_compile_time_arg_val(9);
     constexpr uint32_t K_num_blocks = K_half / K_block_tiles;
     constexpr uint32_t tiles_per_in0_block = K_block_tiles * M_block;
     constexpr uint32_t tiles_per_in1_block = K_block_tiles * N_block;
     constexpr uint32_t num_m_blocks = (Mpc + M_block - 1) / M_block;
 
-    // Runtime arg: global N-tile offset for this core (needed for bG column matching)
     const uint32_t N_global_offset = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t in0_cb = tt::CBIndex::c_0;
@@ -293,13 +296,20 @@ void kernel_main() {
 #else
             cb_wait_front(intermed_cb, intermed_tiles);
             cb_wait_front(reduce_cb, intermed_tiles);
-            add_reduce_block(intermed_cb, reduce_cb, combined_cb, current_M_block, current_N);
+            add_reduce_block(intermed_cb, reduce_cb, combined_cb, current_M_block, current_N, c_bits);
 #ifdef MIRROR_OUTPUT
             add_transpose_block(intermed_cb, reduce_cb, tt::CBIndex::c_4, current_M_block, current_N, current_M_block);
 #endif
             cb_pop_front(intermed_cb, intermed_tiles);
             cb_pop_front(reduce_cb, intermed_tiles);
 #endif
+            // Signal both DM RISCs that post-K-loop phase is done.
+            // Both RISCV_0 and RISCV_1 wait on c_3 before next K-reception.
+            {
+                constexpr uint32_t sync_cb = tt::CBIndex::c_3;
+                cb_reserve_back(sync_cb, 2);
+                cb_push_back(sync_cb, 2);
+            }
 
             if (n_sub + 1 < num_n_blocks) {
                 mm_init(in0_cb, in1_cb, intermed_cb);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// Matmul compute kernel — runs on TRISC (all 3 TRISC processors).
+// Matmul compute kernel for gram_polynomial: bG + cG²
 // Computes M_block x N_block output blocks for the Mpc×Mpc gram matmul.
-// Output streamed per (m_sub, n_sub) block:
-//   REDUCE_SENDER/TRANSPOSE: matmul → c_2, pack c_2 → c_5 (row-major), DM sends c_5 to partner
-//   REDUCE_ACCUMULATOR: matmul → c_2, add own c_2(FP32) + partner's c_5(BF16) → c_6
+// The kernel computes G² + (b/c)*G. Host applies c scaling after: c*(G²+(b/c)*G) = cG²+bG.
+// bG pre-fill: before matmul, copies (b/c)*G[m,n] into matching DST positions from c_0.
 
 #include "api/compute/cb_api.h"
 #include "api/compute/compute_kernel_api.h"
@@ -18,11 +17,7 @@
 #include "api/compute/transpose_wh.h"
 
 // M_block x N_block matmul with K-outer layout.
-// bG pre-fill: before matmul, copies (b/c)*G[m,n] into matching DST positions from c_0.
-// Each core has stride-2 K-columns (even for lower, odd for upper). For output column n_global,
-// G[m, n_global] appears in c_0 at the K-block where k_col == n_global.
-// kb: current K-block index, n_global_base: global column start for this (m_sub, n_sub) block,
-// parity: 0 for even K-cols (lower/diag), 1 for odd (upper), b_over_c: scalar bits.
+// bG pre-fill: copies (b/c)*G[m,n] into DST for matching output columns.
 void matmul_blocks(
     uint32_t in0_cb,
     uint32_t in1_cb,
@@ -34,13 +29,13 @@ void matmul_blocks(
     uint32_t subblock_w,
     uint32_t current_M,
     uint32_t current_N,
-    uint32_t kb = 0,
-    uint32_t n_global_base = 0,
-    uint32_t parity = 0,
-    uint32_t b_over_c = 0) {
+    uint32_t kb,
+    uint32_t n_global_base,
+    uint32_t parity,
+    uint32_t b_over_c) {
     uint32_t last_sh = subblock_h, last_sw = subblock_w;
 
-    // K-column range for this K-block
+    // K-column range for this K-block (stride-2: even or odd columns)
     uint32_t k_col_start = kb * K_block_tiles * 2 + parity;
     uint32_t k_col_end = k_col_start + K_block_tiles * 2;
 
@@ -69,10 +64,8 @@ void matmul_blocks(
                         continue;
                     if (n_global < k_col_start || n_global >= k_col_end)
                         continue;
-                    // This column matches — pre-fill all rows in this subblock
                     if (!any_match) {
                         copy_tile_to_dst_init_short(in0_cb);
-                        binop_with_scalar_tile_init();
                         any_match = true;
                     }
                     uint32_t k_within = (n_global - k_col_start) / 2;
@@ -84,7 +77,6 @@ void matmul_blocks(
                     }
                 }
                 if (any_match) {
-                    // Re-init matmul after copy/sfpu changed pipeline config
                     mm_block_init_short(in0_cb, in1_cb, true, current_sw, current_sh, 1);
                     last_sh = current_sh;
                     last_sw = current_sw;
@@ -152,11 +144,8 @@ void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, u
 }
 
 #ifdef REDUCE_ACCUMULATOR
-// Add c * own_partial + c * partner_partial, pack to output.
-// Both partials are unscaled; c is applied to the sum: result = c * (own + partner).
-// Implementation: add_tiles produces (own + partner) in DST, then mul_unary_tile scales by c.
-void add_reduce_block(
-    uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32_t M_rows, uint32_t N_cols, uint32_t c_scalar) {
+// Add own_partial + partner_partial, pack to output.
+void add_reduce_block(uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32_t M_rows, uint32_t N_cols) {
     add_tiles_init(own_cb, recv_cb);
     reconfig_data_format(own_cb, recv_cb);
     pack_reconfig_data_format(out_cb);
@@ -167,7 +156,6 @@ void add_reduce_block(
         for (uint32_t n = 0; n < N_cols; n++) {
             acquire_dst();
             add_tiles(own_cb, recv_cb, tile_id, tile_id, 0);
-            mul_unary_tile(0, c_scalar);
             pack_tile(0, out_cb);
             release_dst();
             tile_id++;
@@ -178,14 +166,10 @@ void add_reduce_block(
 
 #ifdef MIRROR_OUTPUT
 // Add own_cb + recv_cb, transpose via c_7 staging, pack to mirror_cb (col by col).
-// Produces N_cols columns of M_rows tiles each (matching DM mirror write pattern).
-// src_stride: column stride in source CBs (= M_block for row-major c_2).
-// Note: transpose_wh_dest() is buggy on Blackhole (PCC≈0.2), so we stage through c_7 BF16 CB.
 void add_transpose_block(
     uint32_t own_cb, uint32_t recv_cb, uint32_t mirror_cb, uint32_t M_rows, uint32_t N_cols, uint32_t src_stride) {
     constexpr uint32_t staging_cb = tt::CBIndex::c_7;
     for (uint32_t n = 0; n < N_cols; n++) {
-        // Phase 1: batch add M_rows tiles for column n into staging
         add_tiles_init(own_cb, recv_cb);
         reconfig_data_format(own_cb, recv_cb);
         pack_reconfig_data_format(staging_cb);
@@ -199,7 +183,6 @@ void add_transpose_block(
         }
         cb_push_back(staging_cb, M_rows);
 
-        // Phase 2: transpose all M_rows tiles from staging to mirror
         cb_wait_front(staging_cb, M_rows);
         cb_reserve_back(mirror_cb, M_rows);
         transpose_wh_init(staging_cb, mirror_cb);
@@ -227,8 +210,7 @@ void kernel_main() {
     constexpr uint32_t subblock_h = get_compile_time_arg_val(5);
     constexpr uint32_t N_block = get_compile_time_arg_val(6);
     constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-    constexpr uint32_t b_over_c_bits = get_compile_time_arg_val(8);  // float (b/c) as uint32_t bits
-    constexpr uint32_t c_bits = get_compile_time_arg_val(9);         // float c as uint32_t bits
+    constexpr uint32_t b_over_c_bits = get_compile_time_arg_val(8);
     constexpr uint32_t K_num_blocks = K_half / K_block_tiles;
     constexpr uint32_t tiles_per_in0_block = K_block_tiles * M_block;
     constexpr uint32_t tiles_per_in1_block = K_block_tiles * N_block;
@@ -249,6 +231,8 @@ void kernel_main() {
 
     mm_init(in0_cb, in1_cb, intermed_cb);
     mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
+    if (b_over_c_bits != 0)
+        binop_with_scalar_tile_init();
     reconfig_data_format(in1_cb, in0_cb);
     pack_reconfig_data_format(intermed_cb);
 
@@ -266,11 +250,10 @@ void kernel_main() {
                 cb_wait_front(in0_cb, tiles_per_in0_block);
                 cb_wait_front(in1_cb, tiles_per_in1_block);
 
-                // Compute parity for bG stride-2 column matching
 #ifdef REDUCE_ACCUMULATOR
-                constexpr uint32_t bg_parity = 1;  // upper cores: odd K-columns
+                constexpr uint32_t bg_parity = 1;
 #else
-                constexpr uint32_t bg_parity = 0;  // lower/diagonal cores: even K-columns
+                constexpr uint32_t bg_parity = 0;
 #endif
                 uint32_t n_global_base = N_global_offset + N_start;
 
@@ -290,31 +273,27 @@ void kernel_main() {
                     bg_parity,
                     b_over_c_bits);
 
+                cb_pop_front(in0_cb, tiles_per_in0_block);
+                cb_pop_front(in1_cb, tiles_per_in1_block);
+
                 if (kb == 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
-
-                cb_pop_front(in0_cb, tiles_per_in0_block);
-                cb_pop_front(in1_cb, tiles_per_in1_block);
             }
 
             cb_push_back(intermed_cb, intermed_tiles);
             PACK((llk_pack_reconfig_l1_acc(0)));
 
-            // Pack or reduce immediately after each (m_sub, n_sub) block
 #ifndef REDUCE_ACCUMULATOR
-            // REDUCE_SENDER path: pack c_2 → c_5 for DM to send to partner (unscaled)
             cb_reserve_back(out_cb, intermed_tiles);
             cb_wait_front(intermed_cb, intermed_tiles);
             pack_subblock_pernsb(intermed_cb, out_cb, current_M_block, current_N);
             cb_pop_front(intermed_cb, intermed_tiles);
             cb_push_back(out_cb, intermed_tiles);
 #else
-            // REDUCE_ACCUMULATOR: c * (c_2 + c_5) → c_6
             cb_wait_front(intermed_cb, intermed_tiles);
             cb_wait_front(reduce_cb, intermed_tiles);
-            binop_with_scalar_tile_init();
-            add_reduce_block(intermed_cb, reduce_cb, combined_cb, current_M_block, current_N, c_bits);
+            add_reduce_block(intermed_cb, reduce_cb, combined_cb, current_M_block, current_N);
 #ifdef MIRROR_OUTPUT
             add_transpose_block(intermed_cb, reduce_cb, tt::CBIndex::c_4, current_M_block, current_N, current_M_block);
 #endif
@@ -322,7 +301,6 @@ void kernel_main() {
             cb_pop_front(reduce_cb, intermed_tiles);
 #endif
 
-            // Re-init matmul pipeline after copy/pack changed data formats
             if (n_sub + 1 < num_n_blocks) {
                 mm_init(in0_cb, in1_cb, intermed_cb);
                 mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
@@ -331,7 +309,6 @@ void kernel_main() {
             }
         }
 
-        // Re-init matmul pipeline for next m_sub
         if (m_sub + 1 < num_m_blocks) {
             mm_init(in0_cb, in1_cb, intermed_cb);
             mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -11,6 +11,7 @@
 #include "api/compute/cb_api.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/transpose_wh.h"
@@ -71,9 +72,10 @@ void matmul_blocks(
 }
 
 // Pack c_2 → c_5 in row-major order for DM to send to reduction partner.
+// Scales each tile by c_scalar before packing.
 // REDUCE_SENDER_TRANSPOSE: transpose tile content + swap indices so receiver can add directly.
 // REDUCE_SENDER: identity copy with FP32 → BF16 format conversion.
-void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, uint32_t current_N) {
+void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, uint32_t current_N, uint32_t c_scalar) {
 #ifdef REDUCE_SENDER_TRANSPOSE
     transpose_wh_init(in_cb, out_cb);
     reconfig_data_format_srca(in_cb);
@@ -85,6 +87,7 @@ void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, u
             uint32_t out_tile = n * current_M + m;
             acquire_dst();
             transpose_wh_tile(in_cb, in_tile, 0);
+            mul_unary_tile(0, c_scalar);
             pack_tile<true>(0, out_cb, out_tile);
             release_dst();
         }
@@ -97,6 +100,7 @@ void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, u
     for (uint32_t t = 0; t < current_M * current_N; t++) {
         acquire_dst();
         copy_tile(in_cb, t, 0);
+        mul_unary_tile(0, c_scalar);
         pack_tile<true>(0, out_cb, t);
         release_dst();
     }
@@ -174,6 +178,8 @@ void kernel_main() {
     constexpr uint32_t subblock_h = get_compile_time_arg_val(5);
     constexpr uint32_t N_block = get_compile_time_arg_val(6);
     constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
+    constexpr uint32_t b_bits = get_compile_time_arg_val(8);  // float b as uint32_t bits
+    constexpr uint32_t c_bits = get_compile_time_arg_val(9);  // float c as uint32_t bits
     constexpr uint32_t K_num_blocks = K_half / K_block_tiles;
     constexpr uint32_t tiles_per_in0_block = K_block_tiles * M_block;
     constexpr uint32_t tiles_per_in1_block = K_block_tiles * N_block;
@@ -236,7 +242,8 @@ void kernel_main() {
             // REDUCE_SENDER path: pack c_2 → c_5 for DM to send to partner
             cb_reserve_back(out_cb, intermed_tiles);
             cb_wait_front(intermed_cb, intermed_tiles);
-            pack_subblock_pernsb(intermed_cb, out_cb, current_M_block, current_N);
+            binop_with_scalar_tile_init();
+            pack_subblock_pernsb(intermed_cb, out_cb, current_M_block, current_N, c_bits);
             cb_pop_front(intermed_cb, intermed_tiles);
             cb_push_back(out_cb, intermed_tiles);
 #else

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Matmul compute kernel — runs on TRISC (all 3 TRISC processors).
+// Computes M_block x N_block output blocks for the Mpc×Mpc gram matmul.
+// Output streamed per (m_sub, n_sub) block:
+//   REDUCE_SENDER/TRANSPOSE: matmul → c_2, pack c_2 → c_5 (row-major), DM sends c_5 to partner
+//   REDUCE_ACCUMULATOR: matmul → c_2, add own c_2(FP32) + partner's c_5(BF16) → c_6
+
+#include "api/compute/cb_api.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/transpose_wh.h"
+
+// M_block x N_block matmul with K-outer layout.
+void matmul_blocks(
+    uint32_t in0_cb,
+    uint32_t in1_cb,
+    uint32_t out_cb,
+    uint32_t M_block,
+    uint32_t N_block,
+    uint32_t K_block_tiles,
+    uint32_t subblock_h,
+    uint32_t subblock_w,
+    uint32_t current_M,
+    uint32_t current_N) {
+    uint32_t last_sh = subblock_h, last_sw = subblock_w;
+
+    for (uint32_t ms = 0; ms < current_M; ms += subblock_h) {
+        uint32_t current_sh = std::min(subblock_h, current_M - ms);
+        for (uint32_t ns = 0; ns < current_N; ns += subblock_w) {
+            uint32_t current_sw = std::min(subblock_w, current_N - ns);
+
+            // Only reconfigure when subblock size changes (edge tiles)
+            if (current_sh != last_sh || current_sw != last_sw) {
+                mm_block_init_short(in0_cb, in1_cb, true, current_sw, current_sh, 1);
+                last_sh = current_sh;
+                last_sw = current_sw;
+            }
+
+            tile_regs_acquire();
+
+            for (uint32_t k = 0; k < K_block_tiles; k++) {
+                uint32_t in0_index = k * M_block + ms;
+                uint32_t in1_index = k * N_block + ns;
+                matmul_block(in0_cb, in1_cb, in0_index, in1_index, 0, true, current_sw, current_sh, 1);
+            }
+
+            tile_regs_commit();
+            tile_regs_wait();
+
+            uint32_t dst = 0;
+            for (uint32_t h = 0; h < current_sh; h++) {
+                for (uint32_t w = 0; w < current_sw; w++) {
+                    uint32_t out_tile_id = (ms + h) * current_N + (ns + w);
+                    pack_tile<true>(dst, out_cb, out_tile_id);
+                    dst++;
+                }
+            }
+
+            tile_regs_release();
+        }
+    }
+    // Restore full subblock size for next call
+    if (last_sh != subblock_h || last_sw != subblock_w) {
+        mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
+    }
+}
+
+// Pack c_2 → c_5 in row-major order for DM to send to reduction partner.
+// REDUCE_SENDER_TRANSPOSE: transpose tile content + swap indices so receiver can add directly.
+// REDUCE_SENDER: identity copy with FP32 → BF16 format conversion.
+void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, uint32_t current_N) {
+#ifdef REDUCE_SENDER_TRANSPOSE
+    transpose_wh_init(in_cb, out_cb);
+    reconfig_data_format_srca(in_cb);
+    pack_reconfig_data_format(out_cb);
+
+    for (uint32_t m = 0; m < current_M; m++) {
+        for (uint32_t n = 0; n < current_N; n++) {
+            uint32_t in_tile = m * current_N + n;
+            uint32_t out_tile = n * current_M + m;
+            acquire_dst();
+            transpose_wh_tile(in_cb, in_tile, 0);
+            pack_tile<true>(0, out_cb, out_tile);
+            release_dst();
+        }
+    }
+#else
+    copy_tile_to_dst_init_short(in_cb);
+    reconfig_data_format_srca(in_cb);
+    pack_reconfig_data_format(out_cb);
+
+    for (uint32_t t = 0; t < current_M * current_N; t++) {
+        acquire_dst();
+        copy_tile(in_cb, t, 0);
+        pack_tile<true>(0, out_cb, t);
+        release_dst();
+    }
+#endif
+}
+
+#ifdef REDUCE_ACCUMULATOR
+void add_reduce_block(uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32_t M_rows, uint32_t N_cols) {
+    add_tiles_init(own_cb, recv_cb);
+    reconfig_data_format(own_cb, recv_cb);
+    pack_reconfig_data_format(out_cb);
+
+    uint32_t tile_id = 0;
+    for (uint32_t m = 0; m < M_rows; m++) {
+        cb_reserve_back(out_cb, N_cols);
+        for (uint32_t n = 0; n < N_cols; n++) {
+            acquire_dst();
+            add_tiles(own_cb, recv_cb, tile_id, tile_id, 0);
+            pack_tile(0, out_cb);
+            release_dst();
+            tile_id++;
+        }
+        cb_push_back(out_cb, N_cols);
+    }
+}
+
+#ifdef MIRROR_OUTPUT
+// Add own_cb + recv_cb, transpose via c_7 staging, pack to mirror_cb (col by col).
+// Produces N_cols columns of M_rows tiles each (matching DM mirror write pattern).
+// src_stride: column stride in source CBs (= M_block for row-major c_2).
+// Note: transpose_wh_dest() is buggy on Blackhole (PCC≈0.2), so we stage through c_7 BF16 CB.
+void add_transpose_block(
+    uint32_t own_cb, uint32_t recv_cb, uint32_t mirror_cb, uint32_t M_rows, uint32_t N_cols, uint32_t src_stride) {
+    constexpr uint32_t staging_cb = tt::CBIndex::c_7;
+    for (uint32_t n = 0; n < N_cols; n++) {
+        // Phase 1: batch add M_rows tiles for column n into staging
+        add_tiles_init(own_cb, recv_cb);
+        reconfig_data_format(own_cb, recv_cb);
+        pack_reconfig_data_format(staging_cb);
+        cb_reserve_back(staging_cb, M_rows);
+        for (uint32_t m = 0; m < M_rows; m++) {
+            uint32_t tile_id = n * src_stride + m;
+            acquire_dst();
+            add_tiles(own_cb, recv_cb, tile_id, tile_id, 0);
+            pack_tile<true>(0, staging_cb, m);
+            release_dst();
+        }
+        cb_push_back(staging_cb, M_rows);
+
+        // Phase 2: transpose all M_rows tiles from staging to mirror
+        cb_wait_front(staging_cb, M_rows);
+        cb_reserve_back(mirror_cb, M_rows);
+        transpose_wh_init(staging_cb, mirror_cb);
+        reconfig_data_format_srca(staging_cb);
+        pack_reconfig_data_format(mirror_cb);
+        for (uint32_t m = 0; m < M_rows; m++) {
+            acquire_dst();
+            transpose_wh_tile(staging_cb, m, 0);
+            pack_tile(0, mirror_cb);
+            release_dst();
+        }
+        cb_pop_front(staging_cb, M_rows);
+        cb_push_back(mirror_cb, M_rows);
+    }
+}
+#endif
+#endif
+
+void kernel_main() {
+    constexpr uint32_t K_half = get_compile_time_arg_val(0);
+    constexpr uint32_t K_block_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t Mpc = get_compile_time_arg_val(2);
+    constexpr uint32_t subblock_w = get_compile_time_arg_val(3);
+    constexpr uint32_t M_block = get_compile_time_arg_val(4);
+    constexpr uint32_t subblock_h = get_compile_time_arg_val(5);
+    constexpr uint32_t N_block = get_compile_time_arg_val(6);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
+    constexpr uint32_t K_num_blocks = K_half / K_block_tiles;
+    constexpr uint32_t tiles_per_in0_block = K_block_tiles * M_block;
+    constexpr uint32_t tiles_per_in1_block = K_block_tiles * N_block;
+    constexpr uint32_t num_m_blocks = (Mpc + M_block - 1) / M_block;
+
+    constexpr uint32_t in0_cb = tt::CBIndex::c_0;
+    constexpr uint32_t in1_cb = tt::CBIndex::c_1;
+    constexpr uint32_t intermed_cb = tt::CBIndex::c_2;
+    constexpr uint32_t out_cb = tt::CBIndex::c_5;
+
+#ifdef REDUCE_ACCUMULATOR
+    constexpr uint32_t reduce_cb = tt::CBIndex::c_5;
+    constexpr uint32_t combined_cb = tt::CBIndex::c_6;
+#endif
+
+    mm_init(in0_cb, in1_cb, intermed_cb);
+    mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
+    reconfig_data_format(in1_cb, in0_cb);
+    pack_reconfig_data_format(intermed_cb);
+
+    for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
+        uint32_t current_M_block = std::min(M_block, Mpc - m_sub * M_block);
+
+        for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            uint32_t N_start = n_sub * N_block;
+            uint32_t current_N = std::min(N_block, Mpc - N_start);
+            uint32_t intermed_tiles = current_M_block * current_N;
+
+            cb_reserve_back(intermed_cb, intermed_tiles);
+
+            for (uint32_t kb = 0; kb < K_num_blocks; kb++) {
+                cb_wait_front(in0_cb, tiles_per_in0_block);
+                cb_wait_front(in1_cb, tiles_per_in1_block);
+
+                matmul_blocks(
+                    in0_cb,
+                    in1_cb,
+                    intermed_cb,
+                    M_block,
+                    N_block,
+                    K_block_tiles,
+                    subblock_h,
+                    subblock_w,
+                    current_M_block,
+                    current_N);
+
+                cb_pop_front(in0_cb, tiles_per_in0_block);
+                cb_pop_front(in1_cb, tiles_per_in1_block);
+
+                if (kb == 0) {
+                    PACK((llk_pack_reconfig_l1_acc(1)));
+                }
+            }
+
+            cb_push_back(intermed_cb, intermed_tiles);
+            PACK((llk_pack_reconfig_l1_acc(0)));
+
+            // Pack or reduce immediately after each (m_sub, n_sub) block
+#ifndef REDUCE_ACCUMULATOR
+            // REDUCE_SENDER path: pack c_2 → c_5 for DM to send to partner
+            cb_reserve_back(out_cb, intermed_tiles);
+            cb_wait_front(intermed_cb, intermed_tiles);
+            pack_subblock_pernsb(intermed_cb, out_cb, current_M_block, current_N);
+            cb_pop_front(intermed_cb, intermed_tiles);
+            cb_push_back(out_cb, intermed_tiles);
+#else
+            // REDUCE_ACCUMULATOR: add c_2(FP32) + c_5(BF16) → c_6
+            cb_wait_front(intermed_cb, intermed_tiles);
+            cb_wait_front(reduce_cb, intermed_tiles);
+            add_reduce_block(intermed_cb, reduce_cb, combined_cb, current_M_block, current_N);
+#ifdef MIRROR_OUTPUT
+            add_transpose_block(intermed_cb, reduce_cb, tt::CBIndex::c_4, current_M_block, current_N, current_M_block);
+#endif
+            cb_pop_front(intermed_cb, intermed_tiles);
+            cb_pop_front(reduce_cb, intermed_tiles);
+#endif
+
+            // Re-init matmul pipeline after copy/pack changed data formats
+            if (n_sub + 1 < num_n_blocks) {
+                mm_init(in0_cb, in1_cb, intermed_cb);
+                mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
+                reconfig_data_format(in1_cb, in0_cb);
+                pack_reconfig_data_format(intermed_cb);
+            }
+        }
+
+        // Re-init matmul pipeline for next m_sub
+        if (m_sub + 1 < num_m_blocks) {
+            mm_init(in0_cb, in1_cb, intermed_cb);
+            mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
+            reconfig_data_format(in1_cb, in0_cb);
+            pack_reconfig_data_format(intermed_cb);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -181,12 +181,15 @@ void kernel_main() {
     constexpr uint32_t subblock_h = get_compile_time_arg_val(5);
     constexpr uint32_t N_block = get_compile_time_arg_val(6);
     constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-    constexpr uint32_t b_bits = get_compile_time_arg_val(8);  // float b as uint32_t bits
-    constexpr uint32_t c_bits = get_compile_time_arg_val(9);  // float c as uint32_t bits
+    constexpr uint32_t b_over_c_bits = get_compile_time_arg_val(8);  // float (b/c) as uint32_t bits
+    constexpr uint32_t c_bits = get_compile_time_arg_val(9);         // float c as uint32_t bits
     constexpr uint32_t K_num_blocks = K_half / K_block_tiles;
     constexpr uint32_t tiles_per_in0_block = K_block_tiles * M_block;
     constexpr uint32_t tiles_per_in1_block = K_block_tiles * N_block;
     constexpr uint32_t num_m_blocks = (Mpc + M_block - 1) / M_block;
+
+    // Runtime arg: global N-tile offset for this core (needed for bG column matching)
+    const uint32_t N_global_offset = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t in0_cb = tt::CBIndex::c_0;
     constexpr uint32_t in1_cb = tt::CBIndex::c_1;
@@ -233,45 +236,24 @@ void kernel_main() {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
 
-                // bG fusion: check if any output columns fall in this K-block's range.
-                // Lower/diagonal cores (REDUCE_SENDER*) see even K-cols, upper (REDUCE_ACCUMULATOR) see odd.
-                // K-block kb covers K-columns: kb*K_block_tiles*2 + parity_offset .. + (K_block_tiles-1)*2
-                if (b_bits != 0) {
-#ifdef REDUCE_ACCUMULATOR
-                    constexpr uint32_t parity_offset = 1;  // odd K-columns
-#else
-                    constexpr uint32_t parity_offset = 0;  // even K-columns
-#endif
-                    uint32_t k_col_start = kb * K_block_tiles * 2 + parity_offset;
-                    // Check each output column for a match
-                    for (uint32_t local_n = 0; local_n < current_N; local_n++) {
-                        uint32_t n_global = N_start + local_n;
-                        // Only process columns with matching parity
-                        if ((n_global & 1) != parity_offset)
-                            continue;
-                        // Which k_within in this block?
-                        if (n_global < k_col_start || n_global >= k_col_start + K_block_tiles * 2)
-                            continue;
-                        uint32_t k_within = (n_global - k_col_start) / 2;
-
-                        // Add b * G[m, n_global] for each row in the block
-                        copy_tile_to_dst_init_short(in0_cb);
-                        binop_with_scalar_tile_init();
-                        for (uint32_t local_m = 0; local_m < current_M_block; local_m++) {
-                            uint32_t c0_tile = k_within * M_block + local_m;
-                            uint32_t c2_tile = local_m * current_N + local_n;
-                            acquire_dst();
-                            copy_tile(in0_cb, c0_tile, 0);
-                            mul_unary_tile(0, b_bits);
-                            pack_tile<true>(0, intermed_cb, c2_tile);
-                            release_dst();
-                        }
-                        // Re-init matmul for next K-block
-                        mm_init(in0_cb, in1_cb, intermed_cb);
-                        mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
-                        reconfig_data_format(in1_cb, in0_cb);
-                        pack_reconfig_data_format(intermed_cb);
-                    }
+                // DEBUG: unconditionally add c_0[0] to c_2[0] at kb=0 to test L1 acc
+                // Approach: use add_tiles with c_0 as both inputs — adds c_0[0]+c_0[0] to DST,
+                // then pack with L1 acc. This uses the binary eltwise pipeline which is known to work with L1 acc.
+                if (kb == 0) {
+                    add_tiles_init(in0_cb, in0_cb);
+                    reconfig_data_format(in0_cb, in0_cb);
+                    pack_reconfig_data_format(intermed_cb);
+                    pack_reconfig_l1_acc(1);
+                    acquire_dst();
+                    add_tiles(in0_cb, in0_cb, 0, 0, 0);  // DST[0] = c_0[0] + c_0[0] = 2*G[m,k]
+                    pack_tile<true>(0, intermed_cb, 0);
+                    release_dst();
+                    // Restore matmul config
+                    mm_init(in0_cb, in1_cb, intermed_cb);
+                    mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
+                    reconfig_data_format(in1_cb, in0_cb);
+                    pack_reconfig_data_format(intermed_cb);
+                    pack_reconfig_l1_acc(1);
                 }
 
                 cb_pop_front(in0_cb, tiles_per_in0_block);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -18,6 +18,10 @@
 #include "api/compute/transpose_wh.h"
 
 // M_block x N_block matmul with K-outer layout.
+// If prefill_cb != 0 and prefill_scalar != 0, pre-fills matching DST positions with
+// scaled tiles from prefill_cb before the matmul, so the matmul accumulates on top.
+// prefill_k_within: which K-tile position in in0_cb contains the G[m,n] tiles
+// prefill_col_offset: global column offset for matching output columns
 void matmul_blocks(
     uint32_t in0_cb,
     uint32_t in1_cb,
@@ -28,7 +32,9 @@ void matmul_blocks(
     uint32_t subblock_h,
     uint32_t subblock_w,
     uint32_t current_M,
-    uint32_t current_N) {
+    uint32_t current_N,
+    uint32_t prefill_scalar = 0,
+    int prefill_k_within = -1) {
     uint32_t last_sh = subblock_h, last_sw = subblock_w;
 
     for (uint32_t ms = 0; ms < current_M; ms += subblock_h) {
@@ -44,6 +50,26 @@ void matmul_blocks(
             }
 
             tile_regs_acquire();
+
+            // Pre-fill DST with (b/c)*G[m,n] before matmul accumulates on top.
+            // DST is acquired, so copy_tile writes directly to DST positions.
+            if (prefill_scalar != 0 && prefill_k_within >= 0) {
+                copy_tile_to_dst_init_short(in0_cb);
+                binop_with_scalar_tile_init();
+                uint32_t dst = 0;
+                for (uint32_t h = 0; h < current_sh; h++) {
+                    for (uint32_t w = 0; w < current_sw; w++) {
+                        uint32_t c0_tile = prefill_k_within * M_block + (ms + h);
+                        copy_tile(in0_cb, c0_tile, dst);
+                        mul_unary_tile(dst, prefill_scalar);
+                        dst++;
+                    }
+                }
+                // Re-init matmul after copy/sfpu changed pipeline config
+                mm_block_init_short(in0_cb, in1_cb, true, current_sw, current_sh, 1);
+                last_sh = current_sh;
+                last_sw = current_sw;
+            }
 
             for (uint32_t k = 0; k < K_block_tiles; k++) {
                 uint32_t in0_index = k * M_block + ms;
@@ -220,6 +246,7 @@ void kernel_main() {
                 cb_wait_front(in0_cb, tiles_per_in0_block);
                 cb_wait_front(in1_cb, tiles_per_in1_block);
 
+                // DEBUG: at kb=0, pre-fill DST with (b/c)*G tile from c_0[0]
                 matmul_blocks(
                     in0_cb,
                     in1_cb,
@@ -230,31 +257,17 @@ void kernel_main() {
                     subblock_h,
                     subblock_w,
                     current_M_block,
-                    current_N);
+                    current_N,
+                    (kb == 0) ? b_over_c_bits : 0,
+                    (kb == 0) ? 0 : -1);
 
                 if (kb == 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
 
-                // DEBUG: unconditionally add c_0[0] to c_2[0] at kb=0 to test L1 acc
-                // Approach: use add_tiles with c_0 as both inputs — adds c_0[0]+c_0[0] to DST,
-                // then pack with L1 acc. This uses the binary eltwise pipeline which is known to work with L1 acc.
-                if (kb == 0) {
-                    add_tiles_init(in0_cb, in0_cb);
-                    reconfig_data_format(in0_cb, in0_cb);
-                    pack_reconfig_data_format(intermed_cb);
-                    pack_reconfig_l1_acc(1);
-                    acquire_dst();
-                    add_tiles(in0_cb, in0_cb, 0, 0, 0);  // DST[0] = c_0[0] + c_0[0] = 2*G[m,k]
-                    pack_tile<true>(0, intermed_cb, 0);
-                    release_dst();
-                    // Restore matmul config
-                    mm_init(in0_cb, in1_cb, intermed_cb);
-                    mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
-                    reconfig_data_format(in1_cb, in0_cb);
-                    pack_reconfig_data_format(intermed_cb);
-                    pack_reconfig_l1_acc(1);
-                }
+                // DEBUG: test if L1 acc works by doing a zero-contribution matmul at kb=1
+                // This uses the matmul pipeline which is known to work with L1 acc
+                // TODO: find correct init sequence for copy_tile + L1 acc
 
                 cb_pop_front(in0_cb, tiles_per_in0_block);
                 cb_pop_front(in1_cb, tiles_per_in1_block);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -229,12 +229,53 @@ void kernel_main() {
                     current_M_block,
                     current_N);
 
-                cb_pop_front(in0_cb, tiles_per_in0_block);
-                cb_pop_front(in1_cb, tiles_per_in1_block);
-
                 if (kb == 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
+
+                // bG fusion: check if any output columns fall in this K-block's range.
+                // Lower/diagonal cores (REDUCE_SENDER*) see even K-cols, upper (REDUCE_ACCUMULATOR) see odd.
+                // K-block kb covers K-columns: kb*K_block_tiles*2 + parity_offset .. + (K_block_tiles-1)*2
+                if (b_bits != 0) {
+#ifdef REDUCE_ACCUMULATOR
+                    constexpr uint32_t parity_offset = 1;  // odd K-columns
+#else
+                    constexpr uint32_t parity_offset = 0;  // even K-columns
+#endif
+                    uint32_t k_col_start = kb * K_block_tiles * 2 + parity_offset;
+                    // Check each output column for a match
+                    for (uint32_t local_n = 0; local_n < current_N; local_n++) {
+                        uint32_t n_global = N_start + local_n;
+                        // Only process columns with matching parity
+                        if ((n_global & 1) != parity_offset)
+                            continue;
+                        // Which k_within in this block?
+                        if (n_global < k_col_start || n_global >= k_col_start + K_block_tiles * 2)
+                            continue;
+                        uint32_t k_within = (n_global - k_col_start) / 2;
+
+                        // Add b * G[m, n_global] for each row in the block
+                        copy_tile_to_dst_init_short(in0_cb);
+                        binop_with_scalar_tile_init();
+                        for (uint32_t local_m = 0; local_m < current_M_block; local_m++) {
+                            uint32_t c0_tile = k_within * M_block + local_m;
+                            uint32_t c2_tile = local_m * current_N + local_n;
+                            acquire_dst();
+                            copy_tile(in0_cb, c0_tile, 0);
+                            mul_unary_tile(0, b_bits);
+                            pack_tile<true>(0, intermed_cb, c2_tile);
+                            release_dst();
+                        }
+                        // Re-init matmul for next K-block
+                        mm_init(in0_cb, in1_cb, intermed_cb);
+                        mm_block_init_short(in0_cb, in1_cb, true, subblock_w, subblock_h, 1);
+                        reconfig_data_format(in1_cb, in0_cb);
+                        pack_reconfig_data_format(intermed_cb);
+                    }
+                }
+
+                cb_pop_front(in0_cb, tiles_per_in0_block);
+                cb_pop_front(in1_cb, tiles_per_in1_block);
             }
 
             cb_push_back(intermed_cb, intermed_tiles);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -18,10 +18,11 @@
 #include "api/compute/transpose_wh.h"
 
 // M_block x N_block matmul with K-outer layout.
-// If prefill_cb != 0 and prefill_scalar != 0, pre-fills matching DST positions with
-// scaled tiles from prefill_cb before the matmul, so the matmul accumulates on top.
-// prefill_k_within: which K-tile position in in0_cb contains the G[m,n] tiles
-// prefill_col_offset: global column offset for matching output columns
+// bG pre-fill: before matmul, copies (b/c)*G[m,n] into matching DST positions from c_0.
+// Each core has stride-2 K-columns (even for lower, odd for upper). For output column n_global,
+// G[m, n_global] appears in c_0 at the K-block where k_col == n_global.
+// kb: current K-block index, n_global_base: global column start for this (m_sub, n_sub) block,
+// parity: 0 for even K-cols (lower/diag), 1 for odd (upper), b_over_c: scalar bits.
 void matmul_blocks(
     uint32_t in0_cb,
     uint32_t in1_cb,
@@ -33,9 +34,15 @@ void matmul_blocks(
     uint32_t subblock_w,
     uint32_t current_M,
     uint32_t current_N,
-    uint32_t prefill_scalar = 0,
-    int prefill_k_within = -1) {
+    uint32_t kb = 0,
+    uint32_t n_global_base = 0,
+    uint32_t parity = 0,
+    uint32_t b_over_c = 0) {
     uint32_t last_sh = subblock_h, last_sw = subblock_w;
+
+    // K-column range for this K-block
+    uint32_t k_col_start = kb * K_block_tiles * 2 + parity;
+    uint32_t k_col_end = k_col_start + K_block_tiles * 2;
 
     for (uint32_t ms = 0; ms < current_M; ms += subblock_h) {
         uint32_t current_sh = std::min(subblock_h, current_M - ms);
@@ -51,24 +58,37 @@ void matmul_blocks(
 
             tile_regs_acquire();
 
-            // Pre-fill DST with (b/c)*G[m,n] before matmul accumulates on top.
-            // DST is acquired, so copy_tile writes directly to DST positions.
-            if (prefill_scalar != 0 && prefill_k_within >= 0) {
-                copy_tile_to_dst_init_short(in0_cb);
-                binop_with_scalar_tile_init();
-                uint32_t dst = 0;
-                for (uint32_t h = 0; h < current_sh; h++) {
-                    for (uint32_t w = 0; w < current_sw; w++) {
-                        uint32_t c0_tile = prefill_k_within * M_block + (ms + h);
-                        copy_tile(in0_cb, c0_tile, dst);
-                        mul_unary_tile(dst, prefill_scalar);
-                        dst++;
+            // Pre-fill DST with (b/c)*G[m,n] for output columns that match this K-block.
+            // DST is zero at acquire. Matching positions get bG; non-matching stay zero.
+            // Matmul then accumulates on top of both.
+            if (b_over_c != 0) {
+                bool any_match = false;
+                for (uint32_t w = 0; w < current_sw; w++) {
+                    uint32_t n_global = n_global_base + ns + w;
+                    if ((n_global & 1) != parity)
+                        continue;
+                    if (n_global < k_col_start || n_global >= k_col_end)
+                        continue;
+                    // This column matches — pre-fill all rows in this subblock
+                    if (!any_match) {
+                        copy_tile_to_dst_init_short(in0_cb);
+                        binop_with_scalar_tile_init();
+                        any_match = true;
+                    }
+                    uint32_t k_within = (n_global - k_col_start) / 2;
+                    for (uint32_t h = 0; h < current_sh; h++) {
+                        uint32_t dst_idx = h * current_sw + w;
+                        uint32_t c0_tile = k_within * M_block + (ms + h);
+                        copy_tile(in0_cb, c0_tile, dst_idx);
+                        mul_unary_tile(dst_idx, b_over_c);
                     }
                 }
-                // Re-init matmul after copy/sfpu changed pipeline config
-                mm_block_init_short(in0_cb, in1_cb, true, current_sw, current_sh, 1);
-                last_sh = current_sh;
-                last_sw = current_sw;
+                if (any_match) {
+                    // Re-init matmul after copy/sfpu changed pipeline config
+                    mm_block_init_short(in0_cb, in1_cb, true, current_sw, current_sh, 1);
+                    last_sh = current_sh;
+                    last_sw = current_sw;
+                }
             }
 
             for (uint32_t k = 0; k < K_block_tiles; k++) {
@@ -246,7 +266,14 @@ void kernel_main() {
                 cb_wait_front(in0_cb, tiles_per_in0_block);
                 cb_wait_front(in1_cb, tiles_per_in1_block);
 
-                // DEBUG: at kb=0, pre-fill DST with (b/c)*G tile from c_0[0]
+                // Compute parity for bG stride-2 column matching
+#ifdef REDUCE_ACCUMULATOR
+                constexpr uint32_t bg_parity = 1;  // upper cores: odd K-columns
+#else
+                constexpr uint32_t bg_parity = 0;  // lower/diagonal cores: even K-columns
+#endif
+                uint32_t n_global_base = N_global_offset + N_start;
+
                 matmul_blocks(
                     in0_cb,
                     in1_cb,
@@ -258,16 +285,14 @@ void kernel_main() {
                     subblock_w,
                     current_M_block,
                     current_N,
-                    (kb == 0) ? b_over_c_bits : 0,
-                    (kb == 0) ? 0 : -1);
+                    kb,
+                    n_global_base,
+                    bg_parity,
+                    b_over_c_bits);
 
                 if (kb == 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
-
-                // DEBUG: test if L1 acc works by doing a zero-contribution matmul at kb=1
-                // This uses the matmul pipeline which is known to work with L1 acc
-                // TODO: find correct init sequence for copy_tile + L1 acc
 
                 cb_pop_front(in0_cb, tiles_per_in0_block);
                 cb_pop_front(in1_cb, tiles_per_in1_block);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/compute_matmul.cpp
@@ -12,6 +12,7 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/transpose_wh.h"
@@ -72,10 +73,9 @@ void matmul_blocks(
 }
 
 // Pack c_2 → c_5 in row-major order for DM to send to reduction partner.
-// Scales each tile by c_scalar before packing.
 // REDUCE_SENDER_TRANSPOSE: transpose tile content + swap indices so receiver can add directly.
 // REDUCE_SENDER: identity copy with FP32 → BF16 format conversion.
-void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, uint32_t current_N, uint32_t c_scalar) {
+void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, uint32_t current_N) {
 #ifdef REDUCE_SENDER_TRANSPOSE
     transpose_wh_init(in_cb, out_cb);
     reconfig_data_format_srca(in_cb);
@@ -87,7 +87,6 @@ void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, u
             uint32_t out_tile = n * current_M + m;
             acquire_dst();
             transpose_wh_tile(in_cb, in_tile, 0);
-            mul_unary_tile(0, c_scalar);
             pack_tile<true>(0, out_cb, out_tile);
             release_dst();
         }
@@ -100,7 +99,6 @@ void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, u
     for (uint32_t t = 0; t < current_M * current_N; t++) {
         acquire_dst();
         copy_tile(in_cb, t, 0);
-        mul_unary_tile(0, c_scalar);
         pack_tile<true>(0, out_cb, t);
         release_dst();
     }
@@ -108,7 +106,11 @@ void pack_subblock_pernsb(uint32_t in_cb, uint32_t out_cb, uint32_t current_M, u
 }
 
 #ifdef REDUCE_ACCUMULATOR
-void add_reduce_block(uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32_t M_rows, uint32_t N_cols) {
+// Add c * own_partial + c * partner_partial, pack to output.
+// Both partials are unscaled; c is applied to the sum: result = c * (own + partner).
+// Implementation: add_tiles produces (own + partner) in DST, then mul_unary_tile scales by c.
+void add_reduce_block(
+    uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32_t M_rows, uint32_t N_cols, uint32_t c_scalar) {
     add_tiles_init(own_cb, recv_cb);
     reconfig_data_format(own_cb, recv_cb);
     pack_reconfig_data_format(out_cb);
@@ -119,6 +121,7 @@ void add_reduce_block(uint32_t own_cb, uint32_t recv_cb, uint32_t out_cb, uint32
         for (uint32_t n = 0; n < N_cols; n++) {
             acquire_dst();
             add_tiles(own_cb, recv_cb, tile_id, tile_id, 0);
+            mul_unary_tile(0, c_scalar);
             pack_tile(0, out_cb);
             release_dst();
             tile_id++;
@@ -239,18 +242,18 @@ void kernel_main() {
 
             // Pack or reduce immediately after each (m_sub, n_sub) block
 #ifndef REDUCE_ACCUMULATOR
-            // REDUCE_SENDER path: pack c_2 → c_5 for DM to send to partner
+            // REDUCE_SENDER path: pack c_2 → c_5 for DM to send to partner (unscaled)
             cb_reserve_back(out_cb, intermed_tiles);
             cb_wait_front(intermed_cb, intermed_tiles);
-            binop_with_scalar_tile_init();
-            pack_subblock_pernsb(intermed_cb, out_cb, current_M_block, current_N, c_bits);
+            pack_subblock_pernsb(intermed_cb, out_cb, current_M_block, current_N);
             cb_pop_front(intermed_cb, intermed_tiles);
             cb_push_back(out_cb, intermed_tiles);
 #else
-            // REDUCE_ACCUMULATOR: add c_2(FP32) + c_5(BF16) → c_6
+            // REDUCE_ACCUMULATOR: c * (c_2 + c_5) → c_6
             cb_wait_front(intermed_cb, intermed_tiles);
             cb_wait_front(reduce_cb, intermed_tiles);
-            add_reduce_block(intermed_cb, reduce_cb, combined_cb, current_M_block, current_N);
+            binop_with_scalar_tile_init();
+            add_reduce_block(intermed_cb, reduce_cb, combined_cb, current_M_block, current_N, c_bits);
 #ifdef MIRROR_OUTPUT
             add_transpose_block(intermed_cb, reduce_cb, tt::CBIndex::c_4, current_M_block, current_N, current_M_block);
 #endif

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/helper_dram_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/helper_dram_reader.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Diagonal helper DRAM reader + output writer — runs on RISCV_1/NOC_1 on helper cores (x=grid_dim).
+// Phase 1: Reads odd K-columns from DRAM into c_1 for compute.
+// Phase 2: Writes combined output (c_6) to DRAM per (m_sub, n_sub) block.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t tile_size = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t block_size = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(4);
+    constexpr uint32_t out_tile_size = get_compile_time_arg_val(5);
+    constexpr uint32_t Mpc = get_compile_time_arg_val(6);
+    constexpr uint32_t padded_out_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t num_m_blocks = get_compile_time_arg_val(8);
+    constexpr uint32_t M_block = get_compile_time_arg_val(9);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(10);
+
+    constexpr auto input_ta = TensorAccessorArgs<11>();
+    constexpr auto output_ta = TensorAccessorArgs<input_ta.next_compile_time_args_offset()>();
+
+    uint32_t argidx = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t tile_offset = get_arg_val<uint32_t>(argidx++);  // row offset (y * Mpc)
+    const uint32_t K_tiles = get_arg_val<uint32_t>(argidx++);      // padded K for loop structure
+    const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t logical_M_tiles = get_arg_val<uint32_t>(argidx++);
+    const uint32_t logical_K_tiles = get_arg_val<uint32_t>(argidx++);
+
+    const auto reader = TensorAccessor(input_ta, src_addr, tile_size);
+
+    constexpr uint32_t num_blocks = num_tiles / block_size;
+    // block_size = K_block_tiles * M_block (compile-time), so K_block_tiles = block_size / M_block
+    constexpr uint32_t K_block_tiles = block_size / M_block;
+
+    for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
+        uint32_t M_start = m_sub * M_block;
+        uint32_t current_M_block = (M_block < Mpc - M_start) ? M_block : (Mpc - M_start);
+
+        for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            uint32_t row_base = n_sub * M_block;
+            uint32_t N_start = n_sub * M_block;
+            uint32_t current_N = (M_block < Mpc - N_start) ? M_block : (Mpc - N_start);
+
+            // Read odd K-columns from DRAM
+            for (uint32_t blk = 0; blk < num_blocks; blk++) {
+                uint32_t first_k_col = blk * K_block_tiles * 2 + 1;
+
+                cb_reserve_back(cb_id, block_size);
+                uint32_t base_addr = get_write_ptr(cb_id);
+                for (uint32_t kb = 0; kb < K_block_tiles; kb++) {
+                    uint32_t k_col = first_k_col + kb * 2;
+                    for (uint32_t m = 0; m < M_block; m++) {
+                        uint32_t cb_offset = (kb * M_block + m) * tile_size;
+                        uint32_t global_row = tile_offset + row_base + m;
+                        if (global_row < logical_M_tiles && k_col < logical_K_tiles) {
+                            uint32_t dram_tile = global_row * logical_K_tiles + k_col;
+                            noc_async_read_tile(dram_tile, reader, base_addr + cb_offset);
+                        } else {
+                            fill_tile_zeros(base_addr + cb_offset, tile_size);
+                        }
+                    }
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_id, block_size);
+            }
+
+            // Write output per block
+            const auto out_writer = TensorAccessor(output_ta, out_addr, out_tile_size);
+            for (uint32_t m = 0; m < current_M_block; m++) {
+                cb_wait_front(cb_out, current_N);
+                uint32_t l1_read_addr = get_read_ptr(cb_out);
+                uint32_t row = M_start_tile + M_start + m;
+                for (uint32_t n = 0; n < current_N; n++) {
+                    uint32_t col = N_start_tile + N_start + n;
+                    if (row < logical_M_tiles && col < logical_M_tiles) {
+                        uint32_t tid = row * padded_out_tiles + col;
+                        noc_async_write_tile(tid, out_writer, l1_read_addr + n * out_tile_size);
+                    }
+                }
+                noc_async_write_barrier();
+                cb_pop_front(cb_out, current_N);
+            }
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/helper_dram_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/helper_dram_reader.cpp
@@ -43,11 +43,20 @@ void kernel_main() {
     // block_size = K_block_tiles * M_block (compile-time), so K_block_tiles = block_size / M_block
     constexpr uint32_t K_block_tiles = block_size / M_block;
 
+    constexpr uint32_t sync_cb = tt::CBIndex::c_3;
+    bool first_block = true;
+
     for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
         uint32_t M_start = m_sub * M_block;
         uint32_t current_M_block = (M_block < Mpc - M_start) ? M_block : (Mpc - M_start);
 
         for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            if (!first_block) {
+                cb_wait_front(sync_cb, 1);
+                cb_pop_front(sync_cb, 1);
+            }
+            first_block = false;
+
             uint32_t row_base = n_sub * M_block;
             uint32_t N_start = n_sub * M_block;
             uint32_t current_N = (M_block < Mpc - N_start) ? M_block : (Mpc - N_start);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/helper_dram_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/helper_dram_reader.cpp
@@ -76,7 +76,7 @@ void kernel_main() {
                             uint32_t dram_tile = global_row * logical_K_tiles + k_col;
                             noc_async_read_tile(dram_tile, reader, base_addr + cb_offset);
                         } else {
-                            fill_tile_zeros(base_addr + cb_offset, tile_size);
+                            fill_zeros_async(base_addr + cb_offset, tile_size);
                         }
                     }
                 }

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plain multicast receiver — runs on RISCV_1 (col interior/upper) or RISCV_0 (helper row receiver).
+// Only receives multicast tiles into CB; does not write output.
+// When REDUCE_RECV is defined, also waits for partner's reduce partial per (m_sub, n_sub) block.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t tile_size = get_compile_time_arg_val(1);
+    uint32_t sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(2));
+    uint32_t receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
+    constexpr uint32_t cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t block_size = get_compile_time_arg_val(5);
+
+#ifdef REDUCE_RECV
+    constexpr uint32_t reduce_cb = get_compile_time_arg_val(6);
+    uint32_t reduce_sem_addr = get_semaphore(get_compile_time_arg_val(7));
+    constexpr uint32_t Mpc = get_compile_time_arg_val(8);
+    constexpr uint32_t num_m_blocks = get_compile_time_arg_val(9);
+    constexpr uint32_t M_block = get_compile_time_arg_val(10);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(11);
+    constexpr uint32_t N_block = M_block;
+#else
+    constexpr uint32_t num_m_blocks = get_compile_time_arg_val(6);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
+#endif
+
+    uint32_t argidx = 0;
+    const uint32_t sender_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t sender_noc_y = get_arg_val<uint32_t>(argidx++);
+
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);
+
+    const uint64_t sender_sem_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_semaphore_addr);
+
+    constexpr uint32_t num_blocks = num_tiles / block_size;
+
+    for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
+        for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            for (uint32_t blk = 0; blk < num_blocks; blk++) {
+                cb_reserve_back(cb_id, block_size);
+
+                noc_semaphore_set(receiver_sem_ptr, INVALID);
+                noc_semaphore_inc(sender_sem_noc_addr, 1);
+
+                noc_semaphore_wait(receiver_sem_ptr, VALID);
+
+                cb_push_back(cb_id, block_size);
+            }
+
+#ifdef REDUCE_RECV
+            {
+                volatile tt_l1_ptr uint32_t* reduce_sem_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sem_addr);
+                uint32_t M_start = m_sub * M_block;
+                uint32_t current_M_block = (M_block < Mpc - M_start) ? M_block : (Mpc - M_start);
+                uint32_t N_start = n_sub * N_block;
+                uint32_t current_N = (N_block < Mpc - N_start) ? N_block : (Mpc - N_start);
+                uint32_t block_tiles = current_M_block * current_N;
+                cb_reserve_back(reduce_cb, block_tiles);
+                noc_semaphore_wait(reduce_sem_ptr, 1);
+                noc_semaphore_set(reduce_sem_ptr, 0);
+                cb_push_back(reduce_cb, block_tiles);
+            }
+#endif
+        }
+    }
+
+    noc_async_atomic_barrier();
+}

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver.cpp
@@ -42,8 +42,17 @@ void kernel_main() {
 
     constexpr uint32_t num_blocks = num_tiles / block_size;
 
+    constexpr uint32_t sync_cb = tt::CBIndex::c_3;
+    bool first_block = true;
+
     for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
         for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            if (!first_block) {
+                cb_wait_front(sync_cb, 1);
+                cb_pop_front(sync_cb, 1);
+            }
+            first_block = false;
+
             for (uint32_t blk = 0; blk < num_blocks; blk++) {
                 cb_reserve_back(cb_id, block_size);
 

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver_writer.cpp
@@ -65,6 +65,9 @@ void kernel_main() {
     constexpr uint32_t num_blocks = num_tiles / block_size;
     constexpr uint32_t N_block = M_block;
 
+    constexpr uint32_t sync_cb = tt::CBIndex::c_3;
+    bool first_block = true;
+
     for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
         uint32_t M_start = m_sub * M_block;
         uint32_t current_M_block = (M_block < Mpc - M_start) ? M_block : (Mpc - M_start);
@@ -73,6 +76,12 @@ void kernel_main() {
             uint32_t N_start = n_sub * N_block;
             uint32_t current_N = (N_block < Mpc - N_start) ? N_block : (Mpc - N_start);
             uint32_t block_tiles = current_M_block * current_N;
+
+            if (!first_block) {
+                cb_wait_front(sync_cb, 1);
+                cb_pop_front(sync_cb, 1);
+            }
+            first_block = false;
 
             // --- Receive K-blocks via multicast ---
             for (uint32_t blk = 0; blk < num_blocks; blk++) {

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_receiver_writer.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multicast receiver + output writer — runs on RISCV_0 (row direction) or RISCV_1 (col edge).
+// Receives multicast K-blocks, then per (m_sub, n_sub) handles output:
+//   REDUCE_SEND:  NOC-writes compute partial to partner's reduce CB.
+//   REDUCE_RECV:  waits for partner's partial, then writes combined output to DRAM.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t tile_size = get_compile_time_arg_val(1);
+    uint32_t sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(2));
+    uint32_t receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
+    constexpr uint32_t cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t block_size = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(6);
+    constexpr uint32_t out_tile_size = get_compile_time_arg_val(7);
+    constexpr uint32_t Mpc = get_compile_time_arg_val(8);
+
+#ifdef REDUCE_SEND
+    constexpr uint32_t reduce_cb = get_compile_time_arg_val(9);
+    uint32_t reduce_sem_addr = get_semaphore(get_compile_time_arg_val(10));
+    constexpr uint32_t num_m_blocks = get_compile_time_arg_val(11);
+    constexpr uint32_t M_block = get_compile_time_arg_val(12);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(13);
+#else  // REDUCE_RECV
+    constexpr uint32_t padded_out_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t reduce_cb = get_compile_time_arg_val(10);
+    uint32_t reduce_sem_addr = get_semaphore(get_compile_time_arg_val(11));
+    constexpr uint32_t num_m_blocks = get_compile_time_arg_val(12);
+    constexpr uint32_t M_block = get_compile_time_arg_val(13);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(14);
+    constexpr auto out_tensor_args = TensorAccessorArgs<15>();
+#endif
+
+    uint32_t argidx = 0;
+    const uint32_t sender_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t sender_noc_y = get_arg_val<uint32_t>(argidx++);
+
+#ifdef REDUCE_SEND
+    const uint32_t partner_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t partner_noc_y = get_arg_val<uint32_t>(argidx++);
+#else  // REDUCE_RECV
+    const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t logical_M_tiles = get_arg_val<uint32_t>(argidx++);
+#ifdef MIRROR_OUTPUT
+    const uint32_t mirror_M_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mirror_N_start_tile = get_arg_val<uint32_t>(argidx++);
+    constexpr uint32_t mirror_cb = tt::CBIndex::c_4;
+#endif
+#endif
+
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);
+
+    const uint64_t sender_sem_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_semaphore_addr);
+
+    constexpr uint32_t num_blocks = num_tiles / block_size;
+    constexpr uint32_t N_block = M_block;
+
+    for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
+        uint32_t M_start = m_sub * M_block;
+        uint32_t current_M_block = (M_block < Mpc - M_start) ? M_block : (Mpc - M_start);
+
+        for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            uint32_t N_start = n_sub * N_block;
+            uint32_t current_N = (N_block < Mpc - N_start) ? N_block : (Mpc - N_start);
+            uint32_t block_tiles = current_M_block * current_N;
+
+            // --- Receive K-blocks via multicast ---
+            for (uint32_t blk = 0; blk < num_blocks; blk++) {
+                cb_reserve_back(cb_id, block_size);
+                noc_semaphore_set(receiver_sem_ptr, INVALID);
+                noc_semaphore_inc(sender_sem_noc_addr, 1);
+                noc_semaphore_wait(receiver_sem_ptr, VALID);
+                cb_push_back(cb_id, block_size);
+            }
+
+            // --- Output / reduce ---
+#ifdef REDUCE_SEND
+            {
+                uint32_t partner_reduce_addr = get_write_ptr(reduce_cb);
+                uint64_t partner_noc_addr = get_noc_addr(partner_noc_x, partner_noc_y, partner_reduce_addr);
+                uint64_t partner_sem_noc = get_noc_addr(partner_noc_x, partner_noc_y, reduce_sem_addr);
+
+                cb_wait_front(cb_out, block_tiles);
+                uint32_t l1_addr = get_read_ptr(cb_out);
+                noc_async_write(l1_addr, partner_noc_addr, block_tiles * out_tile_size);
+                noc_async_write_barrier();
+                noc_semaphore_inc(partner_sem_noc, 1);
+                cb_pop_front(cb_out, block_tiles);
+            }
+#else  // REDUCE_RECV
+            {
+                volatile tt_l1_ptr uint32_t* reduce_sem_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sem_addr);
+                cb_reserve_back(reduce_cb, block_tiles);
+                noc_semaphore_wait(reduce_sem_ptr, 1);
+                noc_semaphore_set(reduce_sem_ptr, 0);
+                cb_push_back(reduce_cb, block_tiles);
+            }
+            {
+                const auto out_writer = TensorAccessor(out_tensor_args, out_addr, out_tile_size);
+
+                for (uint32_t m = 0; m < current_M_block; m++) {
+                    cb_wait_front(cb_out, current_N);
+                    uint32_t l1_read_addr = get_read_ptr(cb_out);
+                    uint32_t row = M_start_tile + M_start + m;
+                    for (uint32_t n = 0; n < current_N; n++) {
+                        uint32_t col = N_start_tile + N_start + n;
+                        if (row < logical_M_tiles && col < logical_M_tiles) {
+                            uint32_t tile_id = row * padded_out_tiles + col;
+                            noc_async_write_tile(tile_id, out_writer, l1_read_addr + n * out_tile_size);
+                        }
+                    }
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_out, current_N);
+                }
+#ifdef MIRROR_OUTPUT
+                for (uint32_t n = 0; n < current_N; n++) {
+                    cb_wait_front(mirror_cb, current_M_block);
+                    uint32_t l1_read_addr = get_read_ptr(mirror_cb);
+                    uint32_t col = mirror_N_start_tile + N_start + n;
+                    for (uint32_t m = 0; m < current_M_block; m++) {
+                        uint32_t row = mirror_M_start_tile + M_start + m;
+                        if (row < logical_M_tiles && col < logical_M_tiles) {
+                            uint32_t tile_id = row * padded_out_tiles + col;
+                            noc_async_write_tile(tile_id, out_writer, l1_read_addr + m * out_tile_size);
+                        }
+                    }
+                    noc_async_write_barrier();
+                    cb_pop_front(mirror_cb, current_M_block);
+                }
+#endif
+            }
+#endif
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_sender.cpp
@@ -85,8 +85,18 @@ void kernel_main() {
 
     uint32_t recv_cb_base = get_write_ptr(cb_id);
 
+    constexpr uint32_t sync_cb = tt::CBIndex::c_3;
+    bool first_block = true;
+
     for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
         for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            // Wait for compute to finish previous block's reduce before pushing new K-blocks
+            if (!first_block) {
+                cb_wait_front(sync_cb, 1);
+                cb_pop_front(sync_cb, 1);
+            }
+            first_block = false;
+
             // Row sender (c_0): reads rows m_sub*M_block+m; col sender (c_1): reads rows n_sub*N_block+n
             uint32_t row_base = (cb_id == 0) ? m_sub * rows_per_block : n_sub * rows_per_block;
 

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_sender.cpp
@@ -120,7 +120,7 @@ void kernel_main() {
                             uint32_t dram_tile = global_row * logical_K_tiles + k_col;
                             noc_async_read_tile(dram_tile, reader, base_addr + cb_offset);
                         } else {
-                            fill_tile_zeros(base_addr + cb_offset, tile_size);
+                            fill_zeros_async(base_addr + cb_offset, tile_size);
                         }
                     }
                 }

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/device/kernels/mcast_sender.cpp
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multicast sender — runs on RISCV_0 (row senders) or RISCV_1 (col senders).
+// Reads input tiles from DRAM and multicasts to receiver cores.
+// Row senders (c_0): RISCV_0/NOC_0, read M_block rows indexed by m_sub.
+// Col senders (c_1): RISCV_1/NOC_1, read N_block rows indexed by n_sub.
+// Even K-columns → lower/diag, odd K-columns → upper. One handshake per K-block batch.
+// Pushes own-parity blocks to local CB before multicast (critical for avoiding deadlock).
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t tile_size = get_compile_time_arg_val(1);
+    uint32_t sender_sem_addr = get_semaphore(get_compile_time_arg_val(2));
+    uint32_t receiver_sem_addr = get_semaphore(get_compile_time_arg_val(3));
+    uint32_t sender_sem2_addr = get_semaphore(get_compile_time_arg_val(4));
+    uint32_t receiver_sem2_addr = get_semaphore(get_compile_time_arg_val(5));
+    constexpr uint32_t cb_id = get_compile_time_arg_val(6);
+    constexpr uint32_t block_size = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_size_tiles = get_compile_time_arg_val(8);
+
+#ifdef SENDER_REDUCE_SEND
+    constexpr uint32_t cb_out = get_compile_time_arg_val(9);
+    constexpr uint32_t out_tile_size = get_compile_time_arg_val(10);
+    constexpr uint32_t reduce_cb = get_compile_time_arg_val(11);
+    uint32_t reduce_sem_addr = get_semaphore(get_compile_time_arg_val(12));
+    constexpr uint32_t num_m_blocks = get_compile_time_arg_val(13);
+    constexpr uint32_t M_block = get_compile_time_arg_val(14);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(15);
+    constexpr auto tensor_args = TensorAccessorArgs<16>();
+#else
+    constexpr uint32_t num_m_blocks = get_compile_time_arg_val(9);
+    constexpr uint32_t num_n_blocks = get_compile_time_arg_val(10);
+    constexpr auto tensor_args = TensorAccessorArgs<11>();
+#endif
+
+    uint32_t argidx = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t lower_noc_x_start = get_arg_val<uint32_t>(argidx++);
+    const uint32_t lower_noc_y_start = get_arg_val<uint32_t>(argidx++);
+    const uint32_t lower_noc_x_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t lower_noc_y_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t lower_num_dests = get_arg_val<uint32_t>(argidx++);
+    const uint32_t upper_noc_x_start = get_arg_val<uint32_t>(argidx++);
+    const uint32_t upper_noc_y_start = get_arg_val<uint32_t>(argidx++);
+    const uint32_t upper_noc_x_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t upper_noc_y_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t upper_num_dests = get_arg_val<uint32_t>(argidx++);
+    const uint32_t injector_keeps_odd = get_arg_val<uint32_t>(argidx++);
+    const uint32_t lower_loopback = get_arg_val<uint32_t>(argidx++);
+    const uint32_t tile_offset = get_arg_val<uint32_t>(argidx++);
+    const uint32_t Mpc = get_arg_val<uint32_t>(argidx++);
+    const uint32_t K_tiles = get_arg_val<uint32_t>(argidx++);  // padded K for loop structure
+    const uint32_t logical_M_tiles = get_arg_val<uint32_t>(argidx++);
+    const uint32_t logical_K_tiles = get_arg_val<uint32_t>(argidx++);
+
+#ifdef SENDER_REDUCE_SEND
+    const uint32_t partner_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t partner_noc_y = get_arg_val<uint32_t>(argidx++);
+#endif
+
+    volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
+    volatile tt_l1_ptr uint32_t* sender_sem2_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem2_addr);
+
+    *(receiver_sem_ptr) = VALID;
+    volatile tt_l1_ptr uint32_t* receiver_sem2_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem2_addr);
+    *(receiver_sem2_ptr) = VALID;
+
+    const auto reader = TensorAccessor(tensor_args, src_addr, tile_size);
+
+    constexpr uint32_t block_bytes = block_size * tile_size;
+    constexpr uint32_t num_blocks = num_tiles / block_size;
+    constexpr uint32_t cb_capacity_bytes = cb_size_tiles * tile_size;
+
+    // M_block = num_tiles / K_tiles, K_block_tiles = block_size / M_block
+    uint32_t rows_per_block = num_tiles / K_tiles;
+    uint32_t K_block_tiles = block_size / rows_per_block;
+
+    uint32_t recv_cb_base = get_write_ptr(cb_id);
+
+    for (uint32_t m_sub = 0; m_sub < num_m_blocks; m_sub++) {
+        for (uint32_t n_sub = 0; n_sub < num_n_blocks; n_sub++) {
+            // Row sender (c_0): reads rows m_sub*M_block+m; col sender (c_1): reads rows n_sub*N_block+n
+            uint32_t row_base = (cb_id == 0) ? m_sub * rows_per_block : n_sub * rows_per_block;
+
+            uint32_t lower_recv_offset = 0;
+            uint32_t upper_recv_offset = 0;
+
+            for (uint32_t blk = 0; blk < num_blocks; blk++) {
+                bool is_lower_block = (blk % 2 == 0);
+
+                uint32_t batch_idx = blk / 2;
+                uint32_t first_k_col = batch_idx * K_block_tiles * 2 + (is_lower_block ? 0 : 1);
+
+                cb_reserve_back(cb_id, block_size);
+                uint32_t base_addr = get_write_ptr(cb_id);
+                for (uint32_t kb = 0; kb < K_block_tiles; kb++) {
+                    uint32_t k_col = first_k_col + kb * 2;
+                    for (uint32_t m = 0; m < rows_per_block; m++) {
+                        uint32_t cb_offset = (kb * rows_per_block + m) * tile_size;
+                        uint32_t global_row = tile_offset + row_base + m;
+                        if (global_row < logical_M_tiles && k_col < logical_K_tiles) {
+                            uint32_t dram_tile = global_row * logical_K_tiles + k_col;
+                            noc_async_read_tile(dram_tile, reader, base_addr + cb_offset);
+                        } else {
+                            fill_tile_zeros(base_addr + cb_offset, tile_size);
+                        }
+                    }
+                }
+                noc_async_read_barrier();
+
+                // Push to own CB before multicast — critical to let compute start
+                // while we wait for the multicast handshake
+                bool is_own = (is_lower_block != (bool)injector_keeps_odd);
+                if (is_own) {
+                    cb_push_back(cb_id, block_size);
+                }
+
+                uint32_t recv_dst;
+
+                if (is_lower_block && lower_num_dests > 0) {
+                    recv_dst = recv_cb_base + lower_recv_offset;
+
+                    if (lower_loopback && lower_num_dests == 1) {
+                        if (base_addr != recv_dst) {
+                            noc_async_write(base_addr, get_noc_addr(my_x[0], my_y[0], recv_dst), block_bytes);
+                            noc_async_write_barrier();
+                        }
+                    } else if (lower_loopback) {
+                        noc_semaphore_wait(sender_sem_ptr, lower_num_dests - 1);
+                        noc_semaphore_set(sender_sem_ptr, 0);
+
+                        uint64_t mcast_addr = get_noc_multicast_addr(
+                            lower_noc_x_start, lower_noc_y_start, lower_noc_x_end, lower_noc_y_end, recv_dst);
+                        noc_async_write_multicast_loopback_src(base_addr, mcast_addr, block_bytes, lower_num_dests);
+
+                        uint64_t sem_mcast_addr = get_noc_multicast_addr(
+                            lower_noc_x_start, lower_noc_y_start, lower_noc_x_end, lower_noc_y_end, receiver_sem_addr);
+#ifdef ARCH_BLACKHOLE
+                        noc_async_writes_flushed();
+#endif
+                        noc_semaphore_set_multicast_loopback_src(receiver_sem_addr, sem_mcast_addr, lower_num_dests);
+
+                        noc_semaphore_wait(receiver_sem_ptr, VALID);
+                        noc_semaphore_set(receiver_sem_ptr, INVALID);
+                    } else {
+                        noc_semaphore_wait(sender_sem_ptr, lower_num_dests);
+                        noc_semaphore_set(sender_sem_ptr, 0);
+
+                        uint64_t mcast_addr = get_noc_multicast_addr(
+                            lower_noc_x_start, lower_noc_y_start, lower_noc_x_end, lower_noc_y_end, recv_dst);
+                        noc_async_write_multicast(base_addr, mcast_addr, block_bytes, lower_num_dests);
+
+                        uint64_t sem_mcast_addr = get_noc_multicast_addr(
+                            lower_noc_x_start, lower_noc_y_start, lower_noc_x_end, lower_noc_y_end, receiver_sem_addr);
+#ifdef ARCH_BLACKHOLE
+                        noc_async_writes_flushed();
+#endif
+                        noc_semaphore_set_multicast(receiver_sem_addr, sem_mcast_addr, lower_num_dests);
+                    }
+
+                    lower_recv_offset += block_bytes;
+                    if (lower_recv_offset >= cb_capacity_bytes)
+                        lower_recv_offset = 0;
+                }
+
+                if (!is_lower_block && upper_num_dests > 0) {
+                    recv_dst = recv_cb_base + upper_recv_offset;
+
+                    noc_semaphore_wait(sender_sem2_ptr, upper_num_dests);
+                    noc_semaphore_set(sender_sem2_ptr, 0);
+
+                    uint64_t mcast_addr = get_noc_multicast_addr(
+                        upper_noc_x_start, upper_noc_y_start, upper_noc_x_end, upper_noc_y_end, recv_dst);
+                    noc_async_write_multicast(base_addr, mcast_addr, block_bytes, upper_num_dests);
+
+                    uint64_t sem_mcast_addr = get_noc_multicast_addr(
+                        upper_noc_x_start, upper_noc_y_start, upper_noc_x_end, upper_noc_y_end, receiver_sem2_addr);
+#ifdef ARCH_BLACKHOLE
+                    noc_async_writes_flushed();
+#endif
+                    noc_semaphore_set_multicast(receiver_sem2_addr, sem_mcast_addr, upper_num_dests);
+
+                    upper_recv_offset += block_bytes;
+                    if (upper_recv_offset >= cb_capacity_bytes)
+                        upper_recv_offset = 0;
+                }
+            }
+
+            noc_async_write_barrier();
+            noc_async_atomic_barrier();
+
+#ifdef SENDER_REDUCE_SEND
+            {
+                uint32_t M_start = m_sub * rows_per_block;
+                uint32_t current_M_block = (rows_per_block < Mpc - M_start) ? rows_per_block : (Mpc - M_start);
+                uint32_t N_start = n_sub * rows_per_block;
+                uint32_t current_N = (rows_per_block < Mpc - N_start) ? rows_per_block : (Mpc - N_start);
+                uint32_t block_tiles = current_M_block * current_N;
+
+                uint32_t partner_reduce_addr = get_write_ptr(reduce_cb);
+                uint64_t partner_sem_noc = get_noc_addr(partner_noc_x, partner_noc_y, reduce_sem_addr);
+
+                cb_wait_front(cb_out, block_tiles);
+                uint32_t l1_read_addr = get_read_ptr(cb_out);
+                uint64_t partner_noc_addr = get_noc_addr(partner_noc_x, partner_noc_y, partner_reduce_addr);
+                noc_async_write(l1_read_addr, partner_noc_addr, block_tiles * out_tile_size);
+                noc_async_write_barrier();
+                noc_semaphore_inc(partner_sem_noc, 1);
+                cb_pop_front(cb_out, block_tiles);
+            }
+#endif
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
@@ -11,14 +11,16 @@
 namespace ttml::metal {
 
 ttnn::Tensor gram_polynomial(
-    const ttnn::Tensor& input,
+    const ttnn::Tensor& G,
+    float b,
+    float c,
     OutputMode output_mode,
     MathFidelity math_fidelity,
     const std::optional<ttnn::Tensor>& preallocated_output) {
     using namespace ops::gram_polynomial::device;
-    operation_attributes_t attrs{.output_mode = output_mode, .math_fidelity = math_fidelity};
+    operation_attributes_t attrs{.b = b, .c = c, .output_mode = output_mode, .math_fidelity = math_fidelity};
     return ttnn::device_operation::launch<GramPolynomialDeviceOperation>(
-        attrs, tensor_args_t{.input_tensor = input, .preallocated_output = preallocated_output});
+        attrs, tensor_args_t{.input_tensor = G, .preallocated_output = preallocated_output});
 }
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gram_polynomial.hpp"
+
+#include <ttnn/device_operation.hpp>
+
+#include "device/gram_polynomial_device_operation.hpp"
+
+namespace ttml::metal {
+
+ttnn::Tensor gram_polynomial(
+    const ttnn::Tensor& input,
+    OutputMode output_mode,
+    MathFidelity math_fidelity,
+    const std::optional<ttnn::Tensor>& preallocated_output) {
+    using namespace ops::gram_polynomial::device;
+    operation_attributes_t attrs{.output_mode = output_mode, .math_fidelity = math_fidelity};
+    return ttnn::device_operation::launch<GramPolynomialDeviceOperation>(
+        attrs, tensor_args_t{.input_tensor = input, .preallocated_output = preallocated_output});
+}
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
@@ -5,6 +5,7 @@
 #include "gram_polynomial.hpp"
 
 #include <ttnn/device_operation.hpp>
+#include <ttnn/operations/eltwise/binary/binary.hpp>
 
 #include "device/gram_polynomial_device_operation.hpp"
 
@@ -18,9 +19,17 @@ ttnn::Tensor gram_polynomial(
     MathFidelity math_fidelity,
     const std::optional<ttnn::Tensor>& preallocated_output) {
     using namespace ops::gram_polynomial::device;
+    // Kernel computes G² + (b/c)*G (unscaled). Host applies c scaling after.
+    // This avoids SFPU overhead in the kernel that causes either:
+    //   - 80% slowdown (scaling in K-loop stalls FPU pipeline), or
+    //   - subs>1 deadlock (scaling in reduce phase blocks K-delivery)
     operation_attributes_t attrs{.b = b, .c = c, .output_mode = output_mode, .math_fidelity = math_fidelity};
-    return ttnn::device_operation::launch<GramPolynomialDeviceOperation>(
+    auto result = ttnn::device_operation::launch<GramPolynomialDeviceOperation>(
         attrs, tensor_args_t{.input_tensor = G, .preallocated_output = preallocated_output});
+    if (c != 1.0f) {
+        result = ttnn::multiply(result, c);
+    }
+    return result;
 }
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.cpp
@@ -19,17 +19,9 @@ ttnn::Tensor gram_polynomial(
     MathFidelity math_fidelity,
     const std::optional<ttnn::Tensor>& preallocated_output) {
     using namespace ops::gram_polynomial::device;
-    // Kernel computes G² + (b/c)*G (unscaled). Host applies c scaling after.
-    // This avoids SFPU overhead in the kernel that causes either:
-    //   - 80% slowdown (scaling in K-loop stalls FPU pipeline), or
-    //   - subs>1 deadlock (scaling in reduce phase blocks K-delivery)
     operation_attributes_t attrs{.b = b, .c = c, .output_mode = output_mode, .math_fidelity = math_fidelity};
-    auto result = ttnn::device_operation::launch<GramPolynomialDeviceOperation>(
+    return ttnn::device_operation::launch<GramPolynomialDeviceOperation>(
         attrs, tensor_args_t{.input_tensor = G, .preallocated_output = preallocated_output});
-    if (c != 1.0f) {
-        result = ttnn::multiply(result, c);
-    }
-    return result;
 }
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.hpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.hpp
@@ -11,13 +11,15 @@
 
 namespace ttml::metal {
 
-// Compute G = X @ X^T using interleaved K-split multicast gram matmul.
-// Exploits symmetry: lower triangle computes even-K, upper computes odd-K, results are accumulated.
-// Uses min(device_grid.x - 1, device_grid.y) core grid + column of diagonal helper cores.
+// Compute bG + cG² for symmetric G using interleaved K-split multicast.
+// G must be square [M, M] with even M (in tiles). Output is symmetric [M, M].
+// Exploits symmetry: lower triangle computes even-K partial, upper computes odd-K, then reduce.
 //
-// output_mode: UpperTriangle writes G[i,j] for i<=j. Full also writes transposed mirror G[j,i].
+// output_mode: UpperTriangle writes result[i,j] for i<=j. Full also writes transposed mirror.
 ttnn::Tensor gram_polynomial(
-    const ttnn::Tensor& input,
+    const ttnn::Tensor& G,
+    float b,
+    float c,
     OutputMode output_mode = OutputMode::UpperTriangle,
     MathFidelity math_fidelity = MathFidelity::HiFi4,
     const std::optional<ttnn::Tensor>& preallocated_output = std::nullopt);

--- a/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.hpp
+++ b/tt-train/sources/ttml/metal/ops/gram_polynomial/gram_polynomial.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/base_types.hpp>
+#include <ttnn/tensor/tensor.hpp>
+
+#include "metal/common/const_utils.hpp"
+
+namespace ttml::metal {
+
+// Compute G = X @ X^T using interleaved K-split multicast gram matmul.
+// Exploits symmetry: lower triangle computes even-K, upper computes odd-K, results are accumulated.
+// Uses min(device_grid.x - 1, device_grid.y) core grid + column of diagonal helper cores.
+//
+// output_mode: UpperTriangle writes G[i,j] for i<=j. Full also writes transposed mirror G[j,i].
+ttnn::Tensor gram_polynomial(
+    const ttnn::Tensor& input,
+    OutputMode output_mode = OutputMode::UpperTriangle,
+    MathFidelity math_fidelity = MathFidelity::HiFi4,
+    const std::optional<ttnn::Tensor>& preallocated_output = std::nullopt);
+
+}  // namespace ttml::metal

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -176,6 +176,7 @@ if(TARGET benchmark::benchmark)
         benchmark/adamw_benchmark.cpp
         benchmark/frobenius_normalize_benchmark.cpp
         benchmark/polynorm_fusion_benchmark.cpp
+        benchmark/gram_polynomial_benchmark.cpp
     )
 
     foreach(BENCH_SRC ${BENCHMARK_SOURCES})

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     optimizers/muon_composite_test.cpp
     ops/newton_schulz_op_test.cpp
     ops/frobenius_normalize_test.cpp
+    ops/gram_polynomial_op_test.cpp
     optimizers/adamw_full_precision_test.cpp
     optimizers/no_op_test.cpp
     modules/distributed/linear_test.cpp

--- a/tt-train/tests/benchmark/gram_polynomial_benchmark.cpp
+++ b/tt-train/tests/benchmark/gram_polynomial_benchmark.cpp
@@ -32,10 +32,13 @@ const int num_iters = 10;
 const float b = -4.775f;
 const float c = 2.0315f;
 
+// NS sees G of size [min(rows, cols), min(rows, cols)] after transpose-if-tall.
+// TinyLlama [5632,2048] and [2048,2048] → G = 2048².
+// Llama 70B [28672,8192] and [8192,8192] → G = 8192².
 const std::vector<Shape> shapes = {
-    {2048, "2048"},
+    {2048, "2048 (TinyLlama)"},
     {4096, "4096"},
-    {8192, "8192"},
+    {8192, "8192 (Llama 70B)"},
 };
 
 ttnn::Tensor make_random_tensor(uint32_t M, ttnn::distributed::MeshDevice* device, uint32_t seed) {
@@ -128,15 +131,15 @@ void BM_GramPolynomial(benchmark::State& state) {
 
     // Print results table
     std::cout << "\n  b=" << b << ", c=" << c << "\n";
-    std::cout << "  ┌───────┬──────────────────┬──────────────────┬─────────────┐\n";
-    std::cout << "  │ Shape │ gram_polynomial  │ composite (ttnn) │ speedup     │\n";
-    std::cout << "  ├───────┼──────────────────┼──────────────────┼─────────────┤\n";
+    std::cout << "  ┌──────────────────┬──────────────────┬──────────────────┬─────────────┐\n";
+    std::cout << "  │ Shape            │ gram_polynomial  │ composite (ttnn) │ speedup     │\n";
+    std::cout << "  ├──────────────────┼──────────────────┼──────────────────┼─────────────┤\n";
     for (const auto& r : results) {
         char line[256];
         std::snprintf(
             line,
             sizeof(line),
-            "  │ %5s │ %6.0f us %3.0f TF │ %6.0f us %3.0f TF │      %5.2fx │",
+            "  │ %-16s │ %6.0f us %3.0f TF │ %6.0f us %3.0f TF │      %5.2fx │",
             r.name.c_str(),
             r.fused_us,
             r.fused_tf,
@@ -145,7 +148,7 @@ void BM_GramPolynomial(benchmark::State& state) {
             r.composite_us / r.fused_us);
         std::cout << line << "\n";
     }
-    std::cout << "  └───────┴──────────────────┴──────────────────┴─────────────┘\n";
+    std::cout << "  └──────────────────┴──────────────────┴──────────────────┴─────────────┘\n";
     std::cout << std::flush;
 
     state.SetIterationTime(results.back().fused_us * 1e-6);

--- a/tt-train/tests/benchmark/gram_polynomial_benchmark.cpp
+++ b/tt-train/tests/benchmark/gram_polynomial_benchmark.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <benchmark/benchmark.h>
+
+#include <chrono>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "core/compute_kernel_config.hpp"
+#include "core/random.hpp"
+#include "metal/operations.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+
+namespace {
+
+struct Shape {
+    uint32_t M;
+    std::string name;
+};
+
+const int num_warmup = 3;
+const int num_iters = 10;
+
+const float b = -4.775f;
+const float c = 2.0315f;
+
+const std::vector<Shape> shapes = {
+    {2048, "2048"},
+    {4096, "4096"},
+    {8192, "8192"},
+};
+
+ttnn::Tensor make_random_tensor(uint32_t M, ttnn::distributed::MeshDevice* device, uint32_t seed) {
+    std::vector<float> data(M * M);
+    ttml::core::parallel_generate(
+        std::span{data.data(), data.size()}, []() { return std::uniform_real_distribution<float>(-1.0f, 1.0f); }, seed);
+    auto shape = ttnn::Shape({1, 1, M, M});
+    return ttnn::Tensor::from_vector(
+        data,
+        ttnn::TensorSpec(
+            shape,
+            tt::tt_metal::TensorLayout(ttnn::DataType::BFLOAT16, tt::tt_metal::Layout::TILE, ttnn::DRAM_MEMORY_CONFIG)),
+        device);
+}
+
+double bench_op(auto fn, ttnn::distributed::MeshDevice* device) {
+    for (int i = 0; i < num_warmup; ++i) {
+        fn();
+        tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+    }
+    auto t0 = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < num_iters; ++i) {
+        fn();
+        tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+    }
+    auto t1 = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double, std::micro>(t1 - t0).count() / num_iters;
+}
+
+void BM_GramPolynomial(benchmark::State& state) {
+    auto device = ttnn::device::open_mesh_device(0);
+    device->enable_program_cache();
+
+    auto compute_kernel_config = ttml::core::ComputeKernelConfig::matmul();
+    auto device_grid = device->compute_with_storage_grid_size();
+    auto core_grid = std::make_optional<ttnn::CoreGrid>(device_grid.x, device_grid.y);
+
+    struct Result {
+        std::string name;
+        double fused_us, composite_us;
+        double fused_tf, composite_tf;
+    };
+    std::vector<Result> results;
+
+    for (const auto& s : shapes) {
+        const uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(s.name));
+        auto G = make_random_tensor(s.M, device.get(), seed);
+        auto G_t = ttnn::transpose(G, -2, -1);
+
+        double flops = 2.0 * s.M * s.M * s.M;
+        auto tflops = [&](double us) { return flops / (us * 1e-6) / 1e12; };
+
+        double fused_us = bench_op(
+            [&]() {
+                auto out = ttml::metal::gram_polynomial(G, b, c);
+                out.deallocate();
+            },
+            device.get());
+
+        // Composite: c * ttnn::matmul(G, G^T) + b * G
+        double composite_us = bench_op(
+            [&]() {
+                auto g2 = ttnn::matmul(
+                    G,
+                    G_t,
+                    false,
+                    false,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    compute_kernel_config,
+                    core_grid,
+                    std::nullopt);
+                auto cg2 = ttnn::multiply(g2, c);
+                g2.deallocate();
+                auto bg = ttnn::multiply(G, b);
+                auto out = ttnn::add(cg2, bg);
+                cg2.deallocate();
+                bg.deallocate();
+                out.deallocate();
+            },
+            device.get());
+
+        results.push_back({s.name, fused_us, composite_us, tflops(fused_us), tflops(composite_us)});
+
+        G.deallocate();
+        G_t.deallocate();
+    }
+
+    // Print results table
+    std::cout << "\n  b=" << b << ", c=" << c << "\n";
+    std::cout << "  ┌───────┬──────────────────┬──────────────────┬─────────────┐\n";
+    std::cout << "  │ Shape │ gram_polynomial  │ composite (ttnn) │ speedup     │\n";
+    std::cout << "  ├───────┼──────────────────┼──────────────────┼─────────────┤\n";
+    for (const auto& r : results) {
+        char line[256];
+        std::snprintf(
+            line,
+            sizeof(line),
+            "  │ %5s │ %6.0f us %3.0f TF │ %6.0f us %3.0f TF │      %5.2fx │",
+            r.name.c_str(),
+            r.fused_us,
+            r.fused_tf,
+            r.composite_us,
+            r.composite_tf,
+            r.composite_us / r.fused_us);
+        std::cout << line << "\n";
+    }
+    std::cout << "  └───────┴──────────────────┴──────────────────┴─────────────┘\n";
+    std::cout << std::flush;
+
+    state.SetIterationTime(results.back().fused_us * 1e-6);
+
+    device->close();
+}
+
+}  // namespace
+
+BENCHMARK(BM_GramPolynomial)->Unit(benchmark::kMillisecond)->UseManualTime()->Iterations(1)->Name("GramPolynomial");
+
+BENCHMARK_MAIN();

--- a/tt-train/tests/ops/gram_polynomial_op_test.cpp
+++ b/tt-train/tests/ops/gram_polynomial_op_test.cpp
@@ -123,3 +123,44 @@ TEST_F(GramPolynomialTest, ScaledGSquared_2048x2048) {
     dev = extract_output_tile(out_vec, W, 0, 0);
     check_tile(ref, dev, "cG²[0,0] diagonal", c);
 }
+
+// Phase 3: bG + cG² (Muon coefficients)
+TEST_F(GramPolynomialTest, BgPlusCgSquared_2048x2048) {
+    auto G = make_random_tensor(2048);
+    constexpr float b = -4.775f;
+    constexpr float c = 2.0315f;
+    auto output = ttml::metal::gram_polynomial(G, b, c, ttml::metal::OutputMode::Full);
+    tt::tt_metal::distributed::Synchronize(&ttml::autograd::ctx().get_device(), std::nullopt);
+
+    auto g_vec = G.to_vector<float>();
+    auto out_vec = output.to_vector<float>();
+    uint32_t M = G.logical_shape()[-1];
+    uint32_t W = output.logical_shape()[-1];
+
+    // CPU reference: bG + c*(G@G), tile [2,5]
+    auto g_tile = extract_output_tile(g_vec, M, 2, 5);
+    auto g2_tile = compute_g_squared_tile(g_vec, M, 2, 5);
+    std::vector<float> ref(32 * 32);
+    for (size_t i = 0; i < ref.size(); i++) ref[i] = b * g_tile[i] + c * g2_tile[i];
+    auto dev = extract_output_tile(out_vec, W, 2, 5);
+    // Debug: check if bG is applied by comparing against cG² only
+    auto cg2_ref = compute_g_squared_tile(g_vec, M, 2, 5);
+    for (auto& v : cg2_ref) v *= c;
+    float diff_vs_cg2 = 0, diff_vs_full = 0;
+    for (size_t i = 0; i < ref.size(); i++) {
+        diff_vs_cg2 = std::max(diff_vs_cg2, std::abs(dev[i] - cg2_ref[i]));
+        diff_vs_full = std::max(diff_vs_full, std::abs(dev[i] - ref[i]));
+    }
+    std::cout << "  dev vs cG²_only max_abs=" << diff_vs_cg2 << " (should be large if bG applied)\n";
+    std::cout << "  dev vs bG+cG² max_abs=" << diff_vs_full << " (should be small)\n";
+    std::cout << "  ref[0]=" << ref[0] << " dev[0]=" << dev[0] << " cg2[0]=" << cg2_ref[0] << "\n";
+    float max_scale = std::max(std::abs(b), std::abs(c));
+    check_tile(ref, dev, "bG+cG²[2,5] off-diagonal", max_scale);
+
+    // Diagonal tile [0,0]
+    g_tile = extract_output_tile(g_vec, M, 0, 0);
+    g2_tile = compute_g_squared_tile(g_vec, M, 0, 0);
+    for (size_t i = 0; i < ref.size(); i++) ref[i] = b * g_tile[i] + c * g2_tile[i];
+    dev = extract_output_tile(out_vec, W, 0, 0);
+    check_tile(ref, dev, "bG+cG²[0,0] diagonal", max_scale);
+}

--- a/tt-train/tests/ops/gram_polynomial_op_test.cpp
+++ b/tt-train/tests/ops/gram_polynomial_op_test.cpp
@@ -127,8 +127,8 @@ TEST_F(GramPolynomialTest, ScaledGSquared_2048x2048) {
 // Phase 3: bG + cG² (Muon coefficients)
 TEST_F(GramPolynomialTest, BgPlusCgSquared_2048x2048) {
     auto G = make_random_tensor(2048);
-    constexpr float b = 1000.0f;  // DEBUG: large b to check if bG is applied
-    constexpr float c = 1.0f;
+    constexpr float b = -4.775f;
+    constexpr float c = 2.0315f;
     auto output = ttml::metal::gram_polynomial(G, b, c, ttml::metal::OutputMode::Full);
     tt::tt_metal::distributed::Synchronize(&ttml::autograd::ctx().get_device(), std::nullopt);
 
@@ -143,17 +143,6 @@ TEST_F(GramPolynomialTest, BgPlusCgSquared_2048x2048) {
     std::vector<float> ref(32 * 32);
     for (size_t i = 0; i < ref.size(); i++) ref[i] = b * g_tile[i] + c * g2_tile[i];
     auto dev = extract_output_tile(out_vec, W, 2, 5);
-    // Debug: check if bG is applied by comparing against cG² only
-    auto cg2_ref = compute_g_squared_tile(g_vec, M, 2, 5);
-    for (auto& v : cg2_ref) v *= c;
-    float diff_vs_cg2 = 0, diff_vs_full = 0;
-    for (size_t i = 0; i < ref.size(); i++) {
-        diff_vs_cg2 = std::max(diff_vs_cg2, std::abs(dev[i] - cg2_ref[i]));
-        diff_vs_full = std::max(diff_vs_full, std::abs(dev[i] - ref[i]));
-    }
-    std::cout << "  dev vs cG²_only max_abs=" << diff_vs_cg2 << " (should be large if bG applied)\n";
-    std::cout << "  dev vs bG+cG² max_abs=" << diff_vs_full << " (should be small)\n";
-    std::cout << "  ref[0]=" << ref[0] << " dev[0]=" << dev[0] << " cg2[0]=" << cg2_ref[0] << "\n";
     float max_scale = std::max(std::abs(b), std::abs(c));
     check_tile(ref, dev, "bG+cG²[2,5] off-diagonal", max_scale);
 

--- a/tt-train/tests/ops/gram_polynomial_op_test.cpp
+++ b/tt-train/tests/ops/gram_polynomial_op_test.cpp
@@ -71,10 +71,11 @@ std::vector<float> extract_output_tile(
     return tile;
 }
 
-void check_tile(const std::vector<float>& ref, const std::vector<float>& dev, const char* label) {
+void check_tile(
+    const std::vector<float>& ref, const std::vector<float>& dev, const char* label, float atol_scale = 1.0f) {
     auto ref_xt = xt::adapt(ref, {32u, 32u});
     auto dev_xt = xt::adapt(dev, {32u, 32u});
-    EXPECT_TRUE(xt::allclose(ref_xt, dev_xt, kRtol, kAtol)) << label << " exceeded tolerance";
+    EXPECT_TRUE(xt::allclose(ref_xt, dev_xt, kRtol, kAtol * atol_scale)) << label << " exceeded tolerance";
 }
 
 }  // namespace
@@ -97,4 +98,28 @@ TEST_F(GramPolynomialTest, GSquared_2048x2048) {
     ref = compute_g_squared_tile(g_vec, M, 0, 0);
     dev = extract_output_tile(out_vec, W, 0, 0);
     check_tile(ref, dev, "G²[0,0] diagonal");
+}
+
+// Phase 2: cG² (b=0, c=2.5)
+TEST_F(GramPolynomialTest, ScaledGSquared_2048x2048) {
+    auto G = make_random_tensor(2048);
+    constexpr float c = 2.5f;
+    auto output = ttml::metal::gram_polynomial(G, 0.0f, c, ttml::metal::OutputMode::Full);
+    tt::tt_metal::distributed::Synchronize(&ttml::autograd::ctx().get_device(), std::nullopt);
+
+    auto g_vec = G.to_vector<float>();
+    auto out_vec = output.to_vector<float>();
+    uint32_t M = G.logical_shape()[-1];
+    uint32_t W = output.logical_shape()[-1];
+
+    // CPU reference: c * (G @ G)
+    auto ref = compute_g_squared_tile(g_vec, M, 2, 5);
+    for (auto& v : ref) v *= c;
+    auto dev = extract_output_tile(out_vec, W, 2, 5);
+    check_tile(ref, dev, "cG²[2,5] off-diagonal", c);
+
+    ref = compute_g_squared_tile(g_vec, M, 0, 0);
+    for (auto& v : ref) v *= c;
+    dev = extract_output_tile(out_vec, W, 0, 0);
+    check_tile(ref, dev, "cG²[0,0] diagonal", c);
 }

--- a/tt-train/tests/ops/gram_polynomial_op_test.cpp
+++ b/tt-train/tests/ops/gram_polynomial_op_test.cpp
@@ -177,7 +177,7 @@ TEST_F(GramPolynomialTest, BgPlusCgSquared_4096x4096) {
     check_tile(ref, dev, "4096 bG+cG²[2,5]", max_scale);
 }
 
-TEST_F(GramPolynomialTest, NIGHTLY_BgPlusCgSquared_8192x8192) {
+TEST_F(GramPolynomialTest, BgPlusCgSquared_8192x8192) {
     auto G = make_random_tensor(8192);
     constexpr float b = -4.775f;
     constexpr float c = 2.0315f;

--- a/tt-train/tests/ops/gram_polynomial_op_test.cpp
+++ b/tt-train/tests/ops/gram_polynomial_op_test.cpp
@@ -7,9 +7,11 @@
 #include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
+#include "core/compute_kernel_config.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
 
 class GramPolynomialTest : public ::testing::Test {
 protected:
@@ -152,4 +154,143 @@ TEST_F(GramPolynomialTest, BgPlusCgSquared_2048x2048) {
     for (size_t i = 0; i < ref.size(); i++) ref[i] = b * g_tile[i] + c * g2_tile[i];
     dev = extract_output_tile(out_vec, W, 0, 0);
     check_tile(ref, dev, "bG+cG²[0,0] diagonal", max_scale);
+}
+
+TEST_F(GramPolynomialTest, BgPlusCgSquared_4096x4096) {
+    auto G = make_random_tensor(4096);
+    constexpr float b = -4.775f;
+    constexpr float c = 2.0315f;
+    auto output = ttml::metal::gram_polynomial(G, b, c, ttml::metal::OutputMode::Full);
+    tt::tt_metal::distributed::Synchronize(&ttml::autograd::ctx().get_device(), std::nullopt);
+
+    auto g_vec = G.to_vector<float>();
+    auto out_vec = output.to_vector<float>();
+    uint32_t M = G.logical_shape()[-1];
+    uint32_t W = output.logical_shape()[-1];
+
+    auto g_tile = extract_output_tile(g_vec, M, 2, 5);
+    auto g2_tile = compute_g_squared_tile(g_vec, M, 2, 5);
+    std::vector<float> ref(32 * 32);
+    for (size_t i = 0; i < ref.size(); i++) ref[i] = b * g_tile[i] + c * g2_tile[i];
+    auto dev = extract_output_tile(out_vec, W, 2, 5);
+    float max_scale = std::max(std::abs(b), std::abs(c));
+    check_tile(ref, dev, "4096 bG+cG²[2,5]", max_scale);
+}
+
+TEST_F(GramPolynomialTest, NIGHTLY_BgPlusCgSquared_8192x8192) {
+    auto G = make_random_tensor(8192);
+    constexpr float b = -4.775f;
+    constexpr float c = 2.0315f;
+    auto output = ttml::metal::gram_polynomial(G, b, c, ttml::metal::OutputMode::Full);
+    tt::tt_metal::distributed::Synchronize(&ttml::autograd::ctx().get_device(), std::nullopt);
+
+    auto g_vec = G.to_vector<float>();
+    auto out_vec = output.to_vector<float>();
+    uint32_t M = G.logical_shape()[-1];
+    uint32_t W = output.logical_shape()[-1];
+
+    auto g_tile = extract_output_tile(g_vec, M, 2, 5);
+    auto g2_tile = compute_g_squared_tile(g_vec, M, 2, 5);
+    std::vector<float> ref(32 * 32);
+    for (size_t i = 0; i < ref.size(); i++) ref[i] = b * g_tile[i] + c * g2_tile[i];
+    auto dev = extract_output_tile(out_vec, W, 2, 5);
+    float max_scale = std::max(std::abs(b), std::abs(c));
+    check_tile(ref, dev, "8192 bG+cG²[2,5]", max_scale);
+}
+
+// Compare gram_polynomial error against Newton-Schulz composite (ttnn::matmul + elementwise)
+TEST_F(GramPolynomialTest, DISABLED_ErrorComparison) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    auto compute_kernel_config = ttml::core::ComputeKernelConfig::matmul();
+    auto device_grid = device->compute_with_storage_grid_size();
+    auto core_grid = std::make_optional<ttnn::CoreGrid>(device_grid.x, device_grid.y);
+
+    constexpr float b = -4.775f;
+    constexpr float c = 2.0315f;
+
+    struct Shape {
+        uint32_t M;
+        const char* label;
+    };
+    Shape shapes[] = {{2048, "2048"}};
+
+    std::cout << "\n  Shape | Tile  | gram_poly abs | composite abs | gram_poly rel | composite rel\n";
+    std::cout << "  ------+-------+---------------+---------------+---------------+--------------\n";
+
+    for (auto& s : shapes) {
+        auto G = make_random_tensor(s.M);
+
+        // gram_polynomial: fused bG + cG²
+        auto fused = ttml::metal::gram_polynomial(G, b, c, ttml::metal::OutputMode::Full);
+        tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+
+        // Composite: ttnn::matmul(G,G) then elementwise bG + cG²
+        auto G_t = ttnn::transpose(G, -2, -1);
+        auto G2 = ttnn::matmul(
+            G,
+            G_t,
+            false,
+            false,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_kernel_config,
+            core_grid,
+            std::nullopt);
+        auto bG = ttnn::multiply(G, b);
+        auto composite = ttnn::addalpha(bG, G2, c);
+        tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+
+        auto g_vec = G.to_vector<float>();
+        auto fused_vec = fused.to_vector<float>();
+        auto comp_vec = composite.to_vector<float>();
+        uint32_t M = s.M;
+        uint32_t W_f = fused.logical_shape()[-1];
+        uint32_t W_c = composite.logical_shape()[-1];
+
+        uint32_t tiles[][2] = {{0, 0}, {2, 5}};
+        for (auto& t : tiles) {
+            // CPU reference
+            auto g_tile = extract_output_tile(g_vec, M, t[0], t[1]);
+            auto g2_tile = compute_g_squared_tile(g_vec, M, t[0], t[1]);
+            std::vector<float> ref(32 * 32);
+            float max_abs_ref = 1.0f;
+            for (size_t i = 0; i < ref.size(); i++) {
+                ref[i] = b * g_tile[i] + c * g2_tile[i];
+                max_abs_ref = std::max(max_abs_ref, std::abs(ref[i]));
+            }
+
+            auto f_tile = extract_output_tile(fused_vec, W_f, t[0], t[1]);
+            auto c_tile = extract_output_tile(comp_vec, W_c, t[0], t[1]);
+            float f_abs = 0, c_abs = 0;
+            for (size_t i = 0; i < ref.size(); i++) {
+                f_abs = std::max(f_abs, std::abs(ref[i] - f_tile[i]));
+                c_abs = std::max(c_abs, std::abs(ref[i] - c_tile[i]));
+            }
+
+            char line[128];
+            std::snprintf(
+                line,
+                sizeof(line),
+                "  %5s | [%d,%d] | %13.4f | %13.4f | %13.6f | %13.6f",
+                s.label,
+                t[0],
+                t[1],
+                f_abs,
+                c_abs,
+                f_abs / max_abs_ref,
+                c_abs / max_abs_ref);
+            std::cout << line << "\n";
+        }
+
+        G.deallocate();
+        fused.deallocate();
+        G_t.deallocate();
+        G2.deallocate();
+        bG.deallocate();
+        composite.deallocate();
+    }
+    std::cout << std::flush;
+    SUCCEED();
 }

--- a/tt-train/tests/ops/gram_polynomial_op_test.cpp
+++ b/tt-train/tests/ops/gram_polynomial_op_test.cpp
@@ -127,8 +127,8 @@ TEST_F(GramPolynomialTest, ScaledGSquared_2048x2048) {
 // Phase 3: bG + cG² (Muon coefficients)
 TEST_F(GramPolynomialTest, BgPlusCgSquared_2048x2048) {
     auto G = make_random_tensor(2048);
-    constexpr float b = -4.775f;
-    constexpr float c = 2.0315f;
+    constexpr float b = 1000.0f;  // DEBUG: large b to check if bG is applied
+    constexpr float c = 1.0f;
     auto output = ttml::metal::gram_polynomial(G, b, c, ttml::metal::OutputMode::Full);
     tt::tt_metal::distributed::Synchronize(&ttml::autograd::ctx().get_device(), std::nullopt);
 

--- a/tt-train/tests/ops/gram_polynomial_op_test.cpp
+++ b/tt-train/tests/ops/gram_polynomial_op_test.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <core/ttnn_all_includes.hpp>
+
+#include "autograd/auto_context.hpp"
+#include "core/random.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "metal/operations.hpp"
+
+class GramPolynomialTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ttml::autograd::ctx().open_device();
+    }
+    void TearDown() override {
+        ttml::autograd::ctx().close_device();
+    }
+};
+
+namespace {
+
+// Tolerances for BF16 matmul comparison (same as gram_matmul tests)
+// Diagonal tiles G[i,i] scale linearly with M, accumulating large absolute errors despite <1% relative error.
+constexpr float kRtol = 1e-2f;
+constexpr float kAtol = 15.0f;
+
+ttnn::Tensor make_random_tensor(uint32_t M, uint32_t K = 0, uint32_t seed = 42) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    K = (K > 0) ? K : M;
+    std::vector<float> data(M * K);
+    ttml::core::parallel_generate(
+        std::span{data.data(), data.size()}, []() { return std::uniform_real_distribution<float>(-1.0f, 1.0f); }, seed);
+    auto shape = ttnn::Shape({1, 1, M, K});
+    return ttnn::Tensor::from_vector(
+        data,
+        ttnn::TensorSpec(
+            shape,
+            tt::tt_metal::TensorLayout(ttnn::DataType::BFLOAT16, tt::tt_metal::Layout::TILE, ttnn::DRAM_MEMORY_CONFIG)),
+        device);
+}
+
+// Compute G² = G @ G for a single tile on CPU
+std::vector<float> compute_g_squared_tile(
+    const std::vector<float>& g_vec, uint32_t M, uint32_t tile_r, uint32_t tile_c) {
+    std::vector<float> result(32 * 32, 0.0f);
+    uint32_t M_tiles = M / 32;
+    for (uint32_t k_tile = 0; k_tile < M_tiles; k_tile++) {
+        for (uint32_t i = 0; i < 32; i++) {
+            for (uint32_t j = 0; j < 32; j++) {
+                float sum = 0.0f;
+                for (uint32_t k = 0; k < 32; k++) {
+                    sum +=
+                        g_vec[(tile_r * 32 + i) * M + k_tile * 32 + k] * g_vec[(tile_c * 32 + j) * M + k_tile * 32 + k];
+                }
+                result[i * 32 + j] += sum;
+            }
+        }
+    }
+    return result;
+}
+
+std::vector<float> extract_output_tile(
+    const std::vector<float>& out_vec, uint32_t out_width, uint32_t tile_r, uint32_t tile_c) {
+    std::vector<float> tile(32 * 32);
+    for (uint32_t i = 0; i < 32; i++)
+        for (uint32_t j = 0; j < 32; j++) tile[i * 32 + j] = out_vec[(tile_r * 32 + i) * out_width + tile_c * 32 + j];
+    return tile;
+}
+
+void check_tile(const std::vector<float>& ref, const std::vector<float>& dev, const char* label) {
+    auto ref_xt = xt::adapt(ref, {32u, 32u});
+    auto dev_xt = xt::adapt(dev, {32u, 32u});
+    EXPECT_TRUE(xt::allclose(ref_xt, dev_xt, kRtol, kAtol)) << label << " exceeded tolerance";
+}
+
+}  // namespace
+
+// Phase 1: G² = G @ G (b=0, c=1)
+TEST_F(GramPolynomialTest, GSquared_2048x2048) {
+    auto G = make_random_tensor(2048);
+    auto output = ttml::metal::gram_polynomial(G, 0.0f, 1.0f, ttml::metal::OutputMode::Full);
+    tt::tt_metal::distributed::Synchronize(&ttml::autograd::ctx().get_device(), std::nullopt);
+
+    auto g_vec = G.to_vector<float>();
+    auto out_vec = output.to_vector<float>();
+    uint32_t M = G.logical_shape()[-1];
+    uint32_t W = output.logical_shape()[-1];
+
+    auto ref = compute_g_squared_tile(g_vec, M, 2, 5);
+    auto dev = extract_output_tile(out_vec, W, 2, 5);
+    check_tile(ref, dev, "G²[2,5] off-diagonal");
+
+    ref = compute_g_squared_tile(g_vec, M, 0, 0);
+    dev = extract_output_tile(out_vec, W, 0, 0);
+    check_tile(ref, dev, "G²[0,0] diagonal");
+}


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-metal/issues/38914)

### Problem description
WIP

### Algorithm overview

 `gram_polynomial(G, b, c)` computes `bG + cG²` for symmetric G. It reuses the same
  grid layout, K-split, multicast, and reduction structure as the split-K gram matmul https://github.com/tenstorrent/tt-metal/pull/40928
  
  The differences are:

  ### Inputs and output

  | | `gram_matmul` | `gram_polynomial` |
  |---|---|---|
  | Input | arbitrary `X = [M, K]` | symmetric `G = [M, M]` |
  | Output | `G = X @ X^T` (M × M) | `bG + cG²` (M × M) |
  | Extra args | — | scalars `b`, `c` |

  ### Matmul (step 3)

  Since G is symmetric, `G² = G @ G = G @ G^T`. The kernel exploits this exactly like
  gram_matmul exploits `X @ X^T`: both in0 and in1 read rows of the same input tensor,
  and `matmul_block` is invoked with `transpose_b = true`. K-split parity (even/odd
  columns) and per-core role (lower / upper / diagonal / helper) are unchanged.

  ### Polynomial fusion (the new piece)

  `bG + cG²` is folded into the same K-loop matmul rather than computed as separate
  ops:

  1. **Pre-fill DST with `(b/c)·G[m,n]`** before the K-loop matmul, on cores that own
     the (m,n) output tile. The compute kernel reads the corresponding G tile from
     its in0 stream and scales by `b/c` (passed as a compile-time arg).
  2. **K-loop matmul accumulates `G[m,k]·G[k,n]`** into DST as in gram_matmul.
  3. **After the K-loop completes**, the kernel scales the accumulated DST by `c`
     (also compile-time) and packs to the intermediate CB.

  Net result per output tile: `c · (b/c · G + Σ_k G[m,k]·G[k,n]) = bG + cG²`. No extra
  DRAM passes for the linear term; no separate `multiply` or `add` ops.

### Results
  | Shape | gram_polynomial | TFLOPS | composite (ttnn) | speedup |
  |-------|-----------------|-------:|------------------|--------:|
  | 2048  | 240 µs          | 72     | 442 µs           | 1.84×   |
  | 4096  | 829 µs          | 166    | 1858 µs          | 2.24×   |
  | 8192  | 5374 µs         | 205    | 11120 µs         | 2.07×   |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zbaczewski/split-k-mat-poly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zbaczewski/split-k-mat-poly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:zbaczewski/split-k-mat-poly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/split-k-mat-poly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zbaczewski/split-k-mat-poly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zbaczewski/split-k-mat-poly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zbaczewski/split-k-mat-poly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zbaczewski/split-k-mat-poly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zbaczewski/split-k-mat-poly)