### PR TITLE
[tt-triage] Block location bug fix

### DIFF
--- a/tools/triage/dump_op_mesh.py
+++ b/tools/triage/dump_op_mesh.py
@@ -17,8 +17,9 @@ Description:
       - `(Mesh <m> Chip <c>)` for chips that live on a different host
         (multi-host meshes).
     Subsequent lines list the ops currently dispatched on that chip, one per
-    `host_assigned_id`, sorted ascending. A device with no live ops shows
-    `(idle)`; cross-host chips show `(remote)`.
+    `host_assigned_id`, sorted ascending. A device this process opened but
+    that has no live ops shows `(idle)`; a device on this host that this
+    process never opened shows `(unused)`; cross-host chips show `(remote)`.
 
     A leading `[!] ` on an op line marks that op as a *straggler* — its
     `host_assigned_id` is strictly less than the highest live id in the
@@ -105,6 +106,7 @@ def _format_cell(
     label_to_ops: dict[str, list[RunningOperationAggregation]],
     leading_edge: int | None,
     use_unique_id_labels: bool,
+    in_use_metal_ids: set[int],
 ) -> str:
     if not mapped_device.isLocal:
         return f"(Mesh {mapped_device.fabricMeshId} Chip {mapped_device.fabricChipId})\n(remote)"
@@ -116,6 +118,9 @@ def _format_cell(
 
     prefix = _ubb_prefix(cd, device_id)
     chip_label = f"{prefix} (Device {device_id})".lstrip()
+
+    if metal_id not in in_use_metal_ids:
+        return f"{chip_label}\n(unused)"
 
     op_key = hex(metal_id_mapping.get_unique_id(metal_id)) if use_unique_id_labels else str(device_id)
     aggs = label_to_ops.get(op_key, [])
@@ -154,6 +159,7 @@ def run(args, context: Context):
     label_to_ops = _build_label_to_ops(bundle.aggregations)
     leading_edge = _leading_edge_op_id(bundle.aggregations)
     use_unique_id_labels = any(label.startswith("0x") for label in label_to_ops)
+    in_use_metal_ids = set(inspector_data.getDevicesInUse().metalDeviceIds)
 
     fields_spec: list[tuple[str, type, object]] = [("r", str, triage_field("R\\C"))]
     fields_spec.extend((f"c{c}", str, triage_field(f"C{c}")) for c in range(cols))
@@ -162,7 +168,15 @@ def run(args, context: Context):
     out = []
     for r in range(rows):
         cells = [
-            _format_cell(mapped[r * cols + c], metal_id_mapping, cd, label_to_ops, leading_edge, use_unique_id_labels)
+            _format_cell(
+                mapped[r * cols + c],
+                metal_id_mapping,
+                cd,
+                label_to_ops,
+                leading_edge,
+                use_unique_id_labels,
+                in_use_metal_ids,
+            )
             for c in range(cols)
         ]
         out.append(MeshRow(str(r), *cells))

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -175,50 +175,48 @@ def _make_device_map(devices: list[Device]) -> dict[int, Device]:
     return {device.id: device for device in devices}
 
 
+def _exalens_block_locations(device: Device, block_type: BlockType) -> list[OnChipCoordinate]:
+    if block_type == "active_eth":
+        return device.active_eth_block_locations
+    if block_type == "idle_eth":
+        return device.idle_eth_block_locations
+    if block_type == "dram" and not device.is_blackhole():
+        return []
+    return device.get_block_locations("functional_workers" if block_type == "tensix" else block_type)
+
+
 def get_block_locations(
     devices: list[Device],
     inspector_data: InspectorData | None,
     metal_device_id_mapping: MetalDeviceIdMapping | None,
 ) -> dict[Device, dict[BlockType, list[OnChipCoordinate]]]:
     block_locations: dict[Device, dict[BlockType, list[OnChipCoordinate]]] = defaultdict(dict)
+    covered: set[Device] = set()
 
-    # Without Inspector we can't pre-aggregate active/idle eth core lists per chip,
-    # so fall back to per-device exalens helpers for every block type.
-    if inspector_data is None or metal_device_id_mapping is None:
-        for device in devices:
-            for block_type in BLOCK_TYPES:
-                if block_type == "active_eth":
-                    block_locations[device][block_type] = device.active_eth_block_locations
-                elif block_type == "idle_eth":
-                    block_locations[device][block_type] = device.idle_eth_block_locations
-                elif block_type == "dram" and not device.is_blackhole():
-                    block_locations[device][block_type] = []
-                else:
-                    block_locations[device][block_type] = device.get_block_locations(
-                        "functional_workers" if block_type == "tensix" else block_type
-                    )
-        return block_locations
-
-    device_map = _make_device_map(devices)
-    chip_blocks_list = inspector_data.getBlocksByType().chips
-
-    for i in range(len(chip_blocks_list)):
-        metal_device_id = chip_blocks_list[i].chipId
-        device_id = metal_device_id_mapping.get_device_id(metal_device_id)
-        if device_id in device_map:
-            device = device_map[device_id]
-            for block_type in BLOCK_TYPES:
-                if block_type in INSPECTOR_BLOCK_TYPES:
-                    block_locations[device][block_type] = _convert_to_on_chip_coordinates(
-                        device, getattr(chip_blocks_list[i].blocks, INSPECTOR_BLOCK_TYPES[block_type]), block_type
-                    )
-                else:
-                    if block_type == "dram" and not device.is_blackhole():
-                        block_locations[device][block_type] = []
-                    else:
-                        block_locations[device][block_type] = device.get_block_locations(
-                            "functional_workers" if block_type == "tensix" else block_type
+    if inspector_data is not None and metal_device_id_mapping is not None:
+        device_map = _make_device_map(devices)
+        chip_blocks_list = inspector_data.getBlocksByType().chips
+        for i in range(len(chip_blocks_list)):
+            metal_device_id = chip_blocks_list[i].chipId
+            device_id = metal_device_id_mapping.get_device_id(metal_device_id)
+            if device_id in device_map:
+                device = device_map[device_id]
+                covered.add(device)
+                for block_type in BLOCK_TYPES:
+                    if block_type in INSPECTOR_BLOCK_TYPES:
+                        block_locations[device][block_type] = _convert_to_on_chip_coordinates(
+                            device, getattr(chip_blocks_list[i].blocks, INSPECTOR_BLOCK_TYPES[block_type]), block_type
                         )
+                    else:
+                        block_locations[device][block_type] = _exalens_block_locations(device, block_type)
+
+    # Exalens fallback for any device Inspector didn't cover (no inspector at all, or
+    # Inspector's getBlocksByType is missing this device).
+    for device in devices:
+        if device in covered:
+            continue
+        for block_type in BLOCK_TYPES:
+            block_locations[device][block_type] = _exalens_block_locations(device, block_type)
 
     return block_locations
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
https://github.com/tenstorrent/tt-metal/pull/44273 didn't properly cover the scenario where FW init fails - we do properly fall back to devices from the system mesh, but do not properly fall back to exalens' block types so we still get `Skipping: ` in a bunch of scripts. This PR fixes that issue.

Additionally, just a minor UX fix in `dump_op_mesh.py` to annotate devices not in use by the workflow. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/op_mesh_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/op_mesh_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/op_mesh_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/op_mesh_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/op_mesh_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/op_mesh_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/op_mesh_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/op_mesh_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/op_mesh_bug)