### PR TITLE
Add GELU activation support to `moe_compute` for Gemma 4 26B

### DIFF
--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -119,7 +119,7 @@ _MODELS_1x16 = [
 
 _MODELS_1x8 = [
     MoEModelConfig("deepseek_ocr", N=896,  hidden_size=1280, selected_experts_k=6),
-    MoEModelConfig("gemma_4_26b",  N=704,  hidden_size=2816, selected_experts_k=8),
+    MoEModelConfig("gemma_4_26b",  N=704,  hidden_size=2816, selected_experts_k=8, activation_types=(MoEActivationFunction.GELU,)),
     MoEModelConfig("gpt_oss",      N=2880, hidden_size=2880, selected_experts_k=4, experts_per_device_values=(4,), has_bias_values=(True,), test_modes=("perf", "correctness"), activation_types=(MoEActivationFunction.SWIGLU,)),
 ]
 # fmt: on
@@ -446,6 +446,7 @@ PCC_THRESHOLD_MATMUL_WITH_BIAS = 0.98799
 ATOL_THRESHOLD = 700
 SWIGLU_PCC_THRESHOLD = 0.984
 SILU_PCC_THRESHOLD = 0.986
+GELU_PCC_THRESHOLD = 0.986
 
 
 def _get_base_pcc_threshold(activation_type, has_bias):
@@ -455,8 +456,10 @@ def _get_base_pcc_threshold(activation_type, has_bias):
     act_threshold = None
     if activation_type == MoEActivationFunction.SWIGLU:
         act_threshold = SWIGLU_PCC_THRESHOLD
-    elif activation_type == MoEActivationFunction.SILU:  # SILU
+    elif activation_type == MoEActivationFunction.SILU:
         act_threshold = SILU_PCC_THRESHOLD
+    elif activation_type == MoEActivationFunction.GELU:
+        act_threshold = GELU_PCC_THRESHOLD
     else:
         raise TypeError("Invalid Activation type")
 
@@ -1087,6 +1090,9 @@ def compute_matmul_golden(
         torch_intermediate_ref = torch_silu_output_ref * torch_w1_output_ref  # (L, E, T, N)
     elif activation_type == MoEActivationFunction.SWIGLU:
         torch_intermediate_ref = _swiglu_reference(torch_w0_output_ref, torch_w1_output_ref)  # (L, E, T, N)
+    elif activation_type == MoEActivationFunction.GELU:
+        torch_gelu_output_ref = torch.nn.functional.gelu(torch_w0_output_ref, approximate="tanh")
+        torch_intermediate_ref = torch_gelu_output_ref * torch_w1_output_ref  # (L, E, T, N)
     else:
         raise ValueError(f"Unsupported activation type: {activation_type}")
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/hostdevcommon/config.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/hostdevcommon/config.hpp
@@ -9,6 +9,6 @@
 namespace ttnn::experimental::prim::detail {
 
 // Activation function types for MoE operations
-enum class MoEActivationFunction : uint8_t { SILU = 0, SWIGLU = 1 };
+enum class MoEActivationFunction : uint8_t { SILU = 0, SWIGLU = 1, GELU = 2 };
 
 }  // namespace ttnn::experimental::prim::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -21,10 +21,10 @@
 #include "llk_math_eltwise_binary_sfpu_binop.h"
 #include "ckernel_sfpu_gelu.h"
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_gelu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::calculate_gelu<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_gelu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 #endif
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -19,6 +19,13 @@
 #include "ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h"
 #include "llk_math_eltwise_unary_sfpu_silu.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
+#include "ckernel_sfpu_gelu.h"
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_gelu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::calculate_gelu<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+}
 #endif
 
 namespace detail {
@@ -61,6 +68,20 @@ template <>
 inline void pack_compute_activation<ttnn::experimental::prim::detail::MoEActivationFunction::SWIGLU>() {
     PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(0, 1, 0)));
     PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(2, 3, 2)));
+};
+
+template <>
+inline void pack_init_activation<ttnn::experimental::prim::detail::MoEActivationFunction::GELU>() {
+    PACK((llk_math_eltwise_unary_sfpu_init<SfpuType::gelu>(ckernel::sfpu::gelu_init<true, false>)));
+};
+
+template <>
+inline void pack_compute_activation<ttnn::experimental::prim::detail::MoEActivationFunction::GELU>() {
+    PACK((llk_math_eltwise_unary_sfpu_gelu<true, false>(0)));
+    PACK((llk_math_eltwise_unary_sfpu_gelu<true, false>(2)));
+
+    PACK((llk_math_eltwise_binary_sfpu_binop<true, ckernel::BinaryOp::MUL>(0, 1, 0)));
+    PACK((llk_math_eltwise_binary_sfpu_binop<true, ckernel::BinaryOp::MUL>(2, 3, 2)));
 };
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -21,14 +21,15 @@ void bind_moe_compute(nb::module_& mod) {
     // Bind the activation function enum
     nb::enum_<ttnn::experimental::prim::detail::MoEActivationFunction>(mod, "MoEActivationFunction")
         .value("SILU", ttnn::experimental::prim::detail::MoEActivationFunction::SILU)
-        .value("SWIGLU", ttnn::experimental::prim::detail::MoEActivationFunction::SWIGLU);
+        .value("SWIGLU", ttnn::experimental::prim::detail::MoEActivationFunction::SWIGLU)
+        .value("GELU", ttnn::experimental::prim::detail::MoEActivationFunction::GELU);
     ttnn::bind_function<"moe_compute", "ttnn.experimental.">(
         mod,
         R"doc(
         Experimental fused MoE compute supporting arbitrary ``(hidden_size, intermediate_size)`` pairs.
 
         This operation performs the expert matmuls (gate/up projection via W0/W1, down
-        projection via W2) and activation (SILU or SwiGLU) in a fused compute kernel.
+        projection via W2) and activation (SILU, SwiGLU, or GELU) in a fused compute kernel.
         Tile distribution across the 12-core ring is derived at compile time from
         ``hidden_size`` and ``intermediate_size`` using Euclidean-rhythm (Bresenham)
         shard formulas — no model-specific configuration tables are needed.


### PR DESCRIPTION
## Issue
Closes #44513.

## Changes
* Google's [Gemma 4](https://huggingface.co/google/gemma-4-26B-A4B) model uses [`gelu_pytorch_tanh` as its gating activation](https://huggingface.co/google/gemma-4-26B-A4B/blob/main/config.json#L27).
* This adds GELU as a third activation option in the MoE compute kernel in addition to SILU, SWIGLU, using the hardware SFPU GELU approximation (Chebyshev polynomial) on the PACK thread, mirroring the existing SILU pattern.
* The Gemma 4 test config is updated to use GELU with a tanh-approximated golden reference.

### CI Status
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/44513-add-gelu-activation-for-gemma-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/44513-add-gelu-activation-for-gemma-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/44513-add-gelu-activation-for-gemma-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/44513-add-gelu-activation-for-gemma-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/44513-add-gelu-activation-for-gemma-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/44513-add-gelu-activation-for-gemma-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/44513-add-gelu-activation-for-gemma-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/44513-add-gelu-activation-for-gemma-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gchoudhary/44513-add-gelu-activation-for-gemma-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gchoudhary/44513-add-gelu-activation-for-gemma-4)