### PR TITLE
[tt-triage] Add on-demand triage tests workflow

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -117,6 +117,10 @@ skus:
     runs_on:
       - tt-ubuntu-2204-N150-viommu-stable
 
+  wh_n150_civ2_bare:
+    runs_on:
+      - tt-ubuntu-2204-N150-stable
+
   wh_n300_civ2:
     runs_on:
       - tt-ubuntu-2204-N300-viommu-stable
@@ -138,6 +142,10 @@ skus:
   bh_p150b_civ2_viommu:
     runs_on:
       - tt-ubuntu-2204-P150b-viommu-stable
+
+  bh_p150b_civ2_viommu_prio:
+    runs_on:
+      - tt-ubuntu-2204-P150b-viommu-prio-stable
 
   bh_p150b_civ2:
     runs_on:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -31,6 +31,12 @@ metal_infra:
     bh_llmbox: 0
     bh_loudbox: 0
     bh_qb: 0
+    # Triage tests (tools/tests/triage/) — tests/pipeline_reorg/triage_tests.yaml
+    wh_n150_civ2: 15
+    wh_n150_civ2_bare: 30
+    bh_p150b_civ2: 30
+    bh_p150b_civ2_viommu: 15
+    bh_p150b_civ2_viommu_prio: 15
   unit:
     N150: 0
     N300: 0

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -400,19 +400,14 @@ jobs:
 
   triage-tests:
     needs: [ build, find-changes ]
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N150-viommu","P150b-viommu-prio"]')
-            || fromJSON('["N150-viommu","P150b-viommu"]') }}
     uses: ./.github/workflows/triage.yaml
     with:
-      runner-label: ${{ matrix.platform }}
+      enabled-skus: ${{ github.event_name == 'merge_group'
+          && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio'
+          || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      timeout: 11
 
   load-llk-unit-test-matrix:
     needs: find-changes

--- a/.github/workflows/triage-tests.yaml
+++ b/.github/workflows/triage-tests.yaml
@@ -1,14 +1,14 @@
 name: "(triage) On-demand triage tests"
-run-name: "(triage) ${{ inputs.runner-labels }}${{ inputs.ref && format(' @ {0}', inputs.ref) || '' }}"
+run-name: "(triage) ${{ inputs.enabled-skus }}${{ inputs.ref && format(' @ {0}', inputs.ref) || '' }}"
 
 on:
   workflow_dispatch:
     inputs:
-      runner-labels:
-        description: 'Comma-separated runner labels (e.g. "N150,P150b"). Valid: N150, N300, P150b, P100, N150-viommu, P150b-viommu, P150b-viommu-prio'
+      enabled-skus:
+        description: 'Comma-separated SKUs from .github/sku_config.yaml (e.g. "wh_n150_civ2,bh_p150b_civ2"). Valid: wh_n150_civ2, wh_n150_civ2_bare, bh_p150b_civ2, bh_p150b_civ2_viommu, bh_p150b_civ2_viommu_prio.'
         required: true
         type: string
-        default: "N150"
+        default: "wh_n150_civ2"
       ref:
         description: 'Git ref (branch, tag, or commit SHA) to build. Leave empty to use the branch selected in "Use workflow from".'
         required: false
@@ -31,40 +31,17 @@ on:
         required: false
         type: boolean
         default: true
-      timeout:
-        description: 'Test timeout in minutes'
+      timeout-minutes-override:
+        description: 'If > 0, skip time budget verification and use this as the job timeout in minutes.'
         required: false
         type: number
-        default: 30
+        default: 0
 
 permissions:
   packages: write
   contents: read
 
 jobs:
-  generate-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.parse.outputs.matrix }}
-    steps:
-      - name: Parse runner-labels into matrix
-        id: parse
-        run: |
-          set -euo pipefail
-          raw='${{ inputs.runner-labels }}'
-          matrix=$(echo "$raw" \
-            | tr ',' '\n' \
-            | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
-            | grep -v '^$' \
-            | jq -R . \
-            | jq -sc '{"runner-label": .}')
-          if [[ "$(echo "$matrix" | jq '.["runner-label"] | length')" -eq 0 ]]; then
-            echo "Error: no runner labels parsed from input: \"$raw\"" >&2
-            exit 1
-          fi
-          echo "Matrix: $matrix"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -78,17 +55,15 @@ jobs:
       ref: ${{ inputs.ref }}
 
   triage-tests:
-    needs: [build-artifact, generate-matrix]
+    needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/triage.yaml
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     with:
-      runner-label: ${{ matrix.runner-label }}
+      enabled-skus: ${{ inputs.enabled-skus }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       run-hang-report-test: ${{ inputs.run-hang-report-test }}
       reset-device-after-hang: ${{ inputs.reset-device-after-hang }}
-      timeout: ${{ inputs.timeout }}
+      timeout-minutes-override: ${{ inputs.timeout-minutes-override }}
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/triage-tests.yaml
+++ b/.github/workflows/triage-tests.yaml
@@ -1,0 +1,95 @@
+name: "(triage-tests) On-demand triage tests"
+run-name: "(triage-tests) ${{ inputs.runner-labels }}${{ inputs.ref && format(' @ {0}', inputs.ref) || '' }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner-labels:
+        description: 'Comma-separated runner labels (e.g. "N150,P150b"). Valid: N150, N300, P150b, P100, N150-viommu, P150b-viommu, P150b-viommu-prio'
+        required: true
+        type: string
+        default: "N150"
+      ref:
+        description: 'Git ref (branch, tag, or commit SHA) to build. Leave empty to use the branch selected in "Use workflow from".'
+        required: false
+        type: string
+        default: ""
+      platform:
+        required: false
+        type: choice
+        default: "Ubuntu 22.04"
+        options:
+          - "Ubuntu 22.04"
+          - "Ubuntu 24.04"
+        description: "Platform to build and test"
+      run-hang-report-test:
+        description: 'Run hang report generation test (intentionally hangs a card)'
+        required: false
+        type: boolean
+        default: false
+      reset-device-after-hang:
+        description: 'Reset device after a hang is detected (TT_METAL_RESET_DEVICE_AFTER_HANG)'
+        required: false
+        type: boolean
+        default: true
+      timeout:
+        description: 'Test timeout in minutes'
+        required: false
+        type: number
+        default: 30
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.parse.outputs.matrix }}
+    steps:
+      - name: Parse runner-labels into matrix
+        id: parse
+        run: |
+          set -euo pipefail
+          raw='${{ inputs.runner-labels }}'
+          matrix=$(echo "$raw" \
+            | tr ',' '\n' \
+            | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+            | grep -v '^$' \
+            | jq -R . \
+            | jq -sc '{"runner-label": .}')
+          if [[ "$(echo "$matrix" | jq '.["runner-label"] | length')" -eq 0 ]]; then
+            echo "Error: no runner labels parsed from input: \"$raw\"" >&2
+            exit 1
+          fi
+          echo "Matrix: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: Release
+      build-wheel: true
+      tracy: true
+      platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
+      ref: ${{ inputs.ref }}
+
+  triage-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/triage.yaml
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    with:
+      runner-label: ${{ matrix.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      run-hang-report-test: ${{ inputs.run-hang-report-test }}
+      reset-device-after-hang: ${{ inputs.reset-device-after-hang }}
+      timeout: ${{ inputs.timeout }}

--- a/.github/workflows/triage-tests.yaml
+++ b/.github/workflows/triage-tests.yaml
@@ -1,5 +1,5 @@
-name: "(triage-tests) On-demand triage tests"
-run-name: "(triage-tests) ${{ inputs.runner-labels }}${{ inputs.ref && format(' @ {0}', inputs.ref) || '' }}"
+name: "(triage) On-demand triage tests"
+run-name: "(triage) ${{ inputs.runner-labels }}${{ inputs.ref && format(' @ {0}', inputs.ref) || '' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/triage-tests.yaml
+++ b/.github/workflows/triage-tests.yaml
@@ -20,8 +20,7 @@ on:
         default: "Ubuntu 22.04"
         options:
           - "Ubuntu 22.04"
-          - "Ubuntu 24.04"
-        description: "Platform to build and test"
+        description: "Platform to build and test (currently only Ubuntu 22.04 is supported by this workflow)"
       run-hang-report-test:
         description: 'Run hang report generation test (intentionally hangs a card)'
         required: false

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -35,6 +35,10 @@ on:
         description: 'Run hang report generation test (intentionally hangs a card)'
         default: false
         type: boolean
+      reset-device-after-hang:
+        description: 'Reset device after a hang is detected (TT_METAL_RESET_DEVICE_AFTER_HANG)'
+        default: true
+        type: boolean
 
 jobs:
   triage-tests:
@@ -82,7 +86,10 @@ jobs:
             if [[ "${{ inputs.run-hang-report-test }}" != "true" ]]; then
               IGNORE_ARGS="--ignore=./tools/tests/triage/test_hang_report.py"
             fi
-            TT_METAL_RESET_DEVICE_AFTER_HANG=1 pytest -v -s ./tools/tests/triage/ $IGNORE_ARGS
+            if [[ "${{ inputs.reset-device-after-hang }}" == "true" ]]; then
+              export TT_METAL_RESET_DEVICE_AFTER_HANG=1
+            fi
+            pytest -v -s ./tools/tests/triage/ $IGNORE_ARGS
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -3,13 +3,15 @@ name: "[internal] Triage tests impl"
 on:
   workflow_call:
     inputs:
-      runner-label:
+      enabled-skus:
         required: true
         type: string
-      timeout:
+        description: "Comma-separated SKUs (e.g. wh_n150_civ2,bh_p150b_civ2_viommu). Maps to runs_on via .github/sku_config.yaml."
+      timeout-minutes-override:
         required: false
         type: number
-        default: 30
+        default: 0
+        description: "If > 0, skip time budget verification and use this as the job timeout."
       docker-image:
         required: true
         type: string
@@ -39,10 +41,58 @@ on:
         description: 'Reset device after a hang is detected (TT_METAL_RESET_DEVICE_AFTER_HANG)'
         default: true
         type: boolean
+      ref:
+        required: false
+        type: string
+        default: ""
+        description: "Commit SHA to test (default: HEAD)"
 
 jobs:
+  load-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/triage_tests.yaml
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
+
+      - name: Install dependencies
+        run: |
+          pip3 install PyYAML
+
+      - name: Verify test timeouts against budget
+        if: ${{ inputs.timeout-minutes-override == 0 }}
+        run: |
+          set -e
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "sanity"
+
+      - name: Build test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "${{ inputs.enabled-skus }}" \
+            ./.github/sku_config.yaml
+
   triage-tests:
-    name: Triage tests ${{ inputs.runner-label }}
+    needs: load-test-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
+    name: ${{ matrix.test-group.name }}
+    runs-on: ${{ matrix.test-group.runs_on }}
     container:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
@@ -59,14 +109,13 @@ jobs:
       run:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
-    runs-on: >-
-      ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runner-label) }}
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: docker-job
+          ref: ${{ inputs.ref || github.sha }}
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
@@ -77,19 +126,17 @@ jobs:
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
           auto-triage: false # Disable auto-triage because we need to run triage tests explicitly
-      - name: Run triage tests
-        timeout-minutes: ${{ inputs.timeout }}
+      - name: ${{ matrix.test-group.name }}
+        timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
         run: |
-            mkdir -p generated/test_reports
-            uv pip install -r tools/triage/requirements.txt
-            IGNORE_ARGS=""
-            if [[ "${{ inputs.run-hang-report-test }}" != "true" ]]; then
-              IGNORE_ARGS="--ignore=./tools/tests/triage/test_hang_report.py"
-            fi
-            if [[ "${{ inputs.reset-device-after-hang }}" == "true" ]]; then
-              export TT_METAL_RESET_DEVICE_AFTER_HANG=1
-            fi
-            pytest -v -s ./tools/tests/triage/ $IGNORE_ARGS
+          IGNORE_ARGS=""
+          if [[ "${{ inputs.run-hang-report-test }}" != "true" ]]; then
+            IGNORE_ARGS="--ignore=./tools/tests/triage/test_hang_report.py"
+          fi
+          if [[ "${{ inputs.reset-device-after-hang }}" == "true" ]]; then
+            export TT_METAL_RESET_DEVICE_AFTER_HANG=1
+          fi
+          ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -492,13 +492,9 @@ jobs:
     needs: [build-artifact, generate-arch-matrix]
     if: ${{ needs.generate-arch-matrix.outputs.matrix-wormhole-only != '[]' }}
     secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-wormhole-only) }}
     uses: ./.github/workflows/triage.yaml
     with:
-      runner-label: ${{ matrix.test-group.runner-label }}
+      enabled-skus: "wh_n150_civ2_bare"
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/tests/pipeline_reorg/triage_tests.yaml
+++ b/tests/pipeline_reorg/triage_tests.yaml
@@ -1,0 +1,28 @@
+# =============================================================================
+# Triage tests definitions
+# =============================================================================
+# Tests in this file are consumed by .github/workflows/triage.yaml.
+#
+# Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
+# Per-SKU timeouts are summed and validated against
+# metal_infra.sanity.<sku> in .github/time_budget.yaml.
+# =============================================================================
+
+- name: "triage tests"
+  cmd: |
+    mkdir -p generated/test_reports
+    uv pip install -r tools/triage/requirements.txt
+    pytest -v -s ./tools/tests/triage/ $IGNORE_ARGS
+  skus:
+    wh_n150_civ2:
+      timeout: 15
+    wh_n150_civ2_bare:
+      timeout: 30
+    bh_p150b_civ2:
+      timeout: 30
+    bh_p150b_civ2_viommu:
+      timeout: 15
+    bh_p150b_civ2_viommu_prio:
+      timeout: 15
+  team: metal_infra
+  owner_id: U0AK4BVCFM0 # TODO: update to triage tools maintainer's Slack ID


### PR DESCRIPTION
## Summary
- Adds [.github/workflows/triage-tests.yaml](.github/workflows/triage-tests.yaml), a new `workflow_dispatch` wrapper that builds artifacts and runs the existing reusable `triage.yaml` against one or more runner labels chosen at dispatch time. Lets us run the triage suite on demand from the Actions UI without piggy-backing on `merge-gate` or the nightly L2 run.
- Adds a `reset-device-after-hang` input to [.github/workflows/triage.yaml](.github/workflows/triage.yaml) (default `true`, so merge-gate and l2-nightly behavior is unchanged) so the on-demand wrapper can opt out and preserve a hung device for inspection.

## Dispatch inputs
- `runner-labels` — comma-separated list (e.g. `N150,P150b`); parsed into a parallel matrix by a small `generate-matrix` job. Single shared build is reused across all selected runners.
- `ref` — optional git ref to build (empty = use the branch selected in "Use workflow from").
- `run-hang-report-test` — toggle the intentionally-hanging hang report test.
- `reset-device-after-hang` — toggle `TT_METAL_RESET_DEVICE_AFTER_HANG`.
- `timeout` — test timeout in minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-tests-wf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-tests-wf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/triage-tests-wf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-tests-wf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-tests-wf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-tests-wf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-tests-wf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-tests-wf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-tests-wf)