### PR TITLE
[Performance] tt-llk: improve ttsim sweep throughput and observability

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -648,6 +648,29 @@ def pytest_sessionstart(session):
     except OSError:
         pass
 
+    # AOT-compile the shared brisc.elf + coverage.o before xdist forks
+    # workers. Otherwise every worker's first test hits build_shared_artefacts
+    # and races on /tmp/tt-llk-build-shared.lock; (N-1)/N of them spend tens
+    # of seconds blocked waiting for the FileLock. Doing it here, on the
+    # controller, in advance means workers find the .shared_complete marker
+    # already present and skip via the fast path (test_config.py:837). Wrap
+    # in try/except so a transient build failure doesn't kill the suite —
+    # workers will retry on first test if needed.
+    if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
+        try:
+            # build_shared_artefacts doesn't use any instance-specific fields
+            # (test_name, templates, etc.), only TestConfig class state
+            # already populated by pytest_configure → setup_paths. A throwaway
+            # instance with a sentinel test_name is the minimum-friction way
+            # to call it without refactoring to classmethod.
+            TestConfig(test_name="_aot_shared_bootstrap_").build_shared_artefacts()
+        except Exception as exc:  # noqa: BLE001 — best-effort optimization
+            logger.warning(
+                "AOT shared-artefacts build failed at sessionstart "
+                "(will retry per-worker): {}",
+                exc,
+            )
+
     test_target = TestTargetConfig()
     if not test_target.run_simulator and TestConfig.BUILD_MODE != BuildMode.PRODUCE:
         _send_arc_message("GO_BUSY", test_target.device_id)

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -466,7 +466,18 @@ def pytest_runtest_logreport(report):
     # body) plus collection-error/setup-fail cases. POSIX guarantees atomic
     # appends for writes <= PIPE_BUF (4096) on regular files, so the dozens
     # of xdist workers can all append to the same file without locks.
-    if report.when in ("call", "setup", "teardown") and (
+    #
+    # Skip on the xdist controller: pytest-xdist forwards every worker's
+    # logreport up to the controller, where this hook also runs — without
+    # the skip, every test gets written twice (once by gwN, once by main).
+    # The controller's copy of a forwarded report carries report.worker_id;
+    # local reports (on workers, and on the serial-mode single process)
+    # don't. So gating on `report.worker_id is not None` lets serial-mode
+    # write exactly once and xdist mode write exactly once per test on the
+    # worker that actually ran it.
+    if getattr(report, "worker_id", None) is not None:
+        pass  # forwarded report on controller — worker already wrote it
+    elif report.when in ("call", "setup", "teardown") and (
         report.failed or report.skipped or (report.when == "call" and report.passed)
     ):
         try:

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -9,9 +9,18 @@ import os
 import re
 import signal
 import sys
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
+
+# Live-progress JSONL: pytest's --junit-xml only writes at session end, which
+# leaves operators flying blind during long parallel regressions. This file
+# is appended-to by every xdist worker (POSIX atomic-append for lines under
+# PIPE_BUF), so `tail -f /tmp/tt-llk-progress.jsonl` gives real-time
+# per-test outcome + duration + worker id. Truncated once at session start
+# by the xdist controller (so re-runs don't bleed into each other).
+_PROGRESS_LOG_PATH = os.environ.get("TTSIM_PROGRESS_LOG", "/tmp/tt-llk-progress.jsonl")
 
 # ttsim runs in-process (no ExalensServer). Its init must complete before any helpers.* import,
 # because helpers.chip_architecture.get_chip_architecture() reaches check_context() and this
@@ -453,6 +462,29 @@ def pytest_runtest_logreport(report):
             props.append(("ttsim_func", func))
             report.user_properties = props
 
+    # Live progress: one JSONL line per test "call" phase (the actual test
+    # body) plus collection-error/setup-fail cases. POSIX guarantees atomic
+    # appends for writes <= PIPE_BUF (4096) on regular files, so the dozens
+    # of xdist workers can all append to the same file without locks.
+    if report.when in ("call", "setup", "teardown") and (
+        report.failed or report.skipped or (report.when == "call" and report.passed)
+    ):
+        try:
+            entry = {
+                "ts": time.time(),
+                "phase": report.when,
+                "outcome": report.outcome,
+                "duration": round(report.duration, 4),
+                "nodeid": report.nodeid,
+                "worker": os.environ.get("PYTEST_XDIST_WORKER", "main"),
+            }
+            line = json.dumps(entry, separators=(",", ":")) + "\n"
+            # Mode "a" is O_APPEND — kernel-level atomic seek+write per syscall.
+            with open(_PROGRESS_LOG_PATH, "a", encoding="utf-8") as f:
+                f.write(line)
+        except OSError:
+            pass  # never let progress logging break the test run
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
@@ -595,6 +627,15 @@ def pytest_runtest_setup(item):
 def pytest_sessionstart(session):
     if hasattr(session.config, "workerinput"):
         return
+
+    # Truncate the live-progress JSONL once on the controller — workers will
+    # open in append mode. Avoid raising if the path is unwritable; live
+    # progress is best-effort, not a correctness gate.
+    try:
+        Path(_PROGRESS_LOG_PATH).parent.mkdir(parents=True, exist_ok=True)
+        Path(_PROGRESS_LOG_PATH).write_text("")
+    except OSError:
+        pass
 
     test_target = TestTargetConfig()
     if not test_target.run_simulator and TestConfig.BUILD_MODE != BuildMode.PRODUCE:

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -9,9 +9,18 @@ import os
 import re
 import signal
 import sys
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
+
+# Live-progress JSONL: pytest's --junit-xml only writes at session end, which
+# leaves operators flying blind during long parallel regressions. This file
+# is appended-to by every xdist worker (POSIX atomic-append for lines under
+# PIPE_BUF), so `tail -f /tmp/tt-llk-progress.jsonl` gives real-time
+# per-test outcome + duration + worker id. Truncated once at session start
+# by the xdist controller (so re-runs don't bleed into each other).
+_PROGRESS_LOG_PATH = os.environ.get("TTSIM_PROGRESS_LOG", "/tmp/tt-llk-progress.jsonl")
 
 # ttsim runs in-process (no ExalensServer). Its init must complete before any helpers.* import,
 # because helpers.chip_architecture.get_chip_architecture() reaches check_context() and this
@@ -703,6 +712,29 @@ def pytest_runtest_logreport(report):
             props.append(("ttsim_func", func))
             report.user_properties = props
 
+    # Live progress: one JSONL line per test "call" phase (the actual test
+    # body) plus collection-error/setup-fail cases. POSIX guarantees atomic
+    # appends for writes <= PIPE_BUF (4096) on regular files, so the dozens
+    # of xdist workers can all append to the same file without locks.
+    if report.when in ("call", "setup", "teardown") and (
+        report.failed or report.skipped or (report.when == "call" and report.passed)
+    ):
+        try:
+            entry = {
+                "ts": time.time(),
+                "phase": report.when,
+                "outcome": report.outcome,
+                "duration": round(report.duration, 4),
+                "nodeid": report.nodeid,
+                "worker": os.environ.get("PYTEST_XDIST_WORKER", "main"),
+            }
+            line = json.dumps(entry, separators=(",", ":")) + "\n"
+            # Mode "a" is O_APPEND — kernel-level atomic seek+write per syscall.
+            with open(_PROGRESS_LOG_PATH, "a", encoding="utf-8") as f:
+                f.write(line)
+        except OSError:
+            pass  # never let progress logging break the test run
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
@@ -846,6 +878,15 @@ def pytest_runtest_setup(item):
 def pytest_sessionstart(session):
     if hasattr(session.config, "workerinput"):
         return
+
+    # Truncate the live-progress JSONL once on the controller — workers will
+    # open in append mode. Avoid raising if the path is unwritable; live
+    # progress is best-effort, not a correctness gate.
+    try:
+        Path(_PROGRESS_LOG_PATH).parent.mkdir(parents=True, exist_ok=True)
+        Path(_PROGRESS_LOG_PATH).write_text("")
+    except OSError:
+        pass
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -907,7 +907,7 @@ def pytest_sessionstart(session):
     # already present and skip via the fast path (test_config.py:837). Wrap
     # in try/except so a transient build failure doesn't kill the suite —
     # workers will retry on first test if needed.
-    if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
+    if TestConfig.BUILD_MODE == BuildMode.DEFAULT:
         try:
             # build_shared_artefacts doesn't use any instance-specific fields
             # (test_name, templates, etc.), only TestConfig class state

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -716,7 +716,18 @@ def pytest_runtest_logreport(report):
     # body) plus collection-error/setup-fail cases. POSIX guarantees atomic
     # appends for writes <= PIPE_BUF (4096) on regular files, so the dozens
     # of xdist workers can all append to the same file without locks.
-    if report.when in ("call", "setup", "teardown") and (
+    #
+    # Skip on the xdist controller: pytest-xdist forwards every worker's
+    # logreport up to the controller, where this hook also runs — without
+    # the skip, every test gets written twice (once by gwN, once by main).
+    # The controller's copy of a forwarded report carries report.worker_id;
+    # local reports (on workers, and on the serial-mode single process)
+    # don't. So gating on `report.worker_id is not None` lets serial-mode
+    # write exactly once and xdist mode write exactly once per test on the
+    # worker that actually ran it.
+    if getattr(report, "worker_id", None) is not None:
+        pass  # forwarded report on controller — worker already wrote it
+    elif report.when in ("call", "setup", "teardown") and (
         report.failed or report.skipped or (report.when == "call" and report.passed)
     ):
         try:

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -899,6 +899,29 @@ def pytest_sessionstart(session):
     except OSError:
         pass
 
+    # AOT-compile the shared brisc.elf + coverage.o before xdist forks
+    # workers. Otherwise every worker's first test hits build_shared_artefacts
+    # and races on /tmp/tt-llk-build-shared.lock; (N-1)/N of them spend tens
+    # of seconds blocked waiting for the FileLock. Doing it here, on the
+    # controller, in advance means workers find the .shared_complete marker
+    # already present and skip via the fast path (test_config.py:837). Wrap
+    # in try/except so a transient build failure doesn't kill the suite —
+    # workers will retry on first test if needed.
+    if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
+        try:
+            # build_shared_artefacts doesn't use any instance-specific fields
+            # (test_name, templates, etc.), only TestConfig class state
+            # already populated by pytest_configure → setup_paths. A throwaway
+            # instance with a sentinel test_name is the minimum-friction way
+            # to call it without refactoring to classmethod.
+            TestConfig(test_name="_aot_shared_bootstrap_").build_shared_artefacts()
+        except Exception as exc:  # noqa: BLE001 — best-effort optimization
+            logger.warning(
+                "AOT shared-artefacts build failed at sessionstart "
+                "(will retry per-worker): {}",
+                exc,
+            )
+
 
 @pytest.fixture(scope="module", autouse=True)
 def counter_report(request, worker_id):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -802,6 +802,27 @@ class TestConfig:
 
         return (OPTIONS_COMPILE, MEMORY_LAYOUT_LD_SCRIPT, NON_COVERAGE_OPTIONS_COMPILE)
 
+    def _shared_artefacts_present(self):
+        """Verify the artefacts the done-marker is supposed to gate actually
+        exist on disk. Defends against done-marker leaking a partial build:
+        e.g. a previous run was SIGKILL'd between brisc.elf creation and
+        done_marker.touch(), or done_marker survives while the elf was
+        cleaned by a `pkill -f pytest` (which can drop in-progress gcc
+        outputs zero-length). Without this guard, the fast path returns
+        SHARED_ARTEFACTS_AVAILABLE=True and downstream load_elf hits a
+        missing/empty brisc.elf, surfacing as a deluge of unrelated MMIO
+        errors instead of a clean "elf not found" failure on the first
+        affected test."""
+        if TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR:
+            brisc_elf = TestConfig.SHARED_ELF_DIR / "brisc.elf"
+            if not brisc_elf.is_file() or brisc_elf.stat().st_size == 0:
+                return False
+        if TestConfig.WITH_COVERAGE:
+            coverage_o = TestConfig.SHARED_OBJ_DIR / "coverage.o"
+            if not coverage_o.is_file() or coverage_o.stat().st_size == 0:
+                return False
+        return True
+
     def build_shared_artefacts(self):
         if TestConfig.SHARED_ARTEFACTS_AVAILABLE:
             return
@@ -812,8 +833,8 @@ class TestConfig:
 
         done_marker = shared_obj_dir / ".shared_complete"
 
-        # Fast path: if shared artefacts are already built
-        if done_marker.exists():
+        # Fast path: if shared artefacts are already built AND on disk
+        if done_marker.exists() and self._shared_artefacts_present():
             TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
             return
 
@@ -821,10 +842,16 @@ class TestConfig:
         lock = FileLock(lock_file)
 
         with lock:
-            # Check again inside lock
-            if done_marker.exists():
+            # Check again inside lock — same dual condition. If the marker
+            # exists but the artefact is missing/empty, fall through and
+            # rebuild rather than serving a corrupt cache.
+            if done_marker.exists() and self._shared_artefacts_present():
                 TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
                 return
+            # Clean up a leaked marker so we don't loop on the same stale
+            # state under a transient build failure.
+            if done_marker.exists():
+                done_marker.unlink()
 
             _, local_memory_layout_ld, local_non_coverage = (
                 self.resolve_compile_options()
@@ -1073,8 +1100,19 @@ class TestConfig:
 
         self.build_shared_artefacts()
 
-        # Fast path: if build is already complete, skip entirely
-        if done_marker.exists():
+        def _variant_artefacts_present():
+            """Sibling guard to _shared_artefacts_present: confirm each kernel
+            component's .elf actually exists. Same xdist/SIGKILL races apply
+            here as in build_shared_artefacts."""
+            elf_dir = VARIANT_DIR / "elf"
+            for name in TestConfig.KERNEL_COMPONENTS:
+                elf = elf_dir / f"{name}.elf"
+                if not elf.is_file() or elf.stat().st_size == 0:
+                    return False
+            return True
+
+        # Fast path: if build is already complete AND elfs are on disk
+        if done_marker.exists() and _variant_artefacts_present():
             logger.debug("Build already complete for {}", self.variant_id[:12])
             return
 
@@ -1083,9 +1121,12 @@ class TestConfig:
         lock = FileLock(lock_file)
 
         with lock:
-            # Check again inside lock in case another process just finished
-            if done_marker.exists():
+            # Check again inside lock — same dual condition.
+            if done_marker.exists() and _variant_artefacts_present():
                 return
+            # Stale marker without artefacts → clean and rebuild.
+            if done_marker.exists():
+                done_marker.unlink()
 
             VARIANT_OBJ_DIR = VARIANT_DIR / "obj"
             VARIANT_ELF_DIR = VARIANT_DIR / "elf"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -963,6 +963,27 @@ class TestConfig:
 
         return (OPTIONS_COMPILE, MEMORY_LAYOUT_LD_SCRIPT, NON_COVERAGE_OPTIONS_COMPILE)
 
+    def _shared_artefacts_present(self):
+        """Verify the artefacts the done-marker is supposed to gate actually
+        exist on disk. Defends against done-marker leaking a partial build:
+        e.g. a previous run was SIGKILL'd between brisc.elf creation and
+        done_marker.touch(), or done_marker survives while the elf was
+        cleaned by a `pkill -f pytest` (which can drop in-progress gcc
+        outputs zero-length). Without this guard, the fast path returns
+        SHARED_ARTEFACTS_AVAILABLE=True and downstream load_elf hits a
+        missing/empty brisc.elf, surfacing as a deluge of unrelated MMIO
+        errors instead of a clean "elf not found" failure on the first
+        affected test."""
+        if TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR:
+            brisc_elf = TestConfig.SHARED_ELF_DIR / "brisc.elf"
+            if not brisc_elf.is_file() or brisc_elf.stat().st_size == 0:
+                return False
+        if TestConfig.WITH_COVERAGE:
+            coverage_o = TestConfig.SHARED_OBJ_DIR / "coverage.o"
+            if not coverage_o.is_file() or coverage_o.stat().st_size == 0:
+                return False
+        return True
+
     def build_shared_artefacts(self):
         if TestConfig.SHARED_ARTEFACTS_AVAILABLE:
             return
@@ -973,8 +994,8 @@ class TestConfig:
 
         done_marker = shared_obj_dir / ".shared_complete"
 
-        # Fast path: if shared artefacts are already built
-        if done_marker.exists():
+        # Fast path: if shared artefacts are already built AND on disk
+        if done_marker.exists() and self._shared_artefacts_present():
             TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
             return
 
@@ -982,10 +1003,16 @@ class TestConfig:
         lock = FileLock(lock_file)
 
         with lock:
-            # Check again inside lock
-            if done_marker.exists():
+            # Check again inside lock — same dual condition. If the marker
+            # exists but the artefact is missing/empty, fall through and
+            # rebuild rather than serving a corrupt cache.
+            if done_marker.exists() and self._shared_artefacts_present():
                 TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
                 return
+            # Clean up a leaked marker so we don't loop on the same stale
+            # state under a transient build failure.
+            if done_marker.exists():
+                done_marker.unlink()
 
             _, local_memory_layout_ld, local_non_coverage = (
                 self.resolve_compile_options()
@@ -1250,8 +1277,19 @@ class TestConfig:
 
         self.build_shared_artefacts()
 
-        # Fast path: if build is already complete, skip entirely
-        if done_marker.exists():
+        def _variant_artefacts_present():
+            """Sibling guard to _shared_artefacts_present: confirm each kernel
+            component's .elf actually exists. Same xdist/SIGKILL races apply
+            here as in build_shared_artefacts."""
+            elf_dir = VARIANT_DIR / "elf"
+            for name in TestConfig.KERNEL_COMPONENTS:
+                elf = elf_dir / f"{name}.elf"
+                if not elf.is_file() or elf.stat().st_size == 0:
+                    return False
+            return True
+
+        # Fast path: if build is already complete AND elfs are on disk
+        if done_marker.exists() and _variant_artefacts_present():
             logger.debug("Build already complete for {}", self.variant_id[:12])
             return
 
@@ -1260,9 +1298,12 @@ class TestConfig:
         lock = FileLock(lock_file)
 
         with lock:
-            # Check again inside lock in case another process just finished
-            if done_marker.exists():
+            # Check again inside lock — same dual condition.
+            if done_marker.exists() and _variant_artefacts_present():
                 return
+            # Stale marker without artefacts → clean and rebuild.
+            if done_marker.exists():
+                done_marker.unlink()
 
             VARIANT_OBJ_DIR = VARIANT_DIR / "obj"
             VARIANT_ELF_DIR = VARIANT_DIR / "elf"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -994,8 +994,13 @@ class TestConfig:
 
         done_marker = shared_obj_dir / ".shared_complete"
 
-        # Fast path: if shared artefacts are already built AND on disk
-        if done_marker.exists() and self._shared_artefacts_present():
+        # Fast path: if shared artefacts are already built AND on disk.
+        # Check the artefacts FIRST and the marker LAST: the builder unlinks
+        # the marker before (re)building and touches it only after all
+        # artefacts are complete, so the marker is absent for the entire
+        # rebuild. Reading it last means a concurrent rebuild is always caught
+        # even if the artefact read observed a partially-linked file (TOCTOU).
+        if self._shared_artefacts_present() and done_marker.exists():
             TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
             return
 
@@ -1003,10 +1008,11 @@ class TestConfig:
         lock = FileLock(lock_file)
 
         with lock:
-            # Check again inside lock — same dual condition. If the marker
-            # exists but the artefact is missing/empty, fall through and
-            # rebuild rather than serving a corrupt cache.
-            if done_marker.exists() and self._shared_artefacts_present():
+            # Check again inside lock — same dual condition (artefacts first,
+            # marker last). If the marker exists but the artefact is
+            # missing/empty, fall through and rebuild rather than serving a
+            # corrupt cache.
+            if self._shared_artefacts_present() and done_marker.exists():
                 TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
                 return
             # Clean up a leaked marker so we don't loop on the same stale
@@ -1288,8 +1294,13 @@ class TestConfig:
                     return False
             return True
 
-        # Fast path: if build is already complete AND elfs are on disk
-        if done_marker.exists() and _variant_artefacts_present():
+        # Fast path: if build is already complete AND elfs are on disk.
+        # Check the artefacts FIRST and the marker LAST: the builder unlinks
+        # the marker before (re)building and touches it only after all ELFs
+        # are complete, so the marker is absent for the entire rebuild.
+        # Reading it last means a concurrent rebuild is always caught even if
+        # the artefact read observed a partially-linked ELF (TOCTOU).
+        if _variant_artefacts_present() and done_marker.exists():
             logger.debug("Build already complete for {}", self.variant_id[:12])
             return
 
@@ -1298,8 +1309,9 @@ class TestConfig:
         lock = FileLock(lock_file)
 
         with lock:
-            # Check again inside lock — same dual condition.
-            if done_marker.exists() and _variant_artefacts_present():
+            # Check again inside lock — same dual condition (artefacts first,
+            # marker last).
+            if _variant_artefacts_present() and done_marker.exists():
                 return
             # Stale marker without artefacts → clean and rebuild.
             if done_marker.exists():

--- a/tt_metal/tt-llk/tests/python_tests/pytest.ini
+++ b/tt_metal/tt-llk/tests/python_tests/pytest.ini
@@ -3,7 +3,15 @@ filterwarnings =
     ignore::UserWarning
     ignore::DeprecationWarning
     ignore::FutureWarning
-addopts = -s --maxschedchunk=10
+# -s capture: kept — pytest_runtest_logreport in conftest.py renames
+#   lowercase "captured stdout" sections to capital so forked-crash output
+#   still lands in junit <system-out>.
+# --maxschedchunk=1: needed for --dist=worksteal (run_ttsim_regression.sh).
+#   With chunk=10 worksteal only steals at chunk boundaries, leaving idle
+#   workers on the long tail. chunk=1 gives per-test stealability.
+# -p no:cacheprovider: .pytest_cache lives on overlayfs /tmp — small
+#   per-test write that adds up at 32 workers. We don't use the cache.
+addopts = -s --maxschedchunk=1 -p no:cacheprovider
 python_files =
     test_*.py
     perf_*.py

--- a/tt_metal/tt-llk/tests/python_tests/pytest.ini
+++ b/tt_metal/tt-llk/tests/python_tests/pytest.ini
@@ -6,12 +6,9 @@ filterwarnings =
 # -s capture: kept — pytest_runtest_logreport in conftest.py renames
 #   lowercase "captured stdout" sections to capital so forked-crash output
 #   still lands in junit <system-out>.
-# --maxschedchunk=1: needed for --dist=worksteal (run_ttsim_regression.sh).
-#   With chunk=10 worksteal only steals at chunk boundaries, leaving idle
-#   workers on the long tail. chunk=1 gives per-test stealability.
 # -p no:cacheprovider: .pytest_cache lives on overlayfs /tmp — small
 #   per-test write that adds up at 32 workers. We don't use the cache.
-addopts = -s --maxschedchunk=1 -p no:cacheprovider
+addopts = -s -p no:cacheprovider
 python_files =
     test_*.py
     perf_*.py

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -225,7 +225,11 @@ PYTEST_BASE_ARGS=(
     --run-simulator
     --timeout="$TIMEOUT"
     --forked
-    --show-progress
+    # --show-progress dropped: the in-tree JSONL hook in conftest.py
+    # (commit 0b899ae9291) writes one line per test outcome to
+    # /tmp/tt-llk-progress.jsonl, which is `tail -f`-able and doesn't pay
+    # the controller-side memory cost of pytest-progress's
+    # ProgressTerminalReporter accumulating 37K outcomes in lists.
     -m "not quasar and not nightly and not perf"
     --junit-xml="$XML_PATH"
     # ttsim writes via printf (stdout), so caplog and stderr are always
@@ -247,7 +251,15 @@ PYTEST_BASE_ARGS=(
 if [[ "$WORKERS" -gt 0 ]]; then
     PYTEST_BASE_ARGS+=(
         -n "$WORKERS"
-        --dist=loadfile
+        # worksteal (xdist 3.8+) distributes tests evenly then redistributes
+        # from busy workers when others idle — fixes the long-tail-file
+        # bottleneck that loadfile creates with parametrize-heavy classes
+        # (test_zzz_eltwise_binary, test_matmul, etc.). Cross-file build
+        # races were already defended at the test_config level by
+        # build_shared_artefacts' FileLock + done-marker stat-guard
+        # (see commits c2b04f5d5dd and fe282aa29ae), so loadfile's
+        # belt-AND-braces overkill no longer pays for itself.
+        --dist=worksteal
         --max-worker-restart=10000
     )
 fi

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -285,7 +285,15 @@ PYTEST_BASE_ARGS=(
 if [[ "$WORKERS" -gt 0 ]]; then
     PYTEST_BASE_ARGS+=(
         -n "$WORKERS"
-        --dist=loadfile
+        # worksteal (xdist 3.8+) distributes tests evenly then redistributes
+        # from busy workers when others idle — fixes the long-tail-file
+        # bottleneck that loadfile creates with parametrize-heavy classes
+        # (test_zzz_eltwise_binary, test_matmul, etc.). Cross-file build
+        # races were already defended at the test_config level by
+        # build_shared_artefacts' FileLock + done-marker stat-guard
+        # (see commits c2b04f5d5dd and fe282aa29ae), so loadfile's
+        # belt-AND-braces overkill no longer pays for itself.
+        --dist=worksteal
         --max-worker-restart=10000
     )
 fi


### PR DESCRIPTION
### PR Category
Performance

### Summary
This PR improves LLK ttsim sweep throughput, observability, and resilience without changing LLK kernel behavior.

Changes:
- Harden LLK shared/variant build done markers by checking that the gated ELF artifacts actually exist and are non-empty.
- Add per-test JSONL progress logging for long LLK pytest/ttsim sweeps.
- Switch the ttsim regression xdist scheduler from `loadfile` to `worksteal` (the previously-bundled `--maxschedchunk=1` was dropped: xdist WorkStealingScheduling ignores it).
- AOT-build shared BRISC artifacts before xdist workers fan out, avoiding the startup lock convoy.

### Notes for reviewers
This is sweep/test infrastructure only. Please focus review on xdist behavior, artifact marker correctness, and whether the JSONL hook is acceptable for long-running LLK sweeps.

The artifact marker guard is what makes `worksteal` safe here: workers can now share the build tree without trusting stale `.build_complete` / `.shared_complete` marker files when an ELF is missing or zero-length.

Test plan:
- `git diff --check origin/main..HEAD`
- `python3 -m py_compile tt_metal/tt-llk/tests/python_tests/conftest.py tt_metal/tt-llk/tests/python_tests/helpers/test_config.py`
- `bash -n tt_metal/tt-llk/tests/run_ttsim_regression.sh`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/llk-ttsim-sweep-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/llk-ttsim-sweep-infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/llk-ttsim-sweep-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/llk-ttsim-sweep-infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/llk-ttsim-sweep-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/llk-ttsim-sweep-infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/llk-ttsim-sweep-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/llk-ttsim-sweep-infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/llk-ttsim-sweep-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/llk-ttsim-sweep-infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/llk-ttsim-sweep-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/llk-ttsim-sweep-infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/llk-ttsim-sweep-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/llk-ttsim-sweep-infra)
