### PR TITLE
Fix Fabric get_line_coordinates for large grid topologies

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -86,7 +86,8 @@ TEST(MeshDeviceViewTest, GetLineCoordinates2x2WithOffset) {
         MeshDeviceView::get_line_coordinates(/*length*/ 2, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(1, 0));
     ASSERT_THAT(line_coords, SizeIs(2));
     EXPECT_EQ(line_coords[0], MeshCoordinate(1, 0));
-    EXPECT_EQ(line_coords[1], MeshCoordinate(1, 1));
+    // Hamiltonian cycle for 2x2 is (0,0),(0,1),(1,1),(1,0). Rotated to start at (1,0): next is (0,0).
+    EXPECT_EQ(line_coords[1], MeshCoordinate(0, 0));
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates3x3) {
@@ -173,6 +174,126 @@ TEST(MeshDeviceViewTest, GetLineCoordinatesRingPreferredButNotRequired) {
     std::set<MeshCoordinate> unique_coords_9(line_coords_9.begin(), line_coords_9.end());
     EXPECT_EQ(unique_coords_9.size(), 9);  // All nodes should be unique
     // Function succeeds, ring formation is preferred but not required
+}
+
+// Helper to verify Hamiltonian cycle properties:
+// 1. Correct length
+// 2. All coordinates unique
+// 3. All consecutive pairs are adjacent (Manhattan distance 1)
+// 4. Last coordinate is adjacent to first (ring closure)
+void VerifyHamiltonianCycle(const std::vector<MeshCoordinate>& coords, size_t expected_size) {
+    ASSERT_EQ(coords.size(), expected_size);
+
+    // All unique
+    std::set<MeshCoordinate> unique(coords.begin(), coords.end());
+    EXPECT_EQ(unique.size(), expected_size) << "Not all coordinates are unique";
+
+    auto is_adjacent = [](const MeshCoordinate& a, const MeshCoordinate& b) -> bool {
+        size_t row_diff = (a[0] > b[0]) ? (a[0] - b[0]) : (b[0] - a[0]);
+        size_t col_diff = (a[1] > b[1]) ? (a[1] - b[1]) : (b[1] - a[1]);
+        return (row_diff == 1 && col_diff == 0) || (row_diff == 0 && col_diff == 1);
+    };
+
+    // All consecutive pairs adjacent
+    for (size_t i = 0; i + 1 < coords.size(); ++i) {
+        EXPECT_TRUE(is_adjacent(coords[i], coords[i + 1]))
+            << "Coordinates at index " << i << " " << coords[i] << " and " << i + 1 << " " << coords[i + 1]
+            << " are not adjacent";
+    }
+
+    // Ring closure: last adjacent to first
+    if (coords.size() > 1) {
+        EXPECT_TRUE(is_adjacent(coords.back(), coords.front()))
+            << "Last coordinate " << coords.back() << " is not adjacent to first " << coords.front()
+            << " (ring not closed)";
+    }
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates2x4) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 8, /*mesh_shape*/ Shape2D(2, 4), /*mesh_offset*/ Shape2D(0, 0));
+    VerifyHamiltonianCycle(line_coords, 8);
+    // Verify identical to the old perimeter traversal (backward compatibility)
+    EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(line_coords[2], MeshCoordinate(0, 2));
+    EXPECT_EQ(line_coords[3], MeshCoordinate(0, 3));
+    EXPECT_EQ(line_coords[4], MeshCoordinate(1, 3));
+    EXPECT_EQ(line_coords[5], MeshCoordinate(1, 2));
+    EXPECT_EQ(line_coords[6], MeshCoordinate(1, 1));
+    EXPECT_EQ(line_coords[7], MeshCoordinate(1, 0));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates4x2) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 8, /*mesh_shape*/ Shape2D(4, 2), /*mesh_offset*/ Shape2D(0, 0));
+    VerifyHamiltonianCycle(line_coords, 8);
+    // Verify identical to the old perimeter traversal (backward compatibility)
+    EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(line_coords[2], MeshCoordinate(1, 1));
+    EXPECT_EQ(line_coords[3], MeshCoordinate(2, 1));
+    EXPECT_EQ(line_coords[4], MeshCoordinate(3, 1));
+    EXPECT_EQ(line_coords[5], MeshCoordinate(3, 0));
+    EXPECT_EQ(line_coords[6], MeshCoordinate(2, 0));
+    EXPECT_EQ(line_coords[7], MeshCoordinate(1, 0));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates4x4) {
+    auto line_coords = MeshDeviceView::get_line_coordinates(
+        /*length*/ 16, /*mesh_shape*/ Shape2D(4, 4), /*mesh_offset*/ Shape2D(0, 0));
+    VerifyHamiltonianCycle(line_coords, 16);
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates8x4) {
+    // The Galaxy case: 32 devices in an 8x4 grid
+    auto line_coords = MeshDeviceView::get_line_coordinates(
+        /*length*/ 32, /*mesh_shape*/ Shape2D(8, 4), /*mesh_offset*/ Shape2D(0, 0));
+    VerifyHamiltonianCycle(line_coords, 32);
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates4x8) {
+    auto line_coords = MeshDeviceView::get_line_coordinates(
+        /*length*/ 32, /*mesh_shape*/ Shape2D(4, 8), /*mesh_offset*/ Shape2D(0, 0));
+    VerifyHamiltonianCycle(line_coords, 32);
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates2x8) {
+    auto line_coords = MeshDeviceView::get_line_coordinates(
+        /*length*/ 16, /*mesh_shape*/ Shape2D(2, 8), /*mesh_offset*/ Shape2D(0, 0));
+    VerifyHamiltonianCycle(line_coords, 16);
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates3x4) {
+    // Odd rows, even cols — uses transposed Hamiltonian cycle
+    auto line_coords = MeshDeviceView::get_line_coordinates(
+        /*length*/ 12, /*mesh_shape*/ Shape2D(3, 4), /*mesh_offset*/ Shape2D(0, 0));
+    VerifyHamiltonianCycle(line_coords, 12);
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates4x4WithOffset) {
+    auto line_coords = MeshDeviceView::get_line_coordinates(
+        /*length*/ 16, /*mesh_shape*/ Shape2D(4, 4), /*mesh_offset*/ Shape2D(2, 1));
+    VerifyHamiltonianCycle(line_coords, 16);
+    EXPECT_EQ(line_coords[0], MeshCoordinate(2, 1));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates1x8) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 8, /*mesh_shape*/ Shape2D(1, 8), /*mesh_offset*/ Shape2D(0, 0));
+    ASSERT_THAT(line_coords, SizeIs(8));
+    for (size_t i = 0; i < 8; ++i) {
+        EXPECT_EQ(line_coords[i], MeshCoordinate(0, static_cast<uint32_t>(i)));
+    }
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates8x1) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 8, /*mesh_shape*/ Shape2D(8, 1), /*mesh_offset*/ Shape2D(0, 0));
+    ASSERT_THAT(line_coords, SizeIs(8));
+    for (size_t i = 0; i < 8; ++i) {
+        EXPECT_EQ(line_coords[i], MeshCoordinate(static_cast<uint32_t>(i), 0));
+    }
 }
 
 using MeshDeviceView2x4Test = MeshDevice2x4Fixture;

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -201,6 +201,56 @@ MeshCoordinate MeshDeviceViewImpl::find_device(ChipId device_id) const {
 
 bool MeshDeviceViewImpl::is_mesh_2d() const { return shape_2d_.has_value(); }
 
+// Generate a Hamiltonian cycle (visits every vertex exactly once, last vertex adjacent to first)
+// for an M x N grid where M is even, M > 1, and N > 1. Runs in O(M*N) time.
+//
+// Algorithm: "even-rows zigzag with return column"
+//   1. Row 0: traverse left to right across all N columns
+//   2. Rows 1..M-1: zigzag through columns 1..N-1 (reserving column 0 for the return path)
+//      - Odd rows go right to left (N-1 down to 1)
+//      - Even rows go left to right (1 up to N-1)
+//   3. Column 0: traverse bottom to top from row M-1 down to row 1
+//   Ring closure: last vertex (1,0) is adjacent to first vertex (0,0).
+//
+// When M is odd but N is even, the caller transposes (swaps row/col) to make M the even dimension.
+static std::vector<MeshCoordinate> generate_hamiltonian_cycle(size_t M, size_t N, bool transpose) {
+    std::vector<MeshCoordinate> cycle;
+    cycle.reserve(M * N);
+
+    auto emit = [&](size_t r, size_t c) {
+        if (transpose) {
+            cycle.emplace_back(static_cast<uint32_t>(c), static_cast<uint32_t>(r));
+        } else {
+            cycle.emplace_back(static_cast<uint32_t>(r), static_cast<uint32_t>(c));
+        }
+    };
+
+    // Row 0: left to right
+    for (size_t c = 0; c < N; ++c) {
+        emit(0, c);
+    }
+
+    // Rows 1 to M-1: zigzag through cols 1 to N-1
+    for (size_t r = 1; r < M; ++r) {
+        if (r % 2 == 1) {
+            for (size_t c = N - 1; c >= 1; --c) {
+                emit(r, c);
+            }
+        } else {
+            for (size_t c = 1; c < N; ++c) {
+                emit(r, c);
+            }
+        }
+    }
+
+    // Column 0: bottom to top (M-1 down to 1)
+    for (size_t r = M - 1; r >= 1; --r) {
+        emit(r, 0);
+    }
+
+    return cycle;
+}
+
 std::vector<MeshCoordinate> MeshDeviceViewImpl::get_line_coordinates(
     size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset) {
     const auto [num_rows, num_cols] = mesh_shape;
@@ -215,35 +265,67 @@ std::vector<MeshCoordinate> MeshDeviceViewImpl::get_line_coordinates(
         num_rows,
         num_cols);
 
-    // Iterate in a zigzag pattern from top-left to bottom-right, starting at the offset.
     std::vector<MeshCoordinate> line_coords;
     line_coords.reserve(length);
 
-    // NOTE: Special case: For 2x4 or 4x2 mesh shapes, use perimeter traversal to avoid snake patterns
-    // that cause fabric initialization issues on T3K
-    // https://github.com/tenstorrent/tt-metal/issues/33737
-    if (mesh_shape == Shape2D(2, 4) || mesh_shape == Shape2D(4, 2)) {
-        auto ring_coords = get_ring_coordinates(mesh_shape, mesh_shape);
-        MeshCoordinate start_coord(start_row, start_col);
-        auto start_it = std::find(ring_coords.begin(), ring_coords.end(), start_coord);
-        TT_FATAL(
-            start_it != ring_coords.end(), "Mesh offset ({}, {}) not found in ring coordinates", start_row, start_col);
+    // Case 1: Single row or column — simple linear path, no ring possible
+    if (num_rows == 1 || num_cols == 1) {
+        // Zigzag starting from offset along the non-trivial dimension
+        size_t total = num_rows * num_cols;
+        TT_FATAL(length <= total, "Length {} exceeds grid size {}", length, total);
 
-        // check the length is less than or equal to the number of ring coordinates
-        TT_FATAL(
-            length <= ring_coords.size(),
-            "Length {} is greater than the number of ring coordinates {}",
-            length,
-            ring_coords.size());
-
-        size_t start_idx = std::distance(ring_coords.begin(), start_it);
-        for (size_t i = 0; i < length; ++i) {
-            line_coords.push_back(ring_coords[(start_idx + i) % ring_coords.size()]);
+        if (num_rows == 1) {
+            for (size_t i = 0; i < length; ++i) {
+                line_coords.emplace_back(
+                    static_cast<uint32_t>(start_row), static_cast<uint32_t>((start_col + i) % num_cols));
+            }
+        } else {
+            for (size_t i = 0; i < length; ++i) {
+                line_coords.emplace_back(
+                    static_cast<uint32_t>((start_row + i) % num_rows), static_cast<uint32_t>(start_col));
+            }
         }
         return line_coords;
     }
 
+    // Case 2: At least one even dimension — deterministic O(M*N) Hamiltonian cycle
+    // For WH_B0 architectures, at least one dimension is always even for grids > 1x1.
+    if (num_rows % 2 == 0 || num_cols % 2 == 0) {
+        bool transpose = (num_rows % 2 != 0);
+        size_t M = transpose ? num_cols : num_rows;
+        size_t N = transpose ? num_rows : num_cols;
+
+        auto cycle = generate_hamiltonian_cycle(M, N, transpose);
+        TT_FATAL(
+            cycle.size() == num_rows * num_cols,
+            "Hamiltonian cycle size {} != grid size {}",
+            cycle.size(),
+            num_rows * num_cols);
+        TT_FATAL(length <= cycle.size(), "Length {} exceeds cycle size {}", length, cycle.size());
+
+        // Find the offset position in the cycle and rotate
+        MeshCoordinate start_coord(start_row, start_col);
+        auto start_it = std::find(cycle.begin(), cycle.end(), start_coord);
+        TT_FATAL(
+            start_it != cycle.end(),
+            "Mesh offset ({}, {}) not found in Hamiltonian cycle for mesh shape ({}, {})",
+            start_row,
+            start_col,
+            num_rows,
+            num_cols);
+
+        size_t start_idx = std::distance(cycle.begin(), start_it);
+        for (size_t i = 0; i < length; ++i) {
+            line_coords.push_back(cycle[(start_idx + i) % cycle.size()]);
+        }
+        return line_coords;
+    }
+
+    // Case 3: Both dimensions odd and > 1 — DFS fallback (can't happen on WH_B0)
+    // A Hamiltonian cycle doesn't exist for grids where both dimensions are odd.
+    // Fall back to DFS with backtracking: try ring first, then accept any connected path.
     const MeshCoordinate start_coord(start_row, start_col);
+
     // Lambda to check if two coordinates are adjacent (direct neighbors only: up, down, left, right)
     // Does NOT consider diagonal neighbors
     auto are_adjacent = [](const MeshCoordinate& a, const MeshCoordinate& b) -> bool {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #43749

### Problem
When `open_mesh_device` creates a line topology (e.g., `mesh_shape=(1,32)`) over an MGD with a 2D `device_topology` (e.g., `(8,4)`), the existing `get_line_coordinates` function fails to produce a ring-forming path for grids larger than 2x4/4x2. This causes CCL ops like `reduce_scatter` to hang on Galaxy with `FABRIC_1D` because the ring wrapping pair ends up non-adjacent — the 1D fabric connection code can only route between direct physical neighbors.

The function had a special-case perimeter ring for 2x4/4x2 grids (added for T3K in #33737), but all other grid sizes fell through to a recursive DFS with backtracking. For a 32-vertex grid (8x4), the DFS is O(exponential) and may fall back to a non-ring snake path where the endpoints are physically far apart (e.g., `(7,0)` and `(0,0)` — 7 rows away).

### Root Cause
The DFS-based Hamiltonian cycle search in `get_line_coordinates` has two problems:
1. **Exponential backtracking** for larger grids — the fixed neighbor ordering (right→down→left→up) leads to extensive search for grids beyond 2x4
2. **Fallback to non-ring path** — when the DFS times out or fails to find a cycle, it accepts any connected path, breaking the ring closure property that 1D fabric requires for wrapping

### Fix
Replace the 2x4/4x2 special case and the general DFS with a **deterministic O(M×N) Hamiltonian cycle algorithm** that works for any grid where at least one dimension is even (guaranteed for WH_B0 by the existing validation in `mesh_graph.cpp:386`).

The algorithm uses an "even-rows zigzag with return column" pattern:
1. Row 0: traverse left→right across all columns
2. Rows 1..M-1: zigzag through columns 1..N-1 (reserving column 0 for the return path)
3. Column 0: traverse bottom→top back to row 1

Ring closure: last vertex `(1,0)` is always adjacent to first vertex `(0,0)`.

When M is odd (but N is even), the algorithm transposes coordinates. The DFS is retained as a fallback only for both-dimensions-odd grids (which can't arise on WH_B0 but may on future architectures).

**Backward compatible**: produces identical output for 2x4 and 4x2 (verified by unit tests that check exact coordinate sequences).

### Testing
- 22 unit tests pass (11 new + 11 existing)
- New tests cover: 2x4, 4x2, 4x4, 8x4, 4x8, 2x8, 3x4, offset rotation, 1xN, Nx1
- Each ring test verifies: correct count, all-unique, all-consecutive-adjacent, ring closure
- Hardware verified: `FABRIC_1D` + `mesh=(1,8)` over `MGD=(2,4)` passes `reduce_scatter` on T3K

### Known Limitation (not resolved by this PR)
`FABRIC_2D` with a reshaped mesh (e.g., `mesh=(1,8)` over `MGD=(2,4)`) still hangs. The root cause there is deeper: the CCL's 2D line multicast routing (`get_forward_backward_line_mcast_configuration` in `ccl_common.cpp`) assumes all multicast targets lie along a single physical direction. When the line path turns corners in the 2D grid, the multicast semaphore signals don't reach all downstream devices. This is an architectural mismatch between the 2D ERISC rectangular multicast model and arbitrary line paths through a 2D grid, and requires changes to the CCL kernel protocol to resolve.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-fabric-coords)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-fabric-coords)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/fix-fabric-coords)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-fabric-coords)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-fabric-coords)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-fabric-coords)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-fabric-coords)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-fabric-coords)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-fabric-coords)