### PR TITLE
Bug fix: pinned-memory H2D write correctness (cache invalidation, relay alignment, prefetcher paging, per-MMIO budget)

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -25,17 +25,24 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
 #include "env_lib.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_command_queue.hpp>
 #include <tt-metalium/mesh_config.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/experimental/core_subset_write/mesh_command_queue.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/runtime_args_data.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
 #include <tt-metalium/memory_pin.hpp>
@@ -1301,6 +1308,104 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeUnaligned
             }
         }
     }
+}
+
+TEST_F(MeshBufferTestSuite, EnqueueProgramAfterPinnedMemoryWriteRerunsCorrectly) {
+    if (!tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+
+    constexpr CoreCoord logical_core = {0, 0};
+    const CoreRangeSet single_core(CoreRange(logical_core, logical_core));
+    const MeshCoordinateRange all_devices(mesh_device_->shape());
+    const MeshCoordinate test_coord(0, 0);
+
+    const uint32_t single_tile_size = ::tt::tile_size(DataFormat::Float16_b);
+    const DeviceLocalBufferConfig tile_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
+    const ReplicatedBufferConfig tile_mesh_config{.size = single_tile_size};
+    auto input_buffer = MeshBuffer::create(tile_mesh_config, tile_buffer_config, mesh_device_.get());
+    auto output_buffer = MeshBuffer::create(tile_mesh_config, tile_buffer_config, mesh_device_.get());
+
+    std::vector<uint16_t> input(single_tile_size / sizeof(uint16_t), 1);
+    EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buffer, input, /*blocking=*/true);
+
+    Program program = CreateProgram();
+    auto kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/full_grid_eltwise_device_reuse.cpp",
+        single_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(single_tile_size, {{src0_cb_index, DataFormat::Float16_b}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    CreateCircularBuffer(program, single_core, cb_src0_config);
+
+    constexpr uint32_t semaphore_value = 1;
+    const uint32_t scaling_sem_idx = CreateSemaphore(program, single_core, semaphore_value);
+    constexpr uint32_t first_add_value = 3;
+    constexpr uint32_t second_add_value = 7;
+    SetRuntimeArgs(
+        program,
+        kernel,
+        logical_core,
+        {input_buffer->address(),
+         output_buffer->address(),
+         0, /* src_bank_id */
+         0, /* dst_bank_id */
+         first_add_value,
+         constants::TILE_HEIGHT,
+         constants::TILE_WIDTH,
+         scaling_sem_idx,
+         constants::TILE_HEIGHT + 1});
+
+    MeshWorkload workload;
+    workload.add_program(all_devices, std::move(program));
+
+    auto read_and_check_output = [&](uint16_t expected_value) {
+        std::vector<uint16_t> output;
+        ReadShard(mesh_device_->mesh_command_queue(), output, output_buffer, test_coord);
+        ASSERT_EQ(output.size(), input.size());
+        for (uint16_t value : output) {
+            EXPECT_EQ(value, expected_value);
+        }
+    };
+
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, /*blocking=*/true);
+    read_and_check_output(input[0] + first_add_value);
+
+    constexpr uint32_t pinned_write_tiles = 512;
+    const uint32_t pinned_write_size = pinned_write_tiles * single_tile_size;
+    const DeviceLocalBufferConfig pinned_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+    const ReplicatedBufferConfig pinned_mesh_config{.size = pinned_write_size};
+    auto pinned_write_buffer = MeshBuffer::create(pinned_mesh_config, pinned_buffer_config, mesh_device_.get());
+
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    constexpr int device_read_align = 64;
+    ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
+        << "Source vector alignment must be a multiple of PCIE read alignment: "
+        << hal.get_read_alignment(HalMemType::HOST);
+    auto pinned_src = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>>(
+        pinned_write_size / sizeof(uint32_t), 0);
+    std::iota(pinned_src->begin(), pinned_src->end(), 0);
+    HostBuffer host_buffer(tt::stl::Span<uint32_t>(pinned_src->data(), pinned_src->size()), MemoryPin(pinned_src));
+    auto pinned_memory = tt_metal::experimental::PinnedMemory::Create(
+        *mesh_device_, MeshCoordinateRangeSet(all_devices), host_buffer, /*map_to_noc=*/true);
+    ASSERT_TRUE(pinned_memory);
+
+    auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
+    distributed_host_buffer.emplace_shard(test_coord, [&host_buffer]() { return host_buffer; });
+    mesh_device_->mesh_command_queue().enqueue_write(pinned_write_buffer, distributed_host_buffer, /*blocking=*/true);
+
+    auto& program_after_first_run = workload.get_programs().at(all_devices);
+    auto& rtas = GetRuntimeArgs(program_after_first_run, kernel);
+    rtas[logical_core.x][logical_core.y].at(4) = second_add_value;
+
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, /*blocking=*/true);
+    read_and_check_output(input[0] + second_add_value);
 }
 
 TEST_F(MeshBufferTestSuite, EnqueueWriteDeviceLocalShardedBufferWithPinnedMemory) {

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -17,6 +17,7 @@
 #include <random>
 #include <set>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
@@ -62,7 +63,13 @@ static_assert(std::is_move_constructible_v<MeshBuffer>, "MeshBuffer should be mo
 static_assert(std::is_move_assignable_v<MeshBuffer>, "MeshBuffer should be move assignable");
 
 using MeshBufferTest2x4 = MeshDevice2x4Fixture;
+using MeshBufferTest1x2 = MeshDevice1x2Fixture;
 using MeshBufferTestSuite = GenericMeshDeviceFixture;
+
+class MeshBufferTest1x2MultiCQ : public MeshDeviceFixtureBase {
+protected:
+    MeshBufferTest1x2MultiCQ() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 2}, .num_cqs = 2}) {}
+};
 
 class ScopedPinnedMemoryCacheLimit {
 public:
@@ -1235,6 +1242,113 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeLargePage
         EXPECT_EQ(*src, dst);
         // Pinned memory should have been used, so locking may block.
         EXPECT_TRUE(pinned_shared->lock_may_block());
+    }
+}
+
+// Regression test for remote pinned H2D relays. The extra CQ1 write adds remote traffic while CQ0 relays a large
+// 16-byte-shifted pinned source, making prefetch_h crediting of partially written downstream pages observable.
+TEST_F(MeshBufferTest1x2MultiCQ, EnqueueWriteShardsWithRemotePinnedMemoryAndAlignmentPrefix) {
+    if (!tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+
+    constexpr uint32_t page_size_bytes = 4096;
+    constexpr uint32_t pages_per_device = 128256;
+    constexpr uint32_t bytes_per_device = pages_per_device * page_size_bytes;
+    constexpr size_t aligned_byte_shift = 16;
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = page_size_bytes, .buffer_type = BufferType::DRAM, .bottom_up = true};
+    ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
+    auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+    auto traffic_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    constexpr int device_read_align{64};
+    ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
+        << "Source vector alignment must be a multiple of PCIE read alignment: "
+        << hal.get_read_alignment(HalMemType::HOST);
+    ASSERT_EQ(aligned_byte_shift % hal.get_alignment(HalMemType::L1), 0u)
+        << "Alignment prefix must preserve L1 alignment for pinned relay";
+
+    using AlignedByteVector = std::vector<uint8_t, tt::stl::aligned_allocator<uint8_t, device_read_align>>;
+    const MeshCoordinate remote_coord(0, 1);
+    std::vector<std::shared_ptr<AlignedByteVector>> source_storage;
+    std::vector<HostBuffer> source_host_buffers;
+    std::vector<std::shared_ptr<tt_metal::experimental::PinnedMemory>> pinned_sources;
+    std::vector<distributed::ShardDataTransfer> write_transfers;
+    std::optional<size_t> remote_source_index;
+    const MeshCoordinateRange coord_range(mesh_device_->shape());
+    const std::vector<MeshCoordinate> coords(coord_range.begin(), coord_range.end());
+    source_storage.reserve(coords.size());
+    source_host_buffers.reserve(coords.size());
+    pinned_sources.reserve(coords.size());
+    write_transfers.reserve(coords.size());
+
+    for (size_t coord_idx = 0; coord_idx < coords.size(); ++coord_idx) {
+        const auto& coord = coords[coord_idx];
+        auto src = std::make_shared<AlignedByteVector>(bytes_per_device + aligned_byte_shift, 0);
+        uint8_t* src_shifted = src->data() + aligned_byte_shift;
+        for (uint32_t i = 0; i < bytes_per_device; ++i) {
+            src_shifted[i] = static_cast<uint8_t>((i * 131 + (i / page_size_bytes) + 17 * coord_idx + 0x5a) & 0xff);
+        }
+
+        source_storage.push_back(src);
+        source_host_buffers.emplace_back(tt::stl::Span<uint8_t>(src_shifted, bytes_per_device), MemoryPin(src));
+        pinned_sources.push_back(tt_metal::experimental::PinnedMemory::Create(
+            *mesh_device_,
+            MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord)),
+            source_host_buffers.back(),
+            /*map_to_noc=*/true));
+        ASSERT_TRUE(pinned_sources.back());
+
+        if (coord == remote_coord) {
+            const auto target_device_id = mesh_buffer->get_device_buffer(remote_coord)->device()->id();
+            auto noc_addr = pinned_sources.back()->get_noc_addr(target_device_id);
+            ASSERT_TRUE(noc_addr.has_value());
+            if (noc_addr->device_id == target_device_id) {
+                GTEST_SKIP() << "Pinned source is local to target device; remote relay path is not exercised";
+                return;
+            }
+            remote_source_index = coord_idx;
+        }
+
+        auto write_transfer = distributed::ShardDataTransfer{coord}
+                                  .host_data(static_cast<void*>(src_shifted))
+                                  .region(BufferRegion(0, bytes_per_device));
+        tt_metal::experimental::ShardDataTransferSetPinnedMemory(write_transfer, pinned_sources.back());
+        write_transfers.push_back(std::move(write_transfer));
+    }
+    ASSERT_TRUE(remote_source_index.has_value());
+
+    auto traffic_src = std::make_shared<AlignedByteVector>(bytes_per_device, 0);
+    for (uint32_t i = 0; i < bytes_per_device; ++i) {
+        (*traffic_src)[i] = static_cast<uint8_t>((i * 29 + (i / page_size_bytes) + 0xa5) & 0xff);
+    }
+    auto traffic_write = distributed::ShardDataTransfer{remote_coord}
+                             .host_data(static_cast<void*>(traffic_src->data()))
+                             .region(BufferRegion(0, bytes_per_device));
+    auto& traffic_cq = mesh_device_->mesh_command_queue(1);
+    traffic_cq.enqueue_write_shards(traffic_buffer, {traffic_write}, /*blocking=*/false);
+
+    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, write_transfers, /*blocking=*/false);
+    EXPECT_TRUE(pinned_sources.at(remote_source_index.value())->lock_may_block());
+
+    AlignedByteVector dst(bytes_per_device, 0);
+    auto read_transfer = distributed::ShardDataTransfer{remote_coord}
+                             .host_data(static_cast<void*>(dst.data()))
+                             .region(BufferRegion(0, bytes_per_device));
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+    traffic_cq.finish();
+
+    const uint8_t* src_shifted = source_storage.at(remote_source_index.value())->data() + aligned_byte_shift;
+    auto mismatch = std::mismatch(src_shifted, src_shifted + bytes_per_device, dst.data());
+    if (mismatch.first != src_shifted + bytes_per_device) {
+        const size_t offset = static_cast<size_t>(mismatch.first - src_shifted);
+        FAIL() << "Remote pinned H2D readback mismatch at byte offset " << offset
+               << " expected=" << static_cast<uint32_t>(*mismatch.first)
+               << " actual=" << static_cast<uint32_t>(*mismatch.second);
     }
 }
 

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/move/utility_core.hpp>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <tt-metalium/distributed.hpp>
@@ -1595,6 +1596,83 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteDeviceLocalShardedBufferWithPinnedMemory
         ASSERT_EQ(dst_vec.size(), src_vector.size());
         EXPECT_EQ(dst_vec, src_vector);
     }
+}
+
+// Regression coverage for packed pinned writes to sharded buffers with multiple host ranges per core. Each range is
+// relayed through one contiguous scratch stream before the NoC writes fan out to L1, so the PCIe padding for later
+// ranges must be computed relative to the current scratch stream offset. This uses a host pointer shifted by 16 bytes:
+// it is still L1-aligned for the destination writes, but it is not PCIe-read-aligned. If each range is padded
+// independently instead of stream-relative, data after the first range is written with the wrong byte offset.
+TEST_F(MeshBufferTestSuite, EnqueueWriteDeviceLocalWidthShardedBufferWithPinnedMemoryAndMisalignedRanges) {
+    if (!tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+
+    CoreCoord core_grid_size = mesh_device_->compute_with_storage_grid_size();
+    DeviceLocalShardedBufferTestConfig test_config{
+        .num_pages_per_core = {8, 8},
+        .num_cores = {core_grid_size.x, core_grid_size.y},
+        .page_shape = {1, 2048},
+        .mem_config = TensorMemoryLayout::WIDTH_SHARDED};
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = test_config.page_size(),
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(test_config.shard_parameters(), test_config.mem_config),
+        .bottom_up = false};
+
+    const uint32_t buf_size = test_config.num_pages() * test_config.page_size();
+    auto buf =
+        MeshBuffer::create(ReplicatedBufferConfig{.size = buf_size}, per_device_buffer_config, mesh_device_.get());
+
+    const auto mapping = buf->get_device_buffer(MeshCoordinate(0, 0))->get_buffer_page_mapping();
+    const bool has_multi_range_core = std::any_of(
+        mapping->core_page_mappings.begin(), mapping->core_page_mappings.end(), [](const auto& core_mappings) {
+            return std::any_of(core_mappings.begin(), core_mappings.end(), [](const BufferCorePageMapping& mapping) {
+                return mapping.host_ranges.size() > 1;
+            });
+        });
+    ASSERT_TRUE(has_multi_range_core) << "Test must exercise packed pinned writes with multiple host ranges per core";
+
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    constexpr int device_read_align{64};
+    ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
+        << "Source vector alignment must be a multiple of PCIE read alignment: "
+        << hal.get_read_alignment(HalMemType::HOST);
+
+    constexpr size_t source_byte_shift = 16;
+    static_assert(source_byte_shift % sizeof(uint32_t) == 0);
+    ASSERT_EQ(source_byte_shift % hal.get_alignment(HalMemType::L1), 0u);
+    ASSERT_NE(source_byte_shift % hal.get_read_alignment(HalMemType::HOST), 0u);
+    const size_t source_word_shift = source_byte_shift / sizeof(uint32_t);
+    const size_t num_words = buf_size / sizeof(uint32_t);
+
+    auto src = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>>(
+        num_words + source_word_shift, 0);
+    uint32_t* src_shifted = src->data() + source_word_shift;
+    std::iota(src_shifted, src_shifted + num_words, 0);
+
+    std::vector<uint32_t> expected(src_shifted, src_shifted + num_words);
+    HostBuffer host_buffer(tt::stl::Span<uint32_t>(src_shifted, num_words), MemoryPin(src));
+
+    const MeshCoordinate coord = *MeshCoordinateRange(mesh_device_->shape()).begin();
+    auto pinned_shared = tt_metal::experimental::PinnedMemory::Create(
+        *mesh_device_,
+        MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord)),
+        host_buffer,
+        /*map_to_noc=*/true);
+    ASSERT_TRUE(pinned_shared);
+
+    auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
+    distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
+    mesh_device_->mesh_command_queue().enqueue_write(buf, distributed_host_buffer, /*blocking=*/false);
+    EXPECT_TRUE(pinned_shared->lock_may_block());
+
+    std::vector<uint32_t> dst;
+    ReadShard(mesh_device_->mesh_command_queue(), dst, buf, coord);
+    ASSERT_EQ(dst.size(), expected.size());
+    EXPECT_EQ(dst, expected);
 }
 
 TEST_F(MeshBufferTestSuite, EnqueueWriteDeviceLocalShardedBufferWithCoreFilter) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -6,12 +6,17 @@
 #include <gmock/gmock.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <set>
 #include <vector>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/operations/experimental/core_subset_write/copy_to_device_filtered.hpp"
@@ -581,7 +586,13 @@ protected:
     MeshDevice2x2Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{2, 2}}) {}
 };
 
+class MeshDevice1x1Fixture : public MeshDeviceFixtureBase {
+protected:
+    MeshDevice1x1Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 1}}) {}
+};
+
 using MeshTensorDataMovementTest = MeshDevice2x2Fixture;
+using MeshTensorPinnedMemoryBudgetTest = MeshDevice1x1Fixture;
 
 using tt::tt_metal::DistributedHostBuffer;
 using tt::tt_metal::HostBuffer;
@@ -594,6 +605,22 @@ constexpr int kPinnedMemoryTestAlignment = 64;
 constexpr size_t kPinnedWriteThresholdBytesForTest = 32 * 1024 * 1024;
 
 using AlignedUInt32Vector = std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, kPinnedMemoryTestAlignment>>;
+
+class ScopedPinnedMemoryCacheLimit {
+public:
+    explicit ScopedPinnedMemoryCacheLimit(size_t limit_bytes) :
+        previous_limit_bytes_(
+            tt::tt_metal::MetalContext::instance().rtoptions().get_pinned_memory_cache_limit_bytes()) {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_pinned_memory_cache_limit_bytes(limit_bytes);
+    }
+
+    ~ScopedPinnedMemoryCacheLimit() {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_pinned_memory_cache_limit_bytes(previous_limit_bytes_);
+    }
+
+private:
+    size_t previous_limit_bytes_;
+};
 
 HostBuffer make_aligned_host_buffer(size_t num_words, uint32_t fill) {
     auto data = std::make_shared<AlignedUInt32Vector>(num_words, fill);
@@ -778,6 +805,75 @@ TEST_F(MeshTensorDataMovementTest, UniformCopyToDevice_CopyToHost_Roundtrip) {
     enqueue_read_tensor(cq, device_tensor, result);
 
     expect_host_tensors_eq(host_tensor, result);
+}
+
+TEST_F(MeshTensorPinnedMemoryBudgetTest, LargeHostWriteOverHardwarePinBudgetFallsBackAndKeepsDeviceUsable) {
+    const auto pinning_params = tt::tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_);
+    if (pinning_params.max_pins == 0 || !pinning_params.can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+    if (pinning_params.max_total_pin_size == std::numeric_limits<uint64_t>::max()) {
+        GTEST_SKIP() << "Hardware does not advertise a finite pinned-memory budget";
+        return;
+    }
+
+    // The runtime cache limit can be larger than the hardware NOC-mappable pin budget. This write is intentionally
+    // larger than that hardware budget, so it must fall back to the regular host-to-device path instead of trying to
+    // create an oversized NOC mapping.
+    const ttnn::Shape large_shape{1, 1, 160, 5210112};
+    const ttnn::Shape large_shard_shape{1, 1, 32, 131072};
+    const size_t oversized_buffer_size = static_cast<size_t>(large_shape.volume()) * sizeof(uint32_t);
+    if (oversized_buffer_size <= pinning_params.max_total_pin_size) {
+        GTEST_SKIP() << "Test tensor is not larger than the hardware pinned-memory budget";
+        return;
+    }
+    ScopedPinnedMemoryCacheLimit cache_limit(oversized_buffer_size);
+
+    void* mapping = mmap(
+        nullptr, oversized_buffer_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    ASSERT_NE(mapping, MAP_FAILED) << "mmap failed: " << std::strerror(errno);
+
+    auto mapping_owner = std::shared_ptr<std::byte>(
+        static_cast<std::byte*>(mapping),
+        [oversized_buffer_size](std::byte* ptr) { munmap(static_cast<void*>(ptr), oversized_buffer_size); });
+
+    const size_t num_words = oversized_buffer_size / sizeof(uint32_t);
+    ASSERT_EQ(oversized_buffer_size % sizeof(uint32_t), 0u);
+    ASSERT_EQ(num_words, large_shape.volume());
+
+    auto dram_grid_size = mesh_device_->dram_grid_size();
+    if (dram_grid_size.x == 0 || dram_grid_size.y == 0) {
+        GTEST_SKIP() << "Device does not expose a DRAM grid";
+        return;
+    }
+    // Only use the first DRAM row; higher y values can be replicas of the same DRAM cores.
+    CoreRangeSet dram_cores(CoreRange(CoreCoord{0, 0}, CoreCoord{dram_grid_size.x - 1, 0}));
+    MemoryConfig large_mem_cfg(
+        BufferType::DRAM, NdShardSpec{large_shard_shape, dram_cores, ShardOrientation::ROW_MAJOR});
+    auto large_spec = TensorSpec(large_shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, large_mem_cfg));
+
+    auto large_dhb = DistributedHostBuffer::create(mesh_device_->shape());
+    const auto first_coord = *distributed::MeshCoordinateRange(mesh_device_->shape()).begin();
+    large_dhb.emplace_shard(first_coord, [&]() {
+        return HostBuffer(
+            tt::stl::Span<uint32_t>(reinterpret_cast<uint32_t*>(mapping_owner.get()), num_words),
+            tt::tt_metal::MemoryPin(std::static_pointer_cast<void>(mapping_owner)));
+    });
+    HostTensor large_host_tensor(
+        std::move(large_dhb), large_spec, TensorTopology::create_sharded_tensor_topology(mesh_device_->shape()));
+
+    auto& cq = mesh_device_->mesh_command_queue();
+    MeshTensor large_device_tensor = enqueue_write_tensor(cq, large_host_tensor, *mesh_device_);
+    cq.finish();
+    EXPECT_EQ(large_device_tensor.tensor_spec().logical_shape(), large_shape);
+
+    const ttnn::Shape small_shape{1, 1, 32, 32};
+    auto small_host_tensor = make_full_coverage_host_tensor(small_shape, mesh_device_->shape(), {0x5Au});
+    MeshTensor small_device_tensor = enqueue_write_tensor(cq, small_host_tensor, *mesh_device_);
+    HostTensor small_result = enqueue_read_tensor(cq, small_device_tensor);
+
+    expect_host_tensors_eq(small_host_tensor, small_result);
 }
 
 TEST_F(MeshTensorTest, UniformCopyToDevice_ReusesPinnedMemoryCacheEntries) {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1440,6 +1440,8 @@ std::pair<bool, size_t> FDMeshCommandQueue::query_prefetcher_cache(uint64_t work
 
 void FDMeshCommandQueue::reset_prefetcher_cache_manager() { prefetcher_cache_manager_->reset(); }
 
+void FDMeshCommandQueue::invalidate_prefetcher_cache_after_pinned_write() { this->reset_prefetcher_cache_manager(); }
+
 int FDMeshCommandQueue::get_prefetcher_cache_sizeB() const {
     return this->prefetcher_cache_manager_->get_cache_sizeB();
 }

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -201,6 +201,7 @@ protected:
     MeshEvent enqueue_record_event_to_host_nolock(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
+    void invalidate_prefetcher_cache_after_pinned_write() override;
 
 public:
     FDMeshCommandQueue(

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -265,6 +265,10 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
     }
     dispatch_thread_pool_->wait();
 
+    if (any_pinned_used.load(std::memory_order_relaxed)) {
+        this->invalidate_prefetcher_cache_after_pinned_write();
+    }
+
     if (blocking) {
         this->finish_nolock();
     } else if (any_pinned_used.load(std::memory_order_relaxed)) {

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -46,6 +46,7 @@ protected:
     virtual MeshEvent enqueue_record_event_to_host_nolock(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
+    virtual void invalidate_prefetcher_cache_after_pinned_write() {}
 
     tt::TargetDevice get_target_device_type() const;
 

--- a/tt_metal/distributed/pinned_memory_cache.cpp
+++ b/tt_metal/distributed/pinned_memory_cache.cpp
@@ -61,6 +61,17 @@ void PinnedMemoryCache::erase_entry(std::list<CacheEntry>::iterator it) {
             break;
         }
     }
+    for (ChipId mmio_id : it->mmio_device_ids) {
+        auto current_size_it = current_size_bytes_by_mmio_id_.find(mmio_id);
+        if (current_size_it == current_size_bytes_by_mmio_id_.end()) {
+            continue;
+        }
+        current_size_it->second =
+            entry_size_bytes <= current_size_it->second ? current_size_it->second - entry_size_bytes : size_t{0};
+        if (current_size_it->second == 0) {
+            current_size_bytes_by_mmio_id_.erase(current_size_it);
+        }
+    }
     current_size_bytes_ =
         entry_size_bytes <= current_size_bytes_ ? current_size_bytes_ - entry_size_bytes : static_cast<size_t>(0);
     lru_entries_.erase(it);
@@ -74,17 +85,6 @@ void PinnedMemoryCache::release_locked(const void* host_address) {
         erase_entry(list_it);
         map_it = next_map_it;
     }
-}
-
-bool PinnedMemoryCache::evict_oldest_entry() {
-    for (auto it = lru_entries_.begin(); it != lru_entries_.end(); ++it) {
-        if (it->pinned_memory.use_count() > 1) {
-            continue;
-        }
-        erase_entry(it);
-        return true;
-    }
-    return false;
 }
 
 bool PinnedMemoryCache::evict_oldest_entry_for_mmio_ids(const std::set<ChipId>& target_mmio_ids) {
@@ -102,15 +102,42 @@ bool PinnedMemoryCache::evict_oldest_entry_for_mmio_ids(const std::set<ChipId>& 
     return false;
 }
 
-bool PinnedMemoryCache::evict_oldest_until_within_limit(size_t incoming_size_bytes) {
-    const size_t cache_limit_bytes = MetalContext::instance().rtoptions().get_pinned_memory_cache_limit_bytes();
-    if (incoming_size_bytes > cache_limit_bytes) {
+bool PinnedMemoryCache::evict_oldest_entry() {
+    for (auto it = lru_entries_.begin(); it != lru_entries_.end(); ++it) {
+        if (it->pinned_memory.use_count() > 1) {
+            continue;
+        }
+        erase_entry(it);
+        return true;
+    }
+    return false;
+}
+
+bool PinnedMemoryCache::evict_oldest_until_within_limit(
+    size_t incoming_size_bytes,
+    size_t global_limit_bytes,
+    size_t per_mmio_limit_bytes,
+    const std::set<ChipId>& target_mmio_ids) {
+    if (incoming_size_bytes > global_limit_bytes || incoming_size_bytes > per_mmio_limit_bytes) {
         return false;
     }
 
-    while (current_size_bytes_ > cache_limit_bytes - incoming_size_bytes) {
+    while (current_size_bytes_ > global_limit_bytes - incoming_size_bytes) {
         if (!evict_oldest_entry()) {
             return false;
+        }
+    }
+
+    for (ChipId mmio_id : target_mmio_ids) {
+        auto current_size_bytes = [&]() {
+            auto current_size_it = current_size_bytes_by_mmio_id_.find(mmio_id);
+            return current_size_it == current_size_bytes_by_mmio_id_.end() ? size_t{0} : current_size_it->second;
+        };
+        const std::set<ChipId> single_mmio_id{mmio_id};
+        while (current_size_bytes() > per_mmio_limit_bytes - incoming_size_bytes) {
+            if (!evict_oldest_entry_for_mmio_ids(single_mmio_id)) {
+                return false;
+            }
         }
     }
     return true;
@@ -152,6 +179,8 @@ std::shared_ptr<PinnedMemory> PinnedMemoryCache::try_pin(
     }
     const void* host_addr = static_cast<const void*>(buffer_bytes.data());
     const size_t buffer_size = buffer_bytes.size();
+    const size_t global_cache_limit = MetalContext::instance().rtoptions().get_pinned_memory_cache_limit_bytes();
+    const size_t per_mmio_pin_limit = params.max_total_pin_size;
     std::set<ChipId> target_device_ids = compute_device_ids(mesh_device, coordinate_range_set);
     if (target_device_ids.empty()) {
         return nullptr;
@@ -216,7 +245,7 @@ std::shared_ptr<PinnedMemory> PinnedMemoryCache::try_pin(
         }
     }
 
-    if (!evict_oldest_until_within_limit(buffer_size)) {
+    if (!evict_oldest_until_within_limit(buffer_size, global_cache_limit, per_mmio_pin_limit, target_mmio_ids)) {
         return nullptr;
     }
 
@@ -234,6 +263,9 @@ std::shared_ptr<PinnedMemory> PinnedMemoryCache::try_pin(
             CacheEntry entry{pinned, host_addr, target_device_ids, target_mmio_ids, map_to_noc};
             lru_entries_.push_back(std::move(entry));
             address_map_.emplace(host_addr, std::prev(lru_entries_.end()));
+            for (ChipId mmio_id : target_mmio_ids) {
+                current_size_bytes_by_mmio_id_[mmio_id] += pinned->get_buffer_size();
+            }
             current_size_bytes_ += pinned->get_buffer_size();
             return pinned;
         } catch (...) {

--- a/tt_metal/distributed/pinned_memory_cache.hpp
+++ b/tt_metal/distributed/pinned_memory_cache.hpp
@@ -31,10 +31,11 @@ namespace tt::tt_metal::experimental {
  * tensor read/write paths. HostBuffer::pinned_memory_ is only populated
  * transiently (during enqueue_read calls) and cleared immediately afterward.
  *
- * The cache evicts global LRU entries to keep total cached pinned memory under
- * the runtime-configured limit. When pinning fails due to the kernel pin limit
- * being exhausted, it evicts the oldest entry that shares an MMIO device with
- * the failing pin and retries.
+ * The cache evicts LRU entries to keep total cached pinned memory under the
+ * runtime-configured global limit, and cached memory per MMIO device under the
+ * hardware NOC-mappable pin budget. When pinning fails due to the kernel pin
+ * limit being exhausted, it evicts the oldest entry that shares an MMIO device
+ * with the failing pin and retries.
  *
  * Two cleanup hooks ensure PinnedMemory never outlives its underlying memory
  * or its device:
@@ -116,14 +117,19 @@ private:
     // Erase all entries for `host_address`. Caller must hold mutex_.
     void release_locked(const void* host_address);
 
-    // Evict oldest unreferenced entries until adding `incoming_size_bytes` keeps the cache under its limit.
-    bool evict_oldest_until_within_limit(size_t incoming_size_bytes);
-
-    // Evict the oldest unreferenced entry across all MMIO devices.
-    bool evict_oldest_entry();
+    // Evict oldest unreferenced entries until adding `incoming_size_bytes` keeps the global cache under
+    // `global_limit_bytes` and each target MMIO device under `per_mmio_limit_bytes`.
+    bool evict_oldest_until_within_limit(
+        size_t incoming_size_bytes,
+        size_t global_limit_bytes,
+        size_t per_mmio_limit_bytes,
+        const std::set<int>& target_mmio_ids);
 
     // Evict the oldest unreferenced entry that overlaps the target MMIO devices.
     bool evict_oldest_entry_for_mmio_ids(const std::set<int>& target_mmio_ids);
+
+    // Evict the oldest unreferenced entry across all MMIO devices.
+    bool evict_oldest_entry();
 
     // Check whether any existing entry for `host_addr` has MMIO overlap with
     // `target_mmio_ids` and is still referenced externally (use_count > 1),
@@ -134,6 +140,7 @@ private:
     std::list<CacheEntry> lru_entries_;  // front = oldest (LRU candidate)
     std::unordered_multimap<const void*, std::list<CacheEntry>::iterator> address_map_;
     size_t current_size_bytes_ = 0;
+    std::unordered_map<int, size_t> current_size_bytes_by_mmio_id_;
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -699,6 +699,7 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
     // Build sub-commands on the fly with coalescing
     std::vector<CQDispatchWritePackedLargeUnicastSubCmd> write_sub_cmds;
     std::vector<CQPrefetchRelayLinearPackedSubCmd> relay_sub_cmds;
+    uint32_t relay_stream_offset = 0;
 
     const CoreCoord virtual_core = buffer.device()->virtual_core_from_logical_core(core, buffer.core_type());
     const uint32_t noc_xy_addr = buffer.device()->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_core);
@@ -810,6 +811,13 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
         // Clear for next batch
         write_sub_cmds.clear();
         relay_sub_cmds.clear();
+        relay_stream_offset = 0;
+    };
+
+    auto calculate_aligned_src = [&](uint64_t src_pinned_addr) {
+        const uint32_t relay_alignment_offset = relay_stream_offset % pcie_alignment;
+        const uint32_t padding_bytes = (src_pinned_addr + pcie_alignment - relay_alignment_offset) % pcie_alignment;
+        return std::pair<uint64_t, uint32_t>{src_pinned_addr - padding_bytes, padding_bytes};
     };
 
     // Iterate through host ranges and build sub-commands
@@ -834,14 +842,9 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             dst_addr,
             l1_alignment);
 
-        // Align source address to PCIe alignment if needed
-        uint64_t aligned_src_addr = src_pinned_addr;
-        uint32_t padding_bytes = 0;
-        if (src_pinned_addr % pcie_alignment != 0) {
-            padding_bytes = src_pinned_addr % pcie_alignment;
-            aligned_src_addr = src_pinned_addr - padding_bytes;
-        }
-
+        // Align each read to the scratch stream position. Packed reads concatenate into scratch, so re-aligning every
+        // host range to address 0 mod PCIe alignment can violate NoC source/destination congruence after a prefix.
+        auto [aligned_src_addr, padding_bytes] = calculate_aligned_src(src_pinned_addr);
         uint32_t total_read_length = padding_bytes + data_length;
 
         // Determine if relay or write can be coalesced
@@ -876,6 +879,10 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             // After emitting, we can't coalesce with previous commands (vectors are now empty)
             can_coalesce_relay = false;
             can_coalesce_write = false;
+            const auto aligned_src_info = calculate_aligned_src(src_pinned_addr);
+            aligned_src_addr = aligned_src_info.first;
+            padding_bytes = aligned_src_info.second;
+            total_read_length = padding_bytes + data_length;
         }
 
         // Add or coalesce relay sub-command
@@ -909,6 +916,8 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             write_sub_cmd.length = data_length;
             write_sub_cmds.push_back(write_sub_cmd);
         }
+
+        relay_stream_offset += total_read_length;
     }
 
     // Emit final command pair with remaining sub-commands

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -2171,14 +2171,26 @@ bool process_cmd(
 template <bool test_for_nonzero>
 static void relay_linear_to_downstream(
     uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
-    // Unlike in write_pages_to_dispatcher we always round npages down, so if downstream_data_ptr is at the start of a
-    // page, that means page_residual_space is 0. This is why the logic is different from write_pages_to_dispatcher.
-    uint32_t page_residual_space = -downstream_data_ptr & (downstream_cb_page_size - 1);
+    constexpr uint32_t page_mask = downstream_cb_page_size - 1;
+    uint32_t page_offset = downstream_data_ptr & page_mask;
+    uint32_t end_page_offset = page_offset + amt_to_write;
+    uint32_t pages_touched = (end_page_offset + page_mask) >> downstream_cb_log_page_size;
+    // Acquire pages that this write newly touches. If we are already in a partially filled page, that page was acquired
+    // by the previous write and should not be acquired again.
+    uint32_t pages_to_acquire = pages_touched - static_cast<uint32_t>(page_offset != 0);
+    // Mid-stream, only fully completed pages are safe to credit to prefetch_d. The final chunk can credit its partial
+    // tail page because prefetch_d clamps consumption to the command's remaining length.
+    uint32_t pages_to_release = end_page_offset >> downstream_cb_log_page_size;
+    if constexpr (test_for_nonzero) {
+        pages_to_release = pages_touched;
+    }
 
-    // Following is fine if downstream cb block is bigger than scratch and there are at least a couple of them
-    uint32_t npages = (amt_to_write - page_residual_space + downstream_cb_page_size - 1) / downstream_cb_page_size;
-    if (!test_for_nonzero || (npages != 0)) {
-        DispatchRelayInlineState::cb_writer.acquire_pages(npages);
+    if constexpr (test_for_nonzero) {
+        if (pages_to_acquire != 0) {
+            DispatchRelayInlineState::cb_writer.acquire_pages(pages_to_acquire);
+        }
+    } else {
+        DispatchRelayInlineState::cb_writer.acquire_pages(pages_to_acquire);
     }
     uint64_t noc_addr;
     if (downstream_data_ptr == downstream_cb_end) {
@@ -2195,7 +2207,7 @@ static void relay_linear_to_downstream(
     noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
     relay_client
         .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
-            scratch_write_addr, noc_addr, amt_to_write, npages);
+            scratch_write_addr, noc_addr, amt_to_write, pages_to_release);
     downstream_data_ptr += amt_to_write;
 }
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -401,9 +401,10 @@ void Hal::initialize_wh(
         }
     };
 
+    constexpr size_t kWormholePinnedMemoryBudgetBytes =
+        (2ULL * 1024ULL * 1024ULL * 1024ULL) - (512ULL * 1024ULL * 1024ULL);
     this->max_pinned_memory_count_ = 12;
-    this->total_pinned_memory_size_ =
-        4ULL * 1024ULL * 1024ULL * 1024ULL - static_cast<uint64_t>(tt::tt_metal::DispatchSettings::MAX_HUGEPAGE_SIZE);
+    this->total_pinned_memory_size_ = kWormholePinnedMemoryBudgetBytes;
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -217,7 +217,7 @@ class RunTimeOptions {
     bool clear_l1 = false;
     bool clear_dram = false;
 
-    size_t pinned_memory_cache_limit_bytes = 0;
+    size_t pinned_memory_cache_limit_bytes = 4ULL * 1024 * 1024 * 1024;
 
     bool skip_loading_fw = false;
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes four correctness issues in pinned-memory H2D writes and enables the pinned memory cache by default.

**1. Invalidate FD prefetcher cache after pinned writes**
The FD prefetcher cache manager could keep treating cached program binaries as valid after pinned writes used the prefetcher SRAM path. Now `MeshCommandQueueBase::enqueue_write_shards_nolock` calls a virtual `invalidate_prefetcher_cache_after_pinned_write()` hook after shard write dispatch threads complete. `FDMeshCommandQueue` overrides it to reset the prefetcher cache manager.

**2. Fix PCIe alignment for packed pinned relay sub-commands**
When multiple host ranges were packed into a single relay command, each range's source address was independently aligned to PCIe alignment (address mod 0). Because packed reads concatenate into prefetcher scratch, this broke NoC source/destination congruence after the first range. The fix tracks a running `relay_stream_offset` and computes alignment padding relative to the stream position instead of absolute address 0.

**3. Fix page acquire/release logic in `relay_linear_to_downstream`**
The prefetcher kernel's `relay_linear_to_downstream` function could over-credit partially-filled downstream CB pages to `prefetch_d`. The old code rounded up `npages` and credited that same count, meaning a partial tail page could be credited before all its data was written. The rewrite properly tracks which pages a write newly touches vs. already-acquired partial pages, and only credits fully completed pages mid-stream (the final chunk credits its partial tail page since `prefetch_d` clamps consumption to the command's remaining length).

**4. Per-MMIO-device pinned memory budget enforcement**
The pinned memory cache tracked only a global size limit but not per-MMIO-device usage. On Wormhole, the hardware NOC-mappable pin budget (~1.5 GiB) is smaller than the global cache limit (4 GiB), so the cache could pin more memory through a single MMIO device than the hardware supports, breaking the hugepage mapping. The fix adds per-MMIO-device size tracking (`current_size_bytes_by_mmio_id_`) and extends `evict_oldest_until_within_limit` to enforce both the global cache limit and the per-MMIO hardware pin budget. When a write exceeds the hardware budget, it falls back to the regular (non-pinned) H2D path.

**Other changes:**
- Enable the pinned memory cache by default with a 4 GiB limit (`rtoptions.hpp`).
- Set explicit Wormhole pinned memory budget constant (1.5 GiB) in `wh_hal.cpp`.
- Add regression tests: remote pinned H2D relay with alignment prefix (`EnqueueWriteShardsWithRemotePinnedMemoryAndAlignmentPrefix`), program rerun after pinned write (`EnqueueProgramAfterPinnedMemoryWriteRerunsCorrectly`), unaligned pinned write with multi-range packing (`EnqueueWriteShardsWithPinnedMemoryFullRangeUnalignedWithShift`), and over-budget pinned write fallback (`LargeHostWriteOverHardwarePinBudgetFallsBackAndKeepsDeviceUsable`).

### Notes for reviewers
- The cache invalidation hook is in `MeshCommandQueueBase::enqueue_write_shards_nolock`, running after dispatch threads complete and before blocking/nonblocking completion handling.
- The alignment fix in `dispatch.cpp` is the `calculate_aligned_src` lambda and `relay_stream_offset` tracking.
- The prefetcher kernel change in `cq_prefetch.cpp` replaces the `page_residual_space`/`npages` calculation with explicit `pages_to_acquire`/`pages_to_release` logic.
- The per-MMIO budget fix is in `pinned_memory_cache.cpp`/`.hpp`: `evict_oldest_until_within_limit` now takes `per_mmio_limit_bytes` from the HAL's `GetMemoryPinningParameters().max_total_pin_size`, and eviction targets entries sharing the over-budget MMIO device.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-pinned-prefetcher-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-pinned-prefetcher-cache)