### PR TITLE
[Cleanup] Reduce LLK include headers

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_fast_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_fast_tilize_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "llk_math_unary_datacopy_api.h"
+#include "llk_math_common_api.h"
 #include "experimental/llk_math_fast_tilize.h"
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_fast_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_fast_tilize_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "llk_unpack_tilize_api.h"
+#include "llk_unpack_common_api.h"
 #include "experimental/llk_unpack_fast_tilize.h"
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "llk_unpack_common_api.h"
 #include "experimental/llk_unpack_mul_reduce_scalar.h"
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -6,7 +6,6 @@
 
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_params.h"
-#include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_topk.h"
 
 namespace ckernel {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "llk_unpack_AB.h"
 #include "llk_unpack_common_api.h"
 #include "llk_unpack_tilize.h"
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -6,7 +6,6 @@
 
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_params.h"
-#include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_topk.h"
 
 namespace ckernel {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include "llk_unpack_tilize.h"
-#include "llk_unpack_AB.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -8,7 +8,6 @@
 
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
-#include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -10,9 +10,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
 #include "ckernel_ops.h"
-#include "ckernel_template.h"
 #include "cunpack_common.h"
-#include "llk_assert.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
@@ -7,7 +7,6 @@
 #include "ckernel_globals.h"
 #include "ckernel_include.h"
 #include "llk_defs.h"
-#include "llk_operands.h"
 
 using namespace ckernel;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -11,7 +11,6 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_sfpu.h"
-#include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_math_common.h"
 #include "llk_sfpu_types.h"

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu.h
@@ -10,7 +10,6 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_sfpu.h"
-#include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_math_common.h"
 #include "llk_sfpu_types.h"

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -10,7 +10,6 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_sfpu.h"
-#include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_math_common.h"
 #include "llk_sfpu_types.h"

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu.h
@@ -10,7 +10,6 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_sfpu.h"
-#include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_math_common.h"
 #include "llk_math_eltwise_unary_datacopy.h"

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_welfords_sfpu_params.h
@@ -3,12 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <algorithm>
 #include <cstdint>
 #include <utility>
 
 #include "llk_math_eltwise_ternary_sfpu.h"
-#include "llk_sfpu_types.h"
 
 template <typename Callable, typename... ARGS>
 inline void _llk_math_welfords_sfpu_params_(Callable&& sfpu_func, std::uint32_t dst_index0, ARGS&&... args)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -10,9 +10,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_ops.h"
 #include "cpack_common.h"
-#include "llk_assert.h"
 #include "llk_defs.h"
-#include "llk_memory_checks.h"
 
 using namespace ckernel;
 using namespace ckernel::packer;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_rows.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_rows.h
@@ -12,7 +12,6 @@
 #include "ckernel_template.h"
 #include "llk_assert.h"
 #include "llk_defs.h"
-#include "llk_memory_checks.h"
 #include "llk_pack_common.h"
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -12,7 +12,6 @@
 #include "ckernel_template.h"
 #include "llk_assert.h"
 #include "llk_defs.h"
-#include "llk_memory_checks.h"
 #include "llk_pack_common.h"
 
 using namespace ckernel;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
@@ -12,7 +12,6 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cunpack_common.h"
-#include "llk_assert.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -12,7 +12,6 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cunpack_common.h"
-#include "llk_assert.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Reduces unnecessary LLK include dependencies in Blackhole and Wormhole compute kernel API headers and Blackhole LLK library headers. The change removes duplicate includes and trims clearly unused direct includes so small LLK wrapper headers depend only on the common/API headers they actually use.

This keeps the include graph smaller and easier to reason about while preserving the existing low-level kernel prelude where it is still load-bearing.

### Notes for reviewers
Please focus on whether any of the removed includes were intentionally relied on for standalone header inclusion in LLK build contexts. I kept broad `ckernel`, `cmath`, `cunpack`, and common LLK includes where the dependency was not obviously redundant.

Validation so far:
- `ReadLints` found no diagnostics on edited files.
- `git diff --check` passed for the edited paths.

Requested CI:
- `sanity-tests.yaml` (`Sanity tests`) dispatched for this branch.
- `blackhole-post-commit.yaml` (`Blackhole post-commit tests`) dispatched for this branch.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/reduce_LLK_include_headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/reduce_LLK_include_headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/reduce_LLK_include_headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/reduce_LLK_include_headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/reduce_LLK_include_headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/reduce_LLK_include_headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/reduce_LLK_include_headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/reduce_LLK_include_headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/reduce_LLK_include_headers)