### PR TITLE
[Bug fix] Fix mamba 1D depthwise conv

### DIFF
--- a/docs/conv1d_depthwise_coalesced_reads_plan.md
+++ b/docs/conv1d_depthwise_coalesced_reads_plan.md
@@ -1,0 +1,469 @@
+# Plan: Re-enable Coalesced Reads for 1D Depthwise Conv
+
+## Context
+
+Commit `d9ab05166a78ae96cd707213ccbe6ae498ec9e2b` fixed `conv1d`
+depthwise `kernel_width > 1` by changing the 1D depthwise path from a
+single full-window activation block to one activation block per kernel tap.
+That made Mamba-sized cases legal because each read moves one channel stick,
+even when the full `stick_size * kernel_width` would exceed the NOC burst
+limit.
+
+The reader-side consequence is in
+`ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp`:
+
+```cpp
+constexpr uint32_t num_coalesced_reads = 1;
+constexpr uint32_t coalesced_read_bytes = num_coalesced_reads * conv_act_c_read_bytes;
+```
+
+Before `d9ab051`, this was effectively:
+
+```cpp
+constexpr uint32_t num_coalesced_reads = weight_size_w;
+constexpr uint32_t coalesced_read_bytes = num_coalesced_reads * conv_act_c_read_bytes;
+```
+
+Re-enabling coalescing is useful when the full kernel-width window fits in a
+single NOC burst:
+
+```cpp
+stick_size * kernel_width <= noc_max_burst_size
+```
+
+where `stick_size == conv_act_c_read_bytes`.
+
+## Important Invariant
+
+For the current 1D depthwise route, `filter_h == 1` is always true.
+`is_1d_depthwise_conv(...)` routes through `is_1d_conv(kernel_height,
+image_height)`, and `is_1d_conv` requires `kernel_height == 1` and
+`image_height == 1`.
+
+Therefore, this plan does not need a `filter_h == 1` eligibility check for
+this specific path. The relevant kernel-window dimension is `filter_w`
+(`kernel_width`).
+
+## Goal
+
+Add a dual-path implementation:
+
+1. Use the existing per-tap path for large sticks or non-coalescable cases.
+2. Use a restored coalesced kernel-width path when:
+   - the op is 1D depthwise,
+   - `dilation_w == 1`,
+   - `conv_act_c_read_bytes * filter_w <= NOC_MAX_BURST_SIZE`,
+   - the activation/weight/compute contracts are all configured for a
+     full-kernel-width activation block.
+
+The coalesced path should read all `kernel_width` contiguous sticks for one
+output position with a single stateful NOC read.
+
+## Current Contract After `d9ab051`
+
+Host blocking:
+
+- `num_blocks_act_w = filter_h * filter_w`, which collapses to `filter_w`
+  because `filter_h == 1`.
+- `window_outer = num_blocks_act_w = filter_w`.
+- `window_inner = filter_h * filter_w / num_blocks_act_w = 1`.
+
+Reader:
+
+- Produces one ACT CB block per kernel tap.
+- Reads one stick per output position.
+- Advances `reader_offset_idx` by `window_inner`, so by `1` per tap.
+
+Weight layout:
+
+- Depthwise weight preparation stacks one slab per kernel tap.
+- Each weight block has height `act_block_h_ntiles`, not
+  `act_block_h_ntiles * filter_w`.
+- The weights CB holds one tap at a time.
+
+Compute:
+
+- `compute_depthwise_conv1d.cpp` loops over `in0_num_blocks_w == filter_w`.
+- Each iteration consumes one activation tap block and one weight tap block.
+- It accumulates tap products through dest reuse and `out_cb`.
+
+This contract is correct for Mamba-sized cases where
+`conv_act_c_read_bytes * filter_w` can exceed the NOC burst limit.
+
+## Target Coalesced Contract
+
+For the eligible coalesced mode:
+
+- `num_blocks_act_w = 1`.
+- `window_outer = 1`.
+- `window_inner = filter_w`.
+- Reader produces one ACT CB block containing all `filter_w` contiguous sticks
+  for each output position.
+- `coalesced_read_bytes = filter_w * conv_act_c_read_bytes`.
+- Compute consumes one full-window activation block per output tile and
+  multiplies/adds across the `filter_w` taps inside that block.
+- Weight layout presents the corresponding `filter_w` tap weights in the same
+  inner-dimension order as the activation block.
+
+The existing per-tap mode remains the fallback and should stay behaviorally
+unchanged.
+
+## Eligibility and Host Flag
+
+Add a host-side boolean near the existing sharded factory setup.
+
+```cpp
+const uint32_t noc_max_burst_size = get_conv_noc_max_burst_size(tt::tt_metal::hal::get_arch());
+const bool coalesce_1d_depthwise_kw_reads =
+    is_conv_1d_depthwise_conv &&
+    dilation_w == 1 &&
+    input_tensor_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
+    conv_act_c_read_bytes * filter_w <= noc_max_burst_size;
+```
+
+The `is_conv_1d_depthwise_conv` condition implies `filter_h == 1`, so no
+separate `filter_h` condition is needed.
+
+Device kernels already use `NOC_MAX_BURST_SIZE`. Until there is an existing
+shared host accessor for the same value, keep the host-side architecture split
+local to conv so this change does not broaden into HAL or unrelated operation
+owners.
+
+Prefer computing this after `conv_act_c_read_bytes` is known, since that is the
+actual stick size used by the reader.
+
+The kernel must still use compile-time constants, so pass the mode as a compile
+time argument or derive it from host-selected compile-time values. The cleanest
+approach is a new reader/compute compile-time argument:
+
+```cpp
+coalesce_1d_depthwise_kw_reads ? 1 : 0
+```
+
+## Implementation Steps
+
+### 1. Host Blocking
+
+File:
+
+- `ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp`
+
+Change the 1D depthwise `num_blocks_act_w` selection from one unconditional
+per-tap mode to a dual mode:
+
+```cpp
+const uint32_t num_blocks_act_w =
+    is_conv_1d_depthwise_conv
+        ? (coalesce_1d_depthwise_kw_reads ? 1 : filter_w)
+        : (slice_inner_dim ? filter_h : 1);
+```
+
+Because `filter_h == 1`, this is equivalent to choosing between:
+
+- coalesced: one full `filter_w` activation block,
+- fallback: one activation block per tap.
+
+Then `window_inner = filter_h * filter_w / num_blocks_act_w` naturally becomes:
+
+- `filter_w` in coalesced mode,
+- `1` in fallback mode.
+
+### 2. ACT CB Sizing
+
+Files:
+
+- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp`
+- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp`
+
+Current 1D depthwise ACT block width intentionally excludes `kernel_width`:
+
+```cpp
+act_block_w = round_up(padded_in_channels, TILE_WIDTH);
+```
+
+For coalesced mode, ACT block width must include `filter_w`:
+
+```cpp
+act_block_w = round_up(padded_in_channels * filter_w, TILE_WIDTH);
+```
+
+This likely means `determine_per_core_conv_block_config(...)` needs either:
+
+- a new `coalesce_1d_depthwise_kw_reads` parameter, or
+- a more general "1D depthwise full-window act block" parameter.
+
+The fallback path must keep the current single-stick ACT block width.
+
+### 3. Padding and `act_block_w_extra_align_bytes`
+
+File:
+
+- `ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp`
+
+Verify and adjust `act_block_w_extra_align_bytes`.
+
+In coalesced mode, the ACT block contains `shard_shape[1] * filter_w` scalars.
+In fallback mode, it contains one stick. The current expression is tied to
+`slice_inner_dim`, not to the new 1D depthwise mode. Make this explicit:
+
+```cpp
+if (is_conv_1d_depthwise_conv) {
+    const uint32_t scalars =
+        coalesce_1d_depthwise_kw_reads ? shard_shape[1] * filter_w : shard_shape[1];
+    act_block_w_extra_align_bytes =
+        (round_up(scalars, TILE_WIDTH) - scalars) * a.element_size();
+} else {
+    ...
+}
+```
+
+This keeps the reader write pointer increments consistent with the ACT block
+layout in both modes.
+
+### 4. Reader Kernel
+
+File:
+
+- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp`
+
+Add a compile-time mode flag and restore coalescing only when the host selected
+the coalesced contract:
+
+```cpp
+constexpr bool coalesce_kw_reads = get_compile_time_arg_val(... ) == 1;
+constexpr uint32_t num_coalesced_reads =
+    coalesce_kw_reads ? weight_size_w : 1;
+constexpr uint32_t coalesced_read_bytes =
+    num_coalesced_reads * conv_act_c_read_bytes;
+
+static_assert(!coalesce_kw_reads || coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
+```
+
+The loop structure can remain mostly as-is if host blocking is correct:
+
+- coalesced mode: `window_outer == 1`, `window_inner == weight_size_w`.
+- fallback mode: `window_outer == weight_size_w`, `window_inner == 1`.
+
+For coalesced mode, `reader_offsets[reader_offset_idx]` should point at the
+first tap, and the single read covers the contiguous kernel-width sticks.
+
+Keep `dilation_w == 1` as a host eligibility requirement. Dilation breaks the
+contiguous-read assumption.
+
+### 5. Weight Preparation and Weight CB Sizing
+
+Files:
+
+- `ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp`
+- `ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp`
+- `ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp`
+
+Fallback mode should keep the current `d9ab051` behavior:
+
+- one tap slab per weight block,
+- `weight_block_h_ntiles = act_block_h_ntiles`,
+- weight CB only needs one tap at a time.
+
+Coalesced mode needs the old full-window inner dimension:
+
+- `weight_block_h_ntiles = act_block_h_ntiles * filter_w`,
+- weights CB must hold the full kernel-width block,
+- weight conversion/tiled layout must emit weights in the same inner order as
+  the coalesced activation block.
+
+There are two viable approaches:
+
+1. Restore the pre-`d9ab051` depthwise weight layout for coalesced mode only.
+2. Keep the post-`d9ab051` prepared shape, but modify compute indexing so it
+   consumes the per-tap slabs from one logical full-window block.
+
+Approach 1 is simpler to reason about because it restores a matching full
+inner-dimension activation/weight contract for the coalesced path. Approach 2
+may reduce conversion churn but makes compute indexing more delicate.
+
+### 6. Compute Kernel
+
+File:
+
+- `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp`
+
+Keep the current per-tap compute path as the fallback.
+
+Add a coalesced path that consumes a full kernel-width activation block and the
+matching full-window weight block. The path needs to:
+
+1. Tilize a wider activation block whose inner width is
+   `act_block_w_ntiles == padded_channels * filter_w / TILE_WIDTH`.
+2. For each output tile, perform `filter_w` elementwise muls against the
+   corresponding tap weights.
+3. Accumulate the `filter_w` products with FPU add.
+4. Pack once to `out_cb`.
+
+The current dest-reuse accumulation pattern should be preserved where possible
+because it was introduced to avoid block-float output corruption from
+pack-format round trips.
+
+Required compile-time data:
+
+- mode flag,
+- `filter_w`,
+- full-window `in0_block_w`,
+- possibly `core_in_channels_ntiles` or equivalent stride information for
+  stepping from one tap slice to the next inside the tilized activation block.
+
+### 7. Program Factory Args
+
+Files:
+
+- `ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp`
+
+Reader compile-time args:
+
+- Add `coalesce_1d_depthwise_kw_reads` at the end to avoid shifting existing
+  indexes used by other kernels, then read it by the new index in
+  `reader_depthwise_conv1d.cpp`.
+
+Compute compile-time args:
+
+- Add a depthwise-specific mode flag and `filter_w`.
+- If needed, add the per-tap tile stride inside the coalesced activation block.
+
+Keep the non-depthwise compute arg list untouched.
+
+### 8. Guardrails
+
+Add host assertions for coalesced mode:
+
+```cpp
+TT_FATAL(dilation_w == 1, "Coalesced 1D depthwise reads require dilation_w == 1");
+TT_FATAL(
+    conv_act_c_read_bytes * filter_w <= noc_max_burst_size,
+    "Coalesced 1D depthwise read size exceeds NOC burst size");
+```
+
+Do not reject the op if the guard fails. Instead, select fallback mode.
+The assertions are only sanity checks after the mode has been selected.
+
+Also consider a debug log:
+
+```cpp
+log_debug(
+    tt::LogOp,
+    "1D depthwise conv coalesced kw reads: {}, stick bytes: {}, filter_w: {}",
+    coalesce_1d_depthwise_kw_reads,
+    conv_act_c_read_bytes,
+    filter_w);
+```
+
+## Test Plan
+
+### Unit Tests
+
+Extend:
+
+- `tests/ttnn/unit_tests/operations/conv/test_conv1d_depthwise_kw_gt_1.py`
+
+Add small-stick cases that should select coalescing:
+
+- channels small enough that
+  `channels * element_size * kernel_width <= noc_max_burst_size`,
+- `kernel_size` values 2, 3, 4,
+- `HEIGHT_SHARDED`,
+- `weights_dtype=ttnn.bfloat8_b`,
+- output dtype `ttnn.bfloat8_b`,
+- output dtype `ttnn.bfloat16` if coverage is cheap.
+
+Keep existing large-stick Mamba cases:
+
+- `input_channels=2560`,
+- `kernel_size=2,3,4`,
+- expected fallback mode.
+
+### Mode Coverage
+
+Add a way to confirm mode selection. Options:
+
+1. Add a debug log and run with conv logging enabled.
+2. Add a narrow test-only hook if this repo has precedent for reporting
+   selected kernel compile-time args.
+3. Use kernel cache/build artifacts to inspect compile-time args, if already
+   available in local workflows.
+
+At minimum, test shapes should be chosen so one group can only be coalesced and
+one group can only be fallback.
+
+### Correctness Matrix
+
+Run:
+
+- `kernel_size = 1`: must still work and should behave equivalently in both
+  contracts.
+- `kernel_size = 2, 3, 4`: coalesced small-stick cases.
+- `kernel_size = 2, 3, 4`: fallback large-stick cases.
+- `stride = 1` and any currently supported non-1 stride cases.
+- `dilation_w = 1`: coalesced eligible.
+- `dilation_w > 1`: must force fallback or be rejected if the broader op does
+  not support it.
+
+### Performance Checks
+
+For small-stick eligible cases, compare against the current fallback path:
+
+- total kernel runtime,
+- reader NOC read count if profiling provides it,
+- end-to-end conv latency.
+
+Expected result: fewer reader transactions for `kernel_width > 1`.
+
+### Regression Sweeps
+
+Run the existing relevant sweeps after implementation:
+
+- conv1d depthwise tests,
+- conv2d sweep subset that exercises height-sharded conv,
+- Mamba depthwise conv repro cases.
+
+## Risks
+
+1. Weight/activation ordering mismatch.
+   The coalesced activation block and full-window weight block must agree on
+   tap order. This is the most likely correctness risk.
+
+2. ACT CB sizing mismatch.
+   If `act_block_w_ntiles` remains single-stick while the reader writes
+   `filter_w` sticks, the reader will overwrite beyond the intended block.
+
+3. Compute data-format reconfiguration.
+   The current compute kernel carefully restores srcA/srcB formats for
+   block-float weights/output. The coalesced path must preserve those
+   guarantees.
+
+4. NOC burst size portability.
+   Host selection must match device kernel `NOC_MAX_BURST_SIZE`. Do not
+   duplicate per-arch constants outside the conv implementation unless a shared
+   host accessor already exists.
+
+5. `kernel_size == 1` behavior.
+   This should remain effectively unchanged. It is a good first test because
+   coalesced and fallback modes collapse to the same read size.
+
+## Suggested Milestones
+
+1. Add host-side burst-size selection local to conv.
+2. Add mode selection and logging only, no behavior change.
+3. Thread the mode through reader and compute compile-time args.
+4. Implement reader coalescing with host-selected `num_blocks_act_w`.
+5. Implement ACT CB sizing and padding for coalesced mode.
+6. Implement weight full-window layout for coalesced mode.
+7. Implement compute coalesced mode.
+8. Add tests that force both paths.
+9. Run correctness and performance validation.
+
+## Acceptance Criteria
+
+- Existing Mamba-shaped tests still pass and use fallback mode.
+- New small-stick `kernel_width > 1` tests pass and use coalesced mode.
+- Coalesced mode never builds when `stick_size * kernel_width` exceeds
+  `NOC_MAX_BURST_SIZE`.
+- `kernel_width == 1` remains correct.
+- No behavior changes for non-depthwise conv paths.

--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d_depthwise_kw_gt_1.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d_depthwise_kw_gt_1.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Repro for the Mamba conv regression introduced by commit dadf6a7bf0
+# ("change depthwise condition") and tracked in issue #42163.
+#
+# Mamba's mixer.conv1d is a depthwise 1D conv with kernel_size=4, kernel_height=1.
+# These cases cover both paths in the specialized 1D depthwise factory:
+# - 2560 channels: stick_bytes * kernel_w exceeds WH NOC burst, so reads stay per tap.
+# - 512 channels: stick_bytes * kernel_w fits, so the kernel-width sticks are coalesced.
+
+import pytest
+import torch
+import ttnn
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "input_channels, input_length, kernel_size",
+    [
+        (512, 257, 2),
+        (512, 257, 3),
+        (512, 257, 4),
+        (2560, 1027, 2),
+        (2560, 1027, 3),
+        (2560, 1027, 4),  # mamba 2.8B per-split shape
+    ],
+)
+def test_depthwise_conv1d_kw_gt_1_height_sharded(device, input_channels, input_length, kernel_size):
+    torch.manual_seed(0)
+    batch_size = 1
+    output_channels = input_channels
+    groups = input_channels  # depthwise
+
+    torch_input_ncl = torch.randn([batch_size, input_channels, input_length], dtype=torch.bfloat16).float()
+    torch_input_nlc = torch_input_ncl.permute(0, 2, 1)
+    torch_weight = torch.randn([output_channels, 1, kernel_size], dtype=torch.bfloat16).float()
+    torch_golden = torch.nn.functional.conv1d(torch_input_ncl, torch_weight, groups=groups)
+
+    tt_input = ttnn.from_torch(torch_input_nlc, ttnn.bfloat16)
+    tt_weight = ttnn.from_torch(torch_weight, ttnn.float32)  # bfloat8_b weights are converted from float32
+
+    conv_config = ttnn.Conv1dConfig(
+        weights_dtype=ttnn.bfloat8_b,
+        shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        deallocate_activation=True,
+    )
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+    )
+
+    # On main, the kernel build itself fails with:
+    #   reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp:79:
+    #   static_assertion failed (20480 <= 8192)
+    [tt_out_dev, out_length, _] = ttnn.conv1d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        in_channels=input_channels,
+        out_channels=output_channels,
+        device=device,
+        bias_tensor=None,
+        kernel_size=kernel_size,
+        stride=1,
+        padding=0,
+        batch_size=batch_size,
+        input_length=input_length,
+        dtype=ttnn.bfloat8_b,
+        conv_config=conv_config,
+        compute_config=compute_config,
+        groups=groups,
+        return_output_dim=True,
+        return_weights_and_bias=True,
+    )
+
+    tt_out = ttnn.to_torch(ttnn.from_device(tt_out_dev))
+    tt_out = tt_out.reshape(batch_size, out_length, output_channels).permute(0, 2, 1)
+
+    from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
+    from loguru import logger
+
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(tt_out, torch_golden, pcc=0.99)
+    logger.info(f"kernel_size={kernel_size} PCC={pcc_msg}")
+    assert passing, pcc_msg

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -160,6 +160,13 @@ Result conv2d_L1(
 
     const bool conv_is_1d_depthwise = is_1d_depthwise_conv(
         groups, in_channels, out_channels, kernel_size[0], kernel_size[1], input_height, bias_tensor.has_value());
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        conv_is_1d_depthwise,
+        parallel_config.shard_scheme,
+        in_channels_padded,
+        kernel_size[1],
+        dilation[1],
+        input_tensor_post_tm.dtype());
 
     auto [opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config] = get_conv_configs(
         conv_config,
@@ -173,7 +180,8 @@ Result conv2d_L1(
         output_width,
         kernel_size,
         compute_grid_size,
-        conv_is_1d_depthwise);
+        conv_is_1d_depthwise,
+        coalesce_1d_depthwise_kw_reads);
 
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
@@ -196,6 +204,7 @@ Result conv2d_L1(
         conv_config.enable_kernel_stride_folding.value(),
         conv_config.full_inner_dim,
         conv_config.enable_activation_reuse,
+        coalesce_1d_depthwise_kw_reads,
         orig_stride);
 
     // Prepare weights and move to device if necessary

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -22,6 +22,7 @@ namespace ttnn::prim {
 
 using ttnn::operations::conv::conv_skip_mcast;
 using ttnn::operations::conv::is_1d_depthwise_conv;
+using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
 using ttnn::operations::conv::SkipMcast;
 
 constexpr uint32_t l1_scratchpad_CB_size = 64;
@@ -162,7 +163,11 @@ std::vector<CBInfo> get_cb_info(
     const uint32_t per_core_out_ntiles =
         pconfig.per_core_out_matrix_height_ntile * pconfig.per_core_out_matrix_width_ntile;
 
-    const uint32_t num_blocks_act_w = weight_matrix_height_ntiles / block_config.act_block_w_ntiles;
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        is_1d_depthwise_conv, sharding_scheme, input_channels_padded, kernel_size[1], dilation[1], input_datatype);
+    const uint32_t num_blocks_act_w = is_1d_depthwise_conv
+                                          ? (coalesce_1d_depthwise_kw_reads ? 1 : kernel_size[0] * kernel_size[1])
+                                          : weight_matrix_height_ntiles / block_config.act_block_w_ntiles;
 
     const uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
     const uint32_t in0_num_blocks_w =
@@ -175,10 +180,10 @@ std::vector<CBInfo> get_cb_info(
 
     {
         // Weights CB
-        // For 1D depthwise conv, the weight matrix inner dimension is act_block_h_ntiles * kernel_w,
-        // not act_block_w_ntiles (which is just padded_in_channels for depthwise).
         uint32_t weight_inner_dim_ntiles =
-            is_1d_depthwise_conv ? block_config.act_block_h_ntiles * kernel_size[1] : block_config.act_block_w_ntiles;
+            is_1d_depthwise_conv
+                ? block_config.act_block_h_ntiles * (coalesce_1d_depthwise_kw_reads ? kernel_size[1] : 1)
+                : block_config.act_block_w_ntiles;
         uint32_t weight_block_num_tiles = per_core_out_matrix_width_ntiles * weight_inner_dim_ntiles;
         if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
             // If activation reuse is enabled, we already have full inner dim
@@ -201,10 +206,11 @@ std::vector<CBInfo> get_cb_info(
             .data_format = weights_df});
     }
 
-    // Matmul partials CB
+    // Matmul partials CB. 1D depthwise compute uses dest-reuse accumulation, so the CB is unused
+    // for that path — emit a 0-page entry so allocate_cbs skips the device allocation.
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::MATMUL_PARTIALS,
-        .num_pages = is_1d_depthwise_conv ? 1 : per_core_out_ntiles,
+        .num_pages = is_1d_depthwise_conv ? 0 : per_core_out_ntiles,
         .page_size = partial_tile_size,
         .is_globally_allocated = (!untilize_out && partial_dtype == output_datatype && !is_1d_depthwise_conv),
         .data_format = partial_df});
@@ -246,13 +252,6 @@ std::vector<CBInfo> get_cb_info(
             .page_size = input_tile_size,
             .data_format = conv_input_df});
     }
-
-    // Temp sum CB (1d depthwise conv only)
-    cb_info.emplace_back(CBInfo{
-        .name = Conv2dCb::TEMP_SUM,
-        .num_pages = is_1d_depthwise_conv ? 1 : 0,
-        .page_size = output_tile_size,
-        .data_format = output_df});
 
     // Tilized act CB
     cb_info.emplace_back(CBInfo{

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -32,7 +32,6 @@ enum class Conv2dCb {
     L1_ARRAY,
     MATMUL_PARTIALS,
     OUT,
-    TEMP_SUM,
     COUNT
 };
 struct CBInfo {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -36,6 +36,19 @@ using sliding_window::ParallelConfig;
 using sliding_window::SlidingWindowConfig;
 using ttnn::prim::conv_op_l1_usage;
 
+namespace {
+
+uint32_t get_conv_noc_max_burst_size(tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0: return 256 * 32;
+        case tt::ARCH::BLACKHOLE: return 256 * 64;
+        case tt::ARCH::QUASAR: return 256 * 256;
+        default: TT_THROW("Unsupported architecture for coalesced 1D depthwise conv reads: {}", arch);
+    }
+}
+
+}  // namespace
+
 uint32_t find_closest_largest_divisor(uint32_t num, uint32_t start_divisor) {
     uint32_t divisor = start_divisor;
     while (num % divisor != 0) {
@@ -425,7 +438,8 @@ Conv2dBlockConfig determine_per_core_conv_block_config(
     bool fp32_accum,
     bool full_inner_dim,
     bool enable_activation_reuse,
-    bool is_1d_depthwise_conv) {
+    bool is_1d_depthwise_conv,
+    bool coalesce_1d_depthwise_kw_reads) {
     if (act_block_h_override > 0) {
         TT_ASSERT(
             act_block_h_override % 32 == 0,
@@ -470,10 +484,9 @@ Conv2dBlockConfig determine_per_core_conv_block_config(
     TT_ASSERT(padded_in_channels % act_c_num_blocks == 0);
     uint32_t act_block_w = 0;
     if (parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
-        // For 1D depthwise conv, each channel is processed independently, so activation
-        // block width doesn't need to be multiplied by the kernel window size
         if (is_1d_depthwise_conv) {
-            act_block_w = tt::round_up(padded_in_channels, tt::constants::TILE_WIDTH);
+            const uint32_t depthwise_window_scaler = coalesce_1d_depthwise_kw_reads ? window_w : 1;
+            act_block_w = tt::round_up(padded_in_channels * depthwise_window_scaler, tt::constants::TILE_WIDTH);
         } else {
             act_block_w = enable_activation_reuse
                               ? tt::round_up(padded_in_channels * window_h * window_w, tt::constants::TILE_WIDTH)
@@ -530,10 +543,30 @@ bool is_1d_depthwise_conv(
     uint32_t kernel_width,
     uint32_t image_height,
     bool has_bias) {
+    (void)kernel_width;
     bool is_depthwise_conv = groups == input_channels && groups == output_channels;
-    // Only use 1D depthwise path when kernel is truly pointwise (1x1)
-    // is_1d_conv checks height=1, we also need kernel_width=1 to ensure no spatial computation
-    return is_depthwise_conv && is_1d_conv(kernel_height, image_height) && kernel_width == 1 && !has_bias;
+    // 1D depthwise path supports kernel_height == 1 (and any kernel_width >= 1). The kw>1 case
+    // accumulates across kernel taps via per-tap blocks in the depthwise factory.
+    return is_depthwise_conv && is_1d_conv(kernel_height, image_height) && !has_bias;
+}
+
+bool should_coalesce_1d_depthwise_conv_reads(
+    bool is_1d_depthwise_conv,
+    TensorMemoryLayout input_tensor_memory_layout,
+    uint32_t input_channels_padded,
+    uint32_t kernel_width,
+    uint32_t dilation_w,
+    DataType input_datatype) {
+    if (!is_1d_depthwise_conv || input_tensor_memory_layout != TensorMemoryLayout::HEIGHT_SHARDED ||
+        kernel_width <= 1 || dilation_w != 1) {
+        return false;
+    }
+
+    // Halo output consumed by conv is row-major FLOAT32 only for FLOAT32 input, BFLOAT16 otherwise.
+    const uint32_t conv_input_datum_size = input_datatype == DataType::FLOAT32 ? 4 : 2;
+    const uint64_t coalesced_read_bytes =
+        static_cast<uint64_t>(input_channels_padded) * conv_input_datum_size * kernel_width;
+    return coalesced_read_bytes <= get_conv_noc_max_burst_size(tt::tt_metal::hal::get_arch());
 }
 
 SkipMcast conv_skip_mcast(const Conv2dParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout) {
@@ -998,7 +1031,14 @@ core_count_and_size calculate_L1_usage_for_conv_op(
         output_width,
         kernel_size,
         compute_grid_size,
-        conv_is_1d_depthwise);
+        conv_is_1d_depthwise,
+        should_coalesce_1d_depthwise_conv_reads(
+            conv_is_1d_depthwise,
+            input_parallel_config.shard_scheme,
+            in_channels_padded,
+            kernel_size[1],
+            dilation[1],
+            input_datatype));
 
     SlidingWindowConfig sliding_window_config{
         .input_hw = {input_height, input_width}, .window_hw = {kernel_size[0], kernel_size[1]}};
@@ -1178,7 +1218,8 @@ std::tuple<Conv2dParallelizationConfig, Conv2dBlockConfig, MemoryConfig> get_con
     uint32_t output_width,
     std::array<uint32_t, 2> kernel_size,
     const CoreCoord& /*compute_grid*/,
-    bool is_1d_depthwise_conv) {
+    bool is_1d_depthwise_conv,
+    bool coalesce_1d_depthwise_kw_reads) {
     uint32_t round_up_size = tt::constants::TILE_HEIGHT;
     uint32_t nhw_out = batch_size * output_height * output_width;
     uint32_t out_channels_padded = tt::round_up(
@@ -1209,7 +1250,8 @@ std::tuple<Conv2dParallelizationConfig, Conv2dBlockConfig, MemoryConfig> get_con
         get_fp32_dest_acc_en(compute_config),
         conv_config.full_inner_dim,
         conv_config.enable_activation_reuse,
-        is_1d_depthwise_conv);
+        is_1d_depthwise_conv,
+        coalesce_1d_depthwise_kw_reads);
     return {opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config};
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -65,6 +65,14 @@ bool is_1d_depthwise_conv(
     uint32_t image_height,
     bool has_bias);
 
+bool should_coalesce_1d_depthwise_conv_reads(
+    bool is_1d_depthwise_conv,
+    TensorMemoryLayout input_tensor_memory_layout,
+    uint32_t input_channels_padded,
+    uint32_t kernel_width,
+    uint32_t dilation_w,
+    DataType input_datatype);
+
 struct SkipMcast {
     bool skip_activation_mcast;
     bool skip_weights_mcast;
@@ -147,7 +155,8 @@ Conv2dBlockConfig determine_per_core_conv_block_config(
     bool fp32_accum,
     bool full_inner_dim,
     bool enable_activation_reuse = false,
-    bool is_1d_depthwise_conv = false);
+    bool is_1d_depthwise_conv = false,
+    bool coalesce_1d_depthwise_kw_reads = false);
 
 std::tuple<Conv2dParallelizationConfig, Conv2dBlockConfig, MemoryConfig> get_conv_configs(
     const Conv2dConfig& conv_config,
@@ -161,7 +170,8 @@ std::tuple<Conv2dParallelizationConfig, Conv2dBlockConfig, MemoryConfig> get_con
     uint32_t output_width,
     std::array<uint32_t, 2> kernel_size,
     const CoreCoord& compute_grid,
-    bool is_1d_depthwise_conv = false);
+    bool is_1d_depthwise_conv = false,
+    bool coalesce_1d_depthwise_kw_reads = false);
 
 std::tuple<ttnn::Shape, ttnn::MemoryConfig> determine_input_memory_config(
     TensorMemoryLayout shard_layout,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -32,6 +32,7 @@ namespace unary = ttnn::operations::unary;
 using ttnn::operations::conv::conv_skip_mcast;
 using ttnn::operations::conv::get_num_cores_channels_from_parallel_config;
 using ttnn::operations::conv::is_1d_depthwise_conv;
+using ttnn::operations::conv::should_coalesce_1d_depthwise_conv_reads;
 using ttnn::operations::conv::SkipMcast;
 
 // Compute kernel addressing mode divides addresses with 16
@@ -311,6 +312,18 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
 
     const bool is_conv_1d_depthwise_conv =
         is_1d_depthwise_conv(groups, ashape[3], output_channels, filter_h, filter_w, ashape[1], has_bias);
+    const uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        is_conv_1d_depthwise_conv,
+        a.memory_config().memory_layout(),
+        input_channels_padded,
+        filter_w,
+        dilation_w,
+        a.dtype());
+    TT_FATAL(
+        !coalesce_1d_depthwise_kw_reads || filter_h == 1,
+        "Coalesced 1D depthwise reads require filter_h == 1, got {}",
+        filter_h);
 
     const bool enable_split_reader =
         is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
@@ -348,6 +361,17 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     }
 
     TT_FATAL(input_channels_padded >= ashape[3], "Incorrect padding of input channels!");
+    if (is_conv_1d_depthwise_conv && height_sharded) {
+        const uint32_t expected_act_block_w_ntiles =
+            tt::round_up(
+                input_channels_padded * (coalesce_1d_depthwise_kw_reads ? filter_w : 1), tt::constants::TILE_WIDTH) /
+            tt::constants::TILE_WIDTH;
+        TT_FATAL(
+            act_block_w_ntiles == expected_act_block_w_ntiles,
+            "1D depthwise activation block width mismatch. Got {} tiles, expected {} tiles",
+            act_block_w_ntiles,
+            expected_act_block_w_ntiles);
+    }
     // check is for 16-byte alignment
     TT_FATAL(
         // Since fp16 is smalleset data format used for halo output, 8 input_channels is enough for 16 byte alignment
@@ -404,7 +428,9 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         out_block_h_ntiles);
 
     const uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
-    const uint32_t num_blocks_act_w = slice_inner_dim ? filter_h : 1;
+    const uint32_t num_blocks_act_w = is_conv_1d_depthwise_conv
+                                          ? (coalesce_1d_depthwise_kw_reads ? 1 : filter_h * filter_w)
+                                          : (slice_inner_dim ? filter_h : 1);
     const uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
 
     // act block info
@@ -430,9 +456,9 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         weight_block_w_ntiles,
         out_subblock_w_ntiles);
     uint32_t weight_num_subblocks = weight_block_w_ntiles / out_subblock_w_ntiles;
-    // For 1D depthwise conv, weight_block_h_ntiles must accommodate inner_dim = act_block_h_ntiles * TILE_HEIGHT *
-    // kernel_w. So weight_block_h_ntiles = act_block_h_ntiles * kernel_w (filter_w).
-    uint32_t weight_block_h_ntiles = is_conv_1d_depthwise_conv ? act_block_h_ntiles * filter_w : act_block_w_ntiles;
+    uint32_t weight_block_h_ntiles = is_conv_1d_depthwise_conv
+                                         ? act_block_h_ntiles * (coalesce_1d_depthwise_kw_reads ? filter_w : 1)
+                                         : act_block_w_ntiles;
     uint32_t weight_block_num_tiles = weight_block_w_ntiles * weight_block_h_ntiles;
 
     // writer of conv op partially removes padding on the width
@@ -598,14 +624,13 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     }
     uint32_t bias_ntiles_per_core = bias_ntiles / num_weight_slices_width;
 
-    uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
+    const uint32_t act_block_w_logical_scalars =
+        is_conv_1d_depthwise_conv
+            ? shard_shape[1] * (coalesce_1d_depthwise_kw_reads ? filter_w : 1)
+            : (!slice_inner_dim ? shard_shape[1] * filter_h * filter_w : shard_shape[1] * filter_w);
     uint32_t act_block_w_extra_align_bytes =
-        !slice_inner_dim
-            ? (tt::round_up(shard_shape[1] * filter_h * filter_w, tt::constants::TILE_WIDTH) -
-               (shard_shape[1] * filter_h * filter_w)) *
-                  a.element_size()
-            : (tt::round_up(shard_shape[1] * filter_w, tt::constants::TILE_WIDTH) - (shard_shape[1] * filter_w)) *
-                  a.element_size();
+        (tt::round_up(act_block_w_logical_scalars, tt::constants::TILE_WIDTH) - act_block_w_logical_scalars) *
+        a.element_size();
     const uint32_t act_block_w_extra_align_scalars = act_block_w_extra_align_bytes / a.element_size();
     // When using block float format, we must handle cases where the data doesn't align to 16-scalar boundaries.
     // If act_block_w_extra_align_bytes contains a number of scalars that isn't a multiple of 16,
@@ -734,9 +759,13 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
 
     const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
     const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
-    const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+    // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
+    const bool partials_cb_uses_output =
+        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
     log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
-    const tt::tt_metal::CBHandle cb_partials = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
+    const tt::tt_metal::CBHandle cb_partials = is_conv_1d_depthwise_conv
+                                                   ? tt::tt_metal::CBHandle{}
+                                                   : get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     std::string reader_kernel;
     std::string compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp";
@@ -824,7 +853,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
         get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
         (uint32_t)enable_split_reader,
-        (uint32_t)enable_activation_reuse};
+        (uint32_t)(is_conv_1d_depthwise_conv ? coalesce_1d_depthwise_kw_reads : enable_activation_reuse)};
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
@@ -1002,60 +1031,81 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
 
     const bool check_skip_compute = input_cores != output_cores;
 
-    std::vector<uint32_t> compute_kernel_args = {
-        act_block_w_ntiles,
-        act_num_subblocks,
-        act_block_num_tiles,
-        act_subblock_num_tiles,
-        enable_split_reader ? act_block_h_ntiles : act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
-        weight_num_subblocks,
-        weight_block_num_tiles,
-        weight_block_w_ntiles,
-
-        num_blocks_act_h_per_core,
-        in0_num_blocks_w,
-        num_blocks_weight_w_per_core,
-
-        out_subblock_h_ntiles,
-        out_subblock_w_ntiles,
-        out_subblock_num_tiles,
-
-        height_sharded,
-        untilize_out,
-
-        bias_ntiles_per_core,
-
-        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::TEMP_SUM).index,
-        partials_cb_uses_output,
-        conv_act_c_blocks,
-        check_skip_compute,
-        pack_relu,
-        weight_block_w_ntiles <= 8,  // packer_untilize
-        packer_l1_acc_en,
-        has_bias,
-        enable_split_reader,
-        enable_activation_reuse};
-
-    if (enable_activation_reuse) {
-        compute_kernel_args.push_back(activation_reuse_config.image_width_tiles);
-        compute_kernel_args.push_back(activation_reuse_config.reuse_window_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-        compute_kernel_args.push_back(activation_reuse_config.tilized_cb_row_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-        compute_kernel_args.push_back(
-            activation_reuse_config.tilized_cb_second_reader_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+    std::vector<uint32_t> compute_kernel_args;
+    if (is_conv_1d_depthwise_conv) {
+        // compute_depthwise_conv1d.cpp uses a specialized dest-reuse accumulation path. The last
+        // two args select the coalesced kernel-width activation layout when the reader can fetch
+        // all kernel-width sticks as one NoC packet.
+        compute_kernel_args = {
+            act_block_w_ntiles,                                         // 0: in0_block_w
+            act_num_subblocks,                                          // 1: in0_num_subblocks
+            act_block_num_tiles,                                        // 2: in0_block_num_tiles
+            num_blocks_act_h_per_core,                                  // 3: in0_num_blocks_h
+            in0_num_blocks_w,                                           // 4: in0_num_blocks_w
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,          // 5: in0_cb_id (raw RM)
+            get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,      // 6: in1_cb_id
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,  // 7: tilized_in0_cb_id
+            get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,          // 8: out_cb_id
+            filter_w,                                                   // 9: kernel_width
+            coalesce_1d_depthwise_kw_reads,                             // 10: coalesced activation block
+        };
     } else {
-        std::vector<uint32_t> activation_reuse_dummy_args = {0, 0, 0, 0};
-        compute_kernel_args.insert(
-            compute_kernel_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
+        compute_kernel_args = {
+            act_block_w_ntiles,
+            act_num_subblocks,
+            act_block_num_tiles,
+            act_subblock_num_tiles,
+            enable_split_reader ? act_block_h_ntiles
+                                : act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
+            weight_num_subblocks,
+            weight_block_num_tiles,
+            weight_block_w_ntiles,
+
+            num_blocks_act_h_per_core,
+            in0_num_blocks_w,
+            num_blocks_weight_w_per_core,
+
+            out_subblock_h_ntiles,
+            out_subblock_w_ntiles,
+            out_subblock_num_tiles,
+
+            height_sharded,
+            untilize_out,
+
+            bias_ntiles_per_core,
+
+            get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
+            get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
+            partials_cb_uses_output,
+            conv_act_c_blocks,
+            check_skip_compute,
+            pack_relu,
+            weight_block_w_ntiles <= 8,  // packer_untilize
+            packer_l1_acc_en,
+            has_bias,
+            enable_split_reader,
+            enable_activation_reuse};
+
+        if (enable_activation_reuse) {
+            compute_kernel_args.push_back(activation_reuse_config.image_width_tiles);
+            compute_kernel_args.push_back(activation_reuse_config.reuse_window_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+            compute_kernel_args.push_back(
+                activation_reuse_config.tilized_cb_row_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+            compute_kernel_args.push_back(
+                activation_reuse_config.tilized_cb_second_reader_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+        } else {
+            std::vector<uint32_t> activation_reuse_dummy_args = {0, 0, 0, 0};
+            compute_kernel_args.insert(
+                compute_kernel_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
+        }
+        compute_kernel_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
     }
-    compute_kernel_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
 
     const tt::tt_metal::NOC writer_mcast_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
     const tt::tt_metal::NOC reader_noc =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -475,7 +475,6 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
         get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
-        0,
         partials_cb_uses_output,
         input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
         false,            // check_skip_compute; not used in width sharded

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -4,147 +4,161 @@
 
 #include <cstdint>
 
-#include "internal/mod_div_lib.h"
 #include "api/compute/tilize.h"
-#include "api/compute/pack_untilize.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/matmul.h"
-#include "api/compute/transpose_wh.h"
-#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
-
-#ifdef FUSE_BIAS
-#include "api/compute/bcast.h"
-#endif
-
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/reconfig_data_format.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
-
-#define DEBUG_PRINT 0
 
 ALWI void ACQ() { acquire_dst(); }
 ALWI void REL() { release_dst(); }
 
-inline void eltwise_mul_and_add_block_v2(
-    experimental::CB in0_cb,
-    experimental::CB in1_cb,
-    experimental::CB mul_partials_cb,
-    experimental::CB temp_cb,
-    experimental::CB out_cb,
-    uint32_t block_num_tiles,
-    uint32_t idx,
-    uint32_t total_blocks) {
+// Compute one block (one kernel-tap slice) of a 1D depthwise conv.
+//
+// Per output tile:
+//   dst[0]  = in0 * in1                                                 (FPU mul)
+//   if idx > 0: dst[0] += prior partial loaded from out_cb              (FPU add via DST reuse)
+//   pack dst[0] -> out_cb
+//
+// `idx` is the kernel-tap block index (0 .. filter_h*filter_w-1). The very first call (idx == 0)
+// initializes out_cb with the tap-0 product; subsequent calls accumulate via the DST_TO_SRCB
+// dest-reuse pattern, which keeps the running partial in DST and only pulls the prior partial
+// from L1. This gives a single pack per output tile (to out_cb) and avoids the pack-format flips
+// that corrupt block-float (BFLOAT8_B/BFLOAT4_B) outputs in the round-tripped variant — while
+// still using FPU (not SFPU) for the add.
+//
+// srcB (cfg92) tile descriptor: must match in1 for the mul, and is repopulated from DST for the
+// dest-reuse add. We force srcB back to in1's format every iteration so block-float weights are
+// decoded correctly.
+inline void mul_and_accumulate_block(
+    experimental::CB in0_cb, experimental::CB in1_cb, experimental::CB out_cb, uint32_t block_num_tiles, uint32_t idx) {
     const uint32_t in0_cb_id = in0_cb.get_cb_id();
     const uint32_t in1_cb_id = in1_cb.get_cb_id();
-    const uint32_t mul_partials_cb_id = mul_partials_cb.get_cb_id();
-    const uint32_t temp_cb_id = temp_cb.get_cb_id();
     const uint32_t out_cb_id = out_cb.get_cb_id();
 
     for (uint32_t i = 0; i < block_num_tiles; i++) {
         in1_cb.wait_front(1);
         in0_cb.wait_front(1);
-        mul_partials_cb.reserve_back(1);
-        mul_tiles_init(in0_cb_id, in1_cb_id);
+
         ACQ();
+
+        // mul: srcA = in0 (bf16), srcB = in1 (bf8/bf16) -> dst[0]
+        reconfig_data_format_srcb(in1_cb_id);
+        mul_tiles_init(in0_cb_id, in1_cb_id);
         mul_tiles(in0_cb_id, in1_cb_id, 0, 0, 0);
-        pack_tile(0, mul_partials_cb_id);
-        REL();
-        mul_partials_cb.push_back(1);
-        in0_cb.pop_front(1);
-        in1_cb.pop_front(1);
-        if (idx == 0) {
-            copy_tile_to_dst_init_short(mul_partials_cb_id);
-            ACQ();
-            mul_partials_cb.wait_front(1);
-            out_cb.reserve_back(1);
-            copy_tile(mul_partials_cb_id, 0, 0);
-            pack_tile(0, out_cb_id);
-            REL();
-            out_cb.push_back(1);
-            mul_partials_cb.pop_front(1);
-        } else {
-            add_tiles_init(mul_partials_cb_id, out_cb_id);
-            mul_partials_cb.wait_front(1);
+
+        if (idx != 0) {
+            // dest-reuse add: dst[0] += out_cb. srcA gets out_cb (cfg52 must match out_cb fmt);
+            // srcB is filled from dst[0] by the dest-reuse path.
+            reconfig_data_format_srca(out_cb_id);
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                out_cb_id);
             out_cb.wait_front(1);
-            ACQ();
-            add_tiles(mul_partials_cb_id, out_cb_id, 0, 0, 0);
-            pack_tile(0, temp_cb_id);
-            REL();
-            temp_cb.push_back(1);
-            mul_partials_cb.pop_front(1);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                out_cb_id, 0, 0);
             out_cb.pop_front(1);
 
-            copy_tile_to_dst_init_short(temp_cb_id);
-            ACQ();
-            temp_cb.wait_front(1);
-            out_cb.reserve_back(1);
-            copy_tile(temp_cb_id, 0, 0);
-            pack_tile(0, out_cb_id);
-            REL();
-            out_cb.push_back(1);
-            temp_cb.pop_front(1);
+            // Restore srcA to in0's format for the next iteration's mul unpack.
+            reconfig_data_format_srca(in0_cb_id);
         }
+
+        out_cb.reserve_back(1);
+        pack_tile(0, out_cb_id);
+        out_cb.push_back(1);
+
+        REL();
+
+        in0_cb.pop_front(1);
+        in1_cb.pop_front(1);
     }
 }
 
+template <uint32_t in0_block_w, uint32_t kernel_width, uint32_t block_num_tiles>
+inline void mul_and_accumulate_coalesced_block(
+    experimental::CB in0_cb, experimental::CB in1_cb, experimental::CB out_cb) {
+    static_assert(kernel_width > 1);
+    static_assert(in0_block_w % kernel_width == 0);
+    static_assert(block_num_tiles % in0_block_w == 0);
+
+    constexpr uint32_t in_channels_ntiles = in0_block_w / kernel_width;
+    constexpr uint32_t act_block_h_ntiles = block_num_tiles / in0_block_w;
+
+    const uint32_t in0_cb_id = in0_cb.get_cb_id();
+    const uint32_t in1_cb_id = in1_cb.get_cb_id();
+    const uint32_t out_cb_id = out_cb.get_cb_id();
+
+    in0_cb.wait_front(block_num_tiles);
+    in1_cb.wait_front(block_num_tiles);
+
+    for (uint32_t h = 0; h < act_block_h_ntiles; ++h) {
+        for (uint32_t c = 0; c < in_channels_ntiles; ++c) {
+            ACQ();
+
+            reconfig_data_format_srca(in0_cb_id);
+            reconfig_data_format_srcb(in1_cb_id);
+
+            for (uint32_t tap = 0; tap < kernel_width; ++tap) {
+                const uint32_t act_tile_idx = h * in0_block_w + tap * in_channels_ntiles + c;
+                const uint32_t weight_tile_idx =
+                    tap * act_block_h_ntiles * in_channels_ntiles + h * in_channels_ntiles + c;
+                mul_tiles_init(in0_cb_id, in1_cb_id, tap != 0 ? 1U : 0U, __builtin_LINE());
+                mul_tiles(in0_cb_id, in1_cb_id, act_tile_idx, weight_tile_idx, 0);
+            }
+
+            out_cb.reserve_back(1);
+            pack_tile(0, out_cb_id);
+            out_cb.push_back(1);
+
+            REL();
+        }
+    }
+
+    in0_cb.pop_front(block_num_tiles);
+    in1_cb.pop_front(block_num_tiles);
+}
+
+// Compile-time args (host: 1D depthwise branch in conv2d_op_sharded_program_factory.cpp):
+//   0: in0_block_w (inner block width in tiles)
+//   1: in0_num_subblocks (passed to compute_kernel_lib::tilize)
+//   2: in0_block_num_tiles (output tiles per call to mul_and_accumulate_block)
+//   3: in0_num_blocks_h (per-core H-block count)
+//   4: in0_num_blocks_w (kernel-tap block count, or 1 for coalesced kernel-width reads)
+//   5..8: CB indices (raw in0, in1, tilized in0, out)
+//   9: kernel_width
+//   10: coalesce kernel-width activation reads
 void kernel_main() {
-    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);        // inner block size in tiles
-    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);  // outer row block size (in inner row blocks)
-    constexpr uint32_t in0_block_num_tiles =
-        get_compile_time_arg_val(2);  // out_subblock_h*in0_block_w*in0_num_subblocks;
-    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
-    constexpr uint32_t reader_num_h_subblocks = get_compile_time_arg_val(4);
-    constexpr uint32_t in1_num_subblocks =
-        get_compile_time_arg_val(5);  // outer column block size (in inner column blocks)
-    constexpr uint32_t in1_block_num_tiles =
-        get_compile_time_arg_val(6);                               // out_subblock_w*in0_block_w* in1_num_subblocks;
-    constexpr uint32_t in1_block_w = get_compile_time_arg_val(7);  // out_subblock_w*in1_num_subblocks
-    // if these are not defined as volatile, it causes code size for TRISC2 to be too large if num_blocks > 1
-    constexpr uint32_t in0_num_blocks_h = get_compile_time_arg_val(8);
-    constexpr uint32_t in0_num_blocks_w = get_compile_time_arg_val(9);
-    constexpr uint32_t in1_num_blocks_w = get_compile_time_arg_val(10);
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(11);          // inner row block size in tiles
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(12);          // inner column block size in tiles
-    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(13);  // out_subblock_h * out_subblock_w;
-    constexpr bool tilize_in0 = get_compile_time_arg_val(14);
-    constexpr bool untilize_out = get_compile_time_arg_val(15);
-
-    constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
-    constexpr uint32_t out_block_w = in1_block_w;
-
-    // CB indices
-    constexpr uint32_t in0_cb_id = get_compile_time_arg_val(18);
-    constexpr uint32_t in1_cb_id = get_compile_time_arg_val(19);
-    constexpr uint32_t in0_pretilize_cb_id = get_compile_time_arg_val(20);
-    constexpr uint32_t in0_cb_second_reader_id = get_compile_time_arg_val(21);
-    constexpr uint32_t eltwise_mul_partials_cb = get_compile_time_arg_val(22);
-    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(23);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
-    constexpr uint32_t temp_sum_cb = get_compile_time_arg_val(25);
-
-    constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks;
-
-    constexpr uint32_t num_blocks = in0_num_blocks_h * in0_num_blocks_w;  // num_tokens window
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_num_blocks_h = get_compile_time_arg_val(3);
+    constexpr uint32_t in0_num_blocks_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in0_cb_id = get_compile_time_arg_val(5);
+    constexpr uint32_t in1_cb_id = get_compile_time_arg_val(6);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(7);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(8);
+    constexpr uint32_t kernel_width = get_compile_time_arg_val(9);
+    constexpr bool coalesce_kw_reads = get_compile_time_arg_val(10) == 1;
 
     experimental::CB cb_tilized_in0(tilized_in0_cb_id);
     experimental::CB cb_in1(in1_cb_id);
-    experimental::CB cb_mul_partials(eltwise_mul_partials_cb);
-    experimental::CB cb_temp_sum(temp_sum_cb);
     experimental::CB cb_out(out_cb_id);
 
+    // binary_op_init_common configures pack for out_cb, math for in0/in1, and unpack for in0/in1.
+    // The pack target never changes (we only ever pack to out_cb), so no further pack reconfig is
+    // needed for the lifetime of the kernel.
     binary_op_init_common(in0_cb_id, in1_cb_id, out_cb_id);
 
     for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
         for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
-            uint32_t i = in0_block_h_i * in0_num_blocks_w + in0_block_w_i;
-            if constexpr (tilize_in0) {
-                compute_kernel_lib::tilize<in0_block_w, in0_cb_id, tilized_in0_cb_id>(in0_num_subblocks_read);
-            }
+            compute_kernel_lib::tilize<in0_block_w, in0_cb_id, tilized_in0_cb_id>(in0_num_subblocks);
             reconfig_data_format_srca(tilized_in0_cb_id);
-            pack_reconfig_data_format(eltwise_mul_partials_cb);
-            eltwise_mul_and_add_block_v2(
-                cb_tilized_in0, cb_in1, cb_mul_partials, cb_temp_sum, cb_out, in0_block_num_tiles, i, num_blocks);
-
-        }  // for in0_num_blocks_h
-    }  // for in0_num_blocks_w
-}  // void kernel_main()
+            if constexpr (coalesce_kw_reads) {
+                mul_and_accumulate_coalesced_block<in0_block_w, kernel_width, in0_block_num_tiles>(
+                    cb_tilized_in0, cb_in1, cb_out);
+            } else {
+                const uint32_t idx = in0_block_h_i * in0_num_blocks_w + in0_block_w_i;
+                mul_and_accumulate_block(cb_tilized_in0, cb_in1, cb_out, in0_block_num_tiles, idx);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -227,21 +227,21 @@ void kernel_main() {
     constexpr uint32_t matmul_partials_cb = get_compile_time_arg_val(22);
     constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(23);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
-    constexpr bool partials_cb_uses_output = get_compile_time_arg_val(26);
-    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(27);
-    constexpr bool check_skip_compute = get_compile_time_arg_val(28);
-    constexpr bool pack_relu = get_compile_time_arg_val(29);
-    constexpr bool packer_untilize = get_compile_time_arg_val(30);
-    constexpr bool packer_l1_acc = get_compile_time_arg_val(31);
-    constexpr bool fuse_bias = get_compile_time_arg_val(32);
-    constexpr bool split_reader = get_compile_time_arg_val(33);
-    constexpr bool activation_reuse = get_compile_time_arg_val(34);
+    constexpr bool partials_cb_uses_output = get_compile_time_arg_val(25);
+    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(26);
+    constexpr bool check_skip_compute = get_compile_time_arg_val(27);
+    constexpr bool pack_relu = get_compile_time_arg_val(28);
+    constexpr bool packer_untilize = get_compile_time_arg_val(29);
+    constexpr bool packer_l1_acc = get_compile_time_arg_val(30);
+    constexpr bool fuse_bias = get_compile_time_arg_val(31);
+    constexpr bool split_reader = get_compile_time_arg_val(32);
+    constexpr bool activation_reuse = get_compile_time_arg_val(33);
 
-    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(35);
-    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(36);
-    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(37);
-    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(38);
-    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(39) == 1;
+    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(34);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(35);
+    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(36);
+    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(37);
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(38) == 1;
 
     constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
     constexpr uint32_t out_block_w = in1_block_w;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -24,6 +24,9 @@ void kernel_main() {
     constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
     constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+    // Depthwise reuses the common reader arg slot that non-depthwise height-sharded conv uses for
+    // activation reuse. Activation reuse is unsupported for the 1D depthwise path.
+    constexpr bool coalesce_kw_reads = get_compile_time_arg_val(28) == 1;
 
     // LOOP TO FILL READER OFFSETS
     /* We can add another loop to read chunks of a stick as well.
@@ -55,15 +58,13 @@ void kernel_main() {
 
     uint32_t reader_idx = 0;
 
-    // TODO: need to make the read coalescing optimization cleaner
-    // pass coalesce_window_inner_reads as a compile time arg and num_coalesced_reads so we can constexpr the if
-    // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
-    // src/dst side we check if window_inner == weight_size_w to make sure coalescing is legal along full window_inner
-    // so the loop can be removed
-    constexpr uint32_t num_coalesced_reads = weight_size_w;
+    constexpr uint32_t num_coalesced_reads = coalesce_kw_reads ? weight_size_w : 1;
     constexpr uint32_t coalesced_read_bytes = num_coalesced_reads * conv_act_c_read_bytes;
-    // the conditional selecting between coalescing and no-colescing must be constexpr to that compiler can optimized
-    // the other path away this has shown to be a big perf win
+    static_assert(!coalesce_kw_reads || weight_size_h == 1);
+    static_assert(!coalesce_kw_reads || window_outer == 1);
+    static_assert(!coalesce_kw_reads || window_inner == weight_size_w);
+    static_assert(!coalesce_kw_reads || coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
+
     reader_offset_idx = 0;
     uint32_t act_l1_offset = 0;
     uint32_t act_l1_read_addr = sharded_act_cb.get_read_ptr();
@@ -92,7 +93,7 @@ void kernel_main() {
 
                 for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
                     act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
-                    experimental::read_with_state(noc, l1_write_addr_act, act_l1_offset);
+                    experimental::read_with_state<coalesced_read_bytes>(noc, l1_write_addr_act, act_l1_offset);
                     l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -694,7 +694,11 @@ static Tensor conv_group_weight_zero_pad_helper(
 }
 
 /*
-Helper function to aid in converting depthwise weight tensor to broadcasted weight tensor with repeated input channels
+Helper for depthwise weight prep. Takes a weight tensor of shape [C, 1, kH, kW] and emits a tensor
+of shape [C, act_block_h_repeats * kH * kW, 1, 1]. Each kernel tap (kh, kw) gets its own slab of
+act_block_h_repeats rows in axis 1, broadcast-replicated. This lets the depthwise factory feed
+each kernel tap as a separate weight block via num_blocks_weight_h == kH * kW (see
+num_blocks_act_w in conv2d_op_sharded_program_factory.cpp).
 */
 template <typename T>
 static Tensor conv_depthwise_weight_bcast_helper(
@@ -705,10 +709,20 @@ static Tensor conv_depthwise_weight_bcast_helper(
     auto compute = [&original_weight_shape, &output_weight_shape, output_dtype](
                        const tt::tt_metal::HostBuffer& conv_weight_tensor_host_buffer) {
         auto conv_weight_tensor_buffer = tt::tt_metal::host_buffer::get_as<T>(conv_weight_tensor_host_buffer);
-        // Create a new buffer with the output shape
         auto output_buffer = std::vector<T>(output_weight_shape.volume());
         auto original_strides = compute_strides(original_weight_shape);
         auto output_strides = compute_strides(output_weight_shape);
+
+        const uint32_t window_h = original_weight_shape[2];
+        const uint32_t window_w = original_weight_shape[3];
+        const uint32_t taps = window_h * window_w;
+        TT_FATAL(
+            output_weight_shape[1] % taps == 0,
+            "output_weight_shape[1] ({}) must be divisible by window_h * window_w ({} * {})",
+            output_weight_shape[1],
+            window_h,
+            window_w);
+        const uint32_t broadcast_per_tap = output_weight_shape[1] / taps;
 
         WeightLayoutThreader::parallel_for_channels(
             output_weight_shape[0],
@@ -720,18 +734,17 @@ static Tensor conv_depthwise_weight_bcast_helper(
                 uint32_t out_end,
                 uint32_t in_start,
                 uint32_t in_end) {
-                for (int i = out_start; i < out_end; i++) {
-                    for (int j = in_start; j < in_end; j++) {
-                        for (int k = 0; k < output_weight_shape[2]; k++) {
-                            for (int l = 0; l < output_weight_shape[3]; l++) {
-                                auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
-                                    ttnn::SmallVector<uint32_t>{i, 0, k, l}, original_strides);
-                                auto value = conv_weight_tensor_buffer[value_flat_input_index];
-                                auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
-                                    ttnn::SmallVector<uint32_t>{i, j, k, l}, output_strides);
-                                output_buffer[output_flat_input_index] = value;
-                            }
-                        }
+                for (uint32_t i = out_start; i < out_end; i++) {
+                    for (uint32_t j = in_start; j < in_end; j++) {
+                        const uint32_t tap_index = j / broadcast_per_tap;
+                        const uint32_t k = tap_index / window_w;
+                        const uint32_t l = tap_index % window_w;
+                        auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
+                            ttnn::SmallVector<uint32_t>{i, 0, k, l}, original_strides);
+                        auto value = conv_weight_tensor_buffer[value_flat_input_index];
+                        auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
+                            ttnn::SmallVector<uint32_t>{i, j, 0u, 0u}, output_strides);
+                        output_buffer[output_flat_input_index] = value;
                     }
                 }
             });
@@ -898,20 +911,21 @@ Tensor convert_conv_weight_tensor_to_grouped_layout_for_conv_transpose2d(
 }
 
 /*
-Converts convolution weights to depthwise layout
-This function will take in a weight tensor with shape [out_channels, 1, H, W] and return a newly
-allocated output tensor with shape [out_channels, act_block_h, H, W] The extra channels in shape[1] are repeated
-from the original weight tensor - it would be convolving act_block in conv_matrix in one go
+Converts convolution weights to depthwise layout.
+Takes a weight tensor of shape [out_channels, 1, kH, kW] and returns one of shape
+[out_channels, act_block_h * TILE_HEIGHT * kH * kW, 1, 1]. Each kernel tap (kh, kw) gets its own
+contiguous slab of `act_block_h * TILE_HEIGHT` rows in the broadcast (axis-1) dim, so the
+depthwise factory can feed each tap as a separate weight block via num_blocks_weight_h == kH * kW.
+This works uniformly for pointwise (kH*kW == 1) and 1D depthwise convs along either H or W axis.
 */
 Tensor convert_conv_weight_tensor_to_depthwise_layout(
     const Tensor& conv_weight_tensor, uint32_t act_block_h_ntiles, DataType output_dtype) {
     const auto& original_conv_weight_tensor_shape = conv_weight_tensor.logical_shape();
-    uint32_t num_input_channels_to_repeat = act_block_h_ntiles * constants::TILE_HEIGHT;
+    const uint32_t window_h = original_conv_weight_tensor_shape[2];
+    const uint32_t window_w = original_conv_weight_tensor_shape[3];
+    const uint32_t num_input_channels_to_repeat = act_block_h_ntiles * constants::TILE_HEIGHT * window_h * window_w;
     ttnn::Shape output_conv_weight_tensor_shape{
-        original_conv_weight_tensor_shape[0],
-        num_input_channels_to_repeat,
-        original_conv_weight_tensor_shape[2],
-        original_conv_weight_tensor_shape[3]};
+        original_conv_weight_tensor_shape[0], num_input_channels_to_repeat, 1u, 1u};
 
     // Create newly allocated buffer all initialized to 0 depending on the datatype of the weight tensor
     const static std::unordered_map<DataType, std::function<Tensor(const Tensor&, ttnn::Shape, ttnn::Shape, DataType)>>
@@ -1209,6 +1223,13 @@ static Conv2dBlockConfig get_opt_block_config(
 
     const bool conv_is_1d_depthwise =
         is_1d_depthwise_conv(groups, in_channels, out_channels, kernel_size[0], kernel_size[1], input_height, has_bias);
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        conv_is_1d_depthwise,
+        parallel_config.shard_scheme,
+        in_channels_padded,
+        kernel_size[1],
+        dilation[1],
+        input_dtype);
 
     return determine_per_core_conv_block_config(
         parallel_config,
@@ -1223,7 +1244,8 @@ static Conv2dBlockConfig get_opt_block_config(
         get_fp32_dest_acc_en(compute_config),
         conv_config.full_inner_dim,
         conv_config.enable_activation_reuse,
-        conv_is_1d_depthwise);
+        conv_is_1d_depthwise,
+        coalesce_1d_depthwise_kw_reads);
 }
 
 static uint32_t calculate_out_channels_padded(uint32_t out_channels, const ParallelConfig& output_parallel_config) {
@@ -1487,6 +1509,18 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     ParallelConfig output_parallel_config = determine_output_parallel_config(
         parallel_config, output_compute_grid_size, out_channels, parallel_config.shard_orientation, mm_conv);
 
+    const bool conv_is_1d_depthwise =
+        is_1d_depthwise_conv(groups, in_channels, out_channels, kernel_size[0], kernel_size[1], input_height, has_bias);
+    const uint32_t in_channels_padded = tt::round_up(
+        in_channels, get_num_cores_channels_from_parallel_config(parallel_config) * input_channels_alignment);
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        conv_is_1d_depthwise,
+        parallel_config.shard_scheme,
+        in_channels_padded,
+        kernel_size[1],
+        dilation[1],
+        input_dtype);
+
     const bool auto_shard = !input_memory_config.is_sharded() && !conv_config.shard_layout.has_value();
     return Conv2dWeightsBiasPrepConfig(
         input_channels_alignment,
@@ -1505,6 +1539,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
         conv_config.enable_kernel_stride_folding.value(),
         conv_config.full_inner_dim,
         conv_config.enable_activation_reuse,
+        coalesce_1d_depthwise_kw_reads,
         orig_stride);
 }
 
@@ -1541,11 +1576,14 @@ static ttnn::Tensor prepare_conv_weights_internal(
         if (is_conv_1d_depthwise_conv) {
             weight_tensor_ = convert_conv_weight_tensor_to_depthwise_layout(
                 weight_tensor_, params.act_block_h_ntiles, weight_tensor_.dtype());
-            // After depthwise conversion, in_channels = act_block_h_ntiles * TILE_HEIGHT
-            // inner_dim = in_channels * kernel_w = act_block_h_ntiles * TILE_HEIGHT * kernel_w
-            // weight_block_h_ntiles * TILE_HEIGHT must >= inner_dim
-            // So: weight_block_h_ntiles >= act_block_h_ntiles * kernel_w
-            params.weight_block_h_ntiles = params.act_block_h_ntiles * original_weights_window_w;
+            // After depthwise conversion, the weight tensor has shape
+            //   [out_channels, act_block_h_ntiles * TILE_HEIGHT * kernel_h * kernel_w, 1, 1]
+            // with each kernel tap occupying its own act_block_h_ntiles * TILE_HEIGHT slab in axis 1.
+            // The depthwise factory feeds each tap as a separate weight block via
+            // num_blocks_weight_h == kernel_h * kernel_w, so the per-block height is just
+            // act_block_h_ntiles unless the reader coalesces the whole kernel-width window.
+            params.weight_block_h_ntiles =
+                params.act_block_h_ntiles * (params.coalesce_1d_depthwise_kw_reads ? original_weights_window_w : 1);
         } else {
             weight_tensor_ =
                 convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, params.groups, weight_tensor_.dtype());
@@ -1588,12 +1626,20 @@ static ttnn::Tensor prepare_conv_weights_internal(
             weight_tensor_, weights_channels_padded_shape.to_array_4D(), tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
 
         if (input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
-            weight_tensor_ = convert_conv_weight_tensor_to_special_padding_tiled_layout(
-                weight_tensor_,
-                params.weight_block_h_ntiles,
-                params.weight_block_w_ntiles,
-                params.enable_activation_reuse,
-                weight_tensor_.dtype());
+            // 1D depthwise can either feed each kernel tap separately or one coalesced kernel-width
+            // block. Use the regular tile-layout converter because the special-padding converter
+            // assumes a conventional conv inner dimension.
+            if (is_conv_1d_depthwise_conv) {
+                weight_tensor_ = convert_conv_weight_tensor_to_tiled_layout(
+                    weight_tensor_, params.weight_block_h_ntiles, params.weight_block_w_ntiles, weight_tensor_.dtype());
+            } else {
+                weight_tensor_ = convert_conv_weight_tensor_to_special_padding_tiled_layout(
+                    weight_tensor_,
+                    params.weight_block_h_ntiles,
+                    params.weight_block_w_ntiles,
+                    params.enable_activation_reuse,
+                    weight_tensor_.dtype());
+            }
         } else if (input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
             weight_tensor_ = convert_conv_weight_tensor_to_tiled_layout_block_sharded(
                 weight_tensor_,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -143,6 +143,7 @@ struct Conv2dWeightsBiasPrepConfig {
         bool enable_kernel_stride_folding_ = false,
         bool full_inner_dim_ = false,
         bool enable_activation_reuse_ = false,
+        bool coalesce_1d_depthwise_kw_reads_ = false,
         std::array<uint32_t, 2> stride_ = {1, 1}) :
         input_channels_alignment(input_channels_alignment_),
         weights_bias_dtype(weights_bias_dtype_),
@@ -158,6 +159,7 @@ struct Conv2dWeightsBiasPrepConfig {
         enable_kernel_stride_folding(enable_kernel_stride_folding_),
         full_inner_dim(full_inner_dim_),
         enable_activation_reuse(enable_activation_reuse_),
+        coalesce_1d_depthwise_kw_reads(coalesce_1d_depthwise_kw_reads_),
         stride(stride_),
         interleaved_mm_conv(interleaved_mm_conv),
         out_channels(out_channels_) {}
@@ -180,6 +182,7 @@ struct Conv2dWeightsBiasPrepConfig {
     const bool enable_kernel_stride_folding;
     const bool full_inner_dim;
     const bool enable_activation_reuse;
+    const bool coalesce_1d_depthwise_kw_reads;
 
     // Kernel stride folding parameter
     const std::array<uint32_t, 2> stride;
@@ -203,6 +206,7 @@ struct Conv2dWeightsBiasPrepConfig {
         "enable_kernel_stride_folding",
         "full_inner_dim",
         "enable_activation_reuse",
+        "coalesce_1d_depthwise_kw_reads",
         "stride",
         "interleaved_mm_conv",
         "out_channels");
@@ -222,6 +226,7 @@ struct Conv2dWeightsBiasPrepConfig {
             std::cref(this->enable_kernel_stride_folding),
             std::cref(this->full_inner_dim),
             std::cref(this->enable_activation_reuse),
+            std::cref(this->coalesce_1d_depthwise_kw_reads),
             std::cref(this->stride),
             std::cref(this->interleaved_mm_conv),
             std::cref(this->out_channels));

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -242,6 +242,7 @@ ConvTranspose2dResult conv_transpose2d_L1(
             false,                                      // enable_kernel_stride_folding
             false,                                      // full_inner_dim
             false,                                      // enable_activation_reuse
+            false,                                      // coalesce_1d_depthwise_kw_reads
             ConvTranspose2dDimensions::CONV2D_STRIDE);  // stride (always {1,1} for transposed conv2d)
         tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
             transform_weights_for_conv_transpose2d(weight_for_transform, mirror_kernel), bias_tensor, params, device);

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
@@ -28,10 +28,12 @@ using CB = CircularBuffer;
 // Note: CoreLocalMem<uint32_t> is used internally by the read_with_state raw-address overload below.
 // Prefer passing experimental::CB with offset_bytes args over constructing CoreLocalMem directly.
 
-// Single-packet convenience wrappers for set_async_read_state / async_read_with_state.
-// All conv/pool activation reads are single-packet (size <= NOC_MAX_BURST_SIZE),
-// but the upstream API defaults to multi-packet mode. These wrappers put max_page_size
-// first so callers don't need to spell out VcSelection::DEFAULT every time.
+// Convenience wrappers for set_async_read_state / async_read_with_state.
+// transfer_size is forwarded as max_page_size to the underlying NOC API:
+//   - transfer_size <= NOC_MAX_BURST_SIZE  -> single-packet path
+//   - transfer_size  > NOC_MAX_BURST_SIZE  -> multi-packet path
+// These wrappers put max_page_size first so callers don't need to spell out
+// VcSelection::DEFAULT every time.
 
 // Helper to create UnicastEndpoint src_args for local L1 self-reads.
 // Must use my_x/my_y for the correct NOC — NOC 0 and NOC 1 have different coordinate spaces.
@@ -39,23 +41,23 @@ FORCE_INLINE auto local_addr(uint32_t addr, uint8_t noc_id = noc_index) {
     return noc_traits_t<UnicastEndpoint>::src_args_type{.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = addr};
 }
 
-// Single-packet read with state: call set_read_state once, then read_with_state in a loop.
-// transfer_size is baked into both calls so they always agree on single-packet mode.
+// Read with state: call set_read_state once, then read_with_state in a loop.
+// transfer_size is baked into both calls so they always agree on the transfer mode.
 template <uint32_t transfer_size>
 FORCE_INLINE void set_read_state(Noc noc, uint32_t src_addr) {
-    static_assert(transfer_size <= NOC_MAX_BURST_SIZE, "Use noc.async_read for multi-packet transfers");
     UnicastEndpoint ep;
     noc.set_async_read_state<Noc::VcSelection::DEFAULT, transfer_size>(
         ep, transfer_size, local_addr(src_addr, noc.get_noc_id()));
 }
 
-// Simple form: local L1 src addr -> local L1 dst addr
-// max_page_size=1 selects the single-packet branch (any value <= NOC_MAX_BURST_SIZE works);
-// size_bytes=0 is unused in that branch — the actual transfer size was set by set_read_state.
+// Simple form: local L1 src addr -> local L1 dst addr.
+// transfer_size must match the value used in set_read_state. Default of 1 selects the
+// single-packet branch for legacy callers.
+template <uint32_t transfer_size = 1>
 FORCE_INLINE void read_with_state(Noc noc, uint32_t dst_addr, uint32_t src_addr) {
     UnicastEndpoint ep;
-    noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(
-        ep, CoreLocalMem<uint32_t>(dst_addr), 0, local_addr(src_addr, noc.get_noc_id()), {});
+    noc.async_read_with_state<Noc::VcSelection::DEFAULT, transfer_size>(
+        ep, CoreLocalMem<uint32_t>(dst_addr), transfer_size, local_addr(src_addr, noc.get_noc_id()), {});
 }
 
 // CB/typed destination form with dst_args (e.g. offset_bytes)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix Mamba 1D depthwise convolution for kernel widths greater than 1, including native bf8 weights/output support, and re-enable coalesced depthwise conv1d reads.

This adds focused depthwise conv1d coverage and updates the conv weight preparation / device-side plumbing needed for the corrected path. The PR diff is intentionally scoped away from HAL and matmul-owned files.

### Notes for reviewers
Review focus areas:
- depthwise conv1d reader/compute kernel changes
- weight preparation changes for native bf8 and kw > 1
- coalesced read enablement scoped to conv host selection and conv kernels

CI triggered on this branch before the latest cleanup commit:
- Nightly L2 conv category only: https://github.com/tenstorrent/tt-metal/actions/runs/25918229669
- Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/25918229519
- Blackhole post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/25918229586

Local tests not run. Pre-commit hooks passed for the cleanup commit.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/mamba-conv1d-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/mamba-conv1d-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/mamba-conv1d-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/mamba-conv1d-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/mamba-conv1d-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/mamba-conv1d-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/mamba-conv1d-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/mamba-conv1d-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/mamba-conv1d-fix)