### PR TITLE
Routed experts make use of token count

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_single_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_single_routed_expert.py
@@ -26,9 +26,9 @@ from tests.ttnn.utils_for_testing import comp_pcc
         (1600, 7168, 2048),  # DeepSeek V3 dims, 1.6K tokens
         (2048, 7168, 2048),  # DeepSeek V3 dims, 2K tokens
         (3200, 7168, 2048),  # DeepSeek V3 dims, 3.2K tokens
-        (4096, 7168, 2048),  # DeepSeek V3 dims, 4K tokens
+        (8192, 7168, 2048),  # DeepSeek V3 dims, 8K tokens
     ],
-    ids=["ds-v3-1k", "ds-v3-1.6k", "ds-v3-2k", "ds-v3-3.2k", "ds-v3-4k"],
+    ids=["ds-v3-1k", "ds-v3-1.6k", "ds-v3-2k", "ds-v3-3.2k", "ds-v3-8k"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -505,7 +505,10 @@ class TtMoe(LightweightModule):
         )
         if self.overlap_shared_expert_with_dispatch:
             self.mesh_device.clear_loaded_sub_device_manager()
-        x = ttnn.deallocate(x)
+        # Only deallocate x when the all-gather above produced a new tensor; otherwise x
+        # is still the caller's input and freeing it breaks subsequent forward calls.
+        if self.mesh_device.shape[1] > 1:
+            x = ttnn.deallocate(x)
         scores = ttnn.to_memory_config(scores, ttnn.DRAM_MEMORY_CONFIG)
         indices = ttnn.to_memory_config(indices, ttnn.DRAM_MEMORY_CONFIG)
         logger.debug(f"[TtMoe.forward] Dispatch output: buffer={dispatched_buffer.shape}, metadata={metadata.shape}")
@@ -655,6 +658,7 @@ class TtMoe(LightweightModule):
                 combined_output=combined_output,
                 routed_output=routed_output,
                 expert_token_counts=tt_expert_token_counts,
+                expert_region_offsets=tt_expert_region_offsets,
             )
 
         return final_output, intermediates

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_intermediates.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_intermediates.py
@@ -25,6 +25,7 @@ class TtMoEIntermediates:
     gate_indices: Optional[ttnn.Tensor] = None          # (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
     gate_logits: Optional[ttnn.Tensor] = None           # (dispatch_group_size * seq_len_per_chip, num_routed_experts)
     expert_token_counts: Optional[ttnn.Tensor] = None   # from gate routing setup
+    expert_region_offsets: Optional[ttnn.Tensor] = None # from gate routing setup
     dispatched_buffer: Optional[ttnn.Tensor] = None     # (1, dispatch_group_size, experts_per_chip, max_tokens, emb_dim)
     metadata: Optional[ttnn.Tensor] = None              # (1, dispatch_group_size, experts_per_chip, max_tokens, metadata_len)
     expert_outputs: Optional[ttnn.Tensor] = None        # Same shape as dispatched_buffer

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -12,8 +12,9 @@ Unlike TtSharedExpert, this module:
 - Each device holds weights for `experts_per_chip` local experts
 """
 
+from math import ceil
 from pathlib import Path
-from typing import Optional
+from typing import ClassVar, Optional
 
 import torch
 from loguru import logger
@@ -32,6 +33,8 @@ COMPUTE_KERNEL_CONFIG_LOFI = ttnn.WormholeComputeKernelConfig(
 
 
 class TtRoutedExpert(LightweightModule):
+    FIXED_EXPERT_LENGTH: ClassVar[int] = 2048
+
     @staticmethod
     def check_cache_complete(cache_path: Path, cache_name_prefix: str, experts_per_chip: int) -> bool:
         """Check if all routed expert weight cache files exist."""
@@ -218,10 +221,14 @@ class TtRoutedExpert(LightweightModule):
             activations_dtype: Data type for activations (default: bfloat8_b)
             weights_dtype: Data type for weights (default: bfloat4_b)
             compute_kernel_config: Compute kernel configuration
-            global_expert_idx_table: TTNN tensor mapping local expert slots to global expert ids.
-                          Produced by sharding ExpertMapping.create_global_expert_idx_table via
-                          get_ep_mesh_mapper, so each device holds (1, 1, experts_per_chip) of
-                          global ids. Required.
+            global_expert_idx_table: DRAM uint32 ROW_MAJOR_LAYOUT tensor mapping local
+                          expert slots to global expert ids. Produced by sharding
+                          ExpertMapping.create_global_expert_idx_table via
+                          get_ep_mesh_mapper, so each device holds (1, 1, experts_per_chip)
+                          of global ids. Immutable for the lifetime of this module —
+                          held here (not passed per-forward) because it does not change
+                          across forward calls. Required — drives the per-kernel guard
+                          in the routed_matmul / routed_unary device ops.
         """
         super().__init__()
         self.mesh_device = mesh_device
@@ -366,39 +373,68 @@ class TtRoutedExpert(LightweightModule):
 
         return tt_weight
 
-    def _expert_ffn(
+    def _looped_expert_ffn(
         self,
-        x: ttnn.Tensor,
+        tokens: ttnn.Tensor,
+        out: ttnn.Tensor,
         gate_proj: ttnn.Tensor,
         up_proj: ttnn.Tensor,
         down_proj: ttnn.Tensor,
-        out: Optional[ttnn.Tensor] = None,
-    ) -> ttnn.Tensor:
+        local_expert_idx: int,
+        expert_token_counts: Optional[ttnn.Tensor] = None,
+    ) -> None:
         """
-        Single expert FFN computation.
+        Loop one expert's FFN over fixed-length chunks of ``tokens``.
 
-        Args:
-            x: Input tensor. Shape is (1, tokens, emb_dim) for the Blackhole path
-                (after ttnn.narrow) or (tokens, emb_dim) for the Wormhole path
-                (after tensor indexing).
-            gate_proj: Gate projection weight (emb_dim, hidden_dim)
-            up_proj: Up projection weight (emb_dim, hidden_dim)
-            down_proj: Down projection weight (hidden_dim, emb_dim)
-            out: Optional pre-allocated output tensor for in-place matmul result.
-                When provided, the final matmul writes directly into this buffer.
-                When None, a new tensor is allocated for the output.
+        Splits ``tokens`` along the token dim (-2) into ``ceil(num_tokens /
+        FIXED_EXPERT_LENGTH)`` chunks and calls ``routed_expert_ffn`` once per
+        chunk, writing each result into the matching slice of ``out`` via
+        ``ttnn.narrow``. The final chunk is short when ``num_tokens`` isn't a
+        multiple of ``FIXED_EXPERT_LENGTH``.
 
-        Returns:
-            Output tensor matching the shape of ``x``.
+        Architecture-agnostic: nothing here is BH-specific. The chunked loop
+        is what enables the per-iteration guard — each call passes
+        ``curr_expert_iter`` and ``expert_iter_length`` so the device-side
+        kernel can compare them against
+        ``expert_token_counts[global_expert_idx_table[local_expert_idx]]``
+        and skip iterations past the expert's actual token count, without
+        any device-to-host sync.
+
+        When ``self.global_expert_idx_table`` (set at __init__) and
+        ``expert_token_counts`` are both non-None, the call routes through
+        the forked routed-matmul / routed-unary device ops with the guard
+        active. When either is None, ``routed_expert_ffn`` falls back to
+        plain ttnn::matmul and the chunking still happens but every chunk
+        runs unconditionally.
         """
-        return ttnn.experimental.deepseek_prefill.routed_expert_ffn(
-            x,
-            gate_proj,
-            up_proj,
-            down_proj,
-            compute_kernel_config=self.compute_kernel_config,
-            output=out,
-        )
+        # Tokens can arrive as 2D (num_tokens, emb_dim) from the extract op, or
+        # 3D (1, num_tokens, emb_dim) from the narrow-based flow. The token
+        # dimension is always the second-to-last (`-2`) either way.
+        num_tokens = tokens.shape[-2]
+        expert_iters = ceil(num_tokens / self.FIXED_EXPERT_LENGTH)
+        expert_lengths = [self.FIXED_EXPERT_LENGTH] * expert_iters
+        expert_lengths[-1] = num_tokens - self.FIXED_EXPERT_LENGTH * (expert_iters - 1)
+
+        start = 0
+        for curr_expert_iter in range(expert_iters):
+            expert_tokens = ttnn.narrow(tokens, dim=-2, start=start, length=expert_lengths[curr_expert_iter])
+            expert_out = ttnn.narrow(out, dim=-2, start=start, length=expert_lengths[curr_expert_iter])
+            start += expert_lengths[curr_expert_iter]
+
+            ttnn.experimental.deepseek_prefill.routed_expert_ffn(
+                expert_tokens,
+                gate_proj,
+                up_proj,
+                down_proj,
+                compute_kernel_config=self.compute_kernel_config,
+                output=expert_out,
+                global_expert_idx_table=self.global_expert_idx_table,
+                expert_token_counts=expert_token_counts,
+                local_expert_idx=local_expert_idx,
+                curr_expert_iter=curr_expert_iter,
+                expert_iter_length=self.FIXED_EXPERT_LENGTH,
+            )
+            logger.debug(f"FFN iteration {curr_expert_iter+1} output shape {expert_out.shape}")
 
     def forward(
         self,
@@ -407,43 +443,38 @@ class TtRoutedExpert(LightweightModule):
         expert_region_offsets: ttnn.Tensor,
     ) -> ttnn.Tensor:
         """
-        Blackhole forward implementation using narrow and in-place writes.
+        Forward pass. Extracts per-expert token slices from the shared dispatch
+        buffer using the deepseek_prefill.extract op, runs the chunked guarded
+        FFN per expert (``_looped_expert_ffn``), and writes each expert's result
+        back into the buffer via deepseek_prefill.insert.
 
-        Pre-allocates the output tensor with empty_like and uses narrow to extract
-        per-expert slices and write FFN results directly into the output buffer,
-        avoiding extra allocations from unsqueeze/concat.
+        ``self.global_expert_idx_table`` (set at __init__) together with
+        ``expert_token_counts`` drives the routed_matmul / routed_unary
+        per-kernel guard: iterations where
+        ``expert_token_counts[global_expert_idx_table[local_expert]] <=
+        curr_expert_iter * FIXED_EXPERT_LENGTH`` early-return on device.
 
         Args:
-            dispatched_buffer: Dispatched tokens
-                shape: (max_dispatch_buffer_token_size, emb_dim)
-            expert_token_counts: Token counts per expert per chip
-                If provided, only processes tokens up to the count (currently unused,
-                all tokens are processed for simplicity)
+            dispatched_buffer: Dispatched tokens, shape (max_dispatch_buffer_token_size, emb_dim).
+            expert_token_counts: DRAM uint32 ROW_MAJOR_LAYOUT tensor of token counts
+                per global expert. Shape per device: (1, num_routed_experts).
             expert_region_offsets: Expert region start offsets per expert
                 (shared across source devices in a dispatch group). Produced by
                 offset_cumsum. Shape per device: (1, num_routed_experts).
 
         Returns:
-            expert_outputs: Expert output tensor, same shape as dispatched_buffer
+            expert_outputs: Expert output tensor, same shape as dispatched_buffer.
         """
         logger.debug(f"Forward pass: dispatched_buffer shape={dispatched_buffer.shape}")
 
-        # Convert input to activations dtype if needed
         if dispatched_buffer.dtype != self.activations_dtype:
             logger.warning(f"{dispatched_buffer.dtype=} typecasting to {self.activations_dtype}")
             dispatched_buffer = ttnn.typecast(dispatched_buffer, self.activations_dtype)
-
-        # Process each local expert
-        # dispatched_buffer: (experts_per_chip, max_tokens, emb_dim)
-        # We process expert by expert and reassemble
-
         expert_outputs = dispatched_buffer
         for local_expert in range(self.experts_per_chip):
             signpost(f"Expert {local_expert+1}/{self.experts_per_chip}")
 
-            # Extract tokens for this expert using the deepseek_prefill extract op,
-            # which uses expert_region_offsets and expert_token_counts to slice out
-            # this expert's valid rows
+            # Per-expert slice from the shared dispatch buffer.
             tokens = ttnn.experimental.deepseek_prefill.extract(
                 dispatched_buffer,
                 expert_region_offsets,
@@ -454,21 +485,24 @@ class TtRoutedExpert(LightweightModule):
             )
             logger.debug(f"Expert {local_expert}: input shape {tokens.shape}")
 
-            # Run FFN
-            output = self._expert_ffn(
+            # Pre-allocate the per-expert FFN output — our chunked FFN writes
+            # into it in place, slice by slice.
+            out = ttnn.empty_like(tokens)
+            self._looped_expert_ffn(
                 tokens,
+                out,
                 self.gate_projs[local_expert],
                 self.up_projs[local_expert],
                 self.down_projs[local_expert],
-                out=None,
+                local_expert_idx=local_expert,
+                expert_token_counts=expert_token_counts,
             )
-            logger.debug(f"Expert {local_expert}: output shape {output.shape}")
+            logger.debug(f"Expert {local_expert}: output shape {out.shape}")
 
-            # Insert this expert's output back into the flat expert_outputs buffer at
-            # the expert's region (determined by expert_region_offsets and expert_token_counts).
+            # Write this expert's slice back into the flat buffer.
             expert_outputs = ttnn.experimental.deepseek_prefill.insert(
                 expert_outputs,
-                output,
+                out,
                 expert_region_offsets,
                 expert_token_counts,
                 self.global_expert_idx_table,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/compute/bmm_routed.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/compute/bmm_routed.cpp
@@ -1,0 +1,540 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from
+// ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+// Only change: TRISC-side guard block at the top of kernel_main. See ../../guard.h.
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
+#include "internal/mod_div_lib.h"
+
+#ifdef FUSE_BIAS
+#include "api/compute/bcast.h"
+#endif
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+
+// Guard: mark this as the compute (TRISC) path so guard.h compiles the no-op variant.
+// NOT added to mm_kernel_defines to avoid redefinition in defines_generated.h.
+#define GUARD_COMPUTE_KERNEL
+#include "../guard.h"
+
+// Please update
+// tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+// when making any changes to this file.
+// Have to keep a copy because cannot import ttnn into tests/tt_metal.
+
+/**
+ * @brief Transposes a block of tiles from one circular buffer to another.
+ *
+ * This function reads a block of tiles from the input circular buffer (cb), performs a width-height
+ * (WH) transpose on each tile, and writes the transposed tiles to the output circular buffer.
+ * The operation is performed in blocks of `block_size` tiles for efficiency, with a separate loop
+ * at the end to handle any leftover tiles when the total tile count is not divisible by
+ * `block_size`. The default block size is 4, since there are guaranteed to be 4 tiles in the dst
+ *               regs irrespective of dst sync mode or data format.
+ *
+ * @tparam in0_block_num_tiles The number of tiles in the block to be transposed.
+ * @tparam block_size The number of tiles in each block to be transposed.
+ * @param in0_transpose_cb_id Circular buffer ID to read the original tiles from.
+ * @param in0_cb_id Circular buffer ID to which the transposed tiles are written.
+ */
+template <uint32_t in0_block_num_tiles, uint32_t block_size = 4>
+FORCE_INLINE void transpose_tile_block(uint32_t in0_transpose_cb_id, uint32_t in0_cb_id) {
+    CircularBuffer in0_transpose_cb(in0_transpose_cb_id);
+    CircularBuffer in0_cb(in0_cb_id);
+    constexpr uint32_t num_blocks = in0_block_num_tiles / block_size;
+    constexpr uint32_t last_block_size = in0_block_num_tiles % block_size;
+    // Lets do 2 passes: One loop until last and one last for the left overs
+    for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
+        in0_transpose_cb.wait_front(block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        in0_transpose_cb.pop_front(block_size);
+
+        in0_cb.reserve_back(block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            pack_tile(tile_idx, in0_cb_id);
+        }
+        tile_regs_release();
+        in0_cb.push_back(block_size);
+    }
+
+    if constexpr (last_block_size > 0) {
+        in0_transpose_cb.wait_front(last_block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        in0_transpose_cb.pop_front(last_block_size);
+
+        in0_cb.reserve_back(last_block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            pack_tile(tile_idx, in0_cb_id);
+        }
+        tile_regs_release();
+        in0_cb.push_back(last_block_size);
+    }
+}
+
+FORCE_INLINE void reload_from_cb_to_dst(
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    uint32_t mm_partials_cb_id,
+    bool in1_transpose_tile,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_w,
+    uint32_t out_subblock_h,
+    uint32_t in0_block_w) {
+    CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    // Reconfigure input
+    copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
+    mm_partials_cb.wait_front(out_subblock_num_tiles);
+
+    uint32_t start_dst_index = 0;
+    uint32_t start_tile_index = 0;
+    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+
+    mm_partials_cb.pop_front(out_subblock_num_tiles);
+    // Reconfigure srcA back
+    mm_block_init_short_with_dt(
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+}
+
+template <uint32_t out_subblock_w, uint32_t out_block_w>
+inline void reblock_and_untilize(
+    uint32_t num_out_subblocks_in_col,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_h,
+    uint32_t interm_cb_id,
+    uint32_t out_cb_id) {
+    CircularBuffer interm_cb(interm_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+    uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
+    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
+
+    uint32_t within_block_index = 0;
+    for (uint32_t h = 0; h < out_subblock_h; h++) {
+        uint32_t block_offset = 0;
+
+        out_cb.reserve_back(out_block_w);
+        for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < out_subblock_w; w++) {
+                uint32_t tile_index = block_offset + within_block_index + w;
+                copy_tile(interm_cb_id, tile_index, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            tile_regs_release();
+            block_offset += out_subblock_num_tiles;
+        }
+        out_cb.push_back(out_block_w);
+
+        within_block_index += out_subblock_w;
+    }
+    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
+}
+
+void kernel_main() {
+    if (guard_check_wait()) {
+        return;
+    }
+
+// RUNTIME ARGS
+#ifdef MATMUL_DRAM_SHARDED
+    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    // if not worker core, skip
+    if (not is_worker_core) {
+        return;
+    }
+#endif
+
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);        // inner block size in tiles
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);  // outer row block size (in inner row blocks)
+    constexpr uint32_t in0_block_num_tiles =
+        get_compile_time_arg_val(2);  // out_subblock_h*in0_block_w*in0_num_subblocks;
+    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
+    constexpr uint32_t in1_num_subblocks =
+        get_compile_time_arg_val(4);  // outer column block size (in inner column blocks)
+    constexpr uint32_t in1_block_num_tiles =
+        get_compile_time_arg_val(5);                               // out_subblock_w*in0_block_w* in1_num_subblocks;
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(6);  // out_subblock_w*in1_num_subblocks
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(7);     // outer inner dim (in inner dim blocks)
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(8);         // outer inner dim (in inner dim blocks)
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(9);         // outer inner dim (in inner dim blocks)
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(10);          // inner row block size in tiles
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(11);          // inner column block size in tiles
+    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(12);  // out_subblock_h * out_subblock_w;
+    constexpr uint32_t batch = get_compile_time_arg_val(13);                   // batch dim
+    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(14);     // number of tiles in out_block
+    constexpr bool untilize_out = get_compile_time_arg_val(15);                // untilize output
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(16);
+    constexpr bool in0_transpose_tile = (bool)get_compile_time_arg_val(17);
+
+    constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
+
+    constexpr uint32_t in0_cb_id = in0_transpose_tile ? get_named_compile_time_arg_val("cb_in0_transposed")
+                                                      : get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t in1_cb_id = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t out_cb_id = get_named_compile_time_arg_val("cb_out");
+    constexpr uint32_t mm_partials_cb_id = get_named_compile_time_arg_val("cb_intermed0");
+    constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? mm_partials_cb_id : out_cb_id;
+    // When in0 needs to be transposed, the original data is read from cb_in0 (in0_transpose_cb_id),
+    // transposed, and the result is written to cb_in0_transposed (in0_cb_id), which is then used
+    // as input for the matmul call.
+    constexpr uint32_t in0_transpose_cb_id = get_named_compile_time_arg_val("cb_in0");
+
+    CircularBuffer in0_cb(in0_cb_id);
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+    CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    CircularBuffer untilize_mode_out_cb(untilize_mode_out_cb_id);
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = get_named_compile_time_arg_val("cb_bias");
+    constexpr uint32_t bias_ntiles = get_named_compile_time_arg_val("bias_ntiles");
+    constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
+    CircularBuffer bias_cb(bias_cb_id);
+#else
+    constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
+#endif
+    CircularBuffer mm_out_cb(mm_out_cb_id);
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+    SFPU_OP_INIT_ACTIVATION
+#endif
+
+#ifdef IN1_TRANSPOSE_TILE
+    constexpr uint32_t in1_transpose_tile = true;
+#else
+    constexpr uint32_t in1_transpose_tile = false;
+#endif
+
+    constexpr bool spill = num_blocks_inner_dim > 1;
+
+    mm_block_init(
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+    for (uint32_t b = 0; b < batch; b++) {
+        if constexpr (get_batch_from_reader) {
+            // Check whether this batch is valid
+            bool is_batch_valid = false;
+            UNPACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            MATH(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            PACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            if (!is_batch_valid) {
+                continue;
+            }
+        }
+
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                bool enable_reload = false;
+
+#ifdef PACK_RELU
+                // for each batch we start with relu disabled so that intermediate results are not relu'd
+                if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
+                    PACK((llk_pack_relu_config(ReluType::NO_RELU)));
+                }
+#endif
+
+                if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
+                    PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                }
+
+                for (uint32_t block = 0; block < num_blocks_inner_dim; block++) {
+                    bool last_out = block == (num_blocks_inner_dim - 1);
+// Configure packer once for pack out without Bias
+#if not defined FUSE_BIAS and defined PACK_RELU
+                    if (last_out) {
+                        // if last block we pack the final result with relu enabled
+                        PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+                    }
+#endif
+
+                    if constexpr (in0_transpose_tile) {
+                        reconfig_data_format_srca(in1_cb_id, in0_transpose_cb_id);
+                        transpose_wh_init_short(in0_transpose_cb_id);
+                        PACK((pack_reconfig_data_format(in0_cb_id)));
+#ifdef PACKER_L1_ACC
+                        PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+                        transpose_tile_block<in0_block_num_tiles>(in0_transpose_cb_id, in0_cb_id);
+                        mm_block_init_short_with_dt(
+                            in0_cb_id,
+                            in1_cb_id,
+                            in0_transpose_cb_id,
+                            in1_transpose_tile,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+                        PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                    }
+
+                    in0_cb.wait_front(in0_block_num_tiles);
+                    in1_cb.wait_front(in1_block_num_tiles);
+
+                    if (block == 0 && !last_out) {
+                        out_cb.reserve_back(out_block_num_tiles);
+                    }
+
+                    int in0_index_subblock_offset = 0;
+                    for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                        int in1_index_subblock_offset = 0;
+                        for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                            tile_regs_acquire();
+                            if (enable_reload) {
+                                reload_from_cb_to_dst(
+                                    in0_cb_id,
+                                    in1_cb_id,
+                                    mm_partials_cb_id,
+                                    in1_transpose_tile,
+                                    out_subblock_num_tiles,
+                                    out_subblock_w,
+                                    out_subblock_h,
+                                    in0_block_w);
+                            }
+
+#ifndef SKIP_COMPUTE
+                            // Compute output sub-block
+                            uint32_t dst_index =
+                                0;  // start at 0, each call to matmul_block internally increments dst_index
+                            uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
+                            uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
+                            // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
+                            for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; ++inner_dim_idx) {
+                                // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
+                                // accumulation is done by iterating matmul_block across inner dim
+                                // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride
+                                // in0
+                                matmul_block(
+                                    in0_cb_id,
+                                    in1_cb_id,
+                                    in0_index,
+                                    in1_index,
+                                    dst_index,
+                                    in1_transpose_tile,
+                                    out_subblock_w,
+                                    out_subblock_h,
+                                    in0_block_w);
+                                in0_index++;               // stride right by 1
+                                in1_index += in1_block_w;  // to stride down by 1 need to stride by in_per_core_w
+                                                           // (should be called in1_block_w)
+                            }
+
+#endif  // SKIP_COMPUTE
+
+                            if (last_out) {
+// If we fuse bias, we will pack out and run bias + optional sfpu in a separate loop
+#if not defined FUSE_BIAS and defined SFPU_OP_INIT_ACTIVATION
+                                for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                                    SFPU_OP_FUNC_ACTIVATION
+                                }
+#endif
+                                tile_regs_commit();
+                                // Pack out to output buffer
+                                mm_out_cb.reserve_back(out_subblock_num_tiles);
+                                tile_regs_wait();
+
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                                PACK((pack_reconfig_data_format(mm_out_cb_id)));
+#endif
+
+#ifdef PACKER_L1_ACC
+#ifdef FUSE_BIAS
+                                if (block == 0) {  // no accumulation for first iteration
+                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                } else {
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                }
+#else
+                                PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+#endif
+
+                                uint32_t start_dst_index = 0;
+                                pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+
+                                tile_regs_release();
+                                mm_out_cb.push_back(out_subblock_num_tiles);
+
+                            } else {
+                                tile_regs_commit();
+                                mm_partials_cb.reserve_back(out_subblock_num_tiles);
+                                tile_regs_wait();
+
+#ifdef PACKER_L1_ACC
+                                if (block == 0) {  // no accumulation for first iteration
+                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                } else if (block == 1) {
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                } else if (in0_transpose_tile) {
+                                    // For each block, l1_acc would have been enabled during the
+                                    // transpose stage. So let us put it back here.
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                }
+#endif
+
+                                uint32_t start_dst_index = 0;
+                                pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+
+                                tile_regs_release();
+                                mm_partials_cb.push_back(out_subblock_num_tiles);
+                            }
+
+                            in1_index_subblock_offset += out_subblock_w;
+                        }
+                        in0_index_subblock_offset += in0_subblock_num_tiles;
+                    }
+
+#ifdef PACKER_L1_ACC
+#ifdef FUSE_BIAS
+                    if (block < num_blocks_inner_dim - 1) {
+                        // Wait/pop in subblock-sized steps so the step size
+                        // matches the bias section's wait_front(out_subblock_num_tiles),
+                        // satisfying the CB API requirement that all wait_front
+                        // increments on a given CB are identical.
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
+                    }
+                    // never reload when with bias, bias uses interm buffer
+                    enable_reload = false;
+#else
+                    // Last iteration does spill and reload to output buffer
+                    if (block < num_blocks_inner_dim - 2) {
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
+                    }
+                    if (block == num_blocks_inner_dim - 2) {
+                        enable_reload = true;
+                    }  // reload when last iteration
+#endif
+#else
+                    if constexpr (spill) {
+                        enable_reload = true;
+                    }
+#endif
+
+                    in0_cb.pop_front(in0_block_num_tiles);
+                    in1_cb.pop_front(in1_block_num_tiles);
+                }
+
+#ifdef FUSE_BIAS
+#ifdef PACK_RELU
+                // if last block we pack the final result with relu enabled
+                PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+#endif
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                PACK((pack_reconfig_data_format(out_cb_id)));
+#endif
+#ifdef PACKER_L1_ACC
+                PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+
+                reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
+                add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+                // Reader only pushes bias once when num_blocks_w_dim == 1;
+                // the tiles stay in the CB for reuse across bh/batch iterations.
+                if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                    bias_cb.wait_front(bias_ntiles);
+                }
+                for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                    int in1_index_subblock_offset = 0;
+                    for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                        // Redundant wait since we know data was just pushed
+                        mm_partials_cb.wait_front(out_subblock_num_tiles);
+                        tile_regs_acquire();
+                        for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
+                            uint32_t bcast_tile_idx = in1_index_subblock_offset;
+                            for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
+                                add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, bcast_tile_idx, i);
+                                bcast_tile_idx++;
+                            }
+                        }
+// if there's no SFPU fusion, we commit the regs so packer can start packing
+#ifndef SFPU_OP_INIT_ACTIVATION
+                        tile_regs_commit();
+#endif
+
+                        mm_partials_cb.pop_front(out_subblock_num_tiles);
+
+// sfpu activation
+#ifdef SFPU_OP_INIT_ACTIVATION
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            SFPU_OP_FUNC_ACTIVATION
+                        }
+                        tile_regs_commit();
+#endif
+
+                        // Pack out to output buffer
+                        untilize_mode_out_cb.reserve_back(out_subblock_num_tiles);
+                        tile_regs_wait();
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, untilize_mode_out_cb_id);
+                        }
+                        tile_regs_release();
+                        untilize_mode_out_cb.push_back(out_subblock_num_tiles);
+
+                        in1_index_subblock_offset += out_subblock_w;
+                    }
+                }
+                if constexpr (num_blocks_w_dim > 1) {
+                    bias_cb.pop_front(bias_ntiles);
+                }
+#endif  // FUSE_BIAS
+                if constexpr (untilize_out) {
+#ifdef PACK_RELU
+                    PACK((llk_pack_relu_config(ReluType::NO_RELU)));
+#endif  // PACK_RELU
+#ifndef FUSE_BIAS
+                    reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                    PACK((pack_reconfig_data_format(out_cb_id)));
+#endif
+#ifdef PACKER_L1_ACC
+                    PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+#endif  // FUSE_BIAS
+                    pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
+                    copy_tile_to_dst_init_short(mm_partials_cb_id);
+                    for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                        reblock_and_untilize<out_subblock_w, out_block_w>(
+                            in1_num_subblocks, out_subblock_num_tiles, out_subblock_h, mm_partials_cb_id, out_cb_id);
+                    }
+                    pack_untilize_uninit(mm_partials_cb_id);
+                }
+                if constexpr (batch > 1 || num_blocks_w_dim > 1 || num_blocks_h_dim > 1) {
+#ifdef FUSE_BIAS
+                    // reconfigure unpacker df for src A and src B
+                    reconfig_data_format(mm_partials_cb_id, in1_cb_id, bias_cb_id, in0_cb_id);
+#else
+                    // reconfigure unpacker df for src A
+                    reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
+#endif
+                    // reconfigure init for matmul
+                    mm_block_init_short(
+                        in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in0_receiver.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from
+// ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+// The only change is the guard block at the top of kernel_main: this core reads
+// global_expert_idx_table and expert_token_counts from DRAM and returns early
+// if expert_token_counts[global_expert_idx_table[local_expert_idx]]
+// <= curr_expert_iter * expert_iter_length. See ../guard.h.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+
+#include "../guard.h"
+
+void kernel_main() {
+    if (guard_check_brisc()) {
+        return;
+    }
+
+    // in0 mcast args
+    const uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(0);
+    const uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(1);
+
+    // COMPILE TIME ARGS
+    // in0 block args
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(1);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(3);
+    // in0 mcast args
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
+    // batch args
+    constexpr uint32_t batch = get_compile_time_arg_val(6);
+    // sparsity args
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(7);
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+
+    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        if constexpr (get_batch_from_reader) {
+            // This means we have unstructured sparsity.
+            // The compute kernel needs to be made aware whether this batch is valid or not.
+            // We do this by passing the value to the compute kernel via mailbox.
+            // But first, lets wait for the sparsity data to be multicast to us.
+            // Set in0 semaphore value to INVALID
+            receiver_sem.set(INVALID);
+            // Atomic increment source core counter
+            sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
+            // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+            receiver_sem.wait_min(VALID);
+
+            const auto is_batch_valid = *in0_mcast_receiver_semaphore_addr_ptr == VALID;
+
+            // We need to pass the value to compute cores regardless of the value of is_batch_valid
+            ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_batch_valid);
+            ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_batch_valid);
+            ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_batch_valid);
+
+            // Skip sending the input tensor for this batch as it is not valid.
+            if (!is_batch_valid) {
+                continue;
+            }
+        }
+
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                    // Operand 0
+                    cb_in0.reserve_back(in0_block_num_tiles);
+
+                    // Set in0 semaphore value to INVALID
+                    receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
+
+                    // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    receiver_sem.wait(VALID);
+
+                    cb_in0.push_back(in0_block_num_tiles);
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in0_sender_padding.cpp
@@ -1,0 +1,438 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from
+// ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+// Only change: BRISC-side guard block at the top of kernel_main. See ../guard.h.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+
+#include "../guard.h"
+
+void kernel_main() {
+    if (guard_check_brisc()) {
+        return;
+    }
+
+    uint32_t rt_args_idx = 0;
+    // in0 tensor args
+    const uint32_t in0_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t in0_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // in0 mcast args
+    const uint32_t in0_mcast_dest_noc_start_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_start_y = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_end_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in0_mcast_dest_noc_end_y = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // padding args
+    const uint32_t last_block_h = get_arg_val<uint32_t>(rt_args_idx++);
+    // sparsity args
+    const uint32_t sparsity_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // COMPILE TIME ARGS
+    // in0 tensor args
+    constexpr uint32_t in0_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_tensor_next_inner_dim_block_stride = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_tensor_next_h_dim_block_stride = get_compile_time_arg_val(3);
+    // in0 block args
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in0_block_h = get_compile_time_arg_val(5);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(7);
+    constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(8);
+
+    constexpr bool extract_shard_sub_blocks = (bool)get_compile_time_arg_val(9);
+    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(10);
+    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(11);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(13);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(14);
+    // in0 mcast args
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(17);
+    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(18);
+    // batch args
+    constexpr uint32_t MtKt = get_compile_time_arg_val(19);  // if 0
+    constexpr uint32_t in0_B = get_compile_time_arg_val(20);
+    constexpr uint32_t in1_B = get_compile_time_arg_val(21);
+    constexpr uint32_t in0_reuse_in_CB = get_compile_time_arg_val(22);
+
+    // sparsity args
+
+    constexpr uint32_t batchB = get_compile_time_arg_val(23);
+    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(24);
+    // Boolean that is set when input A is sparse. If set, both input A and B are assumed to be sparse.
+    // Based on the sparsity tensor, the corresponding batch in input A and B are skipped.
+    constexpr bool bcast_A = (bool)get_compile_time_arg_val(25);
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(26);
+
+    constexpr bool fuse_op = (bool)get_compile_time_arg_val(27);
+
+    constexpr auto in0_args = TensorAccessorArgs<28>();
+
+    constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
+
+    // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
+    // 0x1 is used to specify "VALID" state, i.e. when the batch is valid.
+    // 0x2 is used to specify "IGNORE_BATCH" state, i.e. when the batch is not valid.
+    constexpr uint32_t IGNORE_BATCH = 0x2;
+
+    // When sparsity is disabled, we just loop once
+    constexpr uint32_t batchB_lim = batchB == 0 ? 1u : batchB;
+
+    MatmulOpReceiver fused_op_receiver;
+    if constexpr (fuse_op) {
+        fused_op_receiver = MatmulOpReceiver(
+            true, /* wait_for_op_signal */
+            rt_args_idx,
+            num_blocks_inner_dim,
+            in0_block_w /* tiles_per_block (in the same dimension as tensor slice) */
+        );
+    }
+
+    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr uint32_t in0_block_size_bytes = in0_block_num_tiles * in0_single_tile_size_bytes;
+    constexpr uint32_t one_tile = 1;
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(15));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(16));
+
+#ifdef IN0_SHARDED
+    // In case we need to send multiple blocks per shard, in0 sharded cb is cb2 and we extract the sub-blocks to cb0
+    constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
+    constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
+    constexpr uint32_t shard_num_tiles = shard_width_in_tiles * shard_height_in_tiles;
+    constexpr uint32_t in0_tensor_next_h_dim_block_stride_bytes =
+        in0_tensor_next_h_dim_block_stride * in0_single_tile_size_bytes;
+
+    uint32_t noc_shard_read_start_addr = 0;
+    if constexpr (extract_shard_sub_blocks) {
+        constexpr uint32_t cb_id_in2 =
+            get_named_compile_time_arg_val("cb_in0_sharded");  // in0 sharded cb if extract_shard_sub_blocks
+        CircularBuffer cb_in2(cb_id_in2);
+        noc_shard_read_start_addr = cb_in2.get_read_ptr();
+    }
+
+#else
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+#ifndef IN0_SHARDED
+#ifdef INTERMEDIATE_CB_READ
+    constexpr uint32_t in0_intermediate_cb_index = get_named_compile_time_arg_val("cb_in0_intermediate");
+    CircularBuffer cb_helper(in0_intermediate_cb_index);
+#endif  // INTERMEDIATE_CB_READ
+#endif
+#endif  // IN0_SHARDED
+
+    // sparsity accessor
+    constexpr uint32_t cb_id_sparsity = get_named_compile_time_arg_val("cb_sparsity");
+    CircularBuffer cb_sparsity(cb_id_sparsity);
+    const auto s_sparsity = TensorAccessor(sparsity_args, sparsity_addr);
+
+#ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+
+#ifdef IN0_SHARDED
+    uint32_t in0_start_address = cb_in0.get_write_ptr();
+#endif  // IN0_SHARDED
+#endif  // SKIP_MCAST
+
+    uint32_t l1_write_addr_sparsity = 0;
+    if constexpr (batchB > 0) {
+        cb_sparsity.reserve_back(1);
+        l1_write_addr_sparsity = cb_sparsity.get_write_ptr();
+    }
+
+    for (uint32_t b = 0; b < in0_B; ++b) {
+        if constexpr (batchB > 0) {
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+        }
+
+        for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
+            if constexpr (batchB > 0) {
+                volatile auto is_batch_valid =
+                    ((reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_sparsity))[bB]) != 0;
+
+                if constexpr (get_batch_from_reader) {
+#ifndef SKIP_MCAST
+                    // First broadcast this to other cores
+                    sender_sem.wait(in0_mcast_num_dests);
+                    sender_sem.set(0);
+                    receiver_sem.set(is_batch_valid ? VALID : IGNORE_BATCH);
+                    receiver_sem.set_multicast(
+                        noc,
+                        in0_mcast_dest_noc_start_x,
+                        in0_mcast_dest_noc_start_y,
+                        in0_mcast_dest_noc_end_x,
+                        in0_mcast_dest_noc_end_y,
+                        in0_mcast_num_cores);
+                    noc.async_writes_flushed();
+                    // Reset the semaphore value to VALID
+                    receiver_sem.set(VALID);
+#endif  // SKIP_MCAST
+
+                    // We need to pass the value to compute cores regardless of the value of is_batch_valid
+                    ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_batch_valid);
+                    ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_batch_valid);
+                    ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_batch_valid);
+                }
+
+                if (!is_batch_valid) {
+                    if constexpr (!bcast_A) {
+                        in0_tensor_start_tile_id += MtKt;
+                    }
+                    continue;
+                }
+            }
+
+#ifdef IN0_SHARDED
+            uint32_t in0_tensor_current_h_dim_block_start_addr = noc_shard_read_start_addr;
+#endif  // IN0_SHARDED
+            uint32_t in0_tensor_current_h_dim_block_tile_id = in0_tensor_start_tile_id;
+            for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+                for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+#ifdef IN0_SHARDED
+                    uint32_t in0_tensor_current_inner_dim_block_start_addr = in0_tensor_current_h_dim_block_start_addr;
+#endif  // IN0_SHARDED
+                    uint32_t in0_tensor_current_inner_dim_block_start_tile_id = in0_tensor_current_h_dim_block_tile_id;
+                    for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                        if constexpr (fuse_op) {
+                            fused_op_receiver.update_current_block_start_tile_id(
+                                block, in0_tensor_current_inner_dim_block_start_tile_id, in0_tensor_start_tile_id);
+                        }
+
+                        // Operand 0
+                        // Common for sharded and interleaved paths
+                        cb_in0.reserve_back(in0_block_num_tiles);
+#ifndef IN0_SHARDED
+
+#ifdef INTERMEDIATE_CB_READ
+                        cb_helper.reserve_back(one_tile);
+#endif  // INTERMEDIATE_CB_READ
+
+                        uint32_t in0_write_offset = 0;
+
+#ifndef SKIP_MCAST
+                        uint32_t in0_start_address =
+                            cb_in0.get_write_ptr();  // copy start address of block, to be used for mcasting
+#endif                                               // SKIP_MCAST
+
+                        // Copy in0 block into CB, as the default kernel
+                        uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_inner_dim_block_start_tile_id;
+                        for (uint32_t h = 0; h < in0_block_h; ++h) {
+                            uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
+                            for (uint32_t w = 0; w < in0_block_w; ++w) {
+                                if (bh < num_blocks_h_dim - 1 || h < last_block_h) {
+#ifndef INTERMEDIATE_CB_READ
+                                    noc.async_read(
+                                        s0,
+                                        cb_in0,
+                                        in0_single_tile_size_bytes,
+                                        {.page_id = in0_tensor_tile_id},
+                                        {.offset_bytes = in0_write_offset});
+#else
+                                    noc.async_read(
+                                        s0,
+                                        cb_helper,
+                                        in0_single_tile_size_bytes,
+                                        {.page_id = in0_tensor_tile_id},
+                                        {.offset_bytes = 0});
+                                    noc.async_read_barrier();
+                                    memcpy(
+                                        /*dst=*/reinterpret_cast<void*>(cb_in0.get_write_ptr() + in0_write_offset),
+                                        /*src=*/reinterpret_cast<const void*>(cb_helper.get_write_ptr()),
+                                        /*size=*/in0_single_tile_size_bytes);
+#endif  // INTERMEDIATE_CB_READ
+                                }
+
+                                // Zero out padded regions for the very last tile
+                                if constexpr (in0_last_ktile_w > 0) {
+                                    if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
+                                        noc.async_read_barrier();
+                                        const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(
+                                            cb_in0.get_write_ptr() + in0_write_offset);
+                                    }
+                                }
+                                if constexpr (in0_last_ktile_h > 0) {
+                                    if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
+                                        noc.async_read_barrier();
+                                        const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(
+                                            cb_in0.get_write_ptr() + in0_write_offset);
+                                    }
+                                }
+
+                                in0_write_offset += in0_single_tile_size_bytes;
+                                in0_tensor_tile_id += in0_tensor_stride_w;
+                            }
+                            in0_tensor_row_start_tile_id += in0_tensor_stride_h;
+                        }
+                        in0_tensor_current_inner_dim_block_start_tile_id += in0_tensor_next_inner_dim_block_stride;
+
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#else
+                        if constexpr (extract_shard_sub_blocks) {
+                            uint32_t l1_write_addr_in0 = cb_in0.get_write_ptr();
+
+#ifndef SKIP_MCAST
+                            in0_start_address =
+                                l1_write_addr_in0;  // copy start address of block, to be used for mcasting
+#endif  // SKIP_MCAST
+
+                            UnicastEndpoint self_ep;
+                            uint32_t noc_shard_read_l1_addr = in0_tensor_current_inner_dim_block_start_addr;
+
+                            for (uint32_t i = 0; i < in0_block_h; i++) {
+                                noc.async_read(
+                                    self_ep,
+                                    CoreLocalMem<uint32_t>(l1_write_addr_in0),
+                                    shard_read_width,
+                                    {.noc_x = my_x[0], .noc_y = my_y[0], .addr = noc_shard_read_l1_addr},
+                                    {});
+
+                                l1_write_addr_in0 += shard_read_width;
+                                noc_shard_read_l1_addr += shard_read_stride;
+                            }
+
+                            in0_tensor_current_inner_dim_block_start_addr += shard_read_width;
+                            noc.async_read_barrier();
+                        }
+
+                        {
+                            constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+                            uint32_t in0_pad_base_addr = cb_in0.get_write_ptr();
+                            if constexpr (in0_last_ktile_w > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t h = 0; h < in0_block_h; ++h) {
+                                        auto ptr = in0_pad_base_addr +
+                                                   (h * in0_block_w + in0_block_w - 1) * in0_single_tile_size_bytes;
+                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(ptr);
+                                    }
+                                }
+                            }
+                            if constexpr (in0_last_ktile_h > 0) {
+                                if ((block == num_blocks_inner_dim - 1)) {
+                                    for (uint32_t w = 0; w < in0_block_w; ++w) {
+                                        auto ptr = in0_pad_base_addr +
+                                                   ((in0_block_h - 1) * in0_block_w + w) * in0_single_tile_size_bytes;
+                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(ptr);
+                                    }
+                                }
+                            }
+                        }
+#endif  // IN0_SHARDED
+
+#ifndef SKIP_MCAST
+                        // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
+                        // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
+                        // zero for the next block
+                        sender_sem.wait(in0_mcast_num_dests);
+                        sender_sem.set(0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        MulticastEndpoint mcast_dst;
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(in0_start_address),
+                            mcast_dst,
+                            in0_block_size_bytes,
+                            in0_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in0_mcast_dest_noc_start_x,
+                             .noc_y_start = in0_mcast_dest_noc_start_y,
+                             .noc_x_end = in0_mcast_dest_noc_end_x,
+                             .noc_y_end = in0_mcast_dest_noc_end_y,
+                             .addr = in0_start_address},
+                            true);
+
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
+                        // vc, same cmd_buf Also, this only works because we are setting VCs statically (using
+                        // NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV
+                        // latency which means data could be changed before write is issued.
+                        noc.async_writes_flushed();
+#endif  // ARCH_BLACKHOLE
+
+                        // We should also multicast the flag to destinations
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        receiver_sem.set_multicast(
+                            noc,
+                            in0_mcast_dest_noc_start_x,
+                            in0_mcast_dest_noc_start_y,
+                            in0_mcast_dest_noc_end_x,
+                            in0_mcast_dest_noc_end_y,
+                            in0_mcast_num_cores);
+#endif  // SKIP_MCAST
+
+                        // Common for sharded and interleaved paths
+                        cb_in0.push_back(in0_block_num_tiles);
+#ifdef INTERMEDIATE_CB_READ
+                        // Clean up helper CB
+                        cb_helper.push_back(one_tile);
+                        cb_helper.wait_front(one_tile);
+                        cb_helper.pop_front(one_tile);
+#endif  // INTERMEDIATE_CB_READ
+                    }
+                }
+#ifdef IN0_SHARDED
+                in0_tensor_current_h_dim_block_start_addr += in0_tensor_next_h_dim_block_stride_bytes;
+#endif  // IN0_SHARDED
+                in0_tensor_current_h_dim_block_tile_id += in0_tensor_next_h_dim_block_stride;
+            }
+
+            if constexpr (!bcast_A) {
+                in0_tensor_start_tile_id += MtKt;
+            }
+        }
+
+        if constexpr (bcast_A) {
+            in0_tensor_start_tile_id += MtKt;
+        }
+
+        // this is an optimization for the case when in0 is [1, 1, M, K] and in1 is [1, H, K, N], i.e. when in0_B ==
+        // 1 and in1_B > 1 in this case we originally had to replicate the in0 block for each batch, but with this
+        // optimization we just read the tensor slice once into each core's L1 and keep it there for all weight
+        // batches since the needed in0 data is already in L1 after batch 0, we can just move read pointer for this
+        // CB so compute kernel thinks it has new data
+        if (in0_reuse_in_CB) {
+            for (uint32_t fake_batch = 0; fake_batch < in1_B - in0_B; ++fake_batch) {
+                for (uint32_t blk = 0; blk < num_blocks_inner_dim; ++blk) {
+                    cb_in0.reserve_back(in0_block_num_tiles);
+                    cb_in0.push_back(in0_block_num_tiles);
+                }
+            }
+        }
+    }
+    noc.async_write_barrier();
+    // For completeness, we empty the sparsity CB if it was reserved earlier
+    if constexpr (batchB > 0) {
+        cb_sparsity.push_back(1);
+        cb_sparsity.wait_front(1);
+        cb_sparsity.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in1_receiver_writer_padding.cpp
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from
+// ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+// Only change: NCRISC-side guard block at the top of kernel_main. See ../guard.h.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+
+#include "../guard.h"
+
+void kernel_main() {
+    if (guard_check_wait()) {
+        return;
+    }
+
+    // READER
+    uint32_t rt_args_idx = 0;
+    // in1 mcast args
+    const uint32_t in1_mcast_sender_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_sender_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // WRITER
+    // out tensor args
+    const uint32_t out_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // padding args (WRITER)
+    const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_h_skip = get_arg_val<uint32_t>(rt_args_idx++);
+
+    const uint32_t out_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_subblock_tiles_addr_skip = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_w_skip = get_arg_val<uint32_t>(rt_args_idx++);
+
+#ifndef OUT_SHARDED
+    const uint32_t last_num_blocks_h_dim = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
+#endif
+
+    // COMPILE TIME ARGS
+    // READER
+    // in1 block args
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(0);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(1);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(3);
+    // in1 mcast args
+    // batch args
+    constexpr uint32_t batch = get_compile_time_arg_val(6);
+
+    // WRITER
+    // out tensor args
+    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(7);
+    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(8);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(9);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(10);
+    constexpr uint32_t out_tensor_next_w_dim_block_stride = get_compile_time_arg_val(11);
+    constexpr uint32_t out_tensor_next_h_dim_block_stride = get_compile_time_arg_val(12);
+
+    // out subblock args
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(13);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(14);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(15);
+
+    // batch args
+    constexpr uint32_t MtNt = get_compile_time_arg_val(16);  // if 0
+    // Don't need batch; same as batch from READER args
+
+#ifdef FUSE_BIAS
+    // in3 block args
+    constexpr uint32_t in3_block_w = get_compile_time_arg_val(17);
+
+    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+#endif
+    constexpr bool fuse_op_reduce_scatter = (bool)get_compile_time_arg_val(18);
+
+    constexpr auto out_args = TensorAccessorArgs<19>();
+    OpSignaler op_signaler;
+    if constexpr (fuse_op_reduce_scatter) {
+        op_signaler = OpSignaler(rt_args_idx);
+    }
+    // WRITER
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+
+    // WRITER
+    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
+
+    // WRITER
+    // single-tile
+    const uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
+    constexpr const uint32_t output_tile_hw = get_tile_hw(cb_id_out0);
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in3(cb_id_in3);
+#endif
+
+    // WRITER
+    const auto s = TensorAccessor(out_args, out_tensor_addr);
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        uint32_t out_tensor_current_h_dim_block_tile_id = out_tensor_start_tile_id;
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            uint32_t out_tensor_current_w_dim_block_tile_id = out_tensor_current_h_dim_block_tile_id;
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                    // Operand 1
+                    cb_in1.reserve_back(in1_block_num_tiles);
+
+                    // Set in1 semaphore value to INVALID
+                    receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
+
+                    // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    receiver_sem.wait(VALID);
+
+                    cb_in1.push_back(in1_block_num_tiles);
+                }
+
+#ifdef FUSE_BIAS
+                // Only read bias on first batch, or we have multiple output blocks
+                if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                    // Operand 2
+                    cb_in3.reserve_back(in3_block_w);
+
+                    // Set in1 semaphore value to INVALID
+                    receiver_sem.set(INVALID);
+
+                    // Atomic increment source core counter
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
+
+                    // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    receiver_sem.wait(VALID);
+
+                    cb_in3.push_back(in3_block_w);
+                }
+#endif
+
+#ifndef OUT_SHARDED
+                // WRITER
+                uint32_t num_blocks_h_dim_ = bh >= last_num_blocks_h_dim - 1 ? last_num_blocks_h_dim : num_blocks_h_dim;
+                uint32_t num_blocks_w_dim_ = bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
+                uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
+                uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
+                if (bh == num_blocks_h_dim_ - 1) {
+                    out_num_nonzero_subblocks_h_ = out_last_num_nonzero_subblocks_h;
+                }
+                if (bw == num_blocks_w_dim_ - 1) {
+                    out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
+                }
+                uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
+                for (uint32_t sbh = 0; sbh < out_num_nonzero_subblocks_h_; ++sbh) {
+                    uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
+                    for (uint32_t sbw = 0; sbw < out_num_nonzero_subblocks_w_; ++sbw) {
+                        uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+
+                        uint32_t out_subblock_h_ = out_subblock_h;
+                        uint32_t out_subblock_w_ = out_subblock_w;
+                        uint32_t subblock_tiles_addr_skip = 0;
+                        if (bh == num_blocks_h_dim_ - 1 && sbh == out_num_nonzero_subblocks_h_ - 1) {
+                            out_subblock_h_ = out_last_subblock_h;
+                        }
+                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w_ - 1) {
+                            out_subblock_w_ = out_last_subblock_w;
+                            subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
+                        }
+
+                        cb_out.wait_front(out_subblock_tile_count);
+                        uint32_t out_read_offset = 0;
+
+                        for (uint32_t h = 0; h < out_subblock_h_; ++h) {
+                            uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
+                            for (uint32_t w = 0; w < out_subblock_w_; ++w) {
+                                if (bh < num_blocks_h_dim_ && bw < num_blocks_w_dim_) {
+                                    noc.async_write(
+                                        use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                                        s,
+                                        output_single_tile_size_bytes,
+                                        {.offset_bytes = out_read_offset},
+                                        {.page_id = out_tensor_tile_id});
+                                }
+
+                                out_read_offset += output_single_tile_size_bytes;
+
+                                out_tensor_tile_id += out_tensor_stride_w;
+                            }
+                            // Skip padded tiles in subblock along row
+                            out_read_offset += subblock_tiles_addr_skip;
+                            out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+                        }
+
+                        noc.async_write_barrier();
+
+                        cb_out.pop_front(out_subblock_tile_count);
+                        out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+                    }
+                    // Pop fully padded subblocks along the row
+                    if (bw == num_blocks_w_dim_ - 1) {
+                        cb_out.wait_front(padded_block_tiles_w_skip);
+                        cb_out.pop_front(padded_block_tiles_w_skip);
+                    }
+                    out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+                }
+                // Pop row(s) of fully padded subblocks
+                if (bh == num_blocks_h_dim_ - 1) {
+                    cb_out.wait_front(padded_block_tiles_h_skip);
+                    cb_out.pop_front(padded_block_tiles_h_skip);
+                }
+#endif
+                out_tensor_current_w_dim_block_tile_id += out_tensor_next_w_dim_block_stride;
+            }
+            out_tensor_current_h_dim_block_tile_id += out_tensor_next_h_dim_block_stride;
+        }
+        out_tensor_start_tile_id += MtNt;
+
+        if (fuse_op_reduce_scatter) {
+            // Signal reduce_scatter to go
+            op_signaler.synchronize_workers_and_signal_op(0);
+        }
+    }
+
+#if OUT_SHARDED
+    cb_out.wait_front(
+        batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/reader_routed_in1_sender_writer_padding.cpp
@@ -1,0 +1,709 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from
+// ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+// Only change: NCRISC-side guard block at the top of kernel_main. See ../guard.h.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+
+#include "../guard.h"
+
+void kernel_main() {
+    if (guard_check_wait()) {
+        return;
+    }
+
+    // READER
+    uint32_t rt_args_idx = 0;
+    // in1 tensor args
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t in1_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // in1 mcast args
+    const uint32_t in1_mcast_dest_noc_start_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_dest_noc_start_y = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_dest_noc_end_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in1_mcast_dest_noc_end_y = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // sparsity args
+    const uint32_t sparsity_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // WRITER
+    // out tensor args
+    const uint32_t out_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // padding args (READER)
+    const uint32_t last_block_w = get_arg_val<uint32_t>(rt_args_idx++);
+    // padding args (WRITER)
+    const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_h_skip = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_num_nonzero_subblocks_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t out_last_subblock_w = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_subblock_tiles_addr_skip = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t padded_block_tiles_w_skip = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // COMPILE TIME ARGS
+    // READER
+    // in1 tensor args
+    constexpr uint32_t in1_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_tensor_next_block_stride = get_compile_time_arg_val(2);
+    constexpr uint32_t in1_tensor_next_w_dim_block_stride = get_compile_time_arg_val(3);
+    // in1 block args
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_block_h = get_compile_time_arg_val(5);
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(6);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(8);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(9);
+
+    // in1 mcast args
+    constexpr uint32_t in1_mcast_num_dests = get_compile_time_arg_val(12);
+    constexpr uint32_t in1_mcast_num_cores = get_compile_time_arg_val(13);
+    // batch args
+    constexpr uint32_t KtNt = get_compile_time_arg_val(14);
+    constexpr uint32_t batch = get_compile_time_arg_val(15);
+    constexpr uint32_t bcast_B = get_compile_time_arg_val(16);
+    // sparsity args
+    constexpr uint32_t batchB = get_compile_time_arg_val(17);
+    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(18);
+
+    // WRITER
+    // out tensor args
+    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(19);
+    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(20);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(21);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_tensor_next_w_dim_block_stride = get_compile_time_arg_val(23);
+    constexpr uint32_t out_tensor_next_h_dim_block_stride = get_compile_time_arg_val(24);
+    // out subblock args
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(25);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(26);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(27);
+    // batch args
+    constexpr uint32_t MtNt = get_compile_time_arg_val(28);  // if 0
+    // Don't need batch; same as batch from READER args
+
+    // When sparsity is disabled, we just loop once
+    constexpr uint32_t batchB_lim = batchB == 0 ? 1u : batchB;
+
+    constexpr uint32_t one_tile = 1;
+
+#ifdef FUSE_BIAS
+    // in3 mcast args
+    const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in3_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    constexpr uint32_t in3_tensor_stride_w = get_compile_time_arg_val(29);
+
+    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+    constexpr uint32_t bias_single_tile_size_bytes = get_tile_size(cb_id_in3);
+    constexpr const uint32_t in3_tile_hw = get_tile_hw(cb_id_in3);
+
+#ifndef BIAS_SHARDED
+    uint32_t l1_write_addr_in3;
+    // Bias accessor will be defined later after TensorAccessor args
+#endif  // BIAS_SHARDED
+#else
+    rt_args_idx += 2;  // Skip over placeholders
+#endif  // FUSE_BIAS
+#ifndef OUT_SHARDED
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
+#endif  // OUT_SHARDED
+
+    constexpr bool fuse_op_all_gather = (bool)get_compile_time_arg_val(30);
+    constexpr bool fuse_op_reduce_scatter = (bool)get_compile_time_arg_val(31);
+
+    MatmulOpReceiver fused_op_receiver;
+    OpSignaler op_signaler;
+    if constexpr (fuse_op_all_gather) {
+        fused_op_receiver = MatmulOpReceiver(
+            false, /* wait_for_op_signal */
+            rt_args_idx,
+            num_blocks_inner_dim,
+            in1_block_h /* tiles_per_block (in the same dimension */
+        );
+    } else if constexpr (fuse_op_reduce_scatter) {
+        op_signaler = OpSignaler(rt_args_idx);
+    }
+
+    constexpr auto in1_args = TensorAccessorArgs<32>();
+    constexpr auto sparsity_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+    constexpr auto out_args = TensorAccessorArgs<sparsity_args.next_compile_time_args_offset()>();
+#ifdef FUSE_BIAS
+    constexpr auto bias_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+    constexpr auto after_bias_offset = bias_args.next_compile_time_args_offset();
+#else
+    constexpr auto after_bias_offset = out_args.next_compile_time_args_offset();
+#endif  // FUSE_BIAS
+
+// RT and COMPILE TIME ARGS for DRAM sharded weights
+#ifdef IN1_DRAM_WIDTH_SHARDED
+    const uint32_t vc = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t num_dram_shards_to_read = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t dram_tensor_start_offset = get_arg_val<uint32_t>(rt_args_idx++);
+    tt_l1_ptr uint32_t* in1_block_w_dram_stride_bytes = (tt_l1_ptr uint32_t*)get_arg_addr(rt_args_idx++);
+    tt_l1_ptr uint32_t* current_dram_bank_id = (tt_l1_ptr uint32_t*)get_arg_addr(rt_args_idx++);
+
+    constexpr uint32_t in1_dram_block_num_tiles = get_compile_time_arg_val(after_bias_offset);
+    constexpr uint32_t in1_block_w_dram_bytes = get_compile_time_arg_val(after_bias_offset + 1);
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+    constexpr uint32_t in1_KtNt_per_batch = get_compile_time_arg_val(after_bias_offset);        // K*N tiles per batch
+    constexpr uint32_t in1_batches_per_bank = get_compile_time_arg_val(after_bias_offset + 1);  // batches per DRAM bank
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
+#ifdef FUSE_BIAS
+#ifndef BIAS_SHARDED
+    const auto s3 = TensorAccessor(bias_args, in3_tensor_addr);
+#endif  // BIAS_SHARDED
+#endif  // FUSE_BIAS
+
+    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    constexpr const uint32_t in1_tile_hw = get_tile_hw(cb_id_in1);
+    constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
+
+    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
+    constexpr uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
+    constexpr const uint32_t output_tile_hw = get_tile_hw(cb_id_out0);
+
+    Noc noc;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out0);
+    Semaphore<> sender_sem(get_compile_time_arg_val(10));
+    Semaphore<> receiver_sem(get_compile_time_arg_val(11));
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in3(cb_id_in3);
+#endif
+#if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED)
+#ifdef INTERMEDIATE_CB_READ
+    constexpr uint32_t in1_intermediate_cb_index = get_named_compile_time_arg_val("cb_in1_intermediate");
+    CircularBuffer cb_helper(in1_intermediate_cb_index);
+#endif
+#endif
+
+//  READER
+#ifdef IN1_SHARDED
+    cb_in1.reserve_back(in1_block_num_tiles * num_blocks_inner_dim);
+    cb_in1.push_back(in1_block_num_tiles * num_blocks_inner_dim);
+#else
+    uint32_t l1_write_addr_in1;
+
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+#endif  // IN1_SHARDED
+
+    //  WRITER
+    const auto s = TensorAccessor(out_args, out_tensor_addr);
+
+    // sparsity accessor
+    constexpr uint32_t cb_id_sparsity = get_named_compile_time_arg_val("cb_sparsity");
+    CircularBuffer cb_sparsity(cb_id_sparsity);
+    const auto s_sparsity = TensorAccessor(sparsity_args, sparsity_addr);
+
+#ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+
+#ifdef IN1_SHARDED
+    uint64_t in1_start_address = cb_in1.get_write_ptr();
+#endif  // IN1_SHARDED
+#endif  // SKIP_MCAST
+
+    uint32_t l1_write_addr_sparsity = 0;
+    if constexpr (batchB > 0) {
+        cb_sparsity.reserve_back(1);
+        l1_write_addr_sparsity = cb_sparsity.get_write_ptr();
+    }
+
+#ifdef IN1_DRAM_WIDTH_SHARDED
+    constexpr uint32_t in1_dram_block_size_bytes = in1_dram_block_num_tiles * in1_single_tile_size_bytes;
+    uint32_t in1_block_w_bytes = in1_block_w * in1_single_tile_size_bytes;
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+    constexpr uint32_t in1_batch_stride_bytes = in1_KtNt_per_batch * in1_single_tile_size_bytes;
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        uint32_t in1_batch_tile_id = in1_tensor_start_tile_id;
+
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+        // Compute DRAM bank and offset for this batch
+        uint32_t in1_dram_bank_id = b / in1_batches_per_bank;
+        uint32_t in1_batch_in_shard = b % in1_batches_per_bank;
+        AllocatorBank<AllocatorBankType::DRAM> dram_src;
+        uint32_t in1_dram_batch_offset = in1_batch_in_shard * in1_batch_stride_bytes;
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
+        if constexpr (batchB > 0) {
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+        }
+
+        for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
+            if constexpr (batchB > 0) {
+                if (reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_sparsity)[bB] == 0) {
+                    out_tensor_start_tile_id += MtNt;
+                    in1_batch_tile_id += KtNt;
+                    continue;
+                }
+            }
+
+            uint32_t in1_tensor_current_h_dim_block_tile_id = in1_batch_tile_id;
+            uint32_t out_tensor_current_h_dim_block_tile_id = out_tensor_start_tile_id;
+            for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+                uint32_t in1_tensor_current_w_dim_block_tile_id = in1_tensor_current_h_dim_block_tile_id;
+                uint32_t out_tensor_current_w_dim_block_tile_id = out_tensor_current_h_dim_block_tile_id;
+#ifdef FUSE_BIAS
+                uint32_t in3_tensor_current_w_dim_block_tile_id = in3_tensor_start_tile_id;
+#endif  // FUSE_BIAS
+                for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                    uint32_t in1_tensor_current_inner_dim_block_start_tile_id = in1_tensor_current_w_dim_block_tile_id;
+#ifdef IN1_DRAM_WIDTH_SHARDED
+                    // Reset DRAM read offset for each bh block — the inner dim loop
+                    // advances through K, and each output row block re-reads the same
+                    // in1 columns from K=0. (bw is always 1 for DRAM-sharded senders.)
+                    uint32_t l1_read_addr_in1_offset = 0;
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+                    for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
+                        if constexpr (fuse_op_all_gather) {
+                            fused_op_receiver.update_current_block_start_tile_id(
+                                block, in1_tensor_current_inner_dim_block_start_tile_id, in1_batch_tile_id);
+                        }
+#if defined(IN1_DRAM_WIDTH_SHARDED)
+                        // Operand 1 - DRAM width sharded
+                        cb_in1.reserve_back(in1_block_num_tiles);
+
+                        uint64_t in1_start_address =
+                            cb_in1.get_write_ptr();  // copy start address of block, to be used for mcasting
+
+                        uint32_t l1_write_addr_in1_offset = 0;
+                        uint32_t next_bank_id_and_dram_stride_index = 0;
+
+                        AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+                        for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
+                            uint32_t shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t shard_base_addr = in1_tensor_addr;
+                            if (i == 0) {
+                                shard_base_addr += dram_tensor_start_offset;
+                            }
+                            noc.set_async_read_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                dram_bank,
+                                in1_single_tile_size_bytes,
+                                {.bank_id = shard_bank_id, .addr = shard_base_addr},
+                                vc);
+
+                            uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
+                            uint32_t l1_write_addr_in1 = cb_in1.get_write_ptr() + l1_write_addr_in1_offset;
+                            uint32_t in1_block_w_dram =
+                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
+                                in1_single_tile_size_bytes;
+
+                            for (uint32_t m = 0; m < in1_block_h; ++m) {
+                                uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
+                                uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
+                                for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
+                                    noc.async_read_with_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                        dram_bank,
+                                        CoreLocalMem<uint32_t>(l1_write_addr_in1_temp),
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = shard_bank_id, .addr = shard_base_addr + l1_read_addr_in1_temp},
+                                        {},
+                                        vc);
+                                    l1_read_addr_in1_temp += in1_single_tile_size_bytes;
+                                    l1_write_addr_in1_temp += in1_single_tile_size_bytes;
+                                }
+                                l1_read_addr_in1 += in1_block_w_dram_bytes;
+                                l1_write_addr_in1 += in1_block_w_bytes;
+                            }
+                            l1_write_addr_in1_offset +=
+                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index];
+                            next_bank_id_and_dram_stride_index += 2;
+                        }
+                        l1_read_addr_in1_offset += in1_dram_block_size_bytes;
+                        noc.async_read_barrier();
+#elif defined(IN1_DRAM_HEIGHT_SHARDED)
+                        // Operand 1 - DRAM height sharded (batched)
+                        // Each DRAM bank holds batches_per_bank complete [K, N] matrices
+                        // Bank and offset computed at start of batch loop
+                        cb_in1.reserve_back(in1_block_num_tiles);
+
+                        l1_write_addr_in1 = cb_in1.get_write_ptr();
+                        uint64_t in1_start_address =
+                            l1_write_addr_in1;  // copy start address of block, to be used for mcasting
+
+                        // Read in1 block from the correct DRAM bank
+                        // Tile layout within a batch: row-major [K, N], same strides as interleaved
+                        uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_inner_dim_block_start_tile_id;
+                        for (uint32_t h = 0; h < in1_block_h; ++h) {
+                            uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                            for (uint32_t w = 0; w < in1_block_w; ++w) {
+                                if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+                                    uint32_t tile_byte_offset =
+                                        in1_dram_batch_offset + in1_tensor_tile_id * in1_single_tile_size_bytes;
+                                    noc.async_read(
+                                        dram_src,
+                                        CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = in1_dram_bank_id, .addr = in1_tensor_addr + tile_byte_offset},
+                                        {});
+                                }
+                                l1_write_addr_in1 += in1_single_tile_size_bytes;
+                                in1_tensor_tile_id += in1_tensor_stride_w;
+                            }
+                            in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+                        }
+                        in1_tensor_current_inner_dim_block_start_tile_id += in1_tensor_next_block_stride;
+
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#elif !defined(IN1_SHARDED)
+                        // Operand 1 - interleaved
+                        cb_in1.reserve_back(in1_block_num_tiles);
+#ifdef INTERMEDIATE_CB_READ
+                        cb_helper.reserve_back(one_tile);
+#endif  // INTERMEDIATE_CB_READ
+                        uint32_t in1_write_offset = 0;
+                        uint64_t in1_start_address =
+                            cb_in1.get_write_ptr();  // copy start address of block, to be used for mcasting
+
+                        // Copy in1 block into CB, as the default kernel
+                        uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_inner_dim_block_start_tile_id;
+                        for (uint32_t h = 0; h < in1_block_h; ++h) {
+                            uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                            for (uint32_t w = 0; w < in1_block_w; ++w) {
+                                if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+#ifndef INTERMEDIATE_CB_READ
+                                    noc.async_read(
+                                        s1,
+                                        cb_in1,
+                                        in1_single_tile_size_bytes,
+                                        {.page_id = in1_tensor_tile_id},
+                                        {.offset_bytes = in1_write_offset});
+#else
+                                    noc.async_read(
+                                        s1,
+                                        cb_helper,
+                                        in1_single_tile_size_bytes,
+                                        {.page_id = in1_tensor_tile_id},
+                                        {.offset_bytes = 0});
+                                    noc.async_read_barrier();
+                                    memcpy(
+                                        /*dst=*/reinterpret_cast<void*>(cb_in1.get_write_ptr() + in1_write_offset),
+                                        /*src=*/reinterpret_cast<const void*>(cb_helper.get_write_ptr()),
+                                        /*size=*/in1_single_tile_size_bytes);
+#endif  // INTERMEDIATE_CB_READ
+                                }
+                                in1_write_offset += in1_single_tile_size_bytes;
+                                in1_tensor_tile_id += in1_tensor_stride_w;
+                            }
+                            in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+                        }
+                        in1_tensor_current_inner_dim_block_start_tile_id += in1_tensor_next_block_stride;
+
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#endif  // IN1_DRAM_WIDTH_SHARDED / IN1_DRAM_HEIGHT_SHARDED / IN1_SHARDED
+
+#ifndef SKIP_MCAST
+                        // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
+                        // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
+                        // zero for the next block
+                        sender_sem.wait(in1_mcast_num_dests);
+                        sender_sem.set(0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        MulticastEndpoint mcast_dst;
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(static_cast<uint32_t>(in1_start_address)),
+                            mcast_dst,
+                            in1_block_size_bytes,
+                            in1_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                             .addr = static_cast<uint32_t>(in1_start_address)},
+                            true);
+
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id and
+                        // same vc even though cmd bufs are different Also, this only works because we are setting VCs
+                        // statically (using NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
+                        // which means data could be changed before
+                        //  write is issued.
+                        noc.async_writes_flushed();
+#endif  // ARCH_BLACKHOLE
+
+                        // We should also multicast the flag to destinations
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        receiver_sem.set_multicast(
+                            noc,
+                            in1_mcast_dest_noc_start_x,
+                            in1_mcast_dest_noc_start_y,
+                            in1_mcast_dest_noc_end_x,
+                            in1_mcast_dest_noc_end_y,
+                            in1_mcast_num_cores);
+#endif  // SKIP_MCAST
+
+#ifndef IN1_SHARDED
+                        cb_in1.push_back(in1_block_num_tiles);
+#ifdef INTERMEDIATE_CB_READ
+                        // Clean up helper CB
+                        cb_helper.push_back(one_tile);
+                        cb_helper.wait_front(one_tile);
+                        cb_helper.pop_front(one_tile);
+#endif  // INTERMEDIATE_CB_READ
+#endif  // IN1_SHARDED
+                    }
+#ifdef FUSE_BIAS
+                    // Only read bias on first batch, or we have multiple output blocks
+                    if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                        // Operand 1
+#ifndef BIAS_SHARDED
+                        cb_in3.reserve_back(in1_block_w);
+                        uint32_t in3_write_offset = 0;
+
+                        uint64_t in3_start_address =
+                            cb_in3.get_write_ptr();         // copy start address of block, to be used for mcasting
+                        uint32_t in3_block_size_bytes = 0;  // can be optimized later, pass it to kernel
+
+#ifdef IN1_DRAM_WIDTH_SHARDED
+                        uint32_t l1_write_addr_in3_offset = 0;
+                        uint32_t next_bank_id_and_dram_stride_index = 0;
+
+                        AllocatorBank<AllocatorBankType::DRAM> bias_dram_bank;
+                        for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
+                            uint32_t bias_shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t bias_shard_base_addr = in3_tensor_addr;
+                            if (i == 0) {
+                                // dram_tensor_start_offset is in in1 tile bytes; convert to
+                                // bias tile bytes since bias_dtype may differ from in1_dtype.
+                                bias_shard_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
+                                                        bias_single_tile_size_bytes;
+                            }
+
+                            noc.set_async_read_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                bias_dram_bank,
+                                bias_single_tile_size_bytes,
+                                {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr},
+                                vc);
+
+                            uint32_t l1_read_addr_in3 = 0;
+                            l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
+                            // in1_block_w_dram_stride_bytes is in in1 tile bytes, so divide
+                            // by in1_single_tile_size_bytes (not bias) to get the tile count.
+                            uint32_t in3_block_w_dram =
+                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
+                                in1_single_tile_size_bytes;
+
+                            for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
+                                noc.async_read_with_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                    bias_dram_bank,
+                                    CoreLocalMem<uint32_t>(l1_write_addr_in3),
+                                    bias_single_tile_size_bytes,
+                                    {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr + l1_read_addr_in3},
+                                    {},
+                                    vc);
+                                l1_read_addr_in3 += bias_single_tile_size_bytes;
+                                l1_write_addr_in3 += bias_single_tile_size_bytes;
+                                in3_block_size_bytes += bias_single_tile_size_bytes;
+                            }
+                            // Advance L1 offset in bias tile bytes, not in1 stride bytes.
+                            l1_write_addr_in3_offset += in3_block_w_dram * bias_single_tile_size_bytes;
+                            next_bank_id_and_dram_stride_index += 2;
+                        }
+                        noc.async_read_barrier();
+#else
+                        // Copy in1 block into CB, as the default kernel
+                        uint32_t in3_tensor_tile_id = in3_tensor_current_w_dim_block_tile_id;
+                        for (uint32_t w = 0; w < in1_block_w; ++w) {
+                            if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+                                noc.async_read(
+                                    s3,
+                                    cb_in3,
+                                    bias_single_tile_size_bytes,
+                                    {.page_id = in3_tensor_tile_id},
+                                    {.offset_bytes = in3_write_offset});
+                            }
+                            in3_write_offset += bias_single_tile_size_bytes;
+                            in3_tensor_tile_id += in3_tensor_stride_w;
+                            in3_block_size_bytes += bias_single_tile_size_bytes;
+                        }
+                        // Barrier! make sure the reads are done
+                        noc.async_read_barrier();
+#endif  // IN1_DRAM_WIDTH_SHARDED
+
+#ifndef SKIP_MCAST
+
+                        // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
+                        // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
+                        // zero for the next block
+                        sender_sem.wait(in1_mcast_num_dests);
+                        sender_sem.set(0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        MulticastEndpoint mcast_dst;
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(static_cast<uint32_t>(in3_start_address)),
+                            mcast_dst,
+                            in3_block_size_bytes,
+                            in1_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                             .addr = static_cast<uint32_t>(in3_start_address)},
+                            true);
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
+                        // vc, same cmd_buf Also, this only works because we are setting VCs statically (using
+                        // NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+                        // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
+                        // latency which means data could be changed before write is issued.
+                        noc.async_writes_flushed();
+#endif  // ARCH_BLACKHOLE
+
+                        // We should also multicast the flag to destinations
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        receiver_sem.set_multicast(
+                            noc,
+                            in1_mcast_dest_noc_start_x,
+                            in1_mcast_dest_noc_start_y,
+                            in1_mcast_dest_noc_end_x,
+                            in1_mcast_dest_noc_end_y,
+                            in1_mcast_num_cores);
+#endif  // SKIP_MCAST
+
+                        cb_in3.push_back(in1_block_w);
+#else
+                        cb_in3.reserve_back(in1_block_w);
+                        cb_in3.push_back(in1_block_w);
+#endif  // BIAS_SHARDED
+                    }
+#endif  // FUSE_BIAS
+
+#ifndef OUT_SHARDED
+                    // WRITER
+                    uint32_t num_blocks_w_dim_ =
+                        bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
+                    uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
+                    uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
+                    if (bw == num_blocks_w_dim_ - 1) {
+                        out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
+                    }
+                    uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
+                    for (uint32_t sbh = 0; sbh < out_num_nonzero_subblocks_h_; ++sbh) {
+                        uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
+                        for (uint32_t sbw = 0; sbw < out_num_nonzero_subblocks_w_; ++sbw) {
+                            uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+
+                            uint32_t out_subblock_h_ = out_subblock_h;
+                            uint32_t out_subblock_w_ = out_subblock_w;
+                            uint32_t subblock_tiles_addr_skip = 0;
+                            if (bh == num_blocks_h_dim - 1 && sbh == out_num_nonzero_subblocks_h - 1) {
+                                out_subblock_h_ = out_last_subblock_h;
+                            }
+                            if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w_ - 1) {
+                                out_subblock_w_ = out_last_subblock_w;
+                                subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
+                            }
+
+                            cb_out.wait_front(out_subblock_tile_count);
+                            uint32_t out_read_offset = 0;
+
+                            for (uint32_t h = 0; h < out_subblock_h_; ++h) {
+                                uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
+                                for (uint32_t w = 0; w < out_subblock_w_; ++w) {
+                                    if (bw < num_blocks_w_dim_) {
+                                        noc.async_write(
+                                            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                                            s,
+                                            output_single_tile_size_bytes,
+                                            {.offset_bytes = out_read_offset},
+                                            {.page_id = out_tensor_tile_id});
+                                    }
+
+                                    out_read_offset += output_single_tile_size_bytes;
+
+                                    out_tensor_tile_id += out_tensor_stride_w;
+                                }
+                                // Skip padded tiles in subblock along row
+                                out_read_offset += subblock_tiles_addr_skip;
+                                out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+                            }
+
+                            noc.async_write_barrier();
+                            cb_out.pop_front(out_subblock_tile_count);
+                            out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+                        }
+                        // Pop fully padded subblocks along the row
+                        if (bw == num_blocks_w_dim_ - 1) {
+                            cb_out.wait_front(padded_block_tiles_w_skip);
+                            cb_out.pop_front(padded_block_tiles_w_skip);
+                        }
+                        out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+                    }
+                    // Pop row(s) of fully padded subblocks
+                    if (bh == num_blocks_h_dim - 1) {
+                        cb_out.wait_front(padded_block_tiles_h_skip);
+                        cb_out.pop_front(padded_block_tiles_h_skip);
+                    }
+
+#endif
+                    in1_tensor_current_w_dim_block_tile_id += in1_tensor_next_w_dim_block_stride;
+                    out_tensor_current_w_dim_block_tile_id += out_tensor_next_w_dim_block_stride;
+#ifdef FUSE_BIAS
+                    in3_tensor_current_w_dim_block_tile_id += in1_block_w;
+#endif
+                }
+                out_tensor_current_h_dim_block_tile_id += out_tensor_next_h_dim_block_stride;
+            }
+            out_tensor_start_tile_id += MtNt;
+            in1_batch_tile_id += KtNt;
+        }
+        if constexpr (bcast_B == 0) {
+#ifndef IN1_DRAM_HEIGHT_SHARDED
+            // For height-sharded DRAM, tile IDs are relative within a batch;
+            // batch offset is handled by switching DRAM banks
+            in1_tensor_start_tile_id += KtNt;
+#endif
+        }
+
+        if (fuse_op_reduce_scatter) {
+            // Signal reduce_scatter to go
+            op_signaler.synchronize_workers_and_signal_op(0);
+        }
+    }
+
+#if OUT_SHARDED
+    cb_out.wait_front(
+        batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
+#endif
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/guard.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/guard.h
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared guard helpers for routed_matmul kernels.
+//
+// Each dataflow kernel independently reads two DRAM-interleaved ROW_MAJOR uint32
+// tables (global_expert_idx_table, expert_token_counts) into an L1 scratch region
+// (cb_guard) via TensorAccessor. The skip predicate is:
+//
+//   global_idx = global_expert_idx_table[local_expert_idx]
+//   skip       = expert_token_counts[global_idx] <= curr_expert_iter * expert_iter_length
+//
+// TensorAccessor resolves the correct bank + offset for a given page, so this
+// works with arbitrary DRAM-interleaved memory configs — no assumption that the
+// data lives in bank 0. Both tables are read as a single page (their innermost
+// dim × dtype is one page) and then indexed within L1 scratch.
+//
+// Because both tensors are read-only for the duration of the FFN pass, no
+// token-based synchronization between the two dataflow threads is needed —
+// both read the same immutable values and reach the same decision independently.
+//
+// TRISC (compute) cannot issue NOC reads, so it cannot re-read DRAM itself.
+// Instead, the BRISC-side dataflow kernel publishes the skip decision to the
+// three TRISC thread mailboxes (Unpack/Math/Pack) inside guard_check_wait(),
+// and TRISC pops the flag with the hardware-blocking mailbox_read inside its
+// own guard_check_wait(). mailbox_read stalls automatically until BRISC has
+// written, so no extra synchronization is needed. NCRISC cannot link
+// ckernel::mailbox_base and therefore does not participate in the BRISC->TRISC
+// handoff; its decision (identical to BRISC's by construction) is consumed
+// only by its own kernel's early-return.
+//
+// Function names vs. processors (mapping set by the program factory):
+//   guard_check_brisc() — called from in0_* readers, compiled onto RISCV_1 (NCRISC).
+//   guard_check_wait()  — called from in1_* readers, compiled onto RISCV_0 (BRISC).
+//                       — also called from bmm_routed (compute/TRISC) via GUARD_COMPUTE_KERNEL.
+// The historical names predate the BRISC⇄NCRISC swap in the factory; the
+// implementations here reflect the actual processor assignment.
+//
+// Named compile-time args set by the program factory (via named_compile_args):
+//   GUARD_CB_ID                       - CB index for cb_guard (scratch for the DRAM reads;
+//                                       dataflow only). Must be large enough to hold one
+//                                       page of each table back-to-back (see program factory).
+//   GUARD_ARG_BASE                    - starting runtime arg index for the 5 guard args
+//                                       (dataflow only).
+//   GUARD_GLOBAL_TABLE_CTA_OFFSET     - compile-time-arg offset for global_expert_idx_table's
+//                                       TensorAccessorArgs (dataflow only).
+//   GUARD_COUNTS_CTA_OFFSET           - compile-time-arg offset for expert_token_counts'
+//                                       TensorAccessorArgs (dataflow only).
+//
+// Runtime args at positions GUARD_ARG_BASE+{0..4} (dataflow only):
+//   [0] global_expert_idx_table DRAM buffer address (uint32)
+//   [1] expert_token_counts     DRAM buffer address (uint32)
+//   [2] local_expert_idx                           (uint32)
+//   [3] curr_expert_iter                           (uint32)
+//   [4] expert_iter_length                         (uint32)
+//
+// Current limitation: each table is read as a single page (page 0), so the
+// full table must fit in one ROW_MAJOR page (= innermost dim × dtype_bytes)
+// AND in one 1024-byte half of cb_guard (= 256 uint32 elements). Larger tables
+// need either multi-page reads keyed on the logical index or a bigger cb_guard.
+//
+// If ROUTED_GUARD_ENABLED is not defined, the helpers compile to no-ops.
+
+#pragma once
+
+#include <cstdint>
+
+namespace routed_guard_detail {
+// Each table's page is read into its own 1024-byte scratch half of cb_guard so
+// both values are resident simultaneously and the second DRAM read cannot
+// stomp on the first's L1 destination. 1024 bytes = 256 uint32 elements,
+// matching the DeepSeek V3 global expert count.
+constexpr uint32_t kGuardScratchHalfBytes = 1024;
+}  // namespace routed_guard_detail
+
+#ifdef ROUTED_GUARD_ENABLED
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+#ifdef GUARD_COMPUTE_KERNEL
+
+// TRISC: read the skip decision published by the BRISC-side dataflow kernel
+// (in1_* reader/writer) via the hardware mailbox.  mailbox_read is a blocking
+// read — it stalls until BRISC has written — so no explicit synchronization
+// is needed.  Each of Unpack / Math / Pack receives its own message; the
+// compute kernel is compiled once but executes on all three threads, and the
+// UNPACK/MATH/PACK macros select the correct slot per thread.
+FORCE_INLINE bool guard_check_wait() {
+    uint32_t skip = 0;
+    UNPACK(skip = ckernel::mailbox_read(ckernel::ThreadId::BriscThreadId);)
+    MATH(skip = ckernel::mailbox_read(ckernel::ThreadId::BriscThreadId);)
+    PACK(skip = ckernel::mailbox_read(ckernel::ThreadId::BriscThreadId);)
+    return skip != 0;
+}
+
+#else  // dataflow side
+
+#include "api/tensor/tensor_accessor.h"
+
+namespace routed_guard_detail {
+
+// Read page 0 of `accessor` (one innermost-dim row) into `scratch_l1`, barrier,
+// and return the uint32 at position `idx` within that row.
+template <typename Accessor>
+FORCE_INLINE uint32_t read_page_indexed_u32(const Accessor& accessor, uint32_t scratch_l1, uint32_t idx) {
+    noc_async_read_page(0, accessor, scratch_l1);
+    noc_async_read_barrier();
+    return reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_l1)[idx];
+}
+
+}  // namespace routed_guard_detail
+
+// NCRISC (in0_* readers): direct DRAM reads, no mailbox — ckernel::mailbox_base
+// is not linked for NCRISC, and BRISC already owns the BRISC->TRISC handoff.
+FORCE_INLINE bool guard_check_brisc() {
+    constexpr uint32_t kArgBase = get_named_compile_time_arg_val("GUARD_ARG_BASE");
+    constexpr uint32_t kCbId = get_named_compile_time_arg_val("GUARD_CB_ID");
+    constexpr uint32_t kGlobalTableCtaOff = get_named_compile_time_arg_val("GUARD_GLOBAL_TABLE_CTA_OFFSET");
+    constexpr uint32_t kCountsCtaOff = get_named_compile_time_arg_val("GUARD_COUNTS_CTA_OFFSET");
+
+    const uint32_t global_table_addr = get_arg_val<uint32_t>(kArgBase);
+    const uint32_t token_counts_addr = get_arg_val<uint32_t>(kArgBase + 1);
+    const uint32_t local_expert_idx = get_arg_val<uint32_t>(kArgBase + 2);
+    const uint32_t curr_expert_iter = get_arg_val<uint32_t>(kArgBase + 3);
+    const uint32_t expert_iter_length = get_arg_val<uint32_t>(kArgBase + 4);
+
+    constexpr auto global_table_args = TensorAccessorArgs<kGlobalTableCtaOff>();
+    constexpr auto counts_args = TensorAccessorArgs<kCountsCtaOff>();
+    const auto global_table_accessor = TensorAccessor(global_table_args, global_table_addr);
+    const auto counts_accessor = TensorAccessor(counts_args, token_counts_addr);
+
+    const uint32_t scratch_a = get_write_ptr(kCbId);
+    const uint32_t scratch_b = scratch_a + routed_guard_detail::kGuardScratchHalfBytes;
+
+    const uint32_t global_idx =
+        routed_guard_detail::read_page_indexed_u32(global_table_accessor, scratch_a, local_expert_idx);
+    const uint32_t token_count = routed_guard_detail::read_page_indexed_u32(counts_accessor, scratch_b, global_idx);
+
+    return token_count <= curr_expert_iter * expert_iter_length;
+}
+
+// BRISC (in1_* readers): read the two DRAM tables, compute the skip decision,
+// publish it to the three TRISC thread mailboxes so the compute kernel can
+// early-return too, then return the decision for BRISC's own early-return.
+// Always writes to all three mailboxes (even on skip=false) so TRISC always
+// has a defined value to pop.
+FORCE_INLINE bool guard_check_wait() {
+    constexpr uint32_t kArgBase = get_named_compile_time_arg_val("GUARD_ARG_BASE");
+    constexpr uint32_t kCbId = get_named_compile_time_arg_val("GUARD_CB_ID");
+    constexpr uint32_t kGlobalTableCtaOff = get_named_compile_time_arg_val("GUARD_GLOBAL_TABLE_CTA_OFFSET");
+    constexpr uint32_t kCountsCtaOff = get_named_compile_time_arg_val("GUARD_COUNTS_CTA_OFFSET");
+
+    const uint32_t global_table_addr = get_arg_val<uint32_t>(kArgBase);
+    const uint32_t token_counts_addr = get_arg_val<uint32_t>(kArgBase + 1);
+    const uint32_t local_expert_idx = get_arg_val<uint32_t>(kArgBase + 2);
+    const uint32_t curr_expert_iter = get_arg_val<uint32_t>(kArgBase + 3);
+    const uint32_t expert_iter_length = get_arg_val<uint32_t>(kArgBase + 4);
+
+    constexpr auto global_table_args = TensorAccessorArgs<kGlobalTableCtaOff>();
+    constexpr auto counts_args = TensorAccessorArgs<kCountsCtaOff>();
+    const auto global_table_accessor = TensorAccessor(global_table_args, global_table_addr);
+    const auto counts_accessor = TensorAccessor(counts_args, token_counts_addr);
+
+    const uint32_t scratch_a = get_read_ptr(kCbId);
+    const uint32_t scratch_b = scratch_a + routed_guard_detail::kGuardScratchHalfBytes;
+
+    const uint32_t global_idx =
+        routed_guard_detail::read_page_indexed_u32(global_table_accessor, scratch_a, local_expert_idx);
+    const uint32_t token_count = routed_guard_detail::read_page_indexed_u32(counts_accessor, scratch_b, global_idx);
+
+    const bool skip = token_count <= curr_expert_iter * expert_iter_length;
+    // DPRINT << "guard_check_wait: local_expert_idx=" << local_expert_idx << " global_idx=" << global_idx
+    //        << " token_count=" << token_count << " curr_expert_iter=" << curr_expert_iter
+    //        << " expert_iter_length=" << expert_iter_length << " skip=" << (int)skip << "\n";
+    // DEVICE_PRINT("global_idx={} token_count={} skip={}\n", global_idx, token_count, (int)skip);
+
+    const uint32_t skip_u = skip ? 1u : 0u;
+    ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, skip_u);
+    ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, skip_u);
+    ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, skip_u);
+    return skip;
+}
+
+#endif  // GUARD_COMPUTE_KERNEL
+
+#else  // !ROUTED_GUARD_ENABLED
+
+FORCE_INLINE bool guard_check_brisc() { return false; }
+FORCE_INLINE bool guard_check_wait() { return false; }
+
+#endif  // ROUTED_GUARD_ENABLED

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/compute/eltwise_sfpu_routed.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/compute/eltwise_sfpu_routed.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/kernels/compute/eltwise_sfpu.cpp
+// Only change: TRISC-side guard block at the top of kernel_main. See ../../guard.h.
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/trigonometry.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/eltwise_unary/rpow.h"
+#include "api/compute/eltwise_unary/rdiv.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Guard: mark this as the compute (TRISC) path so guard.h compiles the mailbox-read variant.
+#define GUARD_COMPUTE_KERNEL
+#include "../../guard.h"
+
+void kernel_main() {
+    // TRISC (Unpack/Math/Pack): read the skip decision from the mailbox BRISC
+    // published. mailbox_read stalls until BRISC has written, so no extra sync
+    // is needed.
+    if (guard_check_wait()) {
+        return;
+    }
+
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_input = tt::CBIndex::c_0;
+    constexpr auto cb_output = tt::CBIndex::c_2;
+
+    CircularBuffer cb_in(cb_input);
+    CircularBuffer cb_out(cb_output);
+
+    init_sfpu(cb_input, cb_output);
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        tile_regs_acquire();
+
+        cb_in.wait_front(1);
+        cb_out.reserve_back(1);
+
+        copy_tile(cb_input, 0, 0);
+
+#ifdef SFPU_OP_CHAIN_0
+        SFPU_OP_CHAIN_0
+#endif
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        pack_tile(0, cb_output);
+
+        cb_in.pop_front(1);
+        cb_out.push_back(1);
+
+        tile_regs_release();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/dataflow/reader_routed_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/dataflow/reader_routed_unary.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/kernels/dataflow/reader_unary_ng.cpp
+// Only change: BRISC-side guard block at the top of kernel_main. See ../../guard.h.
+//
+// Sharded-only path: input CB (c_0) is backed by the input tensor's L1 shard; the
+// reader just reserves/pushes the CB to signal the compute kernel that the shard
+// contents are ready (which they always are — the tensor is already on device in L1).
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+
+#include "../../guard.h"
+
+void kernel_main() {
+    // BRISC (RISCV_0): publish the skip decision to the three TRISC mailboxes, and
+    // early-return on skip so we don't stall the compute kernel with a CB push it
+    // no longer needs.
+    if (guard_check_wait()) {
+        return;
+    }
+
+    const uint32_t num_pages = get_arg_val<uint32_t>(1);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    CircularBuffer cb_src(cb_id_src);
+
+    cb_src.reserve_back(num_pages);
+    cb_src.push_back(num_pages);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/dataflow/writer_routed_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/dataflow/writer_routed_unary.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/kernels/dataflow/writer_unary_ng.cpp
+// Only change: NCRISC-side guard block at the top of kernel_main. See ../../guard.h.
+//
+// Sharded-only path: output CB (c_2) is backed by the output tensor's L1 shard; the
+// writer just waits for the compute kernel to populate it — no NoC writes needed.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+
+#include "../../guard.h"
+
+void kernel_main() {
+    // NCRISC (RISCV_1): read the guard tables directly from DRAM (no mailbox
+    // writes — BRISC handles the BRISC->TRISC handoff). Early-return on skip so
+    // we don't block waiting for a CB push that never happens.
+    if (guard_check_brisc()) {
+        return;
+    }
+
+    const uint32_t num_pages = get_arg_val<uint32_t>(1);
+
+    constexpr auto cb_id_dst = tt::CBIndex::c_2;
+    CircularBuffer cb_dst(cb_id_dst);
+
+    cb_dst.wait_front(num_pages);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_device_operation.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "routed_matmul_device_operation.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+RoutedMatmulDeviceOperation::program_factory_t RoutedMatmulDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return RoutedMatmulMcast2DProgramFactory{};
+}
+
+void RoutedMatmulDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    TT_FATAL(tensor_args.a.storage_type() == StorageType::DEVICE, "routed_matmul: a must be on device");
+    TT_FATAL(tensor_args.b.storage_type() == StorageType::DEVICE, "routed_matmul: b must be on device");
+
+    TT_FATAL(
+        tensor_args.global_expert_idx_table.storage_type() == StorageType::DEVICE,
+        "routed_matmul: global_expert_idx_table must be on device");
+    TT_FATAL(
+        tensor_args.global_expert_idx_table.buffer() != nullptr &&
+            tensor_args.global_expert_idx_table.buffer()->buffer_type() == BufferType::DRAM,
+        "routed_matmul: global_expert_idx_table must be in DRAM");
+
+    TT_FATAL(
+        tensor_args.expert_token_counts.storage_type() == StorageType::DEVICE,
+        "routed_matmul: expert_token_counts must be on device");
+    TT_FATAL(
+        tensor_args.expert_token_counts.buffer() != nullptr &&
+            tensor_args.expert_token_counts.buffer()->buffer_type() == BufferType::DRAM,
+        "routed_matmul: expert_token_counts must be in DRAM");
+}
+
+void RoutedMatmulDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_hit(operation_attributes, tensor_args);
+
+    // The forked 2D mcast factory only supports the MatmulMultiCoreReuseMultiCastProgramConfig variant
+    // (this is the BH-optimized path). Bail loudly for any other config.
+    TT_FATAL(
+        std::holds_alternative<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>(
+            operation_attributes.program_config),
+        "routed_matmul: only MatmulMultiCoreReuseMultiCastProgramConfig is supported");
+}
+
+RoutedMatmulDeviceOperation::spec_return_value_t RoutedMatmulDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& a = tensor_args.a;
+    const auto& b = tensor_args.b;
+
+    const auto& a_shape = a.logical_shape();
+    const auto& b_shape = b.logical_shape();
+
+    // Output shape: replace last dim of a with last dim of b.
+    std::vector<uint32_t> out_shape_vec(a_shape.cbegin(), a_shape.cend());
+    out_shape_vec[out_shape_vec.size() - 1] = b_shape[-1];
+    const ttnn::Shape out_shape(out_shape_vec);
+
+    const auto out_dtype = operation_attributes.output_dtype;
+    return TensorSpec(
+        out_shape,
+        tt::tt_metal::TensorLayout(
+            out_dtype, tt::tt_metal::PageConfig(Layout::TILE), operation_attributes.output_memory_config));
+}
+
+RoutedMatmulDeviceOperation::tensor_return_value_t RoutedMatmulDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor.value();
+    }
+    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.a.device());
+}
+
+ttsl::hash::hash_t RoutedMatmulDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    // Exclude the three runtime scalars (local_expert_idx, curr_expert_iter,
+    // expert_iter_length). Include everything else that can affect kernel
+    // compilation / program layout: program config, compute config, memory config,
+    // output dtype, and the tensor specs (shape/dtype/layout) of a, b, and the two
+    // guard tables, plus whether an optional output was supplied.
+    return ttsl::hash::hash_objects_with_default_seed(
+        attrs.program_config,
+        attrs.compute_kernel_config,
+        attrs.output_memory_config,
+        attrs.output_dtype,
+        args.a.tensor_spec(),
+        args.b.tensor_spec(),
+        args.global_expert_idx_table.tensor_spec(),
+        args.expert_token_counts.tensor_spec(),
+        args.optional_output_tensor.has_value());
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device
+
+namespace ttnn::prim {
+
+ttnn::Tensor routed_matmul(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
+    const ttnn::Tensor& global_expert_idx_table,
+    const ttnn::Tensor& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length,
+    const ttnn::operations::matmul::MatmulProgramConfig& program_config,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config,
+    std::optional<ttnn::Tensor> optional_output_tensor,
+    const std::optional<tt::tt_metal::DataType>& output_dtype) {
+    namespace rmm = ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device;
+    using OperationType = rmm::RoutedMatmulDeviceOperation;
+
+    const tt::tt_metal::DataType out_dtype = output_dtype.value_or(a.dtype());
+
+    // Resolve output_memory_config: explicit -> caller's value; else inherit from
+    // optional_output_tensor (device op will use that tensor anyway); else
+    // default to DRAM interleaved.
+    const tt::tt_metal::MemoryConfig resolved_output_mem_cfg =
+        output_memory_config.has_value()
+            ? output_memory_config.value()
+            : (optional_output_tensor.has_value()
+                   ? optional_output_tensor->memory_config()
+                   : tt::tt_metal::MemoryConfig{
+                         tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM});
+
+    return ttnn::device_operation::launch<OperationType>(
+        rmm::RoutedMatmulParams{
+            program_config,
+            compute_kernel_config,
+            resolved_output_mem_cfg,
+            out_dtype,
+            local_expert_idx,
+            curr_expert_iter,
+            expert_iter_length},
+        rmm::RoutedMatmulInputs{a, b, global_expert_idx_table, expert_token_counts, std::move(optional_output_tensor)});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_device_operation.hpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "routed_matmul_types.hpp"
+#include "routed_matmul_program_factory.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+struct RoutedMatmulDeviceOperation {
+    using operation_attributes_t = RoutedMatmulParams;
+    using tensor_args_t = RoutedMatmulInputs;
+    using spec_return_value_t = ttnn::TensorSpec;
+    using tensor_return_value_t = ttnn::Tensor;
+    using program_factory_t = std::variant<RoutedMatmulMcast2DProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // Exclude curr_expert_iter from the hash: it varies per call but doesn't change
+    // the program, so we want every iteration to hit the same cached program.
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device
+
+namespace ttnn::prim {
+
+ttnn::Tensor routed_matmul(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
+    const ttnn::Tensor& global_expert_idx_table,
+    const ttnn::Tensor& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length,
+    const ttnn::operations::matmul::MatmulProgramConfig& program_config,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config = std::nullopt,
+    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt,
+    const std::optional<tt::tt_metal::DataType>& output_dtype = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_program_factory.cpp
@@ -1,0 +1,2005 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forked from
+// ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+//
+// Differences from the matmul original:
+//   * Uses RoutedMatmulParams / RoutedMatmulInputs in place of MatmulParams / MatmulInputs.
+//   * Returns a single Tensor (not a vector).
+//   * Kernel source paths point at this op's forked kernels (readers + compute).
+//   * Program creates an extra semaphore (sem_guard) and CB (cb_guard) used by the
+//     per-kernel guard block. GUARD_CB_ID, GUARD_SEM_ID, GUARD_ARG_BASE are added
+//     to each kernel's compile-time defines; the five guard runtime args
+//     (global_table_addr, token_counts_addr, local_expert_idx, curr_expert_iter,
+//     expert_iter_length) are appended to every kernel's rt-args vector.
+//   * override_runtime_arguments updates the appended guard args on cache hits.
+//
+// The matmul body (core-grid layout, CB sizes, mcast topology, compute config) is
+// intentionally unchanged to preserve perf.
+
+#include "routed_matmul_program_factory.hpp"
+#include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
+
+#include <algorithm>
+#include <utility>
+#include <variant>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "tt-metalium/buffer_types.hpp"
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+namespace routed_mcast_optimized_helpers {
+
+RoutedMatmulMcast2DProgramFactory::cached_program_t create_program_mcast_in0_in1(
+    tt::tt_metal::Program& program,
+    tt::tt_metal::IDevice* device,
+    tt::tt_metal::MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    uint32_t B,
+    uint32_t M,
+    uint32_t M_per_batch,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t in0_last_ktile_h,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool transpose_mcast,
+    std::optional<UnaryWithParam> fused_activation,
+    tt::tt_metal::Buffer* in0_buffer,
+    tt::tt_metal::Buffer* in1_buffer,
+    tt::tt_metal::Buffer* bias_buffer,
+    tt::tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    tt::tt_metal::Buffer* global_table_buffer,
+    tt::tt_metal::Buffer* counts_buffer,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using namespace tt;
+    using tt::tt_metal::TensorMemoryLayout;
+
+    const uint32_t global_table_addr = global_table_buffer->address();
+    const uint32_t token_counts_addr = counts_buffer->address();
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    TensorMemoryLayout in0_memory_layout = in0_buffer->buffer_layout();
+
+    uint32_t num_blocks = K / in0_block_w;
+
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
+    const bool in1_is_width_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
+    const bool output_is_sharded = out_buffer->buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+
+    TT_FATAL(
+        !(output_is_sharded && B > 1),
+        "Block-sharded output is incompatible with batch > 1 (B={}). The output CB is backed by the shard buffer "
+        "which only holds per_core_M * per_core_N = {} tiles, but the kernel would produce B * per_core_M * per_core_N "
+        "= {} tiles without draining. Use fuse_batch=True.",
+        B,
+        per_core_M * per_core_N,
+        B * per_core_M * per_core_N);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = out_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    uint32_t start_core_x = sub_device_start_core.x;
+    uint32_t start_core_y = sub_device_start_core.y;
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_cores_with_work_c = num_blocks_x;
+    uint32_t num_cores_with_work_r = num_blocks_y;
+    if (transpose_mcast) {
+        std::swap(num_cores_with_work_c, num_cores_with_work_r);
+    }
+
+    CoreRange all_cores_with_work(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      IN0 SHARDED SENDER/RECEIVER
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t num_cores_c = num_cores_with_work_c;
+    uint32_t num_cores_r = num_cores_with_work_r;
+    uint32_t in0_mcast_receiver_grid_diff_coord_start;
+    uint32_t in0_mcast_receiver_grid_diff_coord_end;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    uint32_t in0_sender_num_cores_along_width = 0;
+
+    // Only used for in0 block sharded
+    std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    if (in0_block_sharded) {
+        CoreCoord in0_shard_grid = in0_buffer->shard_spec().grid().bounding_box().grid_size();
+        // in0 shard grid already accounts for transpose_mcast
+        // ie. If transpose_mcast, in0 width is along y
+        in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
+        if (in0_sender_num_cores_along_width > num_blocks_x) {
+            in0_mcast_cores_without_work_and_not_in_receiver_grid =
+                transpose_mcast ? CoreRange(
+                                      {(std::size_t)start_core_x, (std::size_t)start_core_y + num_blocks_x},
+                                      {(std::size_t)start_core_x + num_blocks_y - 1,
+                                       (std::size_t)start_core_y + in0_sender_num_cores_along_width - 1})
+                                : CoreRange(
+                                      {(std::size_t)start_core_x + num_blocks_x, (std::size_t)start_core_y},
+                                      {(std::size_t)start_core_x + in0_sender_num_cores_along_width - 1,
+                                       (std::size_t)start_core_y + num_blocks_y - 1});
+        }
+
+        if (transpose_mcast) {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).y;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x, start_core_y + num_blocks_x - 1}).y;
+            in0_mcast_noc_y.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_y = 0; core_idx_y < in0_sender_num_cores_along_width; ++core_idx_y) {
+                in0_mcast_noc_y.push_back(
+                    device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+            }
+        } else {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).x;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x + num_blocks_x - 1, start_core_y}).x;
+            in0_mcast_noc_x.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_x = 0; core_idx_x < in0_sender_num_cores_along_width; ++core_idx_x) {
+                in0_mcast_noc_x.push_back(
+                    device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+            }
+        }
+
+        // Set in0 sender/receiver cores to be maximum
+        if (transpose_mcast) {
+            num_cores_r = std::max(num_cores_r, in0_sender_num_cores_along_width);
+        } else {
+            num_cores_c = std::max(num_cores_c, in0_sender_num_cores_along_width);
+        }
+    }
+
+    // Used for setting up CBs and semaphores by both in0 interleaved or sharded
+    CoreRange all_cores(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
+    const auto& cores = grid_to_cores(all_cores.start_coord, all_cores.end_coord, true);
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 SENDER (interleaved only) and IN1 SENDER (both interleaved and sharded)
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Left column
+    CoreRange in0_sender_interleaved(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    // Top row
+    CoreRange in1_sender(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
+
+    // Left column except corner
+    std::optional<CoreRange> in0_sender_in1_receiver;
+    if (num_cores_with_work_r > 1) {
+        in0_sender_in1_receiver = {
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Top row except corner
+    std::optional<CoreRange> in0_receiver_in1_sender;
+    if (num_cores_with_work_c > 1) {
+        in0_receiver_in1_sender = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y}};
+    }
+
+    if (transpose_mcast) {
+        std::swap(in0_sender_interleaved, in1_sender);
+        std::swap(in0_sender_in1_receiver, in0_receiver_in1_sender);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 RECEIVER (interleaved only) and IN1 RECEIVER (both interleaved and sharded)
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // Not exactly half-half; this seems to get slightly better perf for fused qkv and selfout
+    // TODO: Experiment with different splits?
+    bool split_half = num_cores_with_work_c > 2 && num_cores_with_work_r > 1 && !in0_is_sharded;
+    uint32_t half_core = split_half ? (num_cores_with_work_c) / 2 : num_cores_with_work_c - 1;
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_left_half;
+    if (num_cores_with_work_c > 1 and num_cores_with_work_r > 1) {
+        in0_receiver_in1_receiver_left_half = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + half_core, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    std::set<CoreRange> in0_receiver_interleaved_set;
+    std::set<CoreRange> in1_receiver_set;
+    if (in0_receiver_in1_sender.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_sender.value());
+    }
+    if (in0_sender_in1_receiver.has_value()) {
+        in1_receiver_set.insert(in0_sender_in1_receiver.value());
+    }
+    if (in0_receiver_in1_receiver_left_half.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_receiver_left_half.value());
+        in1_receiver_set.insert(in0_receiver_in1_receiver_left_half.value());
+    }
+    CoreRangeSet in0_receiver_interleaved(in0_receiver_interleaved_set);
+    CoreRangeSet in1_receiver(in1_receiver_set);
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_interleaved_other_cores;
+    if (split_half) {
+        in0_receiver_in1_receiver_interleaved_other_cores = {
+            {(std::size_t)start_core_x + half_core + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1,
+             (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Mcast args
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    // Guard CB — 2048 bytes of L1 used as DRAM-read scratch by guard.h. Split
+    // into two 1024-byte halves (256 uint32 elements each), one per table.
+    // CBIndex::c_11 is not used by any other CB in this factory.
+    constexpr uint32_t guard_cb_index = tt::CBIndex::c_11;
+    constexpr uint32_t kGuardCbBytes = 2048;
+    auto cb_guard = tt_metal::CreateCircularBuffer(
+        program,
+        all_cores,
+        tt::tt_metal::CircularBufferConfig(kGuardCbBytes, {{guard_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(guard_cb_index, kGuardCbBytes));
+
+    bool in1_is_dram = in1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    TT_FATAL(
+        out_block_h % out_subblock_h == 0 and out_block_h >= out_subblock_h,
+        "out_block_h must be multiple of out_subblock_h");
+    TT_FATAL(
+        out_block_w % out_subblock_w == 0 and out_block_w >= out_subblock_w,
+        "out_block_w must be multiple of out_subblock_w");
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+
+    uint32_t num_dram_banks = 0;
+    uint32_t per_core_N_storage = 0;
+    uint32_t batches_per_bank = 0;
+    if (in1_is_sharded and in1_is_dram) {
+        num_dram_banks = device->num_dram_channels();
+        if (in1_is_width_sharded) {
+            per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
+        } else {
+            // Height sharded: batches are distributed across DRAM banks
+            uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+            batches_per_bank = in1_shard_height_in_tiles / K;
+        }
+    }
+
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    if (in0_block_sharded) {
+        uint32_t num_x = in0_sender_num_cores_along_width;
+        uint32_t num_y = 1;
+        if (transpose_mcast) {
+            std::swap(num_x, num_y);
+        }
+
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_dests
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_cores
+            (std::uint32_t)num_x,
+            (std::uint32_t)num_y,
+            (std::uint32_t)transpose_mcast,
+            (std::uint32_t)in0_shard_width_in_tiles,
+            (std::uint32_t)in0_shard_height_in_tiles,
+            (std::uint32_t)in0_block_w,
+            (std::uint32_t)in0_block_h,
+            // batch args
+            (std::uint32_t)B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            (std::uint32_t)false,                      // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)in0_shard_width_in_tiles,   // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)in0_shard_height_in_tiles,  // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_dests
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+
+            // sparsity args
+            (std::uint32_t)0,      // batchB
+            (std::uint32_t)0,      // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,   // bcast_A
+            (std::uint32_t)false,  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_dests
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_buffer != nullptr) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
+    if (bias_buffer != nullptr) {
+        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    if (in1_is_sharded and in1_is_dram) {
+        if (in1_is_width_sharded) {
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in0_block_w);
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in1_single_tile_size);
+        } else {
+            // Height sharded: pass tiles per batch and batches per bank
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)(K * N));  // KtNt per batch (tiles)
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)batches_per_bank);
+        }
+    }
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,  // batch
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_buffer != nullptr) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_receiver_writer_compile_time_args);
+
+    // Guard-table accessor args — appended at the END of every dataflow kernel's
+    // compile-time arg vector. The starting offsets are propagated to the kernel
+    // via GUARD_GLOBAL_TABLE_CTA_OFFSET / GUARD_COUNTS_CTA_OFFSET named args. Both
+    // tables are small DRAM-interleaved ROW_MAJOR uint32 buffers; the kernel uses
+    // a TensorAccessor to read a specific page without assuming a fixed bank/offset.
+    const uint32_t in0_sender_global_cta_off = in0_sender_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*global_table_buffer).append_to(in0_sender_compile_time_args);
+    const uint32_t in0_sender_counts_cta_off = in0_sender_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*counts_buffer).append_to(in0_sender_compile_time_args);
+
+    const uint32_t in0_recv_global_cta_off = in0_receiver_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*global_table_buffer).append_to(in0_receiver_compile_time_args);
+    const uint32_t in0_recv_counts_cta_off = in0_receiver_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*counts_buffer).append_to(in0_receiver_compile_time_args);
+
+    const uint32_t in1_sender_global_cta_off = in1_sender_writer_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*global_table_buffer).append_to(in1_sender_writer_compile_time_args);
+    const uint32_t in1_sender_counts_cta_off = in1_sender_writer_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*counts_buffer).append_to(in1_sender_writer_compile_time_args);
+
+    const uint32_t in1_recv_global_cta_off = in1_receiver_writer_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*global_table_buffer).append_to(in1_receiver_writer_compile_time_args);
+    const uint32_t in1_recv_counts_cta_off = in1_receiver_writer_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*counts_buffer).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_interleaved_defines;
+    std::map<std::string, std::string> mm_kernel_in0_receiver_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
+
+    // Enable on-device guard for all kernels.
+    // ROUTED_GUARD_ENABLED goes in defines (-D flag for dataflow; defines_generated.h for compute).
+    // GUARD_CB_ID and GUARD_ARG_BASE go in named_compile_args (accessible via
+    // get_named_compile_time_arg_val in guard.h). GUARD_COMPUTE_KERNEL is already
+    // #defined directly in bmm_routed.cpp — do not add it here to avoid redefinition.
+    mm_kernel_defines["ROUTED_GUARD_ENABLED"] = "1";
+    mm_kernel_in0_sender_interleaved_defines["ROUTED_GUARD_ENABLED"] = "1";
+    mm_kernel_in1_sender_writer_defines["ROUTED_GUARD_ENABLED"] = "1";
+    mm_kernel_in1_receiver_writer_defines["ROUTED_GUARD_ENABLED"] = "1";
+    mm_kernel_in1_receiver_writer_other_noc_setup_defines["ROUTED_GUARD_ENABLED"] = "1";
+    mm_kernel_in0_receiver_defines["ROUTED_GUARD_ENABLED"] = "1";
+
+    if (bias_buffer != nullptr) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            using ttnn::operations::unary::utils::get_defines;
+            mm_kernel_defines.merge(get_defines(
+                fused_activation.value().op_type,
+                fused_activation.value().params,
+                "ACTIVATION",
+                "i",
+                tt_metal::dataformat_to_datatype_converter(output_data_format)));
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), cores.size(), mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), cores.size(), mm_kernel_defines, throttle_level);
+
+    if (in0_receiver_interleaved.num_cores() == 0) {
+        mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";
+    }
+    if (in0_height_sharded) {
+        mm_kernel_in0_sender_interleaved_defines["IN0_SHARDED"] = "1";
+    }
+
+    if (in1_receiver.num_cores() == 0) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+    if (in1_is_sharded) {
+        if (in1_is_dram) {
+            if (in1_is_width_sharded) {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_WIDTH_SHARDED"] = "1";
+            } else {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_HEIGHT_SHARDED"] = "1";
+            }
+        } else {
+            mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+        }
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["OUT_SHARDED"] = "1";
+    }
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    -> CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    -> CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+    bool in0_needs_intermediate_cb_read = false;
+    bool in1_needs_intermediate_cb_read = false;
+    if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
+        if (in0_needs_intermediate_cb_read) {
+            mm_kernel_in0_sender_interleaved_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
+        in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
+        if (in1_needs_intermediate_cb_read) {
+            mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
+    }
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in0_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in1_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_sender_id = 0;
+    tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = 0;
+    if (in0_block_sharded) {
+        mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+            all_cores_with_work,  // in0_mcast_cores_with_work_and_in_receiver_grid
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_sender_compile_time_args,
+                .defines = mm_kernel_in0_sender_sharded_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"cb_in0_sharded", tt::CBIndex::c_2},
+                    {"cb_l1_array", tt::CBIndex::c_6},
+                }});
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.has_value()) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+                in0_mcast_cores_without_work_and_not_in_receiver_grid.value(),
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args,
+                    .defines = mm_kernel_in0_sender_sharded_defines,
+                    .named_compile_args = {
+                        {"cb_in0", tt::CBIndex::c_0},
+                        {"cb_in0_sharded", tt::CBIndex::c_2},
+                        {"cb_l1_array", tt::CBIndex::c_6},
+                    }});
+        }
+    } else {
+        if (fuse_op) {
+            if (fused_op_signaler->is_all_gather()) {
+                // Create semaphores
+                fused_op_signaler->init_fused_op(program, device, in0_sender_interleaved);
+            } else if (fused_op_signaler->is_reduce_scatter()) {
+                fused_op_signaler->init_fused_op(program, device, all_cores, cores);
+            } else {
+                TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+            }
+        }
+
+        mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/"
+            "reader_routed_in0_sender_padding.cpp",
+            in0_sender_interleaved,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_sender_compile_time_args,
+                .defines = mm_kernel_in0_sender_interleaved_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"cb_in0_sharded", tt::CBIndex::c_2},
+                    {"cb_sparsity", tt::CBIndex::c_6},
+                    {"cb_in0_intermediate", tt::CBIndex::c_8},
+                    {"GUARD_CB_ID", guard_cb_index},
+                    {"GUARD_ARG_BASE", 8u},
+                    {"GUARD_GLOBAL_TABLE_CTA_OFFSET", in0_sender_global_cta_off},
+                    {"GUARD_COUNTS_CTA_OFFSET", in0_sender_counts_cta_off},
+                }});
+    }
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/"
+        "reader_routed_in1_sender_writer_padding.cpp",
+        in1_sender,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+                {"cb_in1_intermediate", tt::CBIndex::c_9},
+                {"GUARD_CB_ID", guard_cb_index},
+                // When OUT_SHARDED, the kernel skips last_num_blocks_w_dim arg -> 1 fewer base arg.
+                {"GUARD_ARG_BASE", output_is_sharded ? 20u : 21u},
+                {"GUARD_GLOBAL_TABLE_CTA_OFFSET", in1_sender_global_cta_off},
+                {"GUARD_COUNTS_CTA_OFFSET", in1_sender_counts_cta_off},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id = 0;
+    if (in1_receiver.num_cores() > 0) {
+        mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/"
+            "reader_routed_in1_receiver_writer_padding.cpp",
+            /* in0_sender_in1_receiver, // If not using half-half noc setup */
+            in1_receiver,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                    {"GUARD_CB_ID", guard_cb_index},
+                    // When OUT_SHARDED, the kernel skips last_num_blocks_{h,w} (2 args) -> 2 fewer.
+                    {"GUARD_ARG_BASE", output_is_sharded ? 13u : 15u},
+                    {"GUARD_GLOBAL_TABLE_CTA_OFFSET", in1_recv_global_cta_off},
+                    {"GUARD_COUNTS_CTA_OFFSET", in1_recv_counts_cta_off},
+                }});
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_id = 0;
+    if (!in0_block_sharded and in0_receiver_interleaved.num_cores() > 0) {
+        mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/"
+            "reader_routed_in0_receiver.cpp",
+            /* in0_receiver_in1_sender, // If not using half-half noc setup */
+            in0_receiver_interleaved,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .defines = mm_kernel_in0_receiver_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"GUARD_CB_ID", guard_cb_index},
+                    {"GUARD_ARG_BASE", 2u},
+                    {"GUARD_GLOBAL_TABLE_CTA_OFFSET", in0_recv_global_cta_off},
+                    {"GUARD_COUNTS_CTA_OFFSET", in0_recv_counts_cta_off},
+                }});
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_other_noc_setup_id = mm_kernel_in1_receiver_writer_id;
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_other_noc_setup_id = mm_kernel_in0_receiver_id;
+
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        mm_kernel_in1_receiver_writer_other_noc_setup_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/"
+            "reader_routed_in1_receiver_writer_padding.cpp",
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_split_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_other_noc_setup_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                    {"GUARD_CB_ID", guard_cb_index},
+                    {"GUARD_ARG_BASE", output_is_sharded ? 13u : 15u},
+                    {"GUARD_GLOBAL_TABLE_CTA_OFFSET", in1_recv_global_cta_off},
+                    {"GUARD_COUNTS_CTA_OFFSET", in1_recv_counts_cta_off},
+                }});
+
+        mm_kernel_in0_receiver_other_noc_setup_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/dataflow/"
+            "reader_routed_in0_receiver.cpp",
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_split_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .defines = mm_kernel_in0_receiver_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"GUARD_CB_ID", guard_cb_index},
+                    {"GUARD_ARG_BASE", 2u},
+                    {"GUARD_GLOBAL_TABLE_CTA_OFFSET", in0_recv_global_cta_off},
+                    {"GUARD_COUNTS_CTA_OFFSET", in0_recv_counts_cta_off},
+                }});
+    }
+
+    // Compute kernel compile time args
+
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        out_num_blocks_x,
+        out_num_blocks_y,
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch,
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = true;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    auto mm_compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/compute/"
+        "bmm_routed.cpp",
+        all_cores_with_work,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_intermed0", tt::CBIndex::c_5},
+                {"cb_in0_intermediate", tt::CBIndex::c_8},
+                {"cb_in1_intermediate", tt::CBIndex::c_9},
+                {"cb_in0_transposed", tt::CBIndex::c_10},
+                {"bias_ntiles", in1_per_core_w},
+                {"GUARD_CB_ID", guard_cb_index},
+                {"GUARD_ARG_BASE", 0u},
+            }});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    if (in0_height_sharded) {
+        src0_cb_config.set_globally_allocated_address(*in0_buffer);
+    }
+    tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+    if (in1_is_sharded and not in1_is_dram) {
+        src1_cb_config.set_globally_allocated_address(*in1_buffer);
+    }
+    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CBHandle cb_src2 = 0;
+    if (in0_block_sharded) {
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(*in0_buffer)
+                .set_tile_dims(src2_cb_index, in0_tile);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
+
+        // Local L1 to store temp vars
+        uint32_t l1_cb_index = tt::CBIndex::c_6;
+        tt::tt_metal::CircularBufferConfig cb_for_l1_array_config =
+            tt::tt_metal::CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(l1_cb_index, 32 * 2);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    }
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+    }
+
+    if (output_is_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    // CB for bias
+    if (bias_buffer != nullptr) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_single_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_single_tile_size,
+            in3_CB_size / bias_single_tile_size,
+            in3_CB_size);
+    }
+    // Intermediate CB read
+    if (in1_needs_intermediate_cb_read) {
+        uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
+        tt_metal::CircularBufferConfig cb_in1_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{in1_intermediate_cb_index, in1_data_format}})
+                .set_page_size(in1_intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(in1_intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in1_intermediate_config);
+    }
+    if (in0_needs_intermediate_cb_read) {
+        uint32_t in0_intermediate_cb_index = tt::CBIndex::c_8;
+        tt_metal::CircularBufferConfig cb_in0_intermediate_config =
+            tt_metal::CircularBufferConfig(in0_single_tile_size, {{in0_intermediate_cb_index, in0_data_format}})
+                .set_page_size(in0_intermediate_cb_index, in0_single_tile_size)
+                .set_tile_dims(in0_intermediate_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in0_intermediate_config);
+    }
+
+    if (in0_transpose_tile) {
+        uint32_t in0_transpose_cb_index = tt::CBIndex::c_10;
+        auto in0_transpose_cb_config =
+            tt_metal::CircularBufferConfig(in0_CB_size, {{in0_transpose_cb_index, in0_data_format}})
+                .set_page_size(in0_transpose_cb_index, in0_single_tile_size)
+                .set_tile_dims(in0_transpose_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
+    }
+
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    if (in0_block_sharded) {
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_receiver_grid_diff_coord_start, in0_mcast_receiver_grid_diff_coord_end);
+        }
+    }
+
+    // dram sharded weights stride params
+    uint32_t worker_core_stride = 0;   // stride in the worker core
+    uint32_t storage_core_stride = 0;  // stride in the dram bank
+    uint32_t curr_worker_core = 0;     // current worker core
+    uint32_t curr_storage_core = 0;    // current read dram bank
+    uint32_t vc = 0;
+
+    uint32_t in0_end_idx = num_blocks_y - 1;
+    uint32_t in1_end_idx = num_blocks_x - 1;
+    const auto& in0_sender_interleaved_cores = grid_to_cores(
+        in0_sender_interleaved.start_coord, in0_sender_interleaved.end_coord, true);  // Only used for interleaved in0
+    const auto& in1_sender_cores = grid_to_cores(in1_sender.start_coord, in1_sender.end_coord, true);
+    const auto& in1_receiver_cores = corerange_to_cores(in1_receiver, std::nullopt, true);
+    std::vector<CoreCoord> in1_receiver_other_cores;
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        in1_receiver_other_cores = grid_to_cores(
+            in0_receiver_in1_receiver_interleaved_other_cores.value().start_coord,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().end_coord,
+            true);
+    }
+
+    for (const auto& core : cores) {
+        CoreCoord left_core = {(std::size_t)start_core_x, (std::size_t)core.y};
+        CoreCoord left_core_plus_one = {(std::size_t)start_core_x + 1, (std::size_t)core.y};
+        CoreCoord right_core = {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)core.y};
+        CoreCoord top_core = {(std::size_t)core.x, (std::size_t)start_core_y};
+        CoreCoord top_core_plus_one = {(std::size_t)core.x, (std::size_t)start_core_y + 1};
+        CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)start_core_y + num_cores_with_work_r - 1};
+
+        auto left_core_physical = device->worker_core_from_logical_core(left_core);
+        auto left_core_plus_one_physical = device->worker_core_from_logical_core(left_core_plus_one);
+        auto right_core_physical = device->worker_core_from_logical_core(right_core);
+        auto top_core_physical = device->worker_core_from_logical_core(top_core);
+        auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
+        auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+        uint32_t in0_idx = core.y - start_core_y;
+        uint32_t in1_idx = core.x - start_core_x;
+
+        auto in0_mcast_sender = left_core_physical;
+        auto in1_mcast_sender = top_core_physical;
+
+        // Assuming in0 is NOC0
+        auto in0_mcast_start = left_core_plus_one_physical;
+        auto in0_mcast_end = right_core_physical;
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_start, in0_mcast_end);
+        }
+
+        // Assuming in1 is NOC1
+        auto in1_mcast_start = bottom_core_physical;
+        auto in1_mcast_end = top_core_plus_one_physical;
+        if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+            std::swap(in1_mcast_start, in1_mcast_end);
+        }
+
+        if (transpose_mcast) {
+            std::swap(in0_idx, in1_idx);
+            std::swap(in0_mcast_sender, in1_mcast_sender);
+            std::swap(in0_mcast_start, in1_mcast_end);
+            std::swap(in0_mcast_end, in1_mcast_start);
+        }
+
+        // in0 sender
+        if (in0_block_sharded) {
+            uint32_t in0_mcast_receiver_grid_same_coord;
+            std::vector<uint32_t> mm_in0_sender_args;
+            if (transpose_mcast) {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).x;
+                mm_in0_sender_args.push_back(core.y);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+            } else {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).y;
+                mm_in0_sender_args.push_back(core.x);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+            }
+            if (in1_idx < num_blocks_x) {
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_0_default
+            } else {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            }
+        } else if (in1_idx == 0) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)in0_mcast_start.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)in0_mcast_end.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)in0_mcast_end.y,    // in0_mcast_dest_noc_end_y
+            };
+            if (in0_idx == in0_end_idx) {
+                // padding args (READER)
+                mm_in0_sender_args.push_back(last_out_block_h);  // last_out_block_h
+            } else {
+                mm_in0_sender_args.push_back(out_block_h);
+            }
+
+            // sparsity args
+            mm_in0_sender_args.push_back(0);  // sparsity_addr
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            // guard args [GUARD_ARG_BASE + 0..4]
+            mm_in0_sender_args.push_back(global_table_addr);
+            mm_in0_sender_args.push_back(token_counts_addr);
+            mm_in0_sender_args.push_back(local_expert_idx);
+            mm_in0_sender_args.push_back(curr_expert_iter);
+            mm_in0_sender_args.push_back(expert_iter_length);
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_0_default
+
+            // in0 receiver
+        } else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_sender.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)in0_mcast_sender.y,  // in0_mcast_sender_noc_y
+                // guard args [GUARD_ARG_BASE + 0..4]
+                global_table_addr,
+                token_counts_addr,
+                local_expert_idx,
+                curr_expert_iter,
+                expert_iter_length,
+            };
+            // left half
+            if (core.x <= half_core || (!transpose_mcast and core.y == start_core_y)) {
+                tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);
+            }
+            // right half
+            else {
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in0_receiver_other_noc_setup_id, core, mm_in0_receiver_args);
+            }
+        }
+
+        if (in0_idx < num_blocks_y and in1_idx < num_blocks_x) {
+            // in1 sender
+            if (in0_idx == 0) {
+                std::vector<uint32_t> mm_in1_sender_writer_args = {
+                    // READER
+                    // in1 tensor args
+                    (std::uint32_t)in1_buffer->address(),
+                    (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
+                    (std::uint32_t)in1_mcast_start.y,  // in1_mcast_dest_noc_start_y
+                    (std::uint32_t)in1_mcast_end.x,    // in1_mcast_dest_noc_end_x
+                    (std::uint32_t)in1_mcast_end.y,    // in1_mcast_dest_noc_end_y
+
+                    // sparsity args
+                    (std::uint32_t)0,  // sparsity_addr
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_buffer->address(),
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(0);
+                }
+
+                mm_in1_sender_writer_args.push_back(bias_buffer ? (std::uint32_t)bias_buffer->address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_buffer ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                        mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (in1_is_sharded and in1_is_dram) {  // in1 is dram sharded
+                    if (in1_is_width_sharded) {
+                        uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
+                        vc = vc == 3 ? 0 : vc + 1;
+                        mm_in1_sender_writer_args.push_back(vc);
+
+                        uint32_t num_iter = 0;  // iterate how many banks, till fill the current worker block
+
+                        if (curr_storage_core < num_dram_banks) {
+                            num_iter++;
+
+                            worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                            mm_in1_sender_writer_args.push_back(
+                                storage_core_stride * in1_single_tile_size);  // dram_tensor_start_offset
+                            mm_in1_sender_writer_args.push_back(
+                                worker_core_stride * in1_single_tile_size);          // per_core_N_dram_bytes
+                            mm_in1_sender_writer_args.push_back(curr_storage_core);  // current_dram_bank_id
+
+                            log_debug(
+                                tt::LogOp,
+                                "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                curr_worker_core,
+                                worker_core_stride,
+                                curr_storage_core,
+                                storage_core_stride);
+
+                            curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                            storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                            uint32_t curr_worker_core_old = curr_worker_core;
+                            if (worker_core_stride >= per_core_N) {
+                                curr_worker_core += 1;
+                            }
+
+                            while (curr_worker_core <= curr_worker_core_old and curr_storage_core < num_dram_banks) {
+                                num_iter++;
+
+                                uint32_t stride = worker_core_stride + per_core_N_storage;
+                                stride = std::min(stride, per_core_N);
+
+                                mm_in1_sender_writer_args.push_back(
+                                    (stride - worker_core_stride) * in1_single_tile_size);  // per_core_N_dram_bytes
+                                mm_in1_sender_writer_args.push_back(curr_storage_core);     // current_dram_bank_id
+
+                                log_debug(
+                                    tt::LogOp,
+                                    "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                    curr_worker_core,
+                                    (stride - worker_core_stride),
+                                    curr_storage_core,
+                                    storage_core_stride);
+
+                                if (stride >= per_core_N) {
+                                    curr_worker_core += 1;
+                                }
+                                storage_core_stride = (stride - worker_core_stride) % per_core_N_storage;
+                                curr_storage_core += (stride - worker_core_stride) / per_core_N_storage;
+                                worker_core_stride = stride;
+                            }
+                        }
+                        mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
+                    } else {
+                        // Height sharded: no additional runtime args needed
+                        // (bank/offset computed from compile-time args + batch index)
+                    }
+                }
+                if (fuse_op) {
+                    if (fused_op_signaler->is_all_gather()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+                    } else if (fused_op_signaler->is_reduce_scatter()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, in0_idx, in1_idx);
+                    } else {
+                        TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+                    }
+                }
+                // guard args [GUARD_ARG_BASE + 0..4]
+                mm_in1_sender_writer_args.push_back(global_table_addr);
+                mm_in1_sender_writer_args.push_back(token_counts_addr);
+                mm_in1_sender_writer_args.push_back(local_expert_idx);
+                mm_in1_sender_writer_args.push_back(curr_expert_iter);
+                mm_in1_sender_writer_args.push_back(expert_iter_length);
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_1_default
+
+                // in1 receiver
+            } else {
+                std::vector<uint32_t> mm_in1_receiver_writer_args = {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_sender.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)in1_mcast_sender.y,  // in1_mcast_sender_noc_y
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_buffer->address(),                               // out_tensor_addr
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx and in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                }
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx and
+                        in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (fuse_op && fused_op_signaler->is_reduce_scatter()) {
+                    fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_receiver_writer_args, in0_idx, in1_idx);
+                }
+
+                // guard args [GUARD_ARG_BASE + 0..4]
+                mm_in1_receiver_writer_args.push_back(global_table_addr);
+                mm_in1_receiver_writer_args.push_back(token_counts_addr);
+                mm_in1_receiver_writer_args.push_back(local_expert_idx);
+                mm_in1_receiver_writer_args.push_back(curr_expert_iter);
+                mm_in1_receiver_writer_args.push_back(expert_iter_length);
+
+                // left half
+                if (core.x <= half_core || (transpose_mcast and core.y == start_core_y)) {
+                    tt_metal::SetRuntimeArgs(
+                        program, mm_kernel_in1_receiver_writer_id, core, mm_in1_receiver_writer_args);
+                }
+                // right half
+                else {
+                    tt_metal::SetRuntimeArgs(
+                        program, mm_kernel_in1_receiver_writer_other_noc_setup_id, core, mm_in1_receiver_writer_args);
+                }
+            }
+        }
+    }
+
+    // Compute runtime args: 5 guard args (global_table_addr, token_counts_addr,
+    // local_expert_idx, curr_expert_iter, expert_iter_length). TRISC always proceeds.
+    for (const auto& core : grid_to_cores(all_cores_with_work.start_coord, all_cores_with_work.end_coord, true)) {
+        tt_metal::SetRuntimeArgs(
+            program,
+            mm_compute_kernel_id,
+            core,
+            {global_table_addr, token_counts_addr, local_expert_idx, curr_expert_iter, expert_iter_length});
+    }
+
+    // Collect in0_receiver core lists for override_runtime_arguments.
+    std::vector<CoreCoord> in0_receiver_interleaved_cores;
+    std::vector<CoreCoord> in0_receiver_other_cores;
+    if (!in0_block_sharded) {
+        in0_receiver_interleaved_cores = corerange_to_cores(in0_receiver_interleaved, std::nullopt, true);
+        if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+            in0_receiver_other_cores = grid_to_cores(
+                in0_receiver_in1_receiver_interleaved_other_cores.value().start_coord,
+                in0_receiver_in1_receiver_interleaved_other_cores.value().end_coord,
+                true);
+        }
+    }
+
+    return {
+        std::move(program),
+        {mm_kernel_in0_sender_id,
+         in0_sender_interleaved_cores,
+         mm_kernel_in1_sender_writer_id,
+         in1_sender_cores,
+         mm_kernel_in1_receiver_writer_id,
+         in1_receiver_cores,
+         mm_kernel_in1_receiver_writer_other_noc_setup_id,
+         in1_receiver_other_cores,
+         cb_src2,
+         cb_output,
+         num_cores_with_work_r,
+         num_cores_with_work_c,
+         start_core_x,
+         start_core_y,
+         transpose_mcast,
+         cores,
+         cb_guard,
+         output_is_sharded,
+         mm_compute_kernel_id,
+         mm_kernel_in0_receiver_id,
+         mm_kernel_in0_receiver_other_noc_setup_id,
+         std::move(in0_receiver_interleaved_cores),
+         std::move(in0_receiver_other_cores)}};
+}
+
+void override_runtime_arguments_impl(
+    RoutedMatmulMcast2DProgramFactory::shared_variables_t& shared_variables,
+    tt::tt_metal::Program& program,
+    const RoutedMatmulParams& operation_attributes,
+    const RoutedMatmulInputs& tensor_args,
+    ttnn::Tensor& output_tensor) {
+    auto mm_kernel_in0_sender_id = shared_variables.mm_kernel_in0_sender_id;
+    auto in0_sender_interleaved_cores = shared_variables.in0_sender_interleaved_cores;
+    auto mm_kernel_in1_sender_writer_id = shared_variables.mm_kernel_in1_sender_writer_id;
+    auto in1_sender_cores = shared_variables.in1_sender_cores;
+    auto mm_kernel_in1_receiver_writer_id = shared_variables.mm_kernel_in1_receiver_writer_id;
+    auto in1_receiver_cores = shared_variables.in1_receiver_cores;
+    auto mm_kernel_in1_receiver_writer_other_noc_setup_id =
+        shared_variables.mm_kernel_in1_receiver_writer_other_noc_setup_id;
+    auto in1_receiver_other_cores = shared_variables.in1_receiver_other_cores;
+    auto cb_src2 = shared_variables.cb_src2;
+    auto cb_output = shared_variables.cb_output;
+
+    auto* src_buffer_a = tensor_args.a.buffer();
+    auto* src_buffer_b = tensor_args.b.buffer();
+    auto* dst_buffer = output_tensor.buffer();
+
+    bool src0_sharded = tensor_args.a.memory_config().is_sharded();
+    bool out_sharded = output_tensor.memory_config().is_sharded();
+
+    // Guard args — updated on every dispatch (cache hit). Five slots per kernel:
+    // [global_table_addr, token_counts_addr, local_expert_idx, curr_expert_iter,
+    //  expert_iter_length].
+    const uint32_t global_table_addr = tensor_args.global_expert_idx_table.buffer()->address();
+    const uint32_t token_counts_addr = tensor_args.expert_token_counts.buffer()->address();
+    const uint32_t local_expert_idx = operation_attributes.local_expert_idx;
+    const uint32_t curr_expert_iter = operation_attributes.curr_expert_iter;
+    const uint32_t expert_iter_length = operation_attributes.expert_iter_length;
+
+    auto write_guard = [&](auto& args, uint32_t gb) {
+        args[gb] = global_table_addr;
+        args[gb + 1] = token_counts_addr;
+        args[gb + 2] = local_expert_idx;
+        args[gb + 3] = curr_expert_iter;
+        args[gb + 4] = expert_iter_length;
+    };
+
+    // in0 sender (GUARD_ARG_BASE = 8)
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddress(program, cb_src2, *src_buffer_a);
+    } else {
+        auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
+        for (const auto& core : in0_sender_interleaved_cores) {
+            auto& args = reader_sender_runtime_args_by_core[core.x][core.y];
+            args[0] = src_buffer_a->address();
+            write_guard(args, 8);
+        }
+    }
+
+    // in0 receiver left-half (GUARD_ARG_BASE = 2)
+    if (shared_variables.mm_kernel_in0_receiver_id != 0) {
+        auto& in0_recv_args = GetRuntimeArgs(program, shared_variables.mm_kernel_in0_receiver_id);
+        for (const auto& core : shared_variables.in0_receiver_interleaved_cores) {
+            auto& args = in0_recv_args[core.x][core.y];
+            write_guard(args, 2);
+        }
+    }
+    // in0 receiver right-half
+    if (shared_variables.mm_kernel_in0_receiver_other_noc_setup_id != 0 &&
+        shared_variables.mm_kernel_in0_receiver_other_noc_setup_id != shared_variables.mm_kernel_in0_receiver_id) {
+        auto& in0_recv_other_args = GetRuntimeArgs(program, shared_variables.mm_kernel_in0_receiver_other_noc_setup_id);
+        for (const auto& core : shared_variables.in0_receiver_other_cores) {
+            auto& args = in0_recv_other_args[core.x][core.y];
+            write_guard(args, 2);
+        }
+    }
+
+    // in1 sender: guard base is 20 when out_sharded (25 total args), 21 when not (26 total).
+    auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
+    for (const auto& core : in1_sender_cores) {
+        auto& args = sender_writer_runtime_args_by_core[core.x][core.y];
+        args[0] = src_buffer_b->address();
+        args[7] = dst_buffer->address();
+        const uint32_t gb = (args.size() <= 25u) ? 20u : 21u;
+        write_guard(args, gb);
+    }
+
+    // in1 receiver: guard base is 13 when out_sharded (18 total), 15 when not (20 total).
+    auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id);
+    for (const auto& core : in1_receiver_cores) {
+        auto& args = receiver_writer_runtime_args_by_core[core.x][core.y];
+        args[2] = dst_buffer->address();
+        const uint32_t gb = (args.size() <= 18u) ? 13u : 15u;
+        write_guard(args, gb);
+    }
+    // in1 receiver right-half
+    if (mm_kernel_in1_receiver_writer_id != mm_kernel_in1_receiver_writer_other_noc_setup_id) {
+        auto& receiver_writer_runtime_args_by_core_other =
+            GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_other_noc_setup_id);
+        for (const auto& core : in1_receiver_other_cores) {
+            auto& args = receiver_writer_runtime_args_by_core_other[core.x][core.y];
+            args[2] = dst_buffer->address();
+            const uint32_t gb = (args.size() <= 18u) ? 13u : 15u;
+            write_guard(args, gb);
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+    }
+
+    // compute (GUARD_ARG_BASE = 0): 5 guard args. TRISC always proceeds.
+    auto& compute_args_map = GetRuntimeArgs(program, shared_variables.mm_compute_kernel_id);
+    CoreRange work_range(
+        {shared_variables.start_core_x, shared_variables.start_core_y},
+        {shared_variables.start_core_x + shared_variables.num_cores_with_work_c - 1,
+         shared_variables.start_core_y + shared_variables.num_cores_with_work_r - 1});
+    for (const auto& core : grid_to_cores(work_range.start_coord, work_range.end_coord, true)) {
+        auto& args = compute_args_map[core.x][core.y];
+        write_guard(args, 0);
+    }
+}
+}  // namespace routed_mcast_optimized_helpers
+
+static RoutedMatmulMcast2DProgramFactory::cached_program_t routed_matmul_build_program_(
+    tt::tt_metal::Program& program,
+    const RoutedMatmulParams& operation_attributes,
+    const RoutedMatmulInputs& tensor_args,
+    ttnn::Tensor& tensor_return_value,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
+    using namespace tt;
+    using namespace operations::matmul::utilities;
+
+    const auto& a = tensor_args.a;
+    const auto& b = tensor_args.b;
+    auto& output = tensor_return_value;
+
+    // routed_matmul is BH 2D-mcast only; bias, batch-broadcast, untilize, and
+    // input transpositions are out of scope.
+    const std::optional<const ttnn::Tensor> bias = std::nullopt;
+    const bool bcast_batch = true;
+    const bool transpose_a = false;
+    const bool transpose_b = false;
+    const bool untilize_out = false;
+
+    auto program_config =
+        std::get<operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>(operation_attributes.program_config);
+
+    auto fuse_batch = program_config.fuse_batch;
+    auto in0_block_w = program_config.in0_block_w;
+    auto compute_with_storage_grid_size = program_config.compute_with_storage_grid_size;
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto transpose_mcast = program_config.transpose_mcast;
+
+    auto compute_kernel_config = operation_attributes.compute_kernel_config;
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_tile(b, transpose_b);
+
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());          // in0
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());          // in1
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
+
+    const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    tt_metal::Buffer* bias_buffer = nullptr;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+
+        bias_buffer = c.buffer();
+
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = a.device();
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    tt_metal::Buffer* in0_buffer = a.buffer();
+    tt_metal::Buffer* in1_buffer = b.buffer();
+    TT_FATAL(
+        in0_buffer->size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_buffer->size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_buffer->size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_buffer->size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        a_shape_padded[-1] == b_shape_padded[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        a_shape_padded[-1],
+        b_shape_padded[-2]);
+    TT_FATAL(
+        a_shape_padded[-2] % in0_tile.get_height() == 0,
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        a_shape_padded[-2],
+        in0_tile.get_height());
+    TT_FATAL(
+        a_shape_padded[-1] % in0_tile.get_width() == 0,
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        a_shape_padded[-1],
+        in0_tile.get_width());
+    TT_FATAL(
+        b_shape_padded[-2] % in1_tile.get_height() == 0,
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        b_shape_padded[-2],
+        in1_tile.get_height());
+    TT_FATAL(
+        b_shape_padded[-1] % in1_tile.get_width() == 0,
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        b_shape_padded[-1],
+        in1_tile.get_width());
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
+    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
+    const auto B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
+    const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Mt_per_batch = get_M_dim(a_shape_padded, in0_tile, false);
+    const auto Kt = get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = get_N_dim(b_shape_padded, in1_tile);
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    // This should allocate a DRAM buffer on the device
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+    if (transpose_mcast) {
+        std::swap(num_blocks_x, num_blocks_y);
+    }
+
+    // TODO: Max used grid can actually exceed mcast receiver grid if in0 is sharded
+    // TODO: Move these validates to op validate and properly check for this
+    TT_FATAL(
+        num_blocks_x <= num_cores_x,
+        "Num output blocks along x ({}) must be smaller than or equal to the number of columns in compute grid ({})!",
+        num_blocks_x,
+        num_cores_x);
+    TT_FATAL(
+        num_blocks_y <= num_cores_y,
+        "Num output blocks along y ({}) must be smaller than or equal to the number of rows in compute grid ({})!",
+        num_blocks_y,
+        num_cores_y);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Buffer* out_buffer = output.buffer();
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sub-device start core
+    ////////////////////////////////////////////////////////////////////////////
+    // No sub-device support for routed_matmul.
+    CoreCoord sub_device_start_core = {0, 0};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto* global_table_buffer = tensor_args.global_expert_idx_table.buffer();
+    auto* counts_buffer = tensor_args.expert_token_counts.buffer();
+    const uint32_t local_expert_idx = operation_attributes.local_expert_idx;
+    const uint32_t guard_expert_iter = operation_attributes.curr_expert_iter;
+    const uint32_t expert_iter_length = operation_attributes.expert_iter_length;
+
+    return routed_mcast_optimized_helpers::create_program_mcast_in0_in1(
+        program,
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        B,
+        Mt,
+        Mt_per_batch,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        ttnn::get_throttle_level(compute_kernel_config),
+        in0_block_w,
+        in0_last_ktile_w,
+        in0_last_ktile_h,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        transpose_mcast,
+        program_config.fused_activation,
+        in0_buffer,
+        in1_buffer,
+        bias_buffer,
+        out_buffer,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        fused_op_signaler,
+        global_table_buffer,
+        counts_buffer,
+        local_expert_idx,
+        guard_expert_iter,
+        expert_iter_length,
+        sub_device_start_core);
+}
+
+RoutedMatmulMcast2DProgramFactory::cached_program_t RoutedMatmulMcast2DProgramFactory::create(
+    const RoutedMatmulParams& operation_attributes,
+    const RoutedMatmulInputs& tensor_args,
+    ttnn::Tensor& tensor_return_value) {
+    tt::tt_metal::Program program{};
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
+
+    return routed_matmul_build_program_(
+        program, operation_attributes, tensor_args, tensor_return_value, fused_op_signaler);
+}
+
+void RoutedMatmulMcast2DProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const RoutedMatmulParams& operation_attributes,
+    const RoutedMatmulInputs& tensor_args,
+    ttnn::Tensor& tensor_return_value) {
+    routed_mcast_optimized_helpers::override_runtime_arguments_impl(
+        cached_program.shared_variables,
+        cached_program.program,
+        operation_attributes,
+        tensor_args,
+        tensor_return_value);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_program_factory.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "routed_matmul_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+// Forked 2D-mcast matmul program factory. Same layout/config as matmul's 2D mcast
+// factory; the reader and compute kernels are replaced with forked variants that
+// read the global_expert_idx_table and expert_token_counts tensors from DRAM and
+// early-return when expert_token_counts[global_expert_idx_table[local_expert_idx]]
+// <= curr_expert_iter * expert_iter_length. The three runtime scalars
+// (local_expert_idx, curr_expert_iter, expert_iter_length) are passed as per-kernel
+// runtime args so the program can be cached across experts and chunk iterations.
+struct RoutedMatmulMcast2DProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle mm_kernel_in0_sender_id{};
+        std::vector<tt::tt_metal::CoreCoord> in0_sender_interleaved_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_sender_writer_id{};
+        std::vector<tt::tt_metal::CoreCoord> in1_sender_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id{};
+        std::vector<tt::tt_metal::CoreCoord> in1_receiver_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_other_noc_setup_id{};
+        std::vector<tt::tt_metal::CoreCoord> in1_receiver_other_cores;
+        tt::tt_metal::CBHandle cb_src2{};
+        tt::tt_metal::CBHandle cb_output{};
+        uint32_t num_cores_with_work_r{};
+        uint32_t num_cores_with_work_c{};
+        uint32_t start_core_x{};
+        uint32_t start_core_y{};
+        bool transpose_mcast{};
+        std::vector<tt::tt_metal::CoreCoord> cores;
+        // Guard mechanism
+        tt::tt_metal::CBHandle cb_guard{};
+        bool output_is_sharded{false};
+        tt::tt_metal::KernelHandle mm_compute_kernel_id{};
+        tt::tt_metal::KernelHandle mm_kernel_in0_receiver_id{};
+        tt::tt_metal::KernelHandle mm_kernel_in0_receiver_other_noc_setup_id{};
+        std::vector<tt::tt_metal::CoreCoord> in0_receiver_interleaved_cores;
+        std::vector<tt::tt_metal::CoreCoord> in0_receiver_other_cores;
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const RoutedMatmulParams& operation_attributes,
+        const RoutedMatmulInputs& tensor_args,
+        ttnn::Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const RoutedMatmulParams& operation_attributes,
+        const RoutedMatmulInputs& tensor_args,
+        ttnn::Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_types.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+// Attributes that affect the compiled program (part of the program cache key).
+// The three runtime scalars (local_expert_idx, curr_expert_iter, expert_iter_length)
+// live here so the framework's tensor-visitor on tensor_args_t isn't asked to walk
+// them — and the custom compute_program_hash on RoutedMatmulDeviceOperation hashes
+// only tensor_args + tensor specs, so every scalar here is excluded by construction.
+// That lets the same program be reused across experts and chunk iterations; only
+// runtime args change between dispatches. fused_activation lives inside program_config
+// (on the matmul variant structs).
+struct RoutedMatmulParams {
+    ttnn::operations::matmul::MatmulProgramConfig program_config;
+    ttnn::DeviceComputeKernelConfig compute_kernel_config;
+    tt::tt_metal::MemoryConfig output_memory_config;
+    tt::tt_metal::DataType output_dtype;
+    uint32_t local_expert_idx;
+    uint32_t curr_expert_iter;
+    uint32_t expert_iter_length;
+};
+
+// Tensor inputs for the per-chunk guard predicate:
+//   skip iff expert_token_counts[global_expert_idx_table[local_expert_idx]]
+//           <= curr_expert_iter * expert_iter_length
+// Both tables are small DRAM row-major uint32 tensors. Row-major layout means
+// torch[0, 0, i] lands at DRAM byte i*4 so the kernel can index directly into
+// its L1 scratch with no face/row packing math. Each kernel reads them straight
+// from DRAM — no host involvement.
+struct RoutedMatmulInputs {
+    ttnn::Tensor a;
+    ttnn::Tensor b;
+    ttnn::Tensor global_expert_idx_table;  // (1, 1, experts_per_chip), uint32, DRAM, ROW_MAJOR
+    ttnn::Tensor expert_token_counts;      // (1, 1, num_global_experts), uint32, DRAM, ROW_MAJOR
+    std::optional<ttnn::Tensor> optional_output_tensor;
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_device_operation.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "routed_unary_device_operation.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+RoutedUnaryDeviceOperation::program_factory_t RoutedUnaryDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return RoutedUnaryProgramFactory{};
+}
+
+void RoutedUnaryDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    TT_FATAL(tensor_args.input.storage_type() == StorageType::DEVICE, "routed_unary: input must be on device");
+    TT_FATAL(
+        tensor_args.global_expert_idx_table.storage_type() == StorageType::DEVICE,
+        "routed_unary: global_expert_idx_table must be on device");
+    TT_FATAL(
+        tensor_args.global_expert_idx_table.buffer() != nullptr &&
+            tensor_args.global_expert_idx_table.buffer()->buffer_type() == BufferType::DRAM,
+        "routed_unary: global_expert_idx_table must be in DRAM");
+    TT_FATAL(
+        tensor_args.expert_token_counts.storage_type() == StorageType::DEVICE,
+        "routed_unary: expert_token_counts must be on device");
+    TT_FATAL(
+        tensor_args.expert_token_counts.buffer() != nullptr &&
+            tensor_args.expert_token_counts.buffer()->buffer_type() == BufferType::DRAM,
+        "routed_unary: expert_token_counts must be in DRAM");
+}
+
+void RoutedUnaryDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_hit(operation_attributes, tensor_args);
+
+    TT_FATAL(tensor_args.input.layout() == tt::tt_metal::Layout::TILE, "routed_unary: only TILE layout is supported");
+    TT_FATAL(tensor_args.input.is_sharded(), "routed_unary: only sharded input is supported");
+    TT_FATAL(operation_attributes.output_memory_config.is_sharded(), "routed_unary: only sharded output is supported");
+}
+
+RoutedUnaryDeviceOperation::spec_return_value_t RoutedUnaryDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor->tensor_spec();
+    }
+    const auto& input = tensor_args.input;
+    return tt::tt_metal::TensorSpec(
+        input.logical_shape(),
+        tt::tt_metal::TensorLayout(
+            operation_attributes.output_dtype,
+            tt::tt_metal::PageConfig(input.layout()),
+            operation_attributes.output_memory_config));
+}
+
+RoutedUnaryDeviceOperation::tensor_return_value_t RoutedUnaryDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor.value();
+    }
+    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input.device());
+}
+
+ttsl::hash::hash_t RoutedUnaryDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    // Exclude local_expert_idx / curr_expert_iter / expert_iter_length: these
+    // are runtime-arg values only. Include everything that could affect kernel
+    // compilation or program layout.
+    return ttsl::hash::hash_objects_with_default_seed(
+        attrs.op_chain,
+        attrs.compute_kernel_config,
+        attrs.output_memory_config,
+        attrs.output_dtype,
+        attrs.fp32_dest_acc_en,
+        attrs.preserve_fp32_precision,
+        attrs.bfp8_pack_precise,
+        args.input.tensor_spec(),
+        args.global_expert_idx_table.tensor_spec(),
+        args.expert_token_counts.tensor_spec(),
+        args.optional_output_tensor.has_value());
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device
+
+namespace ttnn::prim {
+
+ttnn::Tensor routed_unary(
+    const ttnn::Tensor& input,
+    const ttnn::operations::unary::EltwiseUnaryWithParam& op,
+    const ttnn::Tensor& global_expert_idx_table,
+    const ttnn::Tensor& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config,
+    std::optional<ttnn::Tensor> optional_output_tensor,
+    const std::optional<tt::tt_metal::DataType>& output_dtype) {
+    namespace ru = ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device;
+    using OperationType = ru::RoutedUnaryDeviceOperation;
+
+    const tt::tt_metal::DataType out_dtype = output_dtype.value_or(input.dtype());
+
+    const tt::tt_metal::MemoryConfig resolved_output_mem_cfg =
+        output_memory_config.has_value()
+            ? output_memory_config.value()
+            : (optional_output_tensor.has_value() ? optional_output_tensor->memory_config() : input.memory_config());
+
+    // Mirror unary_ng's heuristics for fp32 dest accumulation + precision flags.
+    const bool preserve_fp32_precision = (input.dtype() == tt::tt_metal::DataType::FLOAT32);
+    const bool fp32_dest_acc_en =
+        preserve_fp32_precision || out_dtype == tt::tt_metal::DataType::UINT32 ||
+        out_dtype == tt::tt_metal::DataType::INT32 || out_dtype == tt::tt_metal::DataType::FLOAT32 ||
+        out_dtype == tt::tt_metal::DataType::UINT8 || input.dtype() == tt::tt_metal::DataType::UINT8 ||
+        input.dtype() == tt::tt_metal::DataType::UINT32 || input.dtype() == tt::tt_metal::DataType::INT32;
+    const bool bfp8_pack_precise = false;  // no typecast in this fork
+
+    return ttnn::device_operation::launch<OperationType>(
+        ru::RoutedUnaryParams{
+            {op},
+            compute_kernel_config,
+            resolved_output_mem_cfg,
+            out_dtype,
+            fp32_dest_acc_en,
+            preserve_fp32_precision,
+            bfp8_pack_precise,
+            local_expert_idx,
+            curr_expert_iter,
+            expert_iter_length},
+        ru::RoutedUnaryInputs{input, global_expert_idx_table, expert_token_counts, std::move(optional_output_tensor)});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_device_operation.hpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "routed_unary_types.hpp"
+#include "routed_unary_program_factory.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+struct RoutedUnaryDeviceOperation {
+    using operation_attributes_t = RoutedUnaryParams;
+    using tensor_args_t = RoutedUnaryInputs;
+    using spec_return_value_t = ttnn::TensorSpec;
+    using tensor_return_value_t = ttnn::Tensor;
+    using program_factory_t = std::variant<RoutedUnaryProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // Exclude local_expert_idx / curr_expert_iter / expert_iter_length from the
+    // hash so the same cached program is reused across chunk iterations; only
+    // guard runtime args change between dispatches.
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device
+
+namespace ttnn::prim {
+
+ttnn::Tensor routed_unary(
+    const ttnn::Tensor& input,
+    const ttnn::operations::unary::EltwiseUnaryWithParam& op,
+    const ttnn::Tensor& global_expert_idx_table,
+    const ttnn::Tensor& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config = std::nullopt,
+    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt,
+    const std::optional<tt::tt_metal::DataType>& output_dtype = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_program_factory.cpp
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal forked unary program factory scoped to the sharded-TILE path used by
+// the gate routed_matmul's post-activation. Kernels are copies of unary_ng's
+// that early-return via guard.h when
+//   expert_token_counts[global_expert_idx_table[local_expert_idx]]
+//       <= curr_expert_iter * expert_iter_length.
+
+#include "routed_unary_program_factory.hpp"
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+using tt::tt_metal::CircularBufferConfig;
+using tt::tt_metal::CoreCoord;
+using tt::tt_metal::CoreRangeSet;
+
+namespace {
+
+// Guard scratch CB: 2048 bytes (two 1024-byte halves, 256 uint32 elements each).
+// Same role as in the matmul fork. Must not collide with c_0 / c_2.
+constexpr uint32_t kGuardCbIndex = tt::CBIndex::c_11;
+constexpr uint32_t kGuardCbBytes = 2048;
+
+}  // namespace
+
+RoutedUnaryProgramFactory::cached_program_t RoutedUnaryProgramFactory::create(
+    const RoutedUnaryParams& operation_attributes,
+    const RoutedUnaryInputs& tensor_args,
+    ttnn::Tensor& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input;
+    auto& output = tensor_return_value;
+
+    auto* src_buffer = input.buffer();
+    auto* dst_buffer = output.buffer();
+    auto* global_table_buffer = tensor_args.global_expert_idx_table.buffer();
+    auto* counts_buffer = tensor_args.expert_token_counts.buffer();
+
+    // Scope guardrails — this factory is intentionally narrow.
+    TT_FATAL(input.layout() == Layout::TILE, "routed_unary: only TILE layout is supported");
+    TT_FATAL(output.layout() == Layout::TILE, "routed_unary: only TILE output layout is supported");
+    TT_FATAL(input.is_sharded(), "routed_unary: only sharded input is supported");
+    TT_FATAL(output.is_sharded(), "routed_unary: only sharded output is supported");
+    TT_FATAL(
+        input.memory_config().memory_layout() == output.memory_config().memory_layout(),
+        "routed_unary: input and output must share the same sharded layout");
+
+    const auto& in_shard_opt = input.memory_config().shard_spec();
+    const auto& out_shard_opt = output.memory_config().shard_spec();
+    TT_FATAL(in_shard_opt.has_value(), "routed_unary: input must have a shard_spec");
+    TT_FATAL(out_shard_opt.has_value(), "routed_unary: output must have a shard_spec");
+
+    const auto& in_shard = in_shard_opt.value();
+    const auto& out_shard = out_shard_opt.value();
+    TT_FATAL(in_shard.grid == out_shard.grid, "routed_unary: input and output shard grids must match");
+    TT_FATAL(
+        in_shard.shape[0] == out_shard.shape[0] && in_shard.shape[1] == out_shard.shape[1],
+        "routed_unary: input and output shard shapes must match");
+
+    const auto in_tile_shape = input.tensor_spec().tile();
+    const auto out_tile_shape = output.tensor_spec().tile();
+    const uint32_t in_tile_h = in_tile_shape.get_height();
+    const uint32_t in_tile_w = in_tile_shape.get_width();
+
+    TT_FATAL(
+        in_shard.shape[0] % in_tile_h == 0 && in_shard.shape[1] % in_tile_w == 0,
+        "routed_unary: shard shape must be a multiple of tile shape");
+
+    const uint32_t num_tiles_per_core = (in_shard.shape[0] / in_tile_h) * (in_shard.shape[1] / in_tile_w);
+    TT_FATAL(num_tiles_per_core > 0, "routed_unary: zero tiles per core");
+
+    const DataFormat in_data_format = datatype_to_dataformat_converter(input.dtype());
+    const DataFormat out_data_format = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t in_single_tile_size = tile_size(in_data_format);
+    const uint32_t out_single_tile_size = tile_size(out_data_format);
+
+    Program program{};
+
+    const CoreRangeSet all_cores = in_shard.grid;
+
+    // --- CBs ---
+    // cb_src (c_0): globally allocated to the input shard buffer.
+    constexpr uint32_t src_cb_index = tt::CBIndex::c_0;
+    auto src_cb_config =
+        CircularBufferConfig(num_tiles_per_core * in_single_tile_size, {{src_cb_index, in_data_format}})
+            .set_page_size(src_cb_index, in_single_tile_size)
+            .set_globally_allocated_address(*src_buffer)
+            .set_tile_dims(src_cb_index, in_tile_shape);
+    auto cb_src = tt_metal::CreateCircularBuffer(program, all_cores, src_cb_config);
+
+    // cb_out (c_2): globally allocated to the output shard buffer.
+    constexpr uint32_t out_cb_index = tt::CBIndex::c_2;
+    auto out_cb_config =
+        CircularBufferConfig(num_tiles_per_core * out_single_tile_size, {{out_cb_index, out_data_format}})
+            .set_page_size(out_cb_index, out_single_tile_size)
+            .set_globally_allocated_address(*dst_buffer)
+            .set_tile_dims(out_cb_index, out_tile_shape);
+    auto cb_out = tt_metal::CreateCircularBuffer(program, all_cores, out_cb_config);
+
+    // cb_guard (c_11): scratch for DRAM reads of the two guard tables. 2048 bytes
+    // split into two 1024-byte halves (256 uint32 elements each), mirroring the matmul fork.
+    auto guard_cb_config = CircularBufferConfig(kGuardCbBytes, {{kGuardCbIndex, DataFormat::Float16_b}})
+                               .set_page_size(kGuardCbIndex, kGuardCbBytes);
+    auto cb_guard = tt_metal::CreateCircularBuffer(program, all_cores, guard_cb_config);
+
+    // --- Compile-time args ---
+    // Dataflow kernels receive the two guard TensorAccessorArgs at the end of
+    // their compile_args vector. Both tables are small DRAM ROW_MAJOR uint32
+    // buffers; the kernel uses a TensorAccessor to resolve bank+offset per page.
+    std::vector<uint32_t> reader_compile_time_args;
+    const uint32_t reader_global_cta_off = reader_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*global_table_buffer).append_to(reader_compile_time_args);
+    const uint32_t reader_counts_cta_off = reader_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*counts_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args;
+    const uint32_t writer_global_cta_off = writer_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*global_table_buffer).append_to(writer_compile_time_args);
+    const uint32_t writer_counts_cta_off = writer_compile_time_args.size();
+    tt::tt_metal::TensorAccessorArgs(*counts_buffer).append_to(writer_compile_time_args);
+
+    std::vector<uint32_t> compute_compile_time_args;  // empty; compute kernel only needs named args
+
+    // --- Defines ---
+    // Wire the single unary op into SFPU_OP_CHAIN_0 via get_block_defines (the
+    // same helper unary_ng's factory uses).
+    TT_FATAL(
+        operation_attributes.op_chain.size() == 1,
+        "routed_unary: op_chain must contain exactly one op (got {})",
+        operation_attributes.op_chain.size());
+    auto compute_defines =
+        ttnn::operations::unary::utils::get_block_defines(operation_attributes.op_chain, "0", "0", input.dtype());
+
+    std::map<std::string, std::string> reader_defines;
+    std::map<std::string, std::string> writer_defines;
+    reader_defines["ROUTED_GUARD_ENABLED"] = "1";
+    writer_defines["ROUTED_GUARD_ENABLED"] = "1";
+    // Compute kernel: GUARD_COMPUTE_KERNEL is #defined directly in the kernel
+    // source (before `#include "../../guard.h"`), matching bmm_routed.cpp's
+    // pattern — keeping it out of defines avoids a redefinition warning.
+    compute_defines["ROUTED_GUARD_ENABLED"] = "1";
+
+    // --- Kernels ---
+    const auto compute_with_storage_grid = input.device()->compute_with_storage_grid_size();
+    bool noc_set_by_factory = false;  // rely on default NOC
+    (void)noc_set_by_factory;
+    (void)compute_with_storage_grid;
+
+    // Reader = RISCV_0 (BRISC). Publishes skip to TRISC mailboxes via guard_check_wait().
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/"
+        "dataflow/reader_routed_unary.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = reader_compile_time_args,
+            .defines = reader_defines,
+            .named_compile_args = {
+                {"GUARD_CB_ID", kGuardCbIndex},
+                {"GUARD_ARG_BASE", 3u},
+                {"GUARD_GLOBAL_TABLE_CTA_OFFSET", reader_global_cta_off},
+                {"GUARD_COUNTS_CTA_OFFSET", reader_counts_cta_off},
+            }});
+
+    // Writer = RISCV_1 (NCRISC). Direct DRAM reads via guard_check_brisc().
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/"
+        "dataflow/writer_routed_unary.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::RISCV_1_default,
+            .compile_args = writer_compile_time_args,
+            .defines = writer_defines,
+            .named_compile_args = {
+                {"GUARD_CB_ID", kGuardCbIndex},
+                {"GUARD_ARG_BASE", 3u},
+                {"GUARD_GLOBAL_TABLE_CTA_OFFSET", writer_global_cta_off},
+                {"GUARD_COUNTS_CTA_OFFSET", writer_counts_cta_off},
+            }});
+
+    // Compute = TRISC. Reads mailbox published by BRISC via guard_check_wait()
+    // (GUARD_COMPUTE_KERNEL selects the mailbox-read implementation).
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(input.device()->arch(), operation_attributes.compute_kernel_config);
+    (void)packer_l1_acc;
+    (void)dst_full_sync_en;
+
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (operation_attributes.preserve_fp32_precision) {
+        unpack_to_dest_mode[src_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/kernels/routed_unary/"
+        "compute/eltwise_sfpu_routed.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .bfp8_pack_precise = operation_attributes.bfp8_pack_precise,
+            .math_approx_mode = false,
+            .compile_args = compute_compile_time_args,
+            .defines = compute_defines,
+            .named_compile_args = {
+                {"GUARD_CB_ID", kGuardCbIndex},
+                {"GUARD_ARG_BASE", 3u},
+            }});
+
+    // --- Per-core runtime args ---
+    // All cores process the same number of tiles (block-sharded with evenly
+    // divisible grid). Layout:
+    //   reader: [src_addr, num_pages, start_id, guard5]
+    //   writer: [dst_addr, num_pages, start_id, guard5]
+    //   compute: [num_tiles, scalar1, scalar2, guard5]
+    // Only guard5 and the buffer addresses change per dispatch; num_pages /
+    // num_tiles are fixed for a cached program (shard shape is invariant).
+    const uint32_t global_table_addr = global_table_buffer->address();
+    const uint32_t token_counts_addr = counts_buffer->address();
+    const uint32_t local_expert_idx = operation_attributes.local_expert_idx;
+    const uint32_t curr_expert_iter = operation_attributes.curr_expert_iter;
+    const uint32_t expert_iter_length = operation_attributes.expert_iter_length;
+
+    auto cores = corerange_to_cores(all_cores, std::nullopt, /*row_major=*/true);
+    for (const auto& core : cores) {
+        std::vector<uint32_t> reader_args = {
+            src_buffer->address(),
+            num_tiles_per_core,
+            /*start_id=*/0u,
+            global_table_addr,
+            token_counts_addr,
+            local_expert_idx,
+            curr_expert_iter,
+            expert_iter_length,
+        };
+        std::vector<uint32_t> writer_args = {
+            dst_buffer->address(),
+            num_tiles_per_core,
+            /*start_id=*/0u,
+            global_table_addr,
+            token_counts_addr,
+            local_expert_idx,
+            curr_expert_iter,
+            expert_iter_length,
+        };
+        std::vector<uint32_t> compute_args = {
+            num_tiles_per_core,
+            /*scalar1=*/0u,
+            /*scalar2=*/0u,
+            global_table_addr,
+            token_counts_addr,
+            local_expert_idx,
+            curr_expert_iter,
+            expert_iter_length,
+        };
+        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
+        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_args);
+    }
+
+    return {
+        std::move(program),
+        {reader_kernel_id, writer_kernel_id, compute_kernel_id, cb_src, cb_out, cb_guard, std::move(cores)}};
+}
+
+void RoutedUnaryProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const RoutedUnaryParams& operation_attributes,
+    const RoutedUnaryInputs& tensor_args,
+    ttnn::Tensor& tensor_return_value) {
+    using namespace tt::tt_metal;
+
+    auto& shared = cached_program.shared_variables;
+    auto& program = cached_program.program;
+
+    auto* src_buffer = tensor_args.input.buffer();
+    auto* dst_buffer = tensor_return_value.buffer();
+    auto* global_table_buffer = tensor_args.global_expert_idx_table.buffer();
+    auto* counts_buffer = tensor_args.expert_token_counts.buffer();
+
+    // Update globally-allocated CB addresses so a program-cache hit uses the
+    // current input/output shard buffers (which may differ between dispatches).
+    UpdateDynamicCircularBufferAddress(program, shared.cb_src, *src_buffer);
+    UpdateDynamicCircularBufferAddress(program, shared.cb_out, *dst_buffer);
+
+    const uint32_t global_table_addr = global_table_buffer->address();
+    const uint32_t token_counts_addr = counts_buffer->address();
+    const uint32_t local_expert_idx = operation_attributes.local_expert_idx;
+    const uint32_t curr_expert_iter = operation_attributes.curr_expert_iter;
+    const uint32_t expert_iter_length = operation_attributes.expert_iter_length;
+
+    auto& reader_args_by_core = GetRuntimeArgs(program, shared.reader_kernel_id);
+    auto& writer_args_by_core = GetRuntimeArgs(program, shared.writer_kernel_id);
+    auto& compute_args_by_core = GetRuntimeArgs(program, shared.compute_kernel_id);
+
+    // Guard args live at [GUARD_ARG_BASE = 3 .. 7] in every kernel.
+    auto write_guard = [&](auto& args) {
+        args[3] = global_table_addr;
+        args[4] = token_counts_addr;
+        args[5] = local_expert_idx;
+        args[6] = curr_expert_iter;
+        args[7] = expert_iter_length;
+    };
+
+    for (const auto& core : shared.cores) {
+        auto& r = reader_args_by_core[core.x][core.y];
+        r[0] = src_buffer->address();
+        write_guard(r);
+
+        auto& w = writer_args_by_core[core.x][core.y];
+        w[0] = dst_buffer->address();
+        write_guard(w);
+
+        auto& c = compute_args_by_core[core.x][core.y];
+        // c[0] (num_tiles) and c[1]/c[2] (scalars) are program-cache invariants.
+        write_guard(c);
+    }
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_program_factory.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "routed_unary_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+// Forked minimal unary program factory. Scope is intentionally narrow:
+//   * Sharded input + sharded output (same memory config, in-place unary style).
+//   * TILE layout only.
+//   * Single unary op in the chain (no LOGIT / WHERE_TSS / typecast scalars).
+// The reader/writer/compute kernels are forked copies of unary_ng's that read
+// global_expert_idx_table + expert_token_counts from DRAM and early-return when
+// expert_token_counts[global_expert_idx_table[local_expert_idx]]
+// <= curr_expert_iter * expert_iter_length.
+struct RoutedUnaryProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        tt::tt_metal::KernelHandle compute_kernel_id{};
+        tt::tt_metal::CBHandle cb_src{};
+        tt::tt_metal::CBHandle cb_out{};
+        tt::tt_metal::CBHandle cb_guard{};
+        std::vector<tt::tt_metal::CoreCoord> cores;
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const RoutedUnaryParams& operation_attributes,
+        const RoutedUnaryInputs& tensor_args,
+        ttnn::Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const RoutedUnaryParams& operation_attributes,
+        const RoutedUnaryInputs& tensor_args,
+        ttnn::Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_types.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device {
+
+// Single-op, sharded-only routed unary. Mirrors RoutedMatmulParams: only the
+// per-iteration scalars (local_expert_idx, curr_expert_iter, expert_iter_length)
+// change between dispatches — they live here so they can be excluded from the
+// program hash, letting the same cached program be reused across all chunk
+// iterations.
+struct RoutedUnaryParams {
+    // Single-op chain (size must be 1). Stored as a vector so RoutedUnaryParams
+    // is default-constructible — the reflect library used by device_operation
+    // launch/log paths requires that.
+    std::vector<ttnn::operations::unary::EltwiseUnaryWithParam> op_chain;
+    ttnn::DeviceComputeKernelConfig compute_kernel_config;
+    tt::tt_metal::MemoryConfig output_memory_config;
+    tt::tt_metal::DataType output_dtype;
+    bool fp32_dest_acc_en;
+    bool preserve_fp32_precision;
+    bool bfp8_pack_precise;
+    uint32_t local_expert_idx;
+    uint32_t curr_expert_iter;
+    uint32_t expert_iter_length;
+};
+
+// Tensor inputs mirror RoutedMatmulInputs. Both guard tables are small DRAM
+// row-major uint32 tensors — same format the matmul consumes so we can share
+// guard.h without any translation layer.
+struct RoutedUnaryInputs {
+    ttnn::Tensor input;
+    ttnn::Tensor global_expert_idx_table;  // (1, 1, experts_per_chip), uint32, DRAM, ROW_MAJOR
+    ttnn::Tensor expert_token_counts;      // (1, 1, num_global_experts), uint32, DRAM, ROW_MAJOR
+    std::optional<ttnn::Tensor> optional_output_tensor;
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::device

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn.hpp
@@ -17,7 +17,18 @@ ttnn::Tensor routed_expert_ffn(
     const ttnn::Tensor& up_proj,
     const ttnn::Tensor& down_proj,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    std::optional<ttnn::Tensor> output = std::nullopt);
+    std::optional<ttnn::Tensor> output = std::nullopt,
+    // Optional guard tensors. When both are provided (BH only), each of the three
+    // matmuls dispatches via the forked routed_matmul device op, whose per-kernel
+    // guard reads expert_token_counts[global_expert_idx_table[local_expert_idx]]
+    // and skips the chunk iff that value <= curr_expert_iter * expert_iter_length.
+    // When either is nullopt, falls back to ttnn::matmul — identical to pre-routed
+    // behavior, and the three scalars below are ignored.
+    const std::optional<ttnn::Tensor>& global_expert_idx_table = std::nullopt,
+    const std::optional<ttnn::Tensor>& expert_token_counts = std::nullopt,
+    uint32_t local_expert_idx = 0,
+    uint32_t curr_expert_iter = 0,
+    uint32_t expert_iter_length = 0);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_bh.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_bh.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "routed_expert_ffn_common.hpp"
+#include "routed_matmul.hpp"
 
 #include "tt-metalium/math.hpp"
 #include "ttnn/operations/core/to_memory_config/to_memory_config_op.hpp"
@@ -17,17 +18,23 @@ ttnn::Tensor routed_expert_ffn_bh(
     const ttnn::Tensor& up_proj,
     const ttnn::Tensor& down_proj,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    std::optional<ttnn::Tensor> output) {
-    // Blackhole compute grid is fixed at 11x8 = 88 cores. All configs below
-    // are tuned for this grid; bail loudly if the device can't supply it.
-    // gate/up is output-sharded with per_core_N = div_up(N_gate, GRID_X),
-    // which is legal because input A is DRAM-interleaved (the "no padding"
-    // / Kt-divisibility asserts only fire for sharded input A). The multiply
-    // then reshards the block-sharded gate_result + up_result into L1
-    // interleaved, after which down runs with an unsharded input A — no
-    // divisor constraint on in0_block_w.
+    std::optional<ttnn::Tensor> output,
+    const std::optional<ttnn::Tensor>& global_expert_idx_table,
+    const std::optional<ttnn::Tensor>& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length) {
+    const bool use_routed = global_expert_idx_table.has_value() && expert_token_counts.has_value();
+    // Blackhole compute grid is 11x10 = 110 cores (test config; was 11x8 = 88).
+    // All configs below are tuned for this grid; bail loudly if the device
+    // can't supply it. gate/up is output-sharded with
+    // per_core_N = div_up(N_gate, GRID_X), which is legal because input A is
+    // DRAM-interleaved (the "no padding" / Kt-divisibility asserts only fire
+    // for sharded input A). The multiply then reshards the block-sharded
+    // gate_result + up_result into L1 interleaved, after which down runs
+    // with an unsharded input A — no divisor constraint on in0_block_w.
     constexpr uint32_t GRID_X = 11;
-    constexpr uint32_t GRID_Y = 8;
+    constexpr uint32_t GRID_Y = 10;
     const auto grid_size = x.device()->compute_with_storage_grid_size();
     TT_FATAL(
         grid_size.x >= GRID_X && grid_size.y >= GRID_Y,
@@ -76,27 +83,60 @@ ttnn::Tensor routed_expert_ffn_bh(
         gate_up_grid, {gate_up_per_core_M * ttnn::TILE_SIZE, gate_up_per_core_N * ttnn::TILE_SIZE});
     auto gate_up_mem = MemoryConfig{TensorMemoryLayout::BLOCK_SHARDED, BufferType::L1, gate_up_shard};
 
-    auto gate_result = ttnn::matmul(
-        /*input_tensor_a=*/x,
-        /*input_tensor_b=*/gate_proj,
-        /*transpose_a=*/false,
-        /*transpose_b=*/false,
-        /*memory_config=*/gate_up_mem,
-        /*dtype=*/std::nullopt,
-        /*program_config=*/gate_up_config,
-        /*activation=*/std::string("silu"),
-        /*compute_kernel_config=*/compute_kernel_config);
+    ttnn::Tensor gate_result;
+    ttnn::Tensor up_result;
+    if (use_routed) {
+        gate_result = routed_matmul(
+            /*input_tensor_a=*/x,
+            /*input_tensor_b=*/gate_proj,
+            /*memory_config=*/gate_up_mem,
+            /*dtype=*/std::nullopt,
+            /*program_config=*/gate_up_config,
+            /*activation=*/std::string("silu"),
+            /*compute_kernel_config=*/compute_kernel_config,
+            /*optional_output_tensor=*/std::nullopt,
+            /*global_expert_idx_table=*/global_expert_idx_table,
+            /*expert_token_counts=*/expert_token_counts,
+            /*local_expert_idx=*/local_expert_idx,
+            /*curr_expert_iter=*/curr_expert_iter,
+            /*expert_iter_length=*/expert_iter_length);
+        up_result = routed_matmul(
+            /*input_tensor_a=*/x,
+            /*input_tensor_b=*/up_proj,
+            /*memory_config=*/gate_up_mem,
+            /*dtype=*/std::nullopt,
+            /*program_config=*/gate_up_config,
+            /*activation=*/std::nullopt,
+            /*compute_kernel_config=*/compute_kernel_config,
+            /*optional_output_tensor=*/std::nullopt,
+            /*global_expert_idx_table=*/global_expert_idx_table,
+            /*expert_token_counts=*/expert_token_counts,
+            /*local_expert_idx=*/local_expert_idx,
+            /*curr_expert_iter=*/curr_expert_iter,
+            /*expert_iter_length=*/expert_iter_length);
+    } else {
+        gate_result = ttnn::matmul(
+            /*input_tensor_a=*/x,
+            /*input_tensor_b=*/gate_proj,
+            /*transpose_a=*/false,
+            /*transpose_b=*/false,
+            /*memory_config=*/gate_up_mem,
+            /*dtype=*/std::nullopt,
+            /*program_config=*/gate_up_config,
+            /*activation=*/std::string("silu"),
+            /*compute_kernel_config=*/compute_kernel_config);
 
-    auto up_result = ttnn::matmul(
-        /*input_tensor_a=*/x,
-        /*input_tensor_b=*/up_proj,
-        /*transpose_a=*/false,
-        /*transpose_b=*/false,
-        /*memory_config=*/gate_up_mem,
-        /*dtype=*/std::nullopt,
-        /*program_config=*/gate_up_config,
-        /*activation=*/std::nullopt,
-        /*compute_kernel_config=*/compute_kernel_config);
+        up_result = ttnn::matmul(
+            /*input_tensor_a=*/x,
+            /*input_tensor_b=*/up_proj,
+            /*transpose_a=*/false,
+            /*transpose_b=*/false,
+            /*memory_config=*/gate_up_mem,
+            /*dtype=*/std::nullopt,
+            /*program_config=*/gate_up_config,
+            /*activation=*/std::nullopt,
+            /*compute_kernel_config=*/compute_kernel_config);
+    }
 
     // In-place multiply: writes into gate_result's block-sharded L1 buffer.
     // Reshard to L1 interleaved afterwards so the down matmul sees an unsharded
@@ -147,19 +187,41 @@ ttnn::Tensor routed_expert_ffn_bh(
         .fuse_batch = false,
     };
 
-    return ttnn::matmul(
-        /*input_tensor_a=*/activated,
-        /*input_tensor_b=*/down_proj,
-        /*transpose_a=*/false,
-        /*transpose_b=*/false,
-        /*memory_config=*/std::nullopt,
-        /*dtype=*/std::nullopt,
-        /*program_config=*/down_config,
-        /*activation=*/std::nullopt,
-        /*compute_kernel_config=*/compute_kernel_config,
-        /*core_grid=*/std::nullopt,
-        /*output_tile=*/std::nullopt,
-        /*optional_output_tensor=*/std::move(output));
+    ttnn::Tensor result;
+    if (use_routed) {
+        // memory_config omitted — the device op inherits it from the
+        // caller-provided optional_output_tensor, or defaults to DRAM interleaved.
+        result = routed_matmul(
+            /*input_tensor_a=*/activated,
+            /*input_tensor_b=*/down_proj,
+            /*memory_config=*/std::nullopt,
+            /*dtype=*/std::nullopt,
+            /*program_config=*/down_config,
+            /*activation=*/std::nullopt,
+            /*compute_kernel_config=*/compute_kernel_config,
+            /*optional_output_tensor=*/std::move(output),
+            /*global_expert_idx_table=*/global_expert_idx_table,
+            /*expert_token_counts=*/expert_token_counts,
+            /*local_expert_idx=*/local_expert_idx,
+            /*curr_expert_iter=*/curr_expert_iter,
+            /*expert_iter_length=*/expert_iter_length);
+    } else {
+        result = ttnn::matmul(
+            /*input_tensor_a=*/activated,
+            /*input_tensor_b=*/down_proj,
+            /*transpose_a=*/false,
+            /*transpose_b=*/false,
+            /*memory_config=*/std::nullopt,
+            /*dtype=*/std::nullopt,
+            /*program_config=*/down_config,
+            /*activation=*/std::nullopt,
+            /*compute_kernel_config=*/compute_kernel_config,
+            /*core_grid=*/std::nullopt,
+            /*output_tile=*/std::nullopt,
+            /*optional_output_tensor=*/std::move(output));
+    }
+    activated.deallocate(/*force=*/true);
+    return result;
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.cpp
@@ -141,7 +141,12 @@ ttnn::Tensor routed_expert_ffn(
     const ttnn::Tensor& up_proj,
     const ttnn::Tensor& down_proj,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    std::optional<ttnn::Tensor> output) {
+    std::optional<ttnn::Tensor> output,
+    const std::optional<ttnn::Tensor>& global_expert_idx_table,
+    const std::optional<ttnn::Tensor>& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length) {
     const uint32_t M_tiles = x.padded_shape()[-2] / ttnn::TILE_SIZE;
     const bool is_wormhole = x.device()->arch() == tt::ARCH::WORMHOLE_B0;
 
@@ -163,9 +168,21 @@ ttnn::Tensor routed_expert_ffn(
         x.dtype());
 
     if (is_wormhole) {
+        // WH path has no guard; the routed-specific args are silently dropped.
         return detail::routed_expert_ffn_wh(x, gate_proj, up_proj, down_proj, compute_kernel_config, output);
     }
-    return detail::routed_expert_ffn_bh(x, gate_proj, up_proj, down_proj, compute_kernel_config, std::move(output));
+    return detail::routed_expert_ffn_bh(
+        x,
+        gate_proj,
+        up_proj,
+        down_proj,
+        compute_kernel_config,
+        std::move(output),
+        global_expert_idx_table,
+        expert_token_counts,
+        local_expert_idx,
+        curr_expert_iter,
+        expert_iter_length);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.hpp
@@ -51,13 +51,24 @@ ttnn::Tensor routed_expert_ffn_wh(
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& output);
 
-// Blackhole-optimized path (14x10 grid)
+// Blackhole-optimized path (14x10 grid). When both global_expert_idx_table and
+// expert_token_counts are provided, each matmul dispatches via the forked routed
+// device op and evaluates the per-chunk guard on-device:
+//   skip iff expert_token_counts[global_expert_idx_table[local_expert_idx]]
+//         <= curr_expert_iter * expert_iter_length.
+// When either tensor is nullopt, falls back to plain ttnn::matmul (the scalars
+// are ignored in that case).
 ttnn::Tensor routed_expert_ffn_bh(
     const ttnn::Tensor& x,
     const ttnn::Tensor& gate_proj,
     const ttnn::Tensor& up_proj,
     const ttnn::Tensor& down_proj,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    std::optional<ttnn::Tensor> output);
+    std::optional<ttnn::Tensor> output,
+    const std::optional<ttnn::Tensor>& global_expert_idx_table,
+    const std::optional<ttnn::Tensor>& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_nanobind.cpp
@@ -33,6 +33,11 @@ void bind_routed_expert_ffn(nb::module_& mod) {
         Keyword Args:
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration. Defaults to None.
             output (ttnn.Tensor, optional): Pre-allocated output tensor for in-place write of the final matmul result. Defaults to None.
+            global_expert_idx_table (ttnn.Tensor, optional): DRAM uint32 TILE_LAYOUT tensor of shape (1, 1, experts_per_chip) mapping local expert slots to global expert ids. When paired with ``expert_token_counts``, enables the Blackhole routed matmul path whose per-chunk guard skips iff ``expert_token_counts[global_expert_idx_table[local_expert_idx]] <= curr_expert_iter * expert_iter_length``. Falls back to ttnn::matmul when either tensor is None.
+            expert_token_counts (ttnn.Tensor, optional): DRAM uint32 TILE_LAYOUT tensor of shape (1, 1, num_global_experts). See ``global_expert_idx_table`` for semantics.
+            local_expert_idx (int, optional): Index into ``global_expert_idx_table``. Defaults to 0.
+            curr_expert_iter (int, optional): Index of the current chunk iteration (Blackhole only). Defaults to 0.
+            expert_iter_length (int, optional): Tokens per chunk iteration (Blackhole only). Defaults to 0.
 
         Returns:
             ttnn.Tensor: Output tensor with the same shape as ``x``.
@@ -40,7 +45,12 @@ void bind_routed_expert_ffn(nb::module_& mod) {
         Example:
             >>> output = ttnn.experimental.deepseek_prefill.routed_expert_ffn(
                     x, gate_proj, up_proj, down_proj,
-                    compute_kernel_config=compute_kernel_config)
+                    compute_kernel_config=compute_kernel_config,
+                    global_expert_idx_table=table,
+                    expert_token_counts=counts,
+                    local_expert_idx=local_idx,
+                    curr_expert_iter=chunk_idx,
+                    expert_iter_length=2048)
         )doc",
         &routed_expert_ffn,
         nb::arg("x").noconvert(),
@@ -49,7 +59,12 @@ void bind_routed_expert_ffn(nb::module_& mod) {
         nb::arg("down_proj").noconvert(),
         nb::kw_only(),
         nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("output") = nb::none());
+        nb::arg("output") = nb::none(),
+        nb::arg("global_expert_idx_table") = nb::none(),
+        nb::arg("expert_token_counts") = nb::none(),
+        nb::arg("local_expert_idx") = 0u,
+        nb::arg("curr_expert_iter") = 0u,
+        nb::arg("expert_iter_length") = 0u);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_matmul.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "routed_matmul.hpp"
+#include "device/routed_matmul_device_operation.hpp"
+#include "routed_unary.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn {
+
+ttnn::Tensor routed_matmul(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    const std::optional<const tt::tt_metal::MemoryConfig>& memory_config,
+    std::optional<const tt::tt_metal::DataType> dtype,
+    const std::optional<const ttnn::operations::matmul::MatmulProgramConfig>& program_config,
+    const std::optional<const ttnn::Activation>& activation,
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    std::optional<ttnn::Tensor> optional_output_tensor,
+    const std::optional<ttnn::Tensor>& global_expert_idx_table,
+    const std::optional<ttnn::Tensor>& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length) {
+    TT_FATAL(program_config.has_value(), "routed_matmul: program_config is required (no auto-select path)");
+    TT_FATAL(
+        compute_kernel_config.has_value(), "routed_matmul: compute_kernel_config is required (no auto-select path)");
+    TT_FATAL(global_expert_idx_table.has_value(), "routed_matmul: global_expert_idx_table is required");
+    TT_FATAL(expert_token_counts.has_value(), "routed_matmul: expert_token_counts is required");
+    TT_FATAL(expert_iter_length > 0, "routed_matmul: expert_iter_length must be > 0");
+
+    auto result = ttnn::prim::routed_matmul(
+        input_tensor_a,
+        input_tensor_b,
+        global_expert_idx_table.value(),
+        expert_token_counts.value(),
+        local_expert_idx,
+        curr_expert_iter,
+        expert_iter_length,
+        program_config.value(),
+        compute_kernel_config.value(),
+        memory_config,
+        optional_output_tensor,
+        dtype);
+
+    // Route the post-activation through a guarded unary op so it early-returns
+    // on device when the matmul's guard would have skipped — keeps the op
+    // separate on the host trace (matmul fused_activation was measured slower)
+    // while avoiding the ~39 µs SiLU that otherwise runs on skipped iterations.
+    if (auto fused = ttnn::operations::matmul::get_fused_activation(activation); fused.has_value()) {
+        result = routed_unary(
+            /*input=*/result,
+            /*op=*/fused.value(),
+            /*global_expert_idx_table=*/global_expert_idx_table.value(),
+            /*expert_token_counts=*/expert_token_counts.value(),
+            /*local_expert_idx=*/local_expert_idx,
+            /*curr_expert_iter=*/curr_expert_iter,
+            /*expert_iter_length=*/expert_iter_length,
+            /*compute_kernel_config=*/compute_kernel_config,
+            /*optional_output_tensor=*/optional_output_tensor);
+    }
+    return result;
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_matmul.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn {
+
+// Internal (not python-bound) forked matmul with a runtime-gated early-return.
+// Each kernel reads two DRAM tables at entry and skips iff
+//   expert_token_counts[global_expert_idx_table[local_expert_idx]]
+//       <= curr_expert_iter * expert_iter_length.
+// Output on skip is whatever was in the optional_output_tensor before — caller
+// must avoid reading skipped slices.
+//
+// Argument order mirrors ttnn::matmul. program_config and compute_kernel_config are
+// optional in the signature for API parity but are required in practice: the forked
+// factory only supports MatmulMultiCoreReuseMultiCastProgramConfig and has no
+// auto-select path, so passing nullopt TT_FATALs. global_expert_idx_table and
+// expert_token_counts are the routed-specific required device tensors;
+// local_expert_idx / curr_expert_iter / expert_iter_length are the three
+// runtime scalars the guard reads.
+//
+// Intended BH-only.
+ttnn::Tensor routed_matmul(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    // memory_config: when an optional_output_tensor is also provided the device op
+    // ignores it for allocation; when both are omitted we default to DRAM interleaved.
+    const std::optional<const tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    std::optional<const tt::tt_metal::DataType> dtype = std::nullopt,
+    const std::optional<const ttnn::operations::matmul::MatmulProgramConfig>& program_config = std::nullopt,
+    const std::optional<const ttnn::Activation>& activation = std::nullopt,
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt,
+    const std::optional<ttnn::Tensor>& global_expert_idx_table = std::nullopt,
+    const std::optional<ttnn::Tensor>& expert_token_counts = std::nullopt,
+    uint32_t local_expert_idx = 0,
+    uint32_t curr_expert_iter = 0,
+    uint32_t expert_iter_length = 0);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_unary.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "routed_unary.hpp"
+#include "device/routed_unary_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn {
+
+ttnn::Tensor routed_unary(
+    const ttnn::Tensor& input,
+    const ttnn::operations::unary::EltwiseUnaryWithParam& op,
+    const ttnn::Tensor& global_expert_idx_table,
+    const ttnn::Tensor& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    std::optional<ttnn::Tensor> optional_output_tensor) {
+    TT_FATAL(
+        compute_kernel_config.has_value(), "routed_unary: compute_kernel_config is required (no auto-select path)");
+    TT_FATAL(expert_iter_length > 0, "routed_unary: expert_iter_length must be > 0");
+
+    return ttnn::prim::routed_unary(
+        input,
+        op,
+        global_expert_idx_table,
+        expert_token_counts,
+        local_expert_idx,
+        curr_expert_iter,
+        expert_iter_length,
+        compute_kernel_config.value(),
+        /*output_memory_config=*/std::nullopt,
+        std::move(optional_output_tensor),
+        /*output_dtype=*/std::nullopt);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_unary.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_unary.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn {
+
+// Internal (not python-bound) guarded unary used by routed_matmul as the
+// post-activation step. Mirrors routed_matmul's guard semantics: each kernel
+// reads two DRAM tables at entry and skips iff
+//   expert_token_counts[global_expert_idx_table[local_expert_idx]]
+//       <= curr_expert_iter * expert_iter_length.
+//
+// Scope is intentionally narrow (sharded TILE in-place style, single op). See
+// routed_unary_program_factory.hpp for the TT_FATAL-enforced preconditions.
+ttnn::Tensor routed_unary(
+    const ttnn::Tensor& input,
+    const ttnn::operations::unary::EltwiseUnaryWithParam& op,
+    const ttnn::Tensor& global_expert_idx_table,
+    const ttnn::Tensor& expert_token_counts,
+    uint32_t local_expert_idx,
+    uint32_t curr_expert_iter,
+    uint32_t expert_iter_length,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::routed_expert_ffn

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -72,6 +72,12 @@ set(TTNNCPP_SRCS
     cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_wh.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_bh.cpp
+    cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_matmul.cpp
+    cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_unary.cpp
+    cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_device_operation.cpp
+    cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_matmul_program_factory.cpp
+    cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_device_operation.cpp
+    cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/device/routed_unary_program_factory.cpp
     cpp/ttnn/operations/experimental/test/hang_device/hang_device_program_factory.cpp
     cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
     cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp


### PR DESCRIPTION
### Summary

Adds an on-device per-iteration guard for the routed-expert FFN so chunks early-return when the expert has no more tokens, without a host sync.

### Changes

- New routed_matmul and routed_unary device ops with a guard that skips iff `expert_token_counts[global_expert_idx_table[local_expert_idx]] <= curr_expert_iter * expert_iter_length`.
- BH `routed_expert_ffn` dispatches to the guarded matmul when the table + counts are provided; falls back to `ttnn::matmul` otherwise. BH grid bumped 11×8 → 11×10.
- `TtRoutedExpert` now chunks per-expert tokens into `FIXED_EXPERT_LENGTH=2048` slices and threads the guard scalars per call.
- `TtMoe`: fix unconditional `deallocate(x)` that broke subsequent forwards on single-column meshes; expose expert_region_offsets in intermediates.