### PR TITLE
[Feature] MeshWorkloadSpec support for Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_run_params.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//---------------------------------------------------------------------------------
+// Unit tests for the Metal 2.0 Host API: MeshWorkloadRunParams and SetMeshWorkloadRunParameters
+// These tests use a mock Quasar device for API-level validation.
+//---------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/mesh_workload_run_params.hpp>
+#include <tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/experimental/mock_device.hpp>
+
+#include "test_helpers.hpp"
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+namespace {
+
+using test_helpers::MakeMinimalValidProgramSpec;
+using test_helpers::ScopedSlowDispatchOverride;
+
+class MeshWorkloadRunParamsTestQuasar : public ::testing::Test {
+protected:
+    void SetUp() override {
+        slow_dispatch_override_.emplace();
+        experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
+        mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
+    }
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+        experimental::disable_mock_mode();
+        slow_dispatch_override_.reset();
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
+};
+
+// Helper: minimal valid ProgramRunParams matching MakeMinimalValidProgramSpec's kernels
+// (dm_kernel and compute_kernel, both with no RTAs).
+inline ProgramRunParams MakeMinimalValidProgramRunParams() {
+    NodeCoord node{0, 0};
+    ProgramRunParams params;
+    params.kernel_run_params.push_back(ProgramRunParams::KernelRunParams{
+        .kernel_spec_name = "dm_kernel",
+        .runtime_varargs = {{node, {}}},
+        .common_runtime_varargs = {},
+    });
+    params.kernel_run_params.push_back(ProgramRunParams::KernelRunParams{
+        .kernel_spec_name = "compute_kernel",
+        .runtime_varargs = {{node, {}}},
+        .common_runtime_varargs = {},
+    });
+    return params;
+}
+
+// Empty params is a degenerate input — reject at the API boundary.
+TEST_F(MeshWorkloadRunParamsTestQuasar, EmptyParamsFails) {
+    MeshWorkloadSpec spec;
+    spec.programs.push_back({
+        .program = MakeMinimalValidProgramSpec(),
+        .target_range = distributed::MeshCoordinateRange(mesh_device_->shape()),
+    });
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device_, spec);
+
+    MeshWorkloadRunParams params;  // empty
+
+    EXPECT_THAT(
+        [&] { SetMeshWorkloadRunParameters(workload, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("MeshWorkloadRunParams must contain at least one entry")));
+}
+
+// Happy path: single program in workload, single matching entry in params.
+TEST_F(MeshWorkloadRunParamsTestQuasar, MatchingNameSucceeds) {
+    MeshWorkloadSpec spec;
+    spec.programs.push_back({
+        .program = MakeMinimalValidProgramSpec(),
+        .target_range = distributed::MeshCoordinateRange(mesh_device_->shape()),
+    });
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device_, spec);
+
+    MeshWorkloadRunParams params;
+    params.programs.push_back({
+        .program_spec_name = "test_program",  // matches MakeMinimalValidProgramSpec's program_id
+        .run_params = MakeMinimalValidProgramRunParams(),
+    });
+
+    EXPECT_NO_THROW(SetMeshWorkloadRunParameters(workload, params));
+}
+
+// An entry naming a program not in the workload is rejected at validation.
+TEST_F(MeshWorkloadRunParamsTestQuasar, UnknownProgramNameFails) {
+    MeshWorkloadSpec spec;
+    spec.programs.push_back({
+        .program = MakeMinimalValidProgramSpec(),
+        .target_range = distributed::MeshCoordinateRange(mesh_device_->shape()),
+    });
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device_, spec);
+
+    MeshWorkloadRunParams params;
+    params.programs.push_back({
+        .program_spec_name = "nonexistent_program",
+        .run_params = MakeMinimalValidProgramRunParams(),
+    });
+
+    EXPECT_THAT(
+        [&] { SetMeshWorkloadRunParameters(workload, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("not in the target MeshWorkload")));
+}
+
+// Two entries for the same program name should be rejected as a duplicate.
+TEST_F(MeshWorkloadRunParamsTestQuasar, DuplicateEntryFails) {
+    MeshWorkloadSpec spec;
+    spec.programs.push_back({
+        .program = MakeMinimalValidProgramSpec(),
+        .target_range = distributed::MeshCoordinateRange(mesh_device_->shape()),
+    });
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device_, spec);
+
+    MeshWorkloadRunParams params;
+    params.programs.push_back({
+        .program_spec_name = "test_program",
+        .run_params = MakeMinimalValidProgramRunParams(),
+    });
+    params.programs.push_back({
+        .program_spec_name = "test_program",  // duplicate
+        .run_params = MakeMinimalValidProgramRunParams(),
+    });
+
+    EXPECT_THAT(
+        [&] { SetMeshWorkloadRunParameters(workload, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("duplicate entry for program")));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_spec.cpp
@@ -71,6 +71,19 @@ TEST_F(MeshWorkloadSpecTestQuasar, SingleProgramSPMDSucceeds) {
     EXPECT_EQ(workload.get_programs().size(), 1u);
 }
 
+// Ranges outside the target mesh produce a clear API-boundary error rather than
+// propagating to a cryptic downstream failure at enqueue time.
+TEST_F(MeshWorkloadSpecTestQuasar, OutOfBoundsRangeFails) {
+    MeshWorkloadSpec spec;
+    // (1, 1) is out of bounds for a {1, 1} mesh — valid coords are only (0, 0).
+    distributed::MeshCoordinateRange out_of_bounds(distributed::MeshCoordinate(1, 1));
+    spec.programs.emplace_back(out_of_bounds, MakeMinimalValidProgramSpec());
+
+    EXPECT_THAT(
+        [&] { MakeMeshWorkloadFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
+}
+
 // ProgramSpec validation failures must propagate through MakeMeshWorkloadFromSpec —
 // proves the skip_validation=false default isn't silently dropped on the way in.
 TEST_F(MeshWorkloadSpecTestQuasar, InvalidProgramSpecPropagatesValidationFailure) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_spec.cpp
@@ -62,9 +62,10 @@ TEST_F(MeshWorkloadSpecTestQuasar, EmptyMeshWorkloadSpecFails) {
 // and produces a MeshWorkload containing exactly that program.
 TEST_F(MeshWorkloadSpecTestQuasar, SingleProgramSPMDSucceeds) {
     MeshWorkloadSpec spec;
-    spec.programs.emplace_back(
-        distributed::MeshCoordinateRange(mesh_device_->shape()),  //
-        MakeMinimalValidProgramSpec());
+    spec.programs.push_back({
+        .program = MakeMinimalValidProgramSpec(),
+        .target_range = distributed::MeshCoordinateRange(mesh_device_->shape()),
+    });
 
     distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device_, spec);
 
@@ -76,8 +77,10 @@ TEST_F(MeshWorkloadSpecTestQuasar, SingleProgramSPMDSucceeds) {
 TEST_F(MeshWorkloadSpecTestQuasar, OutOfBoundsRangeFails) {
     MeshWorkloadSpec spec;
     // (1, 1) is out of bounds for a {1, 1} mesh — valid coords are only (0, 0).
-    distributed::MeshCoordinateRange out_of_bounds(distributed::MeshCoordinate(1, 1));
-    spec.programs.emplace_back(out_of_bounds, MakeMinimalValidProgramSpec());
+    spec.programs.push_back({
+        .program = MakeMinimalValidProgramSpec(),
+        .target_range = distributed::MeshCoordinateRange(distributed::MeshCoordinate(1, 1)),
+    });
 
     EXPECT_THAT(
         [&] { MakeMeshWorkloadFromSpec(*mesh_device_, spec); },
@@ -91,7 +94,10 @@ TEST_F(MeshWorkloadSpecTestQuasar, InvalidProgramSpecPropagatesValidationFailure
     invalid_spec.program_id = "empty_program";
 
     MeshWorkloadSpec spec;
-    spec.programs.emplace_back(distributed::MeshCoordinateRange(mesh_device_->shape()), invalid_spec);
+    spec.programs.push_back({
+        .program = invalid_spec,
+        .target_range = distributed::MeshCoordinateRange(mesh_device_->shape()),
+    });
 
     EXPECT_THAT(
         [&] { MakeMeshWorkloadFromSpec(*mesh_device_, spec); },

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_spec.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//---------------------------------------------------------------------------------
+// Unit tests for the Metal 2.0 Host API: MeshWorkloadSpec and MakeMeshWorkloadFromSpec
+// These tests use a mock Quasar device for API-level validation.
+//---------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/experimental/mock_device.hpp>
+
+#include "test_helpers.hpp"
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+namespace {
+
+using test_helpers::MakeMinimalValidProgramSpec;
+using test_helpers::ScopedSlowDispatchOverride;
+
+// Test fixture mirrors ProgramSpecTestQuasar: mock Quasar device under slow dispatch.
+class MeshWorkloadSpecTestQuasar : public ::testing::Test {
+protected:
+    void SetUp() override {
+        slow_dispatch_override_.emplace();
+        experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
+        mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
+    }
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+        experimental::disable_mock_mode();
+        slow_dispatch_override_.reset();
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
+};
+
+// An empty MeshWorkloadSpec is a degenerate input — reject at the API boundary
+// with a specific error rather than letting it propagate downstream.
+TEST_F(MeshWorkloadSpecTestQuasar, EmptyMeshWorkloadSpecFails) {
+    MeshWorkloadSpec spec;  // No programs.
+
+    EXPECT_THAT(
+        [&] { MakeMeshWorkloadFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("A MeshWorkloadSpec must contain at least one ProgramSpec")));
+}
+
+// Happy path: a single ProgramSpec covering the full mesh (SPMD convention) succeeds
+// and produces a MeshWorkload containing exactly that program.
+TEST_F(MeshWorkloadSpecTestQuasar, SingleProgramSPMDSucceeds) {
+    MeshWorkloadSpec spec;
+    spec.programs.emplace_back(
+        distributed::MeshCoordinateRange(mesh_device_->shape()),  //
+        MakeMinimalValidProgramSpec());
+
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device_, spec);
+
+    EXPECT_EQ(workload.get_programs().size(), 1u);
+}
+
+// ProgramSpec validation failures must propagate through MakeMeshWorkloadFromSpec —
+// proves the skip_validation=false default isn't silently dropped on the way in.
+TEST_F(MeshWorkloadSpecTestQuasar, InvalidProgramSpecPropagatesValidationFailure) {
+    ProgramSpec invalid_spec;  // Empty kernels — known to fail MakeProgramFromSpec validation.
+    invalid_spec.program_id = "empty_program";
+
+    MeshWorkloadSpec spec;
+    spec.programs.emplace_back(distributed::MeshCoordinateRange(mesh_device_->shape()), invalid_spec);
+
+    EXPECT_THAT(
+        [&] { MakeMeshWorkloadFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("A ProgramSpec must have at least one KernelSpec")));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -22,6 +22,7 @@ set(UNIT_TESTS_API_SOURCES
     dataflow_buffer/test_dataflow_buffer.cpp
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
+    metal2_host_api/test_mesh_workload_run_params.cpp
     metal2_host_api/test_mesh_workload_spec.cpp
     metal2_host_api/test_program_spec.cpp
     metal2_host_api/test_program_spec_hw.cpp

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -22,6 +22,7 @@ set(UNIT_TESTS_API_SOURCES
     dataflow_buffer/test_dataflow_buffer.cpp
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
+    metal2_host_api/test_mesh_workload_spec.cpp
     metal2_host_api/test_program_spec.cpp
     metal2_host_api/test_program_spec_hw.cpp
     metal2_host_api/test_program_run_params.cpp

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_run_params.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+
+//------------------------------------------------
+// MeshWorkloadRunParams
+//------------------------------------------------
+
+// MeshWorkloadRunParams describes the mutable properties of a MeshWorkload:
+// ProgramRunParams for each Program in the MeshWorkload, identified by ProgramSpec name.
+//
+// Analogous to ProgramRunParams, which describes the mutable properties of a single Program.
+//
+// - Every Program in the target MeshWorkload must have a corresponding entry.
+// - Every entry must name a Program in the target MeshWorkload (no extras).
+// - Each ProgramSpec name must appear at most once.
+struct MeshWorkloadRunParams {
+    // ProgramRunParams paired with the name of the ProgramSpec they configure.
+    struct NamedProgramRunParams {
+        ProgramSpecName program_spec_name;
+        ProgramRunParams run_params;
+    };
+    std::vector<NamedProgramRunParams> programs;
+};
+
+//------------------------------------------------
+// Temporary Metal 2.0 API
+// (will become a MeshWorkload member function post-experimental)
+//------------------------------------------------
+
+// Configure the mutable parameters of every Program in a MeshWorkload.
+// Each NamedProgramRunParams entry is dispatched to the corresponding Program
+// (looked up by ProgramSpec name) via SetProgramRunParameters.
+//
+// COMPLETENESS: A NamedProgramRunParams must be specified for every Program in the
+// MeshWorkload, exactly once.
+//
+// PRE-CONDITION: All Programs in the MeshWorkload must have been constructed via
+// MakeProgramFromSpec (so that they carry the program_spec_name needed for lookup).
+void SetMeshWorkloadRunParameters(distributed::MeshWorkload& workload, const MeshWorkloadRunParams& params);
+
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
@@ -27,7 +27,12 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // - A valid MeshWorkloadSpec must contain at least one program.
 //
 struct MeshWorkloadSpec {
-    std::vector<std::pair<distributed::MeshCoordinateRange, ProgramSpec>> programs;
+    // A ProgramSpec paired with its target placement on the mesh.
+    struct ProgramPlacement {
+        ProgramSpec program;
+        distributed::MeshCoordinateRange target_range;
+    };
+    std::vector<ProgramPlacement> programs;
 };
 
 //------------------------------------------------

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+
+//------------------------------------------------
+// MeshWorkloadSpec
+//------------------------------------------------
+
+// A MeshWorkloadSpec describes the immutable properties of a MeshWorkload:
+// a collection of (MeshCoordinateRange, ProgramSpec) pairs.
+//
+// Each ProgramSpec is instantiated as a Program on the devices in its range.
+// A MeshWorkloadSpec need not cover the entire mesh.
+// A valid MeshWorkloadSpec must contain at least one program.
+//
+struct MeshWorkloadSpec {
+    std::vector<std::pair<distributed::MeshCoordinateRange, ProgramSpec>> programs;
+};
+
+//------------------------------------------------
+// Temporary Metal 2.0 API
+// (will become a MeshWorkload constructor post-experimental)
+//------------------------------------------------
+
+// Create a MeshWorkload from a MeshWorkloadSpec.
+//
+// Each ProgramSpec is converted to a Program via MakeProgramFromSpec and added
+// to the MeshWorkload for its corresponding MeshCoordinateRange.
+//
+// JIT compilation of kernels is deferred to first enqueue.
+//
+distributed::MeshWorkload MakeMeshWorkloadFromSpec(
+    const distributed::MeshDevice& mesh_device, const MeshWorkloadSpec& spec, bool skip_validation = false);
+
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
@@ -22,8 +22,9 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // a collection of (MeshCoordinateRange, ProgramSpec) pairs.
 //
 // Each ProgramSpec is instantiated as a Program on the devices in its range.
-// A MeshWorkloadSpec need not cover the entire mesh.
-// A valid MeshWorkloadSpec must contain at least one program.
+// - Each device range must fit within the target mesh (need not cover the entire mesh)
+// - Device ranges must not overlap (at most one ProgramSpec per device)
+// - A valid MeshWorkloadSpec must contain at least one program.
 //
 struct MeshWorkloadSpec {
     std::vector<std::pair<distributed::MeshCoordinateRange, ProgramSpec>> programs;

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -6,7 +6,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -47,6 +49,10 @@ public:
 
     void set_runtime_id(ProgramId id);
     ProgramId get_runtime_id() const;
+
+    // Metal 2.0: Returns the program's identifying name (from its source ProgramSpec).
+    // Returns std::nullopt for Programs not constructed via MakeProgramFromSpec.
+    const std::optional<std::string>& get_program_spec_name() const;
 
     //////////////////////////////
     // Buffer related functions:

--- a/tt_metal/impl/metal2_host_api/mesh_workload_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/mesh_workload_run_params.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/metal2_host_api/mesh_workload_run_params.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+
+#include <tt-logger/tt-logger.hpp>
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+
+void SetMeshWorkloadRunParameters(distributed::MeshWorkload& workload, const MeshWorkloadRunParams& params) {
+    log_debug(tt::LogMetal, "Setting MeshWorkloadRunParameters ({} programs)", params.programs.size());
+
+    TT_FATAL(!params.programs.empty(), "MeshWorkloadRunParams must contain at least one entry");
+
+    // Build name -> Program* lookup from the cached workload.
+    auto& workload_programs = workload.get_programs();
+    std::unordered_map<ProgramSpecName, Program*> name_to_program;
+    name_to_program.reserve(workload_programs.size());
+    for (auto& [range, program] : workload_programs) {
+        const auto& spec_name = program.get_program_spec_name();
+        TT_FATAL(
+            spec_name.has_value(),
+            "MeshWorkload contains a Program with no program_spec_name (not constructed via "
+            "MakeProgramFromSpec); cannot use SetMeshWorkloadRunParameters");
+        auto [it, inserted] = name_to_program.try_emplace(*spec_name, &program);
+        TT_FATAL(inserted, "MeshWorkload contains duplicate program_spec_name '{}'", *spec_name);
+    }
+
+    // Validate every entry against the workload before applying any of them
+    // (so a failure leaves the workload unchanged).
+    std::unordered_set<ProgramSpecName> seen_names;
+    seen_names.reserve(params.programs.size());
+    for (const auto& entry : params.programs) {
+        TT_FATAL(
+            seen_names.insert(entry.program_spec_name).second,
+            "MeshWorkloadRunParams contains duplicate entry for program '{}'",
+            entry.program_spec_name);
+        TT_FATAL(
+            name_to_program.contains(entry.program_spec_name),
+            "MeshWorkloadRunParams names program '{}' which is not in the target MeshWorkload",
+            entry.program_spec_name);
+    }
+    TT_FATAL(
+        seen_names.size() == name_to_program.size(),
+        "MeshWorkloadRunParams has {} entries but the MeshWorkload has {} programs; every program "
+        "must have a corresponding entry exactly once",
+        seen_names.size(),
+        name_to_program.size());
+
+    // Validation passed; apply the run params.
+    for (const auto& entry : params.programs) {
+        SetProgramRunParameters(*name_to_program.at(entry.program_spec_name), entry.run_params);
+    }
+}
+
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/impl/metal2_host_api/mesh_workload_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/mesh_workload_spec.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+
+distributed::MeshWorkload MakeMeshWorkloadFromSpec(
+    const distributed::MeshDevice& mesh_device, const MeshWorkloadSpec& spec, bool skip_validation) {
+    log_debug(tt::LogMetal, "Creating MeshWorkload from MeshWorkloadSpec ({} programs)", spec.programs.size());
+
+    TT_FATAL(!spec.programs.empty(), "A MeshWorkloadSpec must contain at least one ProgramSpec");
+
+    distributed::MeshWorkload mesh_workload;
+    for (const auto& [range, program_spec] : spec.programs) {
+        mesh_workload.add_program(range, MakeProgramFromSpec(mesh_device, program_spec, skip_validation));
+    }
+    return mesh_workload;
+}
+
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/impl/metal2_host_api/mesh_workload_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/mesh_workload_spec.cpp
@@ -15,6 +15,19 @@ distributed::MeshWorkload MakeMeshWorkloadFromSpec(
 
     TT_FATAL(!spec.programs.empty(), "A MeshWorkloadSpec must contain at least one ProgramSpec");
 
+    // Pre-check that each range fits within the target mesh.
+    // (Overlap is caught downstream by MeshWorkload::add_program with a clear message;
+    // out-of-bounds is caught here because downstream enqueue surfaces it as a cryptic
+    // "MeshDeviceViewImpl::is_local rejects unknown coordinate" failure.)
+    const auto mesh_range = distributed::MeshCoordinateRange(mesh_device.shape());
+    for (const auto& entry : spec.programs) {
+        TT_FATAL(
+            mesh_range.contains(entry.first),
+            "MeshWorkloadSpec range {} is out of bounds for mesh of shape {}",
+            entry.first,
+            mesh_device.shape());
+    }
+
     distributed::MeshWorkload mesh_workload;
     for (const auto& [range, program_spec] : spec.programs) {
         mesh_workload.add_program(range, MakeProgramFromSpec(mesh_device, program_spec, skip_validation));

--- a/tt_metal/impl/metal2_host_api/mesh_workload_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/mesh_workload_spec.cpp
@@ -20,17 +20,18 @@ distributed::MeshWorkload MakeMeshWorkloadFromSpec(
     // out-of-bounds is caught here because downstream enqueue surfaces it as a cryptic
     // "MeshDeviceViewImpl::is_local rejects unknown coordinate" failure.)
     const auto mesh_range = distributed::MeshCoordinateRange(mesh_device.shape());
-    for (const auto& entry : spec.programs) {
+    for (const auto& placement : spec.programs) {
         TT_FATAL(
-            mesh_range.contains(entry.first),
+            mesh_range.contains(placement.target_range),
             "MeshWorkloadSpec range {} is out of bounds for mesh of shape {}",
-            entry.first,
+            placement.target_range,
             mesh_device.shape());
     }
 
     distributed::MeshWorkload mesh_workload;
-    for (const auto& [range, program_spec] : spec.programs) {
-        mesh_workload.add_program(range, MakeProgramFromSpec(mesh_device, program_spec, skip_validation));
+    for (const auto& placement : spec.programs) {
+        mesh_workload.add_program(
+            placement.target_range, MakeProgramFromSpec(mesh_device, placement.program, skip_validation));
     }
     return mesh_workload;
 }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1791,6 +1791,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
     // Step 3: Build the Program
     auto program_impl = std::make_shared<detail::ProgramImpl>();
+    program_impl->set_program_spec_name(spec.program_id);
 
     // Register TensorParameters with the program for ValidateProgramRunParams to consult at enqueue.
     for (const auto& tensor_parameter : spec.tensor_parameters) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2026,6 +2026,12 @@ void detail::ProgramImpl::set_runtime_id(ProgramId id) { this->runtime_id = id; 
 
 void Program::set_runtime_id(ProgramId id) { internal_->set_runtime_id(id); }
 
+void detail::ProgramImpl::set_program_spec_name(const std::string& name) { program_spec_name_ = name; }
+
+const std::optional<std::string>& detail::ProgramImpl::get_program_spec_name() const { return program_spec_name_; }
+
+const std::optional<std::string>& Program::get_program_spec_name() const { return internal_->get_program_spec_name(); }
+
 uint32_t detail::ProgramImpl::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = tt::tt_metal::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -339,6 +339,12 @@ public:
     void register_semaphore_spec_name(const SemaphoreSpecName& name, uint32_t sem_id);
     void register_tensor_parameter(const std::string& name, const TensorSpec& spec);
 
+    // Metal 2.0: Program identifier from its ProgramSpec.
+    // Set by MakeProgramFromSpec; not populated for Programs constructed via other paths.
+    // Used by SetMeshWorkloadRunParameters to dispatch run params by program name.
+    void set_program_spec_name(const std::string& name);
+    const std::optional<std::string>& get_program_spec_name() const;
+
     // Metal 2.0: Get handle from name (TT_FATAL if not found)
     KernelHandle get_kernel_handle(const KernelSpecName& name) const;
     uint32_t get_dfb_handle(const DFBSpecName& name) const;
@@ -460,6 +466,10 @@ private:
         std::unordered_map<std::string, TensorSpec> tensor_parameter_layouts;
     };
     std::optional<Metal2NameRegistry> metal2_registry_;  // Only populated for Metal 2.0 programs
+
+    // Metal 2.0: Set by MakeProgramFromSpec to the source ProgramSpec's program_id.
+    // Only populated for Metal 2.0 programs.
+    std::optional<std::string> program_spec_name_;
 
     // Semaphores
     std::vector<Semaphore> semaphores_;

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -47,6 +47,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/uint8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataflow_buffer/dataflow_buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/mesh_workload_run_params.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/mesh_workload_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_run_params.cpp

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -47,6 +47,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/uint8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataflow_buffer/dataflow_buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/mesh_workload_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_run_params.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -60,6 +60,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/mesh_program_descriptor.hpp
     api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+    api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
     api/tt-metalium/experimental/metal2_host_api/program.hpp
     api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -60,6 +60,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/mesh_program_descriptor.hpp
     api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+    api/tt-metalium/experimental/metal2_host_api/mesh_workload_run_params.hpp
     api/tt-metalium/experimental/metal2_host_api/mesh_workload_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
     api/tt-metalium/experimental/metal2_host_api/program.hpp


### PR DESCRIPTION
## PR Category
Feature

## Summary
This PR adds a new member to the Metal 2.0 "`Spec`" descriptor struct family: `MeshWorkloadSpec`.
It parallel's a `MeshWorkload`'s ctor parameters; it associated `ProgramSpec`s to `MeshCoordinateRange`s. 

I also added a (temporary experimental) free function, `MakeMeshWorkloadFromSpec`, which does what it says on the tin and will become a `MeshWorkload` ctor when this graduates from `experimental`.

**Why?**
 - I need this for TTNN generic op integration of Metal 2.0.
 - The old MeshWorkload construction pattern is off. The user creates `Program`s, owns them briefly, then immediately transfers ownership to the `MeshWorkload`. The new factory / soon-to-be-ctor has the correct ownership semantics from the start.

## Future Work
Currently, `Program` construction is semi-lazy: JIT compilation of kernels doesn't occur until the first enqueue. I'd like to change this; it would make for a nicer invariamake the `std::span` views into dispatch buffers stable, 

## CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/meshworkload-from-spec)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/meshworkload-from-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/meshworkload-from-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/meshworkload-from-spec)