### PR TITLE
[Cleanup] rename MeshTensor::legacy_shard_spec() to shard_spec()

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -155,7 +155,7 @@ public:
     bool is_sharded() const;
 
     // For sharded tensors, at least one of ShardSpec or NdShardSpec will be provided.
-    const std::optional<ShardSpec>& legacy_shard_spec() const;
+    const std::optional<ShardSpec>& shard_spec() const;
     const std::optional<NdShardSpec>& nd_shard_spec() const;
 
     DeviceAddr address() const;

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -107,7 +107,7 @@ const MemoryConfig& MeshTensor::memory_config() const { return tensor_spec().mem
 
 bool MeshTensor::is_sharded() const { return memory_config().is_sharded(); }
 
-const std::optional<ShardSpec>& MeshTensor::legacy_shard_spec() const { return memory_config().shard_spec(); }
+const std::optional<ShardSpec>& MeshTensor::shard_spec() const { return memory_config().shard_spec(); }
 
 const std::optional<NdShardSpec>& MeshTensor::nd_shard_spec() const { return memory_config().nd_shard_spec(); }
 


### PR DESCRIPTION
### PR Category
Cleanup?

### Summary

Renames `MeshTensor::legacy_shard_spec` to `shard_spec` to be consistent with `ttnn::Tensor`, as `legacy` isn't an appropriate label for the no-name sharding scheme. 

### Backstory

When `MeshTensor` was first sketched out, having both `shard_spec()` and `nd_shard_spec()` felt asymmetric — and at the time there was significant effort underway to add nd-sharding support to ops. To make the distinction explicit, the plain `shard_spec()` was renamed to `legacy_shard_spec()` to signal it was the "old" sharding path.

After discussing with the ttnn folks at office, we agreed the `legacy_` prefix sends the wrong message — it implies deprecation rather than just "non-nd". Renaming it back to `shard_spec` :(

There's no use site of this method.

### Checks
- [x] Passes compile