### PR TITLE
Scripts/docs cleanup: device-lock heartbeat, signal forwarding, exit-code normalization, op-agnostic NOC guide

### DIFF
--- a/docs/NOC_ALIGNMENT_IN_TT_METAL.md
+++ b/docs/NOC_ALIGNMENT_IN_TT_METAL.md
@@ -1,28 +1,21 @@
 # NOC Alignment in TT-Metal
 
-This note summarizes how NOC alignment works in TT-Metal, why row-major tensors are the awkward case, and how ops like convolutions avoid alignment problems.
+This note is a handoff from the TT-Metal runtime and hardware side to ops authors. It describes the alignment rules the hardware imposes, the buffer/accessor contracts the runtime layers on top, and the shape of the problems an op author can expect to run into. It deliberately does not prescribe how any particular op should solve them.
 
 ## Short Version
 
-There are really two different notions of size:
+There are two different notions of "page size":
 
 - `page_size`: the logical amount of tensor data in one page/row/stick.
 - `aligned_page_size`: the physical stride used when pages are laid out in device memory and when most page-based NOC helpers step through memory.
 
 The important consequence is:
 
-- a row-major page can be logically narrow,
+- a page can be logically narrow,
 - but if it lives in a device buffer it is usually **spaced in memory** by an aligned stride,
-- and kernels either:
-  - operate using that aligned stride, or
-  - reject the input, or
-  - explicitly bounce through an aligned scratch buffer.
+- and any kernel that touches it must either operate on that aligned stride, reject the input, or explicitly bounce through an aligned scratch buffer.
 
-Convolution mainly survives row-major alignment issues by:
-
-1. forcing channel/shard widths to a safe alignment,
-2. materializing halo output with an aligned row stride, and
-3. having the halo kernels read/write with `aligned_stick_nbytes`, not the raw logical row width.
+Row-major tensors are the case where this regularly bites, because one page is usually one row/stick and the logical row width is often smaller than the hardware alignment.
 
 ## 1. What "Alignment" Means Here
 
@@ -46,7 +39,7 @@ See:
 
 - `tt_metal/impl/allocator/l1_banking_allocator.cpp:216`
 
-So if your kernel touches DRAM, the DRAM-side alignment matters even when the local buffer only needs 16-byte L1 alignment.
+So if a kernel touches DRAM, the DRAM-side alignment matters even when the local buffer only needs 16-byte L1 alignment.
 
 ## 2. The Buffer Contract: `page_size` vs `aligned_page_size`
 
@@ -65,11 +58,7 @@ This means two adjacent logical pages are not necessarily packed back-to-back at
 
 - `page_address()` steps by `round_up(page_size, alignment)`.
 
-That is why row-major tensors often "look" unaligned logically but are still safe to traverse page-by-page through a tensor accessor.
-
-You can also see this assumption in generic row-major kernels. For example, the typecast path treats one row-major page as "one full row including padding", not just the unpadded logical row width:
-
-- `ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp:42`
+That is why row-major tensors often "look" unaligned logically but are still safe to traverse page-by-page through a tensor accessor: the per-page gap between logical end-of-data and the next page start is part of the buffer contract.
 
 ## 3. What Page-Based NOC Helpers Actually Use
 
@@ -90,514 +79,83 @@ So the generic model is:
 2. accessors encode that padded spacing,
 3. page-based NOC helpers move one aligned page at a time.
 
-If you bypass that and call raw `noc_async_read` / `noc_async_write` with ad hoc addresses and sizes, then **you** own the alignment problem.
+If a kernel bypasses that and calls raw `noc_async_read` / `noc_async_write` with ad hoc addresses and sizes, **the kernel** owns the alignment problem.
 
 ## 4. Why Row-Major Inputs Are the Problem Case
 
-For a tiled tensor, page sizes are naturally large and alignment-friendly.
+For a tiled tensor, page sizes are naturally large and alignment-friendly (a tile is already much wider than any hardware alignment).
 
 For a row-major tensor, one "page" is often just one row/stick:
 
-- width in elements * element size
+- `width_in_elements * element_size`
 
-That can be awkward:
+That can be awkward. For BF16:
 
-- BF16 with 3 channels is 6 bytes
-- BF16 with 7 channels is 14 bytes
-- BF16 with 8 channels is 16 bytes
+- 3 channels = 6 bytes
+- 7 channels = 14 bytes
+- 8 channels = 16 bytes
 
-So small-channel row-major tensors can easily violate the minimum NOC-friendly width unless the op pads them or chooses a sharding/channel alignment that fixes it.
+Small-channel row-major tensors can easily violate the minimum NOC-friendly width unless something earlier in the pipeline pads them or chooses a sharding/channel alignment that fixes it.
 
-TT-Metal code explicitly codifies this for convolution:
+A useful mental model for BF16 row-major sticks:
 
-- minimum safe row-major input channel alignment is 8 elements for BF16-like data because L1 alignment is 16 bytes.
+- 8 channels = 16 bytes = minimally L1-safe
+- 16 channels = 32 bytes = also safe for Wormhole DRAM reads
+- 32 channels = 64 bytes = also safe for Blackhole DRAM reads
 
-See:
+## 5. The Three Strategies Available to an Op
 
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp:77`
+When an op encounters a row-major input whose logical row width is smaller than the relevant hardware alignment, there are essentially three options. Any new op has to pick one consciously.
 
-That helper also prefers larger safe widths when possible:
+### Strategy A: Reject Unaligned Input
 
-- use 32 if shard width is tile-aligned,
-- else 16,
-- else 8,
-- else fall back to 32.
-
-## 5. How Convolution Gets Around Alignment Problems
-
-The main trick is that convolution does **not** consume arbitrary row-major input rows directly as-is.
-
-### 5.1 Channel Alignment Is Chosen Up Front
-
-`get_input_channels_alignment()` makes the row-major input channel dimension large enough to be safe for NOC movement.
-
-For row-major conv inputs, this is the first line of defense:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp:77`
-
-### 5.2 The Halo Op Materializes an Aligned Row-Major View
-
-Regular conv goes through the halo path before the conv micro-op:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp:252`
-
-The halo/untilize program factory computes:
-
-- `stick_nbytes = output_shard_shape[1] * out_nbytes`
-- `aligned_stick_nbytes = round_up(stick_nbytes, input_tensor.buffer()->alignment())`
-
-and for row-major input (`skip_untilize`) it makes the input CB page size equal to that aligned stick width.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp:173`
-
-This is one of the key escape hatches:
-
-- the logical row may be narrow,
-- but the kernel reads it using an aligned stride that matches the actual buffer layout.
-
-### 5.3 The Halo Kernels Use the Aligned Stick Width Everywhere
-
-The halo gather kernel templates are instantiated with `aligned_stick_nbytes`, and even the padding copy path is sized to avoid misaligned NOC transactions.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp:295`
-
-So by the time the conv micro-op runs, the row-major halo output has already been normalized into an aligned layout that the downstream kernels can move safely.
-
-## 6. Common Escape Hatches Used by Other Row-Major Ops
-
-There are two broad patterns outside conv.
-
-### Pattern A: Reject Unaligned Row-Major Shards
-
-Many ops do not try to be clever. They simply require:
+The op validates up front that the input already satisfies alignment, e.g.:
 
 - `page_size == aligned_page_size`, or
 - `page_size % alignment == 0`
 
-Examples:
+This is the safest pattern when the kernel assumes page-sized reads/writes directly from CBs or tensor accessors. The cost is paid by the caller (they have to pad, reshape, or shard differently before invoking the op). Many existing ops in the codebase take this route.
 
-- `all_gather`: `ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp:37`
-- `tilize` on sharded row-major input: `ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp:118`
-- `pad` on sharded row-major input/output: `ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp:184`
-- `conv3d` on sharded row-major input: `ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp:57`
+### Strategy B: Bounce Through an Aligned Scratch Buffer
 
-This is the safest pattern when the kernel assumes page-sized reads/writes directly from CBs or tensor accessors.
+The op accepts the unaligned input and the kernel reads it into a temporary aligned buffer (often a small L1 scratchpad sized to one aligned stick), then copies/memmoves into the final destination. The pattern is:
 
-### Pattern B: Use an Intermediate Aligned Scratch Buffer
+1. compute `aligned_stick_nbytes = align(stick_nbytes, alignment)`,
+2. allocate a CB / scratch region sized to the aligned width,
+3. issue NOC reads/writes against the aligned width,
+4. drop the tail padding when consuming the data.
 
-Some row-major data movement ops explicitly repack.
+The cost is an extra copy and the extra L1 footprint of the scratch buffer.
 
-The fold DRAM path is a clean example:
+### Strategy C: Pre-Align by Construction
 
-- it computes `aligned_stick_nbytes = align(stick_nbytes, hal::get_dram_alignment())`
-- allocates an aligned source CB,
-- and if the logical stick width is not aligned, it uses an intermediate L1 scratch buffer.
+The op (or a separate normalization pass it owns) materializes an aligned row-major representation before the main kernel runs. Concretely this means:
 
-See:
+- choose a shard / channel / page width that rounds up to the relevant alignment,
+- write a normalization step that produces that aligned layout,
+- have the main kernel only ever see the aligned layout.
 
-- `ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp:292`
-- `ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp:34`
+The cost is the up-front normalization work and the extra memory footprint of the padded layout. The benefit is that the hot path never deals with raw unaligned input.
 
-The `pad_multi_core` example shows the same idea more directly:
+These strategies are not mutually exclusive within one op family — different sharding modes or different input layouts may pick different strategies.
 
-- read the unaligned row into a temporary aligned buffer,
-- then copy/memmove into the final destination.
+## 6. Practical Rules for Op Authors
 
-See:
+1. Do not reason only about `page_size`. In TT-Metal, device page traversal is usually governed by `aligned_page_size`.
 
-- `tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp:83`
+2. If you use `TensorAccessor` or `noc_async_read_page` / `noc_async_write_page`, alignment is normally handled through the accessor's aligned page size — you mostly just have to not fight it.
 
-## 7. Important Rules to Remember
-
-If you are writing kernels or new ops, these are the practical rules that matter.
-
-1. Do not reason only about `page_size`.
-   In TT-Metal, device page traversal is usually governed by `aligned_page_size`.
-
-2. If you use `TensorAccessor` or `noc_async_read_page` / `noc_async_write_page`, alignment is usually handled through the accessor's aligned page size.
-
-3. If you use raw `noc_async_read` / `noc_async_write`, you must ensure the addresses, sizes, and per-row stride are safe yourself.
+3. If you use raw `noc_async_read` / `noc_async_write`, you must ensure the addresses, sizes, and per-row stride are safe yourself. The runtime does not retroactively fix unaligned transactions.
 
 4. For row-major sharded tensors, width in **bytes** should usually be aligned to `buffer()->alignment()`.
-   For L1-backed row-major shards that usually means 16 bytes.
-   For DRAM-backed transfers, the effective constraint can be 32 bytes on Wormhole or 64 bytes on Blackhole.
+   - L1-backed row-major shards: usually 16 bytes.
+   - DRAM-backed transfers: 32 bytes on Wormhole, 64 bytes on Blackhole.
 
-5. Convolution's row-major path is special because it actively engineers an aligned intermediate representation.
-   Do not assume that behavior exists in unrelated ops.
+5. When an op validates `page_size == aligned_page_size`, it is telling you the kernel was written under the assumption that no per-page padding gap exists beyond the natural page size. If you want that op to accept narrower rows, you are picking Strategy B or C, not relaxing the check.
 
-6. When an op validates `page_size == aligned_page_size`, it is telling you the kernel is written under the assumption that no per-page padding gap exists beyond the natural page size.
+6. Be explicit about logical vs physical row width in your own code. If you carry both `logical_row_bytes` and `physical_row_bytes` (or `stick_nbytes` and `aligned_stick_nbytes`) as separate variables, alignment bugs become easy to see. If you collapse them into one variable, they become invisible.
 
-7. A useful mental model for BF16 row-major sticks:
-   - 8 channels = 16 bytes = minimally L1-safe
-   - 16 channels = 32 bytes = nicer for Wormhole DRAM reads
-   - 32 channels = 64 bytes = nicely aligned even for Blackhole DRAM reads
-
-## 8. My Read on "How Convs Get Away With It"
-
-The answer is not that conv ignores alignment.
-
-The answer is that conv moves the problem earlier in the pipeline:
-
-- choose a safe channel alignment,
-- run halo on a row-major representation whose stick stride is explicitly rounded up,
-- do all NOC movement using the aligned stick width,
-- then let the conv micro-op consume that normalized buffer.
-
-So the row-major conv path is really an **aligned row-major transport path**, not an arbitrary unaligned one.
-
-## 9. What The Conv "Pre-Tilize" CB Actually Contains
-
-This is the main point that matters if you are trying to understand TTNN conv internals:
-
-- the pre-tilize CB is **not tiled yet**,
-- it is a **row-major activation matrix** produced by the reader/im2col stage,
-- compute then tilizes that matrix into `ACT_TILIZED`,
-- matmul consumes the tilized version.
-
-The CB names depend on the sharding mode:
-
-- height-sharded conv:
-  - `ACT` is the img2col / pre-tilize CB,
-  - `ACT_SECOND_READER` may hold the other half when split reader is enabled,
-  - `ACT_TILIZED` is the post-tilize CB.
-- width-sharded / block-sharded conv:
-  - `ACT_ROW_MAJOR_BFLOAT16` is the row-major pre-tilize CB,
-  - `ACT_TILIZED` is the post-tilize CB,
-  - `ACT` is often used for multicast / already-tilized activation transport.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp:225`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp:256`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp:270`
-
-The logical shape of that pre-tilize buffer is:
-
-- rows = output patch positions for the current activation block (`M`)
-- cols = flattened receptive-field slice for the current channel block (`K`)
-
-So the reader is effectively materializing an `M x K` matrix for matmul, just not in tile layout yet.
-
-For the height-sharded reader, the code writes row-major segments directly into the CB:
-
-- for dilation 1 it copies one coalesced chunk per selected sliding-window position,
-- then advances the output pointer by `coalesced_read_bytes + act_block_w_extra_align_bytes`.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp:61`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp:65`
-
-That `act_block_w_extra_align_bytes` is important. It means each logical im2col row can have **explicit tail padding**. So the pre-tilize CB is row-major, but it is not necessarily tightly packed row-major.
-
-Another important detail is that the reader pushes data in tile-height chunks:
-
-- every 32 produced rows, it does `push_back(act_cb_w_tiles)`.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp:108`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp:148`
-
-So the best mental model is:
-
-- payload state: row-major im2col matrix,
-- CB accounting: tile-sized pages,
-- production granularity: 32 matrix rows at a time,
-- next stage: tilize into standard MM tiles.
-
-### 9.1 Worked Example: BF16 RGB Input (`C = 3`)
-
-This is the easiest way to visualize it.
-
-For row-major conv, TTNN first enforces an input-channel alignment. For BF16 row-major input, the important minimum is 8 channels, because 8 BF16 values = 16 bytes, which is the L1-safe width.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp:77`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp:606`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp:152`
-
-So an RGB pixel is not treated as a 3-element stick by the conv reader. It is usually normalized to an 8-element stick:
-
-```text
-[r, g, b, 0, 0, 0, 0, 0]
-```
-
-for BF16, that is:
-
-- 8 scalars
-- 16 bytes
-
-That means the pre-tilize CB is built from padded channel groups.
-
-If the kernel is `1x1`, one im2col row is just one padded pixel:
-
-```text
-row_0 = [p0.r, p0.g, p0.b, 0, 0, 0, 0, 0]
-row_1 = [p1.r, p1.g, p1.b, 0, 0, 0, 0, 0]
-...
-```
-
-So the pre-tilize CB for `1x1` / RGB is just a row-major matrix with:
-
-- `M` rows = output pixels,
-- `K = 8` columns per channel block.
-
-If the kernel is `3x3`, each output patch row concatenates 9 of those padded sticks in kernel order:
-
-```text
-row_i =
-[
-  p00.r, p00.g, p00.b, 0, 0, 0, 0, 0,
-  p01.r, p01.g, p01.b, 0, 0, 0, 0, 0,
-  p02.r, p02.g, p02.b, 0, 0, 0, 0, 0,
-  p10.r, p10.g, p10.b, 0, 0, 0, 0, 0,
-  p11.r, p11.g, p11.b, 0, 0, 0, 0, 0,
-  p12.r, p12.g, p12.b, 0, 0, 0, 0, 0,
-  p20.r, p20.g, p20.b, 0, 0, 0, 0, 0,
-  p21.r, p21.g, p21.b, 0, 0, 0, 0, 0,
-  p22.r, p22.g, p22.b, 0, 0, 0, 0, 0
-]
-```
-
-So logically:
-
-- `K = Kh * Kw * C_aligned = 3 * 3 * 8 = 72`
-
-For the common height-sharded path, that row is then physically widened again to a tile-friendly width:
-
-- `act_block_w_extra_align_bytes` pads each row up to a multiple of 32 scalars.
-
-So for BF16 RGB with `3x3`:
-
-- logical payload per row = 72 BF16 values,
-- physical row width in the pre-tilize CB = 96 BF16 slots if this path rounds to the next 32-scalar boundary,
-- the last 24 slots are padding, not real activation payload.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp:601`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp:65`
-
-Important nuance:
-
-- spatial halo padding becomes all-zero padded sticks,
-- channel padding becomes zero-valued lanes in each stick,
-- row-tail padding from `act_block_w_extra_align_bytes` is padding space in the pre-tilize matrix, not meaningful data.
-
-So if you dump the CB for an RGB input, you should not expect to see compact `RGBRGBRGB...`.
-You should expect to see:
-
-- `RGB00000` per spatial position,
-- repeated across the kernel footprint,
-- then possibly additional row-tail padding to make the row tile-friendly.
-
-## 10. How That State Changes In The Optimized Paths
-
-### 10.1 Activation Reuse
-
-Activation reuse does not change the fact that the CB holds a row-major im2col matrix. What changes is **how much new data is written**.
-
-- the first output image width is written as a full window,
-- later widths reuse previously written rows,
-- only the new kernel-width slice is appended / refreshed.
-
-The pointer math for this is driven by `window_reuse_offset`, and the reader explicitly rewinds / repositions the CB write pointer when moving to the next output image width.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp:89`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp:206`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp:255`
-
-So with activation reuse, the pre-tilize CB is still an `M x K` matrix view, but it is maintained with **row reuse and pointer wraparound**, not rebuilt from scratch every time.
-
-### 10.2 Split Reader
-
-Split reader also does not change the representation. It just splits ownership of the row-major pre-tilize matrix across two CBs:
-
-- `ACT`
-- `ACT_SECOND_READER`
-
-Then compute tilizes both into `ACT_TILIZED`.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp:251`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp:357`
-
-### 10.3 Width-Sharded / Block-Sharded
-
-In width-sharded conv, the row-major pre-tilize buffer is very explicit:
-
-- reader fills `ACT_ROW_MAJOR_BFLOAT16`,
-- compute tilizes it,
-- then a tilized activation block may be multicast to other cores.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp:99`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp:165`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp:202`
-
-That is a useful sanity check: TTNN itself treats "im2col output" and "tilized MM input" as two distinct states.
-
-## 11. Other Big Pieces You Must Solve Besides Im2col
-
-Yes, weights preparation is one of the major other problems. It is not optional.
-
-### 11.1 Weight Layout Conversion
-
-For the simple interleaved-MM path, TTNN converts weights from conv layout:
-
-- `[Co, Ci, Kh, Kw]`
-
-into MM layout:
-
-- `[1, 1, KhKwCi, Co]`
-
-and then tilizes / pads it to tile boundaries.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp:272`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp:288`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp:1569`
-
-That matches the activation-side `M x K` matrix:
-
-- activations are `M x K`,
-- weights are `K x N`,
-- output is `M x N`.
-
-If you get that contract wrong, the conv may look "almost right" but still be fundamentally broken.
-
-### 11.2 Weight Padding Depends On The Parallelization Scheme
-
-The non-interleaved paths do more than simple tilization:
-
-- input channels are padded to `num_input_channel_cores * input_channels_alignment`,
-- output channels are padded to match output shard shape,
-- block-sharded and height-sharded paths use specialized weight transforms.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp:1573`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp:1585`
-
-So "prepare weights" really means:
-
-- choose the exact `K` partitioning,
-- pad `K` consistently with activation padding/alignment,
-- choose a weight tilization/layout that matches the chosen sharding scheme.
-
-### 11.3 Bias Preparation Also Has To Match
-
-Bias is padded to tile width / output shard width, converted to tile layout, and cast to the same dtype as weights.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp:1622`
-
-### 11.4 Halo And Reader Indices Are Part Of The Contract
-
-In the normal conv path, TTNN does not feed the raw NHWC tensor directly to the conv reader. It first runs halo, and the conv micro-op then consumes that halo-normalized row-major tensor.
-
-See:
-
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp:252`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp:941`
-
-The reader then uses precomputed reader indices to walk the sliding windows. If your reimplementation changes the patch ordering, the reader-index generation, weight layout, and output interpretation all have to change together.
-
-## 12. If I Had To Reimplement NHWC Conv In TTNN
-
-I would explicitly separate the job into a **correctness-first** version and a **performance** version.
-
-### Phase 1: Correctness-First
-
-1. Keep the logical model simple:
-   - input is NHWC,
-   - output patches define `M`,
-   - flattened receptive field defines `K = Kh * Kw * C`,
-   - output channels define `N`.
-
-2. Materialize the activation-side im2col matrix explicitly as row-major `M x K`.
-   - rows should be in the exact order you want the output NHW traversal to use,
-   - columns should be in the exact order the weight transform uses: usually `kh`, then `kw`, then `c`.
-
-3. Materialize weights explicitly as `K x N`.
-   - start from `[Co, Ci, Kh, Kw]`,
-   - reorder to `[KhKwCi, Co]`,
-   - pad only after the ordering is proven correct.
-
-4. Make padding/alignment visible in the implementation.
-   - keep `logical_row_bytes`,
-   - keep `physical_row_bytes`,
-   - keep `K_logical` and `K_padded`,
-   - do not hide those behind one variable.
-
-5. Only after the row-major `M x K @ K x N` path is correct, add tilize.
-
-### Phase 2: Performance
-
-Then add these one by one:
-
-- halo / sharded halo output,
-- channel alignment policy,
-- tilize into `ACT_TILIZED`,
-- split reader,
-- activation reuse,
-- multicast,
-- output untilize / row-major output path,
-- stride folding.
-
-If you add those too early, you lose the ability to tell whether a wrong answer comes from:
-
-- patch ordering,
-- halo math,
-- weight layout,
-- padding/alignment,
-- or reuse/split-reader pointer bugs.
-
-## 13. The Main Potholes
-
-These are the issues I would warn someone about first.
-
-1. Do not confuse logical im2col shape with physical row stride.
-   `act_block_w_extra_align_bytes` means the pre-tilize CB can be row-major but still padded per row.
-
-2. Keep the activation `K` ordering and weight `K` ordering identical.
-   The activation reader and `prepare_conv2d_weights.cpp` must agree on the exact flattening order.
-
-3. Do not treat halo as incidental.
-   In TTNN conv it is part of the input normalization contract, not just a convenience wrapper.
-
-4. Channel alignment is not just a performance knob.
-   For row-major paths it is part of making the NOC transfers legal at all; the important floor is 8 BF16 channels = 16 bytes.
-
-5. Activation reuse is easy to get subtly wrong.
-   `window_reuse_offset`, image-width padding to tile width, and batch transitions all affect pointer movement.
-
-6. Split reader is representation-preserving but pointer-sensitive.
-   If the two readers do not agree on where their halves land, tilize will silently consume the wrong rows.
-
-7. Width-sharded, block-sharded, and height-sharded convs are not the same algorithm with a different launch grid.
-   They use different CB roles and different activation/weight transport strategies.
-
-8. Kernel-stride folding changes both the input interpretation and the weight interpretation.
-   If you support it, treat it as a separate transform layer, not a small tweak.
-
-9. Bias/output handling matters.
-   Bias padding, fused bias, and row-major output/untilize are separate contracts that can break correctness even when the main matmul is right.
-
-10. Build a reference view of the pre-tilize CB.
-   If you cannot dump and explain one activation block as an `M x K` matrix with row padding, you are debugging blind.
+7. If your kernel writes to a CB or buffer that a later kernel will treat as page-aligned, you are responsible for either honoring that stride (including any tail padding) or documenting that the next stage must repack.
 
 ## Source Pointers
 
@@ -607,17 +165,3 @@ These are the issues I would warn someone about first.
 - `tt_metal/impl/buffers/buffer.cpp`
 - `tt_metal/hw/inc/api/dataflow/dataflow_api.h`
 - `tt_metal/hw/inc/api/tensor/tensor_accessor.h`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp`
-- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp`
-- `ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp`
-- `ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp`
-- `ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp`
-- `ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp`
-- `ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp`

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -118,7 +118,51 @@ if [[ "$SIM_MODE" == false ]]; then
     exec 9>"$LOCK_FILE"
 
     echo "SAFE_PYTEST: Waiting for device lock..."
-    flock 9
+
+    # Find the PID holding an flock on a given path. Tries lslocks first
+    # (fast, works in the global namespace); falls back to scanning /proc/*/fd
+    # for processes with the lockfile open and an active FLOCK in fdinfo
+    # (works inside PID namespaces where lslocks reports holder pid 0).
+    _find_lock_holder() {
+        local lock_path="$1" pid
+        pid=$(lslocks --noheadings --raw --output PID,PATH 2>/dev/null \
+            | awk -v p="$lock_path" '$2==p && $1!="0" {print $1; exit}')
+        if [[ -n "$pid" ]]; then echo "$pid"; return 0; fi
+        local pid_dir fd_link fd_num target
+        for pid_dir in /proc/[0-9]*; do
+            for fd_link in "$pid_dir"/fd/*; do
+                [ -L "$fd_link" ] || continue
+                target=$(readlink "$fd_link" 2>/dev/null) || continue
+                [ "$target" = "$lock_path" ] || continue
+                fd_num=${fd_link##*/}
+                if grep -q '^lock:.*FLOCK' "$pid_dir/fdinfo/$fd_num" 2>/dev/null; then
+                    echo "${pid_dir##*/}"
+                    return 0
+                fi
+            done
+        done
+        return 1
+    }
+
+    LOCK_WAIT_INTERVAL=20
+    LOCK_WAIT_TOTAL=0
+    while ! flock -w "$LOCK_WAIT_INTERVAL" 9; do
+        LOCK_WAIT_TOTAL=$((LOCK_WAIT_TOTAL + LOCK_WAIT_INTERVAL))
+        TS="[$(date '+%Y-%m-%d %H:%M:%S')]"
+        HOLDER_PID=$(_find_lock_holder "$LOCK_FILE")
+        if [[ -n "$HOLDER_PID" && -d /proc/$HOLDER_PID ]]; then
+            HOLDER_CMD=$(tr '\0' ' ' < /proc/$HOLDER_PID/cmdline 2>/dev/null | cut -c1-200)
+            HOLDER_PPID=$(awk '{print $4}' /proc/$HOLDER_PID/stat 2>/dev/null)
+            if [[ -n "$HOLDER_PPID" && "$HOLDER_PPID" -gt 1 && -d /proc/$HOLDER_PPID ]]; then
+                HOLDER_PARENT_CMD=$(tr '\0' ' ' < /proc/$HOLDER_PPID/cmdline 2>/dev/null | cut -c1-150)
+                echo "$TS SAFE_PYTEST: waiting for device (${LOCK_WAIT_TOTAL}s) — holder pid=$HOLDER_PID cmd=\"$HOLDER_CMD\" parent pid=$HOLDER_PPID cmd=\"$HOLDER_PARENT_CMD\""
+            else
+                echo "$TS SAFE_PYTEST: waiting for device (${LOCK_WAIT_TOTAL}s) — holder pid=$HOLDER_PID cmd=\"$HOLDER_CMD\""
+            fi
+        else
+            echo "$TS SAFE_PYTEST: waiting for device (${LOCK_WAIT_TOTAL}s) — holder unknown"
+        fi
+    done
     TT_TIMING_LOCK_ACQUIRED_MS=$(date +%s%3N)
     echo "SAFE_PYTEST: Device lock acquired"
 

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -193,6 +193,11 @@ fi
 # zero overhead for passing tests. On sim there is no hang detection because
 # wall-clock timeouts are meaningless at kHz clock speeds.
 rm -f "$TRIAGE_LOG"
+# Also clear any stale triage JSON from a previous run. Downstream consumers
+# (hooks, CI) treat the JSON's presence as the hang signal — leaving a stale
+# file around causes false-positive "hang detected" classification on the
+# next ordinary test failure.
+rm -f "$TRIAGE_JSON"
 MISSING_TTEXALENS=false
 if [[ "$SIM_MODE" == false ]]; then
     export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
@@ -376,5 +381,10 @@ fi
 
 rm -f "$DIRTY_FLAG"
 rm -f "$TRIAGE_LOG"
-echo "SAFE_PYTEST_RESULT: FAIL (exit code: $EXIT_CODE)"
+# Note: $EXIT_CODE here is pytest's internal exit code (e.g. 1 = test failure,
+# 2 = collection error / user interrupt). The wrapper's own exit code is
+# always 1 for this branch — exit 2 is reserved for real dispatch-timeout
+# hangs (handled above). The label keeps both visible to readers and to
+# hooks parsing this output.
+echo "SAFE_PYTEST_RESULT: FAIL (pytest exit code: $EXIT_CODE; wrapper exit: 1)"
 exit 1

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -104,8 +104,8 @@ done
 
 # --- Argument validation ---
 if [[ $# -eq 0 ]]; then
-    echo "SAFE_PYTEST_ERROR: No test path provided" >&2
-    echo "Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]" >&2
+    echo "SAFE_PYTEST_ERROR: No test path provided"
+    echo "Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]"
     exit 3
 fi
 
@@ -117,20 +117,20 @@ shift
 if [[ "$SIM_MODE" == false ]]; then
     exec 9>"$LOCK_FILE"
 
-    echo "SAFE_PYTEST: Waiting for device lock..." >&2
+    echo "SAFE_PYTEST: Waiting for device lock..."
     flock 9
     TT_TIMING_LOCK_ACQUIRED_MS=$(date +%s%3N)
-    echo "SAFE_PYTEST: Device lock acquired" >&2
+    echo "SAFE_PYTEST: Device lock acquired"
 
     # --- Check if device needs reset from previous hang ---
     if [[ -f "$DIRTY_FLAG" ]]; then
-        echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..." >&2
+        echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..."
         if ! tt-smi -r; then
-            echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed" >&2
+            echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed"
             exit 3
         fi
         rm -f "$DIRTY_FLAG"
-        echo "SAFE_PYTEST: Device reset complete" >&2
+        echo "SAFE_PYTEST: Device reset complete"
     fi
 fi
 
@@ -138,10 +138,10 @@ fi
 cd "$REPO_DIR"
 if [[ -f python_env/bin/activate ]]; then
     if ! source python_env/bin/activate; then
-        echo "SAFE_PYTEST: WARNING: Failed to activate python_env virtual environment" >&2
+        echo "SAFE_PYTEST: WARNING: Failed to activate python_env virtual environment"
     fi
 else
-    echo "SAFE_PYTEST: WARNING: python_env not found; using system Python" >&2
+    echo "SAFE_PYTEST: WARNING: python_env not found; using system Python"
 fi
 
 # --- Hang detection setup (hardware only) ---
@@ -164,9 +164,9 @@ fi
 
 emit_missing_ttexalens_warning() {
     if [[ "$MISSING_TTEXALENS" == true ]]; then
-        echo "" >&2
-        echo "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang is unavailable." >&2
-        echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt" >&2
+        echo ""
+        echo "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang is unavailable."
+        echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt"
     fi
 }
 trap emit_missing_ttexalens_warning EXIT
@@ -198,17 +198,17 @@ if [[ "$DEV_MODE" == true ]]; then
     export TT_METAL_WATCHER_DISABLE_DISPATCH=1
 
     if [[ "$SIM_MODE" == true ]]; then
-        echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling (no hang detection on sim)" >&2
+        echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling (no hang detection on sim)"
     else
-        echo "SAFE_PYTEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s" >&2
+        echo "SAFE_PYTEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s"
     fi
 elif [[ "$SIM_MODE" == true ]]; then
-    echo "SAFE_PYTEST: [sim] no hang detection" >&2
+    echo "SAFE_PYTEST: [sim] no hang detection"
 else
-    echo "SAFE_PYTEST: dispatch_timeout=${DISPATCH_TIMEOUT}s" >&2
+    echo "SAFE_PYTEST: dispatch_timeout=${DISPATCH_TIMEOUT}s"
 fi
-echo "SAFE_PYTEST: pytest ${TEST_PATH} $*" >&2
-echo "========================================" >&2
+echo "SAFE_PYTEST: pytest ${TEST_PATH} $*"
+echo "========================================"
 
 # --- Mark device dirty before running tests (hardware only) ---
 # Pessimistic: assume the device will get corrupted. If the script is killed at any
@@ -234,8 +234,8 @@ PYTEST_CMD+=("$@")
 CHILD_PID=
 _signal_cleanup() {
     local sig=$1
-    echo "" >&2
-    echo "SAFE_PYTEST: Caught SIG${sig} — killing pytest, marking device dirty" >&2
+    echo ""
+    echo "SAFE_PYTEST: Caught SIG${sig} — killing pytest, marking device dirty"
     [[ "$SIM_MODE" == false ]] && touch "$DIRTY_FLAG" 2>/dev/null
     if [[ -n "$CHILD_PID" ]]; then
         pkill -KILL -P "$CHILD_PID" 2>/dev/null || true
@@ -256,13 +256,13 @@ wait "$CHILD_PID"
 EXIT_CODE=$?
 CHILD_PID=
 
-echo "========================================" >&2
+echo "========================================"
 
 # --- Handle result ---
 if [[ $EXIT_CODE -eq 0 ]]; then
     rm -f "$DIRTY_FLAG"
     rm -f "$TRIAGE_LOG"
-    echo "SAFE_PYTEST_RESULT: PASS" >&2
+    echo "SAFE_PYTEST_RESULT: PASS"
     exit 0
 fi
 
@@ -273,9 +273,9 @@ if [[ $EXIT_CODE -eq 4 || $EXIT_CODE -eq 5 ]]; then
     rm -f "$DIRTY_FLAG"
     rm -f "$TRIAGE_LOG"
     if [[ $EXIT_CODE -eq 4 ]]; then
-        echo "SAFE_PYTEST_ERROR: Pytest usage error (invalid path or arguments)" >&2
+        echo "SAFE_PYTEST_ERROR: Pytest usage error (invalid path or arguments)"
     else
-        echo "SAFE_PYTEST_ERROR: No tests collected" >&2
+        echo "SAFE_PYTEST_ERROR: No tests collected"
     fi
     exit 3
 fi
@@ -295,35 +295,35 @@ fi
 # Hangs and crashes corrupt device state. Normal test failures (PCC mismatch,
 # assertion errors) and collection errors don't touch the device.
 if [[ "$IS_HANG" == true ]]; then
-    echo "SAFE_PYTEST: Resetting device..." >&2
+    echo "SAFE_PYTEST: Resetting device..."
     if tt-smi -r; then
         sleep 2
         rm -f "$DIRTY_FLAG"
-        echo "SAFE_PYTEST: Device reset complete" >&2
+        echo "SAFE_PYTEST: Device reset complete"
     else
-        echo "SAFE_PYTEST: Device reset FAILED; leaving device marked dirty" >&2
+        echo "SAFE_PYTEST: Device reset FAILED; leaving device marked dirty"
     fi
 
-    echo "SAFE_PYTEST_RESULT: HANG (exit code: $EXIT_CODE)" >&2
-    echo "" >&2
+    echo "SAFE_PYTEST_RESULT: HANG (exit code: $EXIT_CODE)"
+    echo ""
 
     # Dump full triage log
-    echo "=== TRIAGE LOG ===" >&2
-    cat "$TRIAGE_LOG" >&2
-    echo "=== END TRIAGE LOG ===" >&2
-    echo "" >&2
+    echo "=== TRIAGE LOG ==="
+    cat "$TRIAGE_LOG"
+    echo "=== END TRIAGE LOG ==="
+    echo ""
 
     # In dev mode, also dump watcher log
     if [[ "$DEV_MODE" == true && -f "$WATCHER_LOG" ]]; then
-        echo "=== WATCHER LOG (last 50 lines) ===" >&2
-        tail -50 "$WATCHER_LOG" >&2
-        echo "=== END WATCHER LOG ===" >&2
-        echo "" >&2
+        echo "=== WATCHER LOG (last 50 lines) ==="
+        tail -50 "$WATCHER_LOG"
+        echo "=== END WATCHER LOG ==="
+        echo ""
     fi
 
     # Print the JSON triage path as the last line so machine-readers can find it.
     if [[ -f "$TRIAGE_JSON" ]]; then
-        echo "SAFE_PYTEST: JSON triage: ${TRIAGE_JSON}" >&2
+        echo "SAFE_PYTEST: JSON triage: ${TRIAGE_JSON}"
     fi
 
     rm -f "$TRIAGE_LOG"
@@ -332,5 +332,5 @@ fi
 
 rm -f "$DIRTY_FLAG"
 rm -f "$TRIAGE_LOG"
-echo "SAFE_PYTEST_RESULT: FAIL (exit code: $EXIT_CODE)" >&2
+echo "SAFE_PYTEST_RESULT: FAIL (exit code: $EXIT_CODE)"
 exit 1

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -43,6 +43,38 @@ DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/safe-pytest-triage-$$.log"
 TRIAGE_JSON="${TRIAGE_JSON_DIR}/triage.json"
 
+# --- Device-lock contention profiling ---
+# When $TT_DEVICE_TIMING_LOG is set, on EXIT we append one JSON line:
+#   {source, pid, started_at_ms, wait_ms, run_ms, test_path, exit_code}
+# wait_ms = script entry → flock acquired (contention)
+# run_ms  = flock acquired → script exit  (device occupied)
+# Skipped on sim mode (no flock contention) and when the script exits before
+# acquiring the lock (TT_TIMING_LOCK_ACQUIRED_MS stays 0).
+TT_TIMING_ENTRY_MS=$(date +%s%3N)
+TT_TIMING_LOCK_ACQUIRED_MS=0
+TT_TIMING_SOURCE="run_safe_pytest"
+TT_TIMING_TEST_PATH=""
+
+_emit_device_timing() {
+    local ec=$?
+    if [[ -n "${TT_DEVICE_TIMING_LOG:-}" && "$TT_TIMING_LOCK_ACQUIRED_MS" -ne 0 ]]; then
+        local end_ms wait_ms run_ms log_dir esc_path
+        end_ms=$(date +%s%3N)
+        wait_ms=$(( TT_TIMING_LOCK_ACQUIRED_MS - TT_TIMING_ENTRY_MS ))
+        run_ms=$(( end_ms - TT_TIMING_LOCK_ACQUIRED_MS ))
+        log_dir="$(dirname "$TT_DEVICE_TIMING_LOG")"
+        [[ -n "$log_dir" ]] && mkdir -p "$log_dir" 2>/dev/null
+        # JSON-escape test_path: backslash first, then double-quote.
+        esc_path="${TT_TIMING_TEST_PATH//\\/\\\\}"
+        esc_path="${esc_path//\"/\\\"}"
+        printf '{"source":"%s","pid":%d,"started_at_ms":%s,"wait_ms":%d,"run_ms":%d,"test_path":"%s","exit_code":%d}\n' \
+            "$TT_TIMING_SOURCE" "$$" "$TT_TIMING_ENTRY_MS" "$wait_ms" "$run_ms" "$esc_path" "$ec" \
+            >> "$TT_DEVICE_TIMING_LOG" 2>/dev/null || true
+    fi
+    return $ec
+}
+trap _emit_device_timing EXIT
+
 # --- Detect simulator mode ---
 SIM_MODE=false
 if [[ -n "${TT_METAL_SIMULATOR:-}" ]]; then
@@ -78,6 +110,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 TEST_PATH="$1"
+TT_TIMING_TEST_PATH="$TEST_PATH"
 shift
 
 # --- Acquire flock (hardware only) ---
@@ -86,6 +119,7 @@ if [[ "$SIM_MODE" == false ]]; then
 
     echo "SAFE_PYTEST: Waiting for device lock..." >&2
     flock 9
+    TT_TIMING_LOCK_ACQUIRED_MS=$(date +%s%3N)
     echo "SAFE_PYTEST: Device lock acquired" >&2
 
     # --- Check if device needs reset from previous hang ---

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -227,8 +227,34 @@ if [[ "$FAIL_FAST" == true ]]; then
 fi
 PYTEST_CMD+=("$@")
 
-"${PYTEST_CMD[@]}"
+# Signal handling: if this script is killed (e.g. parent process gets SIGTERM
+# and we get reparented to init, or a watchdog kills us), forward SIGKILL to
+# pytest and its descendants. Without this, pytest is orphaned with fd 9 ->
+# /tmp/tt-device.lock and /dev/tenstorrent/* held, blocking all future runs.
+CHILD_PID=
+_signal_cleanup() {
+    local sig=$1
+    echo "" >&2
+    echo "SAFE_PYTEST: Caught SIG${sig} — killing pytest, marking device dirty" >&2
+    [[ "$SIM_MODE" == false ]] && touch "$DIRTY_FLAG" 2>/dev/null
+    if [[ -n "$CHILD_PID" ]]; then
+        pkill -KILL -P "$CHILD_PID" 2>/dev/null || true
+        kill -KILL "$CHILD_PID" 2>/dev/null || true
+    fi
+    pkill -KILL -P $$ 2>/dev/null || true
+    exit 143
+}
+trap '_signal_cleanup TERM' SIGTERM
+trap '_signal_cleanup HUP'  SIGHUP
+trap '_signal_cleanup INT'  SIGINT
+
+# Run pytest in background so `wait` can be interrupted by a signal. Bash
+# blocks signal delivery while a synchronous foreground command is running.
+"${PYTEST_CMD[@]}" &
+CHILD_PID=$!
+wait "$CHILD_PID"
 EXIT_CODE=$?
+CHILD_PID=
 
 echo "========================================" >&2
 

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -143,6 +143,11 @@ fi
 # inspection (same location run_safe_pytest.sh uses), plus a text log for the
 # stderr dump. Grep targets are documented in CLAUDE.md § "Hang triage".
 rm -f "$TRIAGE_LOG"
+# Also clear any stale triage JSON from a previous run. Downstream consumers
+# (hooks, CI) treat the JSON's presence as the hang signal — leaving a stale
+# file around causes false-positive "hang detected" classification on the
+# next ordinary probe failure.
+rm -f "$TRIAGE_JSON"
 MISSING_TTEXALENS=false
 if [[ "$SIM_MODE" == true ]]; then
     export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="echo HANG > ${TRIAGE_LOG}"
@@ -293,9 +298,13 @@ fi
 rm -f "$TRIAGE_LOG"
 
 # --- Result ---
+# Reserve wrapper exit 2 for the HANG case above. For any other non-zero
+# Python exit, normalize the wrapper exit to 1 so that downstream consumers
+# (hooks, CI) can rely on `wrapper-exit == 2 → hang`.
 if [[ $EXIT_CODE -eq 0 ]]; then
     echo "TT_PROBE_RESULT: PASS"
+    exit 0
 else
-    echo "TT_PROBE_RESULT: FAIL (exit $EXIT_CODE, probe: ${PROBE_REL})"
+    echo "TT_PROBE_RESULT: FAIL (python exit code: $EXIT_CODE; wrapper exit: 1, probe: ${PROBE_REL})"
+    exit 1
 fi
-exit $EXIT_CODE

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -48,6 +48,31 @@ LOCK_FILE="/tmp/tt-device.lock"
 DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/tt-probe-triage-$$.log"
 
+# --- Device-lock contention profiling (see run_safe_pytest.sh for details) ---
+TT_TIMING_ENTRY_MS=$(date +%s%3N)
+TT_TIMING_LOCK_ACQUIRED_MS=0
+TT_TIMING_SOURCE="tt-probe"
+TT_TIMING_TEST_PATH=""
+
+_emit_device_timing() {
+    local ec=$?
+    if [[ -n "${TT_DEVICE_TIMING_LOG:-}" && "$TT_TIMING_LOCK_ACQUIRED_MS" -ne 0 ]]; then
+        local end_ms wait_ms run_ms log_dir esc_path
+        end_ms=$(date +%s%3N)
+        wait_ms=$(( TT_TIMING_LOCK_ACQUIRED_MS - TT_TIMING_ENTRY_MS ))
+        run_ms=$(( end_ms - TT_TIMING_LOCK_ACQUIRED_MS ))
+        log_dir="$(dirname "$TT_DEVICE_TIMING_LOG")"
+        [[ -n "$log_dir" ]] && mkdir -p "$log_dir" 2>/dev/null
+        esc_path="${TT_TIMING_TEST_PATH//\\/\\\\}"
+        esc_path="${esc_path//\"/\\\"}"
+        printf '{"source":"%s","pid":%d,"started_at_ms":%s,"wait_ms":%d,"run_ms":%d,"test_path":"%s","exit_code":%d}\n' \
+            "$TT_TIMING_SOURCE" "$$" "$TT_TIMING_ENTRY_MS" "$wait_ms" "$run_ms" "$esc_path" "$ec" \
+            >> "$TT_DEVICE_TIMING_LOG" 2>/dev/null || true
+    fi
+    return $ec
+}
+trap _emit_device_timing EXIT
+
 # --- Parse flags ---
 DEV_MODE=false
 while [[ $# -gt 0 ]]; do
@@ -76,6 +101,7 @@ if [[ $# -eq 0 ]]; then
     exit 3
 fi
 OP_NAME="$1"
+TT_TIMING_TEST_PATH="$OP_NAME"
 
 # --- Read stdin ---
 SCRIPT=$(cat)
@@ -172,6 +198,7 @@ if [[ "$SIM_MODE" == false ]]; then
     exec 9>"$LOCK_FILE"
     echo "TT_PROBE: Waiting for device lock..." >&2
     flock 9
+    TT_TIMING_LOCK_ACQUIRED_MS=$(date +%s%3N)
     echo "TT_PROBE: Device lock acquired" >&2
 
     if [[ -f "$DIRTY_FLAG" ]]; then

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -82,8 +82,8 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -*)
-            echo "TT_PROBE_ERROR: Unknown flag: $1" >&2
-            echo "Usage: scripts/tt-probe.sh [--dev] <op_name> << 'PYEOF'" >&2
+            echo "TT_PROBE_ERROR: Unknown flag: $1"
+            echo "Usage: scripts/tt-probe.sh [--dev] <op_name> << 'PYEOF'"
             exit 3
             ;;
         *)
@@ -94,10 +94,10 @@ done
 
 # --- Parse positional args ---
 if [[ $# -eq 0 ]]; then
-    echo "TT_PROBE_ERROR: No op name provided" >&2
-    echo "Usage: scripts/tt-probe.sh [--dev] <op_name> << 'PYEOF'" >&2
-    echo "       ... python code ..." >&2
-    echo "       PYEOF" >&2
+    echo "TT_PROBE_ERROR: No op name provided"
+    echo "Usage: scripts/tt-probe.sh [--dev] <op_name> << 'PYEOF'"
+    echo "       ... python code ..."
+    echo "       PYEOF"
     exit 3
 fi
 OP_NAME="$1"
@@ -106,7 +106,7 @@ TT_TIMING_TEST_PATH="$OP_NAME"
 # --- Read stdin ---
 SCRIPT=$(cat)
 if [[ -z "$SCRIPT" ]]; then
-    echo "TT_PROBE_ERROR: No script provided on stdin" >&2
+    echo "TT_PROBE_ERROR: No script provided on stdin"
     exit 3
 fi
 
@@ -122,7 +122,7 @@ PROBE_FILE="${PROBE_DIR}/probe_$(printf '%03d' $NEXT_NUM).py"
 
 printf '%s\n' "$SCRIPT" > "$PROBE_FILE"
 PROBE_REL="${PROBE_FILE#$REPO_DIR/}"
-echo "TT_PROBE: Saved → ${PROBE_REL}" >&2
+echo "TT_PROBE: Saved → ${PROBE_REL}"
 
 # --- Detect simulator mode ---
 SIM_MODE=false
@@ -160,9 +160,9 @@ fi
 
 emit_missing_ttexalens_warning() {
     if [[ "$MISSING_TTEXALENS" == true ]]; then
-        echo "" >&2
-        echo "TT_PROBE: WARNING: tt-exalens not installed — triage on hang is unavailable." >&2
-        echo "TT_PROBE: Install with: uv pip install -r tools/triage/requirements.txt" >&2
+        echo ""
+        echo "TT_PROBE: WARNING: tt-exalens not installed — triage on hang is unavailable."
+        echo "TT_PROBE: Install with: uv pip install -r tools/triage/requirements.txt"
     fi
 }
 trap emit_missing_ttexalens_warning EXIT
@@ -178,7 +178,7 @@ if [[ "$DEV_MODE" == true ]]; then
 
     if [[ "$SIM_MODE" == true ]]; then
         export TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=1
-        echo "TT_PROBE: [sim+dev] watcher=polling(+assert,noc_sanitize=OFF) triage=OFF" >&2
+        echo "TT_PROBE: [sim+dev] watcher=polling(+assert,noc_sanitize=OFF) triage=OFF"
     else
         # Lightweight asserts: compile ASSERT() as ebreak so the core halts at
         # the exact instruction. The dispatch timeout then fires triage, which
@@ -189,26 +189,26 @@ if [[ "$DEV_MODE" == true ]]; then
         # Let ebreak asserts halt the core for triage to capture — bypass watcher's
         # own assert handling so all cores' callstacks get collected together.
         export TT_METAL_WATCHER_DISABLE_ASSERT=1
-        echo "TT_PROBE: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s" >&2
+        echo "TT_PROBE: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s"
     fi
 fi
 
 # --- Acquire flock (hardware only) ---
 if [[ "$SIM_MODE" == false ]]; then
     exec 9>"$LOCK_FILE"
-    echo "TT_PROBE: Waiting for device lock..." >&2
+    echo "TT_PROBE: Waiting for device lock..."
     flock 9
     TT_TIMING_LOCK_ACQUIRED_MS=$(date +%s%3N)
-    echo "TT_PROBE: Device lock acquired" >&2
+    echo "TT_PROBE: Device lock acquired"
 
     if [[ -f "$DIRTY_FLAG" ]]; then
-        echo "TT_PROBE: Device dirty from previous run, resetting..." >&2
+        echo "TT_PROBE: Device dirty from previous run, resetting..."
         if ! tt-smi -r; then
-            echo "TT_PROBE_ERROR: Device reset failed" >&2
+            echo "TT_PROBE_ERROR: Device reset failed"
             exit 3
         fi
         rm -f "$DIRTY_FLAG"
-        echo "TT_PROBE: Device reset complete" >&2
+        echo "TT_PROBE: Device reset complete"
     fi
 fi
 
@@ -223,8 +223,8 @@ if [[ "$SIM_MODE" == false ]]; then
     touch "$DIRTY_FLAG"
 fi
 
-echo "TT_PROBE: python3 ${PROBE_REL}" >&2
-echo "========================================" >&2
+echo "TT_PROBE: python3 ${PROBE_REL}"
+echo "========================================"
 
 # Signal handling: forward SIGKILL to python3 child + descendants if this
 # script is killed (parent SIGTERM, watchdog, etc.). Without this, python3
@@ -233,8 +233,8 @@ echo "========================================" >&2
 CHILD_PID=
 _signal_cleanup() {
     local sig=$1
-    echo "" >&2
-    echo "TT_PROBE: Caught SIG${sig} — killing probe, marking device dirty" >&2
+    echo ""
+    echo "TT_PROBE: Caught SIG${sig} — killing probe, marking device dirty"
     [[ "$SIM_MODE" == false ]] && touch "$DIRTY_FLAG" 2>/dev/null
     if [[ -n "$CHILD_PID" ]]; then
         pkill -KILL -P "$CHILD_PID" 2>/dev/null || true
@@ -255,7 +255,7 @@ wait "$CHILD_PID"
 EXIT_CODE=$?
 CHILD_PID=
 
-echo "========================================" >&2
+echo "========================================"
 
 # --- Cleanup: kill orphans ---
 if [[ $EXIT_CODE -ne 0 ]]; then
@@ -267,35 +267,35 @@ fi
 
 # --- Reset device (hardware only) ---
 if [[ "$SIM_MODE" == false ]]; then
-    echo "TT_PROBE: Resetting device..." >&2
+    echo "TT_PROBE: Resetting device..."
     if tt-smi -r; then
         sleep 2
         rm -f "$DIRTY_FLAG"
-        echo "TT_PROBE: Device reset complete" >&2
+        echo "TT_PROBE: Device reset complete"
     else
-        echo "TT_PROBE: Device reset FAILED; leaving dirty" >&2
+        echo "TT_PROBE: Device reset FAILED; leaving dirty"
     fi
 fi
 
 # --- Detect hang ---
 if [[ -s "$TRIAGE_LOG" ]]; then
-    echo "TT_PROBE: HANG DETECTED" >&2
+    echo "TT_PROBE: HANG DETECTED"
     if [[ "$SIM_MODE" == false ]]; then
-        cat "$TRIAGE_LOG" >&2
+        cat "$TRIAGE_LOG"
         if [[ -s "$TRIAGE_JSON" ]]; then
-            echo "TT_PROBE: JSON triage: ${TRIAGE_JSON}" >&2
+            echo "TT_PROBE: JSON triage: ${TRIAGE_JSON}"
         fi
     fi
     rm -f "$TRIAGE_LOG"
-    echo "TT_PROBE_RESULT: HANG (probe: ${PROBE_REL})" >&2
+    echo "TT_PROBE_RESULT: HANG (probe: ${PROBE_REL})"
     exit 2
 fi
 rm -f "$TRIAGE_LOG"
 
 # --- Result ---
 if [[ $EXIT_CODE -eq 0 ]]; then
-    echo "TT_PROBE_RESULT: PASS" >&2
+    echo "TT_PROBE_RESULT: PASS"
 else
-    echo "TT_PROBE_RESULT: FAIL (exit $EXIT_CODE, probe: ${PROBE_REL})" >&2
+    echo "TT_PROBE_RESULT: FAIL (exit $EXIT_CODE, probe: ${PROBE_REL})"
 fi
 exit $EXIT_CODE

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -226,8 +226,34 @@ fi
 echo "TT_PROBE: python3 ${PROBE_REL}" >&2
 echo "========================================" >&2
 
-python3 "$PROBE_FILE"
+# Signal handling: forward SIGKILL to python3 child + descendants if this
+# script is killed (parent SIGTERM, watchdog, etc.). Without this, python3
+# is orphaned holding fd 9 -> /tmp/tt-device.lock and /dev/tenstorrent/*,
+# blocking all future runs.
+CHILD_PID=
+_signal_cleanup() {
+    local sig=$1
+    echo "" >&2
+    echo "TT_PROBE: Caught SIG${sig} — killing probe, marking device dirty" >&2
+    [[ "$SIM_MODE" == false ]] && touch "$DIRTY_FLAG" 2>/dev/null
+    if [[ -n "$CHILD_PID" ]]; then
+        pkill -KILL -P "$CHILD_PID" 2>/dev/null || true
+        kill -KILL "$CHILD_PID" 2>/dev/null || true
+    fi
+    pkill -KILL -P $$ 2>/dev/null || true
+    exit 143
+}
+trap '_signal_cleanup TERM' SIGTERM
+trap '_signal_cleanup HUP'  SIGHUP
+trap '_signal_cleanup INT'  SIGINT
+
+# Run in background + wait so the trap can fire on signal (bash blocks
+# signal delivery during synchronous foreground commands).
+python3 "$PROBE_FILE" &
+CHILD_PID=$!
+wait "$CHILD_PID"
 EXIT_CODE=$?
+CHILD_PID=
 
 echo "========================================" >&2
 


### PR DESCRIPTION
## Summary

Six commits pulled forward from the registry-model line that aren't specific to that work — script/triage improvements and a docs cleanup that benefit anyone working on `llk_helper_library`.

## Commits

1. **`Profile device-lock contention in test runners`** — Adds timing instrumentation to `run_safe_pytest.sh` / `tt-probe.sh` so you can see how long flock contention is costing you.
2. **`scripts: forward fatal signals to test child to prevent orphan device locks`** — Propagates SIGTERM/SIGINT to the test process so it cleans up its flock instead of leaving the device wedged for the next agent.
3. **`scripts: route run_safe_pytest / tt-probe markers to stdout`** — `SAFE_PYTEST:` / `TT_PROBE:` markers were going to stderr; routing to stdout makes them interleave properly with pytest output and survive piping.
4. **`scripts: heartbeat every 20s while waiting on device lock`** — Without this, a long-waiting agent looks like a hang. Heartbeat clarifies that the run is queued, not stuck.
5. **`docs: make NOC alignment guide op-agnostic`** — `docs/NOC_ALIGNMENT_IN_TT_METAL.md` was heavily op-specific from when it was written; trimmed to the underlying alignment rules.
6. **`hooks/wrappers: normalize exit codes and clear stale triage state`** — Two issues:
   - Different wrappers (`run_safe_pytest.sh`, `tt-probe.sh`) were returning different codes for the same hang condition. Normalized.
   - Stale `generated/tt-triage/triage.json` from a previous hang would mislead the next run. Now cleared at startup.

## Test plan

- [ ] `scripts/run_safe_pytest.sh <some passing test>` exits 0
- [ ] `scripts/run_safe_pytest.sh <some failing test>` exits non-zero with classified failure
- [ ] `scripts/tt-probe.sh` works on an inline probe
- [ ] Heartbeat appears when two agents contend for the device lock
- [ ] Force-killing a test child (SIGTERM) releases the flock and the device
- [ ] `docs/NOC_ALIGNMENT_IN_TT_METAL.md` renders OK on GitHub

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_phase1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_phase1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/llk_helper_library_phase1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/llk_helper_library_phase1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/llk_helper_library_phase1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/llk_helper_library_phase1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/llk_helper_library_phase1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/llk_helper_library_phase1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/llk_helper_library_phase1)