### PR TITLE
[Bug fix] filter out kubernetes network interfaces in run_quad_galaxy_tests.sh

### DIFF
--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -32,7 +32,7 @@ default_mpi_tcp_interface() {
     for n in /sys/class/net/*; do
         n="${n##*/}"
         case "${n}" in
-            lo | docker* | br-* | veth* | tailscale*) continue ;;
+            lo | docker* | br-* | veth* | tailscale* | cali* | flannel*) continue ;;
         esac
         state="$(cat "/sys/class/net/${n}/operstate" 2>/dev/null || true)"
         if [[ "${state}" == "up" ]]; then


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Relates to [jira ticket](https://tenstorrent.atlassian.net/browse/MINFRA-498)
Kubernetes network interfaces were set to tt-run leading to Error in MPI_Isend. Excluding them

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtsishkouski/fix_multihost_network_interfaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtsishkouski/fix_multihost_network_interfaces)