### PR TITLE
Fix LoRA fusion in-place mutation corrupting base state dict

### DIFF
--- a/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
@@ -173,7 +173,7 @@ def fuse_lora_state_dict(
         alpha = alphas.get(base_path, float(rank))
         effective_scale = scale * (alpha / rank)
         delta = effective_scale * (ab["B"].to(torch.float32) @ ab["A"].to(torch.float32))
-        fused[diffusers_key] = base_weight.to(torch.float32).add_(delta).to(base_weight.dtype)
+        fused[diffusers_key] = (base_weight.to(torch.float32) + delta).to(base_weight.dtype)
         applied_pairs += 1
 
     applied_direct = 0


### PR DESCRIPTION
### Summary : 
fuse_lora_state_dict() uses a shallow copy of the base state dict, so both dicts share the same tensor objects. The in-place .add_() mutates the original tensor when base weights are float32 (where .to(float32) is a no-op), causing the post-fusion verification to see zero diff and raise RuntimeError.

Replace in-place add_() with out-of-place + to always create a new tensor regardless of the base weight dtype.


### Root Cause
`fuse_lora_state_dict()` creates a shallow copy of the base state dict
(`fused = dict(base_state_dict)`), so both dicts share the same tensor objects.
When `base_weight.dtype == float32`, `.to(torch.float32)` returns the same tensor (no-op),
and `.add_(delta)` mutates it in-place — modifying both dicts simultaneously.
Dtype-dependent: only triggers with float32 weights (not bfloat16).
## Verification
- **Without fix:** `RuntimeError: weights unchanged, max L2 diff = 0.0`
- **With fix:** `400 tensors changed, max L2 diff = 0.3935`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix_wan2.2_I2V_Lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix_wan2.2_I2V_Lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix_wan2.2_I2V_Lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix_wan2.2_I2V_Lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix_wan2.2_I2V_Lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix_wan2.2_I2V_Lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix_wan2.2_I2V_Lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix_wan2.2_I2V_Lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix_wan2.2_I2V_Lora)