### PR TITLE
#40182: Replace float_to_$TYPE with convert<TYPE>

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/sfpu/llk.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/sfpu/llk.rst
@@ -110,12 +110,18 @@ User Visible Data Types
 
 The following data types are visible to the programmer:
 
-  * ``vFloat``
-  * ``vInt``
-  * ``vUInt``
+  * ``vFloat``, ``vFloat16a``, ``vFloat16b`` - floating point
+  * ``vInt`` - 2's complement integer
+  * ``vUInt``, ``vUInt16``- unsigned integer
+  * ``vSMag``, ``vSMag16``- sign-magnitude integer
   * enum ``LRegs``
 
-Each of the ``v`` types is a strongly typed wrapper around the weakly typed compiler data type ``__rvtt_vec_t``. The width of this type depends on the target architecture. On Wormhole and Blackhole this is a vector of 32 32-bit values. Users should be aware that vector length may change with future architectures
+Each of the ``v`` types is a strongly typed wrapper around the weakly
+typed compiler data type ``__rvtt_vec_t``. All types have the same element
+format, but possibly with a restricted range. The width of this type
+depends on the target architecture. On Wormhole, Blackhole & Quasar this is
+a vector of 32 32-bit values. Users should be aware that vector length
+may change with future architectures.
 
 LRegs are the SFPU's general purpose vector registers.  ``LRegs`` enumerates these registers.
 
@@ -348,19 +354,16 @@ Returns the count of leading (left-most) zeros of ''v'' ignoring the sign bit.
 
 .. code-block:: c++
 
-    vFloat int32_to_float(vInt in, int round_mode = 1)
-    vUInt float_to_fp16a(vFloat in, int round_mode = 1)
-    vUInt float_to_fp16b(vFloat in, int round_mode = 1)
-    vUInt float_to_uint8(vFloat in, int round_mode = 1)
-    vUInt float_to_int8(vFloat in, int round_mode = 1)
-    vUInt int32_to_uint8(vInt in, vUInt descale, int round_mode = 1)
-    vUInt int32_to_uint8(vInt in, unsigned int descale, int round_mode = 1)
-    vUInt int32_to_int8(vInt in, vUInt descale, int round_mode = 1)
-    vUInt int32_to_int8(vInt in, unsigned int descale, int round_mode = 1)
-    vUInt float_to_uint16(vFloat in, int round_mode = 1)
-    vUInt float_to_int16(vFloat in, int round_mode = 1)
+    template<typename ToType, typename FromType>
+    ToType convert (FromType in, RoundMode rounding = RoundMode::Stochastic)
+    template<typename ToType, typename FromType>
+    ToType convert (FromType in, unsigned descale, RoundMode rounding = RoundMode::Stochastic)
 
-Returns the rounded value performing round-to-even when ''round_mode'' is 0 and stochastic rounding when ''round_mode'' is 1.
+Returns the rounded value performing round-to-even when ''rounding''
+is ''RoundMode::NearestEven'', stochastic rounding when ''rounding'' is
+''RoundMode::Stochastic'', and round-to-zero when it is
+''RoundMode::Zero'' (not available on WormHole).  Not all
+conversions are supported, and a compilation error will occur if not available.
 
 Immediate Floating Point Values
 -------------------------------

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
@@ -22,11 +22,10 @@ inline void calculate_add_rsqrt(uint32_t param0) {
         // Use the rsqrt body function (RECIPROCAL=true for rsqrt)
         sfpi::vFloat y = _calculate_sqrt_body_<APPROXIMATION_MODE, true, FAST_APPROX>(x_plus_addend);
 
-        if constexpr (fp32_dest_acc_en) {
-            sfpi::dst_reg[0] = y;
-        } else {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(y, RoundMode::NearestEven));
+        if constexpr (!fp32_dest_acc_en) {
+            y = sfpi::convert<sfpi::vFloat16b>(y, RoundMode::NearestEven);
         }
+        sfpi::dst_reg[0] = y;
         sfpi::dst_reg++;
     }
 }

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -31,12 +31,14 @@ void calculate_recip_first_column() {
     constexpr int ITERATIONS_HALF_FACE = 4;
     for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat out;
         if constexpr (DST_ACCUM_MODE) {
-            sfpi::dst_reg[0] = ckernel::sfpu::_sfpu_reciprocal_<2>(in);
+            out = ckernel::sfpu::_sfpu_reciprocal_<2>(in);
         } else {
-            sfpi::vFloat out = ckernel::sfpu::_sfpu_reciprocal_<1>(in);
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(out, sfpi::RoundMode::NearestEven);
+            out = ckernel::sfpu::_sfpu_reciprocal_<1>(in);
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
         }
+        sfpi::dst_reg[0] = out;
         sfpi::dst_reg += 2;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -88,7 +88,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        r = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
+        r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
     }
 
     r = sfpi::copysgn(r, y);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
@@ -100,7 +100,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_fmod_(sfpi::vFloat in0, sfpi::vFloat in1) 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
 
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -144,7 +144,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
 
     return y;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -154,7 +154,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
 
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -16,11 +16,9 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void cast_fp32_to_fp16a() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // vFloat val = dst_reg[0];
-        // dst_reg[0] = sfpi::float_to_fp16a(val, sfpi::RoundMode::NearestEven);
-        TTI_SFPLOAD(0, 0, 3, 0);
-        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
-        TTI_SFPSTORE(0, 1, 3, 0);
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() =
+            sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -55,17 +55,15 @@ inline void calculate_cube_root() {
             sfpi::vFloat t = c * negative_third + sfpi::vConst1;
             d = sfpi::copysgn(d, a);
             y = d * (t * t);
-
-            sfpi::dst_reg[0] = y;
         } else {
             sfpi::vFloat d = x * (y * y);
             sfpi::vFloat c = d * y;
             sfpi::vFloat t = c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0;
             d = sfpi::copysgn(d, a);
             y = d * (t * t);
-
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
         }
+        sfpi::dst_reg[0] = y;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
     return y;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -284,7 +284,7 @@ inline void calculate_gelu() {
             sfpi::vFloat in = sfpi::dst_reg[0];
             sfpi::vFloat result = calculate_gelu_piecewise(in);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;
@@ -398,7 +398,7 @@ inline void calculate_gelu_derivative_polynomial() {
         sfpi::vFloat val = sfpi::dst_reg[0];
         sfpi::vFloat result = calculate_gelu_derivative_simple<APPROXIMATION_MODE>(val);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -101,6 +101,7 @@ inline void calculate_i1() {
         // ─── Polynomial path (always; valid for |x| ≤ 10) ────────────────
         // Computed unconditionally and stored — its LRegs are then free
         // for the asymptotic block to use.
+        sfpi::vFloat val;
         {
             const sfpi::vFloat t = x * x;
 #ifdef INP_FLOAT32
@@ -129,25 +130,16 @@ inline void calculate_i1() {
             sfpi::vFloat denom =
                 PolynomialEvaluator::eval(t, sfpi::vConst1, -1.6242591070e-02f, 1.0333660750e-04f, -2.5076132990e-07f);
 #endif
-#ifdef INP_FLOAT32
-            sfpi::dst_reg[0] = numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom);
-#else
-            // SFPSTORE truncates FP32->BF16 (round-toward-zero). Explicit
-            // round-to-nearest-even halves the worst-case BF16 ULP error.
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(
-                numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom), sfpi::RoundMode::NearestEven);
-#endif
+            val = numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom);
         }
 
         // ─── Asymptotic overwrite for OOD lanes (|x| > 10) ───────────────
-        v_if(abs_x > I1_THRESHOLD) {
-#ifdef INP_FLOAT32
-            sfpi::dst_reg[0] = calculate_i1_asymptotic_(abs_x, x);
-#else
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(calculate_i1_asymptotic_(abs_x, x), sfpi::RoundMode::NearestEven);
-#endif
-        }
+        v_if(abs_x > I1_THRESHOLD) { val = calculate_i1_asymptotic_(abs_x, x); }
         v_endif;
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::NearestEven);
+#endif
+        sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -45,7 +45,7 @@ inline void calculate_lgamma_stirling() {
         // reflection adjustment for inputs < 0.5 are done in calculate_lgamma_adjusted.
 
         if constexpr (!is_fp32_dest_acc_en) {
-            res = sfpi::float_to_fp16b(res, sfpi::RoundMode::NearestEven);
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = res;
@@ -78,7 +78,7 @@ inline void calculate_lgamma_adjusted(
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         } else {
             sfpi::vInt exp = sfpi::exexp(in);
             sfpi::vInt man = sfpi::exman(in);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -68,7 +68,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     }
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
 
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -139,7 +139,7 @@ inline void calculate_log1p() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -121,7 +121,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
         sfpi::vFloat result = sum * scale;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -26,7 +26,7 @@ inline void calculate_rdiv(const uint value) {
                 recip = _sfpu_reciprocal_<2>(in);
             } else {
                 recip = _sfpu_reciprocal_<1>(in);
-                recip = sfpi::float_to_fp16b(recip, sfpi::RoundMode::NearestEven);
+                recip = sfpi::convert<sfpi::vFloat16b>(recip, sfpi::RoundMode::NearestEven);
             }
         }
         sfpi::vFloat result = recip * val;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -47,7 +47,7 @@ inline void calculate_sigmoid() {
             sfpi::vFloat val = sfpi::dst_reg[0];
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -20,7 +20,7 @@ inline void calculate_silu() {
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -126,7 +126,7 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
         // Round-to-nearest for bf16 destination (SFPSTORE defaults to truncation)
         sfpi::vFloat result = beta_reciprocal * sp;
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -149,7 +149,7 @@ inline void calculate_tanh() {
                 result = _sfpu_tanh_fp32_accurate_<is_fp32_dest_acc_en>(val);
             } else {
                 result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
-                result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -207,7 +207,7 @@ inline void calculate_tanh_derivative_sech2() {
 
         // Explicit RNE rounding for BF16 output — SFPSTORE truncates toward zero by default.
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -128,11 +128,10 @@ inline void calculate_tangent() {
 
         a = sfpu_tan<is_fp32_dest_acc_en>(a, i);
 
-        if constexpr (is_fp32_dest_acc_en) {
-            sfpi::dst_reg[0] = a;
-        } else {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(a, sfpi::RoundMode::NearestEven);
+        if constexpr (!is_fp32_dest_acc_en) {
+            a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::NearestEven);
         }
+        sfpi::dst_reg[0] = a;
         sfpi::dst_reg++;
     }
 }
@@ -197,15 +196,14 @@ inline void calculate_sine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = r;
         } else {
             r = C2 * s + C1;
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
-
+        sfpi::dst_reg[0] = r;
         sfpi::dst_reg++;
     }
 }
@@ -277,21 +275,21 @@ inline void calculate_cosine() {
         sfpi::vFloat s = a * a;
         a = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) ^ q);
 
+        sfpi::vFloat r;
         if constexpr (is_fp32_dest_acc_en) {
-            sfpi::vFloat r = C3 * s + C2;
+            r = C3 * s + C2;
             r = r * s + C1;
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = r;
         } else {
-            sfpi::vFloat r = C2 * s + C1;
+            r = C2 * s + C1;
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
-
+        sfpi::dst_reg[0] = r;
         sfpi::dst_reg++;
     }
 }
@@ -357,7 +355,7 @@ inline void calculate_atan() {
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;
@@ -436,7 +434,7 @@ inline void calculate_asin_acos_impl() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -150,7 +150,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
     // rather than 81 (which would have been correct).
     // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-    y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+    y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
 
     return y;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -93,7 +93,7 @@ template <bool is_fp32_dest_acc_en>
 sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloat addend) {
     sfpi::vFloat result = mul_a * mul_b + addend;
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
     sfpi::dst_reg[0] = result;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -88,7 +88,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        r = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
+        r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
     }
 
     r = sfpi::copysgn(r, y);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
@@ -106,7 +106,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_fmod_(sfpi::vFloat in0, sfpi::vFloat in1) 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -144,7 +144,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
 
     return y;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -207,7 +207,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -20,7 +20,6 @@ inline void cast_fp32_to_fp16a() {
         sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() =
             sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
         sfpi::dst_reg++;
-        dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -16,11 +16,10 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void cast_fp32_to_fp16a() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // vFloat val = dst_reg[0];
-        // dst_reg[0] = sfpi::float_to_fp16a(val, sfpi::RoundMode::NearestEven);
-        TTI_SFPLOAD(0, 0, 3, 0);
-        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
-        TTI_SFPSTORE(0, 1, 3, 0);
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() =
+            sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        sfpi::dst_reg++;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -55,17 +55,15 @@ inline void calculate_cube_root() {
             sfpi::vFloat t = c * negative_third + sfpi::vConst1;
             d = sfpi::copysgn(d, a);
             y = d * (t * t);
-
-            sfpi::dst_reg[0] = y;
         } else {
             sfpi::vFloat d = x * (y * y);
             sfpi::vFloat c = d * y;
             sfpi::vFloat t = c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0;
             d = sfpi::copysgn(d, a);
             y = d * (t * t);
-
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
         }
+        sfpi::dst_reg[0] = y;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
     return y;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -284,7 +284,7 @@ inline void calculate_gelu() {
             sfpi::vFloat in = sfpi::dst_reg[0];
             sfpi::vFloat result = calculate_gelu_piecewise(in);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;
@@ -398,7 +398,7 @@ inline void calculate_gelu_derivative_polynomial() {
         sfpi::vFloat val = sfpi::dst_reg[0];
         sfpi::vFloat result = calculate_gelu_derivative_simple<APPROXIMATION_MODE>(val);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -98,6 +98,7 @@ inline void calculate_i1() {
 
         const sfpi::vFloat abs_x = sfpi::setsgn(x, 0);
 
+        sfpi::vFloat val;
         // ─── Polynomial path (always; valid for |x| ≤ 10) ────────────────
         // Computed unconditionally and stored — its LRegs are then free
         // for the asymptotic block to use.
@@ -129,26 +130,16 @@ inline void calculate_i1() {
             sfpi::vFloat denom =
                 PolynomialEvaluator::eval(t, sfpi::vConst1, -1.6242591070e-02f, 1.0333660750e-04f, -2.5076132990e-07f);
 #endif
-#ifdef INP_FLOAT32
-            sfpi::dst_reg[0] = numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom);
-#else
-            // SFPSTORE truncates FP32->BF16 (round-toward-zero). Explicit
-            // round-to-nearest-even halves the worst-case BF16 ULP error.
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(
-                numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom), sfpi::RoundMode::NearestEven);
-#endif
+            val = numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom);
         }
 
         // ─── Asymptotic overwrite for OOD lanes (|x| > 10) ───────────────
-        v_if(abs_x > I1_THRESHOLD) {
-#ifdef INP_FLOAT32
-            sfpi::dst_reg[0] = calculate_i1_asymptotic_(abs_x, x);
-#else
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(calculate_i1_asymptotic_(abs_x, x), sfpi::RoundMode::NearestEven);
-#endif
-        }
+        v_if(abs_x > I1_THRESHOLD) { val = calculate_i1_asymptotic_(abs_x, x); }
         v_endif;
-
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::NearestEven);
+#endif
+        sfpi::dst_reg[0] = val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -45,7 +45,7 @@ inline void calculate_lgamma_stirling() {
         // reflection adjustment for inputs < 0.5 are done in calculate_lgamma_adjusted.
 
         if constexpr (!is_fp32_dest_acc_en) {
-            res = sfpi::float_to_fp16b(res, sfpi::RoundMode::NearestEven);
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
@@ -148,7 +148,7 @@ inline void calculate_lgamma_adjusted(
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         } else {
             sfpi::vInt exp = sfpi::exexp(in);
             sfpi::vInt man = sfpi::exman(in);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -68,7 +68,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     }
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -139,7 +139,7 @@ inline void calculate_log1p() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -121,7 +121,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
         sfpi::vFloat result = sum * scale;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -26,7 +26,7 @@ inline void calculate_rdiv(const uint value) {
                 recip = _sfpu_reciprocal_<2>(in);
             } else {
                 recip = _sfpu_reciprocal_<1>(in);
-                recip = sfpi::float_to_fp16b(recip, sfpi::RoundMode::NearestEven);
+                recip = sfpi::convert<sfpi::vFloat16b>(recip, sfpi::RoundMode::NearestEven);
             }
         }
         sfpi::vFloat result = recip * val;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -49,7 +49,7 @@ inline void calculate_sigmoid() {
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
 
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -20,7 +20,7 @@ inline void calculate_silu() {
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -126,7 +126,7 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
         // Round-to-nearest for bf16 destination (SFPSTORE defaults to truncation)
         sfpi::vFloat result = beta_reciprocal * sp;
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -147,7 +147,7 @@ inline void calculate_tanh() {
                 result = _sfpu_tanh_fp32_accurate_<is_fp32_dest_acc_en>(val);
             } else {
                 result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
-                result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -207,7 +207,7 @@ inline void calculate_tanh_derivative_sech2() {
 
         // Explicit RNE rounding for BF16 output — SFPSTORE truncates toward zero by default.
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -148,11 +148,10 @@ inline void calculate_tangent() {
 
         a = sfpu_tan<is_fp32_dest_acc_en>(a, i);
 
-        if constexpr (is_fp32_dest_acc_en) {
-            sfpi::dst_reg[0] = a;
-        } else {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(a, sfpi::RoundMode::NearestEven);
+        if constexpr (!is_fp32_dest_acc_en) {
+            a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::NearestEven);
         }
+        sfpi::dst_reg[0] = a;
         sfpi::dst_reg++;
     }
 }
@@ -217,15 +216,14 @@ inline void calculate_sine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = r;
         } else {
             r = C2 * s + C1;
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
-
+        sfpi::dst_reg[0] = r;
         sfpi::dst_reg++;
     }
 }
@@ -297,21 +295,22 @@ inline void calculate_cosine() {
         sfpi::vFloat s = a * a;
         a = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) ^ q);
 
+        sfpi::vFloat r;
         if constexpr (is_fp32_dest_acc_en) {
-            sfpi::vFloat r = C3 * s + C2;
+            r = C3 * s + C2;
             r = r * s + C1;
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = r;
         } else {
-            sfpi::vFloat r = C2 * s + C1;
+            r = C2 * s + C1;
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
 
+        sfpi::dst_reg[0] = r;
         sfpi::dst_reg++;
     }
 }
@@ -377,7 +376,7 @@ inline void calculate_atan() {
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;
@@ -456,7 +455,7 @@ inline void calculate_asin_acos_impl() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -152,7 +152,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
     // rather than 81 (which would have been correct).
     // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-    y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+    y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
 
     return y;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -90,7 +90,7 @@ template <bool is_fp32_dest_acc_en>
 sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloat addend) {
     sfpi::vFloat result = mul_a * mul_b + addend;
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
     sfpi::dst_reg[0] = result;
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -19,11 +19,8 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        // sfpi::vFloat val = sfpi::dst_reg[0];
-        // sfpi::dst_reg[0] = sfpi::float_to_fp16a(val, sfpi::RoundMode::NearestEven);
-        TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
-        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
-        TTI_SFPSTORE(0, 1, ADDR_MOD_7, 0);
+        sfpi::vFloat x   = sfpi::dst_reg[0];
+        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_celu.h
@@ -35,7 +35,7 @@ inline void _calculate_celu_(std::uint32_t param0, std::uint32_t param1)
 
         if constexpr (!is_fp32_dest_acc_en)
         {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -32,7 +32,7 @@ inline void _calculate_elu_(std::uint32_t slope)
 
         if constexpr (!is_fp32_dest_acc_en)
         {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -77,7 +77,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_unsafe_(sfpi::vFloat val)
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
 
     return y;
@@ -145,7 +145,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
 
     return y;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -30,7 +30,7 @@ inline void _calculate_exp2_()
         else
         {
             result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -180,7 +180,7 @@ sfpi_inline void _calculate_stochastic_round_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::float_to_fp16b(x, sfpi::RoundMode::Stochastic);
+        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -110,14 +110,11 @@ inline void _calculate_rsqrt_compat_(const int iterations)
             out = -out;
         }
         v_endif;
-        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
+        if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            sfpi::dst_reg[0] = out;
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
         }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(out, sfpi::RoundMode::NearestEven);
-        }
+        sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;
     }
 }
@@ -146,14 +143,11 @@ inline void _calculate_reciprocal_compat_(const int iterations)
             out = -out;
         }
         v_endif;
-        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
+        if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            sfpi::dst_reg[0] = out;
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
         }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(out, sfpi::RoundMode::NearestEven);
-        }
+        sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_selu.h
@@ -36,7 +36,7 @@ inline void _calculate_selu_(std::uint32_t scale, std::uint32_t alpha)
 
         if constexpr (!is_fp32_dest_acc_en)
         {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -120,14 +120,11 @@ inline void _calculate_sqrt_internal_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL, FAST_APPROX>(sfpi::dst_reg[0]);
-        if constexpr (fp32_dest_acc_en)
+        if constexpr (!fp32_dest_acc_en)
         {
-            sfpi::dst_reg[0] = tmp;
+            tmp = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
         }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(tmp, sfpi::RoundMode::NearestEven);
-        }
+        sfpi::dst_reg[0] = tmp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -214,7 +214,7 @@ inline void _calculate_atanh_()
             }
             else
             {
-                den = sfpi::float_to_fp16b(tmp, sfpi::RoundMode::NearestEven);
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
             }
             num              = num * den;
             den              = _calculate_log_body_no_init_(num);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -18,11 +18,8 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        // sfpi::vFloat val = sfpi::dst_reg[0];
-        // sfpi::dst_reg[0] = sfpi::float_to_fp16a(val, sfpi::RoundMode::NearestEven);
-        TTI_SFPLOAD(0, 0, 3, 0);
-        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
-        TTI_SFPSTORE(0, 1, 3, 0);
+        sfpi::vFloat x   = sfpi::dst_reg[0];
+        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_celu.h
@@ -35,7 +35,7 @@ inline void _calculate_celu_(std::uint32_t param0, std::uint32_t param1)
 
         if constexpr (!is_fp32_dest_acc_en)
         {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -32,7 +32,7 @@ inline void _calculate_elu_(std::uint32_t slope)
 
         if constexpr (!is_fp32_dest_acc_en)
         {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -76,7 +76,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_unsafe_(sfpi::vFloat val)
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
 
     return y;
@@ -144,7 +144,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven);
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
     }
 
     return y;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -30,7 +30,7 @@ inline void _calculate_exp2_()
         else
         {
             result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -82,25 +82,23 @@ inline void _calculate_reciprocal_internal_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat out;
 
         if constexpr (APPROXIMATION_MODE)
         {
-            sfpi::dst_reg[0] = _sfpu_reciprocal_<0>(in);
+            out = _sfpu_reciprocal_<0>(in);
+        }
+        else if constexpr (is_fp32_dest_acc_en)
+        {
+            out = _sfpu_reciprocal_<2>(in);
         }
         else
         {
-            if constexpr (is_fp32_dest_acc_en)
-            {
-                sfpi::dst_reg[0] = _sfpu_reciprocal_<2>(in);
+            out = _sfpu_reciprocal_<1>(in);
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
             }
-            else
-            {
-                sfpi::vFloat out = _sfpu_reciprocal_<1>(in);
-                sfpi::dst_reg[0] = sfpi::float_to_fp16b(out, sfpi::RoundMode::NearestEven);
-            }
-        }
-
-        sfpi::dst_reg++;
+            sfpi::dst_reg[0] = out;
+            sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -188,7 +188,7 @@ sfpi_inline void _calculate_stochastic_round_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::float_to_fp16b(x, sfpi::RoundMode::Stochastic);
+        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -110,14 +110,11 @@ inline void _calculate_rsqrt_compat_(const int iterations)
             out = -out;
         }
         v_endif;
-        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
+        if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            sfpi::dst_reg[0] = out;
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
         }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(out, sfpi::RoundMode::NearestEven);
-        }
+        sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;
     }
 }
@@ -146,14 +143,11 @@ inline void _calculate_reciprocal_compat_(const int iterations)
             out = -out;
         }
         v_endif;
-        if constexpr (fp32_dest_acc_en || APPROXIMATION_MODE)
+        if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            sfpi::dst_reg[0] = out;
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
         }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(out, sfpi::RoundMode::NearestEven);
-        }
+        sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_selu.h
@@ -36,7 +36,7 @@ inline void _calculate_selu_(std::uint32_t scale, std::uint32_t alpha)
 
         if constexpr (!is_fp32_dest_acc_en)
         {
-            result = sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -119,14 +119,11 @@ inline void _calculate_sqrt_internal_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat tmp = _calculate_sqrt_body_<APPROXIMATION_MODE, RECIPROCAL, FAST_APPROX>(sfpi::dst_reg[0]);
-        if constexpr (fp32_dest_acc_en)
+        if constexpr (!fp32_dest_acc_en)
         {
-            sfpi::dst_reg[0] = tmp;
+            tmp = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
         }
-        else
-        {
-            sfpi::dst_reg[0] = sfpi::float_to_fp16b(tmp, sfpi::RoundMode::NearestEven);
-        }
+        sfpi::dst_reg[0] = tmp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -214,7 +214,7 @@ inline void _calculate_atanh_()
             }
             else
             {
-                den = sfpi::float_to_fp16b(tmp, sfpi::RoundMode::NearestEven);
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
             }
             num              = num * den;
             den              = _calculate_log_body_no_init_(num);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -101,7 +101,7 @@ inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, c
 
         // Round to bf16 if not in fp32 dest accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, RoundMode::NearestEven));
+            result = sfpi::convert<sfpi::vFloat16b>(result, RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[out_tile_idx * dst_tile_size] = result;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -234,28 +234,26 @@ void calculate_recip_first_column() {
             //     out = -out;
             // }
             // v_endif;
-            if constexpr (DST_ACCUM_MODE || APPROX) {
-                sfpi::dst_reg[0] = out;
-            } else {
-                sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, RoundMode::NearestEven));
+            if constexpr (!(DST_ACCUM_MODE || APPROX)) {
+                out = sfpi::convert<sfpi::vFloat16b>(out, RoundMode::NearestEven);
             }
+            sfpi::dst_reg[0] = out;
             sfpi::dst_reg += 2;
         }
     } else {
         for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
             sfpi::vFloat in = sfpi::dst_reg[0];
+            sfpi::vFloat out;
 
             if constexpr (APPROX) {
-                sfpi::dst_reg[0] = ckernel::sfpu::_sfpu_reciprocal_<0>(in);
+                out = ckernel::sfpu::_sfpu_reciprocal_<0>(in);
+            } else if constexpr (DST_ACCUM_MODE) {
+                out = ckernel::sfpu::_sfpu_reciprocal_<2>(in);
             } else {
-                if constexpr (DST_ACCUM_MODE) {
-                    sfpi::dst_reg[0] = ckernel::sfpu::_sfpu_reciprocal_<2>(in);
-                } else {
-                    sfpi::vFloat out = ckernel::sfpu::_sfpu_reciprocal_<1>(in);
-                    sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, RoundMode::NearestEven));
-                }
+                out = ckernel::sfpu::_sfpu_reciprocal_<1>(in);
+                out = sfpi::convert<sfpi::vFloat16b>(out, RoundMode::NearestEven);
             }
-
+            sfpi::dst_reg[0] = out;
             sfpi::dst_reg += 2;
         }
     }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
SFPI 7.49.0  added 
* a sign-magnitude vector type, a magnitude-only type and various narrow vector types (such as vFloat16b).  
* implemented `convert<TYPE> (from, RoundMode = Stochastic)` and `convert<TYPE> (from, unsigned descale, RoundMode = Stochastic` conversion functions to replace the various `float32_to_FOO` and `int32_to_FOO` functions.

This patch changes all the `float32_to_FOO` calls to use the new API.  Mostly done with `sed`.  I took the opportunity to clean up some of the kernels by replacing `TTI_FOO` macros with sfpi, and simplifying some constexpr flows.

Once this is in, I will deprecate the old API.

Conversion of the `int32_to_FOO` calls remains

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/short3-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/short3-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/short3-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/short3-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/short3-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/short3-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/short3-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/short3-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/short3-40182)