### PR TITLE
[Bugfix] Small Metal 2.0 validation fixes / improvements (from 1st op port attempt)

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -229,20 +229,41 @@ TEST_F(ProgramRunParamsTestQuasar, WrongCommonRuntimeArgsCountFails) {
 
 // TODO: Currently, we require that all kernels in a ProgramSpec have params specified.
 // Should relax this to omit kernels with no RTAs or CRTAs.
-TEST_F(ProgramRunParamsTestQuasar, MissingKernelParamsFails) {
+TEST_F(ProgramRunParamsTestQuasar, EmptySchemaKernelOmittedFromRunParamsSucceeds) {
     NodeCoord node{0, 0};
+    // Both kernels have empty RTA/CRTA schemas — neither has anything to supply per enqueue.
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
-    // Only provide params for dm_kernel, missing compute_kernel
+    // Only provide params for dm_kernel; omit compute_kernel.
+    // Since compute_kernel's schema is empty, this should succeed.
     ProgramRunParams params;
     params.kernel_run_params.push_back(MakeKernelRunParams("dm_kernel", node, {}, {}));
-    // Missing: compute_kernel params
+
+    EXPECT_NO_THROW({ SetProgramRunParameters(program, params); });
+}
+
+TEST_F(ProgramRunParamsTestQuasar, NonEmptySchemaKernelMissingFromRunParamsFails) {
+    NodeCoord node{0, 0};
+    // compute_kernel has a non-empty schema (2 vararg RTAs).
+    ProgramSpec spec = MakeSpecWithBothKernelRTAs(
+        node,
+        /*dm_per_node_rtas=*/0,
+        /*dm_common_rtas=*/0,
+        /*compute_per_node_rtas=*/2,
+        /*compute_common_rtas=*/0);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Only provide params for dm_kernel; omit compute_kernel.
+    // Since compute_kernel has declared RTAs, this should fail.
+    ProgramRunParams params;
+    params.kernel_run_params.push_back(MakeKernelRunParams("dm_kernel", node, {}, {}));
 
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
-            "Kernel 'compute_kernel' is registered in the Program but has no runtime parameters")));
+            "Kernel 'compute_kernel' is registered in the Program with a non-empty RTA/CRTA schema "
+            "but has no runtime parameters specified in ProgramRunParams")));
 }
 
 TEST_F(ProgramRunParamsTestQuasar, DuplicateKernelParamsFails) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -995,7 +995,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
             ::testing::HasSubstr("DFB 'dfb' is used by a compute kernel, but no data_format_metadata is specified")));
 }
 
-TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBFails) {
+TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnboundDFBFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1004,7 +1004,8 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
 
-    // Set unpack_to_dest_mode referencing a DFB that doesn't exist
+    // Set unpack_to_dest_mode referencing a DFB this kernel doesn't bind
+    // (in this case, a DFB that doesn't exist in the spec at all).
     auto& compute_config = std::get<ComputeConfiguration>(consumer.config_spec);
     compute_config.unpack_to_dest_mode = {{"nonexistent_dfb", UnpackToDestMode::UnpackToDestFp32}};
 
@@ -1021,7 +1022,76 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Kernel 'consumer' unpack_to_dest_mode references unknown DFB 'nonexistent_dfb'")));
+            ::testing::HasSubstr("Kernel 'consumer' unpack_to_dest_mode entry references DFB 'nonexistent_dfb', "
+                                 "which the kernel does not bind")));
+}
+
+TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithoutUnpackToDestModeEntrySucceeds) {
+    // Non-FP32 DFBs default to Default; omitting an entry is the expected idiom.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b (non-FP32)
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithExplicitDefaultUnpackToDestModeSucceeds) {
+    // Existing call sites that explicitly spell out Default for non-FP32 DFBs keep working.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b
+    for (auto& kernel : spec.kernels) {
+        if (kernel.is_compute_kernel()) {
+            auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::Default}};
+        }
+    }
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithUnpackToDestFp32ModeFails) {
+    // UnpackToDestFp32 is FP32-only; setting it on a non-FP32 DFB is rejected.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b
+    for (auto& kernel : spec.kernels) {
+        if (kernel.is_compute_kernel()) {
+            auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::UnpackToDestFp32}};
+        }
+    }
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Kernel 'compute_kernel' unpack_to_dest_mode entry for non-FP32 DFB 'dfb_0' "
+                                 "specifies UnpackToDestFp32")));
+}
+
+TEST_F(ProgramSpecTestQuasar, FP32DFBWithoutUnpackToDestModeEntryFails) {
+    // FP32 DFBs require an explicit unpack_to_dest_mode choice — no implicit default.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    for (auto& dfb : spec.dataflow_buffers) {
+        if (dfb.unique_id == "dfb_0") {
+            dfb.data_format_metadata = tt::DataFormat::Float32;
+        }
+    }
+    // Compute kernel intentionally has no unpack_to_dest_mode entry.
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+            "Kernel 'compute_kernel' binds FP32 DFB 'dfb_0' but has no unpack_to_dest_mode entry for it")));
+}
+
+TEST_F(ProgramSpecTestQuasar, FP32DFBWithDefaultUnpackToDestModeSucceeds) {
+    // For an FP32 DFB the user must choose; Default is one valid choice (precision loss
+    // accepted in exchange for SRCA/B compatibility).
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    for (auto& dfb : spec.dataflow_buffers) {
+        if (dfb.unique_id == "dfb_0") {
+            dfb.data_format_metadata = tt::DataFormat::Float32;
+        }
+    }
+    for (auto& kernel : spec.kernels) {
+        if (kernel.is_compute_kernel()) {
+            auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::Default}};
+        }
+    }
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
@@ -1712,7 +1782,12 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigMathFidelitySucceeds) {
 TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
-    // Set valid unpack_to_dest_mode (referencing an existing DFB)
+    // Switch dfb_0 to FP32 so UnpackToDestFp32 is meaningful (it's the FP32-only mode).
+    for (auto& dfb : spec.dataflow_buffers) {
+        if (dfb.unique_id == "dfb_0") {
+            dfb.data_format_metadata = tt::DataFormat::Float32;
+        }
+    }
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
@@ -1740,7 +1815,8 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
     auto dfb0 = MakeMinimalDFB("dfb_0");
     dfb0.data_format_metadata = tt::DataFormat::Float16_b;
     auto dfb1 = MakeMinimalDFB("dfb_1");
-    dfb1.data_format_metadata = tt::DataFormat::Float16_b;
+    // dfb_1 is FP32 so the user can opt into UnpackToDestFp32 on it.
+    dfb1.data_format_metadata = tt::DataFormat::Float32;
 
     BindDFBToKernel(producer, "dfb_0", "out0", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(producer, "dfb_1", "out1", KernelSpec::DFBEndpointType::PRODUCER);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -358,7 +358,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has no producer")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersFails) {
+TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInSameWorkUnitFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -371,7 +371,8 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    // Two producers for same DFB
+    // Two PRODUCER bindings on the same DFB, both KernelSpecs in the same WorkUnitSpec.
+    // Multi-binding requires non-overlapping WU membership per role; this should fail.
     BindDFBToKernel(producer1, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(producer2, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
@@ -383,10 +384,11 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has multiple producers")));
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("DFB 'dfb' has multiple PRODUCER KernelSpecs sharing WorkUnitSpec 'work_unit'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
+TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -399,7 +401,6 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    // Two consumers for same DFB
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
     BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
@@ -411,7 +412,189 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has multiple consumers")));
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER KernelSpecs sharing WorkUnitSpec 'work_unit'")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInDifferentWorkUnitsSucceeds) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer1 = MakeMinimalComputeKernel("consumer1");
+    auto consumer2 = MakeMinimalComputeKernel("consumer2");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    // producer covers both WUs (placed in both); each consumer covers one WU.
+    spec.kernels = {producer, consumer1, consumer2};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer", "consumer1"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer", "consumer2"}),
+    };
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInDifferentWorkUnitsSucceeds) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer1 = MakeMinimalDMKernel("producer1");
+    auto producer2 = MakeMinimalDMKernel("producer2");
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer1, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(producer2, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer1, producer2, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer1", "consumer"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer2", "consumer"}),
+    };
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    // Producer covers wu_p; consumer covers wu_c. Their coverages differ — invalid.
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_p", node0, {"producer"}),
+        MakeMinimalWorkUnit("wu_c", node1, {"consumer"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("do not cover the same WorkUnitSpec(s)")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBMultiBindingAccessPatternMismatchFails) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer1 = MakeMinimalComputeKernel("consumer1");
+    auto consumer2 = MakeMinimalComputeKernel("consumer2");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER, DFBAccessPattern::STRIDED);
+    BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER, DFBAccessPattern::ALL);
+
+    spec.kernels = {producer, consumer1, consumer2};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer", "consumer1"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer", "consumer2"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER bindings with mismatched access_pattern")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBMultiBindingNumThreadsMismatchFails) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer1 = MakeMinimalComputeKernel("consumer1", /*num_threads=*/1);
+    auto consumer2 = MakeMinimalComputeKernel("consumer2", /*num_threads=*/2);
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer1, consumer2};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer", "consumer1"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer", "consumer2"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER KernelSpecs with mismatched num_threads")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithMultiBindingFails) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    // Two self-looping kernels on disjoint WUs. Each binds "dfb" as both producer and consumer.
+    // Coverage matches (both unions = {wu_g1, wu_g2}); per-role uniformity passes; but the
+    // self-loop multi-binding rule rejects this case.
+    auto self_loop_1 = MakeMinimalComputeKernel("self_loop_1");
+    auto self_loop_2 = MakeMinimalComputeKernel("self_loop_2");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(self_loop_1, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(self_loop_1, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
+    BindDFBToKernel(self_loop_2, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(self_loop_2, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {self_loop_1, self_loop_2};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"self_loop_1"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"self_loop_2"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' is self-looped")));
 }
 
 // ============================================================================
@@ -652,7 +835,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Semaphore bindings are not currently supported for compute kernels.")));
+            ::testing::HasSubstr("Semaphore bindings are not supported for compute kernels.")));
 }
 
 TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
@@ -1077,8 +1260,7 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatch
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("do not share identical WorkUnitSpec membership")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("do not cover the same WorkUnitSpec(s)")));
 }
 
 // ----------------------------------------------------------------------------
@@ -2266,7 +2448,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Semaphore bindings are not currently supported for compute kernels.")));
+            ::testing::HasSubstr("Semaphore bindings are not supported for compute kernels.")));
 }
 
 TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -166,7 +166,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateWorkUnitNameFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate WorkUnitSpec name 'same_name'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
+TEST_F(ProgramSpecTestQuasar, SharedLocalAccessorNameForDifferentDFBsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -176,9 +176,10 @@ TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
     auto dfb0 = MakeMinimalDFB("dfb_0");
     auto dfb1 = MakeMinimalDFB("dfb_1");
 
-    // Bind two DFBs with the same local_accessor_name
+    // Bind two *different* DFBs with the same local_accessor_name — illegal
+    // (self-loop sharing requires the same DFB on both bindings).
     BindDFBToKernel(kernel, "dfb_0", "same_accessor", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(kernel, "dfb_1", "same_accessor", KernelSpec::DFBEndpointType::CONSUMER);  // Duplicate accessor!
+    BindDFBToKernel(kernel, "dfb_1", "same_accessor", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb0, dfb1};
@@ -187,7 +188,53 @@ TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Kernel 'kernel' has duplicate local_accessor_name 'same_accessor'")));
+            ::testing::HasSubstr("Kernel 'kernel' uses local_accessor_name 'same_accessor' for two different DFBs")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DuplicateProducerBindingForSameLocalAccessorNameFails) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer_kernel = MakeMinimalDMKernel("producer");
+    auto consumer_kernel = MakeMinimalDMKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
+
+    // Two PRODUCER bindings on the same kernel sharing a local_accessor_name —
+    // illegal: the self-loop relaxation requires opposite endpoint types.
+    BindDFBToKernel(producer_kernel, "dfb", "shared", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(producer_kernel, "dfb", "shared", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer_kernel, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer_kernel, consumer_kernel};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("duplicate PRODUCER binding for local_accessor_name 'shared'")));
+}
+
+TEST_F(ProgramSpecTestQuasar, SelfLoopWithSharedLocalAccessorNameSucceeds) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    // A kernel that both produces and consumes the same DFB may share a single
+    // local_accessor_name across the PRODUCER and CONSUMER bindings.
+    auto kernel = MakeMinimalDMKernel("kernel");
+    auto dfb = MakeMinimalDFB("dfb");
+    BindDFBToKernel(kernel, "dfb", "acc", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(kernel, "dfb", "acc", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {kernel};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
 TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -564,21 +564,25 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingNumThreadsMismatchFails) {
             ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER KernelSpecs with mismatched num_threads")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithMultiBindingFails) {
+TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    // Two self-looping kernels on disjoint WUs. Each binds "dfb" as both producer and consumer.
-    // Coverage matches (both unions = {wu_g1, wu_g2}); per-role uniformity passes; but the
-    // self-loop multi-binding rule rejects this case.
+    // Two self-looping kernels on disjoint WUs. Each binds "dfb" as both producer and
+    // consumer; producer set equals consumer set = {self_loop_1, self_loop_2}. At each node,
+    // exactly one kernel runs and self-loops the DFB — the local invariant holds.
     auto self_loop_1 = MakeMinimalComputeKernel("self_loop_1");
     auto self_loop_2 = MakeMinimalComputeKernel("self_loop_2");
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    // INTRA-tensix self-loop DFBs require implicit_sync disabled (a lower-layer constraint
+    // enforced in dataflow_buffer.cpp). This matches the pattern real self-loop DFBs use
+    // (e.g. ACC_DFB / INEG_DFB in the reduction op factory's negate path).
+    dfb.disable_implicit_sync = true;
 
     BindDFBToKernel(self_loop_1, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(self_loop_1, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
@@ -592,10 +596,51 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithMultiBindingFails) {
         MakeMinimalWorkUnit("wu_g2", node1, {"self_loop_2"}),
     };
 
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    // self_loop_1 binds "dfb" as BOTH producer and consumer (self-loop). On the other WU,
+    // an unrelated producer-only kernel is bound, while extra_consumer covers the consume side.
+    // Producer set = {self_loop_1, extra_producer}; consumer set = {self_loop_1, extra_consumer}.
+    // The sets are not equal — the self-loop multi-binding rule rejects this mix.
+    auto self_loop_1 = MakeMinimalComputeKernel("self_loop_1");
+    auto extra_producer = MakeMinimalDMKernel("extra_producer");
+    auto extra_consumer = MakeMinimalComputeKernel("extra_consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(self_loop_1, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(self_loop_1, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
+    BindDFBToKernel(extra_producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(extra_consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {self_loop_1, extra_producer, extra_consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"self_loop_1"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"extra_producer", "extra_consumer"}),
+    };
+
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' is self-looped")));
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("DFB 'dfb' is self-looped (some kernel appears as both producer and consumer), but "
+                                 "the set of producer KernelSpecs differs from the set of consumer KernelSpecs")));
 }
+
+// NOTE: A "scope-disagreement" test case is not currently expressible: the only valid scope
+// value today is INTRA (INTER is rejected upstream as not-yet-supported), so two
+// self-loop participants can't meaningfully disagree on scope. When INTER support lands,
+// add a positive scope-disagreement test that exercises the
+// "must agree on DFBComputeSelfLoopScope::Scope" TT_FATAL.
 
 // ============================================================================
 // SECTION 2: Semantic Validation Tests (ValidateProgramSpec)

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -641,5 +641,48 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     EXPECT_EQ(output_data, input_data);
 }
 
+// ============================================================================
+// Multi-binding RISC-mask Uniformity (Gen1)
+// ============================================================================
+//
+// On Gen1 (WH/BH) the per-kernel risc_mask is a deterministic function of the
+// KernelSpec's config_spec. Multi-binding requires all same-role KernelSpecs to
+// share that mask; mismatched processor placement on the producer (or consumer)
+// side is a user error and must be rejected with an actionable message.
+TEST_F(ProgramSpecHWTest, MultiBindingProducerMaskMismatchFails) {
+    auto mesh_device = devices_.at(0);
+
+    NodeCoord node0{0, 0};
+    NodeCoord node1{0, 1};
+
+    auto producer_g1 = MakeMinimalGen1DMKernel("producer_g1", DataMovementProcessor::RISCV_0);
+    auto producer_g2 = MakeMinimalGen1DMKernel("producer_g2", DataMovementProcessor::RISCV_1);
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer_g1, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(producer_g2, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    ProgramSpec spec;
+    spec.program_id = "multi_binding_mask_mismatch";
+    spec.kernels = {producer_g1, producer_g2, consumer};
+    spec.dataflow_buffers = {dfb};
+    // consumer in both WUs (single-KernelSpec multi-WU membership) → consumer-side mask is fine.
+    // producer_g1 in wu_g1 (RISCV_0); producer_g2 in wu_g2 (RISCV_1) → mismatched producer masks.
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer_g1", "consumer"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer_g2", "consumer"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("DFB 'dfb' has multiple PRODUCER KernelSpecs ('producer_g1', 'producer_g2') with "
+                                 "mismatched processor placement")));
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -13,6 +13,7 @@
 // TODO: Switch to using fast dispatch once the MeshWorkload code paths are added.
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <cstdint>
 #include <vector>
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -76,6 +76,11 @@ using KernelSpecName = std::string;
 //  - Kernel argument bindings (for compile-time constant arguments)
 //  - The configuration of any hardware resources controlled by the kernel
 //
+// Specialization: A single kernel source may be represented by multiple KernelSpecs in
+// the same ProgramSpec — for example with different CTA bindings, different DFB endpoint
+// bindings, different semaphore bindings, etc. Each KernelSpec compiles independently
+// and is placed independently via WorkUnitSpec membership.
+//
 // Instancing: A KernelSpec is a *per-node template*. At runtime, one independent
 // instance runs on each node where the kernel is placed, with its own runtime arguments.
 //

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -210,12 +210,25 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
             kernel_params.named_common_runtime_args.size());
     }
 
-    // Validate that all registered kernels have parameters
+    // Validate that all registered kernels with a non-empty RTA/CRTA schema have parameters.
+    // Kernels whose schema declares no named RTAs, no named CRTAs, no vararg RTAs, and no
+    // vararg CRTAs have nothing to supply per enqueue and do not need a kernel_run_params entry.
     std::vector<KernelSpecName> registered_names = program_impl.get_registered_kernel_names();
     for (const KernelSpecName& name : registered_names) {
+        if (kernels_with_params.contains(name)) {
+            continue;
+        }
+        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(name);
+        if (schema == nullptr) {
+            continue;
+        }
+        const bool has_anything_to_supply =
+            !schema->named_runtime_args.empty() || !schema->named_common_runtime_args.empty() ||
+            !schema->num_runtime_varargs_per_node.empty() || schema->num_common_runtime_varargs > 0;
         TT_FATAL(
-            kernels_with_params.contains(name),
-            "Kernel '{}' is registered in the Program but has no runtime parameters specified in ProgramRunParams",
+            !has_anything_to_supply,
+            "Kernel '{}' is registered in the Program with a non-empty RTA/CRTA schema but has no "
+            "runtime parameters specified in ProgramRunParams",
             name);
     }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -721,17 +721,71 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
-    // Validate compute kernel unpack_to_dest_mode references
+    // Validate compute kernel unpack_to_dest_mode entries.
+    // Policy:
+    //   - Each entry must reference a DFB the kernel actually binds.
+    //   - For non-FP32 DFBs, the only meaningful mode is Default — UnpackToDestFp32
+    //     is specifically for unpacking Float32 data with full precision, and makes
+    //     no sense for other formats. We allow entries for non-FP32 DFBs only if
+    //     the value is Default (so existing code that spells it out keeps working;
+    //     pure-busywork specifications get flagged if they specify the wrong value).
+    //   - For FP32 DFBs, an entry is REQUIRED. The choice between Default and
+    //     UnpackToDestFp32 matters for FP32 data (precision vs SRCA/B compatibility),
+    //     so the user must make it explicitly.
     for (const auto& kernel : spec.kernels) {
-        if (kernel.is_compute_kernel()) {
-            const auto& compute_config = std::get<ComputeConfiguration>(kernel.config_spec);
-            for (const auto& [dfb_name, mode] : compute_config.unpack_to_dest_mode) {
-                TT_FATAL(
-                    collected.dfb_by_name.contains(dfb_name),
-                    "Kernel '{}' unpack_to_dest_mode references unknown DFB '{}'",
-                    kernel.unique_id,
-                    dfb_name);
+        if (!kernel.is_compute_kernel()) {
+            continue;
+        }
+        const auto& compute_config = std::get<ComputeConfiguration>(kernel.config_spec);
+
+        // Quick lookup of DFBs this kernel binds.
+        std::unordered_set<DFBSpecName> bound_dfbs;
+        for (const auto& binding : kernel.dfb_bindings) {
+            bound_dfbs.insert(binding.dfb_spec_name);
+        }
+
+        // Check each user-supplied entry against the policy.
+        std::unordered_set<DFBSpecName> entries_seen;
+        for (const auto& [dfb_name, mode] : compute_config.unpack_to_dest_mode) {
+            TT_FATAL(
+                bound_dfbs.contains(dfb_name),
+                "Kernel '{}' unpack_to_dest_mode entry references DFB '{}', which the kernel does not bind",
+                kernel.unique_id,
+                dfb_name);
+            entries_seen.insert(dfb_name);
+
+            const DataflowBufferSpec* dfb_spec = collected.dfb_by_name.at(dfb_name);
+            // If data_format_metadata isn't set, the separate "compute endpoint requires
+            // data_format_metadata" check (below) will fail. Defer to that check.
+            if (!dfb_spec->data_format_metadata.has_value()) {
+                continue;
             }
+            const bool is_fp32 = (dfb_spec->data_format_metadata.value() == tt::DataFormat::Float32);
+            TT_FATAL(
+                is_fp32 || mode == UnpackToDestMode::Default,
+                "Kernel '{}' unpack_to_dest_mode entry for non-FP32 DFB '{}' specifies UnpackToDestFp32. "
+                "UnpackToDestFp32 is only meaningful for FP32 data; non-FP32 DFBs must use Default "
+                "(or omit the entry — Default is the implicit value).",
+                kernel.unique_id,
+                dfb_name);
+        }
+
+        // Every FP32 DFB the kernel binds must have an explicit entry.
+        for (const auto& binding : kernel.dfb_bindings) {
+            const DataflowBufferSpec* dfb_spec = collected.dfb_by_name.at(binding.dfb_spec_name);
+            if (!dfb_spec->data_format_metadata.has_value()) {
+                continue;  // Will be caught by the data_format-required check.
+            }
+            if (dfb_spec->data_format_metadata.value() != tt::DataFormat::Float32) {
+                continue;
+            }
+            TT_FATAL(
+                entries_seen.contains(binding.dfb_spec_name),
+                "Kernel '{}' binds FP32 DFB '{}' but has no unpack_to_dest_mode entry for it. "
+                "FP32 DFBs require an explicit choice between UnpackToDestMode::Default and "
+                "UnpackToDestMode::UnpackToDestFp32.",
+                kernel.unique_id,
+                binding.dfb_spec_name);
         }
     }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -65,11 +65,20 @@ struct CollectedSpecData {
 
     // DFB endpoint info (derived from kernel bindings).
     // Populated for both local and remote DFBs.
+    //
+    // Multiple PRODUCER KernelSpecs (and multiple CONSUMER KernelSpecs) may bind the same DFB,
+    // provided they have non-overlapping node coverage and matching binding-site parameters
+    // (access_pattern, num_threads). This permits the canonical Metal 2.0 expression of the
+    // legacy "two KernelDescriptors per work split, sharing CBs" pattern. The physical
+    // invariant is local: at each node, exactly one producer kernel instance and one
+    // consumer kernel instance.
     struct DFBEndpointInfo {
-        const KernelSpec* producer = nullptr;
-        const KernelSpec* consumer = nullptr;
-        const KernelSpec::DFBBinding* producer_binding = nullptr;
-        const KernelSpec::DFBBinding* consumer_binding = nullptr;
+        struct EndpointRecord {
+            const KernelSpec* kernel = nullptr;
+            const KernelSpec::DFBBinding* binding = nullptr;
+        };
+        std::vector<EndpointRecord> producers;
+        std::vector<EndpointRecord> consumers;
     };
     std::unordered_map<DFBSpecName, DFBEndpointInfo> dfb_endpoints;
 
@@ -315,31 +324,21 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
             CollectedSpecData::DFBEndpointInfo& endpoint_info = collected.dfb_endpoints[dfb_binding.dfb_spec_name];
 
             if (dfb_binding.endpoint_type == KernelSpec::DFBEndpointType::PRODUCER) {
-                TT_FATAL(
-                    endpoint_info.producer == nullptr,
-                    "DFB '{}' has multiple producers (second: '{}')",
-                    dfb_binding.dfb_spec_name,
-                    kernel.unique_id);
-                endpoint_info.producer = &kernel;
-                endpoint_info.producer_binding = &dfb_binding;
+                endpoint_info.producers.push_back({&kernel, &dfb_binding});
             } else if (dfb_binding.endpoint_type == KernelSpec::DFBEndpointType::CONSUMER) {
-                TT_FATAL(
-                    endpoint_info.consumer == nullptr,
-                    "DFB '{}' has multiple consumers (second: '{}')",
-                    dfb_binding.dfb_spec_name,
-                    kernel.unique_id);
-                endpoint_info.consumer = &kernel;
-                endpoint_info.consumer_binding = &dfb_binding;
+                endpoint_info.consumers.push_back({&kernel, &dfb_binding});
             } else {
                 TT_FATAL(false, "RELAY endpoints are only used for remote DFB, which is not supported yet");
             }
         }
     }
 
-    // Completeness: every DFB must have exactly one producer and one consumer
+    // Completeness: every DFB must have at least one producer and one consumer.
+    // (Cross-role coverage matching and within-role binding-site uniformity are checked
+    // later, after kernel node coverage is computed.)
     for (const auto& [dfb_name, endpoint_info] : collected.dfb_endpoints) {
-        TT_FATAL(endpoint_info.producer != nullptr, "DFB '{}' has no producer", dfb_name);
-        TT_FATAL(endpoint_info.consumer != nullptr, "DFB '{}' has no consumer", dfb_name);
+        TT_FATAL(!endpoint_info.producers.empty(), "DFB '{}' has no producer", dfb_name);
+        TT_FATAL(!endpoint_info.consumers.empty(), "DFB '{}' has no consumer", dfb_name);
     }
 
     // Referential integrity: every declared DFB (local or remote) must be bound by some kernel
@@ -468,11 +467,18 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
     }
 
     // Derive each local DFB's allocation node set: union of binding-kernels' node sets.
-    // (Collected, but unvalidated. Semantic integrity checks for DFB take place in ValidateProgramSpec.)
+    // (Collected, but unvalidated. Semantic integrity checks for DFB take place in ValidateProgramSpec.
+    //  Once those pass, producer and consumer coverages are guaranteed equal; here we union both
+    //  sides for safety before that guarantee holds.)
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
-        NodeRangeSet node_set = collected.kernel_node_set.at(endpoints.producer->unique_id);
-        node_set = node_set.merge(collected.kernel_node_set.at(endpoints.consumer->unique_id));
+        NodeRangeSet node_set;
+        for (const auto& rec : endpoints.producers) {
+            node_set = node_set.merge(collected.kernel_node_set.at(rec.kernel->unique_id));
+        }
+        for (const auto& rec : endpoints.consumers) {
+            node_set = node_set.merge(collected.kernel_node_set.at(rec.kernel->unique_id));
+        }
         collected.dfb_node_set[dfb.unique_id] = node_set;
     }
 
@@ -793,9 +799,24 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             dfb.unique_id);
     }
 
-    // Validate local DFB endpoint placement:
-    // A local DFB's producer and consumer kernels must be on the same node (sharing SRAM memory).
-    // For this to be true, the producer and consumer kernels need IDENTICAL WorkUnitSpec membership.
+    // Validate local DFB endpoint placement and multi-binding consistency.
+    //
+    // The hardware invariant is local: at each node where the DFB is instantiated, exactly one
+    // producer kernel instance and one consumer kernel instance run on that node. This is
+    // sufficient — but not strictly necessary — to enforce at the spec level via "one producer
+    // KernelSpec, one consumer KernelSpec". Metal 2.0 also permits multiple PRODUCER KernelSpecs
+    // (and multiple CONSUMER KernelSpecs) per DFB, provided:
+    //   1. Within each role (producer / consumer): KernelSpecs' WorkUnitSpec memberships are
+    //      pairwise disjoint (so no node has two same-role instances).
+    //   2. Across roles: union of producer KernelSpecs' WU memberships ==
+    //      union of consumer KernelSpecs' WU memberships (so every node where the DFB lives
+    //      has both a producer instance and a consumer instance).
+    //   3. All bindings on the same role have matching `access_pattern` (the DFB scheduler
+    //      config is shared per role).
+    //   4. All KernelSpecs on the same role have matching `num_threads` (the per-side
+    //      credit-tracking config is shared per role).
+    // Self-loop (a kernel that appears in both producers and consumers of a DFB) is currently
+    // restricted to the simple single-producer-single-consumer case.
     auto kernel_work_unit_set = [&](const KernelSpecName& name) {
         std::set<const WorkUnitSpec*> work_units;
         for (const WorkUnitSpec* w : collected.kernel_work_units.at(name)) {
@@ -805,17 +826,90 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     };
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
-        const auto producer_work_units = kernel_work_unit_set(endpoints.producer->unique_id);
-        const auto consumer_work_units = kernel_work_unit_set(endpoints.consumer->unique_id);
+
+        // (3) and (4): per-role uniformity of binding-site parameters.
+        auto check_role_uniformity = [&](const auto& records, std::string_view role) {
+            if (records.size() < 2) {
+                return;
+            }
+            const auto first_pattern = records[0].binding->access_pattern;
+            const auto first_threads = records[0].kernel->num_threads;
+            const auto& first_kernel = records[0].kernel->unique_id;
+            for (size_t i = 1; i < records.size(); ++i) {
+                TT_FATAL(
+                    records[i].binding->access_pattern == first_pattern,
+                    "DFB '{}' has multiple {} bindings with mismatched access_pattern (kernel '{}' vs kernel '{}')",
+                    dfb.unique_id,
+                    role,
+                    first_kernel,
+                    records[i].kernel->unique_id);
+                TT_FATAL(
+                    records[i].kernel->num_threads == first_threads,
+                    "DFB '{}' has multiple {} KernelSpecs with mismatched num_threads (kernel '{}' = {} vs kernel '{}' "
+                    "= {})",
+                    dfb.unique_id,
+                    role,
+                    first_kernel,
+                    first_threads,
+                    records[i].kernel->unique_id,
+                    records[i].kernel->num_threads);
+            }
+        };
+        check_role_uniformity(endpoints.producers, "PRODUCER");
+        check_role_uniformity(endpoints.consumers, "CONSUMER");
+
+        // (1) and (2): WU membership disjointness within each role + cross-role equality.
+        // Compute per-role unions while also checking within-role pairwise disjointness.
+        auto compute_role_union = [&](const auto& records, std::string_view role) {
+            std::set<const WorkUnitSpec*> role_union;
+            for (const auto& rec : records) {
+                const auto wu_set = kernel_work_unit_set(rec.kernel->unique_id);
+                for (const WorkUnitSpec* wu : wu_set) {
+                    auto [it, inserted] = role_union.insert(wu);
+                    TT_FATAL(
+                        inserted,
+                        "DFB '{}' has multiple {} KernelSpecs sharing WorkUnitSpec '{}' (kernel '{}' collides with a "
+                        "prior {} binding). Same-role bindings must have pairwise-disjoint WorkUnitSpec membership.",
+                        dfb.unique_id,
+                        role,
+                        wu->unique_id,
+                        rec.kernel->unique_id,
+                        role);
+                }
+            }
+            return role_union;
+        };
+        const auto producer_wu_union = compute_role_union(endpoints.producers, "PRODUCER");
+        const auto consumer_wu_union = compute_role_union(endpoints.consumers, "CONSUMER");
         TT_FATAL(
-            producer_work_units == consumer_work_units,
-            "Local DFB '{}' is bound by producer kernel '{}' and consumer kernel '{}', but they "
-            "do not share identical WorkUnitSpec membership. Local DFBs require both endpoints to "
-            "live on the same set of WorkUnitSpecs; either refactor the placement, or model this as "
+            producer_wu_union == consumer_wu_union,
+            "Local DFB '{}' producer and consumer KernelSpecs do not cover the same WorkUnitSpec(s). "
+            "Local DFBs require every node where the DFB is instantiated to host both a producer "
+            "and a consumer kernel instance; either refactor the placement, or model this as "
             "a RemoteDataflowBufferSpec.",
-            dfb.unique_id,
-            endpoints.producer->unique_id,
-            endpoints.consumer->unique_id);
+            dfb.unique_id);
+
+        // Self-loop interplay with multi-binding: a kernel that self-loops a DFB (appears in
+        // both producers and consumers) must be the only binding on each side. Mixing self-loop
+        // with non-self-loop bindings on the same DFB is not currently supported.
+        const bool has_self_loop = [&] {
+            for (const auto& p : endpoints.producers) {
+                for (const auto& c : endpoints.consumers) {
+                    if (p.kernel == c.kernel) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }();
+        if (has_self_loop) {
+            TT_FATAL(
+                endpoints.producers.size() == 1 && endpoints.consumers.size() == 1,
+                "DFB '{}' is self-looped (bound by a kernel as both producer and consumer) and also "
+                "has additional bindings. Self-loop is currently restricted to a single producer "
+                "KernelSpec and a single consumer KernelSpec.",
+                dfb.unique_id);
+        }
     }
 
     // Remote DFBs are not yet supported.
@@ -848,9 +942,16 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     // Data format metadata (optional param) MUST be specified for a DFB with a compute endpoint
+    auto any_compute_endpoint = [](const auto& records) {
+        for (const auto& rec : records) {
+            if (rec.kernel->is_compute_kernel()) {
+                return true;
+            }
+        }
+        return false;
+    };
     for (const auto& [dfb_name, endpoint_info] : collected.dfb_endpoints) {
-        if ((endpoint_info.producer && endpoint_info.producer->is_compute_kernel()) ||
-            (endpoint_info.consumer && endpoint_info.consumer->is_compute_kernel())) {
+        if (any_compute_endpoint(endpoint_info.producers) || any_compute_endpoint(endpoint_info.consumers)) {
             const DataflowBufferSpec* dfb_spec = collected.dfb_by_name.at(dfb_name);
             TT_FATAL(
                 dfb_spec->data_format_metadata.has_value(),
@@ -1515,8 +1616,14 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     const DataflowBufferSpec* dfb_spec,
     const CollectedSpecData::DFBEndpointInfo& dfb_endpoint_info,
     const KernelRiscMaskMap& kernel_to_risc_mask) {
-    const KernelSpec* producer = dfb_endpoint_info.producer;
-    const KernelSpec* consumer = dfb_endpoint_info.consumer;
+    // With multi-binding, all producer KernelSpecs share the same access_pattern and num_threads
+    // (enforced in ValidateProgramSpec), so any representative producer/consumer gives the
+    // correct DFB config. For risc_mask, same-source KernelSpecs (the canonical multi-binding
+    // case) have identical processor placement and therefore the same mask; we take the first.
+    const KernelSpec* producer = dfb_endpoint_info.producers.front().kernel;
+    const KernelSpec* consumer = dfb_endpoint_info.consumers.front().kernel;
+    const KernelSpec::DFBBinding* producer_binding = dfb_endpoint_info.producers.front().binding;
+    const KernelSpec::DFBBinding* consumer_binding = dfb_endpoint_info.consumers.front().binding;
 
     uint16_t producer_risc_mask = kernel_to_risc_mask.at(producer);
     uint16_t consumer_risc_mask = kernel_to_risc_mask.at(consumer);
@@ -1531,12 +1638,14 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         }
         TT_FATAL(false, "Unknown DFBAccessPattern");
     };
-    auto producer_access_pattern = to_hw_access_pattern(dfb_endpoint_info.producer_binding->access_pattern);
-    auto consumer_access_pattern = to_hw_access_pattern(dfb_endpoint_info.consumer_binding->access_pattern);
+    auto producer_access_pattern = to_hw_access_pattern(producer_binding->access_pattern);
+    auto consumer_access_pattern = to_hw_access_pattern(consumer_binding->access_pattern);
 
     // For a compute kernel that self-loops a DFB (binds it as both producer and consumer), the
-    // lower-layer DFB API requires an explicit scope.
-    // The user can declare it via KernelSpec::dfb_compute_self_loop_scopes:
+    // lower-layer DFB API requires an explicit scope. Self-loop is restricted to
+    // single-producer-single-consumer (validated upstream), so the producer/consumer check is
+    // pointer equality on the representative records.
+    // The user can declare scope via KernelSpec::dfb_compute_self_loop_scopes:
     //  - absence of an entry means we infer INTRA (the common case)
     //  - user-specified INTRA is also fine
     //  - user-specified INTER is not currently supported. This will have already failed validation.
@@ -1558,10 +1667,10 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         .entry_size = dfb_spec->entry_size,
         .num_entries = dfb_spec->num_entries,
         .producer_risc_mask = producer_risc_mask,
-        .num_producers = dfb_endpoint_info.producer->num_threads,
+        .num_producers = producer->num_threads,
         .pap = producer_access_pattern,
         .consumer_risc_mask = consumer_risc_mask,
-        .num_consumers = dfb_endpoint_info.consumer->num_threads,
+        .num_consumers = consumer->num_threads,
         .cap = consumer_access_pattern,
         .enable_implicit_sync = !dfb_spec->disable_implicit_sync,
         .data_format = dfb_spec->data_format_metadata.value_or(tt::DataFormat::Invalid),

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -979,6 +979,9 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             // All self-loop participants must agree on the tensix-scope for this DFB —
             // MakeDataflowBufferConfig writes a single tensix_scope into the DFB config, and the
             // self-loop participants alternate per node, so a disagreement is unresolvable.
+            // Iterate endpoints.producers (a vector) rather than producer_kernels (an
+            // unordered_set), so iteration order — and any resulting error message — is
+            // deterministic across runs.
             auto scope_for_kernel = [&](const KernelSpec* k) {
                 for (const auto& entry : k->dfb_compute_self_loop_scopes) {
                     if (entry.dfb_spec_name == dfb.unique_id) {
@@ -987,16 +990,20 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 }
                 return KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA;
             };
-            const auto* first_kernel = *producer_kernels.begin();
+            const KernelSpec* first_kernel = endpoints.producers.front().kernel;
             const auto first_scope = scope_for_kernel(first_kernel);
-            for (const KernelSpec* k : producer_kernels) {
+            std::unordered_set<const KernelSpec*> seen;
+            for (const auto& rec : endpoints.producers) {
+                if (!seen.insert(rec.kernel).second) {
+                    continue;
+                }
                 TT_FATAL(
-                    scope_for_kernel(k) == first_scope,
+                    scope_for_kernel(rec.kernel) == first_scope,
                     "DFB '{}' is self-looped; all self-loop participants must agree on "
                     "DFBComputeSelfLoopScope::Scope, but kernel '{}' specifies a different scope "
                     "than kernel '{}'.",
                     dfb.unique_id,
-                    k->unique_id,
+                    rec.kernel->unique_id,
                     first_kernel->unique_id);
             }
         }
@@ -1706,10 +1713,11 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     const DataflowBufferSpec* dfb_spec,
     const CollectedSpecData::DFBEndpointInfo& dfb_endpoint_info,
     const KernelRiscMaskMap& kernel_to_risc_mask) {
-    // With multi-binding, all producer KernelSpecs share the same access_pattern and num_threads
-    // (enforced in ValidateProgramSpec), so any representative producer/consumer gives the
-    // correct DFB config. For risc_mask, same-source KernelSpecs (the canonical multi-binding
-    // case) have identical processor placement and therefore the same mask; we take the first.
+    // With multi-binding, all producer KernelSpecs share the same access_pattern, num_threads,
+    // AND risc_mask: the first two are enforced in ValidateProgramSpec; the third is checked
+    // in MakeProgramFromSpec right after the risc-mask solver runs (see the
+    // "check_uniform_mask" loop). So any representative producer/consumer gives the correct
+    // DFB config — we take the first.
     const KernelSpec* producer = dfb_endpoint_info.producers.front().kernel;
     const KernelSpec* consumer = dfb_endpoint_info.consumers.front().kernel;
     const KernelSpec::DFBBinding* producer_binding = dfb_endpoint_info.producers.front().binding;
@@ -2011,6 +2019,77 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     //  - Gen1: processor is user-specified in Gen1DataMovementConfig
     KernelRiscMaskMap kernel_to_risc_mask =
         is_gen2_arch() ? SolveGen2KernelRiscMasks(spec, collected) : BuildGen1KernelRiscMasks(spec);
+
+    // Step 2a-bis: For multi-binding DFBs, all KernelSpecs on the same role must end up with
+    // identical risc_masks. The DFB has a single producer_risc_mask / consumer_risc_mask in
+    // its hardware config; per-node mask variation would require splitting the DFB at lowering
+    // time (deliberately not done here).
+    //
+    // Gen1: the mask is a deterministic function of the user's KernelSpec config_spec (compute
+    //   placement is fixed; DM processor is user-specified via Gen1DataMovementConfig). A
+    //   mismatch is therefore a user error — the user supplied multi-binding KernelSpecs with
+    //   incompatible processor placement.
+    // Gen2 (Quasar): the mask is solver-assigned. The solver currently doesn't know about
+    //   multi-binding equivalence classes, so even when the user's intent is compatible the
+    //   solver may produce a mismatch. The proper fix is to extend the DM/compute solver to
+    //   constrain same-role multi-binding kernels to identical placements; this is intentionally
+    //   deferred. For now, on Gen2 we surface the mismatch as an internal error so a real
+    //   workload exercising the case can find us; the user can't act on it directly.
+    //
+    // TODO(quasar-multi-binding-solver): extend SolveGen2KernelRiscMasks to take the
+    // multi-binding equivalence classes (derived from collected.dfb_endpoints) and constrain
+    // same-class kernels to the same risc_mask. Then this check downgrades to a defensive
+    // assertion on both arches.
+    for (const auto& dfb : spec.dataflow_buffers) {
+        const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
+        auto check_uniform_mask = [&](const auto& records, std::string_view role) {
+            if (records.size() < 2) {
+                return;
+            }
+            const uint16_t first_mask = kernel_to_risc_mask.at(records[0].kernel);
+            const auto* first_kernel = records[0].kernel;
+            for (size_t i = 1; i < records.size(); ++i) {
+                const uint16_t mask = kernel_to_risc_mask.at(records[i].kernel);
+                if (mask == first_mask) {
+                    continue;
+                }
+                if (is_gen2_arch()) {
+                    TT_FATAL(
+                        false,
+                        "Internal error: Inconsistent RISC mask solution failure. DFB '{}' has "
+                        "multiple {} KernelSpecs ('{}', '{}') that the Gen2 (Quasar) solver "
+                        "placed on different processor lanes (mask 0x{:x} vs 0x{:x}). The DFB's "
+                        "hardware config carries a single mask per role; multi-binding requires "
+                        "all same-role kernels to share a mask. The Quasar solver does not yet "
+                        "enforce this constraint; this is a known framework limitation. "
+                        "TODO(quasar-multi-binding-solver): extend the solver to constrain "
+                        "multi-binding equivalence classes.",
+                        dfb.unique_id,
+                        role,
+                        first_kernel->unique_id,
+                        records[i].kernel->unique_id,
+                        first_mask,
+                        mask);
+                } else {
+                    TT_FATAL(
+                        false,
+                        "DFB '{}' has multiple {} KernelSpecs ('{}', '{}') with mismatched "
+                        "processor placement (risc_mask 0x{:x} vs 0x{:x}). Multi-binding "
+                        "requires all same-role kernels to share processor placement (for DM "
+                        "kernels, check Gen1DataMovementConfig::processor; for compute, the "
+                        "placement is determined by the KernelSpec's config_spec type).",
+                        dfb.unique_id,
+                        role,
+                        first_kernel->unique_id,
+                        records[i].kernel->unique_id,
+                        first_mask,
+                        mask);
+                }
+            }
+        };
+        check_uniform_mask(endpoints.producers, "PRODUCER");
+        check_uniform_mask(endpoints.consumers, "CONSUMER");
+    }
 
     // Step 2b: Resolve TensorParameters against the MeshDevice into static CTA payloads.
     //

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -264,20 +264,46 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 
     // Build DFB endpoint info from kernel bindings
     for (const auto& kernel : spec.kernels) {
-        // Check for duplicate local_accessor_names within this kernel
-        std::unordered_set<std::string> accessor_names;
+        // Track per-accessor-name signatures within this kernel. Reusing a single
+        // local_accessor_name across two DFBBindings is permitted as a "self-loop pair":
+        // both bindings target the same DFB with opposite endpoint types (one PRODUCER,
+        // one CONSUMER). This lets a kernel that both produces and consumes the same DFB
+        // use a single device-side accessor name instead of two aliasing wrappers.
+        struct AccessorBindingInfo {
+            DFBSpecName dfb_spec_name;
+            bool has_producer = false;
+            bool has_consumer = false;
+        };
+        std::unordered_map<std::string, AccessorBindingInfo> accessor_bindings;
         for (const auto& dfb_binding : kernel.dfb_bindings) {
-            auto [it, inserted] = accessor_names.insert(dfb_binding.local_accessor_name);
+            auto [it, inserted] = accessor_bindings.try_emplace(
+                dfb_binding.local_accessor_name, AccessorBindingInfo{dfb_binding.dfb_spec_name});
+            AccessorBindingInfo& info = it->second;
+            if (inserted) {
+                TT_FATAL(
+                    IsValidCppIdentifier(dfb_binding.local_accessor_name),
+                    "Kernel '{}' DFB local_accessor_name '{}' must be a valid C++ identifier",
+                    kernel.unique_id,
+                    dfb_binding.local_accessor_name);
+            } else {
+                TT_FATAL(
+                    info.dfb_spec_name == dfb_binding.dfb_spec_name,
+                    "Kernel '{}' uses local_accessor_name '{}' for two different DFBs ('{}' and '{}'). "
+                    "Reusing a name is only permitted when both bindings target the same DFB (self-loop pair).",
+                    kernel.unique_id,
+                    dfb_binding.local_accessor_name,
+                    info.dfb_spec_name,
+                    dfb_binding.dfb_spec_name);
+            }
+            const bool is_producer = (dfb_binding.endpoint_type == KernelSpec::DFBEndpointType::PRODUCER);
+            bool& seen_this_type = is_producer ? info.has_producer : info.has_consumer;
             TT_FATAL(
-                inserted,
-                "Kernel '{}' has duplicate local_accessor_name '{}'",
+                !seen_this_type,
+                "Kernel '{}' has duplicate {} binding for local_accessor_name '{}'",
                 kernel.unique_id,
+                is_producer ? "PRODUCER" : "CONSUMER",
                 dfb_binding.local_accessor_name);
-            TT_FATAL(
-                IsValidCppIdentifier(dfb_binding.local_accessor_name),
-                "Kernel '{}' DFB local_accessor_name '{}' must be a valid C++ identifier",
-                kernel.unique_id,
-                dfb_binding.local_accessor_name);
+            seen_this_type = true;
 
             // Referential integrity: the DFB must exist
             TT_FATAL(

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -704,12 +704,12 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     // Compute kernels cannot have any semaphore bindings.
-    // (This may later change for Quasar.)
+    // (There's no use case for ever wanting this, so best just forbid it.)
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(
             !kernel.is_compute_kernel() || kernel.semaphore_bindings.empty(),
             "KernelSpec '{}' has semaphore bindings. "
-            "Semaphore bindings are not currently supported for compute kernels.",
+            "Semaphore bindings are not supported for compute kernels.",
             kernel.unique_id);
     }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -943,9 +943,12 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             "a RemoteDataflowBufferSpec.",
             dfb.unique_id);
 
-        // Self-loop interplay with multi-binding: a kernel that self-loops a DFB (appears in
-        // both producers and consumers) must be the only binding on each side. Mixing self-loop
-        // with non-self-loop bindings on the same DFB is not currently supported.
+        // Self-loop interplay with multi-binding: when ANY kernel self-loops a DFB (appears in
+        // both producers and consumers), the producer set must equal the consumer set as sets
+        // of KernelSpec*. This permits the natural pattern of multiple same-source KernelSpecs
+        // each self-looping the DFB on their disjoint node ranges, while rejecting the case
+        // where a self-looping kernel shares the DFB with an unrelated kernel (which would
+        // make per-instance tensix-scope semantics ambiguous).
         const bool has_self_loop = [&] {
             for (const auto& p : endpoints.producers) {
                 for (const auto& c : endpoints.consumers) {
@@ -957,12 +960,45 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             return false;
         }();
         if (has_self_loop) {
+            std::unordered_set<const KernelSpec*> producer_kernels;
+            std::unordered_set<const KernelSpec*> consumer_kernels;
+            for (const auto& p : endpoints.producers) {
+                producer_kernels.insert(p.kernel);
+            }
+            for (const auto& c : endpoints.consumers) {
+                consumer_kernels.insert(c.kernel);
+            }
             TT_FATAL(
-                endpoints.producers.size() == 1 && endpoints.consumers.size() == 1,
-                "DFB '{}' is self-looped (bound by a kernel as both producer and consumer) and also "
-                "has additional bindings. Self-loop is currently restricted to a single producer "
-                "KernelSpec and a single consumer KernelSpec.",
+                producer_kernels == consumer_kernels,
+                "DFB '{}' is self-looped (some kernel appears as both producer and consumer), but "
+                "the set of producer KernelSpecs differs from the set of consumer KernelSpecs. "
+                "When a DFB is self-looped, every same-side binding must come from a self-loop "
+                "participant (i.e. a kernel that appears on both sides).",
                 dfb.unique_id);
+
+            // All self-loop participants must agree on the tensix-scope for this DFB —
+            // MakeDataflowBufferConfig writes a single tensix_scope into the DFB config, and the
+            // self-loop participants alternate per node, so a disagreement is unresolvable.
+            auto scope_for_kernel = [&](const KernelSpec* k) {
+                for (const auto& entry : k->dfb_compute_self_loop_scopes) {
+                    if (entry.dfb_spec_name == dfb.unique_id) {
+                        return entry.scope;
+                    }
+                }
+                return KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA;
+            };
+            const auto* first_kernel = *producer_kernels.begin();
+            const auto first_scope = scope_for_kernel(first_kernel);
+            for (const KernelSpec* k : producer_kernels) {
+                TT_FATAL(
+                    scope_for_kernel(k) == first_scope,
+                    "DFB '{}' is self-looped; all self-loop participants must agree on "
+                    "DFBComputeSelfLoopScope::Scope, but kernel '{}' specifies a different scope "
+                    "than kernel '{}'.",
+                    dfb.unique_id,
+                    k->unique_id,
+                    first_kernel->unique_id);
+            }
         }
     }
 
@@ -1696,15 +1732,28 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     auto consumer_access_pattern = to_hw_access_pattern(consumer_binding->access_pattern);
 
     // For a compute kernel that self-loops a DFB (binds it as both producer and consumer), the
-    // lower-layer DFB API requires an explicit scope. Self-loop is restricted to
-    // single-producer-single-consumer (validated upstream), so the producer/consumer check is
-    // pointer equality on the representative records.
+    // lower-layer DFB API requires an explicit scope. Self-loop is detected as any overlap
+    // between the producer and consumer kernel sets — under the multi-binding regime, the
+    // first-record pointers may differ even when the kernel sets are identical (the overlap is
+    // what matters, not vector ordering). Upstream validation guarantees producer set ==
+    // consumer set whenever any overlap exists, and that all self-loop participants agree on
+    // the tensix scope; reading from the first producer is therefore safe and representative.
     // The user can declare scope via KernelSpec::dfb_compute_self_loop_scopes:
     //  - absence of an entry means we infer INTRA (the common case)
     //  - user-specified INTRA is also fine
     //  - user-specified INTER is not currently supported. This will have already failed validation.
+    const bool is_self_loop = [&] {
+        for (const auto& p : dfb_endpoint_info.producers) {
+            for (const auto& c : dfb_endpoint_info.consumers) {
+                if (p.kernel == c.kernel) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }();
     std::optional<experimental::dfb::TensixScope> tensix_scope;
-    if (producer == consumer && producer->is_compute_kernel()) {
+    if (is_self_loop && producer->is_compute_kernel()) {
         auto user_scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA;
         for (const auto& entry : producer->dfb_compute_self_loop_scopes) {
             if (entry.dfb_spec_name == dfb_spec->unique_id) {


### PR DESCRIPTION
### PR Category
Bugfix

### Summary
This PR groups together several very small fixes to the Metal 2.0 validation, error messages, and comments:

1. **Clarify compute kernel semaphore error message**
2. **Document multi-KernelSpec-per-source specialization** — clarify wording in the KernelSpec header that the first reduction-port AI misread as forbidding multi-KernelSpec specialization.
3. **Allow shared local_accessor_name for DFB self-loop bindings** — a kernel that self-loops a DFB no longer has to pick two distinct accessor names.
4. **Don't require empty kernel_run_params entries** — kernels with all-empty RTA/CRTA schemas no longer need a stub entry; kernels with non-empty schemas still require one.
5. **Allow multi-PRODUCER and multi-CONSUMER DFB bindings** — relaxes the strict "one producer KernelSpec, one consumer KernelSpec" rule to its physical equivalent (one producer instance and one consumer instance per node). Unblocks the canonical Metal 2.0 expression of legacy "two KernelDescriptors per work split, sharing CBs".
6. **Improve ComputeConfiguration::unpack_to_dest_mode legality checks** — only required for Float32 DFBs; non-FP32 DFBs may omit (or explicitly use Default).

### Notes for reviewers
The diff is ugly, sorry. It's pretty much all just legality check boilerplate, with mock device tests to match.
The only change to a public API file is a comment.

Two of the legality check changes are genuinely interesting:

 - Item 6 is a bit more restrictive than before, but should help eliminate a frequent source of bugs for kernel authors. I think it will be a great benefit to AI authors, as it forces attention to the pertinent comment in base_types.hpp if it ever sets off the legality check. We can always relax the legality check again if it proves unpopular.

 - Item 5 is an interesting case that I hadn't considered before. @abhullar-tt, this one is pertinent. The issue with "same kernel, different CTAs, but sharing the same CB" issue surfaced during the op porting experiments. This is a cheap fix on WH/BH (implemented here), but a different story on Quasar, where the RISC mask mismatch is a real risk. 

### TODO
This PR handles the Quasar RISC mask mismatch issue with a (temporary) Internal error message. This is to unblock ops porting. I will need to follow up with solver constraints to address this properly on Quasar. (And improve the error messaging on WH/BH.)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/misc-op-port-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/misc-op-port-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/misc-op-port-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/misc-op-port-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/misc-op-port-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/misc-op-port-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/misc-op-port-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/misc-op-port-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/misc-op-port-fixes)