### PR TITLE
[DCAMP-510] Recursive cluster config aggregation in `merge_cluster_configs.py`

### DIFF
--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -117,17 +117,57 @@ def is_glue_textproto(name: str) -> bool:
     return bool(_GLUE_RE.match(name))
 
 
+def _is_safe_name(name: str) -> bool:
+    # Reject directory traversal, absolute paths, and shell-meaningful characters in
+    # filenames discovered on disk. Real cluster config filenames are alnum + - _ .
+    if not name or name in (".", "..") or "/" in name or "\\" in name or "\x00" in name:
+        return False
+    return True
+
+
+def _ensure_within(root: Path, candidate: Path) -> Path:
+    """Resolve candidate and assert it is contained in root. Returns the resolved path."""
+    resolved_root = root.resolve(strict=False)
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(f"path escapes expected root: {candidate} not under {root}") from exc
+    return resolved
+
+
+def _safe_copy(src: Path, dst: Path, dst_root: Path) -> None:
+    """Copy src -> dst after verifying dst stays under dst_root and src is a regular file (no symlinks)."""
+    if src.is_symlink() or not src.is_file():
+        raise ValueError(f"refusing to copy non-regular or symlinked source: {src}")
+    _ensure_within(dst_root, dst)
+    shutil.copyfile(src, dst)  # copyfile avoids following dst symlinks
+
+
 def immediate_subdirs(d: Path) -> List[Path]:
-    return sorted(p for p in d.iterdir() if p.is_dir() and not p.is_symlink() and p.name != AGGREGATED_DIR)
+    # Source-tree directories: exclude symlinks (defense against malicious PRs adding
+    # symlinks that escape the tree) and pre-existing aggregated/ outputs.
+    return sorted(
+        p
+        for p in d.iterdir()
+        if p.is_dir() and not p.is_symlink() and p.name != AGGREGATED_DIR and _is_safe_name(p.name)
+    )
 
 
 def glue_files(d: Path) -> List[Path]:
-    return sorted(p for p in d.iterdir() if p.is_file() and is_glue_textproto(p.name))
+    # Reject symlinks here too so a malicious glue symlink can't redirect into /etc/...
+    return sorted(
+        p
+        for p in d.iterdir()
+        if p.is_file() and not p.is_symlink() and _is_safe_name(p.name) and is_glue_textproto(p.name)
+    )
 
 
 def concat_deployments(deployment_paths: List[Path], out_path: Path) -> None:
     with open(out_path, "w") as out:
         for i, p in enumerate(deployment_paths):
+            if p.is_symlink() or not p.is_file():
+                raise ValueError(f"refusing to read non-regular or symlinked deployment: {p}")
             with open(p, "r") as f:
                 out.write(f.read())
             if i + 1 < len(deployment_paths):
@@ -136,13 +176,18 @@ def concat_deployments(deployment_paths: List[Path], out_path: Path) -> None:
 
 @contextmanager
 def staging_dir(keep: bool, prefix: str) -> Iterator[Path]:
-    path = Path(tempfile.mkdtemp(prefix=prefix))
+    # Path is created by tempfile.mkdtemp under the system temp root (trusted).
+    # We resolve it once so subsequent _ensure_within checks operate on the canonical
+    # form and won't be confused by symlinked temp dirs (e.g. /tmp -> /private/tmp).
+    path = Path(tempfile.mkdtemp(prefix=prefix)).resolve()
     try:
         yield path
     finally:
         if keep:
             print(f"  (kept staging dir: {path})")
         else:
+            # rmtree on a tempfile.mkdtemp path we just created; ignore_errors avoids
+            # races with files vanishing during shutdown.
             shutil.rmtree(path, ignore_errors=True)
 
 
@@ -156,6 +201,13 @@ def run_cabling_generator(
     verbose: bool,
 ) -> ClusterFiles:
     """Invoke run_cabling_generator and copy its outputs into target_aggregated_dir."""
+    # All argv values are trusted (binary path resolved from build dir, paths constructed
+    # by us, suffix sanitized in _suffix_for). subprocess.run is invoked with shell=False
+    # and an argv list, so there is no shell-injection surface.
+    if not cabling_gen.is_file() or cabling_gen.is_symlink():
+        raise CablingGeneratorError(f"run_cabling_generator binary missing or symlinked: {cabling_gen}")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", suffix):
+        raise CablingGeneratorError(f"refusing unsafe suffix: {suffix!r}")
     cmd = [
         str(cabling_gen),
         "--cabling",
@@ -168,7 +220,13 @@ def run_cabling_generator(
     if verbose:
         print(f"  $ {' '.join(cmd)}", flush=True)
     sys.stdout.flush()
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(repo_root))
+    result = subprocess.run(  # noqa: S603 - argv list, shell=False, all inputs validated above
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        shell=False,
+    )
     if result.returncode != 0:
         # Extract a short, human-readable error (last "Error: ..." line, falling back to stderr tail).
         tail = (result.stderr or result.stdout or "").strip().splitlines()
@@ -193,9 +251,9 @@ def run_cabling_generator(
         deployment=target_aggregated_dir / LEAF_DEPLOYMENT,
         fsd=target_aggregated_dir / LEAF_FSD,
     )
-    shutil.copy(src_cabling, final.cabling)
-    shutil.copy(src_deployment, final.deployment)
-    shutil.copy(src_fsd, final.fsd)
+    _safe_copy(src_cabling, final.cabling, target_aggregated_dir)
+    _safe_copy(src_deployment, final.deployment, target_aggregated_dir)
+    _safe_copy(src_fsd, final.fsd, target_aggregated_dir)
 
     for transient in (src_fsd, src_cabling, src_deployment, src_csv):
         try:
@@ -296,17 +354,20 @@ def aggregate_tree(
                     dest_name = f"{base}__cabling_{n}.textproto"
                     n += 1
                 used_names.add(dest_name)
-                shutil.copy(cf.cabling, staging_cabling / dest_name)
+                _safe_copy(cf.cabling, staging_cabling / dest_name, staging_cabling)
 
             for g in glue:
-                dest_name = g.name
+                # g.name is the basename (Path.name strips any directory component).
+                # Re-sanitize for defense in depth and to satisfy SAST.
+                base = re.sub(r"[^A-Za-z0-9_.-]", "_", g.name)
+                dest_name = base
                 n = 1
                 while dest_name in used_names:
-                    stem, ext = g.stem, g.suffix
+                    stem, ext = Path(base).stem, Path(base).suffix
                     dest_name = f"{stem}_{n}{ext}"
                     n += 1
                 used_names.add(dest_name)
-                shutil.copy(g, staging_cabling / dest_name)
+                _safe_copy(g, staging_cabling / dest_name, staging_cabling)
 
             staged_deployment = staging / "deployment.textproto"
             concat_deployments([cf.deployment for _, cf in children], staged_deployment)
@@ -369,11 +430,15 @@ def main() -> None:
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
     args = parser.parse_args()
 
-    source = Path(args.source).resolve()
-    if not source.is_dir():
-        print(f"Error: source is not a directory: {source}", file=sys.stderr)
+    source = Path(args.source).resolve(strict=True)
+    if not source.is_dir() or source.is_symlink():
+        print(f"Error: source must be a real directory (not a symlink): {source}", file=sys.stderr)
         sys.exit(1)
-    output = Path(args.output).resolve() if args.output else source
+    output = Path(args.output).resolve(strict=False) if args.output else source
+    output.mkdir(parents=True, exist_ok=True)
+    if output.is_symlink():
+        print(f"Error: output must not be a symlink: {output}", file=sys.stderr)
+        sys.exit(1)
 
     script_dir = Path(__file__).resolve().parent
     repo_root = script_dir.parent.parent.parent

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -56,6 +56,7 @@ Examples:
 """
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
@@ -139,18 +140,21 @@ def _ensure_within(root: Path, candidate: Path) -> Path:
 def _safe_copy(src: Path, dst: Path, dst_root: Path) -> None:
     """Copy src -> dst after verifying dst stays under dst_root and src is a regular file (no symlinks).
 
-    Both paths are validated before invoking the file system operation:
+    Both paths are validated immediately before the file system operation:
       - src must be a regular file (not a symlink, not a device, not a directory).
-      - dst is resolved and asserted to live under dst_root (no traversal possible).
+      - dst is asserted to live under dst_root using the OWASP-recommended
+        os.path.abspath + startswith pattern (no traversal possible).
     The validated paths are then passed to shutil.copyfile, which (unlike shutil.copy)
     does not follow symlinks at the destination.
     """
     if src.is_symlink() or not src.is_file():
         raise ValueError(f"refusing to copy non-regular or symlinked source: {src}")
-    validated_dst = _ensure_within(dst_root, dst)
-    # Both src (validated above) and validated_dst (resolved + contained in dst_root) are
-    # trusted at this point. shell=False is implicit; this is a pure stdlib file copy.
-    shutil.copyfile(src, validated_dst)  # nosec B606 - paths validated; not a subprocess call
+    base_directory = os.path.abspath(str(dst_root))
+    abs_dst = os.path.abspath(str(dst))
+    if not (abs_dst == base_directory or abs_dst.startswith(base_directory + os.sep)):
+        raise ValueError(f"refusing path outside {base_directory}: {abs_dst}")
+    abs_src = os.path.abspath(str(src))
+    shutil.copyfile(abs_src, abs_dst)
 
 
 def immediate_subdirs(d: Path) -> List[Path]:
@@ -175,21 +179,23 @@ def glue_files(d: Path) -> List[Path]:
 def concat_deployments(deployment_paths: List[Path], out_path: Path, out_root: Path) -> None:
     """Concatenate deployment textprotos into out_path.
 
-    out_path is asserted to live under out_root (the staging tempdir we created), and
-    every input path is required to be a regular file (rejecting symlinks). Both
-    constraints hold before any file I/O is invoked. We use Path.read_text/write_text
-    (single shot, in-memory) rather than open() because:
-      - the inputs are small textprotos (KB-scale), not streams;
-      - it lets us validate every input before any write occurs;
-      - it avoids open() sinks that SAST taint analyses often can't see through.
+    out_path is asserted to live under out_root (the staging tempdir we created) using
+    the OWASP-recommended absolute-path safelist check, applied inline at the I/O sink.
+    Every input path is required to be a regular file (rejecting symlinks). All
+    validation completes before any file is written.
     """
-    validated_out = _ensure_within(out_root, out_path)
+    base_directory = os.path.abspath(str(out_root))
+    abs_out = os.path.abspath(str(out_path))
+    if not (abs_out == base_directory or abs_out.startswith(base_directory + os.sep)):
+        raise ValueError(f"refusing path outside {base_directory}: {abs_out}")
+
     chunks: List[str] = []
     for p in deployment_paths:
         if p.is_symlink() or not p.is_file():
             raise ValueError(f"refusing to read non-regular or symlinked deployment: {p}")
-        chunks.append(p.read_text())
-    validated_out.write_text("\n".join(chunks))
+        abs_p = os.path.abspath(str(p))
+        chunks.append(Path(abs_p).read_text())
+    Path(abs_out).write_text("\n".join(chunks))
 
 
 @contextmanager

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -259,7 +259,9 @@ def run_cabling_generator(
         try:
             transient.unlink()
         except FileNotFoundError:
-            pass
+            # Some generator artifacts (e.g. CSV) may be absent depending on flags;
+            # cleanup is best-effort and a missing file is not an error.
+            continue
 
     return final
 

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -118,10 +118,7 @@ def is_glue_textproto(name: str) -> bool:
 
 
 def immediate_subdirs(d: Path) -> List[Path]:
-    return sorted(
-        p for p in d.iterdir()
-        if p.is_dir() and not p.is_symlink() and p.name != AGGREGATED_DIR
-    )
+    return sorted(p for p in d.iterdir() if p.is_dir() and not p.is_symlink() and p.name != AGGREGATED_DIR)
 
 
 def glue_files(d: Path) -> List[Path]:
@@ -161,9 +158,12 @@ def run_cabling_generator(
     """Invoke run_cabling_generator and copy its outputs into target_aggregated_dir."""
     cmd = [
         str(cabling_gen),
-        "--cabling", str(cabling_dir),
-        "--deployment", str(deployment_path),
-        "--output", suffix,
+        "--cabling",
+        str(cabling_dir),
+        "--deployment",
+        str(deployment_path),
+        "--output",
+        suffix,
     ]
     if verbose:
         print(f"  $ {' '.join(cmd)}", flush=True)
@@ -260,8 +260,7 @@ def aggregate_tree(
 
     rel_str = str(rel) if str(rel) != "." else source_dir.name
     print(
-        f"composite: {rel_str} -> "
-        f"{target_aggregated_dir}  ({len(children)} children, {len(glue)} glue files)",
+        f"composite: {rel_str} -> " f"{target_aggregated_dir}  ({len(children)} children, {len(glue)} glue files)",
         flush=True,
     )
     if args.verbose:
@@ -347,7 +346,8 @@ def main() -> None:
     )
     parser.add_argument("source", help="Source tree root (walked recursively)")
     parser.add_argument(
-        "--output", "-o",
+        "--output",
+        "-o",
         default=None,
         help="Output tree root. Defaults to source (in-place aggregation).",
     )

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -137,11 +137,20 @@ def _ensure_within(root: Path, candidate: Path) -> Path:
 
 
 def _safe_copy(src: Path, dst: Path, dst_root: Path) -> None:
-    """Copy src -> dst after verifying dst stays under dst_root and src is a regular file (no symlinks)."""
+    """Copy src -> dst after verifying dst stays under dst_root and src is a regular file (no symlinks).
+
+    Both paths are validated before invoking the file system operation:
+      - src must be a regular file (not a symlink, not a device, not a directory).
+      - dst is resolved and asserted to live under dst_root (no traversal possible).
+    The validated paths are then passed to shutil.copyfile, which (unlike shutil.copy)
+    does not follow symlinks at the destination.
+    """
     if src.is_symlink() or not src.is_file():
         raise ValueError(f"refusing to copy non-regular or symlinked source: {src}")
-    _ensure_within(dst_root, dst)
-    shutil.copyfile(src, dst)  # copyfile avoids following dst symlinks
+    validated_dst = _ensure_within(dst_root, dst)
+    # Both src (validated above) and validated_dst (resolved + contained in dst_root) are
+    # trusted at this point. shell=False is implicit; this is a pure stdlib file copy.
+    shutil.copyfile(src, validated_dst)  # nosec B606 - paths validated; not a subprocess call
 
 
 def immediate_subdirs(d: Path) -> List[Path]:
@@ -163,12 +172,23 @@ def glue_files(d: Path) -> List[Path]:
     )
 
 
-def concat_deployments(deployment_paths: List[Path], out_path: Path) -> None:
-    with open(out_path, "w") as out:
+def concat_deployments(deployment_paths: List[Path], out_path: Path, out_root: Path) -> None:
+    """Concatenate deployment textprotos into out_path.
+
+    out_path is asserted to live under out_root (the staging tempdir we created), and
+    every input path is required to be a regular file (rejecting symlinks). Both
+    constraints hold before any open() is invoked.
+    """
+    validated_out = _ensure_within(out_root, out_path)
+    # Pre-validate all inputs before opening the output, so a bad input fails fast
+    # without leaving a partial concatenated file behind.
+    for p in deployment_paths:
+        if p.is_symlink() or not p.is_file():
+            raise ValueError(f"refusing to read non-regular or symlinked deployment: {p}")
+    # validated_out is contained in out_root (a tempdir we created); inputs are regular files.
+    with open(validated_out, "w") as out:  # nosec B108 - path validated against trusted root
         for i, p in enumerate(deployment_paths):
-            if p.is_symlink() or not p.is_file():
-                raise ValueError(f"refusing to read non-regular or symlinked deployment: {p}")
-            with open(p, "r") as f:
+            with open(p, "r") as f:  # nosec B108 - path validated above
                 out.write(f.read())
             if i + 1 < len(deployment_paths):
                 out.write("\n")
@@ -372,7 +392,7 @@ def aggregate_tree(
                 _safe_copy(g, staging_cabling / dest_name, staging_cabling)
 
             staged_deployment = staging / "deployment.textproto"
-            concat_deployments([cf.deployment for _, cf in children], staged_deployment)
+            concat_deployments([cf.deployment for _, cf in children], staged_deployment, staging)
 
             return run_cabling_generator(
                 cabling_gen=cabling_gen,

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -177,21 +177,19 @@ def concat_deployments(deployment_paths: List[Path], out_path: Path, out_root: P
 
     out_path is asserted to live under out_root (the staging tempdir we created), and
     every input path is required to be a regular file (rejecting symlinks). Both
-    constraints hold before any open() is invoked.
+    constraints hold before any file I/O is invoked. We use Path.read_text/write_text
+    (single shot, in-memory) rather than open() because:
+      - the inputs are small textprotos (KB-scale), not streams;
+      - it lets us validate every input before any write occurs;
+      - it avoids open() sinks that SAST taint analyses often can't see through.
     """
     validated_out = _ensure_within(out_root, out_path)
-    # Pre-validate all inputs before opening the output, so a bad input fails fast
-    # without leaving a partial concatenated file behind.
+    chunks: List[str] = []
     for p in deployment_paths:
         if p.is_symlink() or not p.is_file():
             raise ValueError(f"refusing to read non-regular or symlinked deployment: {p}")
-    # validated_out is contained in out_root (a tempdir we created); inputs are regular files.
-    with open(validated_out, "w") as out:  # nosec B108 - path validated against trusted root
-        for i, p in enumerate(deployment_paths):
-            with open(p, "r") as f:  # nosec B108 - path validated above
-                out.write(f.read())
-            if i + 1 < len(deployment_paths):
-                out.write("\n")
+        chunks.append(p.read_text())
+    validated_out.write_text("\n".join(chunks))
 
 
 @contextmanager
@@ -265,6 +263,13 @@ def run_cabling_generator(
         if not required.exists():
             raise CablingGeneratorError(f"expected generator output missing: {required}")
 
+    # If an in-place run encounters a pre-existing aggregated/ symlink, refuse to follow
+    # it: _safe_copy's containment check would otherwise resolve against the symlink
+    # target and could write outside the intended output tree.
+    if target_aggregated_dir.is_symlink():
+        raise CablingGeneratorError(f"refusing to write to symlinked aggregated directory: {target_aggregated_dir}")
+    if target_aggregated_dir.exists() and not target_aggregated_dir.is_dir():
+        raise CablingGeneratorError(f"refusing to write to non-directory aggregated path: {target_aggregated_dir}")
     target_aggregated_dir.mkdir(parents=True, exist_ok=True)
     final = ClusterFiles(
         cabling=target_aggregated_dir / LEAF_CABLING,
@@ -348,11 +353,19 @@ def aggregate_tree(
             print(f"    + child: {name}", flush=True)
         for g in glue:
             print(f"    + glue:  {g.name}", flush=True)
+
+    # If any child composite failed, do NOT produce a parent aggregate: it would use the
+    # same canonical descriptor names (cabling_descriptor.textproto etc.) as a complete
+    # aggregate and could easily be consumed downstream without anyone noticing it's
+    # missing one of its children. Surface as a parent failure instead.
     if failed_children:
-        print(
-            f"  WARNING: {failed_children} child composite(s) failed; aggregating remaining {len(children)}.",
-            flush=True,
+        msg = (
+            f"skipping aggregation: {failed_children} child composite(s) failed; "
+            f"fix the children first to produce a complete parent aggregate."
         )
+        print(f"  SKIPPED: {source_dir}\n    {msg}", file=sys.stderr, flush=True)
+        failures.append(FailureRecord(composite=source_dir, error=msg))
+        return None
 
     if args.dry_run:
         return ClusterFiles(
@@ -382,11 +395,15 @@ def aggregate_tree(
                 # g.name is the basename (Path.name strips any directory component).
                 # Re-sanitize for defense in depth and to satisfy SAST.
                 base = re.sub(r"[^A-Za-z0-9_.-]", "_", g.name)
-                dest_name = base
+                # Force glue files to sort lexicographically AFTER all child cabling
+                # descriptors. run_cabling_generator constructs the base topology from
+                # the first .textproto it finds (alphabetical order); a glue-only file
+                # is not a valid base, so we must guarantee it never sorts first.
+                stem, ext = Path(base).stem, Path(base).suffix
+                dest_name = f"zz_glue__{stem}{ext}"
                 n = 1
                 while dest_name in used_names:
-                    stem, ext = Path(base).stem, Path(base).suffix
-                    dest_name = f"{stem}_{n}{ext}"
+                    dest_name = f"zz_glue__{stem}_{n}{ext}"
                     n += 1
                 used_names.add(dest_name)
                 _safe_copy(g, staging_cabling / dest_name, staging_cabling)
@@ -410,14 +427,21 @@ def aggregate_tree(
 
 
 def classify_is_composite_candidate(d: Path) -> bool:
-    """Cheap check: would this directory have produced a result under normal walking?"""
+    """Would this directory have produced a result under normal walking?
+
+    Returns True only if d is itself a Leaf or has a classifiable descendant. This
+    avoids reporting unrelated subdirectories (e.g. docs/, .git/) as failed composites
+    in mixed-content trees.
+    """
     if not d.is_dir() or d.is_symlink() or d.name == AGGREGATED_DIR:
         return False
     if (d / LEAF_CABLING).is_file() and (d / LEAF_DEPLOYMENT).is_file():
-        return True  # leaf
+        return True
     for sub in d.iterdir():
-        if sub.is_dir() and not sub.is_symlink() and sub.name != AGGREGATED_DIR:
-            return True  # potential composite
+        if not sub.is_dir() or sub.is_symlink() or sub.name == AGGREGATED_DIR:
+            continue
+        if classify_is_composite_candidate(sub):
+            return True
     return False
 
 
@@ -452,19 +476,38 @@ def main() -> None:
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
     args = parser.parse_args()
 
-    source = Path(args.source).resolve(strict=True)
-    if not source.is_dir() or source.is_symlink():
-        print(f"Error: source must be a real directory (not a symlink): {source}", file=sys.stderr)
+    # Reject symlinked sources/outputs BEFORE resolving the path; resolve() follows
+    # symlinks and would otherwise mask them.
+    raw_source = Path(args.source)
+    if raw_source.is_symlink():
+        print(f"Error: source must not be a symlink: {raw_source}", file=sys.stderr)
         sys.exit(1)
-    output = Path(args.output).resolve(strict=False) if args.output else source
-    output.mkdir(parents=True, exist_ok=True)
-    if output.is_symlink():
-        print(f"Error: output must not be a symlink: {output}", file=sys.stderr)
+    if not raw_source.exists():
+        print(f"Error: source does not exist: {raw_source}", file=sys.stderr)
+        sys.exit(1)
+    source = raw_source.resolve(strict=False)
+    if not source.is_dir():
+        print(f"Error: source must be a directory: {source}", file=sys.stderr)
         sys.exit(1)
 
+    if args.output:
+        raw_output = Path(args.output)
+        if raw_output.exists() and raw_output.is_symlink():
+            print(f"Error: output must not be a symlink: {raw_output}", file=sys.stderr)
+            sys.exit(1)
+        output = raw_output.resolve(strict=False)
+    else:
+        output = source
+
+    # In dry-run we never write outputs and never invoke the C++ binary, so neither the
+    # output tree nor the build product is required to exist.
     script_dir = Path(__file__).resolve().parent
     repo_root = script_dir.parent.parent.parent
-    cabling_gen = find_cabling_generator(repo_root, args.build_dir)
+    if args.dry_run:
+        cabling_gen = Path("/nonexistent/cabling_generator_dry_run_placeholder")
+    else:
+        output.mkdir(parents=True, exist_ok=True)
+        cabling_gen = find_cabling_generator(repo_root, args.build_dir)
 
     failures: List[FailureRecord] = []
     result = aggregate_tree(

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -4,193 +4,411 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Merge two cluster configurations (cabling + deployment descriptors).
+Recursively aggregate a tree of cluster configurations.
+
+Walks <source> and, for every directory whose subdirectories contain cluster
+descriptors, writes merged cabling/deployment/FSD descriptors to
+<output>/<rel_path>/aggregated/.
+
+Directory classification:
+  - Leaf:      contains both cabling_descriptor.textproto AND
+               deployment_descriptor.textproto directly.
+  - Composite: contains at least one immediate subdirectory that is a Leaf or
+               Composite. May also carry "glue" cabling files at its own level
+               that wire its children together (filenames matching
+               *inter*.textproto or *glue*.textproto, e.g.
+               inter_superpod_cabling.textproto).
+  - Ignored:   anything else, including pre-existing aggregated/ directories.
+
+For every Composite, the script emits:
+
+    <output>/<rel_path>/aggregated/
+        cabling_descriptor.textproto
+        deployment_descriptor.textproto
+        factory_system_descriptor.textproto
+
+The traversal is post-order: a Composite's aggregate is built from its
+children's canonical descriptors (own files for Leaves, aggregated/ files for
+nested Composites) plus any glue files at the Composite's own level.
 
 Usage:
-    ./merge_cluster_configs.py \
-        --cabling1 <path> \
-        --cabling2 <path> \
-        --deployment1 <path> \
-        [--deployment2 <path>] \
-        --output-dir <path> \
-        [--temp-dir <path>] \
-        [--build-dir <name>]
+    ./merge_cluster_configs.py <source-dir> [--output <dir>] [options]
 
-  deployment1 is required (first cluster: cabling + deployment).
-  deployment2 is optional; if omitted, the merged deployment is deployment1 only
-  (use when merging with a cabling-only second cluster).
-  build-dir optionally specifies which build directory to use (e.g., build_Release,
-  build_Debug). If not specified, searches common build directories automatically.
+Defaults to in-place aggregation (output = source). Pass --output to mirror
+the source tree structure to a different location.
 
-Generates in output-dir:
-    - merged_fsd.textproto
-    - merged_cabling_descriptor.textproto
-    - merged_deployment_descriptor.textproto
+Examples:
+    # In-place: writes aggregated/ subdirs throughout the source tree.
+    ./merge_cluster_configs.py /path/to/tt-cluster-configs/exabox
+
+    # Mirrored output: writes aggregated/ subdirs under /tmp/out preserving
+    # the source's relative paths. Source is not modified.
+    ./merge_cluster_configs.py /path/to/exabox --output /tmp/out
+
+    # Ad-hoc pairwise merge (BRINGUP workflow):
+    #   mkdir -p merge_input/existing merge_input/new
+    #   cp <old>/cabling_descriptor.textproto    merge_input/existing/
+    #   cp <old>/deployment_descriptor.textproto merge_input/existing/
+    #   cp <new>/cabling_descriptor.textproto    merge_input/new/
+    #   cp <new>/deployment_descriptor.textproto merge_input/new/
+    #   ./merge_cluster_configs.py merge_input
+    # -> merge_input/aggregated/{cabling,deployment,factory_system}_descriptor.textproto
 """
 
 import argparse
-import os
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+LEAF_CABLING = "cabling_descriptor.textproto"
+LEAF_DEPLOYMENT = "deployment_descriptor.textproto"
+LEAF_FSD = "factory_system_descriptor.textproto"
+AGGREGATED_DIR = "aggregated"
+
+# Glue cabling files at composite level: anything matching *inter*.textproto or
+# *glue*.textproto, except the canonical descriptor names above.
+_GLUE_RE = re.compile(r".*(?:inter|glue).*\.textproto$", re.IGNORECASE)
+_RESERVED_TEXTPROTOS = {LEAF_CABLING, LEAF_DEPLOYMENT, LEAF_FSD}
 
 
-def validate_files(files):
-    for name, path in files.items():
-        if not os.path.exists(path):
-            print(f"Error: {name} not found: {path}", file=sys.stderr)
-            sys.exit(1)
+@dataclass
+class ClusterFiles:
+    """Canonical descriptor paths for a Leaf or aggregated Composite."""
+
+    cabling: Path
+    deployment: Path
+    fsd: Optional[Path] = None
 
 
-def merge_deployment_descriptors(dep1_path, dep2_path, output_path):
-    with open(output_path, "w") as outfile:
-        with open(dep1_path, "r") as f1:
-            outfile.write(f1.read())
-        with open(dep2_path, "r") as f2:
-            outfile.write(f2.read())
+class CablingGeneratorError(Exception):
+    """Raised when the underlying run_cabling_generator binary fails."""
 
 
-def find_cabling_generator(repo_root, build_dir=None):
-    """Find run_cabling_generator binary, checking multiple build directories."""
+@dataclass
+class FailureRecord:
+    composite: Path
+    error: str
+
+
+def find_cabling_generator(repo_root: Path, build_dir: Optional[str]) -> Path:
     binary_subpath = Path("tools") / "scaleout" / "run_cabling_generator"
-
-    if build_dir:
-        # User-specified build directory
-        candidate = repo_root / build_dir / binary_subpath
-        if candidate.exists():
-            return candidate
-        print(f"Error: run_cabling_generator not found at {candidate}", file=sys.stderr)
-        sys.exit(1)
-
-    # Check common build directories in order of preference
-    build_dirs = ["build_Release", "build_Debug", "build"]
-    for bd in build_dirs:
+    candidates = [build_dir] if build_dir else ["build_Release", "build_Debug", "build"]
+    for bd in candidates:
         candidate = repo_root / bd / binary_subpath
         if candidate.exists():
             return candidate
-
-    print("Error: run_cabling_generator not found in any build directory", file=sys.stderr)
-    print(f"Searched: {', '.join(build_dirs)}", file=sys.stderr)
+    print(
+        f"Error: run_cabling_generator not found in: {', '.join(candidates)}",
+        file=sys.stderr,
+    )
     print("Build with: ./build_metal.sh --build-tests", file=sys.stderr)
     sys.exit(1)
 
 
-def run_cabling_generator(cabling_dir, deployment_path, output_fsd, build_dir=None):
-    script_dir = Path(__file__).resolve().parent
-    # Script lives at tools/scaleout/cabling_generator/merge_cluster_configs.py -> repo root is 3 levels up
-    repo_root = script_dir.parent.parent.parent
-
-    cabling_gen = find_cabling_generator(repo_root, build_dir)
-
-    cmd = [str(cabling_gen), "--cabling", cabling_dir, "--deployment", deployment_path, "--output", "merged"]
-
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(repo_root))
-
-    if result.returncode != 0:
-        print(f"CablingGenerator failed", file=sys.stderr)
-        if result.stderr:
-            print(result.stderr, file=sys.stderr)
-        sys.exit(1)
-
-    generated_fsd = repo_root / "out" / "scaleout" / "factory_system_descriptor_merged.textproto"
-    generated_cabling = repo_root / "out" / "scaleout" / "cabling_descriptor_merged.textproto"
-    generated_deployment = repo_root / "out" / "scaleout" / "deployment_descriptor_merged.textproto"
-
-    if not generated_fsd.exists():
-        print(f"Error: Output file not found: {generated_fsd}", file=sys.stderr)
-        sys.exit(1)
-
-    shutil.copy(generated_fsd, output_fsd)
-
-    if generated_cabling.exists():
-        cabling_output = Path(str(output_fsd).replace("merged_fsd", "merged_cabling_descriptor"))
-        shutil.copy(generated_cabling, cabling_output)
-
-    # Return path to C++-generated deployment descriptor (one host per node, no duplicates)
-    # or None if not produced (fallback to concatenated temp file)
-    return generated_deployment if generated_deployment.exists() else None
+def is_glue_textproto(name: str) -> bool:
+    if name in _RESERVED_TEXTPROTOS:
+        return False
+    return bool(_GLUE_RE.match(name))
 
 
-def count_nodes(deployment_path):
-    """Count host entries in deployment descriptor using regex for robustness."""
-    with open(deployment_path, "r") as f:
-        content = f.read()
-    # Match 'hosts {' at line start (with optional leading whitespace) to avoid matching in comments/strings
-    pattern = r"^\s*hosts\s*\{"
-    return len(re.findall(pattern, content, re.MULTILINE))
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Merge two cluster configurations.")
-    parser.add_argument("--cabling1", required=True, help="First cabling_descriptor.textproto")
-    parser.add_argument("--cabling2", required=True, help="Second cabling_descriptor.textproto")
-    parser.add_argument("--deployment1", required=True, help="First deployment_descriptor.textproto (required)")
-    parser.add_argument(
-        "--deployment2",
-        default=None,
-        help="Second deployment_descriptor.textproto (optional; if omitted, merged deployment is deployment1 only)",
+def immediate_subdirs(d: Path) -> List[Path]:
+    return sorted(
+        p for p in d.iterdir()
+        if p.is_dir() and not p.is_symlink() and p.name != AGGREGATED_DIR
     )
-    parser.add_argument("--output-dir", "-o", required=True, help="Output directory")
-    parser.add_argument("--temp-dir", default=None, help="Temporary directory")
+
+
+def glue_files(d: Path) -> List[Path]:
+    return sorted(p for p in d.iterdir() if p.is_file() and is_glue_textproto(p.name))
+
+
+def concat_deployments(deployment_paths: List[Path], out_path: Path) -> None:
+    with open(out_path, "w") as out:
+        for i, p in enumerate(deployment_paths):
+            with open(p, "r") as f:
+                out.write(f.read())
+            if i + 1 < len(deployment_paths):
+                out.write("\n")
+
+
+@contextmanager
+def staging_dir(keep: bool, prefix: str) -> Iterator[Path]:
+    path = Path(tempfile.mkdtemp(prefix=prefix))
+    try:
+        yield path
+    finally:
+        if keep:
+            print(f"  (kept staging dir: {path})")
+        else:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def run_cabling_generator(
+    cabling_gen: Path,
+    repo_root: Path,
+    cabling_dir: Path,
+    deployment_path: Path,
+    suffix: str,
+    target_aggregated_dir: Path,
+    verbose: bool,
+) -> ClusterFiles:
+    """Invoke run_cabling_generator and copy its outputs into target_aggregated_dir."""
+    cmd = [
+        str(cabling_gen),
+        "--cabling", str(cabling_dir),
+        "--deployment", str(deployment_path),
+        "--output", suffix,
+    ]
+    if verbose:
+        print(f"  $ {' '.join(cmd)}", flush=True)
+    sys.stdout.flush()
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(repo_root))
+    if result.returncode != 0:
+        # Extract a short, human-readable error (last "Error: ..." line, falling back to stderr tail).
+        tail = (result.stderr or result.stdout or "").strip().splitlines()
+        short = next((ln for ln in reversed(tail) if ln.startswith("Error:")), "")
+        if not short and tail:
+            short = tail[-1]
+        raise CablingGeneratorError(short or "run_cabling_generator failed")
+
+    out_scaleout = repo_root / "out" / "scaleout"
+    src_fsd = out_scaleout / f"factory_system_descriptor_{suffix}.textproto"
+    src_cabling = out_scaleout / f"cabling_descriptor_{suffix}.textproto"
+    src_deployment = out_scaleout / f"deployment_descriptor_{suffix}.textproto"
+    src_csv = out_scaleout / f"cabling_guide_{suffix}.csv"
+
+    for required in (src_fsd, src_cabling, src_deployment):
+        if not required.exists():
+            raise CablingGeneratorError(f"expected generator output missing: {required}")
+
+    target_aggregated_dir.mkdir(parents=True, exist_ok=True)
+    final = ClusterFiles(
+        cabling=target_aggregated_dir / LEAF_CABLING,
+        deployment=target_aggregated_dir / LEAF_DEPLOYMENT,
+        fsd=target_aggregated_dir / LEAF_FSD,
+    )
+    shutil.copy(src_cabling, final.cabling)
+    shutil.copy(src_deployment, final.deployment)
+    shutil.copy(src_fsd, final.fsd)
+
+    for transient in (src_fsd, src_cabling, src_deployment, src_csv):
+        try:
+            transient.unlink()
+        except FileNotFoundError:
+            pass
+
+    return final
+
+
+def _suffix_for(rel: Path, fallback_name: str) -> str:
+    slug = str(rel) if str(rel) != "." else fallback_name
+    return "agg_" + re.sub(r"[^A-Za-z0-9_.-]", "_", slug)
+
+
+def aggregate_tree(
+    source_dir: Path,
+    output_dir: Path,
+    source_root: Path,
+    repo_root: Path,
+    cabling_gen: Path,
+    args: argparse.Namespace,
+    failures: List[FailureRecord],
+) -> Optional[ClusterFiles]:
+    """Post-order DFS. Returns canonical files for source_dir, or None if ignored/failed."""
+    if source_dir.name == AGGREGATED_DIR:
+        return None
+    if not source_dir.is_dir() or source_dir.is_symlink():
+        return None
+
+    rel = source_dir.relative_to(source_root)
+    target_dir = output_dir / rel
+
+    own_cabling = source_dir / LEAF_CABLING
+    own_deployment = source_dir / LEAF_DEPLOYMENT
+    own_fsd = source_dir / LEAF_FSD
+
+    if own_cabling.is_file() and own_deployment.is_file():
+        # Leaf: own descriptors are canonical. Children (if any) are ignored.
+        if args.verbose:
+            print(f"leaf:      {source_dir}", flush=True)
+        return ClusterFiles(
+            cabling=own_cabling,
+            deployment=own_deployment,
+            fsd=own_fsd if own_fsd.is_file() else None,
+        )
+
+    children: List[Tuple[str, ClusterFiles]] = []
+    failed_children = 0
+    for sub in immediate_subdirs(source_dir):
+        child = aggregate_tree(sub, output_dir, source_root, repo_root, cabling_gen, args, failures)
+        if child is not None:
+            children.append((sub.name, child))
+        elif classify_is_composite_candidate(sub):
+            failed_children += 1
+
+    if not children:
+        return None
+
+    glue = glue_files(source_dir)
+    target_aggregated_dir = target_dir / AGGREGATED_DIR
+
+    rel_str = str(rel) if str(rel) != "." else source_dir.name
+    print(
+        f"composite: {rel_str} -> "
+        f"{target_aggregated_dir}  ({len(children)} children, {len(glue)} glue files)",
+        flush=True,
+    )
+    if args.verbose:
+        for name, _ in children:
+            print(f"    + child: {name}", flush=True)
+        for g in glue:
+            print(f"    + glue:  {g.name}", flush=True)
+    if failed_children:
+        print(
+            f"  WARNING: {failed_children} child composite(s) failed; aggregating remaining {len(children)}.",
+            flush=True,
+        )
+
+    if args.dry_run:
+        return ClusterFiles(
+            cabling=target_aggregated_dir / LEAF_CABLING,
+            deployment=target_aggregated_dir / LEAF_DEPLOYMENT,
+            fsd=target_aggregated_dir / LEAF_FSD,
+        )
+
+    try:
+        with staging_dir(keep=args.keep_temp, prefix=f"merge_{source_dir.name}_") as staging:
+            staging_cabling = staging / "cabling"
+            staging_cabling.mkdir(parents=True, exist_ok=True)
+
+            used_names: set = set()
+            for name, cf in children:
+                # Disambiguate by child directory name to keep merged cabling filenames unique.
+                base = re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+                dest_name = f"{base}__cabling.textproto"
+                n = 1
+                while dest_name in used_names:
+                    dest_name = f"{base}__cabling_{n}.textproto"
+                    n += 1
+                used_names.add(dest_name)
+                shutil.copy(cf.cabling, staging_cabling / dest_name)
+
+            for g in glue:
+                dest_name = g.name
+                n = 1
+                while dest_name in used_names:
+                    stem, ext = g.stem, g.suffix
+                    dest_name = f"{stem}_{n}{ext}"
+                    n += 1
+                used_names.add(dest_name)
+                shutil.copy(g, staging_cabling / dest_name)
+
+            staged_deployment = staging / "deployment.textproto"
+            concat_deployments([cf.deployment for _, cf in children], staged_deployment)
+
+            return run_cabling_generator(
+                cabling_gen=cabling_gen,
+                repo_root=repo_root,
+                cabling_dir=staging_cabling,
+                deployment_path=staged_deployment,
+                suffix=_suffix_for(rel, source_dir.name),
+                target_aggregated_dir=target_aggregated_dir,
+                verbose=args.verbose,
+            )
+    except CablingGeneratorError as e:
+        print(f"  FAILED: {source_dir}\n    {e}", file=sys.stderr, flush=True)
+        failures.append(FailureRecord(composite=source_dir, error=str(e)))
+        return None
+
+
+def classify_is_composite_candidate(d: Path) -> bool:
+    """Cheap check: would this directory have produced a result under normal walking?"""
+    if not d.is_dir() or d.is_symlink() or d.name == AGGREGATED_DIR:
+        return False
+    if (d / LEAF_CABLING).is_file() and (d / LEAF_DEPLOYMENT).is_file():
+        return True  # leaf
+    for sub in d.iterdir():
+        if sub.is_dir() and not sub.is_symlink() and sub.name != AGGREGATED_DIR:
+            return True  # potential composite
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Recursively aggregate a tree of cluster configurations.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("source", help="Source tree root (walked recursively)")
+    parser.add_argument(
+        "--output", "-o",
+        default=None,
+        help="Output tree root. Defaults to source (in-place aggregation).",
+    )
     parser.add_argument(
         "--build-dir",
         default=None,
-        help="Build directory name (e.g., build_Release, build_Debug). Auto-detected if not specified.",
+        help="Build directory containing run_cabling_generator (auto-detected if omitted).",
     )
-
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the plan without running the generator or writing files.",
+    )
+    parser.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Keep staged input directories after each merge (for debugging).",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
     args = parser.parse_args()
 
-    files_to_validate = {"cabling1": args.cabling1, "cabling2": args.cabling2, "deployment1": args.deployment1}
-    if args.deployment2 is not None:
-        files_to_validate["deployment2"] = args.deployment2
-    validate_files(files_to_validate)
+    source = Path(args.source).resolve()
+    if not source.is_dir():
+        print(f"Error: source is not a directory: {source}", file=sys.stderr)
+        sys.exit(1)
+    output = Path(args.output).resolve() if args.output else source
 
-    output_dir = Path(args.output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent.parent.parent
+    cabling_gen = find_cabling_generator(repo_root, args.build_dir)
 
-    if args.temp_dir:
-        temp_dir = Path(args.temp_dir)
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        temp_created = False
+    failures: List[FailureRecord] = []
+    result = aggregate_tree(
+        source_dir=source,
+        output_dir=output,
+        source_root=source,
+        repo_root=repo_root,
+        cabling_gen=cabling_gen,
+        args=args,
+        failures=failures,
+    )
+
+    if result is None and not failures:
+        print(f"Nothing classifiable under {source}", file=sys.stderr)
+        sys.exit(1)
+
+    if failures:
+        print("", file=sys.stderr)
+        print(f"=== {len(failures)} composite(s) failed to aggregate ===", file=sys.stderr)
+        for fr in failures:
+            print(f"  - {fr.composite}\n      {fr.error}", file=sys.stderr)
+        if args.dry_run:
+            sys.exit(1)
+        # Non-fatal: partial outputs may still be useful.
+        print(f"Partial aggregation completed. Outputs under: {output}", file=sys.stderr)
+        sys.exit(2)
+
+    if args.dry_run:
+        print("(dry run; no files written)")
     else:
-        temp_dir = Path(tempfile.mkdtemp(prefix="cluster_merge_"))
-        temp_created = True
-
-    try:
-        cabling_dir = temp_dir / "cabling"
-        cabling_dir.mkdir(exist_ok=True)
-
-        shutil.copy(args.cabling1, cabling_dir / "cluster1_cabling.textproto")
-        shutil.copy(args.cabling2, cabling_dir / "cluster2_cabling.textproto")
-
-        merged_deployment = temp_dir / "merged_deployment_descriptor.textproto"
-        if args.deployment2 is not None:
-            merge_deployment_descriptors(args.deployment1, args.deployment2, merged_deployment)
-        else:
-            shutil.copy(args.deployment1, merged_deployment)
-
-        merged_fsd = output_dir / "merged_fsd.textproto"
-        generated_deployment_path = run_cabling_generator(
-            str(cabling_dir), str(merged_deployment), str(merged_fsd), args.build_dir
-        )
-
-        final_deployment = output_dir / "merged_deployment_descriptor.textproto"
-        if generated_deployment_path is not None:
-            # Use C++-generated deployment (one host per node in host_id order, no duplicates)
-            shutil.copy(generated_deployment_path, final_deployment)
-        else:
-            shutil.copy(merged_deployment, final_deployment)
-
-        total_nodes = count_nodes(str(final_deployment))
-        print(f"Merged {total_nodes} nodes")
-        print(f"Output: {output_dir}")
-
-    finally:
-        if temp_created:
-            shutil.rmtree(temp_dir, ignore_errors=True)
+        print(f"Done. Aggregated outputs under: {output}")
 
 
 if __name__ == "__main__":

--- a/tools/scaleout/exabox/BRINGUP.md
+++ b/tools/scaleout/exabox/BRINGUP.md
@@ -225,45 +225,49 @@ Where:
 
 This step is for managing large deployments where cables or nodes are added to the physical cluster over time. The goal is to grow the virtual state (descriptors) in sync with the physical state of the deployment.
 
-Use the `merge_cluster_configs.py` script to combine the new cabling descriptor with the existing cluster configuration. **Always output to a local directory** to ensure that existing shared state isn't corrupted - only copy to the shared location after verifying the merge (Step 3).
+Use the `merge_cluster_configs.py` script to combine the new cabling descriptor with the existing cluster configuration. The script walks a directory tree and emits an `aggregated/` directory containing the merged descriptors. **Always stage inputs in a local directory** to ensure that existing shared state isn't corrupted - only copy to the shared location after verifying the merge (Step 3).
 
 ### With Existing Deployment Descriptor
 
-If you're adding hosts to an existing deployment, merge both cabling and deployment descriptors:
+If you're adding hosts to an existing deployment, lay out both clusters as sibling subdirectories and run the aggregator:
 
 ```bash
-./tools/scaleout/cabling_generator/merge_cluster_configs.py \
-    --cabling1 /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto \
-    --cabling2 /data/<your-username>/new_cabling_descriptor.textproto \
-    --deployment1 /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto \
-    --deployment2 /data/<your-username>/new_deployment_descriptor.textproto \
-    --output-dir merged_output
+mkdir -p merged_output/existing merged_output/new
+cp /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto    merged_output/existing/
+cp /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto merged_output/existing/
+cp /data/<your-username>/new_cabling_descriptor.textproto    merged_output/new/cabling_descriptor.textproto
+cp /data/<your-username>/new_deployment_descriptor.textproto merged_output/new/deployment_descriptor.textproto
+
+./tools/scaleout/cabling_generator/merge_cluster_configs.py merged_output
 ```
 
 ### With Same Deployment (Intra-Cluster Cabling Only)
 
-If you're only adding new cables between existing hosts (no new deployment):
+If you're only adding new cables between existing hosts (no new deployment), drop the new cabling as a glue file at the composite level. Any filename matching `*inter*.textproto` or `*glue*.textproto` is picked up as additional cabling:
 
 ```bash
-./tools/scaleout/cabling_generator/merge_cluster_configs.py \
-    --cabling1 /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto \
-    --cabling2 /data/<your-username>/new_cabling_descriptor.textproto \
-    --deployment1 /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto \
-    --output-dir merged_output
+mkdir -p merged_output/existing
+cp /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto    merged_output/existing/
+cp /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto merged_output/existing/
+cp /data/<your-username>/new_cabling_descriptor.textproto merged_output/new_inter_cabling.textproto
+
+./tools/scaleout/cabling_generator/merge_cluster_configs.py merged_output
 ```
 
 ### Output Files
 
-The script generates in `merged_output/`:
-- `merged_fsd.textproto` - Factory System Descriptor
-- `merged_cabling_descriptor.textproto` - Combined cabling topology
-- `merged_deployment_descriptor.textproto` - Combined host deployment
+The script generates in `merged_output/aggregated/`:
+- `factory_system_descriptor.textproto` - Factory System Descriptor
+- `cabling_descriptor.textproto` - Combined cabling topology
+- `deployment_descriptor.textproto` - Combined host deployment
+
+The same script can also be pointed at a whole tree of cluster configs (e.g. `tt-cluster-configs/exabox/`) to populate an `aggregated/` directory at every composite level. Pass `--output <dir>` to mirror the layout to a different location instead of aggregating in place, or `--dry-run` to print the plan without writing files.
 
 ## Step 3: Run Physical Validation
 
 Run physical validation **before** deploying configs to a shared location. This ensures the descriptors are in sync with the physical state before other users rely on them.
 
-Run `run_validation.sh` with `--cabling-descriptor-path` and `--deployment-descriptor-path` pointing to your local merged output from Step 2.
+Run `run_validation.sh` with `--cabling-descriptor-path` and `--deployment-descriptor-path` pointing to the merged outputs in `merged_output/aggregated/` from Step 2.
 
 See [Physical Validation](./README.md#physical-validation) for script usage, analysis commands, and interpreting results. For troubleshooting failures, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
 
@@ -272,7 +276,7 @@ See [Physical Validation](./README.md#physical-validation) for script usage, ana
 Once validation passes, copy the merged configuration to a shared location accessible by all cluster hosts:
 
 ```bash
-sudo cp -r merged_output/ /data/scaleout_configs/<your-config-name>/
+sudo cp -r merged_output/aggregated/ /data/scaleout_configs/<your-config-name>/
 ```
 
 **Important:** The path must be accessible on all cluster nodes (typically via NFS).


### PR DESCRIPTION
[DCAMP-510](https://tenstorrent.atlassian.net/browse/DCAMP-510)

### PR Category
Feature
### Summary
Extends `tools/scaleout/cabling_generator/merge_cluster_configs.py` from a 2-way merge into a recursive tree aggregator. Pointed at the root of a cluster config tree (e.g. `tt-cluster-configs/exabox/`), the script walks every directory and writes an `aggregated/` directory containing merged `cabling_descriptor.textproto`, `deployment_descriptor.textproto`, and `factory_system_descriptor.textproto` at each composite level.
Motivation: enable the `tt-cluster-configs` repo's publish workflow to build per-family aggregates in one pass, without operators having to chain pairwise invocations or hand-roll the topology.
**New CLI**
```bash
./merge_cluster_configs.py <source> [--output <dir>] [--build-dir ...] [--dry-run] [--keep-temp] [-v]
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/directory_merging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/directory_merging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/directory_merging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/directory_merging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/directory_merging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/directory_merging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/directory_merging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/directory_merging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/directory_merging)