### PR TITLE
[Bug Fix] DeviceOperation fails early when deallocated tensor is passed to ops

### DIFF
--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -114,18 +114,6 @@ static auto create_mesh_workload_from_workload_factory(
     }
 }
 
-struct CheckDeviceBufferIsAllocated {
-    std::size_t index = 0;
-
-    void operator()(const Tensor& tensor) {
-        if (not tensor.is_allocated()) {
-            // TODO(#40550): This should be a TT_FATAL
-            log_warning(tt::LogOp, "Tensor at index {} is not allocated", index);
-        }
-        index++;
-    }
-};
-
 template <typename device_operation_t>
 auto get_operation_name(const typename device_operation_t::operation_attributes_t& operation_attributes) {
     if constexpr (is_mesh_device_operation_adapter_v<device_operation_t>) {
@@ -399,7 +387,12 @@ void launch_operation_with_adapter(
     log_operation<mesh_device_operation_t>(
         mesh_device->id(), operation_attributes, tensor_args, program_hash, program_cache_hit);
 
-    ttsl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
+    ttsl::reflection::visit_object_of_type<Tensor>(
+        [index = std::size_t{0}](const Tensor& tensor) mutable {
+            TT_FATAL(tensor.is_allocated(), "Tensor at index {} is not allocated", index);
+            index++;
+        },
+        tensor_args);
 
     if (program_cache_hit) {
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -387,13 +387,6 @@ void launch_operation_with_adapter(
     log_operation<mesh_device_operation_t>(
         mesh_device->id(), operation_attributes, tensor_args, program_hash, program_cache_hit);
 
-    ttsl::reflection::visit_object_of_type<Tensor>(
-        [index = std::size_t{0}](const Tensor& tensor) mutable {
-            TT_FATAL(tensor.is_allocated(), "Tensor at index {} is not allocated", index);
-            index++;
-        },
-        tensor_args);
-
     if (program_cache_hit) {
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
@@ -443,8 +436,10 @@ typename device_operation_t::tensor_return_value_t launch(
     const auto operation_name = detail::get_operation_name<device_operation_t>(operation_attributes);
     tt::tt_metal::GraphTracker::instance().track_function_start(operation_name, operation_attributes, input_tensors);
 
-    if (!input_tensors.empty()) {
-        TT_FATAL(is_device_tensor(input_tensors.front().get()), "Device Operations expect tensor with Device storage in inputs");
+    for (const auto& input_tensor_ref : input_tensors) {
+        const auto& input_tensor = input_tensor_ref.get();
+        TT_FATAL(is_device_tensor(input_tensor), "Device Operations expect device tensors as inputs");
+        TT_FATAL(input_tensor.is_allocated(), "Input Tensor is not allocated");
     }
 
     auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

TTNN Device operation infrastructure currently allows deallocated tensor to be passed in as arguments.
It currently provides a `log_warn`, this PR switches to a TT_FATAL.

Closes #40550 . Continuation of #43565. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

I have grepped recent nightly runs and made my best attempt to avoid breaking models.
The `log_warn` was not emitted across 26 nightly pipelines.

All models run is launched: https://github.com/tenstorrent/tt-metal/actions/runs/27384132335
If this PR breaks anything, it should show up with the "tensor deallocated" warning message.

Qwen: PCC error/ fail to allocate
llama: Requested mesh shape MeshShape([8, 4]) requires 32 devices/ subdevice error
gpt-oss: test harness error

All model breakage are not cause by this invariant check.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/disallow-deallocated-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/disallow-deallocated-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/disallow-deallocated-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/disallow-deallocated-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/disallow-deallocated-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/disallow-deallocated-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/disallow-deallocated-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/disallow-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/disallow-deallocated-tensor)