### PR TITLE
[DCAMP-512] Force MPI OOB and BTL channels onto ens5f0np0

### DIFF
--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -200,7 +200,7 @@ default() {
     fi
 
     # Build the command for each rank group
-    local base_mpirun_args="--tag-output --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_exclude docker0,lo,tailscale0"
+    local base_mpirun_args="--tag-output --prtemca oob_tcp_if_include ens5f0np0 --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_include ens5f0np0"
 
     # Add global MPI args to base
     if [[ ${#global_mpi_args[@]} -gt 0 ]]; then

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -4,11 +4,14 @@ print_usage() {
     echo "Usage: $0 [--image <image>] [--empty-entrypoint] [--print] [--print-only] [global-mpi-args] <executable> [args...]"
     echo "       $0 [--image <image>] [--empty-entrypoint] [--print] [--print-only] [global-mpi-args] <per-rank-specs> [: <per-rank-specs> ...]"
     echo
-    echo "  --image <image>       (Optional) Docker image to use"
-    echo "  --empty-entrypoint    (Optional) Pass --entrypoint=\"\" to docker run"
-    echo "  --volume <path>       (Optional) Extra host path to mount into the container (repeatable)"
-    echo "  --print               Print the command alongside execution"
-    echo "  --print-only          Print the command without executing it"
+    echo "  --image <image>           (Optional) Docker image to use"
+    echo "  --empty-entrypoint        (Optional) Pass --entrypoint=\"\" to docker run"
+    echo "  --volume <path>           (Optional) Extra host path to mount into the container (repeatable)"
+    echo "  --mpi-interface <iface>   (Optional) Network interface to pin MPI to (default: ens5f0np0)"
+    echo "                            Passed to --prtemca oob_tcp_if_include and --mca btl_tcp_if_include."
+    echo "                            Interface names vary by site; override on non-Markham clusters."
+    echo "  --print                   Print the command alongside execution"
+    echo "  --print-only              Print the command without executing it"
     echo "  [global-mpi-args]     Global MPI arguments applied to all ranks"
     echo "                        Examples: --host, --hostfile, --bind-to, --map-by, -np, etc."
     echo "  <executable> [args]   Executable and arguments (single mode)"
@@ -44,6 +47,9 @@ default() {
     local extra_volumes=""
     local print_flag=false
     local print_only=false
+    # Interface names differ between sites; default works on Markham,
+    # override elsewhere via --mpi-interface.
+    local mpi_interface="ens5f0np0"
 
     # Parse script-specific arguments first
     local script_args=()
@@ -78,6 +84,24 @@ default() {
                     exit 1
                 fi
                 extra_volumes="$extra_volumes -v ${vol}:${vol}"
+                shift
+                ;;
+            --mpi-interface)
+                if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                    echo "Error: --mpi-interface requires a non-empty interface name"
+                    print_usage
+                    exit 1
+                fi
+                mpi_interface="$2"
+                shift 2
+                ;;
+            --mpi-interface=*)
+                mpi_interface="${1#--mpi-interface=}"
+                if [[ -z "$mpi_interface" ]]; then
+                    echo "Error: --mpi-interface requires a non-empty interface name"
+                    print_usage
+                    exit 1
+                fi
                 shift
                 ;;
             --print)
@@ -200,7 +224,7 @@ default() {
     fi
 
     # Build the command for each rank group
-    local base_mpirun_args="--tag-output --prtemca oob_tcp_if_include ens5f0np0 --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_include ens5f0np0"
+    local base_mpirun_args="--tag-output --prtemca oob_tcp_if_include $mpi_interface --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_include $mpi_interface"
 
     # Add global MPI args to base
     if [[ ${#global_mpi_args[@]} -gt 0 ]]; then


### PR DESCRIPTION
https://tenstorrent.atlassian.net/browse/DCAMP-512

### PR Category
FIX

### Summary
- Added `--prtemca oob_tcp_if_include ens5f0np0` so PRTE's launch/wireup traffic goes over the intended NIC instead of whatever it picks first.
- Replaced `--mca btl_tcp_if_exclude docker0,lo,tailscale0` with `--mca btl_tcp_if_include ens5f0np0` so MPI data traffic is pinned to the same interface rather than relying on an exclusion list.

### Notes for reviewers
This fixes MPI-side errors we notices when running on 16+ hosts

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/mpi_docker_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/mpi_docker_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/mpi_docker_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/mpi_docker_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/mpi_docker_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/mpi_docker_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/mpi_docker_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/mpi_docker_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/mpi_docker_fix)