### PR TITLE
#43801: relax constraints for layer norm shapes

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -229,17 +229,26 @@ def test_layernorm_mix_precision(test_id, in_dtype, gamma_dtype, in0_mem_config,
 
 
 @run_for_blackhole("blackhole specific test")
-def test_layer_norm_block_sharded_height_pad(device):
+@pytest.mark.parametrize(
+    "grid_end, shard_orientation",
+    [
+        ((7, 9), ttnn.ShardOrientation.ROW_MAJOR),
+        ((9, 7), ttnn.ShardOrientation.COL_MAJOR),
+    ],
+    ids=["row_major_8x10", "col_major_10x8"],
+)
+def test_layer_norm_block_sharded_height_pad(device, grid_end, shard_orientation):
     """
     Test for feature request issue #43801: block-sharded layer_norm where Mt (height in tiles)
     is not evenly divisible by num_cores in the H direction, so the bottom row of
     cores carries trailing shard-pad tiles.
 
-    Tensor [32, 1, 96, 512] (Mt=96) sharded [320, 64] on grid (0,0)-(7,9):
-      num_cores_r = 10, block_h = 10, but 96/10 = 9 (with 4 trailing pad tiles per
-      column-of-cores). The op previously rejected this with a strict
-      Mt/num_cores_r == block_h check; relaxing to div_up is correct because the
-      kernel processes block_h tile-rows per core regardless of overall Mt.
+    Tensor [32, 1, 96, 512] (Mt=96, Kt=16) sharded [320, 64]:
+      - ROW_MAJOR on 8x10 grid: num_cores_r=10, block_h=10, 96/10=9 (4 trailing pad tiles).
+      - COL_MAJOR on 10x8 grid: num_cores_c=10, block_h=10, same 4-tile pad in H.
+    The op previously rejected both with a strict Mt/num_cores == block_h check;
+    relaxing to div_up is correct because the kernel processes block_h tile-rows
+    per core regardless of overall Mt.
     """
     torch.manual_seed(0)
     channels = 512
@@ -249,8 +258,8 @@ def test_layer_norm_block_sharded_height_pad(device):
     bias_torch = torch.randn(channels, dtype=torch.bfloat16)
     epsilon = 1e-5
 
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 9))})
-    shard_spec = ttnn.ShardSpec(shard_grid, [320, 64], ttnn.ShardOrientation.ROW_MAJOR)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_end[0], grid_end[1]))})
+    shard_spec = ttnn.ShardSpec(shard_grid, [320, 64], shard_orientation)
     in_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
 
     x = ttnn.from_torch(

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -10,7 +10,7 @@ import torch
 import ttnn
 
 
-from models.common.utility_functions import torch2tt_tensor
+from models.common.utility_functions import pad_by_zero, torch2tt_tensor, run_for_blackhole
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 TEST_PADDING_VALUE = -42
@@ -50,13 +50,8 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
             gamma = torch.rand(test_shape[3]) * 2 - 1
             beta = torch.rand(test_shape[3]) * 2.0 - 1.1
 
-        # Build gamma_t/beta_t with torch2tt_tensor so the ttnn tensors keep their original
-        # logical width and only tile padding is added. Can't use pad_by_zero here because it
-        # zero-pads in torch before constructing the ttnn tensors, expanding the ***logical***
-        # width to the tile boundary, producing gamma and beta whose logical widths don't match
-        # the input's logical width.
-        gamma_t = torch2tt_tensor(gamma, device, tt_memory_config=in0_mem_config, tt_dtype=gamma_dtype)
-        beta_t = torch2tt_tensor(beta, device, tt_memory_config=in0_mem_config, tt_dtype=gamma_dtype)
+        gamma_t = pad_by_zero(gamma, device, in0_mem_config, gamma_dtype)[0]
+        beta_t = pad_by_zero(beta, device, in0_mem_config, gamma_dtype)[0]
 
         compute_kernel_config = ttnn.init_device_compute_kernel_config(
             device.arch(),
@@ -231,6 +226,79 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
 def test_layernorm_mix_precision(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device):
     torch.manual_seed(0)
     run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device)
+
+
+@run_for_blackhole("blackhole specific test")
+def test_layer_norm_block_sharded_height_pad(device):
+    """
+    Test for feature request issue #43801: block-sharded layer_norm where Mt (height in tiles)
+    is not evenly divisible by num_cores in the H direction, so the bottom row of
+    cores carries trailing shard-pad tiles.
+
+    Tensor [32, 1, 96, 512] (Mt=96) sharded [320, 64] on grid (0,0)-(7,9):
+      num_cores_r = 10, block_h = 10, but 96/10 = 9 (with 4 trailing pad tiles per
+      column-of-cores). The op previously rejected this with a strict
+      Mt/num_cores_r == block_h check; relaxing to div_up is correct because the
+      kernel processes block_h tile-rows per core regardless of overall Mt.
+    """
+    torch.manual_seed(0)
+    channels = 512
+
+    x_torch = torch.randn(32, 1, 96, channels, dtype=torch.bfloat16)
+    weight_torch = torch.randn(channels, dtype=torch.bfloat16)
+    bias_torch = torch.randn(channels, dtype=torch.bfloat16)
+    epsilon = 1e-5
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 9))})
+    shard_spec = ttnn.ShardSpec(shard_grid, [320, 64], ttnn.ShardOrientation.ROW_MAJOR)
+    in_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    x = ttnn.from_torch(
+        x_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in_mem_config
+    )
+    weight = ttnn.from_torch(
+        weight_torch.reshape(1, 1, channels // 32, 32),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    bias = ttnn.from_torch(
+        bias_torch.reshape(1, 1, channels // 32, 32),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+    )
+
+    out = ttnn.layer_norm(
+        x,
+        weight=weight,
+        bias=bias,
+        epsilon=epsilon,
+        compute_kernel_config=compute_kernel_config,
+    )
+    out_torch = ttnn.to_torch(out)
+
+    ref = torch.nn.functional.layer_norm(
+        x_torch.to(torch.float32), [channels], weight_torch.to(torch.float32), bias_torch.to(torch.float32), epsilon
+    ).to(torch.bfloat16)
+
+    assert_numeric_metrics(
+        ref,
+        out_torch,
+        pcc_threshold=0.999,
+        rtol=0.006,
+        atol=0.018,
+        frobenius_threshold=0.003,
+    )
 
 
 @pytest.mark.parametrize("h", [22, 1632, 8192, 16384])

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -56,9 +56,12 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             b.value().layout() == Layout::TILE, "Residual tensor must have TILE layout, got: {}", b.value().layout());
         TT_FATAL(
-            a.padded_shape() == b.value().padded_shape(),
-            "Input and residual shapes must match, got input: {} vs residual: {}",
+            a.logical_shape() == b.value().logical_shape() && a.padded_shape() == b.value().padded_shape(),
+            "Input and residual logical and padded shapes must match, got input: logical={} padded={} vs residual: "
+            "logical={} padded={}",
+            a.logical_shape(),
             a.padded_shape(),
+            b.value().logical_shape(),
             b.value().padded_shape());
         TT_FATAL(b.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         TT_FATAL(a.device() == b.value().device(), "Input and residual tensors must be on same device");
@@ -67,9 +70,14 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {
             TT_FATAL(
-                a.padded_shape()[-1] == gamma.value().padded_shape()[-1],
-                "{} != {}",
+                a.padded_shape()[-1] == gamma.value().padded_shape()[-1] &&
+                    gamma.value().logical_shape()[-1] >= a.logical_shape()[-1],
+                "Input and gamma padded widths must match and gamma logical width must be >= input logical width "
+                "(otherwise valid input columns would be multiplied by gamma padding). Got input: logical[-1]={} "
+                "padded[-1]={} vs gamma: logical[-1]={} padded[-1]={}",
+                a.logical_shape()[-1],
                 a.padded_shape()[-1],
+                gamma.value().logical_shape()[-1],
                 gamma.value().padded_shape()[-1]);
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -111,9 +119,14 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
     if (beta.has_value()) {
         if (beta.value().layout() == Layout::TILE) {
             TT_FATAL(
-                a.padded_shape()[-1] == beta.value().padded_shape()[-1],
-                "Input and beta inner dimensions must match, got input: {} vs beta: {}",
+                a.padded_shape()[-1] == beta.value().padded_shape()[-1] &&
+                    beta.value().logical_shape()[-1] >= a.logical_shape()[-1],
+                "Input and beta padded widths must match and beta logical width must be >= input logical width "
+                "(otherwise valid input columns would be offset by beta padding). Got input: logical[-1]={} "
+                "padded[-1]={} vs beta: logical[-1]={} padded[-1]={}",
+                a.logical_shape()[-1],
                 a.padded_shape()[-1],
+                beta.value().logical_shape()[-1],
                 beta.value().padded_shape()[-1]);
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -305,9 +318,11 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                             tt::div_up(Kt, num_cores_c));
                         TT_FATAL(
                             tt::div_up(Mt, num_cores_r) == program_config.block_h,
-                            "block_h ({}) must equal to M (in tiles)/ num_cores_r ({})",
+                            "block_h ({}) must equal ceil(Mt / num_cores_r) ({}); Mt={}, num_cores_r={}",
                             program_config.block_h,
-                            tt::div_up(Mt, num_cores_r));
+                            tt::div_up(Mt, num_cores_r),
+                            Mt,
+                            num_cores_r);
                     } else {
                         TT_FATAL(
                             tt::div_up(Kt, num_cores_r) == program_config.block_w,
@@ -316,9 +331,11 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                             tt::div_up(Kt, num_cores_r));
                         TT_FATAL(
                             tt::div_up(Mt, num_cores_c) == program_config.block_h,
-                            "block_h ({}) must equal to M (in tiles) / num_cores_c ({})",
+                            "block_h ({}) must equal ceil(Mt / num_cores_c) ({}); Mt={}, num_cores_c={}",
                             program_config.block_h,
-                            tt::div_up(Mt, num_cores_c));
+                            tt::div_up(Mt, num_cores_c),
+                            Mt,
+                            num_cores_c);
                     }
                 }
                 if (b.has_value()) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -56,12 +56,9 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             b.value().layout() == Layout::TILE, "Residual tensor must have TILE layout, got: {}", b.value().layout());
         TT_FATAL(
-            a.logical_shape() == b.value().logical_shape() && a.padded_shape() == b.value().padded_shape(),
-            "Input and residual logical and padded shapes must match, got input: logical={} padded={} vs residual: "
-            "logical={} padded={}",
-            a.logical_shape(),
+            a.padded_shape() == b.value().padded_shape(),
+            "Input and residual shapes must match, got input: {} vs residual: {}",
             a.padded_shape(),
-            b.value().logical_shape(),
             b.value().padded_shape());
         TT_FATAL(b.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         TT_FATAL(a.device() == b.value().device(), "Input and residual tensors must be on same device");
@@ -70,13 +67,9 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {
             TT_FATAL(
-                a.logical_shape()[-1] == gamma.value().logical_shape()[-1] &&
-                    a.padded_shape()[-1] == gamma.value().padded_shape()[-1],
-                "Input and gamma last logical and padded dims must match, got input: logical[-1]={} padded[-1]={} vs "
-                "gamma: logical[-1]={} padded[-1]={}",
-                a.logical_shape()[-1],
+                a.padded_shape()[-1] == gamma.value().padded_shape()[-1],
+                "{} != {}",
                 a.padded_shape()[-1],
-                gamma.value().logical_shape()[-1],
                 gamma.value().padded_shape()[-1]);
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -118,13 +111,9 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
     if (beta.has_value()) {
         if (beta.value().layout() == Layout::TILE) {
             TT_FATAL(
-                a.logical_shape()[-1] == beta.value().logical_shape()[-1] &&
-                    a.padded_shape()[-1] == beta.value().padded_shape()[-1],
-                "Input and beta last logical and padded dims must match, got input: logical[-1]={} padded[-1]={} vs "
-                "beta: logical[-1]={} padded[-1]={}",
-                a.logical_shape()[-1],
+                a.padded_shape()[-1] == beta.value().padded_shape()[-1],
+                "Input and beta inner dimensions must match, got input: {} vs beta: {}",
                 a.padded_shape()[-1],
-                beta.value().logical_shape()[-1],
                 beta.value().padded_shape()[-1]);
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -315,10 +304,10 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                             program_config.block_w,
                             tt::div_up(Kt, num_cores_c));
                         TT_FATAL(
-                            Mt / num_cores_r == program_config.block_h,
+                            tt::div_up(Mt, num_cores_r) == program_config.block_h,
                             "block_h ({}) must equal to M (in tiles)/ num_cores_r ({})",
                             program_config.block_h,
-                            Mt / num_cores_r);
+                            tt::div_up(Mt, num_cores_r));
                     } else {
                         TT_FATAL(
                             tt::div_up(Kt, num_cores_r) == program_config.block_w,
@@ -326,10 +315,10 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                             program_config.block_w,
                             tt::div_up(Kt, num_cores_r));
                         TT_FATAL(
-                            Mt / num_cores_c == program_config.block_h,
+                            tt::div_up(Mt, num_cores_c) == program_config.block_h,
                             "block_h ({}) must equal to M (in tiles) / num_cores_c ({})",
                             program_config.block_h,
-                            Mt / num_cores_c);
+                            tt::div_up(Mt, num_cores_c));
                     }
                 }
                 if (b.has_value()) {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #43801 

Feature request was to relax what shapes LayerNorm can handle.

AI said it was reasonably easy, and I told it to do it.

● Changed both H-direction validation checks in layernorm_device_operation.cpp:307,318 to use tt::div_up — matching the existing W-direction treatment. This should
  let the failing [32, 1, 96, 512] / shard [320, 64] / grid 8×10 case through (div_up(96, 10) == 10 == block_h).

● Changed both H-direction validation checks in layernorm_device_operation.cpp:307,318 to use tt::div_up — matching the existing W-direction treatment. This should
  let the failing [32, 1, 96, 512] / shard [320, 64] / grid 8×10 case through (div_up(96, 10) == 10 == block_h).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-43801_relax_layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-43801_relax_layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-43801_relax_layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-43801_relax_layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-43801_relax_layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-43801_relax_layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-43801_relax_layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-43801_relax_layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-43801_relax_layernorm)