### PR TITLE
[skip ci] Increase Galaxy lead_models sweep batches from 3 to 6

### DIFF
--- a/tests/sweep_framework/framework/matrix_runner_config.py
+++ b/tests/sweep_framework/framework/matrix_runner_config.py
@@ -167,7 +167,7 @@ LEAD_MODELS_SUITE_NAME = "model_traced"
 
 # Absent entries use the caller-provided fixed ``batch_size``.
 LEAD_MODELS_BATCH_POLICY = {
-    "lead-models-galaxy": {"parallel_jobs": 3},
+    "lead-models-galaxy": {"parallel_jobs": 6},
 }
 
 


### PR DESCRIPTION
## Summary
- Increase `parallel_jobs` for `lead-models-galaxy` from 3 to 6 in `LEAD_MODELS_BATCH_POLICY`
- Galaxy lead_models sweeps currently run in 3 batches; this spreads to 6 for better CI wall-clock time

## Changes
- `tests/sweep_framework/framework/matrix_runner_config.py`: `"parallel_jobs": 3` → `6`

## Test plan
- [ ] Trigger sweep validation on Galaxy and verify 6 batches are created
- [ ] Confirm all batches complete successfully