### PR TITLE
[BH] pack_untilize MOP perf: CFGSHIFTMASK + AddrMod-driven row advance

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -133,7 +133,7 @@ DEVICE_PERF_EXPECTATIONS = {
     },
     "vae_encode_1024x1024": {
         "wormhole": 328_968_938,  # Note: this is an average value of 30 test runs due to high variability
-        "blackhole": 143_563_697,
+        "blackhole": 141_175_333,
     },
     "vae_encode_512x512": {
         "wormhole": 85_005_572,  # Note: this is an average value of 30 test runs due to high variability

--- a/models/demos/vision/classification/resnet50/blackhole/tests/test_perf_device_resnet50.py
+++ b/models/demos/vision/classification/resnet50/blackhole/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.perf_d
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-16-device_params0", 11009.245],
-        [32, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-32-device_params0", 13596.6552],
+        [16, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-16-device_params0", 11697.7278],
+        [32, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-32-device_params0", 14688.9657],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -19,10 +19,19 @@ using namespace ckernel::packer;
 
 inline void _llk_pack_untilize_configure_addrmod_()
 {
+    // ADDR_MOD_0: used by every inner-loop PACR. y_src stays put (W advances via INCADCZW).
     addr_mod_pack_t {
         .y_src = {.incr = 0, .clr = 0},
     }
         .set(ADDR_MOD_0);
+
+    // ADDR_MOD_1: used by the row-closing PACR (set_last_inner_loop_instr).
+    // y_src.incr=1 folds the per-row "advance Dst face-row" into the PACR itself,
+    // replacing the explicit INCADCXY that previously ran as end_op0.
+    addr_mod_pack_t {
+        .y_src = {.incr = 1, .clr = 0},
+    }
+        .set(ADDR_MOD_1);
 }
 
 /*
@@ -90,32 +99,34 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
     */
     tmp.set_start_op(TT_OP_ADDRCRZW(p_setadc::PAC, 0, 0, 0, 0, 0b0010 /*CH0_W*/)); // W = W_Cr (restore W to start of block)
 
-    const std::uint32_t replay_buf_len = 4;
+    const std::uint32_t replay_buf_len = 2;
     load_replay_buf(
         ckernel::packer::replay_buf_offset,
         replay_buf_len,
         []
         {
-            // Update L1 address
-            TTI_ADDDMAREG(0, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR_OFFSET);
-            TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-            TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
+            // THCON_SEC0_REG1_L1_Dest_addr_ADDR32 += SCRATCH_SEC[CurrentThread].val
+            // Scratch slot loaded in _llk_pack_untilize_init_ holds the per-row L1 stride.
+            // Replaces ADDDMAREG + STALLWAIT + WRCFG + NOP — saves ~3 cyc + 1 STALLWAIT per row.
+            // Mirrors llk_unpack_tilize.h:285 precedent.
+            TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
             TTI_NOP;
         });
 
-    // After the inner loop finishes, move to the next row in the block, and update L1 address.
-    tmp.set_end_ops(TT_OP_INCADCXY(p_setadc::PAC, 0, 0, 1, 0), lltt::replay_insn(ckernel::packer::replay_buf_offset, replay_buf_len));
+    // After the inner loop finishes, update L1 address. The "advance Dst face-row" is folded
+    // into the row-closing PACR's AddrMod (ADDR_MOD_1, set below), so no INCADCXY end_op is needed.
+    tmp.set_end_op(lltt::replay_insn(ckernel::packer::replay_buf_offset, replay_buf_len));
 
     /*
     Close the row in the block by setting the Last bit to 1 in the last inner loop instruction.
-    This will allow the L1 address to be updated for the next row.
+    Use ADDR_MOD_1 so the packer auto-advances y_src by 1 (next row in face) post-PACR.
     Revisit after #22820 to convert last_loop_op to constexpr.
     */
     std::uint32_t last_loop_op = TT_OP_PACR(
         p_pacr::CFG_CTXT_0,
         p_pacr::NO_ROW_PAD_ZERO,
         p_pacr::DST_ACCESS_STRIDED_MODE,
-        ADDR_MOD_0,
+        ADDR_MOD_1,
         p_pacr::ADDR_CNT_CTXT_0,
         0,
         PACK_INTF_SEL,
@@ -176,8 +187,15 @@ inline void _llk_pack_untilize_init_(
         output_addr_offset = SCALE_DATUM_SIZE(pack_dst_format, full_ct_dim * ((num_faces == 1) ? 1 : 2) * FACE_C_DIM);
     }
 
-    // Store 16B aligned row offset address
+    // Store 16B aligned row offset into a scratch cfg slot so the MOP replay buf can use
+    // CFGSHIFTMASK to do `THCON_SEC0_REG1_L1_Dest_addr += SCRATCH` per row.
+    // ScratchIndex=0b11 in the CFGSHIFTMASK selects SCRATCH_SEC[CurrentThread]; pack thread
+    // is TRISC2, so this slot is SCRATCH_SEC2.
     TT_SETDMAREG(0, LOWER_HALFWORD(output_addr_offset / 16), 0, LO_16(p_gpr_pack::OUTPUT_ADDR_OFFSET));
+    TT_SETDMAREG(0, UPPER_HALFWORD(output_addr_offset / 16), 0, HI_16(p_gpr_pack::OUTPUT_ADDR_OFFSET));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+    TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR_OFFSET, 0, SCRATCH_SEC2_val_ADDR32);
+    TTI_NOP;
 
     // Always include setup calls for safety (as recommended by maintainer)
     // Program packer to pack out the correct number of datums per row

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -19,15 +19,18 @@ using namespace ckernel::packer;
 
 inline void _llk_pack_untilize_configure_addrmod_()
 {
-    // ADDR_MOD_0: used by every inner-loop PACR. y_src stays put (W advances via INCADCZW).
+    // In DST_STRIDED_MODE, y_src tracks the row within each Dest face and W tracks
+    // the tile within Dest.
+    // ADDR_MOD_0: used by every inner-loop PACR. y_src stays on the current row;
+    // W advances via INCADCZW between tiles.
     addr_mod_pack_t {
         .y_src = {.incr = 0, .clr = 0},
     }
         .set(ADDR_MOD_0);
 
     // ADDR_MOD_1: used by the row-closing PACR (set_last_inner_loop_instr).
-    // y_src.incr=1 folds the per-row "advance Dst face-row" into the PACR itself,
-    // replacing the explicit INCADCXY that previously ran as end_op0.
+    // y_src.incr=1 advances to the next Dest face-row after packing, folding the
+    // explicit INCADCXY end_op into the PACR itself.
     addr_mod_pack_t {
         .y_src = {.incr = 1, .clr = 0},
     }


### PR DESCRIPTION
## Summary

Two changes to the BH `_llk_pack_untilize_mop_config_` MOP that together cut PACK-isolated cycles on `pack_untilize` by **~35% mean / -58% max** across the 832-variant `perf_pack_untilize.py` corpus.

**T2 — `TTI_CFGSHIFTMASK` replaces ADDDMAREG+STALLWAIT+WRCFG+NOP.** The per-row L1 destination address update becomes the canonical `cfg += SCRATCH_SEC[CurrentThread].val` pattern (mirrors `llk_unpack_tilize.h:285` on BH). Init writes the row stride into `SCRATCH_SEC2_val` (pack thread = TRISC2). MOP replay buf shrinks 4 → 2 instructions; saves ~3 cyc + 1 THCON stall per row.

**T3 — fold post-row Y-advance into the row-closing PACR via `ADDR_MOD_1`** (`y_src.incr=1`). Drops the explicit `INCADCXY` end_op. Row-closing PACR carries `ADDR_MOD_1`; inner-loop PACRs keep `ADDR_MOD_0` (`y_src.incr=0`). One fewer instruction at the end of every inner loop, no functional change.

**Known CI failure — Sanity / ttsim integration (BH):** the BH `ttsim-integration-tests` job crashes the simulator worker on every untilize-using ttnn data-movement test. Root cause is missing instruction support in ttsim, not a defect in this change. The new MOP issues `TTI_CFGSHIFTMASK` from the pack thread (TRISC2) targeting `SCRATCH_SEC[CurrentThread] = SCRATCH_SEC2`; the BH path in ttsim previously asserted `pipe == 0` and `scratch_index == 0`, both narrowings that pre-date any real caller and don't reflect the [BH ISA spec](https://github.com/tenstorrent/tt-isa-documentation/blob/main/BlackholeA0/TensixTile/TensixCoprocessor/CFGSHIFTMASK.md). Fix pending in [ttsim-private#375](https://github.com/tenstorrent/ttsim-private/pull/375) — widens BH `CFGSHIFTMASK` per ISA doc. Bumping `ttsim-version` in `.github/workflows/ttsim.yaml` after #375 ships unblocks Sanity.

## Wins

Cumulative vs `main` (T2+T3, 832-variant corpus):

| Metric              | Mean    | Max     |
|---------------------|---------|---------|
| L1_TO_L1            | -30.2%  | -54.1%  |
| PACK_ISOLATE        | -34.6%  | -57.6%  |
| L1_CONGESTION[PACK] | -32.3%  | -57.6%  |

Per-tile examples:
- `FP16 -> FP16  8×8`:   126.5 → 101.0 cyc/tile (**-20%**)
- `Bfp8 -> FP16  8×7`:   455.2 → 209.2 cyc/tile (**-54%**)

## BH perf-target updates

Adjusted to match the new cycle floor:
- SDXL `vae_encode_1024x1024`: `143_563_697` → `141_175_333` (-1.7%)
- ResNet50 batch 16: `11009.245` → `11697.7278` fps (+6.3%)
- ResNet50 batch 32: `13596.6552` → `14688.9657` fps (+8.0%)

## Test plan

- [x] Blackhole post-commit tests — passing on equivalent pre-squash SHA: [run 25992731109](https://github.com/tenstorrent/tt-metal/actions/runs/25992731109)
- [x] Merge Gate (includes `llk-unit-tests` matrix; gated on `llk-blackhole-changed`) on current tip: [run 25994029941](https://github.com/tenstorrent/tt-metal/actions/runs/25994029941)
- [x] Local: full `tests/ttnn/unit_tests/operations/sdpa/` suite (37 passed)
- [x] Local: `perf_pack_untilize.py` (832 variants pass)
- [x] Local: `test_zzz_pack_untilize.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/bh-untilize-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/bh-untilize-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/bh-untilize-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/bh-untilize-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/bh-untilize-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/bh-untilize-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/bh-untilize-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/bh-untilize-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/bh-untilize-perf)