### PR TITLE
Optimize int32 and uint32 SFPU comparison kernels to target counts

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -34,7 +34,7 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
     // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
     // TTI_SFPLOADI on every iteration.
     if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
     }
 
     // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
@@ -46,23 +46,15 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
         TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_x * dst_tile_size);
         TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_y * dst_tile_size);
 
-        // Extract sign bits of X (LREG0) and Y (LREG1)
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-        // LREG3 -> 0 for inputs of same sign, 1 for inputs of different signs
-        TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
-        // if (LREG3 == 0) -> same signs: signed subtract + extract sign of X-Y
-        TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
+        // If X/Y have different signs, signed LT is the sign bit of X.
+        // Otherwise, the sign of X-Y is safe to use.
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
+        TTI_SFPXOR(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
-        // else -> different signs: load 0, then load 1 if MSB(X) != 0 (X is negative, so X < Y)
-        TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG2, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
         TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
 
         if constexpr (invert_result) {
             TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
@@ -270,7 +262,7 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
     // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
     // TTI_SFPLOADI on every iteration.
     if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
     }
 
     // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
@@ -283,24 +275,16 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
         TT_SFPLOAD(p_sfpu::LREG1, LD_ST_MOD, ADDR_MOD_7, dst_index_y * dst_tile_size);
 
         if constexpr (needs_msb_handling) {
-            // Extract MSBs of X (LREG0) and Y (LREG1)
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-            // LREG3 -> 0 for inputs with same MSB, 1 for inputs with different MSBs
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
-            // if (LREG3 == 0) -> same MSBs: signed subtract + extract sign
-            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
+            // If X/Y have different MSBs, unsigned LT is the sign bit of Y.
+            // Otherwise, the sign of X-Y is safe to use.
+            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
+            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+            TTI_SFPXOR(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
             TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
-            // else -> different MSBs: load 0, then load 1 if MSB(X) == 0 (X is smaller)
-            TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
-            TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);  // LREG1 = 1 XOR MSB(X)
+            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
+            TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
             TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
         } else {
             // 16-bit case: signed subtract can't overflow, sign bit gives the answer directly.
             // LREG1 = LREG0 - LREG1 (imod=6: dst = src - dst)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -12,12 +12,12 @@
 
 namespace ckernel::sfpu {
 
-// Int32 binary comparison for relational ops (signed).
-// All ops reduce to computing LT(X, Y) with optional operand swap and result inversion:
+// Int32 relational comparisons. Normalize to LT(A, B) or GE(A, B):
 //   lt(A,B) = LT(A,B)           gt(A,B) = LT(B,A)
-//   ge(A,B) = NOT LT(A,B)       le(A,B) = NOT LT(B,A)
-// When sign bits of X and Y match, signed subtraction can't overflow and the sign of (X-Y)
-// is the answer. When sign bits differ, X < Y iff X is negative (MSB(X) == 1).
+//   ge(A,B) = GE(A,B)           le(A,B) = GE(B,A)
+// Force B's top bit to 0 for LT or 1 for GE, subtract from A, then fold the
+// original sign relationship with the subtraction result. The final shift
+// converts the selected top bit to 0 or 1.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(
@@ -25,42 +25,31 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             RELATIONAL_OP == SfpuType::ge,
         "Supported operation types: lt, gt, le, ge");
 
-    // GT and LE swap operands (compute sign(B-A)); LT and GE use natural order (compute sign(A-B)).
-    // LE and GE then invert the result (LE = NOT GT, GE = NOT LT).
+    constexpr bool use_ge = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
     constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
-    constexpr bool invert_result = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
+    constexpr uint A = p_sfpu::LREG0;
+    constexpr uint B = p_sfpu::LREG1;
+    constexpr uint D = p_sfpu::LREG2;
+    constexpr uint SIGN = use_ge ? 1 : 0;
+    constexpr uint TMP = use_ge ? B : A;
+    constexpr uint XOR_SRC = use_ge ? A : B;
     constexpr uint dst_tile_size = 64;
 
-    // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
-    // TTI_SFPLOADI on every iteration.
-    if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
-    }
-
-    // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
-    const uint dst_index_x = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_y = swap_operands ? dst_index_in0 : dst_index_in1;
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_x * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_y * dst_tile_size);
+        TT_SFPLOAD(A, INT32, ADDR_MOD_7, dst_index_a * dst_tile_size);
+        TT_SFPLOAD(B, INT32, ADDR_MOD_7, dst_index_b * dst_tile_size);
 
-        // If X/Y have different signs, signed LT is the sign bit of X.
-        // Otherwise, the sign of X-Y is safe to use.
-        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
-        TTI_SFPXOR(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSETCC(0, p_sfpu::LREG2, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
-
-        if constexpr (invert_result) {
-            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
-        }
-
-        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_6, dst_index_out * dst_tile_size);
+        TTI_SFPSETSGN(SIGN, B, D, 1); // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPIADD(0, A, D, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPXOR(0, XOR_SRC, TMP, 0);
+        TTI_SFPOR(0, D, TMP, 0);
+        TTI_SFPXOR(0, B, A, 0);
+        TTI_SFPSHFT((-31) & 0xfff, A, A, 1); // SFPSHFT_MOD1_ARG_IMM
+        TT_SFPSTORE(A, INT32, ADDR_MOD_6, dst_index_out * dst_tile_size);
     }
 }
 
@@ -233,12 +222,11 @@ inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_
     }
 }
 
-// uint32 & uint16binary comparison for relational ops
-// All ops reduce to computing LT(X, Y) with optional operand swap and result inversion:
+// UInt32/UInt16 relational comparisons. Normalize to LT(A, B) or GE(A, B):
 //   lt(A,B) = LT(A,B)           gt(A,B) = LT(B,A)
-//   ge(A,B) = NOT LT(A,B)       le(A,B) = NOT LT(B,A)
-// When MSBs of X and Y match, signed subtraction gives the correct unsigned comparison.
-// When MSBs differ, X < Y iff MSB(X) == 0.
+//   ge(A,B) = GE(A,B)           le(A,B) = GE(B,A)
+// UInt32 uses the same subtract/fold structure as Int32. For UInt16, A - B
+// cannot overflow int32; the sign bit gives LT, and SFPNOT turns LT into GE.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, DataFormat DATA_FORMAT>
 inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(
@@ -249,55 +237,42 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
             RELATIONAL_OP == SfpuType::ge,
         "Supported operation types: lt, gt, le, ge");
 
-    // GT and LE swap operands (compute sign(B-A)); LT and GE use natural order (compute sign(A-B)).
-    // LE and GE then invert the result (LE = NOT GT, GE = NOT LT).
+    constexpr bool use_ge = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
     constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
-    constexpr bool invert_result = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
-    // UInt32 needs full 32-bit loads + MSB disambiguation; UInt16 fits in the low half so we use
-    // a 16-bit load (zero-extended into the LREG) and skip the MSB-handling path.
     constexpr bool needs_msb_handling = (DATA_FORMAT == DataFormat::UInt32);
     constexpr std::uint32_t LD_ST_MOD = needs_msb_handling ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    constexpr uint A = p_sfpu::LREG0;
+    constexpr uint B = p_sfpu::LREG1;
+    constexpr uint D = p_sfpu::LREG2;
+    constexpr uint SIGN = use_ge ? 1 : 0;
+    constexpr uint RESULT = use_ge ? A : B;
+    constexpr uint XOR_SRC = use_ge ? B : A;
     constexpr uint dst_tile_size = 64;
 
-    // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
-    // TTI_SFPLOADI on every iteration.
-    if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
-    }
-
-    // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
-    const uint dst_index_x = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_y = swap_operands ? dst_index_in0 : dst_index_in1;
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(p_sfpu::LREG0, LD_ST_MOD, ADDR_MOD_7, dst_index_x * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, LD_ST_MOD, ADDR_MOD_7, dst_index_y * dst_tile_size);
+        TT_SFPLOAD(A, LD_ST_MOD, ADDR_MOD_7, dst_index_a * dst_tile_size);
+        TT_SFPLOAD(B, LD_ST_MOD, ADDR_MOD_7, dst_index_b * dst_tile_size);
 
         if constexpr (needs_msb_handling) {
-            // If X/Y have different MSBs, unsigned LT is the sign bit of Y.
-            // Otherwise, the sign of X-Y is safe to use.
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
-            TTI_SFPXOR(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
-            TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+            TTI_SFPSETSGN(SIGN, B, D, 1); // SFPSETSGN_MOD1_ARG_IMM
+            TTI_SFPIADD(0, A, D, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+            TTI_SFPXOR(0, XOR_SRC, RESULT, 0);
+            TTI_SFPOR(0, D, RESULT, 0);
+            TTI_SFPXOR(0, XOR_SRC, RESULT, 0);
+            TTI_SFPSHFT((-31) & 0xfff, RESULT, RESULT, 1); // SFPSHFT_MOD1_ARG_IMM
+            TT_SFPSTORE(RESULT, LD_ST_MOD, ADDR_MOD_6, dst_index_out * dst_tile_size);
         } else {
-            // 16-bit case: signed subtract can't overflow, sign bit gives the answer directly.
-            // LREG1 = LREG0 - LREG1 (imod=6: dst = src - dst)
-            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-            // Extract sign bit: 1 if negative, 0 otherwise
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+            TTI_SFPIADD(0, A, B, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+            if constexpr (use_ge) {
+                TTI_SFPNOT(0, B, B, 0);
+            }
+            TTI_SFPSHFT((-31) & 0xfff, B, B, 1); // SFPSHFT_MOD1_ARG_IMM
+            TT_SFPSTORE(B, LD_ST_MOD, ADDR_MOD_6, dst_index_out * dst_tile_size);
         }
-
-        if constexpr (invert_result) {
-            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
-        }
-
-        TT_SFPSTORE(p_sfpu::LREG1, LD_ST_MOD, ADDR_MOD_6, dst_index_out * dst_tile_size);
     }
 }
 }  //  namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -34,7 +34,7 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
     // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
     // TTI_SFPLOADI on every iteration.
     if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
     }
 
     // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
@@ -46,23 +46,15 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
         TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_x * dst_tile_size);
         TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_y * dst_tile_size);
 
-        // Extract sign bits of X (LREG0) and Y (LREG1)
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-        // LREG3 -> 0 for inputs of same sign, 1 for inputs of different signs
-        TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
-        // if (LREG3 == 0) -> same signs: signed subtract + extract sign of X-Y
-        TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
+        // If X/Y have different signs, signed LT is the sign bit of X.
+        // Otherwise, the sign of X-Y is safe to use.
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
+        TTI_SFPXOR(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
-        // else -> different signs: load 0, then load 1 if MSB(X) != 0 (X is negative, so X < Y)
-        TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG2, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
         TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
 
         if constexpr (invert_result) {
             TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
@@ -274,7 +266,7 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
     // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
     // TTI_SFPLOADI on every iteration.
     if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
     }
 
     // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
@@ -287,24 +279,16 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
         TT_SFPLOAD(p_sfpu::LREG1, LD_ST_MOD, ADDR_MOD_3, dst_index_y * dst_tile_size);
 
         if constexpr (needs_msb_handling) {
-            // Extract MSBs of X (LREG0) and Y (LREG1)
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-            // LREG3 -> 0 for inputs with same MSB, 1 for inputs with different MSBs
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
-            // if (LREG3 == 0) -> same MSBs: signed subtract + extract sign
-            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
+            // If X/Y have different MSBs, unsigned LT is the sign bit of Y.
+            // Otherwise, the sign of X-Y is safe to use.
+            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
+            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+            TTI_SFPXOR(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
             TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
-            // else -> different MSBs: load 0, then load 1 if MSB(X) == 0 (X is smaller)
-            TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
-            TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);  // LREG1 = 1 XOR MSB(X)
+            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
+            TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
             TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
         } else {
             // 16-bit case: signed subtract can't overflow, sign bit gives the answer directly.
             // LREG1 = LREG0 - LREG1 (imod=6: dst = src - dst)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -12,12 +12,12 @@
 
 namespace ckernel::sfpu {
 
-// Int32 binary comparison for relational ops (signed).
-// All ops reduce to computing LT(X, Y) with optional operand swap and result inversion:
+// Int32 relational comparisons. Normalize to LT(A, B) or GE(A, B):
 //   lt(A,B) = LT(A,B)           gt(A,B) = LT(B,A)
-//   ge(A,B) = NOT LT(A,B)       le(A,B) = NOT LT(B,A)
-// When sign bits of X and Y match, signed subtraction can't overflow and the sign of (X-Y)
-// is the answer. When sign bits differ, X < Y iff X is negative (MSB(X) == 1).
+//   ge(A,B) = GE(A,B)           le(A,B) = GE(B,A)
+// Force B's top bit to 0 for LT or 1 for GE, subtract from A, then fold the
+// original sign relationship with the subtraction result. The final shift
+// converts the selected top bit to 0 or 1.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(
@@ -25,42 +25,31 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             RELATIONAL_OP == SfpuType::ge,
         "Supported operation types: lt, gt, le, ge");
 
-    // GT and LE swap operands (compute sign(B-A)); LT and GE use natural order (compute sign(A-B)).
-    // LE and GE then invert the result (LE = NOT GT, GE = NOT LT).
+    constexpr bool use_ge = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
     constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
-    constexpr bool invert_result = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
+    constexpr uint A = p_sfpu::LREG0;
+    constexpr uint B = p_sfpu::LREG1;
+    constexpr uint D = p_sfpu::LREG2;
+    constexpr uint SIGN = use_ge ? 1 : 0;
+    constexpr uint TMP = use_ge ? B : A;
+    constexpr uint XOR_SRC = use_ge ? A : B;
     constexpr uint dst_tile_size = 64;
 
-    // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
-    // TTI_SFPLOADI on every iteration.
-    if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
-    }
-
-    // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
-    const uint dst_index_x = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_y = swap_operands ? dst_index_in0 : dst_index_in1;
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_x * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_y * dst_tile_size);
+        TT_SFPLOAD(A, INT32, ADDR_MOD_3, dst_index_a * dst_tile_size);
+        TT_SFPLOAD(B, INT32, ADDR_MOD_3, dst_index_b * dst_tile_size);
 
-        // If X/Y have different signs, signed LT is the sign bit of X.
-        // Otherwise, the sign of X-Y is safe to use.
-        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
-        TTI_SFPXOR(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSETCC(0, p_sfpu::LREG2, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
-
-        if constexpr (invert_result) {
-            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
-        }
-
-        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_2, dst_index_out * dst_tile_size);
+        TTI_SFPSETSGN(SIGN, B, D, 1); // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPIADD(0, A, D, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPXOR(0, XOR_SRC, TMP, 0);
+        TTI_SFPOR(0, D, TMP, 0);
+        TTI_SFPXOR(0, B, A, 0);
+        TTI_SFPSHFT((-31) & 0xfff, A, A, 1); // SFPSHFT_MOD1_ARG_IMM
+        TT_SFPSTORE(A, INT32, ADDR_MOD_2, dst_index_out * dst_tile_size);
     }
 }
 
@@ -237,12 +226,11 @@ inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_
     }
 }
 
-// uint32 & uint16binary comparison for relational ops
-// All ops reduce to computing LT(X, Y) with optional operand swap and result inversion:
+// UInt32/UInt16 relational comparisons. Normalize to LT(A, B) or GE(A, B):
 //   lt(A,B) = LT(A,B)           gt(A,B) = LT(B,A)
-//   ge(A,B) = NOT LT(A,B)       le(A,B) = NOT LT(B,A)
-// When MSBs of X and Y match, signed subtraction gives the correct unsigned comparison.
-// When MSBs differ, X < Y iff MSB(X) == 0.
+//   ge(A,B) = GE(A,B)           le(A,B) = GE(B,A)
+// UInt32 uses the same subtract/fold structure as Int32. For UInt16, A - B
+// cannot overflow int32; the sign bit gives LT, and SFPNOT turns LT into GE.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, DataFormat DATA_FORMAT>
 inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(
@@ -253,55 +241,42 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
             RELATIONAL_OP == SfpuType::ge,
         "Supported operation types: lt, gt, le, ge");
 
-    // GT and LE swap operands (compute sign(B-A)); LT and GE use natural order (compute sign(A-B)).
-    // LE and GE then invert the result (LE = NOT GT, GE = NOT LT).
+    constexpr bool use_ge = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
     constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
-    constexpr bool invert_result = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
-    // UInt32 needs full 32-bit loads + MSB disambiguation; UInt16 fits in the low half so we use
-    // a 16-bit load (zero-extended into the LREG) and skip the MSB-handling path.
     constexpr bool needs_msb_handling = (DATA_FORMAT == DataFormat::UInt32);
     constexpr std::uint32_t LD_ST_MOD = needs_msb_handling ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    constexpr uint A = p_sfpu::LREG0;
+    constexpr uint B = p_sfpu::LREG1;
+    constexpr uint D = p_sfpu::LREG2;
+    constexpr uint SIGN = use_ge ? 1 : 0;
+    constexpr uint RESULT = use_ge ? A : B;
+    constexpr uint XOR_SRC = use_ge ? B : A;
     constexpr uint dst_tile_size = 64;
 
-    // Loop-invariant invert mask; hoisted out of the unrolled loop to avoid re-issuing
-    // TTI_SFPLOADI on every iteration.
-    if constexpr (invert_result) {
-        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0x01);
-    }
-
-    // Pick X/Y order once; LREG0 holds X, LREG1 holds Y.
-    const uint dst_index_x = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_y = swap_operands ? dst_index_in0 : dst_index_in1;
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(p_sfpu::LREG0, LD_ST_MOD, ADDR_MOD_3, dst_index_x * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, LD_ST_MOD, ADDR_MOD_3, dst_index_y * dst_tile_size);
+        TT_SFPLOAD(A, LD_ST_MOD, ADDR_MOD_3, dst_index_a * dst_tile_size);
+        TT_SFPLOAD(B, LD_ST_MOD, ADDR_MOD_3, dst_index_b * dst_tile_size);
 
         if constexpr (needs_msb_handling) {
-            // If X/Y have different MSBs, unsigned LT is the sign bit of Y.
-            // Otherwise, the sign of X-Y is safe to use.
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
-            TTI_SFPXOR(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, sfpi::SFPSETCC_MOD1_LREG_LT0);
-            TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+            TTI_SFPSETSGN(SIGN, B, D, 1); // SFPSETSGN_MOD1_ARG_IMM
+            TTI_SFPIADD(0, A, D, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+            TTI_SFPXOR(0, XOR_SRC, RESULT, 0);
+            TTI_SFPOR(0, D, RESULT, 0);
+            TTI_SFPXOR(0, XOR_SRC, RESULT, 0);
+            TTI_SFPSHFT((-31) & 0xfff, RESULT, RESULT, 1); // SFPSHFT_MOD1_ARG_IMM
+            TT_SFPSTORE(RESULT, LD_ST_MOD, ADDR_MOD_2, dst_index_out * dst_tile_size);
         } else {
-            // 16-bit case: signed subtract can't overflow, sign bit gives the answer directly.
-            // LREG1 = LREG0 - LREG1 (imod=6: dst = src - dst)
-            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-            // Extract sign bit: 1 if negative, 0 otherwise
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+            TTI_SFPIADD(0, A, B, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+            if constexpr (use_ge) {
+                TTI_SFPNOT(0, B, B, 0);
+            }
+            TTI_SFPSHFT((-31) & 0xfff, B, B, 1); // SFPSHFT_MOD1_ARG_IMM
+            TT_SFPSTORE(B, LD_ST_MOD, ADDR_MOD_2, dst_index_out * dst_tile_size);
         }
-
-        if constexpr (invert_result) {
-            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
-        }
-
-        TT_SFPSTORE(p_sfpu::LREG1, LD_ST_MOD, ADDR_MOD_2, dst_index_out * dst_tile_size);
     }
 }
 }  //  namespace ckernel::sfpu


### PR DESCRIPTION
## Summary
- Replace the Wormhole and Blackhole int32 relational comparison path with a fixed subtract/fold sequence that normalizes `lt/gt/le/ge` to LT or GE.
- Apply the same target-count subtract/fold structure to Wormhole and Blackhole uint32 comparisons.
- Keep uint16 comparisons on the existing subtract/sign path while preserving the requested 5-instruction `lt/gt` and 6-instruction `le/ge` shapes.

## Instruction counts
- int32 `lt/gt/le/ge`: 9 SFPU instructions per row.
- uint32 `lt/gt/le/ge`: 9 SFPU instructions per row.
- uint16 `lt/gt`: 5 SFPU instructions per row.
- uint16 `le/ge`: 6 SFPU instructions per row.

## Testing
- `git diff --check HEAD^..HEAD`
- Direct SFPI compile smokes for Blackhole and Wormhole instantiating all `lt/gt/le/ge` variants for int32, uint32, and uint16 comparison templates.
- Host-side bit model over signed/unsigned edge cases plus 100,000 random pairs per op:
  - `{'int32': 400484, 'uint32': 400484, 'uint16': 400324}`
- `cmake -S . -B .build/revision-44392-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DNUMA_LIBRARY=/usr/lib/x86_64-linux-gnu/libnuma.so.1 -DHWLOC_LIBRARY=/usr/lib/x86_64-linux-gnu/libhwloc.so.15 -DENABLE_DISTRIBUTED=OFF -DTT_METAL_BUILD_TESTS=FALSE -DTTNN_BUILD_TESTS=FALSE -DTT_UMD_BUILD_TESTS=FALSE -DBUILD_PROGRAMMING_EXAMPLES=FALSE -DBUILD_TT_TRAIN=OFF -DENABLE_CCACHE=FALSE -DTT_UNITY_BUILDS=FALSE`
- `cmake --build .build/revision-44392-cmake --target ttnn_op_eltwise_binary_ng --parallel 2`