### PR TITLE
[Test Only] tt-llk: read fast tilize guard from worker core

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_full.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_full.py
@@ -308,7 +308,7 @@ def test_fast_tilize_overflow_guard(formats, dest_acc, dimensions):
     last_g_addr = (
         stim.buf_res_addr + (tile_count + guard_tiles - 1) * stim.buf_res_tile_size
     )
-    core_loc = "0,0"  # already "x,y" string
+    core_loc = TestConfig.TENSIX_LOCATION
     raw = read_from_device(core_loc, last_g_addr, num_bytes=10)
     marker = struct.unpack_from("<H", raw, 0)[0]
     assert (


### PR DESCRIPTION
### PR Category
Test Only

### Summary
This PR fixes `test_fast_tilize_overflow_guard` under parallel LLK execution.

The test wrote the sentinel on the worker core but read from hardcoded core `0,0`. Under pytest-xdist, workers run on different Tensix locations, so this produced false failures whenever the worker was not mapped to `0,0`.

### Notes for reviewers
The change is test-only: read the guard sentinel from `TestConfig.TENSIX_LOCATION`, matching the worker core that ran the test.

Test plan:
- `git diff --check origin/main..HEAD`
- `python3 -m py_compile tt_metal/tt-llk/tests/python_tests/test_fast_tilize_full.py`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/llk-fast-tilize-guard-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/llk-fast-tilize-guard-core)