### PR TITLE
Fix bad optional access in CCL matmul paths

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -5382,6 +5382,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig config =
         std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(program_config);
 
+    if (!config.allowed_worker_cores.has_value()) {
+        config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(config.compute_with_storage_grid_size.x - 1, config.compute_with_storage_grid_size.y - 1)));
+    }
     auto resolved_grid = config.allowed_worker_cores.value().bounding_box().grid_size();
 
     return matmul_multi_core_reuse_mcast_1d_optimized_(
@@ -5430,6 +5435,11 @@ MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::create_mesh_workload(
             const ttnn::MeshCoordinateRange mesh_coord_range{mesh_coord, mesh_coord};
             auto pc = std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
                 attributes.program_config.value());
+            if (!pc.allowed_worker_cores.has_value()) {
+                pc.allowed_worker_cores = CoreRangeSet(CoreRange(
+                    CoreCoord(0, 0),
+                    CoreCoord(pc.compute_with_storage_grid_size.x - 1, pc.compute_with_storage_grid_size.y - 1)));
+            }
             auto mesh_grid = pc.allowed_worker_cores.value().bounding_box().grid_size();
             DeviceComputeKernelConfig ckc = attributes.compute_kernel_config.value();
             tt_metal::Program program{};

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3078,6 +3078,14 @@ matmul_multi_core_reuse_mcast_2d_optimized_(
     auto program_config = std::get<operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>(
         operation_attributes.program_config.value());
 
+    if (!program_config.allowed_worker_cores.has_value()) {
+        program_config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(
+                program_config.compute_with_storage_grid_size.x - 1,
+                program_config.compute_with_storage_grid_size.y - 1)));
+    }
+
     auto fuse_batch = program_config.fuse_batch;
     auto in0_block_w = program_config.in0_block_w;
     auto compute_with_storage_grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();


### PR DESCRIPTION
## Summary

- Fixes `RuntimeError: bad optional access` in Llama 3.1-8B attention tests and Llama 3.2-90B-Vision decoder tests caused by #44341
- The `matmul_multi_core_reuse_mcast_1d_optimized_helper` and `MeshWorkload` factory unconditionally read `allowed_worker_cores.value()`, but CCL ops (`all_gather_matmul_async`, `reduce_scatter_matmul`) call these functions directly without going through `normalize_program_config()`
- Adds inline fallback: populate `allowed_worker_cores` from `compute_with_storage_grid_size` when not set

Fixes #44529

## Test plan

- [x] Build passes
- [ ] Llama 3.1-8B attention unit tests pass (previously failing with `bad optional access`)
- [ ] Llama 3.2-90B-Vision decoder unit tests pass (previously failing with `bad optional access`)
- [ ] Existing matmul tests unaffected

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/fix_allowed_worker_cores_ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/fix_allowed_worker_cores_ccl)