### PR TITLE
[Bug fix] tt-llk: add ttsim SFPLOADMACRO fallback for reduce Max

### DIFF
--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -204,7 +204,13 @@ if [[ ! -d "$TESTS_DIR" ]]; then
 fi
 
 # ttsim does not implement SFPLOADMACRO; default to disabling unless caller set it.
-export DISABLE_SFPLOADMACRO="${DISABLE_SFPLOADMACRO:-1}"
+# The compile-time gate (-DDISABLE_SFPLOADMACRO) is added by
+# python_tests/helpers/test_config.py when the env var TT_METAL_DISABLE_SFPLOADMACRO=1
+# is set — that's the documented name in README.md. The bare DISABLE_SFPLOADMACRO
+# spelling we used before never reached the test_config.py gate, so the gate
+# silently no-op'd and every SFPLOADMACRO opcode reached ttsim at runtime and
+# tripped UnsupportedFunctionality.
+export TT_METAL_DISABLE_SFPLOADMACRO="${TT_METAL_DISABLE_SFPLOADMACRO:-1}"
 
 mkdir -p "$RESULTS_DIR"
 
@@ -261,7 +267,7 @@ echo "============================================================"
 echo " Architecture   : ${ARCHITECTURE}"
 echo " Simulator      : ${TT_METAL_SIMULATOR}"
 echo " SoC descriptor : $(dirname "$TT_METAL_SIMULATOR")/soc_descriptor.yaml"
-echo " SFPLOADMACRO   : disabled=${DISABLE_SFPLOADMACRO}"
+echo " SFPLOADMACRO   : disabled=${TT_METAL_DISABLE_SFPLOADMACRO}"
 echo " Workers (-n)   : ${WORKERS}"
 echo " Per-test fork  : on"
 echo " Timeout        : ${TIMEOUT}s"

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -805,7 +805,46 @@ inline void init_reduce_max_min(std::uint32_t num_cols)
 
     configure_addrmod_max_min(num_cols);
 
-    // Record replay buffer for compare-and-swap operations
+    // Record replay buffer for compare-and-swap operations.
+    // MAX uses LOADMACRO mechanism. For MIN, the macro's SFPSWAP-via-template path
+    // produces a numerically different result from inline SFPLOAD+SFPSWAP when the
+    // SFPCONFIG bit-8 invert flag is set (empirically verified 2026-05-14 canary).
+    // So we only inline for MAX under DISABLE_SFPLOADMACRO; MIN keeps the macro form
+    // and will surface as UnsupportedFunctionality under ttsim (no behavioral regression).
+#if defined(DISABLE_SFPLOADMACRO)
+    if constexpr (pool_type == PoolType::MAX)
+    {
+        lltt::record<lltt::NoExec>(0, 15);
+        TTI_INCRWC(0, 4, 0, 0);
+        // Inline expansion of TTI_SFPLOADMACRO(5, M, ADDR_MOD_7, 2):
+        //   MacroIndex=1, VD=LREG1, Imm10=2 → SFPLOAD(LREG1, M, AM, 2); SFPSWAP(0, LREG5, LREG1, 1)
+        TTI_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 2);
+        TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG1, 1);
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 16);
+        TTI_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 18);
+        TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG1, 1);
+        TTI_SFPNOP;
+        TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG0, 1);
+        TTI_SFPNOP;
+        // Inline expansion of TTI_SFPLOADMACRO(0, M, ADDR_MOD_7, 0):
+        //   MacroIndex=0, VD=LREG0, Imm10=0 → SFPLOAD(LREG0, M, AM, 0); SFPSWAP(0, LREG4, LREG0, 1)
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG0, 1);
+    }
+    else
+    {
+        lltt::record<lltt::NoExec>(0, 11);
+        TTI_INCRWC(0, 4, 0, 0);
+        TTI_SFPLOADMACRO(5, INSTRUCTION_MODE, ADDR_MOD_7, 2);
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 16);
+        TTI_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 18);
+        TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG1, 1);
+        TTI_SFPNOP;
+        TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG0, 1);
+        TTI_SFPNOP;
+        TTI_SFPLOADMACRO(0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+    }
+#else
     lltt::record<lltt::NoExec>(0, 11);
     TTI_INCRWC(0, 4, 0, 0);
     TTI_SFPLOADMACRO(5, INSTRUCTION_MODE, ADDR_MOD_7, 2);
@@ -816,6 +855,7 @@ inline void init_reduce_max_min(std::uint32_t num_cols)
     TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG0, 1);
     TTI_SFPNOP;
     TTI_SFPLOADMACRO(0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+#endif
 
     // Dummy loads to increment dest counters
     TTI_SFPLOAD(8, INSTRUCTION_MODE, ADDR_MOD_6, 0);
@@ -979,8 +1019,16 @@ inline void calculate_reduce_max_min(const std::uint32_t block_height)
     static_assert(reduce_dim == REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
     static_assert(pool_type == PoolType::MAX || pool_type == PoolType::MIN, "Only MAX and MIN pool types are supported for this function");
 
+    // The inlined-Max fallback under DISABLE_SFPLOADMACRO records 4 extra instructions
+    // (2 SFPLOAD+SFPSWAP pairs replace 2 SFPLOADMACROs), so the replay offsets shift by 4.
+    // MIN keeps the macro form regardless of the gate.
+#if defined(DISABLE_SFPLOADMACRO)
+    constexpr std::uint32_t replay_buffer_offset    = (pool_type == PoolType::MAX) ? 13 : 9;
+    constexpr std::uint32_t replay_buffer_next_face = (pool_type == PoolType::MAX) ? 14 : 10;
+#else
     constexpr std::uint32_t replay_buffer_offset    = 9;
     constexpr std::uint32_t replay_buffer_next_face = 10;
+#endif
 
     // Initial loads: LREG4-7 will hold maximum values across F0 and F1
     TTI_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, 0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -712,7 +712,42 @@ inline void init_reduce_max_min(std::uint32_t num_cols)
     configure_addrmod_max_min(num_cols);
 
     // Record replay buffer for compare-and-swap operations
-    // MAX uses LOADMACRO mechanism
+    // MAX uses LOADMACRO mechanism. For MIN, the macro's SFPSWAP-via-template path
+    // produces a numerically different result from inline SFPLOAD+SFPSWAP when the
+    // SFPCONFIG bit-8 invert flag is set (empirically verified 2026-05-14 canary).
+    // So we only inline for MAX under DISABLE_SFPLOADMACRO; MIN keeps the macro form
+    // and will surface as UnsupportedFunctionality under ttsim (no behavioral regression).
+    // See ttsim-private docs/audit/2026-05-14-bfp-investigation/phase1B-sfploadmacro-plan.md
+#if defined(DISABLE_SFPLOADMACRO)
+    if constexpr (pool_type == PoolType::MAX)
+    {
+        lltt::record<lltt::NoExec>(0, 13);
+        TTI_INCRWC(0, 4, 0, 0);
+        // Inline expansion of TTI_SFPLOADMACRO(5, M, ADDR_MOD_3, 2):
+        //   MacroIndex=1, VD=LREG1, Imm10=2 → SFPLOAD(LREG1, M, AM, 2); SFPSWAP(0, LREG5, LREG1, 1)
+        TTI_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 2);
+        TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG1, 1);
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 16);
+        TTI_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 18);
+        TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG1, 1);
+        TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG0, 1);
+        // Inline expansion of TTI_SFPLOADMACRO(0, M, ADDR_MOD_3, 0):
+        //   MacroIndex=0, VD=LREG0, Imm10=0 → SFPLOAD(LREG0, M, AM, 0); SFPSWAP(0, LREG4, LREG0, 1)
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG0, 1);
+    }
+    else
+    {
+        lltt::record<lltt::NoExec>(0, 9);
+        TTI_INCRWC(0, 4, 0, 0);
+        TTI_SFPLOADMACRO(5, INSTRUCTION_MODE, ADDR_MOD_3, 2);
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 16);
+        TTI_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 18);
+        TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG1, 1);
+        TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG0, 1);
+        TTI_SFPLOADMACRO(0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+    }
+#else
     lltt::record<lltt::NoExec>(0, 9);
     TTI_INCRWC(0, 4, 0, 0);
     TTI_SFPLOADMACRO(5, INSTRUCTION_MODE, ADDR_MOD_3, 2);
@@ -721,6 +756,7 @@ inline void init_reduce_max_min(std::uint32_t num_cols)
     TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG0, 1);
     TTI_SFPLOADMACRO(0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+#endif
 
     // Dummy loads to increment dest counters
     TTI_SFPLOAD(8, INSTRUCTION_MODE, ADDR_MOD_6, 0);
@@ -823,8 +859,16 @@ inline void calculate_reduce_max_min(const std::uint32_t block_ct_dim = 1, const
     }
     else
     {
+        // The inlined-Max fallback under DISABLE_SFPLOADMACRO records 4 extra instructions
+        // (2 SFPLOAD+SFPSWAP pairs replace 2 SFPLOADMACROs), so the replay offsets shift by 4.
+        // MIN keeps the macro form regardless of the gate. Phase 1B / 2026-05-14-bfp-investigation.
+#if defined(DISABLE_SFPLOADMACRO)
+        constexpr std::uint32_t replay_buffer_offset    = (pool_type == PoolType::MAX) ? 11 : 7;
+        constexpr std::uint32_t replay_buffer_next_face = (pool_type == PoolType::MAX) ? 12 : 8;
+#else
         constexpr std::uint32_t replay_buffer_offset    = 7;
         constexpr std::uint32_t replay_buffer_next_face = 8;
+#endif
 
         // Initial loads: LREG4-7 will hold maximum values across F0 and F1
         TTI_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, 0);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This PR fixes the LLK ttsim SFPLOADMACRO disable path.

Changes:
- Fix `run_ttsim_regression.sh` to export the env var consumed by the LLK pytest harness: `TT_METAL_DISABLE_SFPLOADMACRO`.
- Add a `DISABLE_SFPLOADMACRO` inline fallback for reduce-Max SFPLOADMACRO use on WH/BH.
- Keep reduce-Min on the existing macro path because the inline form diverged under the SFPCONFIG invert case in canary testing.

### Notes for reviewers
`ttsim` does not implement SFPLOADMACRO. The runner intended to disable it, but used the wrong env var name, so the compile-time gate silently did not fire and SFPLOADMACRO reached simulation as unsupported functionality.

The inline fallback is gated by `DISABLE_SFPLOADMACRO`; normal silicon builds do not take this path. Review should focus on the reduce-Max inline expansion and the decision to leave reduce-Min macro-based.

Test plan:
- `git diff --check origin/main..HEAD`
- `bash -n tt_metal/tt-llk/tests/run_ttsim_regression.sh`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/llk-ttsim-sfploadmacro-fallback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/llk-ttsim-sfploadmacro-fallback)