### PR TITLE
Bump WH resnet50 bs=16 BFP8 LoFi device-perf target

### DIFF
--- a/models/demos/vision/classification/resnet50/wormhole/tests/test_perf_device_resnet50.py
+++ b/models/demos/vision/classification/resnet50/wormhole/tests/test_perf_device_resnet50.py
@@ -13,7 +13,7 @@ from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.perf_d
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-16-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-device_params0", 6140.0],
+        [16, "True-16-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-device_params0", 6335.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):


### PR DESCRIPTION
## Summary
- Resnet50 WH bs=16 BFP8 LoFi device-perf got faster: observed **6334.93** samples/s vs previous real perf **~6301** samples/s → ~**+33.93** samples/s (~**+0.54%**).
- Previous perf (~6301) was already close to the test's upper bound `6324.2` (`expected_perf=6140.0` + 3% margin → only ~23 samples/s of headroom). The LLK change pushed it over.
- Bumps `expected_perf` from 6140.0 → 6335.0 so the ±3% test margin re-centers on the new perf (`6145.0–6525.0`).

Triage run: https://github.com/tenstorrent/tt-metal/actions/runs/25928974686

## Root cause
Commit [`971898a4`](https://github.com/tenstorrent/tt-metal/commit/971898a402904daece9bfab34616569d1dabeebd) — **"Avoid unsafe pack untilize HW configure" (#44417)**.

Replaced the broad `llk_pack_untilize_hw_configure_disaggregated` (expensive MMIO write) inside `pack_untilize_dest_init` with the lightweight `llk_pack_reconfig_data_format_disaggregated`.

In resnet50, the dominant beneficiary is the **halo op** (`ttnn/.../sliding_window/halo/device/kernels/compute/pack_untilize.cpp` → `untilize_helpers.inl` → `pack_untilize_init` → `pack_untilize_dest_init`). resnet50 convs typically keep output **tiled**, so conv2d's own pack_untilize branch (`conv_bmm_tilize.cpp:648`, gated on `untilize_out && packer_untilize`) is skipped; halo does the tile→row-major conversion every time, once per conv→halo boundary. The stem maxpool also hits the path once.

Dropping one MMIO write per `pack_untilize_dest_init` call adds up across the many residual-block boundaries → ~+34 samples/s.

Fix is *not* to revert — the LLK change is correct. Just rebase the perf target.

Bisection window:
- Last success: `bfb1f820` — https://github.com/tenstorrent/tt-metal/actions/runs/25914038397
- First failure: `5604687e` — https://github.com/tenstorrent/tt-metal/actions/runs/25924575617

## Test plan
- [ ] Scoped device-perf run (WH resnet50 only): https://github.com/tenstorrent/tt-metal/actions/runs/25957781014

🤖 Generated with [Claude Code](https://claude.com/claude-code)
