### PR TITLE
ci: standardise SKU list across all model test workflows

### DIFF
--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Resolve SKU selection
         id: resolve-skus
         run: |
-          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           VALID_SKUS="wh_n150 wh_n300 wh_llmbox wh_llmbox_perf wh_galaxy wh_galaxy_perf bh_p150 bh_loudbox bh_quietbox_2 bh_galaxy bh_galaxy_perf"
           SKU_INPUT="${{ inputs.skus || 'all' }}"
 

--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -117,7 +117,7 @@ jobs:
         id: resolve-skus
         run: |
           ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
-          VALID_SKUS="wh_n150 wh_n300 wh_llmbox wh_llmbox_perf wh_galaxy wh_galaxy_perf bh_p150 bh_loudbox bh_quietbox_2 bh_galaxy bh_galaxy_perf"
+          VALID_SKUS="wh_n150 wh_n300 wh_llmbox wh_llmbox_perf wh_galaxy wh_galaxy_perf bh_p150 bh_loudbox bh_p300 bh_quietbox_2 bh_galaxy bh_galaxy_perf"
           SKU_INPUT="${{ inputs.skus || 'all' }}"
 
           # Trim leading/trailing whitespace from the entire input
@@ -134,7 +134,7 @@ jobs:
               # Skip empty tokens (e.g. from trailing commas)
               [[ -z "$item" ]] && continue
               if [[ ! " $VALID_SKUS " =~ " $item " ]]; then
-                echo "::error::Invalid SKU '$item'. Valid options: all, wh_n150, wh_n300, wh_llmbox, wh_llmbox_perf, wh_galaxy, wh_galaxy_perf, bh_p150, bh_loudbox, bh_quietbox_2, bh_galaxy, bh_galaxy_perf"
+                echo "::error::Invalid SKU '$item'. Valid options: all, wh_n150, wh_n300, wh_llmbox, wh_llmbox_perf, wh_galaxy, wh_galaxy_perf, bh_p150, bh_loudbox, bh_p300, bh_quietbox_2, bh_galaxy, bh_galaxy_perf"
                 exit 1
               fi
               SKUS="${SKUS:+$SKUS,}$item"

--- a/.github/workflows/models-t1-device-perf-tests.yaml
+++ b/.github/workflows/models-t1-device-perf-tests.yaml
@@ -19,8 +19,17 @@ on:
         options:
           - all
           - "wh_n150 (N150)"
+          - "wh_n300 (N300)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
           - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
           - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -59,7 +68,7 @@ jobs:
       - name: Resolve SKU selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,bh_p150,bh_p300"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           SKU_INPUT="${{ inputs.sku || 'all' }}"
           if [[ "$SKU_INPUT" == "all" ]]; then
             echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT

--- a/.github/workflows/models-t1-e2e-tests.yaml
+++ b/.github/workflows/models-t1-e2e-tests.yaml
@@ -27,7 +27,17 @@ on:
         options:
           - all
           - "wh_n150 (N150)"
-          - "wh_galaxy_perf (Galaxy)"
+          - "wh_n300 (N300)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -74,7 +84,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_galaxy_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/.github/workflows/models-t1-sweep-tests.yaml
+++ b/.github/workflows/models-t1-sweep-tests.yaml
@@ -20,7 +20,17 @@ on:
         options:
           - all
           - "wh_n150 (N150)"
-          - "wh_galaxy (Galaxy)"
+          - "wh_n300 (N300)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -59,7 +69,7 @@ jobs:
       - name: Resolve SKU selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_galaxy"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           SKU_INPUT="${{ inputs.sku || 'all' }}"
           if [[ "$SKU_INPUT" == "all" ]]; then
             echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -26,7 +26,17 @@ on:
         options:
           - all
           - "wh_n150 (N150)"
-          - "wh_galaxy_perf (Galaxy)"
+          - "wh_n300 (N300)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -73,7 +83,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_galaxy_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/.github/workflows/models-t2-e2e-tests.yaml
+++ b/.github/workflows/models-t2-e2e-tests.yaml
@@ -38,7 +38,17 @@ on:
         options:
           - all
           - "wh_n150 (N150)"
-          - "wh_llmbox_perf (T3000)"
+          - "wh_n300 (N300)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -85,7 +95,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_llmbox_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/.github/workflows/models-t2-sweep-tests.yaml
+++ b/.github/workflows/models-t2-sweep-tests.yaml
@@ -18,7 +18,18 @@ on:
         type: choice
         options:
           - all
-          - "wh_llmbox_perf (T3000)"
+          - "wh_n150 (N150)"
+          - "wh_n300 (N300)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -57,7 +68,7 @@ jobs:
       - name: Resolve SKU selection
         id: resolve
         run: |
-          ALL_SKUS="wh_llmbox_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           SKU_INPUT="${{ inputs.sku || 'all' }}"
           if [[ "$SKU_INPUT" == "all" ]]; then
             echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT

--- a/.github/workflows/models-t2-unit-tests.yaml
+++ b/.github/workflows/models-t2-unit-tests.yaml
@@ -38,8 +38,17 @@ on:
         options:
           - all
           - "wh_n150 (N150)"
+          - "wh_n300 (N300)"
           - "wh_llmbox (T3000)"
-          - "wh_llmbox_perf (T3000 perf-grade)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -86,7 +95,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_llmbox,wh_llmbox_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/.github/workflows/models-t3-e2e-tests.yaml
+++ b/.github/workflows/models-t3-e2e-tests.yaml
@@ -34,7 +34,16 @@ on:
           - all
           - "wh_n150 (N150)"
           - "wh_n300 (N300)"
-          - "wh_llmbox_perf (T3000)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -81,7 +90,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_n300,wh_llmbox_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/.github/workflows/models-t3-unit-tests.yaml
+++ b/.github/workflows/models-t3-unit-tests.yaml
@@ -34,7 +34,16 @@ on:
           - all
           - "wh_n150 (N150)"
           - "wh_n300 (N300)"
-          - "wh_llmbox_perf (T3000)"
+          - "wh_llmbox (T3000)"
+          - "wh_llmbox_perf (T3000 perf)"
+          - "wh_galaxy (WH Galaxy)"
+          - "wh_galaxy_perf (WH Galaxy perf)"
+          - "bh_p150 (P150)"
+          - "bh_loudbox (BH LoudBox)"
+          - "bh_p300 (P300)"
+          - "bh_quietbox_2 (BH QB2)"
+          - "bh_galaxy (BH Galaxy)"
+          - "bh_galaxy_perf (BH Galaxy perf)"
       platform:
         required: false
         type: choice
@@ -81,7 +90,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_n300,wh_llmbox_perf"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_loudbox,bh_p300,bh_quietbox_2,bh_galaxy,bh_galaxy_perf"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"


### PR DESCRIPTION
## Summary

Every tiered model-test workflow (`t1/t2/t3 × unit/e2e/sweep/device_perf`) and `all-model-tests` now uses the same canonical `ALL_SKUS` list:

```
wh_n150, wh_n300, wh_llmbox, wh_llmbox_perf,
wh_galaxy, wh_galaxy_perf,
bh_p150, bh_loudbox, bh_p300, bh_quietbox_2,
bh_galaxy, bh_galaxy_perf
```

Previously each workflow had a hand-picked subset, so tests whose SKUs weren't in the eligible list were silently dropped even when their tier matched. Example: `gpt-oss-120b` tier-1 unit tests require `wh_llmbox`/`wh_galaxy` but `models-t1-unit-tests.yaml` only had `wh_n150,wh_galaxy_perf` — so they never ran in the scheduled t1 pipeline, only in `all-model-tests`.

The matrix builder already filters to SKUs actually defined for each test entry, so expanding the eligible list only adds jobs that have matching entries in the pipeline YAML — no spurious runs on unused SKUs.

Also fixes `all-model-tests.yaml` which was missing `bh_p300`, and updates the per-workflow SKU dropdown options for `workflow_dispatch` to match the canonical list.

## Files changed

All 10 model test workflow files under `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/consistent-model-test-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/consistent-model-test-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/consistent-model-test-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/consistent-model-test-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/consistent-model-test-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/consistent-model-test-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/consistent-model-test-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/consistent-model-test-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/consistent-model-test-skus)