### PR TITLE
Cleanup: LLK enum class refactor for VectorMode

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_max_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_max_tile.rst
@@ -2,5 +2,5 @@ binary_max_tile
 ===============
 
 .. doxygenfunction:: binary_max_tile_init
-.. doxygenfunction:: binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, int vector_mode = (int)VectorMode::RC)
+.. doxygenfunction:: binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorMode vector_mode = VectorMode::RC)
 .. doxygenfunction:: binary_max_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_min_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_min_tile.rst
@@ -2,5 +2,5 @@ binary_min_tile
 ===============
 
 .. doxygenfunction:: binary_min_tile_init
-.. doxygenfunction:: binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, int vector_mode = (int)VectorMode::RC)
+.. doxygenfunction:: binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorMode vector_mode = VectorMode::RC)
 .. doxygenfunction:: binary_min_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/exp_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/exp_tile.rst
@@ -2,4 +2,4 @@ exp_tile
 ========
 
 .. doxygenfunction:: exp_tile_init()
-.. doxygenfunction:: exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = 0x3F80)
+.. doxygenfunction:: exp_tile(uint32_t idst, VectorMode vector_mode = VectorMode::RC, uint16_t scale = 0x3F80)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/recip_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/recip_tile.rst
@@ -2,4 +2,4 @@ recip_tile
 ==========
 
 .. doxygenfunction:: recip_tile_init()
-.. doxygenfunction:: recip_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC)
+.. doxygenfunction:: recip_tile(uint32_t idst, VectorMode vector_mode = VectorMode::RC)

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -18,21 +18,21 @@ inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
-    uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_top8(
-    uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, uint32_t eps, uint32_t scale, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_top32_rm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_top32_rm.h
@@ -19,14 +19,14 @@ inline void llk_math_deepseek_top32_rm_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_rm_local_sort(
-    uint dst_index, int idir, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, int idir, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_bitonic_top32_phases_steps_<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, idir);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false>
 inline void llk_math_deepseek_top32_rm_merge(
-    uint dst_index, bool across_tiles, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, bool across_tiles, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_bitonic_top32_merge_<APPROXIMATE, is_fp32_dest_acc_en, idir>,
         dst_index,
@@ -36,7 +36,7 @@ inline void llk_math_deepseek_top32_rm_merge(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_rm_rebuild(
-    uint dst_index, bool idir, bool skip_second, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, bool idir, bool skip_second, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_bitonic_top32_rebuild_<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
@@ -47,7 +47,7 @@ inline void llk_math_deepseek_top32_rm_rebuild(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool top_min>
 inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_prep(
-    uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_prep_<APPROXIMATE, is_fp32_dest_acc_en, top_min>,
         dst_index,
@@ -57,7 +57,7 @@ inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_prep(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_combine(
-    uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_combine_<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
@@ -67,7 +67,7 @@ inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_combine(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_final(
-    uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_final_<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_add_rsqrt_init() {
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_add_rsqrt(
-    uint dst_index, uint32_t param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_add_rsqrt<APPROXIMATE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>,
         dst_index,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -18,21 +18,21 @@ inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
-    uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_top8(
-    uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, uint32_t eps, uint32_t scale, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/add_rsqrt.h
@@ -24,7 +24,7 @@ ALWI void add_rsqrt_tile_init() { MATH((llk_math_eltwise_unary_sfpu_add_rsqrt_in
  * @param idst The index of the tile in DST register buffer
  * @param addend The bit representation of a float to add before computing rsqrt
  */
-template <bool fast_and_approx = false, int vec_mode = VectorMode::RC, int ITERATIONS = 8>
+template <bool fast_and_approx = false, VectorMode vec_mode = VectorMode::RC, int ITERATIONS = 8>
 ALWI void add_rsqrt_tile(uint32_t idst, uint32_t addend) {
     MATH((llk_math_eltwise_unary_sfpu_add_rsqrt<APPROX, DST_ACCUM_MODE, fast_and_approx, ITERATIONS>(
         idst, addend, vec_mode)));

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -428,7 +428,7 @@ void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
  * Wrapper for fused max-sub-exp-add SFPI kernel.
  * Invokes calculate_fused_max_sub_exp_add_tile via LLK unary SFPU parameters.
  */
-template <bool SDPA_EXP_APPROX_MODE, int vector_mode = (int)VectorMode::C, bool final_norm = false>
+template <bool SDPA_EXP_APPROX_MODE, VectorMode vector_mode = VectorMode::C, bool final_norm = false>
 void fused_max_sub_exp_add_tile(uint32_t idst, int scale_bf16) {
     _llk_math_eltwise_unary_sfpu_params_(
         calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE, final_norm>, idst, vector_mode, scale_bf16);
@@ -460,7 +460,7 @@ template <
     bool normalize,
     uint32_t block_size,
     uint32_t scale_fp32,
-    int vector_mode = (int)VectorMode::C,
+    VectorMode vector_mode = VectorMode::C,
     bool pop_ms = false,
     bool dense = false>
 ALWI void sdpa_tail_ms_reduce(uint32_t cb_worker_ms, uint32_t cb_prev_ms, uint32_t cb_cur_ms, uint32_t cb_l_for_init) {
@@ -591,7 +591,7 @@ template <
     uint32_t block_size,
     uint32_t num_blocks,
     uint32_t scale_fp32,
-    int vector_mode = (int)VectorMode::C,
+    VectorMode vector_mode = VectorMode::C,
     bool dense = false,
     bool untilize = false>
 ALWI void sdpa_tail(

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_tail/kernels/sdpa_tail_compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_tail/kernels/sdpa_tail_compute.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
     constexpr bool dense = get_compile_time_arg_val(10);
     constexpr bool untilize = get_compile_time_arg_val(11);
 
-    constexpr int vector_mode = VectorMode::RC_custom;
+    constexpr VectorMode vector_mode = VectorMode::RC_custom;
 
     binary_op_init_common(cb_l1, cb_l1, cb_l_out);
     exp_tile_init<EXP_APPROX_MODE>();

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
@@ -326,13 +326,13 @@ struct DRAMStreamingExpertsMatmul {
 
                         if constexpr (CTArgs::tile_r_dim <= 4) {
                             PACK((llk_math_eltwise_unary_sfpu_silu<false, CTArgs::fp32_dest_acc_en, 2>(
-                                0, (int)VectorMode::R)));
+                                0, VectorMode::R)));
                         } else if constexpr (CTArgs::tile_r_dim == 8) {
                             PACK((llk_math_eltwise_unary_sfpu_silu<false, CTArgs::fp32_dest_acc_en, 4>(
-                                0, (int)VectorMode::R)));
+                                0, VectorMode::R)));
                         } else {
                             PACK((llk_math_eltwise_unary_sfpu_silu<false, CTArgs::fp32_dest_acc_en, 8>(
-                                0, (int)VectorMode::R)));
+                                0, VectorMode::R)));
                         }
 
                         PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
@@ -324,11 +324,11 @@ struct DRAMStreamingMatmul {
                             DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
                         if constexpr (CTArgs::tile_r_dim <= 4) {
-                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2>(0, (int)VectorMode::R)));
+                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2>(0, VectorMode::R)));
                         } else if constexpr (CTArgs::tile_r_dim == 8) {
-                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 4>(0, (int)VectorMode::R)));
+                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 4>(0, VectorMode::R)));
                         } else {
-                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 8>(0, (int)VectorMode::R)));
+                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 8>(0, VectorMode::R)));
                         }
 
                         PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
@@ -324,11 +324,14 @@ struct DRAMStreamingMatmul {
                             DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
                         if constexpr (CTArgs::tile_r_dim <= 4) {
-                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2>(0, VectorMode::R)));
+                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2 /*ITER*/>(
+                                0 /*dst_index*/, VectorMode::R)));
                         } else if constexpr (CTArgs::tile_r_dim == 8) {
-                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 4>(0, VectorMode::R)));
+                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 4 /*ITER*/>(
+                                0 /*dst_index*/, VectorMode::R)));
                         } else {
-                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 8>(0, VectorMode::R)));
+                            PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 8 /*ITER*/>(
+                                0 /*dst_index*/, VectorMode::R)));
                         }
 
                         PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -171,10 +171,10 @@ struct Matmul {
                     if constexpr (CTArgs::fuse_sigmoid) {
                         PACK((ckernel::
                                   llk_math_eltwise_unary_sfpu_sigmoid<CTArgs::fused_activation_approx_mode, false, 2>(
-                                      0, (int)VectorMode::R)));
+                                      0, ckernel::VectorMode::R)));
                     } else {
                         PACK((ckernel::llk_math_eltwise_unary_sfpu_silu<CTArgs::fused_activation_approx_mode, false, 2>(
-                            0, (int)VectorMode::R)));
+                            0, VectorMode::R)));
                     }
 
                     PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
@@ -958,8 +958,8 @@ struct MatmulExpertCompressedDRAM {
                         cb_reserve_back(CTArgs::cb_out_silu, 1);
                         tile_regs_acquire();
                         copy_tile(CTArgs::cb_out_silu, 0, 0);
-                        MATH((
-                            llk_math_eltwise_unary_sfpu_silu<true, DST_ACCUM_MODE, silu_iterations>(0, VectorMode::R)));
+                        MATH((llk_math_eltwise_unary_sfpu_silu<true, DST_ACCUM_MODE, silu_iterations>(
+                            0 /*dst_index*/, VectorMode::R)));
                         tile_regs_commit();
                         tile_regs_wait();
                         pack_tile(0, CTArgs::cb_out_silu, 0);
@@ -1054,7 +1054,8 @@ struct MatmulExpertCompressedDRAM {
                             PACK(TT_SETC16(
                                 DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
                             for (uint32_t sn = 0; sn < CTArgs::subblock_n; sn++) {
-                                PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2>(sn, VectorMode::R)));
+                                PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2 /*ITER*/>(
+                                    sn /*dst_index*/, VectorMode::R)));
                             }
                             PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
                         } else {

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
@@ -958,8 +958,8 @@ struct MatmulExpertCompressedDRAM {
                         cb_reserve_back(CTArgs::cb_out_silu, 1);
                         tile_regs_acquire();
                         copy_tile(CTArgs::cb_out_silu, 0, 0);
-                        MATH((llk_math_eltwise_unary_sfpu_silu<true, DST_ACCUM_MODE, silu_iterations>(
-                            0, (int)VectorMode::R)));
+                        MATH((
+                            llk_math_eltwise_unary_sfpu_silu<true, DST_ACCUM_MODE, silu_iterations>(0, VectorMode::R)));
                         tile_regs_commit();
                         tile_regs_wait();
                         pack_tile(0, CTArgs::cb_out_silu, 0);
@@ -1054,7 +1054,7 @@ struct MatmulExpertCompressedDRAM {
                             PACK(TT_SETC16(
                                 DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
                             for (uint32_t sn = 0; sn < CTArgs::subblock_n; sn++) {
-                                PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2>(sn, (int)VectorMode::R)));
+                                PACK((llk_math_eltwise_unary_sfpu_silu<true, false, 2>(sn, VectorMode::R)));
                             }
                             PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
                         } else {

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -227,7 +227,7 @@ template <
     uint32_t block_size,
     uint32_t scale_fp32,
     uint32_t num_l_chunks,
-    int vector_mode = (int)VectorMode::C>
+    VectorMode vector_mode = VectorMode::C>
 ALWI void sdpa_tail_streaming(
     uint32_t cb_worker_max_sum,
     uint32_t cb_prev_max_sum,
@@ -324,7 +324,7 @@ template <
     uint32_t block_size,
     uint32_t scale_fp32,
     uint32_t num_l_chunks,
-    int vector_mode = (int)VectorMode::C>
+    VectorMode vector_mode = VectorMode::C>
 ALWI void sdpa_tail_streaming_conditional(
     uint32_t cb_worker_max_sum,
     uint32_t cb_prev_max_sum,
@@ -815,7 +815,7 @@ struct SdpaReduceWorker {
         // TRISC (Compute) - streaming SDPA tail reduction
         // ==================================================================
         void compute_impl([[maybe_unused]] const ComputeArgs& args) {
-            constexpr int vector_mode = VectorMode::RC_custom;
+            constexpr VectorMode vector_mode = VectorMode::RC_custom;
 
             reconfig_data_format<false, true>(CTArgs::cb_local_l, CTArgs::cb_local_l);
             pack_reconfig_data_format<true>(CTArgs::cb_l_out);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -50,12 +50,8 @@ void core_agnostic_main() {
             llk_math_eltwise_binary_init<ELWADD, BroadcastType::NONE, MathFidelity::LoFi>();
             for (uint32_t c = 0; c < per_core_block_c_tiles; c++) {
                 llk_math_wait_for_dest_available();
-                llk_math_eltwise_binary<
-                    ELWADD,
-                    BroadcastType::NONE,
-                    DST_ACCUM_MODE,
-                    MATH_FIDELITY,
-                    EltwiseBinaryReuseDestType::NONE>(0 /*dst_index*/);
+                llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
+                    0);
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
         }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -50,8 +50,12 @@ void core_agnostic_main() {
             llk_math_eltwise_binary_init<ELWADD, BroadcastType::NONE, MathFidelity::LoFi>();
             for (uint32_t c = 0; c < per_core_block_c_tiles; c++) {
                 llk_math_wait_for_dest_available();
-                llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
-                    0);
+                llk_math_eltwise_binary<
+                    ELWADD,
+                    BroadcastType::NONE,
+                    DST_ACCUM_MODE,
+                    MATH_FIDELITY,
+                    EltwiseBinaryReuseDestType::NONE>(0 /*dst_index*/);
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
         }

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -44,7 +44,7 @@ void calculate_recip_first_column() {
 }
 
 void recip_tile_first_column(uint32_t idst) {
-    _llk_math_eltwise_unary_sfpu_params_(calculate_recip_first_column, idst, (int)VectorMode::C);
+    _llk_math_eltwise_unary_sfpu_params_(calculate_recip_first_column, idst, VectorMode::C);
 }
 
 // First-column exp with fused scale: exp(scale * x) on column 0 only.
@@ -65,7 +65,7 @@ void calculate_exponential_first_column() {
 
 template <uint16_t scale_bf16>
 void exp_tile_first_column(uint32_t idst) {
-    _llk_math_eltwise_unary_sfpu_params_(calculate_exponential_first_column<scale_bf16>, idst, (int)VectorMode::C);
+    _llk_math_eltwise_unary_sfpu_params_(calculate_exponential_first_column<scale_bf16>, idst, VectorMode::C);
 }
 #endif
 
@@ -137,7 +137,7 @@ void update_cur_row_max_value(
 
         // find max value between current max and previous max
         binary_max_tile_init();
-        binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx, static_cast<int>(VectorMode::C));
+        binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx, VectorMode::C);
     }
     tile_regs_commit();
 
@@ -166,7 +166,7 @@ void apply_exp_inplace_and_find_exp_sum(uint32_t cb_attention_weights, uint32_t 
     // Fused scale+exp: compute exp(scale * (score - max)) in a single SFPU pass.
     constexpr uint16_t scaler_bf16 = static_cast<uint16_t>(scaler_fp32 >> 16);
     exp_tile_init</* approx */ false, scaler_fp32>();
-    exp_tile</* approx */ false, /* scale_en */ true>(exp_dst_idx, (int)VectorMode::RC, scaler_bf16);
+    exp_tile</* approx */ false, /* scale_en */ true>(exp_dst_idx, VectorMode::RC, scaler_bf16);
     tile_regs_commit();
 
     tile_regs_wait();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_add_int_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_add_int(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for add_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -17,11 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
 template <DataFormat format>
 inline void llk_math_eltwise_binary_sfpu_add_top_row(uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
     _llk_math_eltwise_binary_sfpu_params_(
-        sfpu::calculate_add_top_row<format>,
-        dst_index_in_0,
-        dst_index_in_1,
-        dst_index_out,
-        static_cast<int>(VectorMode::RC_custom));
+        sfpu::calculate_add_top_row<format>, dst_index_in_0, dst_index_in_1, dst_index_out, VectorMode::RC_custom);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_binary_sfpu_atan2_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void llk_math_eltwise_binary_sfpu_atan2(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_atan2<APPROXIMATE, ITERATIONS, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <SfpuType OP, bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS>
 inline void llk_math_eltwise_binary_sfpu_rel_int_impl(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format. Supported: Int32, UInt32, UInt16");
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_binary_sfpu_lt_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_lt_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_lt_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::lt, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -48,7 +48,7 @@ inline void llk_math_eltwise_binary_sfpu_gt_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_gt_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_gt_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::gt, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -61,7 +61,7 @@ inline void llk_math_eltwise_binary_sfpu_le_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_le_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_le_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::le, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -74,7 +74,7 @@ inline void llk_math_eltwise_binary_sfpu_ge_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_ge_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_ge_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::ge, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -82,7 +82,7 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::eq>,
         dst_index0,
@@ -95,7 +95,7 @@ inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ne_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
         dst_index0,
@@ -108,7 +108,7 @@ inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
@@ -121,7 +121,7 @@ inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
@@ -134,7 +134,7 @@ inline void llk_math_eltwise_binary_sfpu_le_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
@@ -147,7 +147,7 @@ inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_fmod_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_fmod_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_fmod_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_fmod_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_fmod(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_fmod<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_pow_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_pow(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_pow<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_remainder_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_remainder_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_remainder_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_remainder_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_binary_remainder(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_remainder<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_binop_init() {
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_binary_sfpu_binop(
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_mul(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_mul<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_binop_mul(
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_div(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_div<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_bitwise_init() {
 
 template <bool APPROXIMATE, sfpu::BinaryBitwiseOp BITWISE_OP, DataFormat DATA_FORMAT>
 inline void llk_math_eltwise_binary_sfpu_bitwise(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for bitwise operation. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -13,7 +13,7 @@ namespace ckernel {
 // Generalized version that takes a DataFormat template parameter
 template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
+    uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
@@ -22,7 +22,7 @@ void llk_math_eltwise_binary_sfpu_copy_dest_values(
 // Deprecated: Use the template version with DataFormat parameter instead
 [[deprecated("Use llk_math_eltwise_binary_sfpu_copy_dest_values<DataFormat> instead")]]
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
+    uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_div_int32_floor_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_floor(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_floor<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_div_int32_trunc_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_trunc(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_trunc<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_gcd_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_isclose.h
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_binary_sfpu_isclose(
     uint32_t odst,
     uint32_t rtol_bits,
     uint32_t atol_bits,
-    int vector_mode = (int)VectorMode::RC) {
+    VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_isclose<APPROXIMATE, ITERATIONS, EQUAL_NAN>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_lcm_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
@@ -13,7 +13,7 @@ namespace ckernel {
 // LogSigmoid operation using pre-computed scaled input and exponential
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_logsigmoid<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h
@@ -33,7 +33,7 @@ inline __attribute__((always_inline)) void _sfpu_binary_check_and_call_(
     std::uint32_t dst_index_in0,
     std::uint32_t dst_index_in1,
     std::uint32_t dst_index_out,
-    int vector_mode,
+    VectorMode vector_mode,
     Args&&... args) {
     LLK_ASSERT(
         (dst_index_in0 < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
@@ -94,7 +94,7 @@ inline __attribute__((always_inline)) void _sfpu_binary_check_and_call_(
 
 /*
  * Same as SFPU_BINARY_CALL but vector_mode is given as a `VectorMode`
- * enumerator name. The `(int)VectorMode::MODE` cast is generated.
+ * enumerator token (e.g. RC, C, R).
  *   SFPU_BINARY_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
  *                         calculate_add_fp32, (APPROXIMATE),
  *                         RC, dst_in0, dst_in1, dst_out);
@@ -105,7 +105,7 @@ inline __attribute__((always_inline)) void _sfpu_binary_check_and_call_(
         DST_IN0,                                                                                        \
         DST_IN1,                                                                                        \
         DST_OUT,                                                                                        \
-        (int)::ckernel::VectorMode::MODE,                                                               \
+        ::ckernel::VectorMode::MODE,                                                                    \
         ##__VA_ARGS__)
 
 /*

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, false>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, true>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -51,7 +51,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -62,7 +62,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, false>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -73,7 +73,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, true>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -30,7 +30,7 @@ inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(uint dst_index, u
         dst_index,
         idx_index,
         0 /* DST out unused, but required for _llk_math_eltwise_binary_sfpu_params_ */,
-        static_cast<int>(VectorMode::RC) /* vector_mode */,
+        VectorMode::RC,
         chunk);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -25,7 +25,7 @@ inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_mul_int(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for mul_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point)
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32(
-    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_poin
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32(
-    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -41,7 +41,7 @@ inline void llk_math_eltwise_binary_sfpu_dequant_int32_init(const uint zero_poin
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32(
-    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_rsub_int_init() {
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_rsub_int(
-    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for rsub_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_shift_init() {
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_left_shift(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for left shift. Supported data formats are: Int32, UInt32, UInt16");
@@ -32,7 +32,7 @@ inline void llk_math_eltwise_binary_sfpu_left_shift(
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_right_shift(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for right shift. Supported data formats are: Int32, UInt32, UInt16");
@@ -48,7 +48,7 @@ inline void llk_math_eltwise_binary_sfpu_right_shift(
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for logical right shift. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_sub_int_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_sub_int(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for sub_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_binary_sfpu_xlogy_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_xlogy(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_calculate_sfpu_binary_<APPROXIMATE, BinaryOp::XLOGY, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted(
     uint32_t dst_index1,
     uint32_t dst_index2,
     uint32_t dst_index3,
-    int vector_mode = (int)VectorMode::RC) {
+    VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_adjusted<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,
@@ -52,7 +52,7 @@ inline void llk_math_eltwise_binary_sfpu_lgamma_stirling_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_lgamma_stirling(
-    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_lgamma_stirling_fp32<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_polygamma_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_polygamma(
-    uint32_t dst_index, uint32_t n_packed, uint32_t scale_packed, int vector_mode = (int)VectorMode::RC) {
+    uint32_t dst_index, uint32_t n_packed, uint32_t scale_packed, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_polygamma<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcdiv(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcdiv<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcmul(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcmul<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_lerp(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_lerp<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, DataFormat data_format>
 inline void llk_math_eltwise_ternary_sfpu_where(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, data_format, 8>,
         dst_index0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -15,12 +15,12 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -21,7 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 }
 
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
         dst_index,
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
@@ -47,7 +47,7 @@ inline void llk_math_eltwise_unary_sfpu_celu_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
-    uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t alpha, uint32_t alpha_recip, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         [](uint32_t alpha, uint32_t alpha_recip) {
             ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
@@ -64,7 +64,8 @@ inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_softshrink(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
@@ -75,7 +76,8 @@ inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_hardshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_hardshrink(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_add1_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
@@ -23,14 +23,14 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -16,14 +16,14 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
-    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint min_val, uint max_val, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
-    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint min_val, uint max_val, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
 
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum(
-    uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
+    uint dst_index, bool first, VectorMode vector_mode = VectorMode::RC_custom /*unused*/) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
-    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, uint param1, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -15,7 +15,8 @@ inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_heaviside(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base(
-    uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint base_scale, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -31,7 +31,7 @@ namespace ckernel {
 
 template <DstSync DST_SYNC, bool DST_ACCUM, typename Callable, typename... Args>
 inline __attribute__((always_inline)) void _sfpu_check_and_call_(
-    Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode, Args&&... args) {
+    Callable&& sfpu_func, std::uint32_t dst_index, VectorMode vector_mode, Args&&... args) {
     LLK_ASSERT(
         (dst_index < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
         "dst_index exceeds max dest tiles");
@@ -94,7 +94,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
 
 /*
  * Same as SFPU_CALL but vector_mode is given as a `VectorMode` enumerator name
- * (RC, C, RC_custom, ...). The `(int)VectorMode::MODE` cast is generated.
+ * (RC, C, RC_custom, ...).
  *   SFPU_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
  *                  calculate_erfc,   (8),     RC,        idst);
  *   SFPU_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
@@ -102,7 +102,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
  */
 #define SFPU_CALL_MODE(DST_SYNC, DST_ACCUM, FN, TEMPLATES, MODE, DST_IDX, ...) \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                     \
-        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX, (int)::ckernel::VectorMode::MODE, ##__VA_ARGS__)
+        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX, ::ckernel::VectorMode::MODE, ##__VA_ARGS__)
 
 /*
  * Non-templated functor in `ckernel::sfpu`, runtime vector_mode expression.
@@ -281,7 +281,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
 
 /*
  * SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN takes its mode as a runtime expression,
- * not as a VectorMode enumerator name (note the lack of `(int)VectorMode::` in
+ * not as a VectorMode enumerator name (note the lack of `VectorMode::` in
  * the original definition), so it maps to SFPU_CALL rather than SFPU_CALL_MODE.
  */
 #define SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(FN, APPROXIMATE, FP32, ITER, LEGACY_COMPAT, DST_IDX, MODE) \
@@ -338,7 +338,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
     constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>(                                                \
-        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)          \
     static_assert(                                                                                                 \
@@ -356,4 +356,4 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
                                                                                   : InstrModLoadStore::DEFAULT;    \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>(                                               \
-        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, VectorMode::MODE)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -15,13 +15,13 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask(
-    uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, DataFormat data_format, VectorMode vector_mode = VectorMode::RC) {
     if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
         _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -16,7 +16,8 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_unary_max(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -27,7 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -38,7 +39,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -49,7 +50,8 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_unary_min(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -60,7 +62,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -71,7 +73,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_power_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_power(
-    uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t exponent = 0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
@@ -27,7 +27,7 @@ inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
-    uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t exponent = 0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rdiv_init() {
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rdiv(
-    uint32_t dst_index, uint32_t value, int vector_mode = (int)VectorMode::RC) {
+    uint32_t dst_index, uint32_t value, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -45,7 +45,7 @@ inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
  */
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
-    uint dst_index, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, uint32_t idx_addr, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -16,7 +16,8 @@ inline void llk_math_eltwise_unary_sfpu_rpow_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
-inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_rpow(
+    uint dst_index, uint32_t base_val, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
-inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -15,7 +15,8 @@ inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_rsub_int32(
+    uint dst_index, uint scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -13,7 +13,7 @@ inline void llk_math_eltwise_unary_sfpu_selu_init() { llk_math_eltwise_unary_sfp
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_selu(
-    uint dst_index, uint scale, uint alpha, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint scale, uint alpha, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_sign_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
-    uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
+    uint dst_index, VectorMode vector_mode = VectorMode::RC, uint exponent_size_8 = 1) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
@@ -25,7 +25,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_square_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_threshold_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
-    uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t param0, uint32_t param1, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_start_phase,
     int i_end_step,
     int i_start_step,
-    int vector_mode = (int)VectorMode::RC_custom) {
+    VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
@@ -37,7 +37,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
-    uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, int m_iter, int k, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
@@ -54,7 +54,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int k,
     int logk,
     int skip_second,
-    int vector_mode = (int)VectorMode::RC_custom) {
+    VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -11,7 +11,7 @@
 namespace ckernel {
 
 template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
-inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -33,8 +33,8 @@ namespace ckernel {
 
 template <DstSync DST_SYNC, bool DST_ACCUM, typename Callable, typename... Args>
 inline __attribute__((always_inline)) void _sfpu_check_and_call_(
-    Callable&& sfpu_func, std::uint32_t dst_index, [[maybe_unused]] int vector_mode, Args&&... args) {
-    LLK_ASSERT(vector_mode == (int)VectorMode::RC, "Quasar currently only supports vector mode RC");
+    Callable&& sfpu_func, std::uint32_t dst_index, [[maybe_unused]] VectorMode vector_mode, Args&&... args) {
+    LLK_ASSERT(vector_mode == VectorMode::RC, "Quasar currently only supports vector mode RC");
     _llk_math_eltwise_unary_sfpu_params_(std::forward<Callable>(sfpu_func), dst_index, std::forward<Args>(args)...);
 }
 
@@ -90,14 +90,14 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX, VECTOR_MODE, ##__VA_ARGS__)
 
 // Same as SFPU_CALL but vector_mode is given as a `VectorMode` enumerator name
-// (RC, C, RC_custom, ...). The `(int)VectorMode::MODE` cast is generated.
+// (RC, C, RC_custom, ...).
 //   SFPU_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
 //                  calculate_erfc,   (8),     RC,        idst);
 //   SFPU_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
 //                  calculate_cumsum, (false), RC_custom, dst, first);
 #define SFPU_CALL_MODE(DST_SYNC, DST_ACCUM, FN, TEMPLATES, MODE, DST_IDX, ...) \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                     \
-        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX, (int)::ckernel::VectorMode::MODE, ##__VA_ARGS__)
+        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX, ::ckernel::VectorMode::MODE, ##__VA_ARGS__)
 
 // Non-templated functor in `ckernel::sfpu`, runtime vector_mode expression.
 //   SFPU_CALL_FN(DST_SYNC_MODE, DST_ACCUM_MODE,
@@ -314,7 +314,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
     static_assert(DATA_FORMAT == DataFormat::Int32, "Unsupported data format. Supported: Int32"); \
     constexpr InstrModLoadStore _INSTRUCTION_MODE = InstrModLoadStore::INT32;                     \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>(                              \
-        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE) \
     static_assert(                                                                                        \
@@ -328,4 +328,4 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         : (DATA_FORMAT == DataFormat::Int32) ? InstrModLoadStore::INT32                                   \
                                              : InstrModLoadStore::DEFAULT;                                \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>(                                      \
-        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, VectorMode::MODE)

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -20,8 +20,8 @@ template <
     [[maybe_unused]] bool APPROXIMATE,
     [[maybe_unused]] bool is_fp32_dest_acc_en,
     int ITERATIONS = SFPU_ITERATIONS>
-inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    LLK_ASSERT(vector_mode == (int)VectorMode::RC, "Quasar currently only supports vector mode RC");
+inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
+    LLK_ASSERT(vector_mode == VectorMode::RC, "Quasar currently only supports vector mode RC");
     _llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_sigmoid, dst_index, ITERATIONS);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_add_int_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_add_int(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for add_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -17,11 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
 template <DataFormat format>
 inline void llk_math_eltwise_binary_sfpu_add_top_row(uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
     _llk_math_eltwise_binary_sfpu_params_(
-        sfpu::calculate_add_top_row<format>,
-        dst_index_in_0,
-        dst_index_in_1,
-        dst_index_out,
-        static_cast<int>(VectorMode::RC_custom));
+        sfpu::calculate_add_top_row<format>, dst_index_in_0, dst_index_in_1, dst_index_out, VectorMode::RC_custom);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_binary_sfpu_atan2_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void llk_math_eltwise_binary_sfpu_atan2(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_atan2<APPROXIMATE, ITERATIONS, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <SfpuType OP, bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS>
 inline void llk_math_eltwise_binary_sfpu_rel_int_impl(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format. Supported: Int32, UInt32, UInt16");
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_binary_sfpu_lt_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_lt_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_lt_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::lt, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -48,7 +48,7 @@ inline void llk_math_eltwise_binary_sfpu_gt_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_gt_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_gt_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::gt, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -61,7 +61,7 @@ inline void llk_math_eltwise_binary_sfpu_le_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_le_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_le_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::le, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -74,7 +74,7 @@ inline void llk_math_eltwise_binary_sfpu_ge_int_init() {
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_ge_int(uint i0, uint32_t i1, uint32_t o, int vm = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_ge_int(uint i0, uint32_t i1, uint32_t o, VectorMode vm = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_rel_int_impl<SfpuType::ge, APPROXIMATE, DATA_FORMAT, ITERATIONS>(i0, i1, o, vm);
 }
 
@@ -82,7 +82,7 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::eq>,
         dst_index0,
@@ -95,7 +95,7 @@ inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ne_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
         dst_index0,
@@ -108,7 +108,7 @@ inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
@@ -121,7 +121,7 @@ inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
@@ -134,7 +134,7 @@ inline void llk_math_eltwise_binary_sfpu_le_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
@@ -147,7 +147,7 @@ inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() { llk_math_eltwise_binar
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_fp32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_fmod_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_fmod_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_fmod_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_fmod_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_fmod(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_fmod<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_pow_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_pow(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_pow<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_remainder_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_remainder_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_remainder_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_remainder_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_binary_remainder(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_remainder<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_binop_init() {
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_binary_sfpu_binop(
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_mul(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_mul<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_binop_mul(
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_div(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_div<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_bitwise_init() {
 
 template <bool APPROXIMATE, sfpu::BinaryBitwiseOp BITWISE_OP, DataFormat DATA_FORMAT>
 inline void llk_math_eltwise_binary_sfpu_bitwise(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for bitwise operation. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -13,7 +13,7 @@ namespace ckernel {
 // Generalized version that takes a DataFormat template parameter
 template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
+    uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
@@ -22,7 +22,7 @@ void llk_math_eltwise_binary_sfpu_copy_dest_values(
 // Deprecated: Use the template version with DataFormat parameter instead
 [[deprecated("Use llk_math_eltwise_binary_sfpu_copy_dest_values<DataFormat> instead")]]
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
+    uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_div_int32_floor_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_floor(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_floor<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_div_int32_trunc_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_trunc(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_trunc<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_gcd_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_isclose.h
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_binary_sfpu_isclose(
     uint32_t odst,
     uint32_t rtol_bits,
     uint32_t atol_bits,
-    int vector_mode = (int)VectorMode::RC) {
+    VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_isclose<APPROXIMATE, ITERATIONS, EQUAL_NAN>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_lcm_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
@@ -13,7 +13,7 @@ namespace ckernel {
 // LogSigmoid operation using pre-computed scaled input and exponential
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_logsigmoid<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h
@@ -33,7 +33,7 @@ inline __attribute__((always_inline)) void _sfpu_binary_check_and_call_(
     std::uint32_t dst_index_in0,
     std::uint32_t dst_index_in1,
     std::uint32_t dst_index_out,
-    int vector_mode,
+    VectorMode vector_mode,
     Args&&... args) {
     LLK_ASSERT(
         (dst_index_in0 < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
@@ -94,7 +94,7 @@ inline __attribute__((always_inline)) void _sfpu_binary_check_and_call_(
 
 /*
  * Same as SFPU_BINARY_CALL but vector_mode is given as a `VectorMode`
- * enumerator name. The `(int)VectorMode::MODE` cast is generated.
+ * enumerator token (e.g. RC, C, R).
  *   SFPU_BINARY_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
  *                         calculate_add_fp32, (APPROXIMATE),
  *                         RC, dst_in0, dst_in1, dst_out);
@@ -105,7 +105,7 @@ inline __attribute__((always_inline)) void _sfpu_binary_check_and_call_(
         DST_IN0,                                                                                        \
         DST_IN1,                                                                                        \
         DST_OUT,                                                                                        \
-        (int)::ckernel::VectorMode::MODE,                                                               \
+        ::ckernel::VectorMode::MODE,                                                                    \
         ##__VA_ARGS__)
 
 /*

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, false>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, true>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -51,7 +51,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -62,7 +62,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, false>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -73,7 +73,7 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, true>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -30,7 +30,7 @@ inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(uint dst_index, u
         dst_index,
         idx_index,
         0 /* DST out unused, but required for _llk_math_eltwise_binary_sfpu_params_ */,
-        static_cast<int>(VectorMode::RC) /* vector_mode */,
+        VectorMode::RC,
         chunk);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -25,7 +25,7 @@ inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_mul_int(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for mul_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point)
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32(
-    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_poin
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32(
-    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
@@ -41,7 +41,7 @@ inline void llk_math_eltwise_binary_sfpu_dequant_int32_init(const uint zero_poin
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32(
-    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_rsub_int_init() {
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_rsub_int(
-    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for rsub_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_shift_init() {
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_left_shift(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for left shift. Supported data formats are: Int32, UInt32, UInt16");
@@ -32,7 +32,7 @@ inline void llk_math_eltwise_binary_sfpu_left_shift(
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_right_shift(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for right shift. Supported data formats are: Int32, UInt32, UInt16");
@@ -48,7 +48,7 @@ inline void llk_math_eltwise_binary_sfpu_right_shift(
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for logical right shift. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_binary_sfpu_sub_int_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_sub_int(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for sub_int. Supported data formats are: Int32, UInt32, UInt16");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_binary_sfpu_xlogy_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_xlogy(
-    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_calculate_sfpu_binary_<APPROXIMATE, BinaryOp::XLOGY, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted(
     uint32_t dst_index1,
     uint32_t dst_index2,
     uint32_t dst_index3,
-    int vector_mode = (int)VectorMode::RC) {
+    VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_adjusted<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,
@@ -52,7 +52,7 @@ inline void llk_math_eltwise_binary_sfpu_lgamma_stirling_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_lgamma_stirling(
-    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_lgamma_stirling_fp32<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_polygamma_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_polygamma(
-    uint32_t dst_index, uint32_t n_packed, uint32_t scale_packed, int vector_mode = (int)VectorMode::RC) {
+    uint32_t dst_index, uint32_t n_packed, uint32_t scale_packed, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_polygamma<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcdiv(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcdiv<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcmul(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcmul<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_lerp(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_lerp<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, DataFormat data_format>
 inline void llk_math_eltwise_ternary_sfpu_where(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, data_format, 8>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -15,12 +15,12 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -20,7 +20,7 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 }
 
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
         dst_index,
@@ -34,7 +34,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
@@ -46,7 +46,7 @@ inline void llk_math_eltwise_unary_sfpu_celu_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
-    uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t alpha, uint32_t alpha_recip, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         [](uint32_t alpha, uint32_t alpha_recip) {
             ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
@@ -63,7 +63,8 @@ inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_softshrink(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
@@ -74,7 +75,8 @@ inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_hardshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_hardshrink(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_add1_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
@@ -23,14 +23,14 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -16,14 +16,14 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
-    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint min_val, uint max_val, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
-    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint min_val, uint max_val, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
 
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum(
-    uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
+    uint dst_index, bool first, VectorMode vector_mode = VectorMode::RC_custom /*unused*/) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
-    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, uint param1, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -15,7 +15,8 @@ inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_heaviside(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
@@ -29,7 +29,7 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base(
-    uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint base_scale, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -31,7 +31,7 @@ namespace ckernel {
 
 template <DstSync DST_SYNC, bool DST_ACCUM, typename Callable, typename... Args>
 inline __attribute__((always_inline)) void _sfpu_check_and_call_(
-    Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode, Args&&... args) {
+    Callable&& sfpu_func, std::uint32_t dst_index, VectorMode vector_mode, Args&&... args) {
     LLK_ASSERT(
         (dst_index < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
         "dst_index exceeds max dest tiles");
@@ -94,7 +94,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
 
 /*
  * Same as SFPU_CALL but vector_mode is given as a `VectorMode` enumerator name
- * (RC, C, RC_custom, ...). The `(int)VectorMode::MODE` cast is generated.
+ * (RC, C, RC_custom, ...).
  *   SFPU_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
  *                  calculate_erfc,   (8),     RC,        idst);
  *   SFPU_CALL_MODE(DST_SYNC_MODE, DST_ACCUM_MODE,
@@ -102,7 +102,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
  */
 #define SFPU_CALL_MODE(DST_SYNC, DST_ACCUM, FN, TEMPLATES, MODE, DST_IDX, ...) \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                     \
-        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX, (int)::ckernel::VectorMode::MODE, ##__VA_ARGS__)
+        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX, ::ckernel::VectorMode::MODE, ##__VA_ARGS__)
 
 /*
  * Non-templated functor in `ckernel::sfpu`, runtime vector_mode expression.
@@ -281,7 +281,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
 
 /*
  * SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN takes its mode as a runtime expression,
- * not as a VectorMode enumerator name (note the lack of `(int)VectorMode::` in
+ * not as a VectorMode enumerator name (note the lack of `VectorMode::` in
  * the original definition), so it maps to SFPU_CALL rather than SFPU_CALL_MODE.
  */
 #define SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(FN, APPROXIMATE, FP32, ITER, LEGACY_COMPAT, DST_IDX, MODE) \
@@ -338,7 +338,7 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
     constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>(                                                \
-        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)          \
     static_assert(                                                                                                 \
@@ -356,4 +356,4 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
                                                                                   : InstrModLoadStore::DEFAULT;    \
     ::ckernel::_sfpu_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>(                                               \
-        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, VectorMode::MODE)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -15,13 +15,13 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask(
-    uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, DataFormat data_format, VectorMode vector_mode = VectorMode::RC) {
     if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
         _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -16,7 +16,8 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_unary_max(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -27,7 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -38,7 +39,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -49,7 +50,8 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_unary_min(
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -60,7 +62,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
@@ -71,7 +73,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
-    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_power_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_power(
-    uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t exponent = 0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
@@ -27,7 +27,7 @@ inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
-    uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t exponent = 0, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rdiv_init() {
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rdiv(
-    uint32_t dst_index, uint32_t value, int vector_mode = (int)VectorMode::RC) {
+    uint32_t dst_index, uint32_t value, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -45,7 +45,7 @@ inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
  */
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
-    uint dst_index, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, uint32_t idx_addr, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -16,7 +16,8 @@ inline void llk_math_eltwise_unary_sfpu_rpow_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
-inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_rpow(
+    uint dst_index, uint32_t base_val, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
-inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -15,7 +15,8 @@ inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_rsub_int32(
+    uint dst_index, uint scalar, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -13,7 +13,7 @@ inline void llk_math_eltwise_unary_sfpu_selu_init() { llk_math_eltwise_unary_sfp
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_selu(
-    uint dst_index, uint scale, uint alpha, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint scale, uint alpha, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -15,10 +15,10 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid>(sfpu::sigmoid_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_sign_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
-    uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
+    uint dst_index, VectorMode vector_mode = VectorMode::RC, uint exponent_size_8 = 1) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
@@ -25,7 +25,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_square_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_threshold_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
-    uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint32_t param0, uint32_t param1, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -15,7 +15,7 @@ inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_start_phase,
     int i_end_step,
     int i_start_step,
-    int vector_mode = (int)VectorMode::RC_custom) {
+    VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
@@ -37,7 +37,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
-    uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
+    uint dst_index, int m_iter, int k, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
@@ -54,7 +54,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int k,
     int logk,
     int skip_second,
-    int vector_mode = (int)VectorMode::RC_custom) {
+    VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -11,7 +11,7 @@
 namespace ckernel {
 
 template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
-inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
 

--- a/tt_metal/hw/inc/api/compute/binary_max_min.h
+++ b/tt_metal/hw/inc/api/compute/binary_max_min.h
@@ -86,7 +86,7 @@ ALWI void binary_max_uint32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_bin
  * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX>(idst0, idst1, odst, vector_mode)));
 }
 
@@ -170,7 +170,7 @@ ALWI void binary_min_uint32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_bin
  * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
     MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX>(idst0, idst1, odst, vector_mode)));
 }
 

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -88,7 +88,7 @@ ALWI void sigmoid_tile_init() {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-template <int vec_mode = VectorMode::RC, bool fast_and_approx = false>
+template <VectorMode vec_mode = VectorMode::RC, bool fast_and_approx = false>
 ALWI void sigmoid_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_sigmoid<fast_and_approx, DST_ACCUM_MODE>(idst, vec_mode)));
 }
@@ -119,7 +119,7 @@ ALWI void sigmoid_tile_init_pack() {
     PACK((llk_math_eltwise_unary_sfpu_sigmoid_init<fast_and_approx>()));
 }
 
-template <int vec_mode = VectorMode::RC, bool fast_and_approx = false>
+template <VectorMode vec_mode = VectorMode::RC, bool fast_and_approx = false>
 ALWI void sigmoid_tile_pack(uint32_t idst) {
     PACK((llk_math_eltwise_unary_sfpu_sigmoid<fast_and_approx, DST_ACCUM_MODE>(idst, vec_mode)));
 }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
@@ -508,7 +508,7 @@ ALWI void eqz_tile_uint16(uint32_t idst) {
  */
 // clang-format on
 ALWI void eqz_tile_uint32(uint32_t idst) {
-    MATH((SFPU_TWO_PARAM_KERNEL(calculate_eqz_uint32, APPROX, 8, idst, (int)VectorMode::RC)));
+    MATH((SFPU_TWO_PARAM_KERNEL(calculate_eqz_uint32, APPROX, 8, idst, VectorMode::RC)));
 }
 
 /**
@@ -583,7 +583,7 @@ ALWI void nez_tile_uint16(uint32_t idst) {
  */
 // clang-format on
 ALWI void nez_tile_uint32(uint32_t idst) {
-    MATH((SFPU_TWO_PARAM_KERNEL(calculate_nez_uint32, APPROX, 8, idst, (int)VectorMode::RC)));
+    MATH((SFPU_TWO_PARAM_KERNEL(calculate_nez_uint32, APPROX, 8, idst, VectorMode::RC)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
@@ -31,7 +31,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void unary_ne_tile(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_ne, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_ne, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 /**
@@ -56,7 +56,7 @@ ALWI void unary_ne_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unary_ne, APPROX));
  */
 // clang-format on
 ALWI void unary_ne_tile_int32(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_COMP_INT32_KERNEL(unary_ne, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_COMP_INT32_KERNEL(unary_ne, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 // unary eq : if x == value --> 1.0, else 0.0
@@ -76,7 +76,7 @@ ALWI void unary_ne_tile_int32(uint32_t idst, uint32_t param0) {
  */
 // clang-format on
 ALWI void unary_eq_tile(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_eq, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_eq, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 /**
@@ -101,7 +101,7 @@ ALWI void unary_eq_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unary_eq, APPROX));
  */
 // clang-format on
 ALWI void unary_eq_tile_int32(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_COMP_INT32_KERNEL(unary_eq, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_COMP_INT32_KERNEL(unary_eq, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 // unary gt : if x > value --> 1.0, else 0.0
@@ -121,7 +121,7 @@ ALWI void unary_eq_tile_int32(uint32_t idst, uint32_t param0) {
  */
 // clang-format on
 ALWI void unary_gt_tile(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_gt, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_gt, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 /**
@@ -146,7 +146,7 @@ ALWI void unary_gt_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unary_gt, APPROX));
  */
 // clang-format on
 ALWI void unary_gt_tile_int32(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_gt, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_gt, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 // unary ge : if x >= value --> 1.0, else 0.0
@@ -166,7 +166,7 @@ ALWI void unary_gt_tile_int32(uint32_t idst, uint32_t param0) {
  */
 // clang-format on
 ALWI void unary_ge_tile(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_ge, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_ge, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 /**
@@ -191,7 +191,7 @@ ALWI void unary_ge_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unary_ge, APPROX));
  */
 // clang-format on
 ALWI void unary_ge_tile_int32(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_ge, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_ge, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 // unary lt : if x < value --> 1.0, else 0.0
@@ -211,7 +211,7 @@ ALWI void unary_ge_tile_int32(uint32_t idst, uint32_t param0) {
  */
 // clang-format on
 ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_lt, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_lt, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 // unary lt : if x < value --> 1, else 0
@@ -231,7 +231,7 @@ ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
  */
 // clang-format on
 ALWI void unary_lt_tile_int32(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_lt, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_lt, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 /**
@@ -256,7 +256,7 @@ ALWI void unary_lt_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unary_lt, APPROX));
  */
 // clang-format on
 ALWI void unary_le_tile(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_le, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_le, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 // unary le : if x <= value --> 1, else 0
@@ -276,7 +276,7 @@ ALWI void unary_le_tile(uint32_t idst, uint32_t param0) {
  */
 // clang-format on
 ALWI void unary_le_tile_int32(uint32_t idst, uint32_t param0) {
-    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_le, RC, APPROX, 8, idst, param0));
+    MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_le, RC, APPROX, 8 /*ITER*/, idst, param0));
 }
 
 /**
@@ -508,7 +508,7 @@ ALWI void eqz_tile_uint16(uint32_t idst) {
  */
 // clang-format on
 ALWI void eqz_tile_uint32(uint32_t idst) {
-    MATH((SFPU_TWO_PARAM_KERNEL(calculate_eqz_uint32, APPROX, 8, idst, VectorMode::RC)));
+    MATH((SFPU_TWO_PARAM_KERNEL(calculate_eqz_uint32, APPROX, 8 /*ITER*/, idst, VectorMode::RC)));
 }
 
 /**
@@ -583,7 +583,7 @@ ALWI void nez_tile_uint16(uint32_t idst) {
  */
 // clang-format on
 ALWI void nez_tile_uint32(uint32_t idst) {
-    MATH((SFPU_TWO_PARAM_KERNEL(calculate_nez_uint32, APPROX, 8, idst, VectorMode::RC)));
+    MATH((SFPU_TWO_PARAM_KERNEL(calculate_nez_uint32, APPROX, 8 /*ITER*/, idst, VectorMode::RC)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
@@ -65,7 +65,7 @@ ALWI void erfc_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(erfc, sfpu::erfc_init, t
  */
 // clang-format on
 ALWI void erfc_tile(uint32_t idst) {
-    MATH(_llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_erfc<>, idst, (int)VectorMode::RC));
+    MATH(_llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_erfc<>, idst, VectorMode::RC));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
@@ -63,7 +63,7 @@ ALWI void exp_tile_init() {
  * | Argument    | Description                                                                | Type     | Valid Range                                           | Required |
  * |-------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst        | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | vector_mode | Specifies the vector mode for computation (default: VectorMode::RC)        | int      | Subject to specific hardware/kernel limits            | False    |
+ * | vector_mode | Specifies the vector mode for computation (default: VectorMode::RC)        | VectorMode | Subject to specific hardware/kernel limits            | False    |
  * | scale       | Scale factor to apply in approximate or non-approximate mode if scale_en is true (default: 0x3F80, 1.0f in FP16b) | uint16_t | Valid FP16b representation                            | False    |
  */
 // clang-format on
@@ -72,7 +72,7 @@ template <
     bool scale_en = false,
     InputClamping input_clamping = InputClamping::ClampToNegative,
     int iterations = 8>
-ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
+ALWI void exp_tile(uint32_t idst, VectorMode vector_mode = VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
     MATH(SFPU_TEMPLATE_PARAMS_KERNEL_FN(
         calculate_exponential,
         approx,
@@ -110,7 +110,7 @@ template <
     InputClamping input_clamping = InputClamping::ClampToNegative,
     int iterations = 8>
 ALWI void exp_packthread_tile(
-    uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
+    uint32_t idst, VectorMode vector_mode = VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
     PACK(SFPU_TEMPLATE_PARAMS_KERNEL_FN(
         calculate_exponential,
         approx,

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
@@ -44,12 +44,12 @@ ALWI void gelu_tile_init_pack() {
 // clang-format on
 template <bool fast_and_approx = true>
 ALWI void gelu_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_gelu, fast_and_approx, DST_ACCUM_MODE, idst, (int)VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(calculate_gelu, fast_and_approx, DST_ACCUM_MODE, idst, VectorMode::RC));
 }
 
 template <bool fast_and_approx = true>
 ALWI void gelu_tile_pack(uint32_t idst) {
-    PACK(SFPU_TWO_PARAM_KERNEL(calculate_gelu, fast_and_approx, DST_ACCUM_MODE, idst, (int)VectorMode::RC));
+    PACK(SFPU_TWO_PARAM_KERNEL(calculate_gelu, fast_and_approx, DST_ACCUM_MODE, idst, VectorMode::RC));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
@@ -24,7 +24,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void identity_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity, APPROX, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity, APPROX, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -45,7 +45,7 @@ ALWI void identity_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unused, APPROX)); }
  */
 // clang-format on
 ALWI void identity_tile_uint32(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity_uint, APPROX, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity_uint, APPROX, 8, idst, VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
@@ -24,7 +24,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void identity_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity, APPROX, 8, idst, VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -45,7 +45,7 @@ ALWI void identity_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unused, APPROX)); }
  */
 // clang-format on
 ALWI void identity_tile_uint32(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity_uint, APPROX, 8, idst, VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity_uint, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
@@ -33,11 +33,11 @@ ALWI void negative_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(negative, APPROX));
  */
 // clang-format on
 ALWI void negative_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_, APPROX, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_, APPROX, 8, idst, VectorMode::RC));
 }
 
 ALWI void negative_tile_int32(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_int_, APPROX, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_int_, APPROX, 8, idst, VectorMode::RC));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
@@ -33,11 +33,11 @@ ALWI void negative_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(negative, APPROX));
  */
 // clang-format on
 ALWI void negative_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_, APPROX, 8, idst, VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 ALWI void negative_tile_int32(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_int_, APPROX, 8, idst, VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_int_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rdiv.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rdiv.h
@@ -32,7 +32,7 @@ ALWI void rdiv_tile_init() { MATH((llk_math_eltwise_unary_sfpu_rdiv_init<APPROX>
  */
 // clang-format on
 template <RoundingMode rounding_mode = RoundingMode::None>
-ALWI void rdiv_tile(uint32_t dst_index, uint32_t value, int vector_mode = (int)VectorMode::RC) {
+ALWI void rdiv_tile(uint32_t dst_index, uint32_t value, VectorMode vector_mode = VectorMode::RC) {
     MATH((llk_math_eltwise_unary_sfpu_rdiv<APPROX, DST_ACCUM_MODE, rounding_mode>(dst_index, value, vector_mode)));
 }
 

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/recip.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/recip.h
@@ -29,11 +29,11 @@ ALWI void recip_tile_init() { MATH(SFPU_THREE_TEMPLATE_PARAM_INIT(reciprocal, sf
  * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | vector_mode | Specifies the vector mode for computation (e.g., Row, Column). (default: VectorMode::RC) | int      | Subject to specific hardware/kernel limits          | False    |
+ * | vector_mode | Specifies the vector mode for computation (e.g., Row, Column). (default: VectorMode::RC) | VectorMode | Subject to specific hardware/kernel limits          | False    |
  */
 // clang-format on
 template <bool legacy_compat = true>
-ALWI void recip_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC) {
+ALWI void recip_tile(uint32_t idst, VectorMode vector_mode = VectorMode::RC) {
     MATH(SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(
         calculate_reciprocal, APPROX, DST_ACCUM_MODE, 8, legacy_compat, idst, vector_mode));
 }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
@@ -31,9 +31,7 @@ ALWI void rounding_op_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unused, APPROX))
  * | idst            | The index of the tile in DST register buffer to perform ceil operation     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void ceil_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_ceil_, APPROX, 8, idst, (int)VectorMode::RC));
-}
+ALWI void ceil_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_ceil_, APPROX, 8, idst, VectorMode::RC)); }
 
 // clang-format off
 /**
@@ -49,9 +47,7 @@ ALWI void ceil_tile(uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform floor operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void floor_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_floor_, APPROX, 8, idst, (int)VectorMode::RC));
-}
+ALWI void floor_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_floor_, APPROX, 8, idst, VectorMode::RC)); }
 
 // clang-format off
 /**
@@ -67,9 +63,7 @@ ALWI void floor_tile(uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform trunc operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void trunc_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_trunc_, APPROX, 8, idst, (int)VectorMode::RC));
-}
+ALWI void trunc_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_trunc_, APPROX, 8, idst, VectorMode::RC)); }
 
 // clang-format off
 /**
@@ -87,7 +81,7 @@ ALWI void trunc_tile(uint32_t idst) {
  */
 // clang-format on
 ALWI void round_tile(uint32_t idst, int32_t decimals) {
-    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(_calculate_round_, APPROX, 8, idst, (int)VectorMode::RC, decimals));
+    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(_calculate_round_, APPROX, 8, idst, VectorMode::RC, decimals));
 }
 
 // clang-format off
@@ -109,7 +103,7 @@ ALWI void round_tile(uint32_t idst, int32_t decimals) {
  */
 // clang-format on
 ALWI void stochastic_round_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_stochastic_round_, APPROX, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_stochastic_round_, APPROX, 8, idst, VectorMode::RC));
 }
 
 // clang-format off
@@ -126,8 +120,6 @@ ALWI void stochastic_round_tile(uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform frac operation     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void frac_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_frac_, APPROX, 8, idst, (int)VectorMode::RC));
-}
+ALWI void frac_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_frac_, APPROX, 8, idst, VectorMode::RC)); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
@@ -31,7 +31,9 @@ ALWI void rounding_op_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unused, APPROX))
  * | idst            | The index of the tile in DST register buffer to perform ceil operation     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void ceil_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_ceil_, APPROX, 8, idst, VectorMode::RC)); }
+ALWI void ceil_tile(uint32_t idst) {
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_ceil_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+}
 
 // clang-format off
 /**
@@ -47,7 +49,9 @@ ALWI void ceil_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_ceil_
  * | idst            | The index of the tile in DST register buffer to perform floor operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void floor_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_floor_, APPROX, 8, idst, VectorMode::RC)); }
+ALWI void floor_tile(uint32_t idst) {
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_floor_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+}
 
 // clang-format off
 /**
@@ -63,7 +67,9 @@ ALWI void floor_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_floo
  * | idst            | The index of the tile in DST register buffer to perform trunc operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void trunc_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_trunc_, APPROX, 8, idst, VectorMode::RC)); }
+ALWI void trunc_tile(uint32_t idst) {
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_trunc_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+}
 
 // clang-format off
 /**
@@ -81,7 +87,7 @@ ALWI void trunc_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_trun
  */
 // clang-format on
 ALWI void round_tile(uint32_t idst, int32_t decimals) {
-    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(_calculate_round_, APPROX, 8, idst, VectorMode::RC, decimals));
+    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(_calculate_round_, APPROX, 8 /*ITER*/, idst, VectorMode::RC, decimals));
 }
 
 // clang-format off
@@ -103,7 +109,7 @@ ALWI void round_tile(uint32_t idst, int32_t decimals) {
  */
 // clang-format on
 ALWI void stochastic_round_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_stochastic_round_, APPROX, 8, idst, VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_stochastic_round_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 // clang-format off
@@ -120,6 +126,8 @@ ALWI void stochastic_round_tile(uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform frac operation     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void frac_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_frac_, APPROX, 8, idst, VectorMode::RC)); }
+ALWI void frac_tile(uint32_t idst) {
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_frac_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+}
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rpow.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rpow.h
@@ -29,7 +29,7 @@ ALWI void rpow_tile_init() { MATH((llk_math_eltwise_unary_sfpu_rpow_init<APPROX>
  * | base_val       | The base value to raise to the power of each element in the tile            | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void rpow_tile(uint32_t idst, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
+ALWI void rpow_tile(uint32_t idst, uint32_t base_val, VectorMode vector_mode = VectorMode::RC) {
     MATH((llk_math_eltwise_unary_sfpu_rpow<APPROX, DST_ACCUM_MODE>(idst, base_val, vector_mode)));
 }
 

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
@@ -15,15 +15,15 @@ namespace ckernel {
 ALWI void sfpu_sum_int_init() { MATH(SFPU_INIT_KERNEL_CALL(unused, sfpu::sum_int_init, APPROX)); }
 
 ALWI void sfpu_sum_int_col(uint32_t idst) {
-    MATH(SFPU_ONE_PARAM_KERNEL(calculate_sum_int_col, APPROX, idst, (int)VectorMode::R));
+    MATH(SFPU_ONE_PARAM_KERNEL(calculate_sum_int_col, APPROX, idst, VectorMode::R));
 }
 
 ALWI void sfpu_sum_int_row(uint32_t idst) {
-    MATH(SFPU_ONE_PARAM_KERNEL(calculate_sum_int_row, APPROX, idst, (int)VectorMode::C));
+    MATH(SFPU_ONE_PARAM_KERNEL(calculate_sum_int_row, APPROX, idst, VectorMode::C));
 }
 
 ALWI void sfpu_add_int(uint32_t idst, uint32_t dst_offset = 2, int32_t iterations = 8) {
-    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(add_int, APPROX, 8, idst, (int)VectorMode::RC, dst_offset));
+    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(add_int, APPROX, 8, idst, VectorMode::RC, dst_offset));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
@@ -23,7 +23,7 @@ ALWI void sfpu_sum_int_row(uint32_t idst) {
 }
 
 ALWI void sfpu_add_int(uint32_t idst, uint32_t dst_offset = 2, int32_t iterations = 8) {
-    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(add_int, APPROX, 8, idst, VectorMode::RC, dst_offset));
+    MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(add_int, APPROX, 8 /*ITER*/, idst, VectorMode::RC, dst_offset));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/tanh_derivative.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/tanh_derivative.h
@@ -40,8 +40,7 @@ ALWI void tanh_derivative_tile_init() {
 // clang-format on
 template <bool fast_and_approx = false>
 ALWI void tanh_derivative_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(
-        calculate_tanh_derivative_sech2, fast_and_approx, DST_ACCUM_MODE, idst, (int)VectorMode::RC));
+    MATH(SFPU_TWO_PARAM_KERNEL(calculate_tanh_derivative_sech2, fast_and_approx, DST_ACCUM_MODE, idst, VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -32,7 +32,7 @@ ALWI void sin_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(sine, ckernel::sfpu::sine
  */
 // clang-format on
 ALWI void sin_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sine, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sine, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -55,7 +55,7 @@ ALWI void cos_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosine, ckernel::sfpu::co
  */
 // clang-format on
 ALWI void cos_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosine, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosine, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -77,9 +77,7 @@ ALWI void acosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(acosh, ckernel::sfpu::_
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void acosh_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_acosh_, APPROX, 8, idst, (int)VectorMode::RC));
-}
+ALWI void acosh_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_acosh_, APPROX, 8, idst, VectorMode::RC)); }
 
 /**
  * Please refer to documentation for any_init.
@@ -101,7 +99,7 @@ ALWI void tan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(tan, ckernel::sfpu::tange
  */
 // clang-format on
 ALWI void tan_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_tangent, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_tangent, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -123,9 +121,7 @@ ALWI void asinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(asinh, ckernel::sfpu::_
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void asinh_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_asinh_, APPROX, 8, idst, (int)VectorMode::RC));
-}
+ALWI void asinh_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_asinh_, APPROX, 8, idst, VectorMode::RC)); }
 
 /**
  * Please refer to documentation for any_init.
@@ -147,8 +143,7 @@ ALWI void atanh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atanh, ckernel::sfpu::_
  */
 // clang-format on
 ALWI void atanh_tile(uint32_t idst) {
-    MATH(
-        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(_calculate_atanh_, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(_calculate_atanh_, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 // clang-format off
@@ -166,7 +161,7 @@ ALWI void atanh_tile(uint32_t idst) {
  */
 // clang-format on
 ALWI void asin_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asin, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asin, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -189,7 +184,7 @@ ALWI void asin_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(asin, true)); }
  */
 // clang-format on
 ALWI void atan_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atan, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atan, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -212,7 +207,7 @@ ALWI void atan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atan, sfpu::atan_init, t
  */
 // clang-format on
 ALWI void acos_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acos, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acos, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -240,8 +235,7 @@ ALWI void cosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosh, ckernel::sfpu::ini
  */
 // clang-format on
 ALWI void cosh_tile(uint32_t idst) {
-    MATH(
-        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosh, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosh, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 /**
@@ -264,8 +258,7 @@ ALWI void sinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(sinh, ckernel::sfpu::ini
  */
 // clang-format on
 ALWI void sinh_tile(uint32_t idst) {
-    MATH(
-        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sinh, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sinh, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -32,7 +32,7 @@ ALWI void sin_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(sine, ckernel::sfpu::sine
  */
 // clang-format on
 ALWI void sin_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sine, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sine, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -55,7 +55,8 @@ ALWI void cos_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosine, ckernel::sfpu::co
  */
 // clang-format on
 ALWI void cos_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosine, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(
+        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosine, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -77,7 +78,9 @@ ALWI void acosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(acosh, ckernel::sfpu::_
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void acosh_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_acosh_, APPROX, 8, idst, VectorMode::RC)); }
+ALWI void acosh_tile(uint32_t idst) {
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_acosh_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -99,7 +102,8 @@ ALWI void tan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(tan, ckernel::sfpu::tange
  */
 // clang-format on
 ALWI void tan_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_tangent, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(
+        calculate_tangent, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -121,7 +125,9 @@ ALWI void asinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(asinh, ckernel::sfpu::_
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void asinh_tile(uint32_t idst) { MATH(SFPU_TWO_PARAM_KERNEL(_calculate_asinh_, APPROX, 8, idst, VectorMode::RC)); }
+ALWI void asinh_tile(uint32_t idst) {
+    MATH(SFPU_TWO_PARAM_KERNEL(_calculate_asinh_, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -143,7 +149,8 @@ ALWI void atanh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atanh, ckernel::sfpu::_
  */
 // clang-format on
 ALWI void atanh_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(_calculate_atanh_, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(
+        _calculate_atanh_, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 // clang-format off
@@ -161,7 +168,7 @@ ALWI void atanh_tile(uint32_t idst) {
  */
 // clang-format on
 ALWI void asin_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asin, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asin, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -184,7 +191,7 @@ ALWI void asin_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(asin, true)); }
  */
 // clang-format on
 ALWI void atan_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atan, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atan, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -207,7 +214,7 @@ ALWI void atan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atan, sfpu::atan_init, t
  */
 // clang-format on
 ALWI void acos_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acos, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acos, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -235,7 +242,7 @@ ALWI void cosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosh, ckernel::sfpu::ini
  */
 // clang-format on
 ALWI void cosh_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosh, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -258,7 +265,7 @@ ALWI void sinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(sinh, ckernel::sfpu::ini
  */
 // clang-format on
 ALWI void sinh_tile(uint32_t idst) {
-    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sinh, APPROX, DST_ACCUM_MODE, 8, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sinh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -159,8 +159,7 @@ template <
     bool FAST_MODE      = false,
     bool STABLE_SORT    = false,
     bool CLAMP_NEGATIVE = false>
-void call_unary_sfpu_operation(
-    std::uint32_t dst_index, std::uint32_t math_format = 0, float fill_const_value = 5.0f, int vector_mode = static_cast<int>(VectorMode::None))
+void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_format = 0, float fill_const_value = 5.0f, VectorMode vector_mode = VectorMode::None)
 {
     if constexpr (OPERATION == SfpuType::abs)
     {
@@ -473,7 +472,7 @@ void call_binary_sfpu_operation(
     const std::uint32_t dst_index_in0 = 0,
     const std::uint32_t dst_index_in1 = 1,
     const std::uint32_t dst_index_out = 0,
-    int vector_mode                   = static_cast<int>(VectorMode::RC))
+    ckernel::VectorMode vector_mode   = ckernel::VectorMode::RC)
 {
     // NOTE: The functions invoked via SFPU_BINARY_CALL below run inside
     // _llk_math_eltwise_binary_sfpu_params_, which already loops over 4 faces
@@ -553,7 +552,7 @@ void call_binary_sfpu_operation(
             dst_index_in0,
             dst_index_in1,
             dst_index_out,
-            static_cast<int>(VectorMode::RC_custom));
+            ckernel::VectorMode::RC_custom);
     }
     else
     {

--- a/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_full.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_full.py
@@ -308,7 +308,7 @@ def test_fast_tilize_overflow_guard(formats, dest_acc, dimensions):
     last_g_addr = (
         stim.buf_res_addr + (tile_count + guard_tiles - 1) * stim.buf_res_tile_size
     )
-    core_loc = "0,0"  # already "x,y" string
+    core_loc = TestConfig.TENSIX_LOCATION  # already "x,y" string
     raw = read_from_device(core_loc, last_g_addr, num_bytes=10)
     marker = struct.unpack_from("<H", raw, 0)[0]
     assert (

--- a/tt_metal/tt-llk/tests/sources/sort_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sort_test.cpp
@@ -204,7 +204,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     constexpr bool APPROX             = false;
     constexpr std::uint32_t dst_index = 0;
-    constexpr int vector_mode         = (int)VectorMode::RC_custom;
+    constexpr VectorMode vector_mode  = VectorMode::RC_custom;
     constexpr int start_phase         = 0;
     constexpr int end_step            = 0;
     constexpr int start_step          = 0;

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -249,7 +249,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr int start_phase         = 0;
     constexpr int end_step            = 0;
     constexpr int start_step          = 0;
-    constexpr int vector_mode         = (int)VectorMode::RC_custom;
+    constexpr VectorMode vector_mode  = VectorMode::RC_custom;
 
     const std::uint32_t math_data_types[NUM_STAGES] = {formats.math, ckernel::to_underlying(DataFormat::UInt16)};
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
@@ -11,7 +11,7 @@
 namespace ckernel
 {
 
-enum VectorMode
+enum class VectorMode : std::uint8_t
 {
     None      = 0,
     R         = 1,

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu_params.h
@@ -15,7 +15,7 @@ inline void _llk_math_eltwise_binary_sfpu_params_(
     std::uint32_t dst_index_in0,
     std::uint32_t dst_index_in1,
     std::uint32_t dst_index_out,
-    int vector_mode = static_cast<int>(VectorMode::RC),
+    VectorMode vector_mode = VectorMode::RC,
     Args&&... args)
 {
     _llk_math_eltwise_sfpu_start_(0);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_sfpu_common.h
@@ -51,11 +51,9 @@ inline void _llk_math_eltwise_sfpu_assert_dst_index_(std::uint32_t dst_index, [[
 }
 
 template <typename Callable, typename... Args>
-inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_mode_(Callable&& sfpu_func, int vector_mode, Args&&... args)
+inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_mode_(Callable&& sfpu_func, VectorMode vector_mode, Args&&... args)
 {
-    VectorMode mode = static_cast<VectorMode>(vector_mode);
-
-    if (mode == VectorMode::R)
+    if (vector_mode == VectorMode::R)
     {
         // Do a row vector, Face0 + Face1 -- first iteration (first row)
 #pragma GCC unroll 0
@@ -68,7 +66,7 @@ inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_m
         _llk_math_eltwise_sfpu_inc_dst_face_addr_();
         _llk_math_eltwise_sfpu_inc_dst_face_addr_();
     }
-    else if (mode == VectorMode::C)
+    else if (vector_mode == VectorMode::C)
     {
         // Do a column vector, Face0 + Face2 -- All iterations for full face
 #pragma GCC unroll 0
@@ -79,7 +77,7 @@ inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_m
             _llk_math_eltwise_sfpu_inc_dst_face_addr_();
         }
     }
-    else if (mode == VectorMode::RC)
+    else if (vector_mode == VectorMode::RC)
     {
         // Do all four faces, and iterate through all 4 blocks of 4 rows each
 #pragma GCC unroll 0

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
@@ -16,7 +16,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
     std::uint32_t dst_index_in1,
     std::uint32_t dst_index_in2,
     std::uint32_t dst_index_out,
-    int vector_mode = static_cast<int>(VectorMode::RC),
+    VectorMode vector_mode = VectorMode::RC,
     Args&&... args)
 {
     _llk_math_eltwise_sfpu_assert_dst_index_<DST_SYNC_MODE, DST_ACCUM_MODE>(dst_index_in0, "dst_index_in0 exceeds max dest tiles");

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -10,8 +10,7 @@
 #include "llk_math_eltwise_unary_sfpu.h"
 
 template <typename Callable, typename... Args>
-inline void _llk_math_eltwise_unary_sfpu_params_(
-    Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
+inline void _llk_math_eltwise_unary_sfpu_params_(Callable&& sfpu_func, std::uint32_t dst_index, VectorMode vector_mode = VectorMode::RC, Args&&... args)
 {
     _llk_math_eltwise_sfpu_start_(dst_index);
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -10,7 +10,7 @@ namespace ckernel
 {
 
 // Currently unused but kept for backwards compatibility
-enum class VectorMode
+enum class VectorMode : std::uint8_t
 {
     None      = 0,
     R         = 1,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -11,7 +11,7 @@
 namespace ckernel
 {
 
-enum VectorMode
+enum class VectorMode : std::uint8_t
 {
     None      = 0,
     R         = 1,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu_params.h
@@ -15,7 +15,7 @@ inline void _llk_math_eltwise_binary_sfpu_params_(
     std::uint32_t dst_index_in0,
     std::uint32_t dst_index_in1,
     std::uint32_t dst_index_out,
-    int vector_mode = static_cast<int>(VectorMode::RC),
+    VectorMode vector_mode = VectorMode::RC,
     Args&&... args)
 {
     _llk_math_eltwise_sfpu_start_(0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_sfpu_common.h
@@ -47,11 +47,9 @@ inline void _llk_math_eltwise_sfpu_assert_dst_index_(std::uint32_t dst_index, [[
 }
 
 template <typename Callable, typename... Args>
-inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_mode_(Callable&& sfpu_func, int vector_mode, Args&&... args)
+inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_mode_(Callable&& sfpu_func, VectorMode vector_mode, Args&&... args)
 {
-    VectorMode mode = static_cast<VectorMode>(vector_mode);
-
-    if (mode == VectorMode::R)
+    if (vector_mode == VectorMode::R)
     {
         // Do a row vector, Face0 + Face1 -- first iteration (first row)
 #pragma GCC unroll 0
@@ -64,7 +62,7 @@ inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_m
         _llk_math_eltwise_sfpu_inc_dst_face_addr_();
         _llk_math_eltwise_sfpu_inc_dst_face_addr_();
     }
-    else if (mode == VectorMode::C)
+    else if (vector_mode == VectorMode::C)
     {
         // Do a column vector, Face0 + Face2 -- All iterations for full face
 #pragma GCC unroll 0
@@ -75,7 +73,7 @@ inline __attribute__((always_inline)) void _llk_math_eltwise_sfpu_apply_vector_m
             _llk_math_eltwise_sfpu_inc_dst_face_addr_();
         }
     }
-    else if (mode == VectorMode::RC)
+    else if (vector_mode == VectorMode::RC)
     {
         // Do all four faces, and iterate through all 4 blocks of 4 rows each
 #pragma GCC unroll 0

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
@@ -16,7 +16,7 @@ inline void _llk_math_eltwise_ternary_sfpu_params_(
     std::uint32_t dst_index_in1,
     std::uint32_t dst_index_in2,
     std::uint32_t dst_index_out,
-    int vector_mode = static_cast<int>(VectorMode::RC),
+    VectorMode vector_mode = VectorMode::RC,
     Args&&... args)
 {
     _llk_math_eltwise_sfpu_assert_dst_index_<DST_SYNC_MODE, DST_ACCUM_MODE>(dst_index_in0, "dst_index_in0 exceeds max dest tiles");

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -10,8 +10,7 @@
 #include "llk_math_eltwise_unary_sfpu.h"
 
 template <typename Callable, typename... Args>
-inline void _llk_math_eltwise_unary_sfpu_params_(
-    Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
+inline void _llk_math_eltwise_unary_sfpu_params_(Callable&& sfpu_func, std::uint32_t dst_index, VectorMode vector_mode = VectorMode::RC, Args&&... args)
 {
     _llk_math_eltwise_sfpu_start_(dst_index);
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/compute_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/compute_kernel.cpp
@@ -44,7 +44,7 @@ inline OutputCBs reduce_fct(
     uint32_t cb_l1_temp,
     uint32_t cb_l2_temp,
     uint32_t loop_size) {
-    constexpr int mode = VectorMode::R;
+    constexpr VectorMode mode = VectorMode::R;
     const uint32_t out_tiles = Sq_chunk_t * vDHt;
 
     // Wait for all inputs to be available
@@ -126,8 +126,6 @@ void kernel_main() {
 
     // for last round of device 1 add extra compute:
     // out = l / s
-    const bool use_half_tile = true;
-    constexpr int vector_mode = use_half_tile ? VectorMode::R : VectorMode::RC;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
     mm_init(cb_out_accumulate_im, cb_out_accumulate_im, cb_out_accumulate_im);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -263,9 +263,10 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             TT_FATAL(
                 (int32_t)param0 == (int32_t)VecMode::C || (int32_t)param0 == (int32_t)VecMode::RC,
                 "Invalid Vector mode value. Expected vector mode C (2) or RC (4) for sigmoid");
+            const char* vec_mode_sym = (int32_t)param0 == (int32_t)VecMode::C ? "VectorMode::C" : "VectorMode::RC";
             return {
                 fmt::format("sigmoid_tile_init<{}u>();", param1),
-                fmt::format("sigmoid_tile<{1}, {2}u>({0});", idst, (int32_t)param0, param1)};
+                fmt::format("sigmoid_tile<{}, {}u>({});", vec_mode_sym, param1, idst)};
         }
         case UnaryOpType::ERF:
             return {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -124,7 +124,7 @@ inline void llk_math_eltwise_binary_sfpu_swiglu_init() {
 
 template <bool is_fp32_dest_acc_en = false, class Config = ckernel::sfpu::SwiGLUConfigGPTOSS>
 inline void llk_math_eltwise_binary_sfpu_swiglu(
-    uint gate_tile, uint32_t up_tile, uint32_t out_tile, int vector_mode = VectorMode::RC) {
+    uint gate_tile, uint32_t up_tile, uint32_t out_tile, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_swiglu<is_fp32_dest_acc_en, 8, Config>, gate_tile, up_tile, out_tile, vector_mode);
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp
@@ -83,7 +83,9 @@ struct ActivationApplyHelper {
             relu_max_tile_pack(tile_index, max);
         } else if constexpr (ACT == KernelActivation::SIGMOID) {
             // Enhanced: PARAM0 is vector mode, PARAM1 is fast_approximate
-            constexpr int vec_mode = (PARAM0 == 1) ? VectorMode::R : (PARAM0 == 2) ? VectorMode::C : VectorMode::RC;
+            constexpr VectorMode vec_mode = (PARAM0 == 1)   ? VectorMode::R
+                                            : (PARAM0 == 2) ? VectorMode::C
+                                                            : VectorMode::RC;
             sigmoid_tile_pack<vec_mode, PARAM1 != 0>(tile_index);
         } else if constexpr (ACT == KernelActivation::HARDSIGMOID) {
             hardsigmoid_tile_pack(tile_index);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -331,7 +331,7 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
             tile_regs_acquire();
             for (uint32_t j = 0; j < dst_tiles; ++j) {
                 sub_tiles_bcast_cols(in0_cb, in1_cb, j, i, j);
-                constexpr int iterations = (vector_mode == VectorMode::RC) ? 32 : 8;
+                constexpr int iterations = (vector_mode == VectorMode::RC) ? 32 /*ITER*/ : 8 /*ITER*/;
                 constexpr VectorMode vector_mode_exp = (vector_mode == VectorMode::RC) ? VectorMode::None : vector_mode;
                 exp_tile<true /* approx */, false /* scale_en */, InputClamping::None, iterations>(j, vector_mode_exp);
             }
@@ -1091,10 +1091,11 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
         sub_tiles(in0_cb, in1_cb, i, i, 0);
         // exp_tile<false, true /*SCALE_EN*/>(0, (int)VectorMode::C, (uint16_t)0xBF80 /*bf16(-1.0) scale*/);
         MATH((exp_tile_first_column<false /*APPROX_MODE*/, (uint16_t)0xBF80 /*bf16(-1.0) scale*/>(0)));
-        // add_unary_tile(0, 0x3F800000); // Call the LLK directly to get access to VectorMode argument
-        MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY>(0, 0x3F800000, VectorMode::C)));
+        // add_unary_tile(0 /*dst_index*/, 0x3F800000); // Call the LLK directly to get access to VectorMode argument
+        MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY>(
+            0 /*dst_index*/, 0x3F800000 /*scalar*/, VectorMode::C)));
         // recip_tile<false>(0, (int)VectorMode::C);
-        MATH((recip_tile_first_column<false>(0)));
+        MATH((recip_tile_first_column<false>(0 /*dst_index*/)));
         pack_tile(0, out_cb);
         release_dst();
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -56,7 +56,7 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
         acquire_dst();
         copy_tile(in0, i, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
-        binary_max_tile(dst_reg_0, dst_reg_1, dst_reg_0, static_cast<int>(VectorMode::C));
+        binary_max_tile(dst_reg_0, dst_reg_1, dst_reg_0, VectorMode::C);
         pack_tile(dst_reg_0, in0);
         release_dst();
     }
@@ -68,7 +68,7 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
 /**
  * out_cb = eltwise_max(in0, in1)
  */
-template <int vector_mode = (int)VectorMode::RC>
+template <VectorMode vector_mode = VectorMode::RC>
 void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) {
     // inputs come in full, outputs go out full
     copy_tile_to_dst_init_short(in0);
@@ -83,7 +83,7 @@ void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) 
         acquire_dst();
         copy_tile(in0, i, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
-        binary_max_tile(dst_reg_0, dst_reg_1, dst_reg_0, static_cast<int>(VectorMode::C));
+        binary_max_tile(dst_reg_0, dst_reg_1, dst_reg_0, vector_mode);
         pack_tile(dst_reg_0, out_cb, i);
         release_dst();
     }
@@ -100,7 +100,7 @@ template <
     uint32_t scale_cb,
     uint32_t rows,
     uint32_t cols,
-    int vector_mode = static_cast<int>(VectorMode::C)>
+    VectorMode vector_mode = VectorMode::C>
 void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
     // Precondition: in0_cb has rows*cols produced. in0_cb has tiles in row-major order
     // Precondition: scale_cb has 1 produced
@@ -179,7 +179,7 @@ template <
     uint32_t in0_cb,
     uint32_t scale_cb,
     uint32_t rows,
-    int vector_mode = static_cast<int>(VectorMode::C)>
+    VectorMode vector_mode = VectorMode::C>
 void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_max = false) {
     // Precondition: in0_cb has rows*cols produced. in0_cb has tiles in row-major order
     // Precondition: scale_cb has 1 produced
@@ -207,7 +207,7 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
         if (do_eltwise_max) {
             copy_tile_to_dst_init_short(prev_cb);
             copy_tile(prev_cb, i, prev_max_dst_idx);
-            binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx, static_cast<int>(vector_mode));
+            binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx, vector_mode);
         }
 
         pack_tile(reduce_dst_idx, out_cb);
@@ -261,7 +261,7 @@ void calculate_recip_first_column() {
 
 template <bool legacy_compat = true>
 void recip_tile_first_column(uint32_t idst) {
-    _llk_math_eltwise_unary_sfpu_params_(calculate_recip_first_column<legacy_compat>, idst, (int)VectorMode::C);
+    _llk_math_eltwise_unary_sfpu_params_(calculate_recip_first_column<legacy_compat>, idst, VectorMode::C);
 }
 #endif
 
@@ -298,7 +298,7 @@ template <
     uint32_t scale_fp32,
     bool write_result_inplace = true,
     bool do_reduce = true,
-    int vector_mode = (int)VectorMode::RC>
+    VectorMode vector_mode = VectorMode::RC>
 void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint32_t cols) {
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
@@ -332,7 +332,7 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
             for (uint32_t j = 0; j < dst_tiles; ++j) {
                 sub_tiles_bcast_cols(in0_cb, in1_cb, j, i, j);
                 constexpr int iterations = (vector_mode == VectorMode::RC) ? 32 : 8;
-                constexpr int vector_mode_exp = (vector_mode == VectorMode::RC) ? VectorMode::None : vector_mode;
+                constexpr VectorMode vector_mode_exp = (vector_mode == VectorMode::RC) ? VectorMode::None : vector_mode;
                 exp_tile<true /* approx */, false /* scale_en */, InputClamping::None, iterations>(j, vector_mode_exp);
             }
             tile_regs_commit();
@@ -848,7 +848,7 @@ void calculate_exponential_first_column() {
 template <bool SDPA_EXP_APPROX_MODE, uint16_t scale_bf16>
 void exp_tile_first_column(uint32_t idst) {
     _llk_math_eltwise_unary_sfpu_params_(
-        calculate_exponential_first_column<SDPA_EXP_APPROX_MODE, scale_bf16>, idst, (int)VectorMode::C);
+        calculate_exponential_first_column<SDPA_EXP_APPROX_MODE, scale_bf16>, idst, VectorMode::C);
 }
 #endif  // defined(TRISC_MATH) || defined(TRISC_PACK)
 
@@ -940,14 +940,14 @@ void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
     }
 }
 
-template <bool SDPA_EXP_APPROX_MODE, int vector_mode = (int)VectorMode::C>
+template <bool SDPA_EXP_APPROX_MODE, VectorMode vector_mode = VectorMode::C>
 void fused_max_sub_exp_add_tile(uint32_t idst, int scale_bf16) {
     _llk_math_eltwise_unary_sfpu_params_(
         calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE>, idst, vector_mode, scale_bf16);
 }
 #endif
 
-template <uint32_t scale_fp32, int vector_mode = (int)VectorMode::C>
+template <uint32_t scale_fp32, VectorMode vector_mode = VectorMode::C>
 void correction_block(
     uint32_t cb_worker_max,
     uint32_t cb_worker_sum,
@@ -1092,7 +1092,7 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
         // exp_tile<false, true /*SCALE_EN*/>(0, (int)VectorMode::C, (uint16_t)0xBF80 /*bf16(-1.0) scale*/);
         MATH((exp_tile_first_column<false /*APPROX_MODE*/, (uint16_t)0xBF80 /*bf16(-1.0) scale*/>(0)));
         // add_unary_tile(0, 0x3F800000); // Call the LLK directly to get access to VectorMode argument
-        MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY>(0, 0x3F800000, (int)VectorMode::C)));
+        MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY>(0, 0x3F800000, VectorMode::C)));
         // recip_tile<false>(0, (int)VectorMode::C);
         MATH((recip_tile_first_column<false>(0)));
         pack_tile(0, out_cb);
@@ -1119,7 +1119,7 @@ void calculate_softplus_first_column(uint param0, uint param1, uint param2) {
 
 void softplus_tile_first_column(uint32_t idst, uint beta, uint beta_reciprocal, uint threshold) {
     _llk_math_eltwise_unary_sfpu_params_(
-        calculate_softplus_first_column<APPROX>, idst, (int)VectorMode::C, beta, beta_reciprocal, threshold);
+        calculate_softplus_first_column<APPROX>, idst, VectorMode::C, beta, beta_reciprocal, threshold);
 }
 #endif
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -319,7 +319,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
         MaybeDeviceZoneScopedN(profiling_enabled, "EXP");
         uint32_t dst_index = 0;
         constexpr int iterations = 32;
-        constexpr int vector_mode_exp = (int)VectorMode::None;
+        constexpr VectorMode vector_mode_exp = VectorMode::None;
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             for (uint32_t j = 0; j < tiles_per_column; j++) {
                 exp_packthread_tile<true, false, InputClamping::None, iterations>(dst_index++, vector_mode_exp);
@@ -530,7 +530,7 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
 #ifdef ARCH_BLACKHOLE
             recip_tile_init<false>();
-            MATH((recip_tile<false>(0, (int)VectorMode::C)));
+            MATH((recip_tile<false>(0, VectorMode::C)));
 #else
             recip_tile_init();
             MATH((recip_tile_first_column_wh_idst0_direct()));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -530,7 +530,7 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
 #ifdef ARCH_BLACKHOLE
             recip_tile_init<false>();
-            MATH((recip_tile<false>(0, VectorMode::C)));
+            MATH((recip_tile<false>(0 /*dst_index*/, VectorMode::C)));
 #else
             recip_tile_init();
             MATH((recip_tile_first_column_wh_idst0_direct()));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -252,7 +252,7 @@ void kernel_main() {
     // - VectorMode::RC is equivalent to 32x32 tiles
     // - VectorMode::R is equivalent to 16x32 tiles
     // NOTE: Using VectorMode::RC for 16x32 tiles will be correct accuracy, just slower due to unnecessary math
-    constexpr int vector_mode = use_half_tile ? VectorMode::R : VectorMode::RC;
+    constexpr VectorMode vector_mode = use_half_tile ? VectorMode::R : VectorMode::RC;
 
     // We set up Ping Pong intermediate buffers between loops
     uint32_t cb_cur_max = cb_max_1;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This change continues the LLK enum migration by tightening type safety around `VectorMode`, the mode selector used by SFPU helpers and compute-kernel APIs.

**Motivation.** `VectorMode` represents a small hardware-facing set of modes, but the unscoped Blackhole/Wormhole definitions leaked `None`, `R`, `C`, `RC`, and related constants into the `ckernel` namespace and allowed implicit integer conversions. Making the type scoped keeps callsites explicit while preserving the existing ISA-visible numeric values.

**What was done.**
- Converted `VectorMode` in Blackhole and Wormhole `llk_defs.h` from an unscoped enum to `enum class VectorMode : std::uint8_t` with the same enumerator values.
- Updated Quasar's existing scoped `VectorMode` to also declare `std::uint8_t` explicitly, keeping its values aligned with Blackhole/Wormhole.
- Updated LLK SFPU helper plumbing to accept/pass `VectorMode` directly where dispatch is internal, including the common vector-mode apply path and unary/binary/ternary parameter helpers.
- Qualified `VectorMode` callsites across mirrored HW ckernels, public compute-kernel APIs and docs, TTNN kernels, TT-Train SDPA code, DeepSeek demo kernels, and LLK tests.
- Kept explicit casts only at integer/template boundary APIs where the surrounding code still expects an integral non-type template parameter or legacy integer argument.

**Benefits.** The PR makes `VectorMode` usage clearer and harder to mix with unrelated constants, while keeping behavior and encoded values unchanged.

**Issues**
- Related to #43036
- Part of #44441
- Part of #44442
- Closes #44444

### Notes for reviewers
- This PR is intentionally scoped to `VectorMode`; other LLK enums and `ckernel_ops.h`/instruction-mod macros are not changed here.
- Quasar already used `enum class`; its change is the explicit `std::uint8_t` underlying type.
- Most of the diff is mechanical qualification in architecture-specific SFPU headers and copied demo/kernel include trees.

### Testing
Not run locally; PR CI status is tracked by the badges below.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/convert_enums_to_enum_class)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/convert_enums_to_enum_class)
