### PR TITLE
Benchmark ttlang vs ttml polynorm3_bw

### DIFF
--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -49,12 +49,14 @@ void AutoContext::reset_graph() {
 }
 
 void AutoContext::open_device(
-    const tt::tt_metal::distributed::MeshShape& mesh_shape, const std::vector<int>& device_ids) {
+    const tt::tt_metal::distributed::MeshShape& mesh_shape,
+    const std::vector<int>& device_ids,
+    size_t worker_l1_size) {
     if (m_device) {
         throw std::runtime_error("open_device was called after the device was created.");
     }
     m_mesh_shape = mesh_shape;
-    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape, device_ids);
+    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape, device_ids, worker_l1_size);
 }
 
 void AutoContext::close_profiler() {

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -101,7 +101,8 @@ public:
 
     void open_device(
         const tt::tt_metal::distributed::MeshShape& mesh_shape = tt::tt_metal::distributed::MeshShape(1, 1),
-        const std::vector<int>& device_ids = std::vector<int>{});
+        const std::vector<int>& device_ids = std::vector<int>{},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
     void close_device();
 

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -10,7 +10,10 @@
 
 namespace ttml::core {
 
-MeshDevice::MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const std::vector<int>& device_ids) :
+MeshDevice::MeshDevice(
+    const tt::tt_metal::distributed::MeshShape& shape,
+    const std::vector<int>& device_ids,
+    size_t worker_l1_size) :
     m_mesh_device(ttnn::distributed::open_mesh_device(
         shape,
         DEFAULT_L1_SMALL_SIZE,
@@ -18,7 +21,8 @@ MeshDevice::MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const 
         /* num_command_queues=*/1,
         tt::tt_metal::DispatchCoreConfig{},
         /*offset=*/std::nullopt,
-        /*physical_device_ids=*/device_ids)) {
+        /*physical_device_ids=*/device_ids,
+        worker_l1_size)) {
     assert(m_mesh_device);
 }
 

--- a/tt-train/sources/ttml/core/mesh_device.hpp
+++ b/tt-train/sources/ttml/core/mesh_device.hpp
@@ -11,7 +11,10 @@ namespace ttml::core {
 // should I implement pimpl or its fine
 class MeshDevice {
 public:
-    explicit MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const std::vector<int>& device_ids);
+    explicit MeshDevice(
+        const tt::tt_metal::distributed::MeshShape& shape,
+        const std::vector<int>& device_ids,
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
     MeshDevice(MeshDevice&& device) = default;
     MeshDevice(const MeshDevice&) = delete;
 

--- a/tt-train/sources/ttml/nanobind/nb_autograd.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_autograd.cpp
@@ -235,7 +235,7 @@ void py_module(nb::module_& m) {
         py_auto_context.def("get_gradient_mode", &AutoContext::get_gradient_mode, "Get gradient mode");
         py_auto_context.def(
             "open_device",
-            [](AutoContext& self, nb::object mesh_shape_obj, nb::object device_ids_obj) {
+            [](AutoContext& self, nb::object mesh_shape_obj, nb::object device_ids_obj, nb::object worker_l1_size_obj) {
                 tt::tt_metal::distributed::MeshShape mesh_shape(1, 1);
 
                 if (!mesh_shape_obj.is_none()) {
@@ -255,10 +255,16 @@ void py_module(nb::module_& m) {
                     device_ids = nb::cast<std::vector<int>>(device_ids_obj);
                 }
 
-                self.open_device(mesh_shape, device_ids);
+                size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE;
+                if (!worker_l1_size_obj.is_none()) {
+                    worker_l1_size = nb::cast<size_t>(worker_l1_size_obj);
+                }
+
+                self.open_device(mesh_shape, device_ids, worker_l1_size);
             },
             nb::arg("mesh_shape") = nb::none(),
             nb::arg("device_ids") = nb::none(),
+            nb::arg("worker_l1_size") = nb::none(),
             "Open a mesh device");
         py_auto_context.def("close_device", &AutoContext::close_device, "Close mesh device");
         py_auto_context.def("get_device", &AutoContext::get_device, nb::rv_policy::reference, "Get mesh device");

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -14,6 +14,7 @@
 #include "autograd/autocast_tensor.hpp"
 #include "autograd/tensor.hpp"
 #include "metal/ops/moe_group/moe_group.hpp"
+#include "metal/ops/polynorm_bw/polynorm_bw.hpp"
 #include "nb_export_enum.hpp"
 #include "nb_fwd.hpp"
 #include "ops/binary_ops.hpp"
@@ -61,6 +62,7 @@ void py_module_types(nb::module_& m) {
     m.def_submodule("multi_head_utils");
     m.def_submodule("attention");
     m.def_submodule("reshape");
+    m.def_submodule("polynorm");
     m.def_submodule("rmsnorm");
     m.def_submodule("sample");
     m.def_submodule("swiglu");
@@ -367,6 +369,27 @@ void py_module(nb::module_& m) {
             },
             nb::arg("tensor"),
             nb::arg("shape"));
+    }
+
+    {
+        auto py_polynorm = static_cast<nb::module_>(m.attr("polynorm"));
+        py_polynorm.def(
+            "polynorm3_bw",
+            [](const autograd::TensorPtr& input,
+               const autograd::TensorPtr& dL_dout,
+               const autograd::TensorPtr& weight,
+               float epsilon) -> std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> {
+                auto [dL_dx, dL_dw, dL_db] =
+                    ttml::metal::polynorm3_bw(input->get_value(), dL_dout->get_value(), weight->get_value(), epsilon);
+                return std::make_tuple(
+                    autograd::create_tensor(std::move(dL_dx)),
+                    autograd::create_tensor(std::move(dL_dw)),
+                    autograd::create_tensor(std::move(dL_db)));
+            },
+            nb::arg("input"),
+            nb::arg("dL_dout"),
+            nb::arg("weight"),
+            nb::arg("epsilon") = 1e-5F);
     }
 
     {

--- a/tt-train/sources/ttml/ttlang/polynorm3_bw_benchmark.py
+++ b/tt-train/sources/ttml/ttlang/polynorm3_bw_benchmark.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PolyNorm3 backward microbenchmark in Python using nanobind-backed ``ttml`` ops.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import zlib
+from pathlib import Path
+
+import numpy as np
+import torch
+import ttnn
+
+TILE = 32
+POLYNORM_EPS = 1e-5
+POLYNORM_W0 = 0.2
+POLYNORM_W1 = 0.3
+POLYNORM_W2 = 0.5
+NUM_WARMUP = 5
+NUM_MEASURE = 50
+
+_TTL_WORKER_L1_RESERVE_BYTES = 77824
+
+_TTML_SOURCES = Path(__file__).resolve().parents[1]
+_TTLANG = _TTML_SOURCES / "ttlang"
+for _p in (_TTML_SOURCES, _TTLANG):
+    if _p.is_dir() and str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+def _ensure_ttl_package_path() -> None:
+    """Put the nanobind ``ttl`` package on ``sys.path``."""
+    candidates: list[Path] = []
+    env = os.environ.get("TTL_PYTHON_PACKAGES", "").strip()
+    if env:
+        candidates.append(Path(env).expanduser())
+    candidates.append(Path("/opt/ttlang-toolchain/python_packages"))
+    exe_parent = Path(sys.executable).resolve().parent.parent
+    if (exe_parent / "python_packages").is_dir():
+        candidates.append(exe_parent / "python_packages")
+    for p in candidates:
+        if p.is_dir() and (p / "ttl").is_dir() and str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+            return
+
+
+def _import_ttl_polynorm3_bw():
+    """Import ``ttl_polynorm3_bw`` (needs ``ttl`` + this repo's ``ttlang`` on ``sys.path``)."""
+    _ensure_ttl_package_path()
+    import ttl_polynorm3_bw  # noqa: PLC0415
+
+    return ttl_polynorm3_bw
+
+
+import ttml
+from ttml.autograd import AutoContext, Tensor, create_tensor
+
+
+def _open_mesh_for_kernel_bw(ctx: AutoContext, bw_kernel: str) -> None:
+    """Open a single-device mesh ``(1, 1)``; TTL reserves worker L1 for large kernel configs."""
+    if bw_kernel != "ttl":
+        ctx.open_device((1, 1))
+        return
+    max_l1 = ttnn.device.get_max_worker_l1_unreserved_size()
+    if _TTL_WORKER_L1_RESERVE_BYTES >= max_l1:
+        raise RuntimeError(
+            f"_TTL_WORKER_L1_RESERVE_BYTES ({_TTL_WORKER_L1_RESERVE_BYTES}) must be less than "
+            f"max worker L1 unreserved size ({max_l1}); not enough L1 to reserve headroom for TTL kernel configs."
+        )
+    worker_l1 = max_l1 - _TTL_WORKER_L1_RESERVE_BYTES
+    try:
+        ctx.open_device((1, 1), None, worker_l1)
+    except TypeError:
+        ctx.open_device((1, 1))
+
+
+SHAPES = (
+    ([1, 1, 256, 384], "256x384"),
+    ([1, 1, 256, 2048], "256x2048"),
+    ([1, 1, 2048, 5632], "2048x5632"),
+    ([2, 1, 2048, 5632], "4096x5632"),
+    ([4, 1, 2048, 5632], "8192x5632"),
+    ([8, 1, 2048, 5632], "16384x5632"),
+    ([16, 1, 2048, 5632], "32768x5632"),
+    ([1, 1, 4096, 4096], "4096x4096"),
+    ([2, 1, 4096, 4096], "8192x4096"),
+    ([4, 1, 4096, 4096], "16384x4096"),
+    ([8, 1, 4096, 4096], "32768x4096"),
+    ([16, 1, 4096, 4096], "65536x4096"),
+)
+
+
+def _seed_for_name(name: str) -> int:
+    return zlib.crc32(name.encode("utf-8")) & 0xFFFFFFFF
+
+
+def _weight_numpy() -> np.ndarray:
+    w = np.zeros((1, 1, 1, 3), dtype=np.float32)
+    w[0, 0, 0, 0] = POLYNORM_W0
+    w[0, 0, 0, 1] = POLYNORM_W1
+    w[0, 0, 0, 2] = POLYNORM_W2
+    return w
+
+
+def _metal_polynorm_bw_tensors_from_numpy(
+    x_np: np.ndarray,
+    d_np: np.ndarray,
+    w_np: np.ndarray,
+):
+    """Numpy activations / upstream grad / weight → tile-backed autograd tensors for ``polynorm3_bw``."""
+    x_storage = Tensor.from_numpy(x_np, ttnn.Layout.TILE)
+    d_storage = Tensor.from_numpy(d_np, ttnn.Layout.TILE)
+    w_storage = Tensor.from_numpy(w_np, ttnn.Layout.TILE)
+    x_t = create_tensor(x_storage.get_value(), False)
+    dL_t = create_tensor(d_storage.get_value(), False)
+    w_t = create_tensor(w_storage.get_value(), False)
+    return x_t, dL_t, w_t
+
+
+def _ttl_polynorm_bw_tensors_to_device(
+    ttl_mod,
+    mesh,
+    x2: torch.Tensor,
+    dL2: torch.Tensor,
+    w0: float,
+    w1: float,
+    w2: float,
+    eps: float,
+    height: int,
+    width: int,
+):
+    """Build TTL PolyNorm3 backward device tensors from 2D host torch buffers."""
+    wstrip = torch.zeros(TILE, 3 * TILE, dtype=torch.float32)
+    wstrip[:, 0:TILE] = w2
+    wstrip[:, TILE : 2 * TILE] = w1
+    wstrip[:, 2 * TILE : 3 * TILE] = w0
+    eps_t = torch.full((TILE, TILE), eps, dtype=torch.float32)
+
+    x_tt = ttl_mod._to_dev_f32(mesh, x2.float())
+    dout_tt = ttl_mod._to_dev_f32(mesh, dL2.float())
+    w_tt = ttl_mod._to_dev_f32(mesh, wstrip)
+    ep_tt = ttl_mod._to_dev_f32(mesh, eps_t)
+    gx_tt = ttl_mod._to_dev_f32(mesh, torch.zeros(height, width, dtype=torch.float32))
+    gp_tt = ttl_mod._to_dev_f32(mesh, torch.zeros(height, 4 * TILE, dtype=torch.float32))
+    return x_tt, dout_tt, w_tt, ep_tt, gx_tt, gp_tt
+
+
+def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
+    """Benchmark PolyNorm3 backward kernel only (random upstream grad on host)."""
+
+    ttl_mod = _import_ttl_polynorm3_bw() if bw_kernel == "ttl" else None
+
+    ctx = AutoContext.get_instance()
+    _open_mesh_for_kernel_bw(ctx, bw_kernel)
+    try:
+        mesh = ctx.get_device()
+        mesh.enable_program_cache()
+
+        tag = "TTL" if bw_kernel == "ttl" else "Metal"
+        print(f"Mode: KernelBw / {tag} (backward-only, random dL_dout on host)\n")
+
+        w_np = _weight_numpy()
+
+        for shape, name in SHAPES:
+            seed = _seed_for_name(name)
+            rng = np.random.default_rng(seed)
+            b, _, s_len, c = shape
+            x_np = rng.uniform(-1.0, 1.0, (b, 1, s_len, c)).astype(np.float32)
+            d_np = rng.uniform(-1.0, 1.0, (b, 1, s_len, c)).astype(np.float32)
+
+            if bw_kernel == "metal":
+                x_t, dL_t, w_t = _metal_polynorm_bw_tensors_from_numpy(x_np, d_np, w_np)
+
+                def run_step() -> None:
+                    ttml.ops.polynorm.polynorm3_bw(x_t, dL_t, w_t, POLYNORM_EPS)
+
+            elif bw_kernel == "ttl":
+                assert ttl_mod is not None
+                rows = b * s_len
+                columns = c
+                x2 = torch.from_numpy(x_np).reshape(rows, columns)
+                dL2 = torch.from_numpy(d_np).reshape(rows, columns)
+                x_tt, dout_tt, w_tt, ep_tt, gx_tt, gp_tt = _ttl_polynorm_bw_tensors_to_device(
+                    ttl_mod,
+                    mesh,
+                    x2,
+                    dL2,
+                    POLYNORM_W0,
+                    POLYNORM_W1,
+                    POLYNORM_W2,
+                    POLYNORM_EPS,
+                    rows,
+                    columns,
+                )
+
+                def run_step() -> None:
+                    ttl_mod.polynorm3_bw(x_tt, dout_tt, w_tt, ep_tt, gx_tt, gp_tt)
+
+            else:
+                raise ValueError(f"unknown bw_kernel: {bw_kernel}")
+
+            for _ in range(NUM_WARMUP):
+                run_step()
+
+            total = 0.0
+            for _ in range(NUM_MEASURE):
+                t0 = time.perf_counter()
+                run_step()
+                ttnn.synchronize_device(mesh)
+                total += time.perf_counter() - t0
+            avg_s = total / NUM_MEASURE
+            suffix = "KernelBw_TTL" if bw_kernel == "ttl" else "KernelBw_Metal"
+            row = f"{name}_{suffix}"
+            print(f"  {row:28}  Time_us={avg_s * 1e6:10.2f}")
+    finally:
+        ctx.reset_graph()
+        ctx.close_device()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--bw-kernel",
+        choices=("metal", "ttl"),
+        default="metal",
+        help=(
+            "metal: ttml "
+            "ttl: ttlang "
+        ),
+    )
+    args = p.parse_args()
+
+    print(f"warmup={NUM_WARMUP}  measure={NUM_MEASURE}  epsilon={POLYNORM_EPS}  " f"--bw-kernel={args.bw_kernel}\n")
+
+    _run_kernel_bw_only(args.bw_kernel)
+    print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except ImportError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)

--- a/tt-train/sources/ttml/ttlang/polynorm3_bw_benchmark.py
+++ b/tt-train/sources/ttml/ttlang/polynorm3_bw_benchmark.py
@@ -28,58 +28,6 @@ NUM_MEASURE = 50
 
 _TTL_WORKER_L1_RESERVE_BYTES = 77824
 
-_TTML_SOURCES = Path(__file__).resolve().parents[1]
-_TTLANG = _TTML_SOURCES / "ttlang"
-for _p in (_TTML_SOURCES, _TTLANG):
-    if _p.is_dir() and str(_p) not in sys.path:
-        sys.path.insert(0, str(_p))
-
-
-def _ensure_ttl_package_path() -> None:
-    """Put the nanobind ``ttl`` package on ``sys.path``."""
-    candidates: list[Path] = []
-    env = os.environ.get("TTL_PYTHON_PACKAGES", "").strip()
-    if env:
-        candidates.append(Path(env).expanduser())
-    candidates.append(Path("/opt/ttlang-toolchain/python_packages"))
-    exe_parent = Path(sys.executable).resolve().parent.parent
-    if (exe_parent / "python_packages").is_dir():
-        candidates.append(exe_parent / "python_packages")
-    for p in candidates:
-        if p.is_dir() and (p / "ttl").is_dir() and str(p) not in sys.path:
-            sys.path.insert(0, str(p))
-            return
-
-
-def _import_ttl_polynorm3_bw():
-    """Import ``ttl_polynorm3_bw`` (needs ``ttl`` + this repo's ``ttlang`` on ``sys.path``)."""
-    _ensure_ttl_package_path()
-    import ttl_polynorm3_bw  # noqa: PLC0415
-
-    return ttl_polynorm3_bw
-
-
-import ttml
-from ttml.autograd import AutoContext, Tensor, create_tensor
-
-
-def _open_mesh_for_kernel_bw(ctx: AutoContext, bw_kernel: str) -> None:
-    """Open a single-device mesh ``(1, 1)``; TTL reserves worker L1 for large kernel configs."""
-    if bw_kernel != "ttl":
-        ctx.open_device((1, 1))
-        return
-    max_l1 = ttnn.device.get_max_worker_l1_unreserved_size()
-    if _TTL_WORKER_L1_RESERVE_BYTES >= max_l1:
-        raise RuntimeError(
-            f"_TTL_WORKER_L1_RESERVE_BYTES ({_TTL_WORKER_L1_RESERVE_BYTES}) must be less than "
-            f"max worker L1 unreserved size ({max_l1}); not enough L1 to reserve headroom for TTL kernel configs."
-        )
-    worker_l1 = max_l1 - _TTL_WORKER_L1_RESERVE_BYTES
-    try:
-        ctx.open_device((1, 1), None, worker_l1)
-    except TypeError:
-        ctx.open_device((1, 1))
-
 
 SHAPES = (
     ([1, 1, 256, 384], "256x384"),
@@ -95,6 +43,30 @@ SHAPES = (
     ([8, 1, 4096, 4096], "32768x4096"),
     ([16, 1, 4096, 4096], "65536x4096"),
 )
+
+
+import ttl_polynorm3_bw  # noqa: PLC0415
+import ttml
+from ttml.autograd import AutoContext, Tensor, create_tensor
+
+
+def _open_mesh_for_kernel_bw(ctx: AutoContext, kernel: str) -> None:
+    """Open a single-device mesh ``(1, 1)``; TTL reserves worker L1 for large kernel configs."""
+    if kernel != "ttl":
+        ctx.open_device((1, 1))
+        return
+    max_l1 = ttnn.device.get_max_worker_l1_unreserved_size()
+    if _TTL_WORKER_L1_RESERVE_BYTES >= max_l1:
+        raise RuntimeError(
+            f"_TTL_WORKER_L1_RESERVE_BYTES ({_TTL_WORKER_L1_RESERVE_BYTES}) must be less than "
+            f"max worker L1 unreserved size ({max_l1}); not enough L1 to reserve headroom for TTL kernel configs."
+        )
+    worker_l1 = max_l1 - _TTL_WORKER_L1_RESERVE_BYTES
+    try:
+        ctx.open_device((1, 1), None, worker_l1)
+    except TypeError:
+        ctx.open_device((1, 1))
+
 
 
 def _seed_for_name(name: str) -> int:
@@ -152,18 +124,20 @@ def _ttl_polynorm_bw_tensors_to_device(
     return x_tt, dout_tt, w_tt, ep_tt, gx_tt, gp_tt
 
 
-def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
+def _run_kernel(kernel: str = "metal") -> None:
     """Benchmark PolyNorm3 backward kernel only (random upstream grad on host)."""
 
-    ttl_mod = _import_ttl_polynorm3_bw() if bw_kernel == "ttl" else None
+    ttl_mod = None
+    if kernel == "ttl":
+        ttl_mod = ttl_polynorm3_bw
 
     ctx = AutoContext.get_instance()
-    _open_mesh_for_kernel_bw(ctx, bw_kernel)
+    _open_mesh_for_kernel_bw(ctx, kernel)
     try:
         mesh = ctx.get_device()
         mesh.enable_program_cache()
 
-        tag = "TTL" if bw_kernel == "ttl" else "Metal"
+        tag = "TTL" if kernel == "ttl" else "Metal"
         print(f"Mode: KernelBw / {tag} (backward-only, random dL_dout on host)\n")
 
         w_np = _weight_numpy()
@@ -175,13 +149,13 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
             x_np = rng.uniform(-1.0, 1.0, (b, 1, s_len, c)).astype(np.float32)
             d_np = rng.uniform(-1.0, 1.0, (b, 1, s_len, c)).astype(np.float32)
 
-            if bw_kernel == "metal":
+            if kernel == "metal":
                 x_t, dL_t, w_t = _metal_polynorm_bw_tensors_from_numpy(x_np, d_np, w_np)
 
                 def run_step() -> None:
                     ttml.ops.polynorm.polynorm3_bw(x_t, dL_t, w_t, POLYNORM_EPS)
 
-            elif bw_kernel == "ttl":
+            elif kernel == "ttl":
                 assert ttl_mod is not None
                 rows = b * s_len
                 columns = c
@@ -204,7 +178,7 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
                     ttl_mod.polynorm3_bw(x_tt, dout_tt, w_tt, ep_tt, gx_tt, gp_tt)
 
             else:
-                raise ValueError(f"unknown bw_kernel: {bw_kernel}")
+                raise ValueError(f"unknown kernel: {kernel}")
 
             for _ in range(NUM_WARMUP):
                 run_step()
@@ -216,7 +190,7 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
                 ttnn.synchronize_device(mesh)
                 total += time.perf_counter() - t0
             avg_s = total / NUM_MEASURE
-            suffix = "KernelBw_TTL" if bw_kernel == "ttl" else "KernelBw_Metal"
+            suffix = "Kernel_TTL" if kernel == "ttl" else "Kernel_Metal"
             row = f"{name}_{suffix}"
             print(f"  {row:28}  Time_us={avg_s * 1e6:10.2f}")
     finally:
@@ -227,7 +201,7 @@ def _run_kernel_bw_only(bw_kernel: str = "metal") -> None:
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
-        "--bw-kernel",
+        "--kernel",
         choices=("metal", "ttl"),
         default="metal",
         help=(
@@ -237,9 +211,9 @@ def main() -> int:
     )
     args = p.parse_args()
 
-    print(f"warmup={NUM_WARMUP}  measure={NUM_MEASURE}  epsilon={POLYNORM_EPS}  " f"--bw-kernel={args.bw_kernel}\n")
+    print(f"warmup={NUM_WARMUP}  measure={NUM_MEASURE}  epsilon={POLYNORM_EPS}  " f"--kernel={args.kernel}\n")
 
-    _run_kernel_bw_only(args.bw_kernel)
+    _run_kernel(args.kernel)
     print()
 
     return 0

--- a/tt-train/sources/ttml/ttlang/ttl_polynorm3_bw.py
+++ b/tt-train/sources/ttml/ttlang/ttl_polynorm3_bw.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+PolyNorm3 backward - TT-Lang
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import torch
+import ttnn
+
+TILE = 32
+
+
+@ttl.operation(grid="auto", fp32_dest_acc_en=True)
+def polynorm3_bw(x, dout, weight_strip, eps_tile, grad_x, grad_packed):
+    rows = x.shape[0] // TILE
+    cols = x.shape[1] // TILE
+    one = (1, 1)
+    n_row_elems = x.shape[1]
+    inv_n_row = 1.0 / float(n_row_elems)
+
+    grid_cols, grid_rows = ttl.grid_size(dims=2)
+    # How many cores in the grid
+    n_cores = grid_rows * grid_cols
+
+    rows_per_node = -(-rows // n_cores)
+    # Input buffers
+    x_tile = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+    dout_tile = ttl.make_dataflow_buffer_like(dout, shape=one, block_count=2)
+    gx_accum_tile = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+    eps_dfb = ttl.make_dataflow_buffer_like(eps_tile, shape=one, block_count=1)
+
+    # Pass-1 strip accumulators
+    inv_rms_x = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+    inv_rms_x2 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+    inv_rms_x3 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+
+    scalar_1 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+    scalar_2 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+    scalar_3 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+
+    # Weights
+    w0_dfb = ttl.make_dataflow_buffer_like(weight_strip, shape=one, block_count=2)
+    w1_dfb = ttl.make_dataflow_buffer_like(weight_strip, shape=one, block_count=2)
+    w2_dfb = ttl.make_dataflow_buffer_like(weight_strip, shape=one, block_count=2)
+
+    # coeff_k = inv_rms_k^3 * (scalar_k * w_k) * (1/N)
+    coeff1 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    coeff2 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    coeff3 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+
+    # wk * inv_rms_k
+    w2_inv_rms_x = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    w1_inv_rms_x2 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    w0_inv_rms_x3 = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+
+    # Output buffers
+    dl_dw0_row = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    dl_dw1_row = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    dl_dw2_row = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    dl_db_row = ttl.make_dataflow_buffer_like(x, shape=one, block_count=2)
+
+    # Helper buffers for the partial computation
+    t1_scratch = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+    red_dfb = ttl.make_dataflow_buffer_like(x, shape=one, block_count=1)
+
+    @ttl.compute()
+    def compute():
+        node_col, node_row = ttl.node(dims=2)
+        node_linear = node_row * grid_cols + node_col
+        # Pass-1 strip accumulations
+        for local_row in range(rows_per_node):
+            row = node_linear * rows_per_node + local_row
+            if row < rows:
+                with inv_rms_x.reserve() as z0:
+                    z0.store(ttl.math.fill(z0, 0.0))
+                with inv_rms_x2.reserve() as z0:
+                    z0.store(ttl.math.fill(z0, 0.0))
+                with inv_rms_x3.reserve() as z0:
+                    z0.store(ttl.math.fill(z0, 0.0))
+                with scalar_1.reserve() as z0:
+                    z0.store(ttl.math.fill(z0, 0.0))
+                with scalar_2.reserve() as z0:
+                    z0.store(ttl.math.fill(z0, 0.0))
+                with scalar_3.reserve() as z0:
+                    z0.store(ttl.math.fill(z0, 0.0))
+                with red_dfb.reserve() as z0:
+                    z0.store(ttl.math.fill(z0, 0.0))
+
+                for _local_col in range(cols):
+                    with (
+                        # inputs
+                        x_tile.wait() as xv,
+                        dout_tile.wait() as dv,
+                        # intermediate results
+                        inv_rms_x.wait() as s2,
+                        inv_rms_x2.wait() as s4,
+                        inv_rms_x3.wait() as s6,
+                        scalar_1.wait() as sxd,
+                        scalar_2.wait() as sx2d,
+                        scalar_3.wait() as sx3d,
+                        red_dfb.wait() as sd,
+                    ):
+                        ninv = ttl.math.fill(xv, inv_n_row)
+                        reduce_tile = ttl.math.fill(ninv, 1.0)
+                        x2v = xv * xv
+                        x3v = x2v * xv
+                        x4v = x2v * x2v
+                        x6v = x4v * x2v
+                        ns2 = s2 + (x2v @ reduce_tile)
+                        ns4 = s4 + (x4v @ reduce_tile)
+                        ns6 = s6 + (x6v @ reduce_tile)
+                        nsxd = sxd + ((xv * dv) @ reduce_tile)
+                        nsx2d = sx2d + ((x2v * dv) @ reduce_tile)
+                        nsx3d = sx3d + ((x3v * dv) @ reduce_tile)
+                        nsd = sd + (dv @ reduce_tile)
+                        with inv_rms_x.reserve() as o:
+                            o.store(ns2)
+                        with inv_rms_x2.reserve() as o:
+                            o.store(ns4)
+                        with inv_rms_x3.reserve() as o:
+                            o.store(ns6)
+                        with scalar_1.reserve() as o:
+                            o.store(nsxd)
+                        with scalar_2.reserve() as o:
+                            o.store(nsx2d)
+                        with scalar_3.reserve() as o:
+                            o.store(nsx3d)
+                        with red_dfb.reserve() as o:
+                            o.store(nsd)
+
+                with red_dfb.wait() as sd:
+                    with dl_db_row.reserve() as o:
+                        o.store(sd)
+
+                with (
+                    inv_rms_x.wait() as sum_x2,
+                    inv_rms_x2.wait() as sum_x4,
+                    inv_rms_x3.wait() as sum_x6,
+                    eps_dfb.wait() as epsv,
+                ):
+                    with inv_rms_x.reserve() as o:
+                        o.store(ttl.math.rsqrt(sum_x2 * ttl.math.fill(sum_x2, inv_n_row) + epsv))
+                    with inv_rms_x2.reserve() as o:
+                        o.store(ttl.math.rsqrt(sum_x4 * ttl.math.fill(sum_x4, inv_n_row) + epsv))
+                    with inv_rms_x3.reserve() as o:
+                        o.store(ttl.math.rsqrt(sum_x6 * ttl.math.fill(sum_x6, inv_n_row) + epsv))
+
+                with w0_dfb.wait() as w0v, w1_dfb.wait() as w1v, w2_dfb.wait() as w2v:
+                    # 1/N_row via fill(iv, inv_n_row) stored in ninv block.
+                    with inv_rms_x.wait() as iv, scalar_1.wait() as sv:
+                        with t1_scratch.reserve() as ninv:
+                            ninv.store(ttl.math.fill(ninv, inv_n_row))
+                        ninv = t1_scratch.wait()
+                        with coeff1.reserve() as o:
+                            o.store(iv * iv * iv * (sv * w2v) * ninv)
+                        with w2_inv_rms_x.reserve() as o:
+                            o.store(iv * w2v)
+                        with dl_dw2_row.reserve() as o:
+                            o.store(iv * sv)
+                    with inv_rms_x2.wait() as iv, scalar_2.wait() as sv:
+                        with t1_scratch.reserve() as ninv:
+                            ninv.store(ttl.math.fill(ninv, inv_n_row))
+                        ninv = t1_scratch.wait()
+                        with coeff2.reserve() as o:
+                            o.store(iv * iv * iv * (sv * w1v) * ninv)
+                        with w1_inv_rms_x2.reserve() as o:
+                            o.store(iv * w1v)
+                        with dl_dw1_row.reserve() as o:
+                            o.store(iv * sv)
+                    with inv_rms_x3.wait() as iv, scalar_3.wait() as sv:
+                        with t1_scratch.reserve() as ninv:
+                            ninv.store(ttl.math.fill(ninv, inv_n_row))
+                        ninv = t1_scratch.wait()
+                        with coeff3.reserve() as o:
+                            o.store(iv * iv * iv * (sv * w0v) * ninv)
+                        with w0_inv_rms_x3.reserve() as o:
+                            o.store(iv * w0v)
+                        with dl_dw0_row.reserve() as o:
+                            o.store(iv * sv)
+
+                c1 = coeff1.wait()
+                c2 = coeff2.wait()
+                c3 = coeff3.wait()
+                w0t = w0_inv_rms_x3.wait()
+                w1t = w1_inv_rms_x2.wait()
+                w2t = w2_inv_rms_x.wait()
+
+                # Pass-2 - grad_x computation
+                for _local_col in range(cols):
+                    xv = x_tile.wait()
+                    dv = dout_tile.wait()
+                    x2v = xv * xv
+                    x3v = x2v * xv
+                    t1 = dv * w2t - xv * c1
+                    with t1_scratch.reserve() as o:
+                        o.store(t1)
+                    t2 = (dv * w1t - x2v * c2) * (xv + xv)
+                    with t1_scratch.wait() as acc, red_dfb.reserve() as o:
+                        o.store(acc + t2)
+                    t3 = (dv * w0t - x3v * c3) * (x2v + x2v + x2v)
+                    with red_dfb.wait() as acc, gx_accum_tile.reserve() as o:
+                        o.store(acc + t3)
+
+    @ttl.datamovement()
+    def dm_read():
+        node_col, node_row = ttl.node(dims=2)
+        node_linear = node_row * grid_cols + node_col
+        for local_row in range(rows_per_node):
+            row = node_linear * rows_per_node + local_row
+            if row < rows:
+                # Pass-1
+                for local_col in range(cols):
+                    with x_tile.reserve() as b:
+                        ttl.copy(x[row, local_col], b).wait()
+                    with dout_tile.reserve() as b:
+                        ttl.copy(dout[row, local_col], b).wait()
+
+                # Pass-2
+                with eps_dfb.reserve() as b:
+                    ttl.copy(eps_tile[0, 0], b).wait()
+                with w0_dfb.reserve() as b:
+                    ttl.copy(weight_strip[0, 2], b).wait()
+                with w1_dfb.reserve() as b:
+                    ttl.copy(weight_strip[0, 1], b).wait()
+                with w2_dfb.reserve() as b:
+                    ttl.copy(weight_strip[0, 0], b).wait()
+
+                for local_col in range(cols):
+                    with x_tile.reserve() as b:
+                        ttl.copy(x[row, local_col], b).wait()
+                    with dout_tile.reserve() as b:
+                        ttl.copy(dout[row, local_col], b).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        node_col, node_row = ttl.node(dims=2)
+        node_linear = node_row * grid_cols + node_col
+        for local_row in range(rows_per_node):
+            row = node_linear * rows_per_node + local_row
+            if row < rows:
+                for local_col in range(cols):
+                    with gx_accum_tile.wait() as b:
+                        ttl.copy(b, grad_x[row, local_col]).wait()
+                with dl_db_row.wait() as b:
+                    ttl.copy(b, grad_packed[row, 0 * 4 + 3]).wait()
+                with dl_dw0_row.wait() as b:
+                    ttl.copy(b, grad_packed[row, 0 * 4 + 0]).wait()
+                with dl_dw1_row.wait() as b:
+                    ttl.copy(b, grad_packed[row, 0 * 4 + 1]).wait()
+                with dl_dw2_row.wait() as b:
+                    ttl.copy(b, grad_packed[row, 0 * 4 + 2]).wait()
+
+
+def _to_dev_f32(dev, t: torch.Tensor):
+    return ttnn.from_torch(
+        t,
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+        device=dev,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )

--- a/tt-train/sources/ttml/ttlang/ttl_polynorm3_bw_test.py
+++ b/tt-train/sources/ttml/ttlang/ttl_polynorm3_bw_test.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Compare TT-Lang PolyNorm3 backward (``ttl_polynorm3_bw``) to a PyTorch reference.
+"""
+from __future__ import annotations
+
+import torch
+import ttnn
+
+TILE = 32
+
+import ttl_polynorm3_bw  # noqa: E402
+
+
+def polynorm3_forward_torch(x: torch.Tensor, w0, w1, w2, b: float, eps: float) -> torch.Tensor:
+    """Torch PolyNorm3 forward used for reference ``backward``::
+
+    out = w0 * RmsNorm(x^3) + w1 * RmsNorm(x^2) + w2 * RmsNorm(x) + b
+    """
+    xf = x.float()
+
+    def rmsnorm_row(t: torch.Tensor) -> torch.Tensor:
+        # One scalar sum/mean per row over W, then divide by row RMS.
+        var = t.pow(2).mean(dim=-1, keepdim=True)
+        rms = (var + eps).sqrt()
+        return t / rms
+
+    w0t = w0 if isinstance(w0, torch.Tensor) else torch.tensor(w0, dtype=xf.dtype, device=xf.device)
+    w1t = w1 if isinstance(w1, torch.Tensor) else torch.tensor(w1, dtype=xf.dtype, device=xf.device)
+    w2t = w2 if isinstance(w2, torch.Tensor) else torch.tensor(w2, dtype=xf.dtype, device=xf.device)
+    bt = b if isinstance(b, torch.Tensor) else torch.tensor(b, dtype=xf.dtype, device=xf.device)
+    return w0t * rmsnorm_row(xf**3) + w1t * rmsnorm_row(xf**2) + w2t * rmsnorm_row(xf) + bt
+
+
+def torch_polynorm_bw(x_bf16: torch.Tensor, dout_bf16: torch.Tensor, w0, w1, w2, b: float, eps: float):
+    """Torch PolyNorm3 backward"""
+    x = x_bf16.float().clone().detach().requires_grad_(True)
+    w0t = torch.tensor(w0, dtype=torch.float32, requires_grad=True)
+    w1t = torch.tensor(w1, dtype=torch.float32, requires_grad=True)
+    w2t = torch.tensor(w2, dtype=torch.float32, requires_grad=True)
+    y = polynorm3_forward_torch(x, w0t, w1t, w2t, b, eps)
+    (y * dout_bf16.float()).sum().backward()
+    return x.grad, w0t.grad, w1t.grad, w2t.grad
+
+
+def _torch_polynorm_bw_grad_x_ref(
+    x_t: torch.Tensor, dout_t: torch.Tensor, w0, w1, w2, b: float, eps: float
+) -> torch.Tensor:
+    """Autograd reference for ``grad_x``, shape ``(H, W)``.
+
+    Uses ``torch_polynorm_bw`` (full backward through the PolyNorm forward). This is separate
+    from the row-partial refs because ``grad_x`` is a dense per-element tensor, while weight/bias
+    partials from the device are packed as one ``(H, TILE)`` face per row in ``grad_packed``.
+    """
+    gx, _g0, _g1, _g2 = torch_polynorm_bw(x_t, dout_t, w0, w1, w2, b, eps)
+    return gx.float()
+
+
+def _torch_polynorm_bw_packed_row_refs(
+    x_t: torch.Tensor, dout_t: torch.Tensor, eps: float
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Analytic row-partial refs for ``grad_packed``, each block shape ``(H, TILE)``.
+
+    Each row scalar (``dL/db``, ``dL/dw_k``) is expanded across TILE lanes to match the tile
+    faces the kernel writes. Closed-form ``Σ dout·RmsNorm(t)`` per row — not taken from
+    autograd weight ``.grad`` scalars, which would be global sums.
+    """
+    xf = x_t.float()
+    df = dout_t.float()
+
+    def rmsnorm_row(t: torch.Tensor) -> torch.Tensor:
+        var = t.pow(2).mean(dim=-1, keepdim=True)
+        return t / (var + eps).sqrt()
+
+    rx = rmsnorm_row(xf)
+    rx2 = rmsnorm_row(xf * xf)
+    x3 = xf * xf * xf
+    rx3 = rmsnorm_row(x3)
+
+    db_block = df.sum(dim=-1, keepdim=True).expand(-1, TILE)
+    gw2_block = (rx * df).sum(dim=-1, keepdim=True).expand(-1, TILE)
+    gw1_block = (rx2 * df).sum(dim=-1, keepdim=True).expand(-1, TILE)
+    gw0_block = (rx3 * df).sum(dim=-1, keepdim=True).expand(-1, TILE)
+    return db_block.float(), gw0_block.float(), gw1_block.float(), gw2_block.float()
+
+
+def _decode_slot_from_packed(gp_dev: torch.Tensor, height: int, slot: int) -> torch.Tensor:
+    """Return decoded packed slot block from ``(height, 4 * TILE)`` host tensor.
+
+    ``slot`` must be in ``{0,1,2,3}``; returned tensor shape is ``(height, TILE)``.
+    """
+    if gp_dev.shape[0] != height or gp_dev.shape[1] != 4 * TILE:
+        raise ValueError(f"expected gp_dev shape ({height}, {4 * TILE}), got {tuple(gp_dev.shape)}")
+    if slot < 0 or slot > 3:
+        raise ValueError(f"slot must be in [0, 3], got {slot}")
+    # Four contiguous blocks (dw0, dw1, dw2, db), each of shape (height, TILE).
+    return gp_dev[:, slot * TILE : (slot + 1) * TILE].float()
+
+
+def _make_case() -> tuple[float, float, float, float]:
+    """Host fixture aligned with c++ PolyNorm3 tests."""
+    w0, w1, w2 = 0.2, 0.3, 0.5
+    b = 0.1
+    return w0, w1, w2, b
+
+
+def polynorm3_bw_smoke_test(device, height: int, width: int) -> None:
+    """Smoke test for the polynorm3 backward pass"""
+    assert height % TILE == 0 and width % TILE == 0, (height, width)
+    eps = 1e-5
+    w0, w1, w2, b = _make_case()
+    x_t = torch.empty((height, width), dtype=torch.bfloat16)
+    x_t.uniform_(-1.0, 1.0)
+
+    # Old tolerances from c++ PolyNorm3 tests, current are (5e-3, 5e-3)
+    POLY_ATOL = 8e-2
+    POLY_RTOL = 8e-2
+
+    with torch.no_grad():
+        dout_t = polynorm3_forward_torch(x_t, w0, w1, w2, b, eps).to(torch.bfloat16)
+
+    g_x_ref = _torch_polynorm_bw_grad_x_ref(x_t, dout_t, w0, w1, w2, b, eps)
+    db_row_ref, gw0_row_ref, gw1_row_ref, gw2_row_ref = _torch_polynorm_bw_packed_row_refs(x_t, dout_t, eps)
+
+    wstrip = torch.zeros(TILE, 3 * TILE, dtype=torch.bfloat16)
+    wstrip[:, 0:TILE] = w2
+    wstrip[:, TILE : 2 * TILE] = w1
+    wstrip[:, 2 * TILE : 3 * TILE] = w0
+
+    eps_t = torch.full((TILE, TILE), eps, dtype=torch.bfloat16)
+
+    x_tt = ttl_polynorm3_bw._to_dev_f32(device, x_t.float())
+    dout_tt = ttl_polynorm3_bw._to_dev_f32(device, dout_t.float())
+    w_tt = ttl_polynorm3_bw._to_dev_f32(device, wstrip.float())
+    ep_tt = ttl_polynorm3_bw._to_dev_f32(device, eps_t.float())
+
+    gx_tt = ttl_polynorm3_bw._to_dev_f32(device, torch.zeros(height, width, dtype=torch.float32))
+    gp_tt = ttl_polynorm3_bw._to_dev_f32(device, torch.zeros(height, 4 * TILE, dtype=torch.float32))
+
+    ttl_polynorm3_bw.polynorm3_bw(x_tt, dout_tt, w_tt, ep_tt, gx_tt, gp_tt)
+    ttnn.synchronize_device(device)
+
+    gx_dev = ttnn.to_torch(gx_tt).to(torch.bfloat16)
+    gp_dev = ttnn.to_torch(gp_tt).float()
+    g_x_ref_bf = g_x_ref.to(torch.bfloat16)
+
+    torch.testing.assert_close(
+        gx_dev,
+        g_x_ref_bf,
+        rtol=POLY_RTOL,
+        atol=POLY_ATOL,
+    )
+    dw0_block = _decode_slot_from_packed(gp_dev, height, slot=0)
+    dw1_block = _decode_slot_from_packed(gp_dev, height, slot=1)
+    dw2_block = _decode_slot_from_packed(gp_dev, height, slot=2)
+    db_block = _decode_slot_from_packed(gp_dev, height, slot=3)
+
+    gw0_ref_block = gw0_row_ref.to(torch.float32)
+    gw1_ref_block = gw1_row_ref.to(torch.float32)
+    gw2_ref_block = gw2_row_ref.to(torch.float32)
+    db_ref_block = db_row_ref.to(torch.float32)
+
+    torch.testing.assert_close(
+        dw0_block,
+        gw0_ref_block,
+        rtol=POLY_RTOL,
+        atol=POLY_ATOL,
+    )
+    torch.testing.assert_close(
+        dw1_block,
+        gw1_ref_block,
+        rtol=POLY_RTOL,
+        atol=POLY_ATOL,
+    )
+    torch.testing.assert_close(
+        dw2_block,
+        gw2_ref_block,
+        rtol=POLY_RTOL,
+        atol=POLY_ATOL,
+    )
+    torch.testing.assert_close(
+        db_block,
+        db_ref_block,
+        rtol=POLY_RTOL,
+        atol=POLY_ATOL,
+    )
+    print(f"OK: polynorm3_bw {height}x{width}")
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    device = ttnn.open_device(device_id=0)
+    try:
+        polynorm3_bw_smoke_test(device, 8192, 8192)
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/ttml/ttlang/ttl_polynorm3_bw_test.py
+++ b/tt-train/sources/ttml/ttlang/ttl_polynorm3_bw_test.py
@@ -62,7 +62,7 @@ def _torch_polynorm_bw_packed_row_refs(
     """Analytic row-partial refs for ``grad_packed``, each block shape ``(H, TILE)``.
 
     Each row scalar (``dL/db``, ``dL/dw_k``) is expanded across TILE lanes to match the tile
-    faces the kernel writes. Closed-form ``Σ dout·RmsNorm(t)`` per row — not taken from
+    faces the kernel writes. Closed-form ``Sum dout·RmsNorm(t)`` per row - not taken from
     autograd weight ``.grad`` scalars, which would be global sums.
     """
     xf = x_t.float()


### PR DESCRIPTION
### Summary
Implement polynorm3_bw in tt-lang and compare performance to ttml.

### Notes for reviewers
Keep in mind this PR is not planned to be merged, it is only used to get benchmark results.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/benchmark_ttlang_vs_ttml_polynorm_bw)