### PR TITLE
[Feature] Replace column-parallel LM head with row-parallel LM head for DeepSeek v3

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -194,9 +194,6 @@ def test_lm_head(
     logger.debug("Converting TTNN output to torch for comparison")
     tt_output_torch = tt_model.logit_to_host(tt_output, device_id)
     logger.debug(f"TTNN output converted to torch: {tt_output_torch.shape}")
-    assert (
-        tt_output_torch.shape[-1] == vocab_size
-    ), f"Expected full vocab on last dim ({vocab_size}), got {tt_output_torch.shape[-1]}"
 
     logger.debug("Comparing outputs with PCC")
     expected = torch_output[device_id]

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -50,7 +50,7 @@ def random_weights(config, emb_dim: int, vocab_size: int, dtype: torch.dtype):
     return config, weights
 
 
-@pytest.mark.parametrize("mode", ["column", "row"], ids=["col", "row"])
+@pytest.mark.parametrize("is_column_parallel", [True, False], ids=["col", "row"])
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
 @pytest.mark.parametrize(
     "batch_seq_len, emb_dim, vocab_size, run_full_pcc_check",
@@ -112,7 +112,7 @@ def test_lm_head(
     num_links: int,
     topology: ttnn.Topology,
     is_balanced: bool,
-    mode: str,
+    is_column_parallel: bool,
 ):
     """
     Test TtLMHead PCC against torch.nn.Linear reference.
@@ -155,7 +155,7 @@ def test_lm_head(
         logger.debug(f"Torch output shape: {torch_output.shape}")
 
     # Create TTNN LM head model
-    logger.debug(f"Creating TtLMHead (mode={mode})")
+    logger.debug(f"Creating TtLMHead (is_column_parallel={is_column_parallel})")
     tt_model = TtLMHead(
         mesh_device=mesh_device,
         emb_dim=emb_dim,
@@ -166,7 +166,7 @@ def test_lm_head(
         activations_dtype=ttnn_activations_dtype,
         weights_dtype=ttnn_weights_dtype,
         is_balanced=is_balanced,
-        mode=mode,
+        is_column_parallel=is_column_parallel,
     )
 
     tt_input = ttnn.from_torch(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -180,7 +180,7 @@ def test_lm_head(
 
     logger.debug("Running ttnn forward pass")
     global_token_id = batch_seq_len * dispatch_group_size - 1
-    tt_output, token_offset = tt_model(tt_input, global_token_id=global_token_id)
+    tt_output, (device_id, token_offset) = tt_model(tt_input, global_token_id=global_token_id)
     logger.debug(f"TTNN output shape (sharded): {tt_output.shape}")
 
     # For now, we only run the full PCC check on input tensors with seq_len == TILE_SIZE to avoid slicing
@@ -190,20 +190,20 @@ def test_lm_head(
         logger.debug("run_full_pcc_check=False, skipping full PCC validation")
         return
 
-    # Convert and compare — use the production helper so column/row are handled correctly.
-    # Inline ConcatMesh2dToTensor(dims=(0, -1)) only works for column mode; in row mode
-    # the TP-replicated slices would be concat'd on vocab and produce a 4× too-wide tensor.
+    # Convert and compare
     logger.debug("Converting TTNN output to torch for comparison")
-    tt_output_torch = tt_model.logit_to_host(tt_output)
+    tt_output_torch = tt_model.logit_to_host(tt_output, device_id)
     logger.debug(f"TTNN output converted to torch: {tt_output_torch.shape}")
     assert (
         tt_output_torch.shape[-1] == vocab_size
     ), f"Expected full vocab on last dim ({vocab_size}), got {tt_output_torch.shape[-1]}"
 
     logger.debug("Comparing outputs with PCC")
+    expected = torch_output[device_id]
+    actual = tt_output_torch.squeeze(0)
     pcc_passed, pcc_message = assert_with_pcc(
-        torch_output.to(torch.float32),
-        tt_output_torch.to(torch.float32),
+        expected.to(torch.float32),
+        actual.to(torch.float32),
         pcc=0.9999,
     )
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -50,6 +50,7 @@ def random_weights(config, emb_dim: int, vocab_size: int, dtype: torch.dtype):
     return config, weights
 
 
+@pytest.mark.parametrize("mode", ["column", "row"], ids=["col", "row"])
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
 @pytest.mark.parametrize(
     "batch_seq_len, emb_dim, vocab_size, run_full_pcc_check",
@@ -87,6 +88,16 @@ def random_weights(config, emb_dim: int, vocab_size: int, dtype: torch.dtype):
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
             id="2x4-linear",
         ),
+        pytest.param(
+            (8, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -101,6 +112,7 @@ def test_lm_head(
     num_links: int,
     topology: ttnn.Topology,
     is_balanced: bool,
+    mode: str,
 ):
     """
     Test TtLMHead PCC against torch.nn.Linear reference.
@@ -143,7 +155,7 @@ def test_lm_head(
         logger.debug(f"Torch output shape: {torch_output.shape}")
 
     # Create TTNN LM head model
-    logger.debug("Creating TtLMHead")
+    logger.debug(f"Creating TtLMHead (mode={mode})")
     tt_model = TtLMHead(
         mesh_device=mesh_device,
         emb_dim=emb_dim,
@@ -154,6 +166,7 @@ def test_lm_head(
         activations_dtype=ttnn_activations_dtype,
         weights_dtype=ttnn_weights_dtype,
         is_balanced=is_balanced,
+        mode=mode,
     )
 
     tt_input = ttnn.from_torch(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -190,13 +190,15 @@ def test_lm_head(
         logger.debug("run_full_pcc_check=False, skipping full PCC validation")
         return
 
-    # Convert and compare
+    # Convert and compare — use the production helper so column/row are handled correctly.
+    # Inline ConcatMesh2dToTensor(dims=(0, -1)) only works for column mode; in row mode
+    # the TP-replicated slices would be concat'd on vocab and produce a 4× too-wide tensor.
     logger.debug("Converting TTNN output to torch for comparison")
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_device.shape, dims=(0, -1)),
-    )
+    tt_output_torch = tt_model.logit_to_host(tt_output)
     logger.debug(f"TTNN output converted to torch: {tt_output_torch.shape}")
+    assert (
+        tt_output_torch.shape[-1] == vocab_size
+    ), f"Expected full vocab on last dim ({vocab_size}), got {tt_output_torch.shape[-1]}"
 
     logger.debug("Comparing outputs with PCC")
     pcc_passed, pcc_message = assert_with_pcc(

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -175,7 +175,7 @@ class TtLMHead(LightweightModule):
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_HIFI2,
         is_balanced: bool = False,
         weight_cache_path: Optional[Path] = None,
-        mode: LMHeadMode = "column",
+        mode: LMHeadMode = "row",
     ):
         """
         Initialize TtLMHead module.

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -204,6 +204,7 @@ class TtLMHead(LightweightModule):
         self.vocab_size = vocab_size
         self.num_devices = mesh_device.get_num_devices()
         self.sp_factor = mesh_device.shape[0]
+        self.dp_factor = mesh_device.shape[1]
         self.num_links = num_links
         self.topology = topology
         self.activations_dtype = activations_dtype
@@ -416,16 +417,14 @@ class TtLMHead(LightweightModule):
                     mesh_shape_override=ttnn.MeshShape(self.mesh_device.shape[0], self.mesh_device.shape[1]),
                 ),
             )
-        else:
-            # Row mode: output is TP-replicated, so only take one TP slice per SP row.
-            composer = ttnn.create_mesh_composer(
-                self.mesh_device,
-                config=ttnn.MeshComposerConfig(
-                    dims=(0, 1),
-                    mesh_shape_override=ttnn.MeshShape(self.mesh_device.shape[0], 1),
-                ),
-            )
-        return ttnn.to_torch(tt_logit, mesh_composer=composer).to(torch.bfloat16)
+            return ttnn.to_torch(tt_logit, mesh_composer=composer).to(torch.bfloat16)
+
+        # Row mode: output is TP-replicated by the all-reduce, so the 4 TP slices
+        # of each SP row are identical
+        shards = ttnn.get_device_tensors(tt_logit)
+        tp0_handles = [shards[sp_i * self.dp_factor + 0] for sp_i in range(self.sp_factor)]
+        host_pieces = [ttnn.to_torch(h).to(torch.bfloat16) for h in tp0_handles]
+        return torch.stack([p.squeeze(0) for p in host_pieces], dim=0)
 
     def select_first_token(self, logit_host: torch.Tensor, device_id: int, token_offset: int) -> torch.Tensor:
         return logit_host[device_id, 0, token_offset, :].unsqueeze(0).unsqueeze(0)

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -406,25 +406,28 @@ class TtLMHead(LightweightModule):
         # The target token is on SP rank device_id at row token_offset within the tile.
         return output, (device_id, token_offset)
 
-    def logit_to_host(self, tt_logit: ttnn.Tensor) -> torch.Tensor:
-        ttnn.synchronize_device(self.mesh_device)  # ensure all computation is done before copying to host
-        if self.mode == "column":
-            # SP fracture on torch dim 0, TP concat on vocab (-1) to reassemble full vocab.
-            composer = ttnn.create_mesh_composer(
-                self.mesh_device,
-                config=ttnn.MeshComposerConfig(
-                    dims=(0, -1),
-                    mesh_shape_override=ttnn.MeshShape(self.mesh_device.shape[0], self.mesh_device.shape[1]),
-                ),
-            )
-            return ttnn.to_torch(tt_logit, mesh_composer=composer).to(torch.bfloat16)
+    def logit_to_host(self, tt_logit: ttnn.Tensor, device_id: int) -> torch.Tensor:
+        """Pull only the SP rank that holds the target token's logits.
 
-        # Row mode: output is TP-replicated by the all-reduce, so the 4 TP slices
-        # of each SP row are identical
+        - row mode: TP slices are replicated, so 1 DMA suffices (the full vocab
+                    sits on every TP rank).
+        - column mode: TP slices are vocab/tp shards, so 4 DMAs are issued and
+                       concatenated on host to assemble the full vocab.
+        """
+        ttnn.synchronize_device(self.mesh_device)
+        tp = self.mesh_device.shape[1]
         shards = ttnn.get_device_tensors(tt_logit)
-        tp0_handles = [shards[sp_i * self.dp_factor + 0] for sp_i in range(self.sp_factor)]
-        host_pieces = [ttnn.to_torch(h).to(torch.bfloat16) for h in tp0_handles]
-        return torch.stack([p.squeeze(0) for p in host_pieces], dim=0)
+        # Mesh row-major flat index: sp_i * tp + tp_j
+        base_idx = device_id * tp
 
-    def select_first_token(self, logit_host: torch.Tensor, device_id: int, token_offset: int) -> torch.Tensor:
-        return logit_host[device_id, 0, token_offset, :].unsqueeze(0).unsqueeze(0)
+        if self.mode == "row":
+            # All TP slices on this SP row are identical (TP-replicated by
+            # all-reduce). Take TP=0.
+            return ttnn.to_torch(shards[base_idx + 0]).to(torch.bfloat16)
+
+        # column: 4 TP slices, each holds vocab/tp; concat on vocab dim to assemble the full vocab on host.
+        host_pieces = [ttnn.to_torch(shards[base_idx + j]).to(torch.bfloat16) for j in range(tp)]
+        return torch.cat(host_pieces, dim=-1)
+
+    def select_first_token(self, logit_host: torch.Tensor, token_offset: int) -> torch.Tensor:
+        return logit_host[..., token_offset, :].unsqueeze(0).unsqueeze(0)

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -60,17 +60,12 @@ class TtLMHead(LightweightModule):
         return (None, -1) if is_column_parallel else (None, -2)
 
     @staticmethod
-    def _cache_file_basename(is_column_parallel: bool) -> str:
-        return "lm_head_weight" if is_column_parallel else "lm_head_weight_row"
-
-    @staticmethod
-    def check_cache_complete(cache_path: Path, is_column_parallel: bool = True) -> bool:
+    def check_cache_complete(cache_path: Path) -> bool:
         """Check if LM head weights cache files exist for the requested mode."""
         from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
 
-        pattern = f"{TtLMHead._cache_file_basename(is_column_parallel)}*.tensorbin"
-        if not pattern_exists(pattern, "LMHead"):
-            logger.debug(f"TTNN cache missing: {pattern}")
+        if not pattern_exists("lm_head_weight*.tensorbin", "LMHead"):
+            logger.debug("TTNN cache missing: lm_head_weight")
             return False
         return True
 
@@ -83,7 +78,7 @@ class TtLMHead(LightweightModule):
         dtype: ttnn.DataType,
         cache_path: Path | None,
         device: ttnn.MeshDevice | None = None,
-        is_column_parallel: bool = True,
+        is_column_parallel: bool = False,
     ) -> ttnn.Tensor | None:
         """
         Shared logic for converting LM head weight to ttnn with caching.
@@ -119,7 +114,7 @@ class TtLMHead(LightweightModule):
             dims=TtLMHead._weight_shard_dims(is_column_parallel),
         )
 
-        cache_file_name = str(cache_path / TtLMHead._cache_file_basename(is_column_parallel)) if cache_path else None
+        cache_file_name = str(cache_path / "lm_head_weight") if cache_path else None
 
         tt_weight = ttnn.as_tensor(
             torch_weight,
@@ -148,7 +143,7 @@ class TtLMHead(LightweightModule):
         mesh_device: ttnn.MeshDevice,
         cache_path: Path,
         dtype: ttnn.DataType = ttnn.bfloat16,
-        is_column_parallel: bool = True,
+        is_column_parallel: bool = False,
     ):
         """Build TTNN cache for LM head weight without device copy."""
         TtLMHead._convert_and_cache_weight(
@@ -165,6 +160,8 @@ class TtLMHead(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
         emb_dim: int = DeepSeekV3Config.EMB_SIZE,
         vocab_size: int = DeepSeekV3Config.VOCAB_SIZE,
         torch_weight: torch.Tensor = None,
@@ -203,8 +200,10 @@ class TtLMHead(LightweightModule):
         self.emb_dim = emb_dim
         self.vocab_size = vocab_size
         self.num_devices = mesh_device.get_num_devices()
-        self.sp_factor = mesh_device.shape[0]
-        self.dp_factor = mesh_device.shape[1]
+        self.sp_factor = mesh_device.shape[sp_axis]
+        self.tp_factor = mesh_device.shape[tp_axis]
+        self.sp_axis = sp_axis
+        self.tp_axis = tp_axis
         self.num_links = num_links
         self.topology = topology
         self.activations_dtype = activations_dtype
@@ -359,8 +358,6 @@ class TtLMHead(LightweightModule):
         x = ttnn.narrow(x, dim=-2, start=tile_start, length=ttnn.TILE_SIZE)
         logger.debug(f"[TtLMHead.forward] After narrow ({local_token_id=} {tile_start=}): {x.shape=} {token_offset=}")
 
-        tp_size = self.mesh_device.shape[1]
-
         if self.is_column_parallel:
             # ========================================
             # Column-parallel: All-gather x to get full emb_dim (replicated across TP axis)
@@ -368,11 +365,11 @@ class TtLMHead(LightweightModule):
             # Input x is sharded: (dispatch_group_size/axis0, seq_len_per_chip, emb_dim/axis1)
             # Both shared_expert and dispatch need full emb_dim, so all-gather first
             # Only needed if there are multiple devices in TP axis (axis 1)
-            if tp_size > 1:
+            if self.tp_factor > 1:
                 x_full = ttnn.all_gather(
                     x,
                     dim=-1,  # Gather along emb_dim
-                    cluster_axis=1,  # Gather across axis 1 (TP axis)
+                    cluster_axis=self.tp_axis,  # Gather across TP axis
                     num_links=self.num_links,
                     topology=self.topology,
                 )
@@ -391,10 +388,10 @@ class TtLMHead(LightweightModule):
             partial = ttnn.matmul(x, self.weight, compute_kernel_config=self.compute_kernel_config)
             logger.debug(f"[TtLMHead.forward] partial (after matmul) shape: {partial.shape}")
 
-            if tp_size > 1:
+            if self.tp_factor > 1:
                 output = ttnn.experimental.all_reduce_async(
                     partial,
-                    cluster_axis=1,
+                    cluster_axis=self.tp_axis,
                     mesh_device=self.mesh_device,
                     num_links=self.num_links,
                     math_op=ttnn.ReduceType.Sum,
@@ -419,10 +416,9 @@ class TtLMHead(LightweightModule):
                        concatenate on host to assemble the full vocab.
         """
         ttnn.synchronize_device(self.mesh_device)
-        tp = self.mesh_device.shape[1]
         shards = ttnn.get_device_tensors(tt_logit)
         # Mesh row-major flat index: sp_i * tp + tp_j
-        base_idx = device_id * tp
+        base_idx = device_id * self.tp_factor
 
         if not self.is_column_parallel:
             # Row-parallel: all TP slices on this SP row are identical (TP-replicated by all-reduce).
@@ -430,8 +426,8 @@ class TtLMHead(LightweightModule):
             return ttnn.to_torch(shards[base_idx + 0]).to(torch.bfloat16)
 
         # column: 4 TP slices, each holds vocab/tp; concat on vocab dim to assemble the full vocab on host.
-        host_pieces = [ttnn.to_torch(shards[base_idx + j]).to(torch.bfloat16) for j in range(tp)]
+        host_pieces = [ttnn.to_torch(shards[base_idx + j]).to(torch.bfloat16) for j in range(self.tp_factor)]
         return torch.cat(host_pieces, dim=-1)
 
     def select_first_token(self, logit_host: torch.Tensor, token_offset: int) -> torch.Tensor:
-        return logit_host[..., token_offset, :].unsqueeze(0).unsqueeze(0)
+        return logit_host[..., token_offset, :]

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -12,16 +12,14 @@ Projects hidden states to vocabulary logits:
 Two TP strategies are supported via the `is_column_parallel` flag:
 
 - is_column_parallel=True:
-    Weight sharded on output (vocab) dim across mesh columns.
+    Weights sharded on vocab dim across mesh columns.
     Per-device weight: [emb_dim, vocab_size / tp_factor]
-    mesh_mapper dims=(None, -1)
     Forward: all_gather(x, dim=emb) -> matmul -> output is TP-sharded on vocab.
     Host-side concat reassembles the full vocab.
 
 - is_column_parallel=False (default — row-parallel):
-    Weight sharded on input (emb) dim across mesh columns.
+    Weights sharded on emb dim across mesh columns.
     Per-device weight: [emb_dim / tp_factor, vocab_size]
-    mesh_mapper dims=(None, -2)
     Forward: matmul (partial sum) -> all_reduce(across TP) -> output is replicated.
     No host-side concat needed.
 """
@@ -58,19 +56,16 @@ class TtLMHead(LightweightModule):
 
     @staticmethod
     def _weight_shard_dims(is_column_parallel: bool) -> tuple:
-        """TP sharding dims for the transposed [emb, vocab] weight."""
         # column: shard vocab (last dim) across TP; row: shard emb (second-to-last) across TP.
         return (None, -1) if is_column_parallel else (None, -2)
 
     @staticmethod
     def _cache_file_basename(is_column_parallel: bool) -> str:
-        """Cache filename stem. Column keeps the historical name so existing caches still load;
-        row gets a suffix so the two modes don't collide."""
         return "lm_head_weight" if is_column_parallel else "lm_head_weight_row"
 
     @staticmethod
     def check_cache_complete(cache_path: Path, is_column_parallel: bool = True) -> bool:
-        """Check if LM head weight cache files exist for the requested mode."""
+        """Check if LM head weights cache files exist for the requested mode."""
         from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
 
         pattern = f"{TtLMHead._cache_file_basename(is_column_parallel)}*.tensorbin"
@@ -102,7 +97,7 @@ class TtLMHead(LightweightModule):
             dtype: Data type
             cache_path: Cache directory path
             device: None for cache-only, mesh_device for cache+load
-            is_column_parallel: True → column-parallel sharding (vocab dim), False → row-parallel (emb dim).
+            is_column_parallel: True - column-parallel sharding (vocab dim), False - row-parallel (emb dim).
 
         Returns:
             ttnn.Tensor if device is not None, else None
@@ -199,8 +194,8 @@ class TtLMHead(LightweightModule):
             is_balanced: If True, uses zigzag token mapping. If False (default),
                          uses sequential mapping. Should match TtMLA's is_balanced.
             weight_cache_path: Optional path to weight cache directory
-            is_column_parallel: TP strategy. True → column-parallel (all_gather emb, output
-                                TP-sharded on vocab). False (default) → row-parallel
+            is_column_parallel: TP strategy. True - column-parallel (all_gather emb, output
+                                TP-sharded on vocab). False (default) - row-parallel
                                 (matmul partials + all_reduce, output TP-replicated).
         """
         super().__init__()
@@ -338,7 +333,7 @@ class TtLMHead(LightweightModule):
             tuple[ttnn.Tensor, tuple[int, int]]:
                 - Logits tensor. Per-device shape:
                     is_column_parallel=True:  [dispatch_group_size, TILE_SIZE, vocab_size/tp]
-                    is_column_parallel=False: [dispatch_group_size, TILE_SIZE, vocab_size] (TP-replicated)
+                    is_column_parallel=False: [dispatch_group_size, TILE_SIZE, vocab_size]
                 - (device_id, token_offset): which SP device holds the target token
                   and the index within the tile
         """
@@ -346,7 +341,7 @@ class TtLMHead(LightweightModule):
         logger.debug(f"  x.shape={x.shape}")
 
         # ========================================
-        # Step 0: Extract the tile containing the target token
+        # Extract the tile containing the target token
         # ========================================
         # Use negative indexing: seq_len is at dim -2, emb_dim at dim -1
         seq_len_per_device = x.shape[-2]
@@ -385,6 +380,7 @@ class TtLMHead(LightweightModule):
                 x_full = x  # No TP sharding, x already has full emb_dim
             logger.debug(f"[TtLMHead.forward] x_full (after all_gather) shape: {x_full.shape}")
 
+            # Local matmul with sharded weight
             output = ttnn.matmul(x_full, self.weight, compute_kernel_config=self.compute_kernel_config)
             logger.debug(f"[TtLMHead.forward] output (after matmul) shape: {output.shape}")
             # output: [1, 1, TILE, vocab/tp], SP-fractured, TP-sharded on vocab.
@@ -394,7 +390,6 @@ class TtLMHead(LightweightModule):
             # ========================================
             partial = ttnn.matmul(x, self.weight, compute_kernel_config=self.compute_kernel_config)
             logger.debug(f"[TtLMHead.forward] partial (after matmul) shape: {partial.shape}")
-            # partial: [1, 1, TILE, vocab] partial sum on each TP rank.
 
             if tp_size > 1:
                 output = ttnn.experimental.all_reduce_async(
@@ -415,12 +410,13 @@ class TtLMHead(LightweightModule):
         return output, (device_id, token_offset)
 
     def logit_to_host(self, tt_logit: ttnn.Tensor, device_id: int) -> torch.Tensor:
-        """Pull only the SP rank that holds the target token's logits.
+        """
+        Read only from the row of devices that holds the target token's logits.
 
-        - row mode: TP slices are replicated, so 1 DMA suffices (the full vocab
-                    sits on every TP rank).
-        - column mode: TP slices are vocab/tp shards, so 4 DMAs are issued and
-                       concatenated on host to assemble the full vocab.
+        - row mode: TP slices are replicated, so read only from one device (the full vocab
+                    sits on every device in the row).
+        - column mode: TP slices are vocab/tp shards, so read from all devices in the row and
+                       concatenate on host to assemble the full vocab.
         """
         ttnn.synchronize_device(self.mesh_device)
         tp = self.mesh_device.shape[1]
@@ -429,8 +425,8 @@ class TtLMHead(LightweightModule):
         base_idx = device_id * tp
 
         if not self.is_column_parallel:
-            # Row-parallel: all TP slices on this SP row are identical
-            # (TP-replicated by all-reduce). Take TP=0.
+            # Row-parallel: all TP slices on this SP row are identical (TP-replicated by all-reduce).
+            # Take from the first device in the row.
             return ttnn.to_torch(shards[base_idx + 0]).to(torch.bfloat16)
 
         # column: 4 TP slices, each holds vocab/tp; concat on vocab dim to assemble the full vocab on host.

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -368,8 +368,11 @@ class TtLMHead(LightweightModule):
 
         if self.is_column_parallel:
             # ========================================
-            # Column-parallel: all_gather emb -> matmul (output TP-sharded on vocab)
+            # Column-parallel: All-gather x to get full emb_dim (replicated across TP axis)
             # ========================================
+            # Input x is sharded: (dispatch_group_size/axis0, seq_len_per_chip, emb_dim/axis1)
+            # Both shared_expert and dispatch need full emb_dim, so all-gather first
+            # Only needed if there are multiple devices in TP axis (axis 1)
             if tp_size > 1:
                 x_full = ttnn.all_gather(
                     x,

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -9,16 +9,16 @@ Projects hidden states to vocabulary logits:
     Input:  [dispatch_group_size, seq_len, emb_dim]
     Output: [dispatch_group_size, TILE_SIZE, vocab_size]
 
-Two TP strategies are supported via the `mode` parameter:
+Two TP strategies are supported via the `is_column_parallel` flag:
 
-- mode="column" (default, current behavior):
+- is_column_parallel=True:
     Weight sharded on output (vocab) dim across mesh columns.
     Per-device weight: [emb_dim, vocab_size / tp_factor]
     mesh_mapper dims=(None, -1)
     Forward: all_gather(x, dim=emb) -> matmul -> output is TP-sharded on vocab.
     Host-side concat reassembles the full vocab.
 
-- mode="row":
+- is_column_parallel=False (default — row-parallel):
     Weight sharded on input (emb) dim across mesh columns.
     Per-device weight: [emb_dim / tp_factor, vocab_size]
     mesh_mapper dims=(None, -2)
@@ -27,7 +27,7 @@ Two TP strategies are supported via the `mode` parameter:
 """
 
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Optional
 
 import torch
 from loguru import logger
@@ -36,8 +36,6 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tt.mla.utils import global_to_local_token_id
-
-LMHeadMode = Literal["column", "row"]
 
 COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
     math_fidelity=ttnn.MathFidelity.HiFi2,
@@ -59,23 +57,23 @@ class TtLMHead(LightweightModule):
     """
 
     @staticmethod
-    def _weight_shard_dims(mode: LMHeadMode) -> tuple:
-        """TP sharding dims for the transposed [emb, vocab] weight, by mode."""
+    def _weight_shard_dims(is_column_parallel: bool) -> tuple:
+        """TP sharding dims for the transposed [emb, vocab] weight."""
         # column: shard vocab (last dim) across TP; row: shard emb (second-to-last) across TP.
-        return (None, -1) if mode == "column" else (None, -2)
+        return (None, -1) if is_column_parallel else (None, -2)
 
     @staticmethod
-    def _cache_file_basename(mode: LMHeadMode) -> str:
+    def _cache_file_basename(is_column_parallel: bool) -> str:
         """Cache filename stem. Column keeps the historical name so existing caches still load;
         row gets a suffix so the two modes don't collide."""
-        return "lm_head_weight" if mode == "column" else "lm_head_weight_row"
+        return "lm_head_weight" if is_column_parallel else "lm_head_weight_row"
 
     @staticmethod
-    def check_cache_complete(cache_path: Path, mode: LMHeadMode = "column") -> bool:
+    def check_cache_complete(cache_path: Path, is_column_parallel: bool = True) -> bool:
         """Check if LM head weight cache files exist for the requested mode."""
         from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
 
-        pattern = f"{TtLMHead._cache_file_basename(mode)}*.tensorbin"
+        pattern = f"{TtLMHead._cache_file_basename(is_column_parallel)}*.tensorbin"
         if not pattern_exists(pattern, "LMHead"):
             logger.debug(f"TTNN cache missing: {pattern}")
             return False
@@ -90,7 +88,7 @@ class TtLMHead(LightweightModule):
         dtype: ttnn.DataType,
         cache_path: Path | None,
         device: ttnn.MeshDevice | None = None,
-        mode: LMHeadMode = "column",
+        is_column_parallel: bool = True,
     ) -> ttnn.Tensor | None:
         """
         Shared logic for converting LM head weight to ttnn with caching.
@@ -104,7 +102,7 @@ class TtLMHead(LightweightModule):
             dtype: Data type
             cache_path: Cache directory path
             device: None for cache-only, mesh_device for cache+load
-            mode: Determines weight sharding dims.
+            is_column_parallel: True → column-parallel sharding (vocab dim), False → row-parallel (emb dim).
 
         Returns:
             ttnn.Tensor if device is not None, else None
@@ -123,10 +121,10 @@ class TtLMHead(LightweightModule):
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
             mesh_shape=mesh_device.shape,
-            dims=TtLMHead._weight_shard_dims(mode),
+            dims=TtLMHead._weight_shard_dims(is_column_parallel),
         )
 
-        cache_file_name = str(cache_path / TtLMHead._cache_file_basename(mode)) if cache_path else None
+        cache_file_name = str(cache_path / TtLMHead._cache_file_basename(is_column_parallel)) if cache_path else None
 
         tt_weight = ttnn.as_tensor(
             torch_weight,
@@ -155,11 +153,18 @@ class TtLMHead(LightweightModule):
         mesh_device: ttnn.MeshDevice,
         cache_path: Path,
         dtype: ttnn.DataType = ttnn.bfloat16,
-        mode: LMHeadMode = "column",
+        is_column_parallel: bool = True,
     ):
         """Build TTNN cache for LM head weight without device copy."""
         TtLMHead._convert_and_cache_weight(
-            torch_weight, emb_dim, vocab_size, mesh_device, dtype, cache_path, device=None, mode=mode
+            torch_weight,
+            emb_dim,
+            vocab_size,
+            mesh_device,
+            dtype,
+            cache_path,
+            device=None,
+            is_column_parallel=is_column_parallel,
         )
 
     def __init__(
@@ -175,7 +180,7 @@ class TtLMHead(LightweightModule):
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_HIFI2,
         is_balanced: bool = False,
         weight_cache_path: Optional[Path] = None,
-        mode: LMHeadMode = "row",
+        is_column_parallel: bool = False,
     ):
         """
         Initialize TtLMHead module.
@@ -194,11 +199,11 @@ class TtLMHead(LightweightModule):
             is_balanced: If True, uses zigzag token mapping. If False (default),
                          uses sequential mapping. Should match TtMLA's is_balanced.
             weight_cache_path: Optional path to weight cache directory
-            mode: Weights parallelism strategy - "column" (all_gather emb, output TP-sharded on
-                  vocab) or "row" (matmul partials + all_reduce, output TP-replicated).
+            is_column_parallel: TP strategy. True → column-parallel (all_gather emb, output
+                                TP-sharded on vocab). False (default) → row-parallel
+                                (matmul partials + all_reduce, output TP-replicated).
         """
         super().__init__()
-        assert mode in ("column", "row"), f"mode must be 'column' or 'row', got {mode!r}"
         self.mesh_device = mesh_device
         self.emb_dim = emb_dim
         self.vocab_size = vocab_size
@@ -212,7 +217,7 @@ class TtLMHead(LightweightModule):
         self.compute_kernel_config = compute_kernel_config
         self.is_balanced = is_balanced
         self.weight_cache_path = weight_cache_path
-        self.mode = mode
+        self.is_column_parallel = is_column_parallel
 
         logger.debug(f"Initializing TtLMHead with emb_dim={emb_dim}, vocab_size={vocab_size}")
         logger.debug(f"Mesh shape: {mesh_device.shape}, num_devices={self.num_devices}")
@@ -232,13 +237,13 @@ class TtLMHead(LightweightModule):
                 self.weights_dtype,
                 self.weight_cache_path,
                 device=self.mesh_device,
-                mode=self.mode,
+                is_column_parallel=self.is_column_parallel,
             )
         else:
             logger.debug("Creating random sharded weight")
             self.weight = self._create_random_sharded_weight(
                 shape=(emb_dim, vocab_size),
-                dims=self._weight_shard_dims(self.mode),
+                dims=self._weight_shard_dims(self.is_column_parallel),
                 name="lm_head_weight",
                 dtype=self.weights_dtype,
             )
@@ -304,9 +309,9 @@ class TtLMHead(LightweightModule):
             torch_weight: [vocab_size, emb_dim] in HF format
 
         Returns:
-            Sharded ttnn tensor. Per-device shape depends on mode:
-            - column: [emb_dim, vocab_size / tp_factor]
-            - row:    [emb_dim / tp_factor, vocab_size]
+            Sharded ttnn tensor. Per-device shape depends on is_column_parallel:
+            - True (column):  [emb_dim, vocab_size / tp_factor]
+            - False (row):    [emb_dim / tp_factor, vocab_size]
         """
         tt_weight = self._convert_and_cache_weight(
             torch_weight,
@@ -316,7 +321,7 @@ class TtLMHead(LightweightModule):
             self.weights_dtype,
             self.weight_cache_path,
             device=self.mesh_device,
-            mode=self.mode,
+            is_column_parallel=self.is_column_parallel,
         )
         logger.debug(f"Created sharded LM head weight: {tt_weight.shape}")
         return tt_weight
@@ -332,8 +337,8 @@ class TtLMHead(LightweightModule):
         Returns:
             tuple[ttnn.Tensor, tuple[int, int]]:
                 - Logits tensor. Per-device shape:
-                    column mode: [dispatch_group_size, TILE_SIZE, vocab_size/tp]
-                    row mode:    [dispatch_group_size, TILE_SIZE, vocab_size] (TP-replicated)
+                    is_column_parallel=True:  [dispatch_group_size, TILE_SIZE, vocab_size/tp]
+                    is_column_parallel=False: [dispatch_group_size, TILE_SIZE, vocab_size] (TP-replicated)
                 - (device_id, token_offset): which SP device holds the target token
                   and the index within the tile
         """
@@ -361,7 +366,7 @@ class TtLMHead(LightweightModule):
 
         tp_size = self.mesh_device.shape[1]
 
-        if self.mode == "column":
+        if self.is_column_parallel:
             # ========================================
             # Column-parallel: all_gather emb -> matmul (output TP-sharded on vocab)
             # ========================================
@@ -420,9 +425,9 @@ class TtLMHead(LightweightModule):
         # Mesh row-major flat index: sp_i * tp + tp_j
         base_idx = device_id * tp
 
-        if self.mode == "row":
-            # All TP slices on this SP row are identical (TP-replicated by
-            # all-reduce). Take TP=0.
+        if not self.is_column_parallel:
+            # Row-parallel: all TP slices on this SP row are identical
+            # (TP-replicated by all-reduce). Take TP=0.
             return ttnn.to_torch(shards[base_idx + 0]).to(torch.bfloat16)
 
         # column: 4 TP slices, each holds vocab/tp; concat on vocab dim to assemble the full vocab on host.

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -9,14 +9,25 @@ Projects hidden states to vocabulary logits:
     Input:  [dispatch_group_size, seq_len, emb_dim]
     Output: [dispatch_group_size, TILE_SIZE, vocab_size]
 
-Weight Sharding (across mesh columns):
-    - weight: Sharded on output dimension (-1) across mesh columns
-      Shape: [emb_dim, vocab_size]
-      mesh_mapper dims=(None, -1)
+Two TP strategies are supported via the `mode` parameter:
+
+- mode="column" (default, current behavior):
+    Weight sharded on output (vocab) dim across mesh columns.
+    Per-device weight: [emb_dim, vocab_size / tp_factor]
+    mesh_mapper dims=(None, -1)
+    Forward: all_gather(x, dim=emb) -> matmul -> output is TP-sharded on vocab.
+    Host-side concat reassembles the full vocab.
+
+- mode="row":
+    Weight sharded on input (emb) dim across mesh columns.
+    Per-device weight: [emb_dim / tp_factor, vocab_size]
+    mesh_mapper dims=(None, -2)
+    Forward: matmul (partial sum) -> all_reduce(across TP) -> output is replicated.
+    No host-side concat needed.
 """
 
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 import torch
 from loguru import logger
@@ -25,6 +36,8 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tt.mla.utils import global_to_local_token_id
+
+LMHeadMode = Literal["column", "row"]
 
 COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
     math_fidelity=ttnn.MathFidelity.HiFi2,
@@ -46,12 +59,25 @@ class TtLMHead(LightweightModule):
     """
 
     @staticmethod
-    def check_cache_complete(cache_path: Path) -> bool:
-        """Check if LM head weight cache files exist."""
+    def _weight_shard_dims(mode: LMHeadMode) -> tuple:
+        """TP sharding dims for the transposed [emb, vocab] weight, by mode."""
+        # column: shard vocab (last dim) across TP; row: shard emb (second-to-last) across TP.
+        return (None, -1) if mode == "column" else (None, -2)
+
+    @staticmethod
+    def _cache_file_basename(mode: LMHeadMode) -> str:
+        """Cache filename stem. Column keeps the historical name so existing caches still load;
+        row gets a suffix so the two modes don't collide."""
+        return "lm_head_weight" if mode == "column" else "lm_head_weight_row"
+
+    @staticmethod
+    def check_cache_complete(cache_path: Path, mode: LMHeadMode = "column") -> bool:
+        """Check if LM head weight cache files exist for the requested mode."""
         from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
 
-        if not pattern_exists("lm_head_weight*.tensorbin", "LMHead"):
-            logger.debug("TTNN cache missing: lm_head_weight")
+        pattern = f"{TtLMHead._cache_file_basename(mode)}*.tensorbin"
+        if not pattern_exists(pattern, "LMHead"):
+            logger.debug(f"TTNN cache missing: {pattern}")
             return False
         return True
 
@@ -64,6 +90,7 @@ class TtLMHead(LightweightModule):
         dtype: ttnn.DataType,
         cache_path: Path | None,
         device: ttnn.MeshDevice | None = None,
+        mode: LMHeadMode = "column",
     ) -> ttnn.Tensor | None:
         """
         Shared logic for converting LM head weight to ttnn with caching.
@@ -77,6 +104,7 @@ class TtLMHead(LightweightModule):
             dtype: Data type
             cache_path: Cache directory path
             device: None for cache-only, mesh_device for cache+load
+            mode: Determines weight sharding dims.
 
         Returns:
             ttnn.Tensor if device is not None, else None
@@ -95,10 +123,10 @@ class TtLMHead(LightweightModule):
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
             mesh_shape=mesh_device.shape,
-            dims=(None, -1),  # Shard vocab_size across TP axis (columns)
+            dims=TtLMHead._weight_shard_dims(mode),
         )
 
-        cache_file_name = str(cache_path / "lm_head_weight") if cache_path else None
+        cache_file_name = str(cache_path / TtLMHead._cache_file_basename(mode)) if cache_path else None
 
         tt_weight = ttnn.as_tensor(
             torch_weight,
@@ -127,10 +155,11 @@ class TtLMHead(LightweightModule):
         mesh_device: ttnn.MeshDevice,
         cache_path: Path,
         dtype: ttnn.DataType = ttnn.bfloat16,
+        mode: LMHeadMode = "column",
     ):
         """Build TTNN cache for LM head weight without device copy."""
         TtLMHead._convert_and_cache_weight(
-            torch_weight, emb_dim, vocab_size, mesh_device, dtype, cache_path, device=None
+            torch_weight, emb_dim, vocab_size, mesh_device, dtype, cache_path, device=None, mode=mode
         )
 
     def __init__(
@@ -146,6 +175,7 @@ class TtLMHead(LightweightModule):
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_HIFI2,
         is_balanced: bool = False,
         weight_cache_path: Optional[Path] = None,
+        mode: LMHeadMode = "column",
     ):
         """
         Initialize TtLMHead module.
@@ -164,8 +194,11 @@ class TtLMHead(LightweightModule):
             is_balanced: If True, uses zigzag token mapping. If False (default),
                          uses sequential mapping. Should match TtMLA's is_balanced.
             weight_cache_path: Optional path to weight cache directory
+            mode: Weights parallelism strategy - "column" (all_gather emb, output TP-sharded on
+                  vocab) or "row" (matmul partials + all_reduce, output TP-replicated).
         """
         super().__init__()
+        assert mode in ("column", "row"), f"mode must be 'column' or 'row', got {mode!r}"
         self.mesh_device = mesh_device
         self.emb_dim = emb_dim
         self.vocab_size = vocab_size
@@ -178,6 +211,7 @@ class TtLMHead(LightweightModule):
         self.compute_kernel_config = compute_kernel_config
         self.is_balanced = is_balanced
         self.weight_cache_path = weight_cache_path
+        self.mode = mode
 
         logger.debug(f"Initializing TtLMHead with emb_dim={emb_dim}, vocab_size={vocab_size}")
         logger.debug(f"Mesh shape: {mesh_device.shape}, num_devices={self.num_devices}")
@@ -197,11 +231,15 @@ class TtLMHead(LightweightModule):
                 self.weights_dtype,
                 self.weight_cache_path,
                 device=self.mesh_device,
+                mode=self.mode,
             )
         else:
             logger.debug("Creating random sharded weight")
             self.weight = self._create_random_sharded_weight(
-                shape=(emb_dim, vocab_size), dims=(None, -1), name="lm_head_weight", dtype=self.weights_dtype
+                shape=(emb_dim, vocab_size),
+                dims=self._weight_shard_dims(self.mode),
+                name="lm_head_weight",
+                dtype=self.weights_dtype,
             )
 
     def _to_sharded_ttnn(self, torch_weight: torch.Tensor, dims: tuple, name: str, dtype: ttnn.DataType) -> ttnn.Tensor:
@@ -265,7 +303,9 @@ class TtLMHead(LightweightModule):
             torch_weight: [vocab_size, emb_dim] in HF format
 
         Returns:
-            Sharded ttnn tensor: each TP device gets [emb_dim, vocab_size / tp_factor]
+            Sharded ttnn tensor. Per-device shape depends on mode:
+            - column: [emb_dim, vocab_size / tp_factor]
+            - row:    [emb_dim / tp_factor, vocab_size]
         """
         tt_weight = self._convert_and_cache_weight(
             torch_weight,
@@ -275,6 +315,7 @@ class TtLMHead(LightweightModule):
             self.weights_dtype,
             self.weight_cache_path,
             device=self.mesh_device,
+            mode=self.mode,
         )
         logger.debug(f"Created sharded LM head weight: {tt_weight.shape}")
         return tt_weight
@@ -289,7 +330,9 @@ class TtLMHead(LightweightModule):
 
         Returns:
             tuple[ttnn.Tensor, tuple[int, int]]:
-                - Logits tensor [dispatch_group_size, TILE_SIZE, vocab_size/tp]
+                - Logits tensor. Per-device shape:
+                    column mode: [dispatch_group_size, TILE_SIZE, vocab_size/tp]
+                    row mode:    [dispatch_group_size, TILE_SIZE, vocab_size] (TP-replicated)
                 - (device_id, token_offset): which SP device holds the target token
                   and the index within the tile
         """
@@ -315,48 +358,74 @@ class TtLMHead(LightweightModule):
         x = ttnn.narrow(x, dim=-2, start=tile_start, length=ttnn.TILE_SIZE)
         logger.debug(f"[TtLMHead.forward] After narrow ({local_token_id=} {tile_start=}): {x.shape=} {token_offset=}")
 
-        # ========================================
-        # Step 1: All-gather x to get full emb_dim (replicated across TP axis)
-        # ========================================
-        # Input x is sharded: (dispatch_group_size/axis0, seq_len_per_chip, emb_dim/axis1)
-        # Both shared_expert and dispatch need full emb_dim, so all-gather first
-        # Only needed if there are multiple devices in TP axis (axis 1)
-        if self.mesh_device.shape[1] > 1:
-            x_full = ttnn.all_gather(
-                x,
-                dim=-1,  # Gather along emb_dim
-                cluster_axis=1,  # Gather across axis 1 (TP axis)
-                num_links=self.num_links,
-                topology=self.topology,
-            )
+        tp_size = self.mesh_device.shape[1]
+
+        if self.mode == "column":
+            # ========================================
+            # Column-parallel: all_gather emb -> matmul (output TP-sharded on vocab)
+            # ========================================
+            if tp_size > 1:
+                x_full = ttnn.all_gather(
+                    x,
+                    dim=-1,  # Gather along emb_dim
+                    cluster_axis=1,  # Gather across axis 1 (TP axis)
+                    num_links=self.num_links,
+                    topology=self.topology,
+                )
+            else:
+                x_full = x  # No TP sharding, x already has full emb_dim
+            logger.debug(f"[TtLMHead.forward] x_full (after all_gather) shape: {x_full.shape}")
+
+            output = ttnn.matmul(x_full, self.weight, compute_kernel_config=self.compute_kernel_config)
+            logger.debug(f"[TtLMHead.forward] output (after matmul) shape: {output.shape}")
+            # output: [1, 1, TILE, vocab/tp], SP-fractured, TP-sharded on vocab.
         else:
-            x_full = x  # No TP sharding, x already has full emb_dim
-        logger.debug(f"[TtLMHead.forward] x_full (after all_gather) shape: {x_full.shape}")
+            # ========================================
+            # Row-parallel: matmul (partial sum) -> all_reduce (TP-replicated full vocab)
+            # ========================================
+            partial = ttnn.matmul(x, self.weight, compute_kernel_config=self.compute_kernel_config)
+            logger.debug(f"[TtLMHead.forward] partial (after matmul) shape: {partial.shape}")
+            # partial: [1, 1, TILE, vocab] partial sum on each TP rank.
 
-        # ========================================
-        # Step 2: Local matmul with sharded weight
-        # ========================================
-        output = ttnn.matmul(x_full, self.weight, compute_kernel_config=self.compute_kernel_config)
-        logger.debug(f"[TtLMHead.forward] output (after matmul) shape: {output.shape}")
+            if tp_size > 1:
+                output = ttnn.experimental.all_reduce_async(
+                    partial,
+                    cluster_axis=1,
+                    mesh_device=self.mesh_device,
+                    num_links=self.num_links,
+                    math_op=ttnn.ReduceType.Sum,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    topology=self.topology,
+                )
+            else:
+                output = partial
+            logger.debug(f"[TtLMHead.forward] output (after all_reduce) shape: {output.shape}")
+            # output: [1, 1, TILE, vocab], SP-fractured, TP-replicated.
 
-        # output is logits [1,1, TILE_SIZE, vocab_size/tp]
-        # fractured over SP; TP-sharded on vocab dim
-        # the last logit/token is on device_id at token_offset within the tile
+        # The target token is on SP rank device_id at row token_offset within the tile.
         return output, (device_id, token_offset)
 
     def logit_to_host(self, tt_logit: ttnn.Tensor) -> torch.Tensor:
         ttnn.synchronize_device(self.mesh_device)  # ensure all computation is done before copying to host
-        tt_logit_host = ttnn.to_torch(
-            tt_logit,
-            mesh_composer=ttnn.create_mesh_composer(
+        if self.mode == "column":
+            # SP fracture on torch dim 0, TP concat on vocab (-1) to reassemble full vocab.
+            composer = ttnn.create_mesh_composer(
                 self.mesh_device,
                 config=ttnn.MeshComposerConfig(
-                    dims=(0, -1),  # SP fractured on dim 0, TP concat on vocab dim
+                    dims=(0, -1),
                     mesh_shape_override=ttnn.MeshShape(self.mesh_device.shape[0], self.mesh_device.shape[1]),
                 ),
-            ),
-        ).to(torch.bfloat16)
-        return tt_logit_host
+            )
+        else:
+            # Row mode: output is TP-replicated, so only take one TP slice per SP row.
+            composer = ttnn.create_mesh_composer(
+                self.mesh_device,
+                config=ttnn.MeshComposerConfig(
+                    dims=(0, 1),
+                    mesh_shape_override=ttnn.MeshShape(self.mesh_device.shape[0], 1),
+                ),
+            )
+        return ttnn.to_torch(tt_logit, mesh_composer=composer).to(torch.bfloat16)
 
     def select_first_token(self, logit_host: torch.Tensor, device_id: int, token_offset: int) -> torch.Tensor:
         return logit_host[device_id, 0, token_offset, :].unsqueeze(0).unsqueeze(0)

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -50,6 +50,7 @@ class TtPrefillTransformer(LightweightModule):
         num_layers: int,
         experts_per_chip: int = 8,
         first_k_dense: int = 3,
+        lm_head_is_column_parallel: bool = False,
     ) -> bool:
         """
         Top-level cache completeness check for the full transformer.
@@ -62,6 +63,10 @@ class TtPrefillTransformer(LightweightModule):
             num_layers: Number of transformer layers
             experts_per_chip: Number of routed experts per chip (default: 8)
             first_k_dense: Number of initial dense (non-MoE) layers (default: 3)
+            lm_head_is_column_parallel: Selects the LM head cache filename to look for.
+                Must match the value passed to the TtPrefillTransformer constructor so
+                the cache check and the actual load reference the same files.
+                Defaults to False (row-parellel mode) to match TtLMHead's default.
 
         Returns:
             True if all expected cache files exist, False otherwise
@@ -87,8 +92,8 @@ class TtPrefillTransformer(LightweightModule):
         if not TtDistributedRmsNorm.check_cache_complete(cache_path, "norm"):
             return False
 
-        # LM head
-        if not TtLMHead.check_cache_complete(cache_path):
+        # LM head — must match the mode the constructor will use to read the cache.
+        if not TtLMHead.check_cache_complete(cache_path, is_column_parallel=lm_head_is_column_parallel):
             return False
 
         logger.info(f"TTNN cache complete at {cache_path} ({num_layers} layers)")
@@ -114,6 +119,7 @@ class TtPrefillTransformer(LightweightModule):
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         weight_cache_path: Optional[Path] = None,
+        lm_head_is_column_parallel: bool = False,
     ):
         super().__init__()
         self.mesh_device = mesh_device
@@ -200,6 +206,7 @@ class TtPrefillTransformer(LightweightModule):
             topology=topology,
             is_balanced=is_balanced,
             weight_cache_path=weight_cache_path,
+            is_column_parallel=lm_head_is_column_parallel,
         )
 
         self.is_balanced = is_balanced

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -332,11 +332,11 @@ class TtPrefillTransformer(LightweightModule):
 
         logits, (device_id, token_offset) = self.lm_head(h, global_token_id)
 
-        logits_host = self.lm_head.logit_to_host(logits)
+        logits_host = self.lm_head.logit_to_host(logits, device_id)
         assert (
             logits_host.shape[-1] == self.lm_head.vocab_size
         ), f"Expected full vocab {self.lm_head.vocab_size}, got {logits_host.shape[-1]} — TP concat may be broken"
-        first_token_logits = self.lm_head.select_first_token(logits_host, device_id, token_offset)
+        first_token_logits = self.lm_head.select_first_token(logits_host, token_offset)
 
         logger.debug(f"[TtPrefillTransformer._extract] {logits.shape}")
         logger.debug(f"[TtPrefillTransformer._extract] {logits_host.shape}")

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -50,7 +50,6 @@ class TtPrefillTransformer(LightweightModule):
         num_layers: int,
         experts_per_chip: int = 8,
         first_k_dense: int = 3,
-        lm_head_is_column_parallel: bool = False,
     ) -> bool:
         """
         Top-level cache completeness check for the full transformer.
@@ -63,10 +62,6 @@ class TtPrefillTransformer(LightweightModule):
             num_layers: Number of transformer layers
             experts_per_chip: Number of routed experts per chip (default: 8)
             first_k_dense: Number of initial dense (non-MoE) layers (default: 3)
-            lm_head_is_column_parallel: Selects the LM head cache filename to look for.
-                Must match the value passed to the TtPrefillTransformer constructor so
-                the cache check and the actual load reference the same files.
-                Defaults to False (row-parellel mode) to match TtLMHead's default.
 
         Returns:
             True if all expected cache files exist, False otherwise
@@ -92,8 +87,8 @@ class TtPrefillTransformer(LightweightModule):
         if not TtDistributedRmsNorm.check_cache_complete(cache_path, "norm"):
             return False
 
-        # LM head — must match the mode the constructor will use to read the cache.
-        if not TtLMHead.check_cache_complete(cache_path, is_column_parallel=lm_head_is_column_parallel):
+        # LM head
+        if not TtLMHead.check_cache_complete(cache_path):
             return False
 
         logger.info(f"TTNN cache complete at {cache_path} ({num_layers} layers)")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/43131

### Problem description
Current LM head uses column-parallel: all-gather input across TP to get full emb_dim, then matmul with vocab-sharded weight `[emb, vocab/tp]`. Output is TP-sharded on vocab, requiring concat to reconstruct full vocab for sampling. Alternative approach is to keep input TP-sharded `[TILE, emb/tp]`, use emb-sharded weight `[emb/tp, vocab]`, matmul gives partial sum `[TILE, vocab]`, then all-reduce across TP. Output is replicated with full vocab — no concat needed for sampling.

### What's changed
Implemented row-parallel LM head alongside the existing column-parallel, benchmarked both on Blackhole 8×4 at DSv3 dimensions (emb=7168, vocab=129280), and identified that the dominant cost were not the CCL ops but the device-to-host transfer of logits.

Column-parallel uses the following sequence of ops:
```
input -> All Gather -> Matmul -> output -> device-to-host 
```

Row-parallel uses:
```
input -> Matmul -> All Reduce (Reduce Scatter + All Gather) -> output -> device-to-host
```

We measured the cost of CCL ops and device to host transfer in column-parallel and row-parallel cases and got the following numbers:

| | Column-parallel | Row-parallel |
| :------- | :-------: | :------: |
| CCL ops | 38 us | 184 us + 165 us = 349 us |
| Optimized device to host | 13.60 ms | 6.67 ms |
| Total | 13.64 ms | 7.02 ms |

We also managed to optimize device to host transfers by reducing the number of chips we read from. In case of column-parallel approach, we now read only the row of devices that have the token of interest - tensors from those 4 devices are transferred to host where they are concatenated. In row-parallel case, we need to read from only one device in row that contains the token of interest. We read from only one device as data is replicated on all devices across columns.

Full analysis is available on the ticket: https://github.com/tenstorrent/tt-metal/issues/43131

Code changes:
* `models/demos/deepseek_v3_d_p/tt/tt_lm_head.py` — added a mode parameter (`is_column_parallel` parameter, default to `False` as the results show that it is more efficient)
* `models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py` — parametrized it over both modes
* `models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py` — propagates `lm_head_is_column_parallel` flag through both `check_cache_complete()` and `__init__` so the cache check and the LM head construction reference the same mode-specific cache files.

### DeepSeek Prefill CI

- [ ] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/lm_head_row_parallel)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nbabin/lm_head_row_parallel)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nbabin/lm_head_row_parallel)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nbabin/lm_head_row_parallel)
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nbabin/lm_head_row_parallel)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/lm_head_row_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/lm_head_row_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nbabin/lm_head_row_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/lm_head_row_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/lm_head_row_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/lm_head_row_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/lm_head_row_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/lm_head_row_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/lm_head_row_parallel)