### PR TITLE
PDL update pcc and perf 

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -56,7 +56,7 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         (
             DEEPLAB_V3_PLUS,
             {
-                "semantic": {"pcc": 0.983, "abs_err": 1.7, "rel_err": 0.4},
+                "semantic": {"pcc": 0.985, "abs_err": 1.7, "rel_err": 0.4},
             },
             skip_if_not_blackhole_110_cores,
         ),

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -40,8 +40,8 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         (
             PANOPTIC_DEEPLAB,
             {
-                "semantic": {"pcc": 0.983, "abs_err": 1.7, "rel_err": 0.4},
-                "center": {"pcc": 0.95, "abs_err": 0.1, "rel_err": 2.1},
+                "semantic": {"pcc": 0.985, "abs_err": 1.7, "rel_err": 0.4},
+                "center": {"pcc": 0.948, "abs_err": 0.1, "rel_err": 2.1},
                 "offset": {"pcc": 0.992, "abs_err": 8.5, "rel_err": 0.5},
             },
             skip_if_not_blackhole_110_cores,

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -54,7 +54,7 @@ def test_device_perf_pdl_20_cores(
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k panoptic_deeplab_110_cores",
-            5_995_663,
+            5_852_074,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
@@ -64,7 +64,7 @@ def test_device_perf_pdl_20_cores(
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_110_cores",
-            3_971_348,
+            3_908_667,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,


### PR DESCRIPTION
### Summary

[Failing CI](https://github.com/tenstorrent/tt-metal/actions/runs/25856126236/job/75975457642#step:25:596)

  ### Problem description
  The Blackhole 110-core PDL PCC test (`test_model_panoptic_deeplab[panoptic_deeplab_110_cores]`) started failing on the `center` output with PCC = 0.9487 vs. an expected ≥ 0.95 — a ~0.0013 miss. The other two heads (`semantic`,
  `offset`) pass.

  Bisecting between last green commit `f622a01` and first red `762719cbc8f` points to **#44275** ("pool: fix EfficientNet B0 global-pool regression introduced by #43820"). That PR loosened the `is_global_pool` fast-path gate in `ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp` so that block-float TILE inputs with tile-aligned spatial extent now hit the reduce-based `pool_sum` path (and skip the `to_layout(TILE → ROW_MAJOR)` conversion). PDL's ASPP global pool feeds exactly this case: `(1, 1, 2048, 2048)` `bfloat8_b` `TILE`, `2048 % 32 == 0`, `batch_size=1`. Previously the same call was routed to the sliding-window pool kernel.

  The two pool implementations accumulate the 64 tile-rows of bfp8 data in different orders. With block-float (shared exponent per tile of 32 values), even reordered partial sums can shift the final value by 1–2 ULPs of the shared mantissa. That tiny shift propagates through the remainder of ASPP and the instance head's `center_predictor` — a single-channel heatmap regression, the most numerically sensitive of the three outputs — and pushes its PCC just below the 0.95 threshold.

  This is a numerical-path change, not a correctness regression:
  - the new path is the one #44275 explicitly tuned PDL ASPP for (the PR description cites the ~127 µs win on this exact site)
  - `semantic` PCC improved (0.985 vs 0.983 expected)

  ### What's changed
  - Relax `center` PCC from `0.95` → `0.948`
  - Bump `semantic` PCC from `0.983` → `0.985` 
  - Bump perf for both panoptic (`140us` less) and v3 (`70us`) on 110 cores

### CI
- [ ] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/pdl-pcc-relax)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/pdl-pcc-relax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/pdl-pcc-relax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmilicevic/pdl-pcc-relax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/pdl-pcc-relax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/pdl-pcc-relax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/pdl-pcc-relax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/pdl-pcc-relax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/pdl-pcc-relax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/pdl-pcc-relax)