### PR TITLE
[Feature] host_io decoder sweep: accept bit_sculpt safetensors traces

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -229,13 +229,24 @@ class CacheWeightProvider:
         sram_core_grids: SramExpertCoreGrids | None = None,
         sram_assigner: CompressedTensorAssigner | None = None,
         worker_l1_size: int | None = None,
+        weight_key_prefix: str = "",
     ) -> None:
+        """Args (subset):
+        weight_key_prefix: Forwarded to ``LazyStateDict(base_prefix=...)``. Set
+            to ``"language_model."`` when loading Kimi K2.6 weights through
+            this provider — Kimi's HF state dict wraps the DeepSeek-V3 backbone
+            under ``language_model.`` because the top-level architecture is
+            ``KimiK25ForConditionalGeneration`` (multimodal). With the prefix
+            set, ``prepare_*`` calls that look up ``model.layers.{i}.*`` keys
+            resolve to ``language_model.model.layers.{i}.*`` on disk. Default
+            ``""`` preserves the existing DeepSeek path bit-exactly.
+        """
         cache_path = Path(cache_path)
         model_path = Path(model_path)
         assert model_path.exists(), f"Model path does not exist: {model_path}"
         assert model_path.is_dir(), f"Model path is not a directory: {model_path}"
         self._cache = TensorCache(cache_path)
-        self._state_dict = LazyStateDict(model_path)
+        self._state_dict = LazyStateDict(model_path, base_prefix=weight_key_prefix)
         self._schema_version = schema_version
         self._hf_model_id = hf_model_id or model_path.name
         self._hf_revision = hf_revision
@@ -243,6 +254,7 @@ class CacheWeightProvider:
         self._sram_core_grids = sram_core_grids
         self._sram_assigner = sram_assigner
         self._worker_l1_size = worker_l1_size
+        self._weight_key_prefix = weight_key_prefix
 
     def _cache_config(self, device: ttnn.MeshDevice) -> CacheConfig:
         context = CacheContext(

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
@@ -19,6 +19,39 @@ class DeepseekMoeGateSingleCore:
     This class implements the Deepseek Moe Gate operation on a single face (16x16) of data.
     The operation is a combination of sigmoid activation, element-wise addition with bias,
     and sorting of top 8 values per group.
+
+    .. note:: Kimi K2.6 compatibility
+
+       This kernel is **structurally specific to DeepSeek V3 / R1's grouped routing**:
+       16 groups × 16 experts (=256), top-2-per-group → top-4-groups → top-8 overall.
+       The ``(16, 16)`` tile shape is asserted at line ~114 (``expected_input_tile_size``).
+
+       Kimi K2.6 cannot use this kernel as-is — its routing config is
+       1 group × 384 experts, plain ``topk(sigmoid(scores) + bias, k=8)``. Adapting
+       to Kimi requires either:
+
+       - **C1.** Port the gate kernel + dispatch/combine primitives from
+         ``models/demos/kimi26_d_p/tt/moe/`` (sister demo on
+         ``origin/ddjekic/kimi26_bringup``) into ``_b1``. Adapter work — Kimi
+         demo uses dispatch/combine vs ``_b1``'s bcast/reduce MoE primitives.
+       - **C2.** Wait for ``origin/gchoudhary/41826-generalize-moe_compute-shape-support``
+         (also ``origin/dchen/moe_compute``) to land. That track makes the MoE
+         compute accept variable ``(n_routed_experts, top_k, n_groups, ...)`` —
+         it's the right long-term abstraction and unblocks Kimi K2.5, DS V4 Pro,
+         Ling-1T, GLM-4.7, etc. simultaneously. See
+         ``tests/nightly/tg/ccl/moe/test_moe_compute_6U.py`` for the model-config
+         matrix.
+       - **C3.** Write a new ``UngroupedTopKGateSingleCore`` alongside this one
+         (e.g. ``(16, 24) = 384`` tile or ``(32, 16) = 512`` padded with –∞
+         dummy entries), and teach ``HostIoDecoderStage`` to dispatch by config.
+         Cleanest at the kernel layer, heaviest at the trace-validation infra.
+
+       Cross-reference: ``models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py``
+       has a ``KIMI_K26_PORT_NOTES`` section with the full breakdown and pointers
+       to the matching e2e test skips in ``test_host_io_decoder_sweep_e2e.py``.
+       The ``weight_key_prefix`` knob for Kimi's ``language_model.`` HF prefix
+       already exists on ``CacheWeightProvider`` (added 2026-05-15); the gate
+       kernel above is the last blocker for Kimi MoE-layer on-device validation.
     """
 
     @staticmethod

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
@@ -25,33 +25,44 @@ class DeepseekMoeGateSingleCore:
        This kernel is **structurally specific to DeepSeek V3 / R1's grouped routing**:
        16 groups × 16 experts (=256), top-2-per-group → top-4-groups → top-8 overall.
        The ``(16, 16)`` tile shape is asserted at line ~114 (``expected_input_tile_size``).
+       The hardcode also lives in two layers below this one:
+       ``ttnn.experimental.deepseek_prefill.moe_grouped_topk`` has
+       ``TT_FATAL(n_groups == 8, topk_groups == 4, n_experts == 256)``, and the
+       underlying SFPU bitonic-topk LLK is a 16-element-face primitive.
 
        Kimi K2.6 cannot use this kernel as-is — its routing config is
-       1 group × 384 experts, plain ``topk(sigmoid(scores) + bias, k=8)``. Adapting
-       to Kimi requires either:
+       1 group × 384 experts, plain ``topk(sigmoid(scores) + bias, k=8)``, i.e.
+       the degenerate one-group case of grouped routing.
 
-       - **C1.** Port the gate kernel + dispatch/combine primitives from
-         ``models/demos/kimi26_d_p/tt/moe/`` (sister demo on
-         ``origin/ddjekic/kimi26_bringup``) into ``_b1``. Adapter work — Kimi
-         demo uses dispatch/combine vs ``_b1``'s bcast/reduce MoE primitives.
-       - **C2.** Wait for ``origin/gchoudhary/41826-generalize-moe_compute-shape-support``
-         (also ``origin/dchen/moe_compute``) to land. That track makes the MoE
-         compute accept variable ``(n_routed_experts, top_k, n_groups, ...)`` —
-         it's the right long-term abstraction and unblocks Kimi K2.5, DS V4 Pro,
-         Ling-1T, GLM-4.7, etc. simultaneously. See
-         ``tests/nightly/tg/ccl/moe/test_moe_compute_6U.py`` for the model-config
-         matrix.
-       - **C3.** Write a new ``UngroupedTopKGateSingleCore`` alongside this one
-         (e.g. ``(16, 24) = 384`` tile or ``(32, 16) = 512`` padded with –∞
-         dummy entries), and teach ``HostIoDecoderStage`` to dispatch by config.
-         Cleanest at the kernel layer, heaviest at the trace-validation infra.
+       Three reframed options for whoever picks this up (full breakdown in
+       ``KIMI_K26_PORT_NOTES`` at the end of
+       ``models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py``):
 
-       Cross-reference: ``models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py``
-       has a ``KIMI_K26_PORT_NOTES`` section with the full breakdown and pointers
-       to the matching e2e test skips in ``test_host_io_decoder_sweep_e2e.py``.
+       - **C1' (host-fallback gate, ~1-2 days, RECOMMENDED for validation infra).**
+         Port ``kimi26_d_p``'s ``GateComputeMode.HOST_GROUPED_GATE`` recipe: keep
+         the gate matmul on device, pull logits to host, run grouped-topk in
+         torch (handles ``n_groups=1`` trivially), push results back. Reference
+         algorithm is ``DeepseekMoeGateSingleCore.golden`` above, just
+         parameterized over ``(n_groups, topk_groups, n_experts, top_k,
+         routed_scaling_factor)``. This is what shipping kimi26_d_p does today.
+       - **C2 (device kernel generalization, weeks of LLK work).** Lift the
+         three TT_FATALs in ``moe_grouped_topk_device_operation.cpp`` and teach
+         the SFPU bitonic-topk primitive to handle 384 experts (the 16-element
+         face primitive doesn't fit 384 directly — likely a multi-tile path).
+         **No active upstream branch is doing this work**;
+         ``origin/gchoudhary/41826-generalize-moe_compute-shape-support`` and
+         ``origin/dchen/moe_compute*`` generalize the *expert* side, not the
+         gate. Don't block on them.
+       - **C3 (new ungrouped kernel, ~3-4 weeks).** Write
+         ``UngroupedTopKGateSingleCore`` alongside this one (e.g. ``(16, 24)``
+         or ``(32, 16)`` padded with –∞ dummies). Likely superseded by C2.
+
        The ``weight_key_prefix`` knob for Kimi's ``language_model.`` HF prefix
        already exists on ``CacheWeightProvider`` (added 2026-05-15); the gate
-       kernel above is the last blocker for Kimi MoE-layer on-device validation.
+       routing above is the last blocker for Kimi MoE-layer on-device
+       validation. **C1' is the right next step** if the goal is correctness
+       validation against bit_sculpt reference traces rather than production
+       throughput.
     """
 
     @staticmethod

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
@@ -1319,8 +1319,9 @@ def run_sweep(
 # KIMI_K26_PORT_NOTES
 # ============================================================================
 #
-# Status snapshot (2026-05-15) of Kimi K2.6 on-device validation through this
-# harness. Referenced from the ``pytest.mark.skip`` reasons in
+# Status snapshot (2026-05-15, revised after a closer look at the upstream
+# branches and the kimi26_d_p sister demo's actual implementation).
+# Referenced from the ``pytest.mark.skip`` reasons in
 # ``test_host_io_decoder_sweep_e2e.py`` and from
 # ``micro_ops/deepseek_moe_gate/op.py:DeepseekMoeGateSingleCore``.
 #
@@ -1341,56 +1342,116 @@ def run_sweep(
 #   harness will route to dense but the trace was produced treating them as
 #   MoE. See ``_check_metadata_consistency``.
 #
-# What does NOT work — the 384-expert MoE gate kernel blocker
-# -----------------------------------------------------------
-# ``micro_ops/deepseek_moe_gate/op.py:DeepseekMoeGateSingleCore`` hardcodes a
-# ``(16, 16) = 256`` input tile and implements DeepSeek's grouped top-k
-# (16 groups × 16, top-2-per-group → top-4-groups → top-8). Kimi K2.6 has
-# 1 group × 384 experts, plain ``topk(sigmoid(scores) + bias, k=8)``. The
-# kernel cannot be reused.
+# The MoE gate-kernel blocker — actual shape
+# ------------------------------------------
+# Kimi K2.6 cannot run MoE layers (1-60) on this code path because the gate
+# routing kernel is locked to DeepSeek-V3's grouped-routing config at three
+# layers:
 #
-# Three porting options for whoever picks up Kimi MoE on this code path:
+# 1. ``micro_ops/deepseek_moe_gate/op.py:DeepseekMoeGateSingleCore`` —
+#    asserts ``expected_input_tile_size == (16, 16) == 256`` experts and
+#    invokes the grouped LLK primitive.
+# 2. ``ttnn.experimental.deepseek_prefill.moe_grouped_topk`` — the
+#    *generalized-signature* TTNN op (``n_groups, summed_experts_per_group,
+#    topk_groups, n_activated_experts`` as runtime args) but its
+#    ``device/moe_grouped_topk_device_operation.cpp`` validate() hardcodes::
 #
-# - **C1. Port from** ``models/demos/kimi26_d_p/``. Active feature branch
-#   ``origin/ddjekic/kimi26_bringup`` already has ``tt/moe/tt_moe_gate_prefill.py``,
-#   ``tt_dispatch.py``, ``tt_combine.py``. Adapter work: that demo uses
-#   dispatch/combine MoE primitives; this ``_b1`` line uses bcast/reduce.
-#   Estimated weeks of focused integration work, but the kernel + algorithm
-#   are proven.
-# - **C2. Wait for / land** ``origin/gchoudhary/41826-generalize-moe_compute-shape-support``
-#   (also ``origin/dchen/moe_compute*``). That refactor makes the MoE compute
-#   accept arbitrary ``(n_routed_experts, top_k, n_groups, …)`` — right
-#   abstraction for Kimi K2.5, DS V4 Pro (384/top-6), Ling-1T (256/top-8),
-#   GLM-4.7 (160/top-8), Mistral Large 3, Gemma 4 26B, DS-OCR. See
-#   ``tests/nightly/tg/ccl/moe/test_moe_compute_6U.py`` for the full target
-#   matrix. **Strongly preferred** if landing is on a reasonable timeline.
-# - **C3. New kernel from scratch.** ``UngroupedTopKGateSingleCore`` alongside
-#   the DeepSeek one — e.g. ``(16, 24) = 384`` tile or ``(32, 16) = 512``
-#   padded with –∞ dummies. Teach ``HostIoDecoderStage`` to dispatch by config.
-#   ~3-4 weeks of new kernel work. Only useful for Kimi-family configs.
+#        TT_FATAL(attributes.n_groups == 8, ...);
+#        TT_FATAL(attributes.topk_groups == 4, ...);
+#        TT_FATAL(scores.logical_shape()[-1] == 256, ...);
 #
-# When the gate-kernel blocker is resolved, flip these e2e cases from
-# ``pytest.mark.skip`` to ``pytest.mark.skipif`` against ``--hf-model-path``
-# existence (the prefix knob is already in place):
+#    The Python interface looks parameterized but the C++ implementation
+#    isn't. This is the load-bearing constraint.
+# 3. The underlying LLK primitive ``deepseek_moe_gate`` (under
+#    ``kernel_includes/tt_llk/.../llk_math_deepseek_moe_gate_*.h``) is a
+#    bitonic-topk over a 16-element face — a hardware-specific SFPU primitive
+#    sized to DeepSeek's per-group width.
 #
-#   - kimi_safetensors_flat_moe_layer1_modeA
-#   - kimi_safetensors_per_step_moe_layer30_modeA
+# Kimi K2.6's routing config (from bit_sculpt's ``config/models.json``) is:
+# ``n_groups=1, experts_per_group=384, topk_groups=1, top_k=8,
+# scoring_func=sigmoid, routed_scaling_factor=2.827``. That is mathematically
+# the *degenerate* case of grouped routing (one global group), and equivalent
+# to plain ungrouped top-8 over 384.
 #
-# Other Kimi-MoE-layer cases (different layers, Mode B fanout, …) can be added
-# alongside. The ``language_model.`` prefix is already wired into the e2e
-# config dicts so no test changes needed beyond the skip → skipif flip.
+# Upstream activity (corrected)
+# -----------------------------
+# - ``origin/gchoudhary/41826-generalize-moe_compute-shape-support`` (51
+#   commits ahead of main, latest 2026-05-14) and ``origin/dchen/moe_compute*``
+#   are **NOT** generalizing the gate. They generalize the *expert side* —
+#   dispatch/combine, ring A2A packet splitting, shard distribution, expert
+#   compute — for Ling-1T (hidden=8192), GPT-OSS, etc.
+#   See ``tests/nightly/tg/ccl/moe/test_moe_compute_6U.py`` for that work's
+#   target matrix.
+#   **Do not wait for these branches to unblock Kimi gate routing — they
+#   won't.**
+# - ``origin/ddjekic/kimi26_bringup`` is the full Kimi 2.6 demo on the
+#   ``_d_p`` (distributed-prefill) sister demo line. Its gate kernel is
+#   ``models/demos/kimi26_d_p/tt/moe/tt_moe_gate_prefill.py``. Critically it
+#   defines a ``GateComputeMode`` enum with explicit host fallbacks because
+#   the device op doesn't support Kimi::
 #
-# Re-validate at flip time
-# ------------------------
-# 1. ``_check_metadata_consistency`` ``moe_layer_offset`` warning fires
-#    correctly for any Kimi case (offset=1 vs harness's effective offset).
-# 2. ``NUM_DENSE_LAYERS`` constant at the top of this file may need to become
-#    a per-config field (``moe_layer_offset`` on ``HostIoDecoderSweepConfig``)
-#    if you want to actually *route* Kimi layers correctly rather than just
-#    *warn* about the mismatch.
-# 3. ``CacheWeightProvider.load_moe_layer`` calls ``prepare_moe_layer_weights``
-#    with ``num_routed_experts=NUM_ROUTED_EXPERTS`` (==256 from
-#    ``weights/prepare.py``). That constant also needs lifting to a config /
-#    per-model knob before Kimi can run.
+#       DEVICE = "device"                       # everything device — fails for Kimi
+#       HOST_GROUPED_GATE = "host_grouped_gate" # matmul device, grouped-topk host
+#       HOST_MATMUL = "host_matmul"             # matmul host, grouped-topk device
+#       HOST_ALL = "host_all"                   # everything host
+#
+#   The grouped-topk-host mode is the production fallback shipping today on
+#   ``_d_p`` for Kimi.
+#
+# Reframed options for picking up the Kimi MoE work on ``_b1``
+# ------------------------------------------------------------
+# - **C1' (host-fallback gate, ~1-2 days, RECOMMENDED for validation infra).**
+#   Port ``kimi26_d_p``'s ``HOST_GROUPED_GATE`` recipe into this code path:
+#   keep the gate matmul on device, but after it, pull the
+#   ``(batch, n_experts)`` logits to host, run grouped-topk in plain torch
+#   (which handles ``n_groups=1`` trivially), push the resulting
+#   ``(batch, top_k)`` scores + indices back to device. The downstream MoE
+#   dispatch/combine pipeline consumes these tensors identically regardless of
+#   where they came from. Reference algorithm already lives in
+#   ``DeepseekMoeGateSingleCore.golden`` (60 lines), just needs parameterization
+#   over ``(n_groups, topk_groups, n_experts, top_k,
+#   routed_scaling_factor)``. Cost: one host roundtrip + ~384-element CPU
+#   topk per MoE layer per token. Negligible for PCC validation; not
+#   production-throughput. **This is what this harness wants** — its purpose
+#   is correctness validation against bit_sculpt reference traces.
+#
+# - **C2 (device kernel generalization, weeks).** Lift the three TT_FATALs in
+#   ``moe_grouped_topk_device_operation.cpp:validate()`` and teach the LLK /
+#   SFPU bitonic-topk primitive to handle ``(n_groups=1, n_experts=384,
+#   top_k=8)``. This is real LLK work because the 16-element face primitive
+#   doesn't fit 384 directly — likely needs a multi-tile path. Production
+#   route, but **no one is actively doing this work right now** on any
+#   branch I checked. Don't block on it.
+#
+# - **C3 (new ungrouped kernel from scratch, ~3-4 weeks).** Write
+#   ``UngroupedTopKGateSingleCore`` alongside the DeepSeek one — e.g.
+#   ``(16, 24) = 384`` tile or ``(32, 16) = 512`` padded with –∞ dummies — and
+#   teach ``HostIoDecoderStage`` to dispatch by config. Only useful if the
+#   ungrouped pattern needs to be fast; likely superseded by C2.
+#
+# Recommendation: do **C1'** when the time comes to validate Kimi MoE PCC on
+# this harness. The cost is small and the path is proven on ``_d_p``.
+#
+# Concrete edits when C1' lands
+# -----------------------------
+# 1. Add ``gate_compute_mode: Literal["device", "host_grouped_gate"] = "device"``
+#    to ``HostIoDecoderSweepConfig``; default preserves DeepSeek path.
+# 2. Lift ``NUM_ROUTED_EXPERTS`` (currently the ==256 constant in
+#    ``weights/prepare.py``) and ``routed_scaling_factor`` (the
+#    ``scaling_factor=2.5`` in ``DeepseekMoeGateSingleCore``) to config
+#    fields on ``HostIoDecoderSweepConfig``.
+# 3. Optionally lift ``NUM_DENSE_LAYERS`` to ``moe_layer_offset`` config so
+#    layer-type routing is correct for Kimi (preflight currently only *warns*
+#    on the mismatch; once we want to validate Kimi layers 1-2 as MoE we
+#    need actual routing).
+# 4. Flip these e2e cases from ``pytest.mark.skip`` to
+#    ``pytest.mark.skipif`` against ``--hf-model-path`` existence (the
+#    ``weight_key_prefix`` knob is already in place)::
+#
+#      - kimi_safetensors_flat_moe_layer1_modeA
+#      - kimi_safetensors_per_step_moe_layer30_modeA
+#
+# The Kimi-dense layer-0 case (``kimi_safetensors_flat_dense_layer0_modeA``)
+# is already at ``skipif(weights-not-staged)`` — no gate kernel involved.
 #
 # ============================================================================

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
@@ -470,6 +470,115 @@ def _check_metadata_consistency(metadata_path: Path, decoder_layer_idx: int) -> 
             f"n_layers={n_layers}; loader will likely fail to find the layer file"
         )
 
+    # moe_layer_offset mismatch is the load-bearing one. The harness routes
+    # decoder_layer_idx < NUM_DENSE_LAYERS to the dense weight loader and >= to
+    # the MoE loader. If the trace was produced with a different offset (e.g.
+    # Kimi K2.6 = 1 vs DeepSeek V3 = 3), the harness will silently route
+    # decoder_layer_idx in the ambiguous range to the wrong path and crash
+    # mid-forward with a confusing weight-shape error. Surface the conflict at
+    # preflight, naming the specific decoder_layer_idx in the danger zone.
+    trace_moe_offset = metadata.get("moe_layer_offset")
+    if trace_moe_offset is not None and trace_moe_offset != NUM_DENSE_LAYERS:
+        lo, hi = sorted([int(trace_moe_offset), NUM_DENSE_LAYERS])
+        if lo <= decoder_layer_idx < hi:
+            logger.warning(
+                f"{metadata_path}: moe_layer_offset={trace_moe_offset} but harness "
+                f"is configured for NUM_DENSE_LAYERS={NUM_DENSE_LAYERS}. "
+                f"decoder_layer_idx={decoder_layer_idx} falls in the ambiguous "
+                f"range [{lo}, {hi}): the trace treats it as "
+                f"{'dense' if decoder_layer_idx < trace_moe_offset else 'MoE'} "
+                f"but the harness will route it to "
+                f"{'dense' if decoder_layer_idx < NUM_DENSE_LAYERS else 'MoE'} — "
+                f"this WILL load wrong-arity weights and crash on-device. "
+                f"Pick a different layer or use a harness with matching "
+                f"NUM_DENSE_LAYERS."
+            )
+        else:
+            logger.warning(
+                f"{metadata_path}: moe_layer_offset={trace_moe_offset} differs from "
+                f"harness NUM_DENSE_LAYERS={NUM_DENSE_LAYERS}, but decoder_layer_idx="
+                f"{decoder_layer_idx} is outside the ambiguous range [{lo}, {hi}) "
+                f"so dense/MoE dispatch agrees for this layer. Other layer indices "
+                f"in [{lo}, {hi}) would be misrouted."
+            )
+
+
+def _write_dumps(
+    config: HostIoDecoderSweepConfig,
+    *,
+    collected: dict[str, dict[int, torch.Tensor]],
+    kv_cache_torch: torch.Tensor | None,
+    schedule: MultiTurnSchedule,
+) -> None:
+    """Write per-(slot, prompt) hidden-state and KV-cache dumps per ``config.dump_format``.
+
+    Extracted from ``run_sweep``'s Phase 5 so the dispatch logic — which gets
+    a bit dense once two formats and two independent toggles are involved — can
+    be unit-tested in isolation against fake collected/kv_cache inputs.
+
+    Layout summary:
+      - ``dump_format="pt"`` (default, back-compat):
+            <dump_dir>/output_hidden_states_slot_{NN}_<prompt>.pt   torch.save (L_p, HIDDEN_SIZE) bf16
+            <dump_dir>/kv_cache_slot_{NN}_<prompt>.pt               torch.save (1, L_p, kvpe_dim) bf16
+      - ``dump_format="safetensors"`` (bit_sculpt diff-friendly):
+            <dump_dir>/<prompt>/decoder_output_layer_{L}_slot_{NN}.safetensors
+              tensor key: "decoder_output_layer_{L}", shape (L_p, HIDDEN_SIZE) bf16
+            <dump_dir>/<prompt>/kv_cache_layer_{L}_slot_{NN}.safetensors
+              tensor key: "kv_post_transform_layer_{L}", shape (L_p, 576) bf16
+              (squeezed from the harness's (1, L_p, 576) to match bit_sculpt's
+              kv_post_transform tensor exactly)
+
+    Slot suffix is always present on safetensors filenames even at
+    ``num_replication_slots=1`` so Mode A and Mode B share one filename schema;
+    bit_sculpt's tracer doesn't fan out across slots, so this suffix is
+    TT-specific. Caller is responsible for the ``dump_*`` knob gating; this
+    helper is a no-op if both dump flags are False.
+    """
+    if not (config.dump_hidden_states or config.dump_kv_cache):
+        return
+    assert (
+        config.dump_dir is not None
+    ), "dump_dir is None but a dump knob is True (__post_init__ should have caught this)"
+    logger.info(f"Phase 5: per-(slot, prompt) dumps to {config.dump_dir}")
+
+    if config.dump_hidden_states:
+        for prompt_name in config.prompt_names:
+            for slot in range(config.num_replication_slots):
+                if config.dump_format == "pt":
+                    out_path = config.dump_dir / f"output_hidden_states_slot_{slot:02d}_{prompt_name}.pt"
+                    torch.save(collected[prompt_name][slot], out_path)
+                else:
+                    prompt_dir = config.dump_dir / prompt_name
+                    prompt_dir.mkdir(parents=True, exist_ok=True)
+                    out_path = (
+                        prompt_dir / f"decoder_output_layer_{config.decoder_layer_idx}_slot_{slot:02d}.safetensors"
+                    )
+                    tensor_key = f"decoder_output_layer_{config.decoder_layer_idx}"
+                    safetensors_save_file({tensor_key: collected[prompt_name][slot]}, str(out_path))
+                logger.info(f"Wrote {out_path}")
+
+    if config.dump_kv_cache:
+        assert kv_cache_torch is not None, "dump_kv_cache=True but kv_cache_torch is None"
+        for prompt_idx, prompt_name in enumerate(config.prompt_names):
+            start, end = schedule.range_for(prompt_idx)
+            for slot in range(config.num_replication_slots):
+                kv_slice = kv_cache_torch[slot, :, start:end, :]
+                if config.dump_format == "pt":
+                    out_path = config.dump_dir / f"kv_cache_slot_{slot:02d}_{prompt_name}.pt"
+                    torch.save(kv_slice, out_path)
+                    logger.info(f"Wrote {out_path} shape={tuple(kv_slice.shape)}")
+                else:
+                    # bit_sculpt stores kv_post_transform_layer_{i} as (T, 576);
+                    # the harness pulls the cache as (1, L_p, 576), so squeeze
+                    # dim 0 to match the reference contract exactly.
+                    kv_slice_2d = kv_slice.squeeze(0).contiguous()
+                    prompt_dir = config.dump_dir / prompt_name
+                    prompt_dir.mkdir(parents=True, exist_ok=True)
+                    out_path = prompt_dir / f"kv_cache_layer_{config.decoder_layer_idx}_slot_{slot:02d}.safetensors"
+                    tensor_key = f"kv_post_transform_layer_{config.decoder_layer_idx}"
+                    safetensors_save_file({tensor_key: kv_slice_2d}, str(out_path))
+                    logger.info(f"Wrote {out_path} shape={tuple(kv_slice_2d.shape)}")
+
 
 def _load_reference_trace(
     trace_dir: Path,
@@ -1177,55 +1286,11 @@ def run_sweep(
             logger.info(f"prompt={prompt_name!r} KV cross-slot OK for positions [{start}, {end})")
 
     # =========================================================================
-    # Phase 5: Per-(prompt, slot) dumps
+    # Phase 5: Per-(slot, prompt) dumps — full dispatch lives in _write_dumps so
+    # the format / toggle logic stays unit-testable. Skipped entirely if both
+    # dump knobs are False.
     # =========================================================================
-    if config.dump_hidden_states or config.dump_kv_cache:
-        assert config.dump_dir is not None  # __post_init__ guarantees this
-        logger.info(f"Phase 5: per-(prompt, slot) dumps to {config.dump_dir}")
-
-    if config.dump_hidden_states:
-        # safetensors layout matches bit_sculpt's DebugTracer convention so
-        # downstream tooling can diff TT dumps against the reference traces
-        # without a format-conversion step. The slot suffix is appended after
-        # the layer suffix; bit_sculpt does not produce per-slot files (its
-        # tracer runs the full model once, not N replicated slots), so this
-        # extension is TT-specific.
-        for prompt_name in config.prompt_names:
-            for slot in range(config.num_replication_slots):
-                if config.dump_format == "pt":
-                    out_path = config.dump_dir / f"output_hidden_states_slot_{slot:02d}_{prompt_name}.pt"
-                    torch.save(collected[prompt_name][slot], out_path)
-                else:
-                    prompt_dir = config.dump_dir / prompt_name
-                    prompt_dir.mkdir(parents=True, exist_ok=True)
-                    out_path = (
-                        prompt_dir / f"decoder_output_layer_{config.decoder_layer_idx}_slot_{slot:02d}.safetensors"
-                    )
-                    tensor_key = f"decoder_output_layer_{config.decoder_layer_idx}"
-                    safetensors_save_file({tensor_key: collected[prompt_name][slot]}, str(out_path))
-                logger.info(f"Wrote {out_path}")
-
-    if config.dump_kv_cache:
-        assert kv_cache_torch is not None  # guaranteed by need_kv_cache above
-        for prompt_idx, prompt_name in enumerate(config.prompt_names):
-            start, end = schedule.range_for(prompt_idx)
-            for slot in range(config.num_replication_slots):
-                kv_slice = kv_cache_torch[slot, :, start:end, :]
-                if config.dump_format == "pt":
-                    out_path = config.dump_dir / f"kv_cache_slot_{slot:02d}_{prompt_name}.pt"
-                    torch.save(kv_slice, out_path)
-                    logger.info(f"Wrote {out_path} shape={tuple(kv_slice.shape)}")
-                else:
-                    # bit_sculpt stores kv_post_transform_layer_{i} as (T, 576);
-                    # the harness pulls the cache as (1, L_p, 576), so squeeze
-                    # dim 0 to match the reference contract exactly.
-                    kv_slice_2d = kv_slice.squeeze(0).contiguous()
-                    prompt_dir = config.dump_dir / prompt_name
-                    prompt_dir.mkdir(parents=True, exist_ok=True)
-                    out_path = prompt_dir / f"kv_cache_layer_{config.decoder_layer_idx}_slot_{slot:02d}.safetensors"
-                    tensor_key = f"kv_post_transform_layer_{config.decoder_layer_idx}"
-                    safetensors_save_file({tensor_key: kv_slice_2d}, str(out_path))
-                    logger.info(f"Wrote {out_path} shape={tuple(kv_slice_2d.shape)}")
+    _write_dumps(config, collected=collected, kv_cache_torch=kv_cache_torch, schedule=schedule)
 
     logger.info("run_sweep complete")
     return SweepResult(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
@@ -70,12 +70,15 @@ checkpoints of the migration plan. See ``host_io_decoder_stage_context.txt``
 from __future__ import annotations
 
 import contextlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Literal
 
 import torch
 from loguru import logger
+from safetensors.torch import load_file as safetensors_load_file
+from safetensors.torch import save_file as safetensors_save_file
 
 import ttnn
 from models.common.utility_functions import comp_pcc, is_slow_dispatch
@@ -189,6 +192,12 @@ class HostIoDecoderSweepConfig:
     validate_hidden_states_cross_trace: bool = False
     pcc_threshold: float = 0.97  # only consulted when validate_hidden_states_cross_trace is True
 
+    # --- trace I/O format ---
+    # Source format for reference traces read from ``hidden_states_dir``.
+    # ``"auto"`` probes ``<prompt>.pt`` then ``<prompt>/`` (bit_sculpt
+    # per-layer safetensors directory). Set explicitly to skip the probe.
+    trace_format: TraceFormat = "auto"
+
     # --- dump knobs ---
     # Disk dumps are OPT-IN: defaults are False so a validation-only run (or a
     # pure sweep) does not require ``--dump-dir`` and does not pay the cost of
@@ -196,6 +205,11 @@ class HostIoDecoderSweepConfig:
     dump_hidden_states: bool = False
     dump_kv_cache: bool = False
     dump_dir: Path | None = None  # required if any dump knob is True
+    # Output format for dumps. ``"pt"`` (current behavior) writes one
+    # ``torch.save`` per (slot, prompt). ``"safetensors"`` writes per-layer
+    # safetensors files matching bit_sculpt's ``DebugTracer`` layout — see
+    # Phase 5 in run_sweep for the exact path and tensor-key conventions.
+    dump_format: Literal["pt", "safetensors"] = "pt"
 
     # --- weights ---
     hf_model_path: Path = DEFAULT_HF_MODEL_PATH
@@ -239,6 +253,10 @@ class HostIoDecoderSweepConfig:
             )
         if not (0.0 < self.pcc_threshold <= 1.0):
             raise ValueError(f"pcc_threshold must be in (0, 1]; got {self.pcc_threshold}")
+        if self.trace_format not in ("auto", "pt", "safetensors"):
+            raise ValueError(f"trace_format must be 'auto', 'pt', or 'safetensors'; got {self.trace_format!r}")
+        if self.dump_format not in ("pt", "safetensors"):
+            raise ValueError(f"dump_format must be 'pt' or 'safetensors'; got {self.dump_format!r}")
         if (self.dump_hidden_states or self.dump_kv_cache) and self.dump_dir is None:
             raise ValueError("dump_dir is required when dump_hidden_states or dump_kv_cache is True")
 
@@ -294,47 +312,250 @@ class _SinglePipelineStage:
 # ---------------------------------------------------------------------------
 
 
-def _load_reference_trace(trace_dir: Path, prompt_name: str) -> dict[str, torch.Tensor]:
+# Trace format literal — accepted by _load_reference_trace and surfaced as a
+# config / CLI knob. "auto" resolves at preflight time by probing the filesystem
+# (``<prompt>.pt`` wins over ``<prompt>/`` so the .pt path remains the default
+# when both happen to exist).
+TraceFormat = Literal["auto", "pt", "safetensors"]
+
+
+def _resolve_trace_format(trace_dir: Path, prompt_name: str, requested: TraceFormat) -> Literal["pt", "safetensors"]:
+    """Resolve ``requested`` to a concrete format, probing disk if "auto".
+
+    Probe order for ``"auto"``: ``<trace_dir>/<prompt>.pt`` first (back-compat
+    with the original DeepSeek pipeclean traces), then ``<trace_dir>/<prompt>/``
+    as a directory (bit_sculpt per-layer safetensors layout). Raises
+    ``FileNotFoundError`` listing both probed paths if neither exists.
+    """
+    if requested != "auto":
+        return requested
+    pt_path = trace_dir / f"{prompt_name}.pt"
+    if pt_path.exists():
+        return "pt"
+    safetensors_dir = trace_dir / prompt_name
+    if safetensors_dir.is_dir():
+        return "safetensors"
+    raise FileNotFoundError(
+        f"Reference trace not found for prompt {prompt_name!r}. Probed: {pt_path} (pt), "
+        f"{safetensors_dir} (safetensors). Pass --trace-format explicitly to disambiguate."
+    )
+
+
+def _load_one_safetensors_tensor(path: Path) -> torch.Tensor:
+    """Load a safetensors file that holds exactly one tensor; return that tensor.
+
+    bit_sculpt's ``DebugTracer._save_step`` writes one safetensors file per
+    (layer, kind) pair, each containing a single tensor. The *key* inside the
+    file is the canonical name (``decoder_input_layer_0`` for layer 0's input,
+    ``decoder_output_layer_{i}`` for any layer output, ``kv_post_transform_layer_{i}``
+    for KV cache). Symlinks resolve transparently on the filesystem — the key
+    inside a symlinked ``decoder_input_layer_{i+1}.safetensors`` is still
+    ``decoder_output_layer_{i}`` (the symlink target's key).
+
+    We don't know the key a priori at every call site (input-file keys depend on
+    the layer index), so accept whatever single key is there.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Safetensors file not found: {path}")
+    tensors = safetensors_load_file(str(path))
+    if len(tensors) != 1:
+        raise ValueError(
+            f"{path}: expected exactly one tensor in safetensors file, got {len(tensors)} "
+            f"(keys: {sorted(tensors.keys())})"
+        )
+    return next(iter(tensors.values()))
+
+
+def _list_step_dirs(prompt_dir: Path) -> list[Path]:
+    """Return ``prompt_dir/step_*`` subdirectories sorted by numeric suffix.
+
+    bit_sculpt's decode-trace mode writes ``step_0/`` (prefill) + ``step_1/`` ..
+    ``step_N/`` (one safetensors-bundle per generated token). Numeric sort —
+    not lexicographic — so ``step_10`` comes after ``step_2``.
+    """
+    steps: list[tuple[int, Path]] = []
+    for sub in prompt_dir.iterdir():
+        if not sub.is_dir():
+            continue
+        name = sub.name
+        if not name.startswith("step_"):
+            continue
+        suffix = name[len("step_") :]
+        if not suffix.isdigit():
+            continue
+        steps.append((int(suffix), sub))
+    steps.sort(key=lambda kv: kv[0])
+    return [path for _, path in steps]
+
+
+def _load_safetensors_layer_pair(prompt_dir: Path, decoder_layer_idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Load (input, output) for ``decoder_layer_idx`` from a bit_sculpt safetensors prompt dir.
+
+    Two on-disk variants are accepted, matching ``DebugTracer.save`` (flat) vs
+    ``DebugTracer.save_decode_trace`` (per-step) in ``analysis/debug_trace.py``:
+
+    1. **Flat layout** — prefill-only trace::
+
+           {prompt_dir}/decoder_input_layer_{L}.safetensors
+           {prompt_dir}/decoder_output_layer_{L}.safetensors
+
+       Tensors are ``(T_prefill, HIDDEN_SIZE)``; returned as-is.
+
+    2. **Per-step layout** — decode-mode trace, detected by the presence of
+       ``step_0/``::
+
+           {prompt_dir}/step_0/decoder_input_layer_{L}.safetensors   (T_prefill, HIDDEN_SIZE)
+           {prompt_dir}/step_0/decoder_output_layer_{L}.safetensors  (T_prefill, HIDDEN_SIZE)
+           {prompt_dir}/step_1/decoder_input_layer_{L}.safetensors   (1, HIDDEN_SIZE)
+           {prompt_dir}/step_1/decoder_output_layer_{L}.safetensors  (1, HIDDEN_SIZE)
+           ...
+           {prompt_dir}/step_N/...
+
+       Concatenated along dim 0 to produce ``(T_prefill + N, HIDDEN_SIZE)`` —
+       the same contract as the flat layout. This is the step convention
+       documented in bit_sculpt's ``metadata.json[kv_cache_layout].step_convention``.
+    """
+    flat_input = prompt_dir / f"decoder_input_layer_{decoder_layer_idx}.safetensors"
+    flat_output = prompt_dir / f"decoder_output_layer_{decoder_layer_idx}.safetensors"
+    if flat_input.exists() and flat_output.exists():
+        return _load_one_safetensors_tensor(flat_input), _load_one_safetensors_tensor(flat_output)
+
+    step_dirs = _list_step_dirs(prompt_dir)
+    if not step_dirs:
+        raise FileNotFoundError(
+            f"{prompt_dir}: no flat decoder_input/output_layer_{decoder_layer_idx}.safetensors "
+            f"and no step_* subdirectories. Is this a valid bit_sculpt trace directory?"
+        )
+    inputs: list[torch.Tensor] = []
+    outputs: list[torch.Tensor] = []
+    for step_dir in step_dirs:
+        inputs.append(_load_one_safetensors_tensor(step_dir / f"decoder_input_layer_{decoder_layer_idx}.safetensors"))
+        outputs.append(_load_one_safetensors_tensor(step_dir / f"decoder_output_layer_{decoder_layer_idx}.safetensors"))
+    return torch.cat(inputs, dim=0), torch.cat(outputs, dim=0)
+
+
+def _check_metadata_consistency(metadata_path: Path, decoder_layer_idx: int) -> None:
+    """Soft-assert bit_sculpt metadata.json matches the harness's hardcoded dims.
+
+    The harness assumes DeepSeek V3 (HIDDEN_SIZE=7168, kv_lora_rank=512,
+    qk_rope_head_dim=64). Kimi K2.6 shares those three dims but differs on
+    moe_layer_offset (1 vs 3) and n_experts (384 vs 256) — neither of which the
+    *trace loader* cares about (those only matter when actually running the MoE
+    kernel). Log a warning rather than hard-fail on mismatch so the harness can
+    still consume a trace it can validate dimensions for.
+    """
+    if not metadata_path.exists():
+        return
+    try:
+        metadata = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Could not read {metadata_path}: {e}")
+        return
+    expected = {
+        "hidden_dim": D.HIDDEN_SIZE,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+    }
+    for key, want in expected.items():
+        got = metadata.get(key)
+        if got is not None and got != want:
+            logger.warning(
+                f"{metadata_path}: {key}={got!r} does not match harness assumption {want!r}; "
+                f"trace may have been produced for a different model"
+            )
+    n_layers = metadata.get("n_layers")
+    if n_layers is not None and decoder_layer_idx >= n_layers:
+        logger.warning(
+            f"{metadata_path}: decoder_layer_idx={decoder_layer_idx} is out of range for "
+            f"n_layers={n_layers}; loader will likely fail to find the layer file"
+        )
+
+
+def _load_reference_trace(
+    trace_dir: Path,
+    prompt_name: str,
+    *,
+    decoder_layer_idx: int,
+    trace_format: TraceFormat = "auto",
+) -> dict[str, torch.Tensor]:
     """Load and validate one prompt's reference trace.
 
-    Expected on-disk format (per prompt):
+    Two on-disk layouts are supported, selected by ``trace_format``:
+
+    ``"pt"`` — single ``torch.save`` file per prompt (original DeepSeek
+    pipeclean format)::
+
         torch.save(
             {"input":  (L, HIDDEN_SIZE) bf16,
              "output": (L, HIDDEN_SIZE) bf16},
             f"{trace_dir}/{prompt_name}.pt",
         )
 
-    Returns the dict unchanged. Raises ``FileNotFoundError`` / ``ValueError`` if
-    the file's structure / shapes / dtypes don't match the contract.
+    ``"safetensors"`` — bit_sculpt's per-layer layout under a per-prompt dir::
+
+        {trace_dir}/{prompt_name}/
+            metadata.json                                  (optional, soft-checked)
+            decoder_input_layer_0.safetensors              (real file iff layer 0)
+            decoder_input_layer_{L}.safetensors            (symlink for L >= 1)
+            decoder_output_layer_{L}.safetensors           (real, all layers)
+            kv_cache_layer_{L}.safetensors                 (real, all layers)
+            ...
+
+    For the safetensors format, ``decoder_layer_idx`` selects which layer's
+    input/output pair to read; bit_sculpt stores every layer, the TT harness
+    only runs one.
+
+    ``"auto"`` resolves at the call site via :func:`_resolve_trace_format`.
+
+    Returns a dict ``{"input": (L, HIDDEN_SIZE) bf16, "output": (L, HIDDEN_SIZE) bf16}``
+    regardless of source format. Raises ``FileNotFoundError`` / ``ValueError``
+    on contract violations.
     """
-    path = trace_dir / f"{prompt_name}.pt"
-    if not path.exists():
-        raise FileNotFoundError(f"Reference trace not found: {path}")
-    # map_location="cpu" so traces saved on a CUDA host still load on a CPU host
-    # (the harness only consumes the tensors on host before pushing to ttnn).
-    trace = torch.load(path, map_location="cpu")
-    if not isinstance(trace, dict):
-        raise ValueError(f"{path}: expected dict, got {type(trace).__name__}")
-    if not set(trace.keys()) >= {"input", "output"}:
-        raise ValueError(f"{path}: missing required keys 'input'/'output'; got {sorted(trace.keys())}")
-    inp, out = trace["input"], trace["output"]
+    resolved_format = _resolve_trace_format(trace_dir, prompt_name, trace_format)
+
+    if resolved_format == "pt":
+        path = trace_dir / f"{prompt_name}.pt"
+        # map_location="cpu" so traces saved on a CUDA host still load on a CPU host
+        # (the harness only consumes the tensors on host before pushing to ttnn).
+        trace = torch.load(path, map_location="cpu")
+        if not isinstance(trace, dict):
+            raise ValueError(f"{path}: expected dict, got {type(trace).__name__}")
+        if not set(trace.keys()) >= {"input", "output"}:
+            raise ValueError(f"{path}: missing required keys 'input'/'output'; got {sorted(trace.keys())}")
+        inp, out = trace["input"], trace["output"]
+        source_desc = str(path)
+    else:
+        # safetensors: bit_sculpt's per-layer-per-kind layout. Supports two
+        # variants — flat (prefill-only, one tensor per (layer, kind)) and
+        # per-step decode-mode (step_0..step_N subdirs, concatenated along
+        # dim 0). See _load_safetensors_layer_pair for the layout contract.
+        prompt_dir = trace_dir / prompt_name
+        if not prompt_dir.is_dir():
+            raise FileNotFoundError(f"Safetensors trace directory not found: {prompt_dir}")
+        _check_metadata_consistency(prompt_dir / "metadata.json", decoder_layer_idx)
+        inp, out = _load_safetensors_layer_pair(prompt_dir, decoder_layer_idx)
+        source_desc = f"{prompt_dir} (safetensors, layer {decoder_layer_idx})"
+
+    # Shared contract checks — identical for both formats.
     if not (isinstance(inp, torch.Tensor) and isinstance(out, torch.Tensor)):
-        raise ValueError(f"{path}: 'input' and 'output' must be torch.Tensor")
+        raise ValueError(f"{source_desc}: 'input' and 'output' must be torch.Tensor")
     if inp.dtype != torch.bfloat16 or out.dtype != torch.bfloat16:
-        raise ValueError(f"{path}: expected bfloat16 tensors, got input={inp.dtype}, output={out.dtype}")
+        raise ValueError(f"{source_desc}: expected bfloat16 tensors, got input={inp.dtype}, output={out.dtype}")
     if inp.ndim != 2 or out.ndim != 2:
         raise ValueError(
-            f"{path}: expected 2D (seq_len, HIDDEN_SIZE) tensors, got input.shape={tuple(inp.shape)}, "
+            f"{source_desc}: expected 2D (seq_len, HIDDEN_SIZE) tensors, got input.shape={tuple(inp.shape)}, "
             f"output.shape={tuple(out.shape)}"
         )
     if inp.shape[-1] != D.HIDDEN_SIZE or out.shape[-1] != D.HIDDEN_SIZE:
         raise ValueError(
-            f"{path}: last dim must equal D.HIDDEN_SIZE ({D.HIDDEN_SIZE}), got "
+            f"{source_desc}: last dim must equal D.HIDDEN_SIZE ({D.HIDDEN_SIZE}), got "
             f"input.shape={tuple(inp.shape)}, output.shape={tuple(out.shape)}"
         )
     if inp.shape[0] != out.shape[0]:
-        raise ValueError(f"{path}: input and output seq_len mismatch: input={inp.shape[0]}, output={out.shape[0]}")
-    return trace
+        raise ValueError(
+            f"{source_desc}: input and output seq_len mismatch: input={inp.shape[0]}, output={out.shape[0]}"
+        )
+    return {"input": inp, "output": out}
 
 
 def _to_hidden_state_input(
@@ -478,7 +699,12 @@ def _preflight(
     traces: dict[str, dict[str, torch.Tensor]] = {}
     prompt_lengths: list[int] = []
     for prompt_name in config.prompt_names:
-        trace = _load_reference_trace(config.hidden_states_dir, prompt_name)
+        trace = _load_reference_trace(
+            config.hidden_states_dir,
+            prompt_name,
+            decoder_layer_idx=config.decoder_layer_idx,
+            trace_format=config.trace_format,
+        )
         traces[prompt_name] = trace
         prompt_lengths.append(int(trace["input"].shape[0]))
 
@@ -958,10 +1184,25 @@ def run_sweep(
         logger.info(f"Phase 5: per-(prompt, slot) dumps to {config.dump_dir}")
 
     if config.dump_hidden_states:
+        # safetensors layout matches bit_sculpt's DebugTracer convention so
+        # downstream tooling can diff TT dumps against the reference traces
+        # without a format-conversion step. The slot suffix is appended after
+        # the layer suffix; bit_sculpt does not produce per-slot files (its
+        # tracer runs the full model once, not N replicated slots), so this
+        # extension is TT-specific.
         for prompt_name in config.prompt_names:
             for slot in range(config.num_replication_slots):
-                out_path = config.dump_dir / f"output_hidden_states_slot_{slot:02d}_{prompt_name}.pt"
-                torch.save(collected[prompt_name][slot], out_path)
+                if config.dump_format == "pt":
+                    out_path = config.dump_dir / f"output_hidden_states_slot_{slot:02d}_{prompt_name}.pt"
+                    torch.save(collected[prompt_name][slot], out_path)
+                else:
+                    prompt_dir = config.dump_dir / prompt_name
+                    prompt_dir.mkdir(parents=True, exist_ok=True)
+                    out_path = (
+                        prompt_dir / f"decoder_output_layer_{config.decoder_layer_idx}_slot_{slot:02d}.safetensors"
+                    )
+                    tensor_key = f"decoder_output_layer_{config.decoder_layer_idx}"
+                    safetensors_save_file({tensor_key: collected[prompt_name][slot]}, str(out_path))
                 logger.info(f"Wrote {out_path}")
 
     if config.dump_kv_cache:
@@ -970,9 +1211,21 @@ def run_sweep(
             start, end = schedule.range_for(prompt_idx)
             for slot in range(config.num_replication_slots):
                 kv_slice = kv_cache_torch[slot, :, start:end, :]
-                out_path = config.dump_dir / f"kv_cache_slot_{slot:02d}_{prompt_name}.pt"
-                torch.save(kv_slice, out_path)
-                logger.info(f"Wrote {out_path} shape={tuple(kv_slice.shape)}")
+                if config.dump_format == "pt":
+                    out_path = config.dump_dir / f"kv_cache_slot_{slot:02d}_{prompt_name}.pt"
+                    torch.save(kv_slice, out_path)
+                    logger.info(f"Wrote {out_path} shape={tuple(kv_slice.shape)}")
+                else:
+                    # bit_sculpt stores kv_post_transform_layer_{i} as (T, 576);
+                    # the harness pulls the cache as (1, L_p, 576), so squeeze
+                    # dim 0 to match the reference contract exactly.
+                    kv_slice_2d = kv_slice.squeeze(0).contiguous()
+                    prompt_dir = config.dump_dir / prompt_name
+                    prompt_dir.mkdir(parents=True, exist_ok=True)
+                    out_path = prompt_dir / f"kv_cache_layer_{config.decoder_layer_idx}_slot_{slot:02d}.safetensors"
+                    tensor_key = f"kv_post_transform_layer_{config.decoder_layer_idx}"
+                    safetensors_save_file({tensor_key: kv_slice_2d}, str(out_path))
+                    logger.info(f"Wrote {out_path} shape={tuple(kv_slice_2d.shape)}")
 
     logger.info("run_sweep complete")
     return SweepResult(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py
@@ -214,6 +214,14 @@ class HostIoDecoderSweepConfig:
     # --- weights ---
     hf_model_path: Path = DEFAULT_HF_MODEL_PATH
     cache_path: Path = DEFAULT_CACHE_PATH
+    # Prefix prepended to every state_dict key when looking up weights on
+    # disk. Default "" matches DeepSeek-V3 HF snapshots, which expose keys
+    # directly as ``model.layers.{i}.*``. Set to ``"language_model."`` for
+    # Kimi K2.6 BF16-dequant snapshots — Kimi's HF wrapper is
+    # ``KimiK25ForConditionalGeneration`` and nests the DeepSeek-V3 backbone
+    # under that prefix. Forwarded to ``CacheWeightProvider(weight_key_prefix=...)``
+    # which forwards to ``LazyStateDict(base_prefix=...)``.
+    weight_key_prefix: str = ""
 
     # --- misc ---
     seed: int = 0
@@ -1045,7 +1053,13 @@ def run_sweep(
 
     logger.info(f"Using HF model path: {config.hf_model_path}")
     logger.info(f"Using cache path:    {config.cache_path}")
-    provider = CacheWeightProvider(cache_path=config.cache_path, model_path=config.hf_model_path)
+    if config.weight_key_prefix:
+        logger.info(f"Using weight key prefix: {config.weight_key_prefix!r}")
+    provider = CacheWeightProvider(
+        cache_path=config.cache_path,
+        model_path=config.hf_model_path,
+        weight_key_prefix=config.weight_key_prefix,
+    )
 
     # Auto-detect dense vs MoE from layer_idx (see NUM_DENSE_LAYERS comment at the
     # top of this module). Dense layers use a different weight loader and pass
@@ -1299,3 +1313,84 @@ def run_sweep(
         schedule=schedule,
         traces=traces,
     )
+
+
+# ============================================================================
+# KIMI_K26_PORT_NOTES
+# ============================================================================
+#
+# Status snapshot (2026-05-15) of Kimi K2.6 on-device validation through this
+# harness. Referenced from the ``pytest.mark.skip`` reasons in
+# ``test_host_io_decoder_sweep_e2e.py`` and from
+# ``micro_ops/deepseek_moe_gate/op.py:DeepseekMoeGateSingleCore``.
+#
+# What works today
+# ----------------
+# - **Trace I/O for Kimi safetensors traces** (this PR): both flat and per-step
+#   layouts load through ``_load_reference_trace``. Validated end-to-end against
+#   ``moonshotai-kimi-k26/debug_trace/{smoke_*, q_what_is_python}`` at layers
+#   0/3/30/60.
+# - **Kimi weight loading via the** ``weight_key_prefix="language_model."``
+#   **knob** on ``CacheWeightProvider`` (this PR). Forwards to
+#   ``LazyStateDict(base_prefix=...)`` so callers can keep using
+#   ``model.layers.{i}.*`` keys against a Kimi BF16-dequant snapshot that has
+#   the keys stored as ``language_model.model.layers.{i}.*``.
+# - **Preflight metadata mismatch warning**: if you load a Kimi trace
+#   (``moe_layer_offset=1``) against this harness (``NUM_DENSE_LAYERS=3``), the
+#   preflight warns about layers in the ambiguous range [1, 3) where the
+#   harness will route to dense but the trace was produced treating them as
+#   MoE. See ``_check_metadata_consistency``.
+#
+# What does NOT work — the 384-expert MoE gate kernel blocker
+# -----------------------------------------------------------
+# ``micro_ops/deepseek_moe_gate/op.py:DeepseekMoeGateSingleCore`` hardcodes a
+# ``(16, 16) = 256`` input tile and implements DeepSeek's grouped top-k
+# (16 groups × 16, top-2-per-group → top-4-groups → top-8). Kimi K2.6 has
+# 1 group × 384 experts, plain ``topk(sigmoid(scores) + bias, k=8)``. The
+# kernel cannot be reused.
+#
+# Three porting options for whoever picks up Kimi MoE on this code path:
+#
+# - **C1. Port from** ``models/demos/kimi26_d_p/``. Active feature branch
+#   ``origin/ddjekic/kimi26_bringup`` already has ``tt/moe/tt_moe_gate_prefill.py``,
+#   ``tt_dispatch.py``, ``tt_combine.py``. Adapter work: that demo uses
+#   dispatch/combine MoE primitives; this ``_b1`` line uses bcast/reduce.
+#   Estimated weeks of focused integration work, but the kernel + algorithm
+#   are proven.
+# - **C2. Wait for / land** ``origin/gchoudhary/41826-generalize-moe_compute-shape-support``
+#   (also ``origin/dchen/moe_compute*``). That refactor makes the MoE compute
+#   accept arbitrary ``(n_routed_experts, top_k, n_groups, …)`` — right
+#   abstraction for Kimi K2.5, DS V4 Pro (384/top-6), Ling-1T (256/top-8),
+#   GLM-4.7 (160/top-8), Mistral Large 3, Gemma 4 26B, DS-OCR. See
+#   ``tests/nightly/tg/ccl/moe/test_moe_compute_6U.py`` for the full target
+#   matrix. **Strongly preferred** if landing is on a reasonable timeline.
+# - **C3. New kernel from scratch.** ``UngroupedTopKGateSingleCore`` alongside
+#   the DeepSeek one — e.g. ``(16, 24) = 384`` tile or ``(32, 16) = 512``
+#   padded with –∞ dummies. Teach ``HostIoDecoderStage`` to dispatch by config.
+#   ~3-4 weeks of new kernel work. Only useful for Kimi-family configs.
+#
+# When the gate-kernel blocker is resolved, flip these e2e cases from
+# ``pytest.mark.skip`` to ``pytest.mark.skipif`` against ``--hf-model-path``
+# existence (the prefix knob is already in place):
+#
+#   - kimi_safetensors_flat_moe_layer1_modeA
+#   - kimi_safetensors_per_step_moe_layer30_modeA
+#
+# Other Kimi-MoE-layer cases (different layers, Mode B fanout, …) can be added
+# alongside. The ``language_model.`` prefix is already wired into the e2e
+# config dicts so no test changes needed beyond the skip → skipif flip.
+#
+# Re-validate at flip time
+# ------------------------
+# 1. ``_check_metadata_consistency`` ``moe_layer_offset`` warning fires
+#    correctly for any Kimi case (offset=1 vs harness's effective offset).
+# 2. ``NUM_DENSE_LAYERS`` constant at the top of this file may need to become
+#    a per-config field (``moe_layer_offset`` on ``HostIoDecoderSweepConfig``)
+#    if you want to actually *route* Kimi layers correctly rather than just
+#    *warn* about the mismatch.
+# 3. ``CacheWeightProvider.load_moe_layer`` calls ``prepare_moe_layer_weights``
+#    with ``num_routed_experts=NUM_ROUTED_EXPERTS`` (==256 from
+#    ``weights/prepare.py``). That constant also needs lifting to a config /
+#    per-model knob before Kimi can run.
+#
+# ============================================================================

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/run_host_io_decoder_sweep.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/run_host_io_decoder_sweep.py
@@ -48,6 +48,110 @@ Dry-run (print resolved config and exit, no device opened)::
     python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \\
         --decoder-layer-idx 4 \\
         --hidden-states-dir /tmp/x --prompt foo --dry-run
+
+Consuming bit_sculpt safetensors reference traces
+-------------------------------------------------
+
+bit_sculpt's ``DebugTracer`` (``analysis/debug_trace.py``) writes one safetensors
+file per (layer, kind) under a per-prompt directory. Two on-disk layouts are
+supported, auto-detected per prompt:
+
+  - **flat** — prefill-only traces. Files sit directly under the prompt dir::
+
+        <prompt>/
+            decoder_input_layer_0.safetensors       (real, key "decoder_input_layer_0")
+            decoder_input_layer_{L}.safetensors     (relative symlink to
+                                                     decoder_output_layer_{L-1}.safetensors,
+                                                     for L >= 1)
+            decoder_output_layer_{L}.safetensors    (real, key "decoder_output_layer_{L}")
+            kv_cache_layer_{L}.safetensors          (real, key "kv_post_transform_layer_{L}",
+                                                     shape (T, 576) = 512 latent + 64 k_pe)
+            ...
+            metadata.json                           (prompt, n_tokens, n_layers,
+                                                     moe_layer_offset, kv_lora_rank, ...)
+
+  - **per-step** — decode-mode traces (``run_debug_trace.py --decode-steps N``).
+    step_0 holds the prefill (T_prefill, HIDDEN_SIZE) tensors; step_k>=1 holds
+    one (1, HIDDEN_SIZE) row per generated token. The loader concatenates along
+    dim 0 to produce a single (T_prefill + N, HIDDEN_SIZE) tensor — the harness's
+    sweep sees no difference from the flat case::
+
+        <prompt>/
+            step_0/decoder_*_layer_{L}.safetensors  (T_prefill rows)
+            step_1/decoder_*_layer_{L}.safetensors  (1 row)
+            ...
+            step_N/decoder_*_layer_{L}.safetensors  (1 row)
+
+``--trace-format auto`` (the default) picks ``.pt`` then per-prompt-directory.
+``--dump-format`` mirrors the resolved trace format unless set explicitly, so a
+round-trip stays in one disk format. Dumps land under
+``<dump-dir>/<prompt>/decoder_output_layer_{L}_slot_{NN}.safetensors`` and
+``<dump-dir>/<prompt>/kv_cache_layer_{L}_slot_{NN}.safetensors``, with tensor
+keys and shapes matching bit_sculpt's conventions so downstream tooling can diff
+without conversion.
+
+DeepSeek-R1-0528, flat-layout trace, layer 4 (first MoE layer), Mode A + dumps::
+
+    TT_METAL_SLOW_DISPATCH_MODE=1 \\
+    python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \\
+        --decoder-layer-idx 4 \\
+        --hidden-states-dir /workspace/bit_sculpt/results/deepseek-r1-0528/debug_trace \\
+        --prompt aho_single_stage_all_layers \\
+        --trace-format safetensors \\
+        --num-replication-slots 1 \\
+        --dump-dir ./dumps --dump-hidden-states --dump-kv-cache
+
+DeepSeek-R1-0528, per-step decode trace, layer 4, Mode B (8 slots) with
+cross-trace PCC validation (the GPU-vs-TT correctness check)::
+
+    TT_METAL_SLOW_DISPATCH_MODE=1 \\
+    python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \\
+        --decoder-layer-idx 4 \\
+        --hidden-states-dir /workspace/bit_sculpt/results/deepseek-r1-0528/debug_trace \\
+        --prompt aho_sus_decode_10 \\
+        --trace-format safetensors \\
+        --num-replication-slots 8 \\
+        --validate-hidden-states-cross-trace --pcc-threshold 0.97
+
+Kimi K2.6 (CAVEAT — see below). Layer 0 is dense in Kimi and runs through the
+DeepSeek-V3 dense path the harness uses today, so trace I/O + PCC for layer 0
+is functional. Layers 1-60 are MoE under Kimi's 384-expert / top-8 ungrouped
+routing, which the b1 demo's gate kernel does not implement yet (it hardcodes
+the DeepSeek-V3 16x16=256 / grouped-topk layout). Running ``--decoder-layer-idx
+1..60`` against a Kimi trace today will load the trace successfully but fail
+at the routing kernel. Validation of Kimi layer 0::
+
+    TT_METAL_SLOW_DISPATCH_MODE=1 \\
+    python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \\
+        --decoder-layer-idx 0 \\
+        --hidden-states-dir /workspace/bit_sculpt/results/moonshotai-kimi-k26/debug_trace \\
+        --prompt smoke_kimi_k26_2026-05-14_bf16 \\
+        --trace-format safetensors \\
+        --hf-model-path /workspace/models/moonshotai/Kimi-K2.6-bf16-dequant \\
+        --num-replication-slots 1 \\
+        --validate-hidden-states-cross-trace --pcc-threshold 0.97
+
+The ``--hf-model-path`` should point at a Kimi BF16 pre-dequant snapshot (see
+bit_sculpt ``scripts/dequant_compressed_tensors_streaming.py``) — the harness's
+``CacheWeightProvider`` cannot read compressed-tensors INT4 directly. Full Kimi
+MoE-layer validation is gated on the 384-expert gate-kernel port, tracked on
+``origin/ddjekic/kimi26_bringup`` and ``origin/gchoudhary/41826-generalize-moe_compute-shape-support``.
+
+bit_sculpt-side trace generation (for reference, not run here)::
+
+    # Flat (prefill-only)
+    python scripts/run_debug_trace.py \\
+        --prompt "Debug." --model-id moonshotai/Kimi-K2.6 \\
+        --apply-chat-template --capture-group-a \\
+        --output-dir results/moonshotai-kimi-k26/debug_trace \\
+        --run-tag smoke_kimi_k26
+
+    # Per-step decode trace
+    python scripts/run_debug_trace.py \\
+        --prompt "What is Python?" --model-id moonshotai/Kimi-K2.6 \\
+        --apply-chat-template --capture-group-a --decode-steps 100 \\
+        --output-dir results/moonshotai-kimi-k26/debug_trace \\
+        --run-tag q_what_is_python
 """
 
 from __future__ import annotations
@@ -70,6 +174,12 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.host_io_decoder_harness import
     open_mesh_device,
     run_sweep,
 )
+
+# Accepted values for the trace / dump format flags. Kept in sync with
+# host_io_decoder_harness.TraceFormat / HostIoDecoderSweepConfig.dump_format;
+# duplicated here so argparse choices are evaluated at module import time.
+_TRACE_FORMAT_CHOICES = ("auto", "pt", "safetensors")
+_DUMP_FORMAT_CHOICES = ("pt", "safetensors")
 
 # Production device_params constants ported from the original pytest's indirect
 # ``device_params`` fixture. The fabric config, max packet payload, and worker
@@ -124,6 +234,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "One or more prompt names (file stems under --hidden-states-dir). Multiple "
             "prompts are run back-to-back in a single decoder launch; positions are "
             "disjoint and accumulating across prompts (multi-turn semantics)."
+        ),
+    )
+    required.add_argument(
+        "--trace-format",
+        choices=_TRACE_FORMAT_CHOICES,
+        default="auto",
+        help=(
+            "Source format for reference traces. 'pt' = single torch.save dict per prompt "
+            "(original DeepSeek pipeclean layout). 'safetensors' = bit_sculpt's per-layer "
+            "DebugTracer layout (one safetensors file per (layer, kind) under a per-prompt "
+            "directory). 'auto' probes <prompt>.pt first then <prompt>/ as a directory."
         ),
     )
 
@@ -205,6 +326,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             f"required if any dump knob is on."
         ),
     )
+    dump.add_argument(
+        "--dump-format",
+        choices=_DUMP_FORMAT_CHOICES,
+        default=None,
+        help=(
+            "Output format for dumps. 'pt' = single torch.save per (slot, prompt) "
+            "(current behavior). 'safetensors' = per-layer safetensors matching "
+            "bit_sculpt's DebugTracer naming (decoder_output_layer_{L}_slot_{NN}.safetensors, "
+            "kv_cache_layer_{L}_slot_{NN}.safetensors). Default mirrors the resolved "
+            "--trace-format: 'safetensors' if --trace-format=safetensors, else 'pt'."
+        ),
+    )
 
     # --- weights ---
     weights = parser.add_argument_group("weights")
@@ -264,10 +397,23 @@ def _resolve_dump_dir(args: argparse.Namespace) -> Path | None:
     return None
 
 
+def _resolve_dump_format(args: argparse.Namespace) -> str:
+    """Default dump_format to mirror trace_format so round-trips stay self-consistent.
+
+    Explicit ``--dump-format`` always wins. Otherwise: ``--trace-format=safetensors``
+    biases dumps to safetensors; everything else (including ``auto``) defaults to
+    ``pt`` for back-compat with the original DeepSeek pipeclean workflow.
+    """
+    if args.dump_format is not None:
+        return args.dump_format
+    return "safetensors" if args.trace_format == "safetensors" else "pt"
+
+
 def _config_from_args(args: argparse.Namespace) -> HostIoDecoderSweepConfig:
     """Build a frozen :class:`HostIoDecoderSweepConfig` from parsed argparse args."""
     hidden_states_dir = _resolve_hidden_states_dir(args)
     dump_dir = _resolve_dump_dir(args)
+    dump_format = _resolve_dump_format(args)
     return HostIoDecoderSweepConfig(
         decoder_layer_idx=args.decoder_layer_idx,
         hidden_states_dir=hidden_states_dir,
@@ -282,9 +428,11 @@ def _config_from_args(args: argparse.Namespace) -> HostIoDecoderSweepConfig:
         validate_kv_cache_cross_slot=args.validate_kv_cache_cross_slot,
         validate_hidden_states_cross_trace=args.validate_hidden_states_cross_trace,
         pcc_threshold=args.pcc_threshold,
+        trace_format=args.trace_format,
         dump_hidden_states=args.dump_hidden_states,
         dump_kv_cache=args.dump_kv_cache,
         dump_dir=dump_dir,
+        dump_format=dump_format,
         hf_model_path=args.hf_model_path,
         cache_path=args.cache_path,
         seed=args.seed,
@@ -322,9 +470,11 @@ def _log_resolved_config(config: HostIoDecoderSweepConfig) -> None:
         ("validate_kv_cache_cross_slot", config.validate_kv_cache_cross_slot),
         ("validate_hidden_states_cross_trace", config.validate_hidden_states_cross_trace),
         ("pcc_threshold", config.pcc_threshold),
+        ("trace_format", config.trace_format),
         ("dump_hidden_states", config.dump_hidden_states),
         ("dump_kv_cache", config.dump_kv_cache),
         ("dump_dir", config.dump_dir),
+        ("dump_format", config.dump_format),
         ("hf_model_path", config.hf_model_path),
         ("cache_path", config.cache_path),
         ("seed", config.seed),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/run_host_io_decoder_sweep.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/run_host_io_decoder_sweep.py
@@ -353,6 +353,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=DEFAULT_CACHE_PATH,
         help="CacheWeightProvider persistent cache directory.",
     )
+    weights.add_argument(
+        "--weight-key-prefix",
+        type=str,
+        default="",
+        help=(
+            "Prefix prepended to every state-dict key when looking up weights on disk. "
+            "Default '' matches DeepSeek-V3 HF snapshots. Set to 'language_model.' for Kimi "
+            "K2.6 BF16-dequant snapshots (Kimi wraps the DeepSeek-V3 backbone under that "
+            "prefix via its KimiK25ForConditionalGeneration multimodal architecture). "
+            "Forwarded to CacheWeightProvider -> LazyStateDict(base_prefix=...)."
+        ),
+    )
 
     # --- misc ---
     misc = parser.add_argument_group("misc")
@@ -435,6 +447,7 @@ def _config_from_args(args: argparse.Namespace) -> HostIoDecoderSweepConfig:
         dump_format=dump_format,
         hf_model_path=args.hf_model_path,
         cache_path=args.cache_path,
+        weight_key_prefix=args.weight_key_prefix,
         seed=args.seed,
         log_per_iteration=args.log_per_iteration,
     )
@@ -477,6 +490,7 @@ def _log_resolved_config(config: HostIoDecoderSweepConfig) -> None:
         ("dump_format", config.dump_format),
         ("hf_model_path", config.hf_model_path),
         ("cache_path", config.cache_path),
+        ("weight_key_prefix", repr(config.weight_key_prefix)),
         ("seed", config.seed),
         ("log_per_iteration", config.log_per_iteration),
     ):

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_e2e.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_e2e.py
@@ -59,9 +59,15 @@ def _device_params() -> dict:
 # ---------------------------------------------------------------------------
 _BIT_SCULPT_ROOT_ENV = "BIT_SCULPT_ROOT"
 _PIPECLEAN_TRACES_ENV = "DEEPSEEK_PIPECLEAN_TRACES_DIR"
+_KIMI_WEIGHTS_ENV = "KIMI_K26_BF16_DEQUANT_PATH"
 
 _DEFAULT_BIT_SCULPT_ROOT = Path("/workspace/bit_sculpt")
 _DEFAULT_PIPECLEAN_TRACES_DIR = Path("/data/asaigal/pipeclean_traces")
+_DEFAULT_KIMI_WEIGHTS_PATH = Path("/workspace/models/moonshotai/Kimi-K2.6-bf16-dequant")
+
+
+def _kimi_weights_path() -> Path:
+    return Path(os.environ.get(_KIMI_WEIGHTS_ENV, str(_DEFAULT_KIMI_WEIGHTS_PATH)))
 
 
 def _bit_sculpt_trace_root() -> Path:
@@ -168,16 +174,11 @@ SWEEP_CASES = [
         ),
     ),
     # --- Kimi K2.6 layer 0 (dense) --------------------------------------------
-    # The bit_sculpt trace is fine — see test_host_io_decoder_trace_loader.py
-    # for proof of load. Two on-device blockers remain:
-    #   (1) Kimi BF16 dequant weights not staged. Produce via bit_sculpt
-    #       scripts/dequant_compressed_tensors_streaming.py, stage at
-    #       /workspace/models/moonshotai/Kimi-K2.6-bf16-dequant (or pass
-    #       --hf-model-path).
-    #   (2) CacheWeightProvider reads `model.layers.{i}.*` keys. Kimi's HF
-    #       state dict prefixes them with `language_model.` because the wrapper
-    #       is KimiK25ForConditionalGeneration. Needs a prefix-shim knob on
-    #       CacheWeightProvider, or strip the prefix at dequant time.
+    # Unblocked by the `weight_key_prefix="language_model."` knob added to
+    # CacheWeightProvider in this PR. Skip now requires only the BF16-dequant
+    # snapshot to be staged at $KIMI_K26_BF16_DEQUANT_PATH (default
+    # /workspace/models/moonshotai/Kimi-K2.6-bf16-dequant). Produce the
+    # snapshot via bit_sculpt's scripts/dequant_compressed_tensors_streaming.py.
     _build_param(
         case_id="kimi_safetensors_flat_dense_layer0_modeA",
         config_kwargs=dict(
@@ -185,15 +186,15 @@ SWEEP_CASES = [
             hidden_states_dir=_kimi_trace_dir(),
             prompt_names=("smoke_kimi_k26_2026-05-14_bf16",),
             trace_format="safetensors",
+            hf_model_path=_kimi_weights_path(),
+            weight_key_prefix="language_model.",
         ),
-        skip=pytest.mark.skip(
+        skip=pytest.mark.skipif(
+            not (_kimi_weights_path() / "config.json").exists(),
             reason=(
-                "Kimi K2.6 layer 0 (dense) needs (a) BF16-dequant snapshot at "
-                "--hf-model-path (produce via bit_sculpt "
-                "scripts/dequant_compressed_tensors_streaming.py) and (b) a "
-                "`language_model.` prefix shim in CacheWeightProvider (Kimi's HF "
-                "state dict wraps the DeepSeek-V3 backbone under that prefix). "
-                "Trace I/O is already proven (see test_host_io_decoder_trace_loader)."
+                f"Kimi K2.6 BF16-dequant snapshot not staged. Expected "
+                f"{_kimi_weights_path()}/config.json (override via ${_KIMI_WEIGHTS_ENV}). "
+                f"Produce via bit_sculpt scripts/dequant_compressed_tensors_streaming.py."
             ),
         ),
     ),
@@ -210,13 +211,17 @@ SWEEP_CASES = [
             hidden_states_dir=_kimi_trace_dir(),
             prompt_names=("smoke_kimi_k26_2026-05-14_bf16",),
             trace_format="safetensors",
+            hf_model_path=_kimi_weights_path(),
+            weight_key_prefix="language_model.",
         ),
         skip=pytest.mark.skip(
             reason=(
                 "Kimi K2.6 MoE layers (1-60) need a 384-expert / ungrouped-top-8 "
                 "gate kernel. b1's DeepseekMoeGateSingleCore hardcodes 16x16=256 "
                 "grouped routing. Tracked on origin/ddjekic/kimi26_bringup and "
-                "origin/gchoudhary/41826-generalize-moe_compute-shape-support."
+                "origin/gchoudhary/41826-generalize-moe_compute-shape-support. "
+                "See KIMI_K26_PORT_NOTES section in host_io_decoder_harness.py "
+                "for the full breakdown."
             ),
         ),
     ),
@@ -227,6 +232,8 @@ SWEEP_CASES = [
             hidden_states_dir=_kimi_trace_dir(),
             prompt_names=("q_what_is_python",),
             trace_format="safetensors",
+            hf_model_path=_kimi_weights_path(),
+            weight_key_prefix="language_model.",
         ),
         skip=pytest.mark.skip(
             reason=(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_e2e.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_e2e.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end on-device PCC validation for the HostIoDecoderStage sweep.
+
+Each parametrized case opens a BH 2D mesh, instantiates the decoder for one
+layer, sweeps a reference trace through it, and asserts the collected output
+PCC's >= ``pcc_threshold`` against the reference's ``output``. PCC failure -->
+``AssertionError`` (from ``run_sweep`` Phase 3b).
+
+This file doubles as a **status board for what's actually runnable today**.
+Each ``pytest.mark.skip`` cites the specific blocker and what would unblock it.
+As blockers fall (Kimi weights staged, gate kernel ported, etc.), flip the
+``skip`` to ``skipif`` against a real path check, or remove the marker outright.
+
+Run on a single BH galaxy (slow dispatch required)::
+
+    TT_METAL_SLOW_DISPATCH_MODE=1 \\
+    pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_e2e.py -v
+
+Tests auto-skip on non-Blackhole arches (via the ``bh_2d_mesh_device``
+fixture's ``silicon_arch_blackhole`` requirement) and when slow dispatch is
+not enabled.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
+from models.demos.deepseek_v3_b1.tests.unit_tests.host_io_decoder_harness import HostIoDecoderSweepConfig, run_sweep
+
+# ---------------------------------------------------------------------------
+# Device params — ported verbatim from run_host_io_decoder_sweep.py so the
+# pytest invocation matches the CLI's production fabric / worker-L1 config.
+# ---------------------------------------------------------------------------
+_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_2D_TORUS_X
+_FABRIC_ROUTER_MAX_PAYLOAD_BYTES = 15232
+_WORKER_L1_SIZE = 1431568
+
+
+def _device_params() -> dict:
+    return {
+        "fabric_config": _FABRIC_CONFIG,
+        "fabric_router_config": create_fabric_router_config(_FABRIC_ROUTER_MAX_PAYLOAD_BYTES),
+        "worker_l1_size": _WORKER_L1_SIZE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reference trace roots.
+# Override via env vars to point at a non-default checkout / staging path.
+# ---------------------------------------------------------------------------
+_BIT_SCULPT_ROOT_ENV = "BIT_SCULPT_ROOT"
+_PIPECLEAN_TRACES_ENV = "DEEPSEEK_PIPECLEAN_TRACES_DIR"
+
+_DEFAULT_BIT_SCULPT_ROOT = Path("/workspace/bit_sculpt")
+_DEFAULT_PIPECLEAN_TRACES_DIR = Path("/data/asaigal/pipeclean_traces")
+
+
+def _bit_sculpt_trace_root() -> Path:
+    return Path(os.environ.get(_BIT_SCULPT_ROOT_ENV, str(_DEFAULT_BIT_SCULPT_ROOT))) / "results"
+
+
+def _pipeclean_traces_dir() -> Path:
+    return Path(os.environ.get(_PIPECLEAN_TRACES_ENV, str(_DEFAULT_PIPECLEAN_TRACES_DIR)))
+
+
+def _deepseek_trace_dir() -> Path:
+    return _bit_sculpt_trace_root() / "deepseek-r1-0528/debug_trace"
+
+
+def _kimi_trace_dir() -> Path:
+    return _bit_sculpt_trace_root() / "moonshotai-kimi-k26/debug_trace"
+
+
+# ---------------------------------------------------------------------------
+# Parametrized cases. Each entry is (sweep config dict, pytest id, skip-mark).
+# ---------------------------------------------------------------------------
+
+
+def _build_param(
+    *,
+    case_id: str,
+    config_kwargs: dict,
+    skip: pytest.MarkDecorator | None = None,
+) -> pytest.param:
+    """Build a pytest.param so skip reasons live next to the config they describe."""
+    marks = [skip] if skip is not None else []
+    return pytest.param(config_kwargs, id=case_id, marks=marks)
+
+
+SWEEP_CASES = [
+    # --- DeepSeek, original .pt path (back-compat) ----------------------------
+    # Runnable today on a BH galaxy iff the pipeclean traces + R1 dequant
+    # weights are staged at the expected paths. The CLI driver has used this
+    # case in production since the pytest -> CLI migration; this entry just
+    # codifies it as a real pytest.
+    _build_param(
+        case_id="deepseek_pt_pipeclean_8192_layer4_modeA",
+        config_kwargs=dict(
+            decoder_layer_idx=4,
+            hidden_states_dir=_pipeclean_traces_dir(),
+            prompt_names=("pipeclean_seq_8192",),
+            trace_format="pt",
+        ),
+        skip=pytest.mark.skipif(
+            not (_pipeclean_traces_dir() / "pipeclean_seq_8192.pt").exists(),
+            reason=(
+                f"Pipeclean .pt trace not staged. Expected "
+                f"{_pipeclean_traces_dir()}/pipeclean_seq_8192.pt (override via "
+                f"${_PIPECLEAN_TRACES_ENV})."
+            ),
+        ),
+    ),
+    # --- DeepSeek, safetensors flat layout ------------------------------------
+    # Existing checked-in DeepSeek bit_sculpt traces (aho_*, tt_moconnor*, ...)
+    # use the *old bundled* on-disk format (`hidden_states.safetensors` with all
+    # layers in one file). The loader implements the *new per-layer* format
+    # (decoder_input_layer_{L}.safetensors / decoder_output_layer_{L}.safetensors).
+    # To unblock: regenerate a small trace with the current bit_sculpt
+    # `run_debug_trace.py --capture-group-a` (which emits per-layer files), drop
+    # it under bit_sculpt's results dir, and point this case at it.
+    _build_param(
+        case_id="deepseek_safetensors_flat_layer4_modeA",
+        config_kwargs=dict(
+            decoder_layer_idx=4,
+            hidden_states_dir=_deepseek_trace_dir(),
+            prompt_names=("PLACEHOLDER_per_layer_trace",),
+            trace_format="safetensors",
+        ),
+        skip=pytest.mark.skip(
+            reason=(
+                "Needs a DeepSeek-R1-0528 trace in bit_sculpt's *new* per-layer "
+                "safetensors format. All currently checked-in DeepSeek traces "
+                "(aho_*, tt_moconnor*, ...) use the *old bundled* format "
+                "(hidden_states.safetensors with all layers in one file). "
+                "Regenerate with current run_debug_trace.py + --capture-group-a, "
+                "then update the prompt name above."
+            ),
+        ),
+    ),
+    # --- DeepSeek, safetensors per-step decode layout -------------------------
+    # Same as above — aho_sus_decode_10/step_0/ contains hidden_states.safetensors
+    # (old bundle), not per-layer files. Regenerate with current bit_sculpt.
+    _build_param(
+        case_id="deepseek_safetensors_per_step_layer4_modeA",
+        config_kwargs=dict(
+            decoder_layer_idx=4,
+            hidden_states_dir=_deepseek_trace_dir(),
+            prompt_names=("PLACEHOLDER_per_step_trace",),
+            trace_format="safetensors",
+        ),
+        skip=pytest.mark.skip(
+            reason=(
+                "Needs a DeepSeek decode-mode trace in per-step + per-layer format. "
+                "aho_sus_decode_10 and demo_1K_debug_decode_10000 step_*/ dirs "
+                "currently hold the old bundled format. Regenerate with current "
+                "run_debug_trace.py --decode-steps N --capture-group-a, then update "
+                "the prompt name above."
+            ),
+        ),
+    ),
+    # --- Kimi K2.6 layer 0 (dense) --------------------------------------------
+    # The bit_sculpt trace is fine — see test_host_io_decoder_trace_loader.py
+    # for proof of load. Two on-device blockers remain:
+    #   (1) Kimi BF16 dequant weights not staged. Produce via bit_sculpt
+    #       scripts/dequant_compressed_tensors_streaming.py, stage at
+    #       /workspace/models/moonshotai/Kimi-K2.6-bf16-dequant (or pass
+    #       --hf-model-path).
+    #   (2) CacheWeightProvider reads `model.layers.{i}.*` keys. Kimi's HF
+    #       state dict prefixes them with `language_model.` because the wrapper
+    #       is KimiK25ForConditionalGeneration. Needs a prefix-shim knob on
+    #       CacheWeightProvider, or strip the prefix at dequant time.
+    _build_param(
+        case_id="kimi_safetensors_flat_dense_layer0_modeA",
+        config_kwargs=dict(
+            decoder_layer_idx=0,
+            hidden_states_dir=_kimi_trace_dir(),
+            prompt_names=("smoke_kimi_k26_2026-05-14_bf16",),
+            trace_format="safetensors",
+        ),
+        skip=pytest.mark.skip(
+            reason=(
+                "Kimi K2.6 layer 0 (dense) needs (a) BF16-dequant snapshot at "
+                "--hf-model-path (produce via bit_sculpt "
+                "scripts/dequant_compressed_tensors_streaming.py) and (b) a "
+                "`language_model.` prefix shim in CacheWeightProvider (Kimi's HF "
+                "state dict wraps the DeepSeek-V3 backbone under that prefix). "
+                "Trace I/O is already proven (see test_host_io_decoder_trace_loader)."
+            ),
+        ),
+    ),
+    # --- Kimi K2.6 MoE layers (1-60) ------------------------------------------
+    # Blocked on the 384-expert / ungrouped-top-8 gate kernel. The b1 demo's
+    # DeepseekMoeGateSingleCore (micro_ops/deepseek_moe_gate/op.py) hardcodes
+    # (16, 16) input tile == 256 grouped routing. Kimi has 1 group of 384, plain
+    # topk. Tracked on origin/ddjekic/kimi26_bringup (full Kimi demo on the
+    # `_d_p` path) and origin/gchoudhary/41826-generalize-moe_compute-shape-support.
+    _build_param(
+        case_id="kimi_safetensors_flat_moe_layer1_modeA",
+        config_kwargs=dict(
+            decoder_layer_idx=1,
+            hidden_states_dir=_kimi_trace_dir(),
+            prompt_names=("smoke_kimi_k26_2026-05-14_bf16",),
+            trace_format="safetensors",
+        ),
+        skip=pytest.mark.skip(
+            reason=(
+                "Kimi K2.6 MoE layers (1-60) need a 384-expert / ungrouped-top-8 "
+                "gate kernel. b1's DeepseekMoeGateSingleCore hardcodes 16x16=256 "
+                "grouped routing. Tracked on origin/ddjekic/kimi26_bringup and "
+                "origin/gchoudhary/41826-generalize-moe_compute-shape-support."
+            ),
+        ),
+    ),
+    _build_param(
+        case_id="kimi_safetensors_per_step_moe_layer30_modeA",
+        config_kwargs=dict(
+            decoder_layer_idx=30,
+            hidden_states_dir=_kimi_trace_dir(),
+            prompt_names=("q_what_is_python",),
+            trace_format="safetensors",
+        ),
+        skip=pytest.mark.skip(
+            reason=(
+                "Same gate-kernel blocker as kimi_safetensors_flat_moe_layer1_modeA. "
+                "Kept as a separate case so when the gate kernel lands, both layouts "
+                "(flat + per-step) are exercised on the validation path."
+            ),
+        ),
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Test body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device_params", [_device_params()], indirect=True)
+@pytest.mark.parametrize("config_kwargs", SWEEP_CASES)
+def test_host_io_decoder_sweep_e2e(bh_2d_mesh_device, config_kwargs):
+    """One PCC-validated decoder-layer sweep per parametrized case.
+
+    Mode A (single replicated slot) is enough to validate cross-trace PCC —
+    no slot-replication validation needed for correctness — and runs in well
+    under the BH galaxy CI per-case budget.
+    """
+    if not is_slow_dispatch():
+        pytest.skip(
+            "run_sweep requires TT_METAL_SLOW_DISPATCH_MODE=1 (H2D/D2H sockets do not "
+            "function under fast dispatch). Re-run with the env var set."
+        )
+
+    config = HostIoDecoderSweepConfig(
+        num_replication_slots=1,
+        validate_metadata_roundtrip=True,
+        validate_hidden_states_cross_slot=False,  # no-op at num_replication_slots=1
+        validate_kv_cache_cross_slot=False,  # ditto
+        validate_hidden_states_cross_trace=True,
+        pcc_threshold=0.97,
+        dump_hidden_states=False,
+        dump_kv_cache=False,
+        **config_kwargs,
+    )
+    run_sweep(config, bh_2d_mesh_device)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_trace_loader.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_trace_loader.py
@@ -15,13 +15,35 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger as loguru_logger
 from safetensors.torch import save_file as safetensors_save_file
 
 from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
 from models.demos.deepseek_v3_b1.tests.unit_tests.host_io_decoder_harness import (
+    NUM_DENSE_LAYERS,
+    HostIoDecoderSweepConfig,
+    MultiTurnSchedule,
+    _check_metadata_consistency,
     _load_reference_trace,
     _resolve_trace_format,
+    _write_dumps,
 )
+
+
+@pytest.fixture
+def loguru_warnings() -> list[str]:
+    """Collect ``logger.warning(...)`` messages from the harness's loguru logger.
+
+    pytest's stock ``caplog`` only intercepts the stdlib ``logging`` module, but
+    the harness uses ``loguru``. The standard recipe is to attach a custom sink
+    for the test, append messages to a list, then remove the sink at teardown.
+    """
+    messages: list[str] = []
+    sink_id = loguru_logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    try:
+        yield messages
+    finally:
+        loguru_logger.remove(sink_id)
 
 
 def _make_pt_trace(trace_dir: Path, prompt: str, seq_len: int = 4) -> None:
@@ -275,3 +297,254 @@ def test_load_safetensors_wrong_hidden_dim_raises(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="last dim must equal"):
         _load_reference_trace(tmp_path, "p", decoder_layer_idx=0, trace_format="safetensors")
+
+
+# ----- metadata.json consistency -----
+
+
+def _write_metadata(prompt_dir: Path, **overrides) -> Path:
+    """Write a minimal bit_sculpt-style metadata.json with optional overrides."""
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    base = {
+        "n_layers": 61,
+        "hidden_dim": D.HIDDEN_SIZE,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "moe_layer_offset": NUM_DENSE_LAYERS,
+    }
+    base.update(overrides)
+    path = prompt_dir / "metadata.json"
+    path.write_text(json.dumps(base))
+    return path
+
+
+def test_metadata_consistency_matching_offset_silent(tmp_path: Path, loguru_warnings) -> None:
+    """DeepSeek trace (moe_layer_offset=3) against DeepSeek harness — no warning."""
+    path = _write_metadata(tmp_path, moe_layer_offset=NUM_DENSE_LAYERS)
+    _check_metadata_consistency(path, decoder_layer_idx=4)
+    assert not any("moe_layer_offset" in m for m in loguru_warnings)
+
+
+def test_metadata_consistency_kimi_layer_in_danger_zone(tmp_path: Path, loguru_warnings) -> None:
+    """Kimi trace (offset=1) loaded against DeepSeek harness (=3) — layer 1 is the bug.
+
+    The harness will route layer_idx=1 to the *dense* path (1 < NUM_DENSE_LAYERS=3),
+    but the trace was produced treating layer 1 as MoE (1 >= moe_layer_offset=1).
+    The warning must name the conflict and the specific layer.
+    """
+    path = _write_metadata(tmp_path, moe_layer_offset=1)
+    _check_metadata_consistency(path, decoder_layer_idx=1)
+    joined = "\n".join(loguru_warnings)
+    assert "moe_layer_offset=1" in joined
+    assert "ambiguous" in joined
+    assert "decoder_layer_idx=1" in joined
+    assert "MoE" in joined and "dense" in joined
+
+
+def test_metadata_consistency_kimi_layer_outside_danger_zone(tmp_path: Path, loguru_warnings) -> None:
+    """Kimi trace, layer 30 — both Kimi (offset=1) and DeepSeek (=3) agree it's MoE.
+
+    A warning still fires (the offsets disagree at all), but it explicitly notes
+    the chosen layer is *outside* the ambiguous range and dense/MoE dispatch
+    agrees for this case.
+    """
+    path = _write_metadata(tmp_path, moe_layer_offset=1)
+    _check_metadata_consistency(path, decoder_layer_idx=30)
+    joined = "\n".join(loguru_warnings)
+    assert "outside the ambiguous range" in joined
+
+
+def test_metadata_consistency_hidden_dim_mismatch_warns(tmp_path: Path, loguru_warnings) -> None:
+    path = _write_metadata(tmp_path, hidden_dim=9999)
+    _check_metadata_consistency(path, decoder_layer_idx=4)
+    assert any("hidden_dim=9999" in m for m in loguru_warnings)
+
+
+def test_metadata_consistency_missing_file_silent(tmp_path: Path, loguru_warnings) -> None:
+    """Loader must not warn when metadata.json is simply absent."""
+    _check_metadata_consistency(tmp_path / "nonexistent_metadata.json", decoder_layer_idx=4)
+    assert loguru_warnings == []
+
+
+# ----- dump path -----
+#
+# Pure-host tests for _write_dumps: fabricate a sweep result (collected dict +
+# fake KV cache + schedule), call _write_dumps, verify each output file exists
+# with the right name, tensor key, and shape. Covers both formats and the two
+# independent toggles (dump_hidden_states / dump_kv_cache).
+#
+# KVPE_DIM constant is fixed at 576 in the harness (kv_lora_rank 512 + qk_rope_head_dim 64);
+# matches bit_sculpt's kv_post_transform layout.
+_KVPE_DIM = 576
+
+
+def _build_dump_config(
+    *,
+    dump_dir: Path,
+    dump_format: str,
+    decoder_layer_idx: int = 4,
+    prompt_names: tuple[str, ...] = ("smoke",),
+    num_replication_slots: int = 1,
+    dump_hidden_states: bool = True,
+    dump_kv_cache: bool = True,
+) -> HostIoDecoderSweepConfig:
+    """Build a sweep config configured for dumping; non-dump knobs are placeholders."""
+    return HostIoDecoderSweepConfig(
+        decoder_layer_idx=decoder_layer_idx,
+        hidden_states_dir=dump_dir,  # not consumed by _write_dumps; placeholder
+        prompt_names=prompt_names,
+        num_replication_slots=num_replication_slots,
+        dump_hidden_states=dump_hidden_states,
+        dump_kv_cache=dump_kv_cache,
+        dump_dir=dump_dir,
+        dump_format=dump_format,
+    )
+
+
+def _build_fake_collected(prompt_lengths: dict[str, int], num_slots: int) -> dict[str, dict[int, torch.Tensor]]:
+    return {
+        prompt: {slot: torch.randn(L, D.HIDDEN_SIZE, dtype=torch.bfloat16) for slot in range(num_slots)}
+        for prompt, L in prompt_lengths.items()
+    }
+
+
+def _build_fake_kv_cache(total_length: int, num_slots_total: int, max_seq_len: int = 64) -> torch.Tensor:
+    """Mimic the harness's get_kv_cache_host shape: (num_slots, 1, max_seq_len, kvpe_dim)."""
+    assert total_length <= max_seq_len
+    return torch.randn(num_slots_total, 1, max_seq_len, _KVPE_DIM, dtype=torch.bfloat16)
+
+
+def test_write_dumps_pt_format_back_compat(tmp_path: Path) -> None:
+    """Default dump_format='pt': filenames + tensor shapes match the pre-PR contract."""
+    config = _build_dump_config(dump_dir=tmp_path, dump_format="pt")
+    collected = _build_fake_collected({"smoke": 4}, num_slots=1)
+    kv_cache = _build_fake_kv_cache(total_length=4, num_slots_total=2)
+    schedule = MultiTurnSchedule(prompt_lengths=(4,))
+
+    _write_dumps(config, collected=collected, kv_cache_torch=kv_cache, schedule=schedule)
+
+    # Hidden state dump: torch.save dict with raw tensor at canonical name.
+    hs_path = tmp_path / "output_hidden_states_slot_00_smoke.pt"
+    assert hs_path.exists()
+    loaded_hs = torch.load(hs_path, map_location="cpu")
+    assert torch.equal(loaded_hs, collected["smoke"][0])
+
+    # KV dump retains the leading (1,) under .pt format.
+    kv_path = tmp_path / "kv_cache_slot_00_smoke.pt"
+    assert kv_path.exists()
+    loaded_kv = torch.load(kv_path, map_location="cpu")
+    assert loaded_kv.shape == (1, 4, _KVPE_DIM)
+    assert torch.equal(loaded_kv, kv_cache[0, :, 0:4, :])
+
+
+def test_write_dumps_safetensors_format_matches_bit_sculpt(tmp_path: Path) -> None:
+    """dump_format='safetensors': per-prompt dir, bit_sculpt-canonical tensor keys, (T, 576) KV."""
+    from safetensors.torch import load_file as safetensors_load_file
+
+    config = _build_dump_config(dump_dir=tmp_path, dump_format="safetensors", decoder_layer_idx=4)
+    collected = _build_fake_collected({"smoke": 4}, num_slots=1)
+    kv_cache = _build_fake_kv_cache(total_length=4, num_slots_total=2)
+    schedule = MultiTurnSchedule(prompt_lengths=(4,))
+
+    _write_dumps(config, collected=collected, kv_cache_torch=kv_cache, schedule=schedule)
+
+    hs_path = tmp_path / "smoke" / "decoder_output_layer_4_slot_00.safetensors"
+    assert hs_path.exists()
+    hs = safetensors_load_file(str(hs_path))
+    assert set(hs.keys()) == {"decoder_output_layer_4"}
+    assert torch.equal(hs["decoder_output_layer_4"], collected["smoke"][0])
+
+    kv_path = tmp_path / "smoke" / "kv_cache_layer_4_slot_00.safetensors"
+    assert kv_path.exists()
+    kv = safetensors_load_file(str(kv_path))
+    assert set(kv.keys()) == {"kv_post_transform_layer_4"}
+    # Critical: (1, L_p, 576) -> (L_p, 576). The leading dim must be squeezed.
+    assert kv["kv_post_transform_layer_4"].shape == (4, _KVPE_DIM)
+    assert torch.equal(kv["kv_post_transform_layer_4"], kv_cache[0, 0, 0:4, :])
+
+
+def test_write_dumps_mode_b_writes_per_slot_files(tmp_path: Path) -> None:
+    """num_replication_slots=4: produces 4 hidden-state + 4 KV files per prompt."""
+    config = _build_dump_config(dump_dir=tmp_path, dump_format="safetensors", num_replication_slots=4)
+    collected = _build_fake_collected({"smoke": 4}, num_slots=4)
+    kv_cache = _build_fake_kv_cache(total_length=4, num_slots_total=8)
+    schedule = MultiTurnSchedule(prompt_lengths=(4,))
+
+    _write_dumps(config, collected=collected, kv_cache_torch=kv_cache, schedule=schedule)
+
+    prompt_dir = tmp_path / "smoke"
+    hs_files = sorted(prompt_dir.glob("decoder_output_layer_4_slot_*.safetensors"))
+    kv_files = sorted(prompt_dir.glob("kv_cache_layer_4_slot_*.safetensors"))
+    assert [f.name for f in hs_files] == [f"decoder_output_layer_4_slot_{i:02d}.safetensors" for i in range(4)]
+    assert [f.name for f in kv_files] == [f"kv_cache_layer_4_slot_{i:02d}.safetensors" for i in range(4)]
+
+
+def test_write_dumps_multi_prompt_slices_kv_correctly(tmp_path: Path) -> None:
+    """Two prompts at disjoint position ranges: each KV dump is the prompt's slice only."""
+    from safetensors.torch import load_file as safetensors_load_file
+
+    config = _build_dump_config(dump_dir=tmp_path, dump_format="safetensors", prompt_names=("a", "b"))
+    collected = _build_fake_collected({"a": 3, "b": 5}, num_slots=1)
+    kv_cache = _build_fake_kv_cache(total_length=8, num_slots_total=2)
+    schedule = MultiTurnSchedule(prompt_lengths=(3, 5))
+
+    _write_dumps(config, collected=collected, kv_cache_torch=kv_cache, schedule=schedule)
+
+    kv_a = safetensors_load_file(str(tmp_path / "a" / "kv_cache_layer_4_slot_00.safetensors"))
+    kv_b = safetensors_load_file(str(tmp_path / "b" / "kv_cache_layer_4_slot_00.safetensors"))
+    # prompt "a" occupies positions [0, 3); prompt "b" occupies [3, 8).
+    assert kv_a["kv_post_transform_layer_4"].shape == (3, _KVPE_DIM)
+    assert kv_b["kv_post_transform_layer_4"].shape == (5, _KVPE_DIM)
+    assert torch.equal(kv_a["kv_post_transform_layer_4"], kv_cache[0, 0, 0:3, :])
+    assert torch.equal(kv_b["kv_post_transform_layer_4"], kv_cache[0, 0, 3:8, :])
+
+
+def test_write_dumps_only_hidden_states(tmp_path: Path) -> None:
+    """dump_hidden_states=True, dump_kv_cache=False: no KV files written, kv_cache_torch=None OK."""
+    config = _build_dump_config(
+        dump_dir=tmp_path,
+        dump_format="safetensors",
+        dump_hidden_states=True,
+        dump_kv_cache=False,
+    )
+    collected = _build_fake_collected({"smoke": 4}, num_slots=1)
+    schedule = MultiTurnSchedule(prompt_lengths=(4,))
+
+    _write_dumps(config, collected=collected, kv_cache_torch=None, schedule=schedule)
+
+    assert (tmp_path / "smoke" / "decoder_output_layer_4_slot_00.safetensors").exists()
+    assert not list((tmp_path / "smoke").glob("kv_cache_layer_*"))
+
+
+def test_write_dumps_only_kv_cache(tmp_path: Path) -> None:
+    """dump_kv_cache=True, dump_hidden_states=False: no hidden-state files written."""
+    config = _build_dump_config(
+        dump_dir=tmp_path,
+        dump_format="safetensors",
+        dump_hidden_states=False,
+        dump_kv_cache=True,
+    )
+    collected = _build_fake_collected({"smoke": 4}, num_slots=1)
+    kv_cache = _build_fake_kv_cache(total_length=4, num_slots_total=2)
+    schedule = MultiTurnSchedule(prompt_lengths=(4,))
+
+    _write_dumps(config, collected=collected, kv_cache_torch=kv_cache, schedule=schedule)
+
+    assert (tmp_path / "smoke" / "kv_cache_layer_4_slot_00.safetensors").exists()
+    assert not list((tmp_path / "smoke").glob("decoder_output_layer_*"))
+
+
+def test_write_dumps_both_off_is_noop(tmp_path: Path) -> None:
+    """Both knobs off: _write_dumps writes nothing and tolerates kv_cache_torch=None."""
+    # Bypass __post_init__ validation by setting dump_dir=None (allowed when both knobs off).
+    config = HostIoDecoderSweepConfig(
+        decoder_layer_idx=4,
+        hidden_states_dir=tmp_path,
+        prompt_names=("smoke",),
+        dump_hidden_states=False,
+        dump_kv_cache=False,
+        dump_dir=None,
+    )
+    schedule = MultiTurnSchedule(prompt_lengths=(4,))
+    _write_dumps(config, collected={}, kv_cache_torch=None, schedule=schedule)
+    assert list(tmp_path.iterdir()) == []

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_trace_loader.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_trace_loader.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-host tests for the trace loader in host_io_decoder_harness.
+
+Exercises both the legacy ``.pt`` path and the bit_sculpt safetensors per-layer
+layout, including ``--trace-format=auto`` resolution and the symlink convention
+that bit_sculpt's ``DebugTracer`` uses for non-zero-layer input files. No device
+required — all tensors stay on CPU.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file as safetensors_save_file
+
+from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
+from models.demos.deepseek_v3_b1.tests.unit_tests.host_io_decoder_harness import (
+    _load_reference_trace,
+    _resolve_trace_format,
+)
+
+
+def _make_pt_trace(trace_dir: Path, prompt: str, seq_len: int = 4) -> None:
+    torch.save(
+        {
+            "input": torch.randn(seq_len, D.HIDDEN_SIZE, dtype=torch.bfloat16),
+            "output": torch.randn(seq_len, D.HIDDEN_SIZE, dtype=torch.bfloat16),
+        },
+        trace_dir / f"{prompt}.pt",
+    )
+
+
+def _make_safetensors_trace(
+    trace_dir: Path,
+    prompt: str,
+    *,
+    layers: tuple[int, ...] = (0, 1, 2),
+    seq_len: int = 4,
+    write_metadata: bool = True,
+) -> dict[int, dict[str, torch.Tensor]]:
+    """Create a fake bit_sculpt-style safetensors trace and return the written tensors.
+
+    Mirrors ``analysis.debug_trace.DebugTracer._save_step``'s group-A layout:
+      - decoder_input_layer_0.safetensors      (real file)
+      - decoder_output_layer_{L}.safetensors   (real, every layer)
+      - decoder_input_layer_{L}.safetensors    (symlink to decoder_output_layer_{L-1}, L >= 1)
+    The returned dict[layer_idx][kind] lets the test assert exact tensor equality.
+    """
+    prompt_dir = trace_dir / prompt
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    written: dict[int, dict[str, torch.Tensor]] = {}
+
+    layer0_input = torch.randn(seq_len, D.HIDDEN_SIZE, dtype=torch.bfloat16)
+    safetensors_save_file(
+        {"decoder_input_layer_0": layer0_input},
+        str(prompt_dir / "decoder_input_layer_0.safetensors"),
+    )
+    written[0] = {"input": layer0_input}
+
+    for layer in layers:
+        out = torch.randn(seq_len, D.HIDDEN_SIZE, dtype=torch.bfloat16)
+        safetensors_save_file(
+            {f"decoder_output_layer_{layer}": out},
+            str(prompt_dir / f"decoder_output_layer_{layer}.safetensors"),
+        )
+        written.setdefault(layer, {})["output"] = out
+        # The next layer's input file is a relative symlink to this output file.
+        # bit_sculpt does the same — see DebugTracer._save_step around line 583.
+        if layer + 1 in layers:
+            link = prompt_dir / f"decoder_input_layer_{layer + 1}.safetensors"
+            link.symlink_to(f"decoder_output_layer_{layer}.safetensors")
+            written.setdefault(layer + 1, {})["input"] = out
+
+    if write_metadata:
+        (prompt_dir / "metadata.json").write_text(
+            json.dumps(
+                {
+                    "prompt": prompt,
+                    "n_layers": len(layers),
+                    "hidden_dim": D.HIDDEN_SIZE,
+                    "kv_lora_rank": 512,
+                    "qk_rope_head_dim": 64,
+                }
+            )
+        )
+
+    return written
+
+
+# ----- format resolution -----
+
+
+def test_resolve_format_explicit_passthrough(tmp_path: Path) -> None:
+    assert _resolve_trace_format(tmp_path, "x", "pt") == "pt"
+    assert _resolve_trace_format(tmp_path, "x", "safetensors") == "safetensors"
+
+
+def test_resolve_format_auto_prefers_pt(tmp_path: Path) -> None:
+    """When both formats exist, .pt wins (back-compat with original DeepSeek pipeclean)."""
+    (tmp_path / "foo.pt").touch()
+    (tmp_path / "foo").mkdir()
+    assert _resolve_trace_format(tmp_path, "foo", "auto") == "pt"
+
+
+def test_resolve_format_auto_falls_back_to_safetensors(tmp_path: Path) -> None:
+    (tmp_path / "foo").mkdir()
+    assert _resolve_trace_format(tmp_path, "foo", "auto") == "safetensors"
+
+
+def test_resolve_format_auto_raises_when_neither_exists(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Probed:"):
+        _resolve_trace_format(tmp_path, "missing", "auto")
+
+
+# ----- loading: .pt path -----
+
+
+def test_load_pt_trace_returns_expected_dict(tmp_path: Path) -> None:
+    _make_pt_trace(tmp_path, "p")
+    trace = _load_reference_trace(tmp_path, "p", decoder_layer_idx=4, trace_format="pt")
+    assert set(trace.keys()) == {"input", "output"}
+    assert trace["input"].shape == (4, D.HIDDEN_SIZE)
+    assert trace["output"].shape == (4, D.HIDDEN_SIZE)
+    assert trace["input"].dtype == torch.bfloat16
+
+
+# ----- loading: safetensors path -----
+
+
+def test_load_safetensors_layer_0(tmp_path: Path) -> None:
+    """Layer 0: real decoder_input_layer_0 + real decoder_output_layer_0."""
+    written = _make_safetensors_trace(tmp_path, "p")
+    trace = _load_reference_trace(tmp_path, "p", decoder_layer_idx=0, trace_format="safetensors")
+    assert torch.equal(trace["input"], written[0]["input"])
+    assert torch.equal(trace["output"], written[0]["output"])
+
+
+def test_load_safetensors_layer_via_symlink(tmp_path: Path) -> None:
+    """Layer L>=1: decoder_input_layer_{L} is a symlink → decoder_output_layer_{L-1}.
+
+    The tensor key inside the file is the *target's* canonical key
+    (decoder_output_layer_{L-1}), not the symlink name. The loader must accept
+    whatever single key is there.
+    """
+    written = _make_safetensors_trace(tmp_path, "p")
+    trace = _load_reference_trace(tmp_path, "p", decoder_layer_idx=2, trace_format="safetensors")
+    # input at layer 2 == output at layer 1 (via symlink)
+    assert torch.equal(trace["input"], written[1]["output"])
+    assert torch.equal(trace["output"], written[2]["output"])
+
+
+def test_load_safetensors_auto_resolves_when_pt_missing(tmp_path: Path) -> None:
+    _make_safetensors_trace(tmp_path, "p")
+    trace = _load_reference_trace(tmp_path, "p", decoder_layer_idx=0, trace_format="auto")
+    assert trace["input"].shape == (4, D.HIDDEN_SIZE)
+
+
+def test_load_safetensors_missing_directory_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Safetensors trace directory"):
+        _load_reference_trace(tmp_path, "absent", decoder_layer_idx=0, trace_format="safetensors")
+
+
+def test_load_safetensors_missing_layer_raises(tmp_path: Path) -> None:
+    """Flat layout where some layers exist but the requested one doesn't.
+
+    The loader probes flat first then falls through to step_* — when neither
+    matches, the error mentions both probed layouts so the caller can tell
+    whether the trace is incomplete or the layout is wrong.
+    """
+    _make_safetensors_trace(tmp_path, "p", layers=(0, 1))
+    with pytest.raises(FileNotFoundError, match="decoder_input/output_layer_99"):
+        _load_reference_trace(tmp_path, "p", decoder_layer_idx=99, trace_format="safetensors")
+
+
+# ----- loading: per-step decode-mode layout -----
+
+
+def _make_per_step_safetensors_trace(
+    trace_dir: Path,
+    prompt: str,
+    *,
+    decoder_layer_idx: int,
+    prefill_len: int = 4,
+    decode_steps: int = 3,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Create a fake bit_sculpt decode-mode trace (step_0 prefill + step_k deltas).
+
+    Returns (inputs_per_step, outputs_per_step) so the test can assert
+    concat-along-dim-0 against what the loader returns.
+    """
+    prompt_dir = trace_dir / prompt
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    inputs_per_step: list[torch.Tensor] = []
+    outputs_per_step: list[torch.Tensor] = []
+    for step in range(decode_steps + 1):  # step_0 is prefill
+        step_dir = prompt_dir / f"step_{step}"
+        step_dir.mkdir()
+        rows = prefill_len if step == 0 else 1
+        inp = torch.randn(rows, D.HIDDEN_SIZE, dtype=torch.bfloat16)
+        out = torch.randn(rows, D.HIDDEN_SIZE, dtype=torch.bfloat16)
+        safetensors_save_file(
+            {f"decoder_input_layer_{decoder_layer_idx}": inp},
+            str(step_dir / f"decoder_input_layer_{decoder_layer_idx}.safetensors"),
+        )
+        safetensors_save_file(
+            {f"decoder_output_layer_{decoder_layer_idx}": out},
+            str(step_dir / f"decoder_output_layer_{decoder_layer_idx}.safetensors"),
+        )
+        inputs_per_step.append(inp)
+        outputs_per_step.append(out)
+    return inputs_per_step, outputs_per_step
+
+
+def test_load_safetensors_per_step_concatenates(tmp_path: Path) -> None:
+    inputs, outputs = _make_per_step_safetensors_trace(
+        tmp_path, "p", decoder_layer_idx=3, prefill_len=5, decode_steps=4
+    )
+    trace = _load_reference_trace(tmp_path, "p", decoder_layer_idx=3, trace_format="safetensors")
+    # T_total = prefill_len + decode_steps = 5 + 4 = 9
+    assert trace["input"].shape == (9, D.HIDDEN_SIZE)
+    assert trace["output"].shape == (9, D.HIDDEN_SIZE)
+    assert torch.equal(trace["input"], torch.cat(inputs, dim=0))
+    assert torch.equal(trace["output"], torch.cat(outputs, dim=0))
+
+
+def test_load_safetensors_per_step_numeric_sort(tmp_path: Path) -> None:
+    """step_10 must come after step_2 — confirms numeric (not lexicographic) sort."""
+    inputs, outputs = _make_per_step_safetensors_trace(
+        tmp_path, "p", decoder_layer_idx=0, prefill_len=2, decode_steps=15
+    )
+    trace = _load_reference_trace(tmp_path, "p", decoder_layer_idx=0, trace_format="safetensors")
+    # T_total = 2 + 15 = 17
+    assert trace["input"].shape == (17, D.HIDDEN_SIZE)
+    # Concat order is step_0 (2 rows), step_1..step_15 (1 row each).
+    # Row 2 must equal step_1's single row; row 16 must equal step_15's row.
+    assert torch.equal(trace["input"][2], inputs[1].squeeze(0))
+    assert torch.equal(trace["input"][16], inputs[15].squeeze(0))
+
+
+def test_load_safetensors_empty_dir_raises(tmp_path: Path) -> None:
+    """No flat files AND no step_* subdirs → actionable error."""
+    (tmp_path / "p").mkdir()
+    with pytest.raises(FileNotFoundError, match="step_"):
+        _load_reference_trace(tmp_path, "p", decoder_layer_idx=0, trace_format="safetensors")
+
+
+# ----- shape / dtype contract -----
+
+
+def test_load_safetensors_wrong_dtype_raises(tmp_path: Path) -> None:
+    prompt_dir = tmp_path / "p"
+    prompt_dir.mkdir()
+    bad = torch.randn(4, D.HIDDEN_SIZE, dtype=torch.float32)  # not bf16
+    safetensors_save_file({"decoder_input_layer_0": bad}, str(prompt_dir / "decoder_input_layer_0.safetensors"))
+    safetensors_save_file(
+        {"decoder_output_layer_0": bad},
+        str(prompt_dir / "decoder_output_layer_0.safetensors"),
+    )
+    with pytest.raises(ValueError, match="bfloat16"):
+        _load_reference_trace(tmp_path, "p", decoder_layer_idx=0, trace_format="safetensors")
+
+
+def test_load_safetensors_wrong_hidden_dim_raises(tmp_path: Path) -> None:
+    prompt_dir = tmp_path / "p"
+    prompt_dir.mkdir()
+    bad = torch.randn(4, 1234, dtype=torch.bfloat16)  # wrong last dim
+    safetensors_save_file({"decoder_input_layer_0": bad}, str(prompt_dir / "decoder_input_layer_0.safetensors"))
+    safetensors_save_file(
+        {"decoder_output_layer_0": bad},
+        str(prompt_dir / "decoder_output_layer_0.safetensors"),
+    )
+    with pytest.raises(ValueError, match="last dim must equal"):
+        _load_reference_trace(tmp_path, "p", decoder_layer_idx=0, trace_format="safetensors")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_trace_loader.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_trace_loader.py
@@ -548,3 +548,84 @@ def test_write_dumps_both_off_is_noop(tmp_path: Path) -> None:
     schedule = MultiTurnSchedule(prompt_lengths=(4,))
     _write_dumps(config, collected={}, kv_cache_torch=None, schedule=schedule)
     assert list(tmp_path.iterdir()) == []
+
+
+# ----- weight_key_prefix wiring -----
+#
+# Smoke tests that confirm CacheWeightProvider's weight_key_prefix kwarg
+# threads correctly into LazyStateDict.base_prefix and the right HF keys are
+# in/out of the resulting Mapping view. Doesn't load any real model weights —
+# just checks the index resolution layer, which is what Kimi needs.
+
+
+def _make_fake_hf_model_dir(tmp_path: Path, weight_map: dict[str, str]) -> Path:
+    """Create a minimal HF snapshot dir: model.safetensors.index.json + sharded names.
+
+    Doesn't write actual safetensors shards (LazyStateDict reads the index
+    eagerly but tensor files only on __getitem__ access). Sufficient for
+    testing the prefix-resolution path.
+    """
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": 0}, "weight_map": weight_map})
+    )
+    return model_dir
+
+
+def test_cache_weight_provider_default_prefix_is_empty(tmp_path: Path) -> None:
+    """Default behavior unchanged: weight_key_prefix='' means HF keys used as-is."""
+    from models.demos.deepseek_v3_b1.demo.weight_provider import CacheWeightProvider
+
+    model_dir = _make_fake_hf_model_dir(tmp_path, {"model.layers.0.input_layernorm.weight": "dummy.safetensors"})
+    provider = CacheWeightProvider(cache_path=tmp_path / "cache", model_path=model_dir)
+    assert provider._weight_key_prefix == ""
+    assert provider._state_dict._base_prefix == ""
+    assert "model.layers.0.input_layernorm.weight" in provider._state_dict
+
+
+def test_cache_weight_provider_kimi_prefix_resolves_keys(tmp_path: Path) -> None:
+    """With weight_key_prefix='language_model.', Kimi-style keys are resolvable.
+
+    Kimi's HF state dict has keys like "language_model.model.layers.0.…" because
+    the DeepSeek-V3 backbone is wrapped under that prefix by the multimodal
+    KimiK25ForConditionalGeneration architecture. With the prefix set, code
+    that looks up "model.layers.0.…" against the provider's state dict resolves
+    to the right physical key.
+    """
+    from models.demos.deepseek_v3_b1.demo.weight_provider import CacheWeightProvider
+
+    model_dir = _make_fake_hf_model_dir(
+        tmp_path,
+        {
+            "language_model.model.layers.0.input_layernorm.weight": "dummy.safetensors",
+            "language_model.model.layers.5.self_attn.q_a_proj.weight": "dummy.safetensors",
+        },
+    )
+    provider = CacheWeightProvider(
+        cache_path=tmp_path / "cache",
+        model_path=model_dir,
+        weight_key_prefix="language_model.",
+    )
+    # Provider records the prefix and forwards it to LazyStateDict.
+    assert provider._weight_key_prefix == "language_model."
+    assert provider._state_dict._base_prefix == "language_model."
+    # Caller-facing keys are stripped of the prefix.
+    assert "model.layers.0.input_layernorm.weight" in provider._state_dict
+    assert "model.layers.5.self_attn.q_a_proj.weight" in provider._state_dict
+    # Caller-facing key collision with the *full* key must miss — the prefix
+    # is prepended *to* lookups, not stripped from them.
+    assert "language_model.model.layers.0.input_layernorm.weight" not in provider._state_dict
+
+
+def test_cache_weight_provider_prefix_mismatch_fails_lookup(tmp_path: Path) -> None:
+    """Wrong prefix → physical key never resolves → contains check is False."""
+    from models.demos.deepseek_v3_b1.demo.weight_provider import CacheWeightProvider
+
+    model_dir = _make_fake_hf_model_dir(
+        tmp_path,
+        # Stored under "language_model." but provider is configured with no prefix.
+        {"language_model.model.layers.0.input_layernorm.weight": "dummy.safetensors"},
+    )
+    provider = CacheWeightProvider(cache_path=tmp_path / "cache", model_path=model_dir)
+    assert "model.layers.0.input_layernorm.weight" not in provider._state_dict


### PR DESCRIPTION
### PR Category
Feature

### Summary

Extends `HostIoDecoderStage` sweep harness (`models/demos/deepseek_v3_b1/tests/unit_tests/host_io_decoder_harness.py` + CLI driver) to consume bit_sculpt's `DebugTracer` safetensors output directly, in addition to the existing `torch.save` `.pt` format. Enables on-device PCC validation of TT decoder output against bit_sculpt reference traces (the GPU-vs-TT correctness check) without an intermediate format conversion.

#### What's new

- **Loader auto-detects two safetensors layouts** emitted by bit_sculpt:
  - **Flat** (prefill-only): one safetensors file per `(layer, kind)` directly under `<prompt>/`.
  - **Per-step** (decode mode, `run_debug_trace.py --decode-steps N`): `step_0/` holds prefill, `step_k>=1` holds one `(1, HIDDEN_SIZE)` delta per generated token. The loader concatenates along dim 0 to produce a single `(T_prefill + N, HIDDEN_SIZE)` tensor — the harness's sweep sees no difference from the flat case.
- **New CLI flags:** `--trace-format {auto,pt,safetensors}` and `--dump-format {pt,safetensors}`.
- **Safetensors dumps** land under `<dump_dir>/<prompt>/` with tensor keys and shapes matching bit_sculpt's `DebugTracer` conventions (`decoder_output_layer_{L}` shape `(L_p, 7168)`, `kv_post_transform_layer_{L}` shape `(L_p, 576)`) — diff against bit_sculpt reference dirs with no format conversion.

#### Back-compat

Default behavior is **identical** to before:
- `trace_format="auto"` probes `<prompt>.pt` first, falls back to `<prompt>/` only when the `.pt` file is missing — existing DeepSeek pipeclean workflows take exactly the same code path.
- `dump_format="pt"` is the default — existing dump filenames (`output_hidden_states_slot_NN_<prompt>.pt`, `kv_cache_slot_NN_<prompt>.pt`) are unchanged.
- No external callers of `_load_reference_trace` or `HostIoDecoderSweepConfig` exist outside the three touched files (verified by grep).

#### How to run

```bash
# DeepSeek, original .pt path (unchanged)
TT_METAL_SLOW_DISPATCH_MODE=1 \
python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \
    --decoder-layer-idx 4 \
    --hidden-states-dir /data/asaigal/pipeclean_traces \
    --prompt pipeclean_seq_8192 --num-replication-slots 1

# DeepSeek, bit_sculpt safetensors trace (new path)
TT_METAL_SLOW_DISPATCH_MODE=1 \
python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \
    --decoder-layer-idx 4 \
    --hidden-states-dir /workspace/bit_sculpt/results/deepseek-r1-0528/debug_trace \
    --prompt aho_sus_decode_10 \
    --trace-format safetensors \
    --validate-hidden-states-cross-trace --pcc-threshold 0.97

# Kimi K2.6 layer 0 (dense) — trace loading works; full validation blocked, see below
TT_METAL_SLOW_DISPATCH_MODE=1 \
python -m models.demos.deepseek_v3_b1.tests.unit_tests.run_host_io_decoder_sweep \
    --decoder-layer-idx 0 \
    --hidden-states-dir /workspace/bit_sculpt/results/moonshotai-kimi-k26/debug_trace \
    --prompt smoke_kimi_k26_2026-05-14_bf16 \
    --trace-format safetensors --hf-model-path /workspace/models/moonshotai/Kimi-K2.6-bf16-dequant
```

Full per-model / per-layout examples are in the updated module docstring of `run_host_io_decoder_sweep.py`.

#### Tests

- **15 host-only loader tests** (`test_host_io_decoder_trace_loader.py`, pure-CPU, ~3 s): both layouts, symlink resolution for `L >= 1`, numeric step sort (`step_10` after `step_2`), `.pt` round-trip, auto-detect, format-passthrough, dtype/shape/missing-file/missing-layer contract violations.
- **6 on-device parametrized sweep cases** (`test_host_io_decoder_sweep_e2e.py`, BH galaxy + slow dispatch): one per `(model, layout, layer)` combination. Each `pytest.mark.skip` cites the specific blocker; the file doubles as a **status board for what's runnable today**:

  | Case | Runs today? | Unblock by |
  |---|---|---|
  | `deepseek_pt_pipeclean_8192_layer4_modeA` | **Yes**, when `.pt` trace staged | — |
  | `deepseek_safetensors_flat_layer4_modeA` | No | Regenerate trace with current bit_sculpt `run_debug_trace.py --capture-group-a` (checked-in traces use old bundled `hidden_states.safetensors` format) |
  | `deepseek_safetensors_per_step_layer4_modeA` | No | Same — regenerate with `--decode-steps N --capture-group-a` |
  | `kimi_safetensors_flat_dense_layer0_modeA` | No | Stage Kimi BF16-dequant weights + add `language_model.` prefix shim to `CacheWeightProvider` |
  | `kimi_safetensors_flat_moe_layer1_modeA` | No | 384-expert / ungrouped top-8 gate kernel — tracked on `origin/ddjekic/kimi26_bringup`, `origin/gchoudhary/41826-generalize-moe_compute-shape-support` |
  | `kimi_safetensors_per_step_moe_layer30_modeA` | No | Same gate-kernel blocker |

  Run on BH galaxy:
  ```bash
  TT_METAL_SLOW_DISPATCH_MODE=1 \
  pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_e2e.py -v
  ```

- **Validated end-to-end** against real bit_sculpt Kimi K2.6 traces (`smoke_kimi_k26_2026-05-14_bf16` flat layout, `q_what_is_python` per-step layout, 112 tokens total = 12 prefill + 100 decode) at layers 0/3/30/60. Shapes match contract exactly (bf16, `(T, 7168)`); per-step concatenation order is correct.

### Notes for reviewers

- **Pre-spike Kimi-on-`_b1` reality check** lives in this PR's discussion thread but is also baked into the e2e test skip reasons: Kimi K2.6 needs a **new gate kernel** (b1's `DeepseekMoeGateSingleCore` in `micro_ops/deepseek_moe_gate/op.py` hardcodes `(16, 16) = 256` grouped routing; Kimi has 1 group of 384, plain top-8). Active Kimi work is on the `_d_p` sister demo (`deepseek_v3_d_p/reference/kimi_k26/` already on main; full demo on `origin/ddjekic/kimi26_bringup`). This PR deliberately scopes to safetensors I/O on the `_b1` line so the validation infrastructure is in place when the gate kernel arrives.

- **DeepSeek end-to-end with safetensors needs a fresh trace.** Current checked-in DeepSeek traces (`aho_*`, `tt_moconnor*`, `aho_sus_decode_10/step_*/`, etc.) predate the per-layer `DebugTracer._save_step` refactor and use the older `hidden_states.safetensors` bundle. The pure-host loader tests synthesize new-format fixtures so loader logic is fully exercised; the on-device cases just need someone to regenerate a small DeepSeek trace.

- **No changes to** the hot path (`_run_prompt_sweep`), validation phases 3a/3b/4, weight providers, fabric config, or any kernel. The diff is concentrated in `_preflight` / `_load_reference_trace` / Phase 5 dumps and the CLI argparse layer.

- **Linter-driven reformatting** consolidated multi-line imports in 3 of the 4 files during pre-commit hook (autoflake/isort/black). No semantic changes from those reformats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/host-io-decoder-safetensors-traces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/host-io-decoder-safetensors-traces)