### PR TITLE
Optimize exp2 SFPU path for fp32 and bf16

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -108,3 +108,63 @@ def test_exp2_atol(input_shapes, low, high, device):
     tt_result = ttnn.exp2(tt_in)
     result = ttnn.to_torch(tt_result)
     assert_allclose(tt_result, golden, rtol=1e-2, atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "tt_dtype, torch_dtype",
+    [
+        (ttnn.bfloat16, torch.bfloat16),
+        (ttnn.float32, torch.float32),
+    ],
+)
+def test_exp2_special_values(tt_dtype, torch_dtype, device):
+    special_inputs = [
+        0.0,
+        1.0,
+        -1.0,
+        10.0,
+        -10.0,
+        127.0,
+        -126.0,
+        float("inf"),
+        float("-inf"),
+        float("nan"),
+        128.0,
+        -127.0,
+    ]
+
+    pad_count = 32 * 32 - len(special_inputs)
+    torch_input = torch.tensor(special_inputs + [0.0] * pad_count, dtype=torch_dtype).reshape(1, 1, 32, 32)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=tt_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    result = ttnn.to_torch(ttnn.exp2(tt_in)).reshape(-1)
+
+    expected = torch.exp2(torch_input.to(torch.float32)).reshape(-1)
+    expected[8] = 0.0
+    expected[10] = float("inf")
+    expected[11] = 0.0
+
+    finite_indices = []
+    for index, value in enumerate(special_inputs):
+        actual_value = result[index].item()
+        expected_value = expected[index].item()
+
+        if np.isnan(expected_value):
+            assert np.isnan(actual_value), f"exp2({value}): expected NaN, got {actual_value}"
+        elif np.isinf(expected_value):
+            assert np.isinf(actual_value) and np.sign(actual_value) == np.sign(expected_value), (
+                f"exp2({value}): expected {expected_value}, got {actual_value}"
+            )
+        else:
+            finite_indices.append(index)
+
+    if finite_indices:
+        indices = torch.tensor(finite_indices)
+        assert_with_ulp(expected[indices], result[indices].to(torch.float32), 1)

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 #include "ckernel_sfpu_exp.h"
 #include "sfpi.h"
@@ -12,28 +13,151 @@
 namespace ckernel::sfpu
 {
 
+sfpi_inline sfpi::vFloat _sfpu_exp2_core_fp32_(sfpi::vFloat x)
+{
+    sfpi::vInt k_int;
+    sfpi::vFloat k = _sfpu_round_to_nearest_int32_(x, k_int);
+    sfpi::vFloat f = x - k;
+
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        f,
+        sfpi::vConst1,
+        0.6931471805599453f,
+        0.2402265069591007f,
+        0.05550410866482158f,
+        0.009618129107628477f,
+        0.0013333558146428442f,
+        0.0001540353039338164f,
+        0.00001525273328683212f);
+
+    sfpi::vInt p_exp = sfpi::exexp(p, sfpi::ExponentMode::NoDebias);
+    return sfpi::setexp(p, p_exp + k_int);
+}
+
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_exp2_core_bf16_(sfpi::vFloat x)
+{
+    sfpi::vFloat xlog2 = x + 127.f;
+
+    sfpi::vFloat threshold_low = 0.f;
+    sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
+    sfpi::vec_min_max(threshold_low, xlog2);
+    sfpi::vec_min_max(xlog2, threshold_high);
+
+    sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
+
+    sfpi::vInt exponential_part = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias);
+    sfpi::vInt fractional_part = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));
+
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
+    frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
+
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
+
+    if constexpr (!is_fp32_dest_acc_en)
+    {
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
+    }
+
+    return y;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_exp2_special_or_fp32_(sfpi::vFloat x)
+{
+    sfpi::vFloat result = sfpi::vConst0;
+
+    sfpi::vInt bits = sfpi::reinterpret<sfpi::vInt>(x);
+    sfpi::vInt abs_bits = bits & 0x7fffffff;
+
+    v_if (abs_bits == 0x7f800000)
+    {
+        v_if (bits < 0)
+        {
+            result = sfpi::vConst0;
+        }
+        v_else
+        {
+            result = std::numeric_limits<float>::infinity();
+        }
+        v_endif;
+    }
+    v_elseif (abs_bits > 0x7f800000)
+    {
+        result = x;
+    }
+    v_elseif (x >= 128.0f)
+    {
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_elseif (x <= -127.0f)
+    {
+        result = sfpi::vConst0;
+    }
+    v_else
+    {
+        result = _sfpu_exp2_core_fp32_(x);
+    }
+    v_endif;
+
+    return result;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_exp2_special_or_bf16_(sfpi::vFloat x)
+{
+    sfpi::vFloat result = sfpi::vConst0;
+
+    sfpi::vInt bits = sfpi::reinterpret<sfpi::vInt>(x);
+    sfpi::vInt abs_bits = bits & 0x7fffffff;
+
+    v_if (abs_bits == 0x7f800000)
+    {
+        v_if (bits < 0)
+        {
+            result = sfpi::vConst0;
+        }
+        v_else
+        {
+            result = std::numeric_limits<float>::infinity();
+        }
+        v_endif;
+    }
+    v_elseif (abs_bits > 0x7f800000)
+    {
+        result = x;
+    }
+    v_elseif (x >= 128.0f)
+    {
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_elseif (x <= -127.0f)
+    {
+        result = sfpi::vConst0;
+    }
+    v_else
+    {
+        result = _sfpu_exp2_core_bf16_<true>(x);
+    }
+    v_endif;
+
+    return sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+}
+
 template <bool APPROXIMATION_MODE /*unused*/, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void _calculate_exp2_()
 {
-    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
-        v = v * sfpi::vConstFloatPrgm0;
-        sfpi::vFloat result;
-
         if constexpr (is_fp32_dest_acc_en)
         {
-            result = _sfpu_exp_fp32_accurate_(v);
+            sfpi::dst_reg[0] = _sfpu_exp2_special_or_fp32_(v);
         }
         else
         {
-            result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+            sfpi::dst_reg[0] = _sfpu_exp2_special_or_bf16_(v);
         }
 
-        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
@@ -41,7 +165,6 @@ inline void _calculate_exp2_()
 template <bool APPROXIMATION_MODE /*unused*/>
 inline void _init_exp2_()
 {
-    sfpi::vConstFloatPrgm0 = 0.6931471805f;
 }
 
 } // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 #include "ckernel_sfpu_exp.h"
 #include "sfpi.h"
@@ -12,28 +13,151 @@
 namespace ckernel::sfpu
 {
 
+sfpi_inline sfpi::vFloat _sfpu_exp2_core_fp32_(sfpi::vFloat x)
+{
+    sfpi::vInt k_int;
+    sfpi::vFloat k = _sfpu_round_to_nearest_int32_(x, k_int);
+    sfpi::vFloat f = x - k;
+
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        f,
+        sfpi::vConst1,
+        0.6931471805599453f,
+        0.2402265069591007f,
+        0.05550410866482158f,
+        0.009618129107628477f,
+        0.0013333558146428442f,
+        0.0001540353039338164f,
+        0.00001525273328683212f);
+
+    sfpi::vInt p_exp = sfpi::exexp(p, sfpi::ExponentMode::NoDebias);
+    return sfpi::setexp(p, p_exp + k_int);
+}
+
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_exp2_core_bf16_(sfpi::vFloat x)
+{
+    sfpi::vFloat xlog2 = x + 127.f;
+
+    sfpi::vFloat threshold_low = 0.f;
+    sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
+    sfpi::vec_min_max(threshold_low, xlog2);
+    sfpi::vec_min_max(xlog2, threshold_high);
+
+    sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
+
+    sfpi::vInt exponential_part = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias);
+    sfpi::vInt fractional_part = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));
+
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
+    frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
+
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
+
+    if constexpr (!is_fp32_dest_acc_en)
+    {
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
+    }
+
+    return y;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_exp2_special_or_fp32_(sfpi::vFloat x)
+{
+    sfpi::vFloat result = sfpi::vConst0;
+
+    sfpi::vInt bits = sfpi::reinterpret<sfpi::vInt>(x);
+    sfpi::vInt abs_bits = bits & 0x7fffffff;
+
+    v_if (abs_bits == 0x7f800000)
+    {
+        v_if (bits < 0)
+        {
+            result = sfpi::vConst0;
+        }
+        v_else
+        {
+            result = std::numeric_limits<float>::infinity();
+        }
+        v_endif;
+    }
+    v_elseif (abs_bits > 0x7f800000)
+    {
+        result = x;
+    }
+    v_elseif (x >= 128.0f)
+    {
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_elseif (x <= -127.0f)
+    {
+        result = sfpi::vConst0;
+    }
+    v_else
+    {
+        result = _sfpu_exp2_core_fp32_(x);
+    }
+    v_endif;
+
+    return result;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_exp2_special_or_bf16_(sfpi::vFloat x)
+{
+    sfpi::vFloat result = sfpi::vConst0;
+
+    sfpi::vInt bits = sfpi::reinterpret<sfpi::vInt>(x);
+    sfpi::vInt abs_bits = bits & 0x7fffffff;
+
+    v_if (abs_bits == 0x7f800000)
+    {
+        v_if (bits < 0)
+        {
+            result = sfpi::vConst0;
+        }
+        v_else
+        {
+            result = std::numeric_limits<float>::infinity();
+        }
+        v_endif;
+    }
+    v_elseif (abs_bits > 0x7f800000)
+    {
+        result = x;
+    }
+    v_elseif (x >= 128.0f)
+    {
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_elseif (x <= -127.0f)
+    {
+        result = sfpi::vConst0;
+    }
+    v_else
+    {
+        result = _sfpu_exp2_core_bf16_<true>(x);
+    }
+    v_endif;
+
+    return sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+}
+
 template <bool APPROXIMATION_MODE /*unused*/, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void _calculate_exp2_()
 {
-    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
-        v = v * sfpi::vConstFloatPrgm0;
-        sfpi::vFloat result;
-
         if constexpr (is_fp32_dest_acc_en)
         {
-            result = _sfpu_exp_fp32_accurate_(v);
+            sfpi::dst_reg[0] = _sfpu_exp2_special_or_fp32_(v);
         }
         else
         {
-            result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+            sfpi::dst_reg[0] = _sfpu_exp2_special_or_bf16_(v);
         }
 
-        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
@@ -41,7 +165,6 @@ inline void _calculate_exp2_()
 template <bool APPROXIMATION_MODE /*unused*/>
 inline void _init_exp2_()
 {
-    sfpi::vConstFloatPrgm0 = 0.6931471805f;
 }
 
 } // namespace ckernel::sfpu


### PR DESCRIPTION
## Summary

Contributes to #44507.

This replaces the current `exp2(x) = exp(x * ln2)` SFPU path with a direct base-2 implementation for both Wormhole B0 and Blackhole:

- fp32: range-reduce with `k = round(x)`, approximate `2^f` on `[-0.5, 0.5]`, then rebuild the exponent with `setexp`.
- bf16: take the direct exponent/mantissa reconstruction route (`x + 127`, clamp, convert, split integer/fractional parts), avoiding the unnecessary `ln2` multiply and natural-exp path.
- Adds explicit handling/tests for `inf`, `-inf`, `nan`, overflow, underflow edge values, and normal finite values for both bf16 and fp32.

## Why this route

I checked the live competing implementation/review notes and folded in the maintainer feedback asking for direct base-2 fp32/bf16 handling rather than another `exp`-based wrapper. The fp32 polynomial is intentionally degree 7 on the reduced interval, which gives tighter local approximation than the lower-degree Taylor attempt while keeping the path simple.

## Validation

Local non-hardware checks run:

- `git diff --check origin/main..HEAD`
- `python3 -m py_compile tests/ttnn/unit_tests/operations/eltwise/test_exp2.py`
- standalone reduced-interval fp32 approximation sweep for `2^f`, `f in [-0.5, 0.5]`, observed max error within 1 ulp against float32 rounding

I do not have Tenstorrent hardware in this environment, so I could not run the device `ttnn.exp2` tests or collect cycle counts locally. The PR is structured to make the hardware validation focused on the existing exp2 ULP tests plus the added special-value coverage.