### PR TITLE
Benchmark ttlang vs ttml rmsnorm_bw

### DIFF
--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -49,12 +49,14 @@ void AutoContext::reset_graph() {
 }
 
 void AutoContext::open_device(
-    const tt::tt_metal::distributed::MeshShape& mesh_shape, const std::vector<int>& device_ids) {
+    const tt::tt_metal::distributed::MeshShape& mesh_shape,
+    const std::vector<int>& device_ids,
+    size_t worker_l1_size) {
     if (m_device) {
         throw std::runtime_error("open_device was called after the device was created.");
     }
     m_mesh_shape = mesh_shape;
-    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape, device_ids);
+    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape, device_ids, worker_l1_size);
 }
 
 void AutoContext::close_profiler() {

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -101,7 +101,8 @@ public:
 
     void open_device(
         const tt::tt_metal::distributed::MeshShape& mesh_shape = tt::tt_metal::distributed::MeshShape(1, 1),
-        const std::vector<int>& device_ids = std::vector<int>{});
+        const std::vector<int>& device_ids = std::vector<int>{},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
     void close_device();
 

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -10,7 +10,10 @@
 
 namespace ttml::core {
 
-MeshDevice::MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const std::vector<int>& device_ids) :
+MeshDevice::MeshDevice(
+    const tt::tt_metal::distributed::MeshShape& shape,
+    const std::vector<int>& device_ids,
+    size_t worker_l1_size) :
     m_mesh_device(ttnn::distributed::open_mesh_device(
         shape,
         DEFAULT_L1_SMALL_SIZE,
@@ -18,7 +21,8 @@ MeshDevice::MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const 
         /* num_command_queues=*/1,
         tt::tt_metal::DispatchCoreConfig{},
         /*offset=*/std::nullopt,
-        /*physical_device_ids=*/device_ids)) {
+        /*physical_device_ids=*/device_ids,
+        worker_l1_size)) {
     assert(m_mesh_device);
 }
 

--- a/tt-train/sources/ttml/core/mesh_device.hpp
+++ b/tt-train/sources/ttml/core/mesh_device.hpp
@@ -11,7 +11,10 @@ namespace ttml::core {
 // should I implement pimpl or its fine
 class MeshDevice {
 public:
-    explicit MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const std::vector<int>& device_ids);
+    explicit MeshDevice(
+        const tt::tt_metal::distributed::MeshShape& shape,
+        const std::vector<int>& device_ids,
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
     MeshDevice(MeshDevice&& device) = default;
     MeshDevice(const MeshDevice&) = delete;
 

--- a/tt-train/sources/ttml/nanobind/nb_autograd.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_autograd.cpp
@@ -235,7 +235,7 @@ void py_module(nb::module_& m) {
         py_auto_context.def("get_gradient_mode", &AutoContext::get_gradient_mode, "Get gradient mode");
         py_auto_context.def(
             "open_device",
-            [](AutoContext& self, nb::object mesh_shape_obj, nb::object device_ids_obj) {
+            [](AutoContext& self, nb::object mesh_shape_obj, nb::object device_ids_obj, nb::object worker_l1_size_obj) {
                 tt::tt_metal::distributed::MeshShape mesh_shape(1, 1);
 
                 if (!mesh_shape_obj.is_none()) {
@@ -255,10 +255,16 @@ void py_module(nb::module_& m) {
                     device_ids = nb::cast<std::vector<int>>(device_ids_obj);
                 }
 
-                self.open_device(mesh_shape, device_ids);
+                size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE;
+                if (!worker_l1_size_obj.is_none()) {
+                    worker_l1_size = nb::cast<size_t>(worker_l1_size_obj);
+                }
+
+                self.open_device(mesh_shape, device_ids, worker_l1_size);
             },
             nb::arg("mesh_shape") = nb::none(),
             nb::arg("device_ids") = nb::none(),
+            nb::arg("worker_l1_size") = nb::none(),
             "Open a mesh device");
         py_auto_context.def("close_device", &AutoContext::close_device, "Close mesh device");
         py_auto_context.def("get_device", &AutoContext::get_device, nb::rv_policy::reference, "Get mesh device");

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -14,6 +14,7 @@
 #include "autograd/autocast_tensor.hpp"
 #include "autograd/tensor.hpp"
 #include "metal/ops/moe_group/moe_group.hpp"
+#include "metal/ops/rmsnorm_bw/rmsnorm_bw.hpp"
 #include "nb_export_enum.hpp"
 #include "nb_fwd.hpp"
 #include "ops/binary_ops.hpp"
@@ -378,6 +379,30 @@ void py_module(nb::module_& m) {
             nb::arg("tensor"),
             nb::arg("gamma"),
             nb::arg("epsilon"));
+
+        // Low-level RMSNorm backward (matches tt-train C++ `ttml::metal::rmsnorm_bw`), for microbenchmarks.
+        py_rmsnorm.def(
+            "rmsnorm_bw",
+            [](const autograd::TensorPtr& input,
+               const autograd::TensorPtr& gamma,
+               const autograd::TensorPtr& rms,
+               const autograd::TensorPtr& dL_dout) -> std::tuple<autograd::TensorPtr, autograd::TensorPtr> {
+                auto grads = ttml::metal::rmsnorm_bw(
+                    input->get_value(), gamma->get_value(), rms->get_value(), dL_dout->get_value());
+                if (grads.size() != 2U) {
+                    throw std::runtime_error("rmsnorm_bw: unexpected number of tensors from metal rmsnorm_bw");
+                }
+                if (!grads[0].has_value() || !grads[1].has_value()) {
+                    throw std::runtime_error("rmsnorm_bw: expected gradients for input and gamma");
+                }
+                return std::make_tuple(
+                    autograd::create_tensor(std::move(grads[0].value())),
+                    autograd::create_tensor(std::move(grads[1].value())));
+            },
+            nb::arg("input"),
+            nb::arg("gamma"),
+            nb::arg("rms"),
+            nb::arg("dL_dout"));
     }
 
     m.def(

--- a/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
+++ b/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
@@ -26,44 +26,14 @@ NUM_MEASURE = 50
 
 _TTL_WORKER_L1_RESERVE_BYTES = 77824
 
-_TTML_SOURCES = Path(__file__).resolve().parents[1]
-_TTLANG = _TTML_SOURCES / "ttlang"
-for _p in (_TTML_SOURCES, _TTLANG):
-    if _p.is_dir() and str(_p) not in sys.path:
-        sys.path.insert(0, str(_p))
-
-
-def _ensure_ttl_package_path() -> None:
-    """Put the nanobind ``ttl`` package on ``sys.path`` (same logic as ``ttl_tml_rmsnorm_comp``)."""
-    candidates: list[Path] = []
-    env = os.environ.get("TTL_PYTHON_PACKAGES", "").strip()
-    if env:
-        candidates.append(Path(env).expanduser())
-    candidates.append(Path("/opt/ttlang-toolchain/python_packages"))
-    exe_parent = Path(sys.executable).resolve().parent.parent
-    if (exe_parent / "python_packages").is_dir():
-        candidates.append(exe_parent / "python_packages")
-    for p in candidates:
-        if p.is_dir() and (p / "ttl").is_dir() and str(p) not in sys.path:
-            sys.path.insert(0, str(p))
-            return
-
-
-def _import_ttl_rmsnorm_bw_2pass():
-    """Import ``ttl_rmsnorm_bw_2pass`` (2-pass tile-streaming TTL backward; needs ``ttl``)."""
-    _ensure_ttl_package_path()
-    import ttl_rmsnorm_bw_2pass  # noqa: PLC0415
-
-    return ttl_rmsnorm_bw_2pass
-
-
+import ttl_rmsnorm_bw_2pass
 import ttml
 from ttml.autograd import AutoContext, Tensor, create_tensor
 
 
-def _open_mesh_for_kernel_bw(ctx: AutoContext, bw_kernel: str) -> None:
+def _open_mesh_for_kernel_bw(ctx: AutoContext, kernel: str) -> None:
     """Open a single-device mesh ``(1, 1)``; TTL reserves worker L1 for large kernel configs."""
-    if bw_kernel != "ttl_2pass":
+    if kernel != "ttl_2pass":
         ctx.open_device((1, 1))
         return
     max_l1 = ttnn.device.get_max_worker_l1_unreserved_size()
@@ -164,24 +134,20 @@ def _metal_rmsnorm_bw_tensors_from_numpy(
     return x_t, g_t, dL_t, rms_t
 
 
-def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
+def _run_kernel(kernel: str = "metal") -> None:
     """Benchmark RMSNorm backward kernel"""
 
     ttl_mod = None
-    twopass_mod = None
-    if bw_kernel == "ttl_2pass":
-        twopass_mod = _import_ttl_rmsnorm_bw_2pass()
-        import ttl_rmsnorm_bw  # noqa: PLC0415
-
-        ttl_mod = ttl_rmsnorm_bw
+    if kernel == "ttl_2pass":
+        ttl_mod = ttl_rmsnorm_bw_2pass
 
     ctx = AutoContext.get_instance()
-    _open_mesh_for_kernel_bw(ctx, bw_kernel)
+    _open_mesh_for_kernel_bw(ctx, kernel)
     try:
         mesh = ctx.get_device()
         mesh.enable_program_cache()
 
-        if bw_kernel == "metal":
+        if kernel == "metal":
             tag = "Metal"
         else:
             tag = "TTL (2-pass)"
@@ -196,15 +162,14 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
             d_np = rng.uniform(-1.0, 1.0, (b, 1, s_len, c)).astype(np.float32)
             rms_np = _torch_rmsnorm_rms_numpy(x_np, RMSNORM_EPS)
 
-            if bw_kernel == "metal":
+            if kernel == "metal":
                 x_t, g_t, dL_t, rms_t = _metal_rmsnorm_bw_tensors_from_numpy(x_np, g_np, d_np, rms_np)
 
                 def run_step() -> None:
                     d_in, d_gamma = ttml.ops.rmsnorm.rmsnorm_bw(x_t, g_t, rms_t, dL_t)
 
-            elif bw_kernel == "ttl_2pass":
+            elif kernel == "ttl_2pass":
                 assert ttl_mod is not None
-                assert twopass_mod is not None
                 rows = b * s_len
                 columns = c
                 x2, dL2, g2, r2 = _ttl_rmsnorm_bw_numpy_to_2d(x_np, d_np, g_np, rms_np, rows, columns)
@@ -212,13 +177,13 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
                 x_p, g_p, rms_p, dL_p, out_da, out_dg = _ttl_rmsnorm_bw_tensors_to_padded_device(
                     ttl_mod, mesh, x2, g2, r2, dL2, rows_p, cols_p
                 )
-                k_2pass = twopass_mod.make_kernel()
+                ttl_kernel = ttl_mod.make_kernel()
 
                 def run_step() -> None:
-                    k_2pass(x_p, g_p, rms_p, dL_p, out_da, out_dg)
+                    ttl_kernel(x_p, g_p, rms_p, dL_p, out_da, out_dg)
 
             else:
-                raise ValueError(f"unknown bw_kernel: {bw_kernel}")
+                raise ValueError(f"unknown kernel: {kernel}")
 
             for _ in range(NUM_WARMUP):
                 run_step()
@@ -230,10 +195,10 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
                 ttnn.synchronize_device(mesh)
                 total += time.perf_counter() - t0
             avg_s = total / NUM_MEASURE
-            if bw_kernel == "metal":
-                suffix = "KernelBw_Metal"
+            if kernel == "metal":
+                suffix = "Kernel_Metal"
             else:
-                suffix = "KernelBw_TTL_2Pass"
+                suffix = "Kernel_TTL_2Pass"
             row = f"{name}_{suffix}"
             print(f"  {row:28}  Time_us={avg_s * 1e6:10.2f}")
     finally:
@@ -244,19 +209,19 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
-        "--bw-kernel",
+        "--kernel",
         choices=("metal", "ttl_2pass"),
         default="metal",
         help=(
             "metal: ttml rmsnorm_bw; "
-            "ttl_2pass: ttl rmsnorm_bw "
+            "ttl_2pass: ttl_2pass rmsnorm_bw "
         ),
     )
     args = p.parse_args()
 
-    print(f"warmup={NUM_WARMUP}  measure={NUM_MEASURE}  epsilon={RMSNORM_EPS}  --bw-kernel={args.bw_kernel}\n")
+    print(f"warmup={NUM_WARMUP}  measure={NUM_MEASURE}  epsilon={RMSNORM_EPS}  --kernel={args.kernel}\n")
 
-    _run_kernel_bw_only(args.bw_kernel)
+    _run_kernel(args.kernel)
     print()
 
     return 0

--- a/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
+++ b/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""RMSNorm microbenchmark in Python using nanobind-backed ``ttml`` ops.
+"""
+
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import zlib
+from pathlib import Path
+
+import numpy as np
+import torch
+import ttnn
+
+TILE = 32
+RMSNORM_EPS = 0.0078125
+NUM_WARMUP = 5
+NUM_MEASURE = 50
+
+_TTL_WORKER_L1_RESERVE_BYTES = 77824
+
+_TTML_SOURCES = Path(__file__).resolve().parents[1]
+_TTLANG = _TTML_SOURCES / "ttlang"
+for _p in (_TTML_SOURCES, _TTLANG):
+    if _p.is_dir() and str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+def _ensure_ttl_package_path() -> None:
+    """Put the nanobind ``ttl`` package on ``sys.path`` (same logic as ``ttl_tml_rmsnorm_comp``)."""
+    candidates: list[Path] = []
+    env = os.environ.get("TTL_PYTHON_PACKAGES", "").strip()
+    if env:
+        candidates.append(Path(env).expanduser())
+    candidates.append(Path("/opt/ttlang-toolchain/python_packages"))
+    exe_parent = Path(sys.executable).resolve().parent.parent
+    if (exe_parent / "python_packages").is_dir():
+        candidates.append(exe_parent / "python_packages")
+    for p in candidates:
+        if p.is_dir() and (p / "ttl").is_dir() and str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+            return
+
+
+def _import_ttl_rmsnorm_bw_2pass():
+    """Import ``ttl_rmsnorm_bw_2pass`` (2-pass tile-streaming TTL backward; needs ``ttl``)."""
+    _ensure_ttl_package_path()
+    import ttl_rmsnorm_bw_2pass  # noqa: PLC0415
+
+    return ttl_rmsnorm_bw_2pass
+
+
+import ttml
+from ttml.autograd import AutoContext, Tensor, create_tensor
+
+
+def _open_mesh_for_kernel_bw(ctx: AutoContext, bw_kernel: str) -> None:
+    """Open a single-device mesh ``(1, 1)``; TTL reserves worker L1 for large kernel configs."""
+    if bw_kernel != "ttl_2pass":
+        ctx.open_device((1, 1))
+        return
+    max_l1 = ttnn.device.get_max_worker_l1_unreserved_size()
+    if _TTL_WORKER_L1_RESERVE_BYTES >= max_l1:
+        raise RuntimeError(
+            f"_TTL_WORKER_L1_RESERVE_BYTES ({_TTL_WORKER_L1_RESERVE_BYTES}) must be less than "
+            f"max worker L1 unreserved size ({max_l1}); not enough L1 to reserve headroom for TTL kernel configs."
+        )
+    worker_l1 = max_l1 - _TTL_WORKER_L1_RESERVE_BYTES
+    ctx.open_device((1, 1), None, worker_l1)
+
+
+SHAPES = (
+    ([1, 1, 256, 384], "256x384"),
+    ([1, 1, 256, 2048], "256x2048"),
+    ([1, 1, 2048, 2048], "2048x2048"),
+    ([2, 1, 2048, 2048], "4096x2048"),
+    ([4, 1, 2048, 2048], "8192x2048"),
+    ([8, 1, 2048, 2048], "16384x2048"),
+    ([16, 1, 2048, 2048], "32768x2048"),
+    ([1, 1, 2048, 4096], "2048x4096"),
+    ([2, 1, 2048, 4096], "4096x4096"),
+    ([4, 1, 2048, 4096], "8192x4096"),
+    ([8, 1, 2048, 4096], "16384x4096"),
+    ([16, 1, 2048, 4096], "32768x4096")
+)
+
+
+def _torch_rmsnorm_rms_numpy(x_np: np.ndarray, eps: float) -> np.ndarray:
+    """``sqrt(mean(x^2, dim=C, keepdim) + eps)`` → ``[B,1,S,1]`` float32, same reduction as ``rmsnorm_op`` composite."""
+    x = torch.from_numpy(np.asarray(x_np, dtype=np.float32))
+    mean_sq = (x * x).mean(dim=-1, keepdim=True)
+    rms = torch.sqrt(mean_sq + eps)
+    return np.asarray(rms.numpy(), dtype=np.float32)
+
+
+def _seed_for_name(name: str) -> int:
+    return zlib.crc32(name.encode("utf-8")) & 0xFFFFFFFF
+
+
+def _ttl_rmsnorm_bw_numpy_to_2d(
+    x_np: np.ndarray,
+    d_np: np.ndarray,
+    g_np: np.ndarray,
+    rms_np: np.ndarray,
+    rows: int,
+    columns: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Change ``[B,1,S,C]`` / ``[B,1,S,1]`` / ``[1,1,1,C]`` arrays to 2D."""
+    x2 = torch.from_numpy(x_np).reshape(rows, columns)
+    dL2 = torch.from_numpy(d_np).reshape(rows, columns)
+    g1d = torch.from_numpy(g_np).reshape(columns)
+    g2 = g1d.unsqueeze(0).expand(rows, columns).contiguous()
+    r_row = torch.from_numpy(rms_np).squeeze(-1).reshape(rows, 1)
+    r2 = r_row.expand(rows, columns).contiguous()
+    return x2, dL2, g2, r2
+
+
+def _ttl_rmsnorm_bw_tensors_to_padded_device(
+    ttl_mod,
+    mesh,
+    x2: torch.Tensor,
+    g2: torch.Tensor,
+    r2: torch.Tensor,
+    dL2: torch.Tensor,
+    rows_p: int,
+    cols_p: int,
+):
+    """Pad 2D torch inputs to ``(rows_p, cols_p)`` and ``_to_dev``."""
+    x_p = ttl_mod._to_dev(ttl_mod._pad(x2, rows_p, cols_p), mesh)
+    g_p = ttl_mod._to_dev(ttl_mod._pad(g2, rows_p, cols_p), mesh)
+    rms_p = ttl_mod._to_dev(ttl_mod._pad(r2, rows_p, cols_p), mesh)
+    dL_p = ttl_mod._to_dev(ttl_mod._pad(dL2, rows_p, cols_p), mesh)
+    out_da = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
+    out_dg = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
+    return x_p, g_p, rms_p, dL_p, out_da, out_dg
+
+
+def _tile_padded_shape(rows: int, cols: int) -> tuple[int, int]:
+    return -(-rows // TILE) * TILE, -(-cols // TILE) * TILE
+
+
+def _metal_rmsnorm_bw_tensors_from_numpy(
+    x_np: np.ndarray,
+    g_np: np.ndarray,
+    d_np: np.ndarray,
+    rms_np: np.ndarray,
+):
+    """Numpy activations / gamma / upstream grad / RMS → tile-backed autograd tensors for ``rmsnorm_bw``."""
+    x_storage = Tensor.from_numpy(x_np, ttnn.Layout.TILE)
+    g_storage = Tensor.from_numpy(g_np, ttnn.Layout.TILE)
+    d_storage = Tensor.from_numpy(d_np, ttnn.Layout.TILE)
+    rms_storage = Tensor.from_numpy(rms_np, ttnn.Layout.TILE)
+    x_t = create_tensor(x_storage.get_value(), False)
+    g_t = create_tensor(g_storage.get_value(), False)
+    dL_t = create_tensor(d_storage.get_value(), False)
+    rms_t = create_tensor(rms_storage.get_value(), False)
+    return x_t, g_t, dL_t, rms_t
+
+
+def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
+    """Benchmark RMSNorm backward kernel"""
+
+    ttl_mod = None
+    twopass_mod = None
+    if bw_kernel == "ttl_2pass":
+        twopass_mod = _import_ttl_rmsnorm_bw_2pass()
+        import ttl_rmsnorm_bw  # noqa: PLC0415
+
+        ttl_mod = ttl_rmsnorm_bw
+
+    ctx = AutoContext.get_instance()
+    _open_mesh_for_kernel_bw(ctx, bw_kernel)
+    try:
+        mesh = ctx.get_device()
+        mesh.enable_program_cache()
+
+        if bw_kernel == "metal":
+            tag = "Metal"
+        else:
+            tag = "TTL (2-pass)"
+        print(f"Mode: KernelBw / {tag} (backward-only, RMS from torch forward on host)\n")
+
+        for shape, name in SHAPES:
+            seed = _seed_for_name(name)
+            rng = np.random.default_rng(seed)
+            b, _, s_len, c = shape
+            x_np = rng.uniform(-1.0, 1.0, (b, 1, s_len, c)).astype(np.float32)
+            g_np = rng.uniform(-1.0, 1.0, (1, 1, 1, c)).astype(np.float32)
+            d_np = rng.uniform(-1.0, 1.0, (b, 1, s_len, c)).astype(np.float32)
+            rms_np = _torch_rmsnorm_rms_numpy(x_np, RMSNORM_EPS)
+
+            if bw_kernel == "metal":
+                x_t, g_t, dL_t, rms_t = _metal_rmsnorm_bw_tensors_from_numpy(x_np, g_np, d_np, rms_np)
+
+                def run_step() -> None:
+                    d_in, d_gamma = ttml.ops.rmsnorm.rmsnorm_bw(x_t, g_t, rms_t, dL_t)
+
+            elif bw_kernel == "ttl_2pass":
+                assert ttl_mod is not None
+                assert twopass_mod is not None
+                rows = b * s_len
+                columns = c
+                x2, dL2, g2, r2 = _ttl_rmsnorm_bw_numpy_to_2d(x_np, d_np, g_np, rms_np, rows, columns)
+                rows_p, cols_p = _tile_padded_shape(rows, columns)
+                x_p, g_p, rms_p, dL_p, out_da, out_dg = _ttl_rmsnorm_bw_tensors_to_padded_device(
+                    ttl_mod, mesh, x2, g2, r2, dL2, rows_p, cols_p
+                )
+                k_2pass = twopass_mod.make_kernel()
+
+                def run_step() -> None:
+                    k_2pass(x_p, g_p, rms_p, dL_p, out_da, out_dg)
+
+            else:
+                raise ValueError(f"unknown bw_kernel: {bw_kernel}")
+
+            for _ in range(NUM_WARMUP):
+                run_step()
+
+            total = 0.0
+            for _ in range(NUM_MEASURE):
+                t0 = time.perf_counter()
+                run_step()
+                ttnn.synchronize_device(mesh)
+                total += time.perf_counter() - t0
+            avg_s = total / NUM_MEASURE
+            if bw_kernel == "metal":
+                suffix = "KernelBw_Metal"
+            else:
+                suffix = "KernelBw_TTL_2Pass"
+            row = f"{name}_{suffix}"
+            print(f"  {row:28}  Time_us={avg_s * 1e6:10.2f}")
+    finally:
+        ctx.reset_graph()
+        ctx.close_device()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--bw-kernel",
+        choices=("metal", "ttl_2pass"),
+        default="metal",
+        help=(
+            "metal: ttml rmsnorm_bw; "
+            "ttl_2pass: ttl rmsnorm_bw "
+        ),
+    )
+    args = p.parse_args()
+
+    print(f"warmup={NUM_WARMUP}  measure={NUM_MEASURE}  epsilon={RMSNORM_EPS}  --bw-kernel={args.bw_kernel}\n")
+
+    _run_kernel_bw_only(args.bw_kernel)
+    print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except ImportError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)

--- a/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
+++ b/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
@@ -76,27 +76,25 @@ def _ttl_rmsnorm_bw_numpy_to_2d(
     """Change ``[B,1,S,C]`` / ``[B,1,S,1]`` / ``[1,1,1,C]`` arrays to 2D."""
     x2 = torch.from_numpy(x_np).reshape(rows, columns)
     dL2 = torch.from_numpy(d_np).reshape(rows, columns)
-    g1d = torch.from_numpy(g_np).reshape(columns)
-    g2 = g1d.unsqueeze(0).expand(rows, columns).contiguous()
+    g_row = torch.from_numpy(g_np).reshape(columns).unsqueeze(0)
     r_row = torch.from_numpy(rms_np).squeeze(-1).reshape(rows, 1)
-    r2 = r_row.expand(rows, columns).contiguous()
-    return x2, dL2, g2, r2
+    return x2, dL2, g_row, r_row
 
 
 def _ttl_rmsnorm_bw_tensors_to_padded_device(
     ttl_mod,
     mesh,
     x2: torch.Tensor,
-    g2: torch.Tensor,
-    r2: torch.Tensor,
+    g_row: torch.Tensor,
+    r_row: torch.Tensor,
     dL2: torch.Tensor,
     rows_p: int,
     cols_p: int,
 ):
-    """Pad 2D torch inputs to ``(rows_p, cols_p)`` and ``_to_dev``."""
+    """Pad 2D torch inputs and ``to_dev`` (gamma ``[1, cols_p]``, rms ``[rows_p, 1]``)."""
     x_p = ttl_mod.to_dev(ttl_mod.pad(x2, rows_p, cols_p), mesh)
-    g_p = ttl_mod.to_dev(ttl_mod.pad(g2, rows_p, cols_p), mesh)
-    rms_p = ttl_mod.to_dev(ttl_mod.pad(r2, rows_p, cols_p), mesh)
+    g_p = ttl_mod.to_dev(ttl_mod.pad(g_row, 1, cols_p), mesh)
+    rms_p = ttl_mod.to_dev(ttl_mod.pad(r_row, rows_p, 1), mesh)
     dL_p = ttl_mod.to_dev(ttl_mod.pad(dL2, rows_p, cols_p), mesh)
     out_da = ttl_mod.to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
     out_dg = ttl_mod.to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
@@ -163,10 +161,12 @@ def _run_kernel(kernel: str = "metal") -> None:
                 assert ttl_mod is not None
                 rows = b * s_len
                 columns = c
-                x2, dL2, g2, r2 = _ttl_rmsnorm_bw_numpy_to_2d(x_np, d_np, g_np, rms_np, rows, columns)
+                x2, dL2, g_row, r_row = _ttl_rmsnorm_bw_numpy_to_2d(
+                    x_np, d_np, g_np, rms_np, rows, columns
+                )
                 rows_p, cols_p = _tile_padded_shape(rows, columns)
                 x_p, g_p, rms_p, dL_p, out_da, out_dg = _ttl_rmsnorm_bw_tensors_to_padded_device(
-                    ttl_mod, mesh, x2, g2, r2, dL2, rows_p, cols_p
+                    ttl_mod, mesh, x2, g_row, r_row, dL2, rows_p, cols_p
                 )
                 ttl_kernel = ttl_mod.make_kernel()
 

--- a/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
+++ b/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
@@ -9,11 +9,9 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 import time
 import zlib
-from pathlib import Path
 
 import numpy as np
 import torch
@@ -24,7 +22,7 @@ RMSNORM_EPS = 0.0078125
 NUM_WARMUP = 5
 NUM_MEASURE = 50
 
-_TTL_WORKER_L1_RESERVE_BYTES = 77824
+_TTL_WORKER_L1_RESERVE_BYTES = 90112
 
 import ttl_rmsnorm_bw_2pass
 import ttml
@@ -47,18 +45,11 @@ def _open_mesh_for_kernel_bw(ctx: AutoContext, kernel: str) -> None:
 
 
 SHAPES = (
-    ([1, 1, 256, 384], "256x384"),
-    ([1, 1, 256, 2048], "256x2048"),
-    ([1, 1, 2048, 2048], "2048x2048"),
-    ([2, 1, 2048, 2048], "4096x2048"),
-    ([4, 1, 2048, 2048], "8192x2048"),
-    ([8, 1, 2048, 2048], "16384x2048"),
-    ([16, 1, 2048, 2048], "32768x2048"),
-    ([1, 1, 2048, 4096], "2048x4096"),
-    ([2, 1, 2048, 4096], "4096x4096"),
-    ([4, 1, 2048, 4096], "8192x4096"),
-    ([8, 1, 2048, 4096], "16384x4096"),
-    ([16, 1, 2048, 4096], "32768x4096")
+    ([1, 1, 2048, 5632], "2048x5632"),
+    ([2, 1, 2048, 5632], "4096x5632"),
+    ([4, 1, 2048, 5632], "8192x5632"),
+    ([8, 1, 2048, 5632], "16384x5632"),
+    ([16, 1, 2048, 5632], "32768x5632"),
 )
 
 
@@ -103,12 +94,12 @@ def _ttl_rmsnorm_bw_tensors_to_padded_device(
     cols_p: int,
 ):
     """Pad 2D torch inputs to ``(rows_p, cols_p)`` and ``_to_dev``."""
-    x_p = ttl_mod._to_dev(ttl_mod._pad(x2, rows_p, cols_p), mesh)
-    g_p = ttl_mod._to_dev(ttl_mod._pad(g2, rows_p, cols_p), mesh)
-    rms_p = ttl_mod._to_dev(ttl_mod._pad(r2, rows_p, cols_p), mesh)
-    dL_p = ttl_mod._to_dev(ttl_mod._pad(dL2, rows_p, cols_p), mesh)
-    out_da = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
-    out_dg = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
+    x_p = ttl_mod.to_dev(ttl_mod.pad(x2, rows_p, cols_p), mesh)
+    g_p = ttl_mod.to_dev(ttl_mod.pad(g2, rows_p, cols_p), mesh)
+    rms_p = ttl_mod.to_dev(ttl_mod.pad(r2, rows_p, cols_p), mesh)
+    dL_p = ttl_mod.to_dev(ttl_mod.pad(dL2, rows_p, cols_p), mesh)
+    out_da = ttl_mod.to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
+    out_dg = ttl_mod.to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), mesh)
     return x_p, g_p, rms_p, dL_p, out_da, out_dg
 
 
@@ -166,7 +157,7 @@ def _run_kernel(kernel: str = "metal") -> None:
                 x_t, g_t, dL_t, rms_t = _metal_rmsnorm_bw_tensors_from_numpy(x_np, g_np, d_np, rms_np)
 
                 def run_step() -> None:
-                    d_in, d_gamma = ttml.ops.rmsnorm.rmsnorm_bw(x_t, g_t, rms_t, dL_t)
+                    _, _ = ttml.ops.rmsnorm.rmsnorm_bw(x_t, g_t, rms_t, dL_t)
 
             elif kernel == "ttl_2pass":
                 assert ttl_mod is not None
@@ -180,20 +171,23 @@ def _run_kernel(kernel: str = "metal") -> None:
                 ttl_kernel = ttl_mod.make_kernel()
 
                 def run_step() -> None:
-                    ttl_kernel(x_p, g_p, rms_p, dL_p, out_da, out_dg)
+                    _, _ = ttl_mod.run_rmsnorm_bw_2pass(
+                        mesh, ttl_kernel, x_p, g_p, rms_p, dL_p, out_da, out_dg
+                    )
 
             else:
                 raise ValueError(f"unknown kernel: {kernel}")
 
             for _ in range(NUM_WARMUP):
                 run_step()
+            ttnn.synchronize_device(mesh)
 
             total = 0.0
+            t0 = time.perf_counter()
             for _ in range(NUM_MEASURE):
-                t0 = time.perf_counter()
                 run_step()
-                ttnn.synchronize_device(mesh)
-                total += time.perf_counter() - t0
+            ttnn.synchronize_device(mesh)
+            total = time.perf_counter() - t0
             avg_s = total / NUM_MEASURE
             if kernel == "metal":
                 suffix = "Kernel_Metal"
@@ -212,10 +206,7 @@ def main() -> int:
         "--kernel",
         choices=("metal", "ttl_2pass"),
         default="metal",
-        help=(
-            "metal: ttml rmsnorm_bw; "
-            "ttl_2pass: ttl_2pass rmsnorm_bw "
-        ),
+        help=("metal: ttml rmsnorm_bw; " "ttl_2pass: ttl_2pass rmsnorm_bw "),
     )
     args = p.parse_args()
 

--- a/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
+++ b/tt-train/sources/ttml/ttlang/rmsnorm_bw_benchmark.py
@@ -161,9 +161,7 @@ def _run_kernel(kernel: str = "metal") -> None:
                 assert ttl_mod is not None
                 rows = b * s_len
                 columns = c
-                x2, dL2, g_row, r_row = _ttl_rmsnorm_bw_numpy_to_2d(
-                    x_np, d_np, g_np, rms_np, rows, columns
-                )
+                x2, dL2, g_row, r_row = _ttl_rmsnorm_bw_numpy_to_2d(x_np, d_np, g_np, rms_np, rows, columns)
                 rows_p, cols_p = _tile_padded_shape(rows, columns)
                 x_p, g_p, rms_p, dL_p, out_da, out_dg = _ttl_rmsnorm_bw_tensors_to_padded_device(
                     ttl_mod, mesh, x2, g_row, r_row, dL2, rows_p, cols_p
@@ -171,9 +169,7 @@ def _run_kernel(kernel: str = "metal") -> None:
                 ttl_kernel = ttl_mod.make_kernel()
 
                 def run_step() -> None:
-                    _, _ = ttl_mod.run_rmsnorm_bw_2pass(
-                        mesh, ttl_kernel, x_p, g_p, rms_p, dL_p, out_da, out_dg
-                    )
+                    _, _ = ttl_mod.run_rmsnorm_bw_2pass(mesh, ttl_kernel, x_p, g_p, rms_p, dL_p, out_da, out_dg)
 
             else:
                 raise ValueError(f"unknown kernel: {kernel}")
@@ -182,7 +178,6 @@ def _run_kernel(kernel: str = "metal") -> None:
                 run_step()
             ttnn.synchronize_device(mesh)
 
-            total = 0.0
             t0 = time.perf_counter()
             for _ in range(NUM_MEASURE):
                 run_step()

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+RMSNorm backward — 2-pass tile streaming (vs. ``remsnorm_whole_row.py`` whole-row strip).
+
+**Pass 1:** per tile-column, accumulate row scalar
+``scale = Σ_c (x · (γ/rms) · dL_dout)`` via ``(contrib @ ones)`` matmul reduction
+(same workaround as ``polynorm3_on_tiles_2pass_working.py``).
+
+**Pass 2:** re-stream tiles and emit
+``dL_dinput = (γ/rms)·dL_dout − scale·x·(1/rms)²·(1/C)``,
+``dL_dgamma = x·(1/rms)·dL_dout``.
+"""
+from __future__ import annotations
+
+import ttl
+
+TILE_WIDTH = 32
+
+
+def make_kernel():
+    bc = 2
+
+    @ttl.operation(grid="auto", fp32_dest_acc_en=True)
+    def rmsnorm_bw_2pass(
+        input_t,
+        gamma_t,
+        rms_t,
+        dL_dout_t,
+        dL_dinput_out,
+        dL_dgamma_comp_out,
+    ):
+        ht = input_t.shape[0] // TILE_WIDTH
+        wt = input_t.shape[1] // TILE_WIDTH
+        one = (1, 1)
+        elem_c = wt * TILE_WIDTH
+        inv_c_scalar = 1.0 / elem_c
+
+        grid_cols, grid_rows = ttl.grid_size(dims=2)
+        total_cores = grid_cols * grid_rows
+        rows_per_core = -(-ht // total_cores)
+
+        # Input buffers
+        inp_tile = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=bc)
+        gamma_tile = ttl.make_dataflow_buffer_like(gamma_t, shape=one, block_count=bc)
+        rms_tile = ttl.make_dataflow_buffer_like(rms_t, shape=one, block_count=bc)
+        dL_tile = ttl.make_dataflow_buffer_like(dL_dout_t, shape=one, block_count=bc)
+
+        # Output buffers
+        out_da_tile = ttl.make_dataflow_buffer_like(dL_dinput_out, shape=one, block_count=bc)
+        out_dg_tile = ttl.make_dataflow_buffer_like(dL_dgamma_comp_out, shape=one, block_count=bc)
+
+        # Scale accumulator
+        scale_acc = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=bc)
+
+        # Constant 1/C tile for rhs
+        inv_c_dfb = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=1)
+
+        @ttl.compute()
+        def compute():
+            core_col, core_row = ttl.node(dims=2)
+            core_linear = core_row * grid_cols + core_col
+            with inv_c_dfb.reserve() as ic:
+                ic.store(ttl.math.fill(ic, inv_c_scalar))
+            inv_c = inv_c_dfb.wait()
+
+            for local_row in range(rows_per_core):
+                row = core_linear * rows_per_core + local_row
+                if row < ht:
+                    with scale_acc.reserve() as z:
+                        z.store(ttl.math.fill(z, 0.0))
+
+                    # Pass 1: accumulate row scalar
+                    for _local_col in range(wt):
+                        with (
+                            inp_tile.wait() as iv,
+                            gamma_tile.wait() as gv,
+                            rms_tile.wait() as rmv,
+                            dL_tile.wait() as dlv,
+                            scale_acc.wait() as s,
+                        ):
+                            recip = ttl.math.recip(rmv)
+                            gained = recip * gv * dlv
+                            contrib = iv * gained
+                            reduce_tile = ttl.math.fill(contrib, 1.0)
+                            with scale_acc.reserve() as o:
+                                o.store(s + (contrib @ reduce_tile))
+
+                    scale = scale_acc.wait()
+
+                    # Pass 2: emit dL_dinput and dL_dgamma
+                    for _local_col in range(wt):
+                        with (
+                            inp_tile.wait() as iv,
+                            gamma_tile.wait() as gv,
+                            rms_tile.wait() as rmv,
+                            dL_tile.wait() as dlv,
+                        ):
+                            recip = ttl.math.recip(rmv)
+                            with out_da_tile.reserve() as oa:
+                                oa.store(recip * gv * dlv - scale * iv * recip * recip * inv_c)
+                            with out_dg_tile.reserve() as og:
+                                og.store(iv * recip * dlv)
+
+        @ttl.datamovement()
+        def dm_read():
+            core_col, core_row = ttl.node(dims=2)
+            core_linear = core_row * grid_cols + core_col
+            for local_row in range(rows_per_core):
+                r = core_linear * rows_per_core + local_row
+                if r < ht:
+                    for local_col in range(wt):
+                        with inp_tile.reserve() as b:
+                            ttl.copy(input_t[r, local_col], b).wait()
+                        with gamma_tile.reserve() as b:
+                            ttl.copy(gamma_t[r, local_col], b).wait()
+                        with rms_tile.reserve() as b:
+                            ttl.copy(rms_t[r, local_col], b).wait()
+                        with dL_tile.reserve() as b:
+                            ttl.copy(dL_dout_t[r, local_col], b).wait()
+                    for local_col in range(wt):
+                        with inp_tile.reserve() as b:
+                            ttl.copy(input_t[r, local_col], b).wait()
+                        with gamma_tile.reserve() as b:
+                            ttl.copy(gamma_t[r, local_col], b).wait()
+                        with rms_tile.reserve() as b:
+                            ttl.copy(rms_t[r, local_col], b).wait()
+                        with dL_tile.reserve() as b:
+                            ttl.copy(dL_dout_t[r, local_col], b).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            core_col, core_row = ttl.node(dims=2)
+            core_linear = core_row * grid_cols + core_col
+            for local_row in range(rows_per_core):
+                r = core_linear * rows_per_core + local_row
+                if r < ht:
+                    for local_col in range(wt):
+                        with out_da_tile.wait() as b:
+                            ttl.copy(b, dL_dinput_out[r, local_col]).wait()
+                        with out_dg_tile.wait() as b:
+                            ttl.copy(b, dL_dgamma_comp_out[r, local_col]).wait()
+
+    return rmsnorm_bw_2pass

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 """
-RMSNorm backward — 2-pass tile streaming (vs. ``remsnorm_whole_row.py`` whole-row strip).
+RMSNorm backward — 2-pass tile streaming.
 
 **Pass 1:** per tile-column, accumulate row scalar
-``scale = Σ_c (x · (γ/rms) · dL_dout)`` via ``(contrib @ ones)`` matmul reduction
-(same workaround as ``polynorm3_on_tiles_2pass_working.py``).
+``scale = Sum_c (x · (gamma/rms) · dL_dout)`` via ``(contrib @ ones)`` matmul reduction
 
 **Pass 2:** re-stream tiles and emit
-``dL_dinput = (γ/rms)·dL_dout − scale·x·(1/rms)²·(1/C)``,
+``dL_dinput = (gamma/rms)·dL_dout - scale·x·(1/rms)^2·(1/C)``,
 ``dL_dgamma = x·(1/rms)·dL_dout``.
 """
 from __future__ import annotations
@@ -55,6 +54,8 @@ def make_kernel():
 
         # Constant 1/C tile for rhs
         inv_c_dfb = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=1)
+        # Unity tile for (contrib @ ones) row reduction
+        reduce_tile_dfb = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=1)
 
         @ttl.compute()
         def compute():
@@ -63,6 +64,10 @@ def make_kernel():
             with inv_c_dfb.reserve() as ic:
                 ic.store(ttl.math.fill(ic, inv_c_scalar))
             inv_c = inv_c_dfb.wait()
+
+            with reduce_tile_dfb.reserve() as rt:
+                rt.store(ttl.math.fill(rt, 1.0))
+            reduce_tile = reduce_tile_dfb.wait()
 
             for local_row in range(rows_per_core):
                 row = core_linear * rows_per_core + local_row
@@ -82,7 +87,6 @@ def make_kernel():
                             recip = ttl.math.recip(rmv)
                             gained = recip * gv * dlv
                             contrib = iv * gained
-                            reduce_tile = ttl.math.fill(contrib, 1.0)
                             with scale_acc.reserve() as o:
                                 o.store(s + (contrib @ reduce_tile))
 
@@ -142,3 +146,17 @@ def make_kernel():
                             ttl.copy(b, dL_dgamma_comp_out[r, local_col]).wait()
 
     return rmsnorm_bw_2pass
+
+
+def _to_dev(t, device):
+    return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+                            device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+
+def _pad(t, rows_padded, cols_padded):
+    rows, cols = t.shape
+    pad_r = rows_padded - rows
+    pad_c = cols_padded - cols
+    if pad_r == 0 and pad_c == 0:
+        return t
+    return torch.nn.functional.pad(t, (0, pad_c, 0, pad_r), value=0.0)

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
@@ -18,6 +18,7 @@ import torch
 
 TILE_WIDTH = 32
 
+
 def get_block_size(whole_row_width: int = 32, max_block_size: int = 4) -> int:
     """
     Same logic as tt-train/.../metal/common/program_utils.hpp get_block_size:
@@ -26,6 +27,7 @@ def get_block_size(whole_row_width: int = 32, max_block_size: int = 4) -> int:
         if whole_row_width % block_size == 0:
             return block_size
     return 1
+
 
 def make_kernel():
     bc = 2
@@ -41,9 +43,7 @@ def make_kernel():
     ):
         cols = input_t.shape[1]
         if cols % TILE_WIDTH != 0:
-            raise ValueError(
-                f"input_t width ({cols}) must be divisible by TILE_WIDTH ({TILE_WIDTH})"
-            )
+            raise ValueError(f"input_t width ({cols}) must be divisible by TILE_WIDTH ({TILE_WIDTH})")
         ht = input_t.shape[0] // TILE_WIDTH
         wt = cols // TILE_WIDTH
         block_size = get_block_size(wt, 2)
@@ -139,10 +139,7 @@ def make_kernel():
                                     dL_blk.wait() as dlv,
                                 ):
                                     with out_da_blk.reserve() as oa:
-                                        oa.store(
-                                            recip_w * gv * dlv
-                                            - scale_w * iv * recip_w * recip_w * inv_c_w
-                                        )
+                                        oa.store(recip_w * gv * dlv - scale_w * iv * recip_w * recip_w * inv_c_w)
                                     with out_dg_blk.reserve() as og:
                                         og.store(iv * recip_w * dlv)
 
@@ -214,9 +211,10 @@ def run_rmsnorm_bw_2pass(device, kernel, x_p, g_p, rms_p, dL_p, out_da, out_dg):
 
 
 def to_dev(t, device):
-   return ttnn.from_torch(
+    return ttnn.from_torch(
         t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
+
 
 def pad(t, rows_padded, cols_padded):
     rows, cols = t.shape

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
@@ -13,9 +13,19 @@ RMSNorm backward — 2-pass tile streaming.
 from __future__ import annotations
 
 import ttl
+import ttnn
+import torch
 
 TILE_WIDTH = 32
 
+def get_block_size(whole_row_width: int = 32, max_block_size: int = 4) -> int:
+    """
+    Same logic as tt-train/.../metal/common/program_utils.hpp get_block_size:
+    """
+    for block_size in range(max_block_size, 1, -1):
+        if whole_row_width % block_size == 0:
+            return block_size
+    return 1
 
 def make_kernel():
     bc = 2
@@ -31,7 +41,10 @@ def make_kernel():
     ):
         ht = input_t.shape[0] // TILE_WIDTH
         wt = input_t.shape[1] // TILE_WIDTH
-        one = (1, 1)
+        block_size = get_block_size(wt, 2)
+        blk = (1, block_size)
+        tile = (1, 1)
+        num_col_blocks = wt // block_size
         elem_c = wt * TILE_WIDTH
         inv_c_scalar = 1.0 / elem_c
 
@@ -39,23 +52,27 @@ def make_kernel():
         total_cores = grid_cols * grid_rows
         rows_per_core = -(-ht // total_cores)
 
-        # Input buffers
-        inp_tile = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=bc)
-        gamma_tile = ttl.make_dataflow_buffer_like(gamma_t, shape=one, block_count=bc)
-        rms_tile = ttl.make_dataflow_buffer_like(rms_t, shape=one, block_count=bc)
-        dL_tile = ttl.make_dataflow_buffer_like(dL_dout_t, shape=one, block_count=bc)
+        # Input buffers (width streamed in blocks of block_size tiles)
+        inp_blk = ttl.make_dataflow_buffer_like(input_t, shape=blk, block_count=bc)
+        gamma_blk = ttl.make_dataflow_buffer_like(gamma_t, shape=blk, block_count=bc)
+        rms_tile = ttl.make_dataflow_buffer_like(rms_t, shape=tile, block_count=bc)
+        dL_blk = ttl.make_dataflow_buffer_like(dL_dout_t, shape=blk, block_count=bc)
 
         # Output buffers
-        out_da_tile = ttl.make_dataflow_buffer_like(dL_dinput_out, shape=one, block_count=bc)
-        out_dg_tile = ttl.make_dataflow_buffer_like(dL_dgamma_comp_out, shape=one, block_count=bc)
+        out_da_blk = ttl.make_dataflow_buffer_like(dL_dinput_out, shape=blk, block_count=bc)
+        out_dg_blk = ttl.make_dataflow_buffer_like(dL_dgamma_comp_out, shape=blk, block_count=bc)
 
-        # Scale accumulator
-        scale_acc = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=bc)
+        # Scale accumulator (row scalar)
+        scale_acc = ttl.make_dataflow_buffer_like(input_t, shape=tile, block_count=bc)
 
         # Constant 1/C tile for rhs
-        inv_c_dfb = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=1)
-        # Unity tile for (contrib @ ones) row reduction
-        reduce_tile_dfb = ttl.make_dataflow_buffer_like(input_t, shape=one, block_count=1)
+        inv_c_dfb = ttl.make_dataflow_buffer_like(input_t, shape=tile, block_count=1)
+        # Unity column for (1, block_size) @ (block_size, 1) row reduction (reduce_sum unsupported).
+        reduce_col_dfb = ttl.make_dataflow_buffer_like(input_t, shape=(block_size, 1), block_count=1)
+        # Broadcast scalars to block width once per row (reused each col block).
+        recip_bc_blk = ttl.make_dataflow_buffer_like(input_t, shape=blk, block_count=1)
+        scale_bc_blk = ttl.make_dataflow_buffer_like(input_t, shape=blk, block_count=1)
+        inv_c_bc_blk = ttl.make_dataflow_buffer_like(input_t, shape=blk, block_count=1)
 
         @ttl.compute()
         def compute():
@@ -65,9 +82,9 @@ def make_kernel():
                 ic.store(ttl.math.fill(ic, inv_c_scalar))
             inv_c = inv_c_dfb.wait()
 
-            with reduce_tile_dfb.reserve() as rt:
-                rt.store(ttl.math.fill(rt, 1.0))
-            reduce_tile = reduce_tile_dfb.wait()
+            with reduce_col_dfb.reserve() as rc:
+                rc.store(ttl.math.fill(rc, 1.0))
+            reduce_col = reduce_col_dfb.wait()
 
             for local_row in range(rows_per_core):
                 row = core_linear * rows_per_core + local_row
@@ -75,36 +92,54 @@ def make_kernel():
                     with scale_acc.reserve() as z:
                         z.store(ttl.math.fill(z, 0.0))
 
-                    # Pass 1: accumulate row scalar
-                    for _local_col in range(wt):
-                        with (
-                            inp_tile.wait() as iv,
-                            gamma_tile.wait() as gv,
-                            rms_tile.wait() as rmv,
-                            dL_tile.wait() as dlv,
-                            scale_acc.wait() as s,
-                        ):
-                            recip = ttl.math.recip(rmv)
-                            gained = recip * gv * dlv
-                            contrib = iv * gained
-                            with scale_acc.reserve() as o:
-                                o.store(s + (contrib @ reduce_tile))
+                    # Pass 1: accumulate row scalar (one RMS tile per row).
+                    with rms_tile.wait() as rmv:
+                        recip = ttl.math.recip(rmv)
+                        with recip_bc_blk.reserve() as rb:
+                            rb.store(ttl.math.broadcast(recip, rb, dims=[1]))
+                        with recip_bc_blk.wait() as recip_w:
+                            for blk_idx in range(num_col_blocks):
+                                with (
+                                    inp_blk.wait() as iv,
+                                    gamma_blk.wait() as gv,
+                                    dL_blk.wait() as dlv,
+                                    scale_acc.wait() as s,
+                                ):
+                                    gained = recip_w * gv * dlv
+                                    contrib = iv * gained
+                                    partial = contrib @ reduce_col
+                                    with scale_acc.reserve() as o:
+                                        o.store(s + partial)
 
                     scale = scale_acc.wait()
 
                     # Pass 2: emit dL_dinput and dL_dgamma
-                    for _local_col in range(wt):
+                    with rms_tile.wait() as rmv:
+                        recip = ttl.math.recip(rmv)
+                        with recip_bc_blk.reserve() as rb:
+                            rb.store(ttl.math.broadcast(recip, rb, dims=[1]))
+                        with scale_bc_blk.reserve() as sb:
+                            sb.store(ttl.math.broadcast(scale, sb, dims=[1]))
+                        with inv_c_bc_blk.reserve() as ib:
+                            ib.store(ttl.math.broadcast(inv_c, ib, dims=[1]))
                         with (
-                            inp_tile.wait() as iv,
-                            gamma_tile.wait() as gv,
-                            rms_tile.wait() as rmv,
-                            dL_tile.wait() as dlv,
+                            recip_bc_blk.wait() as recip_w,
+                            scale_bc_blk.wait() as scale_w,
+                            inv_c_bc_blk.wait() as inv_c_w,
                         ):
-                            recip = ttl.math.recip(rmv)
-                            with out_da_tile.reserve() as oa:
-                                oa.store(recip * gv * dlv - scale * iv * recip * recip * inv_c)
-                            with out_dg_tile.reserve() as og:
-                                og.store(iv * recip * dlv)
+                            for blk_idx in range(num_col_blocks):
+                                with (
+                                    inp_blk.wait() as iv,
+                                    gamma_blk.wait() as gv,
+                                    dL_blk.wait() as dlv,
+                                ):
+                                    with out_da_blk.reserve() as oa:
+                                        oa.store(
+                                            recip_w * gv * dlv
+                                            - scale_w * iv * recip_w * recip_w * inv_c_w
+                                        )
+                                    with out_dg_blk.reserve() as og:
+                                        og.store(iv * recip_w * dlv)
 
         @ttl.datamovement()
         def dm_read():
@@ -113,24 +148,40 @@ def make_kernel():
             for local_row in range(rows_per_core):
                 r = core_linear * rows_per_core + local_row
                 if r < ht:
-                    for local_col in range(wt):
-                        with inp_tile.reserve() as b:
-                            ttl.copy(input_t[r, local_col], b).wait()
-                        with gamma_tile.reserve() as b:
-                            ttl.copy(gamma_t[r, local_col], b).wait()
-                        with rms_tile.reserve() as b:
-                            ttl.copy(rms_t[r, local_col], b).wait()
-                        with dL_tile.reserve() as b:
-                            ttl.copy(dL_dout_t[r, local_col], b).wait()
-                    for local_col in range(wt):
-                        with inp_tile.reserve() as b:
-                            ttl.copy(input_t[r, local_col], b).wait()
-                        with gamma_tile.reserve() as b:
-                            ttl.copy(gamma_t[r, local_col], b).wait()
-                        with rms_tile.reserve() as b:
-                            ttl.copy(rms_t[r, local_col], b).wait()
-                        with dL_tile.reserve() as b:
-                            ttl.copy(dL_dout_t[r, local_col], b).wait()
+                    # Pass 1
+                    with rms_tile.reserve() as b:
+                        ttl.copy(rms_t[r, 0], b).wait()
+                    for blk_idx in range(num_col_blocks):
+                        col_start = blk_idx * block_size
+                        col_end = col_start + block_size
+                        with (
+                            inp_blk.reserve() as i_blk,
+                            gamma_blk.reserve() as g_blk,
+                            dL_blk.reserve() as d_blk,
+                        ):
+                            i_tx = ttl.copy(input_t[r, col_start:col_end], i_blk)
+                            g_tx = ttl.copy(gamma_t[r, col_start:col_end], g_blk)
+                            d_tx = ttl.copy(dL_dout_t[r, col_start:col_end], d_blk)
+                            i_tx.wait()
+                            g_tx.wait()
+                            d_tx.wait()
+                    # Pass 2
+                    with rms_tile.reserve() as b:
+                        ttl.copy(rms_t[r, 0], b).wait()
+                    for blk_idx in range(num_col_blocks):
+                        col_start = blk_idx * block_size
+                        col_end = col_start + block_size
+                        with (
+                            inp_blk.reserve() as i_blk,
+                            gamma_blk.reserve() as g_blk,
+                            dL_blk.reserve() as d_blk,
+                        ):
+                            i_tx = ttl.copy(input_t[r, col_start:col_end], i_blk)
+                            g_tx = ttl.copy(gamma_t[r, col_start:col_end], g_blk)
+                            d_tx = ttl.copy(dL_dout_t[r, col_start:col_end], d_blk)
+                            i_tx.wait()
+                            g_tx.wait()
+                            d_tx.wait()
 
         @ttl.datamovement()
         def dm_write():
@@ -139,21 +190,30 @@ def make_kernel():
             for local_row in range(rows_per_core):
                 r = core_linear * rows_per_core + local_row
                 if r < ht:
-                    for local_col in range(wt):
-                        with out_da_tile.wait() as b:
-                            ttl.copy(b, dL_dinput_out[r, local_col]).wait()
-                        with out_dg_tile.wait() as b:
-                            ttl.copy(b, dL_dgamma_comp_out[r, local_col]).wait()
+                    for blk_idx in range(num_col_blocks):
+                        col_start = blk_idx * block_size
+                        col_end = col_start + block_size
+                        with out_da_blk.wait() as b:
+                            ttl.copy(b, dL_dinput_out[r, col_start:col_end]).wait()
+                        with out_dg_blk.wait() as b:
+                            ttl.copy(b, dL_dgamma_comp_out[r, col_start:col_end]).wait()
 
     return rmsnorm_bw_2pass
 
 
-def _to_dev(t, device):
-    return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-                            device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+def run_rmsnorm_bw_2pass(device, kernel, x_p, g_p, rms_p, dL_p, out_da, out_dg):
+    """Run 2-pass TTL kernel; reduce per-row dL/dgamma components like ``ttml::rmsnorm_bw``."""
+    kernel(x_p, g_p, rms_p, dL_p, out_da, out_dg)
+    dg_reduced = ttnn.sum(out_dg, dim=[0], keepdim=True)
+    return out_da, dg_reduced
 
 
-def _pad(t, rows_padded, cols_padded):
+def to_dev(t, device):
+   return ttnn.from_torch(
+        t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+def pad(t, rows_padded, cols_padded):
     rows, cols = t.shape
     pad_r = rows_padded - rows
     pad_c = cols_padded - cols

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass.py
@@ -39,8 +39,13 @@ def make_kernel():
         dL_dinput_out,
         dL_dgamma_comp_out,
     ):
+        cols = input_t.shape[1]
+        if cols % TILE_WIDTH != 0:
+            raise ValueError(
+                f"input_t width ({cols}) must be divisible by TILE_WIDTH ({TILE_WIDTH})"
+            )
         ht = input_t.shape[0] // TILE_WIDTH
-        wt = input_t.shape[1] // TILE_WIDTH
+        wt = cols // TILE_WIDTH
         block_size = get_block_size(wt, 2)
         blk = (1, block_size)
         tile = (1, 1)
@@ -160,7 +165,7 @@ def make_kernel():
                             dL_blk.reserve() as d_blk,
                         ):
                             i_tx = ttl.copy(input_t[r, col_start:col_end], i_blk)
-                            g_tx = ttl.copy(gamma_t[r, col_start:col_end], g_blk)
+                            g_tx = ttl.copy(gamma_t[0, col_start:col_end], g_blk)
                             d_tx = ttl.copy(dL_dout_t[r, col_start:col_end], d_blk)
                             i_tx.wait()
                             g_tx.wait()
@@ -177,7 +182,7 @@ def make_kernel():
                             dL_blk.reserve() as d_blk,
                         ):
                             i_tx = ttl.copy(input_t[r, col_start:col_end], i_blk)
-                            g_tx = ttl.copy(gamma_t[r, col_start:col_end], g_blk)
+                            g_tx = ttl.copy(gamma_t[0, col_start:col_end], g_blk)
                             d_tx = ttl.copy(dL_dout_t[r, col_start:col_end], d_blk)
                             i_tx.wait()
                             g_tx.wait()

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Compare TT-Lang 2-pass RMSNorm backward (``ttl_rmsnorm_bw_2pass``) to a PyTorch reference.
+"""
+from __future__ import annotations
+
+import torch
+import ttnn
+
+TILE = 32
+
+import ttl_rmsnorm_bw_2pass as ttl_mod  # noqa: E402
+
+
+def _torch_ref(x, gamma_1d, eps, dL):
+    x = x.float().clone().requires_grad_(True)
+    g = gamma_1d.float().clone().requires_grad_(True)
+    dL = dL.float()
+    var = x.pow(2).mean(-1, keepdim=True)
+    rms = (var + eps).sqrt()
+    y = x / rms * g
+    y.backward(dL)
+    return x.grad.to(torch.bfloat16), g.grad.to(torch.bfloat16), rms.detach().to(torch.bfloat16)
+
+
+def _pad(t, rows_padded, cols_padded):
+    rows, cols = t.shape
+    pad_r = rows_padded - rows
+    pad_c = cols_padded - cols
+    if pad_r == 0 and pad_c == 0:
+        return t
+    return torch.nn.functional.pad(t, (0, pad_c, 0, pad_r), value=0.0)
+
+
+def _run_case(
+    device: ttnn.Device,
+    rows: int,
+    cols: int,
+    label: str,
+    rtol: float,
+    atol: float,
+) -> None:
+    eps = 1e-5 if cols // TILE > 1 else 0.0078125
+    torch.manual_seed(0)
+    x = torch.randn(rows, cols, dtype=torch.bfloat16)
+    g1d = torch.randn(cols, dtype=torch.bfloat16)
+    g2d = g1d.unsqueeze(0).expand(rows, cols).contiguous()
+    with torch.no_grad():
+        var = x.float().pow(2).mean(-1, keepdim=True)
+        rms = (var + eps).sqrt()
+        y = x.float() / rms * g2d.float()
+    dL = ((2.0 / y.numel()) * y).to(torch.bfloat16)
+    rms_2d = rms.float().expand(-1, cols).contiguous()
+
+    dL_dx_ref, dL_dg_ref, _ = _torch_ref(x, g1d, eps, dL)
+
+    rows_p = -(-rows // TILE) * TILE
+    cols_p = -(-cols // TILE) * TILE
+    x_p = _pad(x, rows_p, cols_p)
+    g_p = _pad(g2d, rows_p, cols_p)
+    rms_p = _pad(rms_2d, rows_p, cols_p)
+    dL_p = _pad(dL, rows_p, cols_p)
+
+    k = ttl_mod.make_kernel()
+    out_da = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), device)
+    out_dg = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), device)
+    k(
+        ttl_mod._to_dev(x_p, device),
+        ttl_mod._to_dev(g_p, device),
+        ttl_mod._to_dev(rms_p, device),
+        ttl_mod._to_dev(dL_p, device),
+        out_da,
+        out_dg,
+    )
+    ttnn.synchronize_device(device)
+
+    da = ttnn.to_torch(out_da)[:rows, :cols]
+    dg = ttnn.to_torch(out_dg)[:rows, :cols]
+    ttnn.deallocate(out_da)
+    ttnn.deallocate(out_dg)
+
+    torch.testing.assert_close(da, dL_dx_ref, rtol=rtol, atol=atol)
+    print(f"OK {label}: dL/dx matches torch ref (rtol={rtol}, atol={atol}).")
+    torch.testing.assert_close(dg.sum(dim=0), dL_dg_ref, rtol=rtol, atol=atol)
+    print(f"OK {label}: dL/dgamma (column sum) matches torch ref (rtol={rtol}, atol={atol}).")
+
+
+def main() -> None:
+    # Taken from tests/ops/rmsnorm_op_test.cpp
+    rtol, atol = 1.0e-3, 2.0e-3
+    device = ttnn.open_device(device_id=0)
+
+    try:
+        _run_case(device, 64, 384, "64x384", rtol, atol)
+        _run_case(device, 4096, 4096, "4096x4096", rtol, atol)
+        _run_case(device, 8192, 8192, "8192x8192", rtol, atol)
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
@@ -76,8 +76,6 @@ def _run_case(
 
     da = ttnn.to_torch(out_da)[:rows, :cols]
     dg = ttnn.to_torch(out_dg)[:rows, :cols]
-    ttnn.deallocate(out_da)
-    ttnn.deallocate(out_dg)
 
     torch.testing.assert_close(da, dL_dx_ref, rtol=rtol, atol=atol)
     print(f"OK {label}: dL/dx matches torch ref (rtol={rtol}, atol={atol}).")

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
@@ -35,22 +35,21 @@ def _run_case(
     torch.manual_seed(0)
     x = torch.randn(rows, cols, dtype=torch.bfloat16)
     g1d = torch.randn(cols, dtype=torch.bfloat16)
-    g2d = g1d.unsqueeze(0).expand(rows, cols).contiguous()
     with torch.no_grad():
         var = x.float().pow(2).mean(-1, keepdim=True)
         rms = (var + eps).sqrt()
-        y = x.float() / rms * g2d.float()
+        y = x.float() / rms * g1d.float()
     dL = ((2.0 / y.numel()) * y).to(torch.bfloat16)
-    rms_2d = rms.float().expand(-1, cols).contiguous()
 
     dL_dx_ref, dL_dg_ref, _ = _torch_ref(x, g1d, eps, dL)
+    # Match run_rmsnorm_bw_2pass: ttnn.sum(..., dim=[0], keepdim=True) -> [1, C].
     dL_dg_ref = dL_dg_ref.unsqueeze(0)
 
     rows_p = -(-rows // TILE) * TILE
     cols_p = -(-cols // TILE) * TILE
     x_p = ttl_mod.pad(x, rows_p, cols_p)
-    g_p = ttl_mod.pad(g2d, rows_p, cols_p)
-    rms_p = ttl_mod.pad(rms_2d, rows_p, cols_p)
+    g_p = ttl_mod.pad(g1d.unsqueeze(0), 1, cols_p)
+    rms_p = ttl_mod_pad(rms.to(torch.bfloat16), rows_p, 1)
     dL_p = ttl_mod.pad(dL, rows_p, cols_p)
 
     k = ttl_mod.make_kernel()

--- a/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
+++ b/tt-train/sources/ttml/ttlang/ttl_rmsnorm_bw_2pass_test.py
@@ -23,15 +23,6 @@ def _torch_ref(x, gamma_1d, eps, dL):
     return x.grad.to(torch.bfloat16), g.grad.to(torch.bfloat16), rms.detach().to(torch.bfloat16)
 
 
-def _pad(t, rows_padded, cols_padded):
-    rows, cols = t.shape
-    pad_r = rows_padded - rows
-    pad_c = cols_padded - cols
-    if pad_r == 0 and pad_c == 0:
-        return t
-    return torch.nn.functional.pad(t, (0, pad_c, 0, pad_r), value=0.0)
-
-
 def _run_case(
     device: ttnn.Device,
     rows: int,
@@ -53,34 +44,37 @@ def _run_case(
     rms_2d = rms.float().expand(-1, cols).contiguous()
 
     dL_dx_ref, dL_dg_ref, _ = _torch_ref(x, g1d, eps, dL)
+    dL_dg_ref = dL_dg_ref.unsqueeze(0)
 
     rows_p = -(-rows // TILE) * TILE
     cols_p = -(-cols // TILE) * TILE
-    x_p = _pad(x, rows_p, cols_p)
-    g_p = _pad(g2d, rows_p, cols_p)
-    rms_p = _pad(rms_2d, rows_p, cols_p)
-    dL_p = _pad(dL, rows_p, cols_p)
+    x_p = ttl_mod.pad(x, rows_p, cols_p)
+    g_p = ttl_mod.pad(g2d, rows_p, cols_p)
+    rms_p = ttl_mod.pad(rms_2d, rows_p, cols_p)
+    dL_p = ttl_mod.pad(dL, rows_p, cols_p)
 
     k = ttl_mod.make_kernel()
-    out_da = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), device)
-    out_dg = ttl_mod._to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), device)
-    k(
-        ttl_mod._to_dev(x_p, device),
-        ttl_mod._to_dev(g_p, device),
-        ttl_mod._to_dev(rms_p, device),
-        ttl_mod._to_dev(dL_p, device),
+    out_da = ttl_mod.to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), device)
+    out_dg = ttl_mod.to_dev(torch.zeros(rows_p, cols_p, dtype=torch.bfloat16), device)
+    out_da, dg_reduced_ttnn = ttl_mod.run_rmsnorm_bw_2pass(
+        device,
+        k,
+        ttl_mod.to_dev(x_p, device),
+        ttl_mod.to_dev(g_p, device),
+        ttl_mod.to_dev(rms_p, device),
+        ttl_mod.to_dev(dL_p, device),
         out_da,
         out_dg,
     )
     ttnn.synchronize_device(device)
 
     da = ttnn.to_torch(out_da)[:rows, :cols]
-    dg = ttnn.to_torch(out_dg)[:rows, :cols]
+    dg_reduced = ttnn.to_torch(dg_reduced_ttnn)[:, :cols]
 
     torch.testing.assert_close(da, dL_dx_ref, rtol=rtol, atol=atol)
     print(f"OK {label}: dL/dx matches torch ref (rtol={rtol}, atol={atol}).")
-    torch.testing.assert_close(dg.sum(dim=0), dL_dg_ref, rtol=rtol, atol=atol)
-    print(f"OK {label}: dL/dgamma (column sum) matches torch ref (rtol={rtol}, atol={atol}).")
+    torch.testing.assert_close(dg_reduced, dL_dg_ref, rtol=rtol, atol=atol)
+    print(f"OK {label}: dL/dgamma matches torch ref (rtol={rtol}, atol={atol}).")
 
 
 def main() -> None:


### PR DESCRIPTION
### Summary
Implement rmsnorm_bw in tt-lang and compare performance to [ttml version](https://github.com/tenstorrent/tt-metal/pull/22828).

### Notes for reviewers
Keep in mind this PR is not planned to be merged, it is only used to get benchmark results.

### Benchmark

Shape | Kernel_Metal (µs) | Kernel_TTL_2Pass (µs) | Metal / TTL
-- | -- | -- | --
2048×5632 | 1086.16 | 537.74 | 2.02×
4096×5632 | 2106.76 | 1072.54 | 1.96×
8192×5632 | 3677.81 | 2314.69 | 1.59×
16384×5632 | 6791.88 | 4586.70 | 1.48×
32768×5632 | 13254.15 | 9079.14 | 1.46×


When last dim size is `<= 4096` ttml use `all in L1` implementation - there is no second read from DRAM which is different from the presented ttlang code.


Shape | Kernel_Metal (µs) | Kernel_TTL_2Pass (µs) | Metal / TTL
-- | -- | -- | --
2048×2048 | 403.89 | 308.64 | 1.31×
4096×2048 | 699.38 | 411.38 | 1.70×
8192×2048 | 1101.77 | 877.50 | 1.26×
16384×2048 | 1937.98 | 1750.81 | 1.11×
32768×2048 | 3727.66 | 3456.82 | 1.08×


Shape | Kernel_Metal (µs) | Kernel_TTL_2Pass (µs) | Metal / TTL
-- | -- | -- | --
2048×4096 | 808.51 | 415.16 | 1.95×
4096×4096 | 1406.34 | 817.01 | 1.72×
8192×4096 | 2206.46 | 1753.49 | 1.26×
16384×4096 | 3870.89 | 3463.69 | 1.12×
32768×4096 | 7513.34 | 6858.11 | 1.10×


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_rmsnorm_bw)