### PR TITLE
Fix conv3d garbage output when batch size changes (#44565)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -8,6 +8,7 @@ import pytest
 import ttnn
 import torch.nn as nn
 from tests.ttnn.utils_for_testing import check_with_pcc
+from models.common.utility_functions import skip_with_watcher
 
 from tests.ttnn.unit_tests.operations.conv.test_conv3d import (
     setup_conv3d_test,
@@ -874,3 +875,29 @@ def test_conv3d_auto_blocking_large_c_in(device, input_shape, out_channels, kern
     pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
     logger.info(f"Conv3d auto-blocking large C_in (issue #35436): {pcc_message}")
     assert pcc_passed, pcc_message
+
+
+@skip_with_watcher("Skipping test with watcher enabled due to failure, see github issue #37184")
+def test_conv3d_program_cache_batch_size(device):
+    """Regression for issue #44565: B=1 then B=2 on the same device used to produce garbage output for B=2."""
+    grid_size = device.compute_with_storage_grid_size()
+    out_channels = 64
+    kernel_size = (3, 3, 3)
+    stride = (1, 1, 1)
+    groups = 1
+    padding = (0, 1, 1)
+    padding_mode = "zeros"
+
+    for B in (1, 2):
+        input_shape = (B, 12, 8, 10, 9)
+        run_conv3d_test(
+            device,
+            input_shape,
+            out_channels,
+            kernel_size,
+            stride,
+            groups,
+            padding,
+            padding_mode,
+            grid_size=grid_size,
+        )

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -155,7 +155,7 @@ Tensor prepare_conv3d_weights(
     uint32_t ALIGN_PAD = alignment - (C % alignment);
     if (C % alignment != 0) {
         ttnn::SmallVector<std::array<uint32_t, 2>> padding_shape({{0, 0}, {0, 0}, {0, 0}, {0, ALIGN_PAD}, {0, 0}});
-        prepare_weights = ttnn::pad(prepare_weights, padding_shape, 0.0f);
+        prepare_weights = ttnn::pad(prepare_weights, padding_shape, 0.0f, /*use_multicore=*/true);
     }
     // Reshape and permute weights
     auto weights_shape = prepare_weights.logical_shape();


### PR DESCRIPTION
## Summary
- `prepare_conv3d_weights` was calling `ttnn::pad` without `use_multicore`, defaulting to single-core pad in C++ (Python binding defaults to multi-core)
- Single-core pad's `override_runtime_arguments` cache-hit path is buggy — on alternating invocations the output keeps only half the non-zero values with the first elements zeroed, which then corrupts the weight buffer that conv3d mcasts
- Pass `use_multicore=true` to route to the working multi-core pad

Fixes: https://github.com/tenstorrent/tt-metal/issues/44565

## Test plan
- [x] `tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py::test_conv3d_program_cache_batch_size` — new regression, B=1 then B=2 on same device
- [x] Full local conv3d suite (`tests/ttnn/unit_tests/operations/conv/test_conv3d.py`): 1553/1553 PASS
- [x] Reproduced on ttsim with a 2×2 minimal repro; fixed there as well
- [ ] Sanity tests workflow on this branch
- [ ] Blackhole post-commit on this branch
- [ ] Nightly L2 (conv-only) on this branch

## Note
The underlying single-core `ttnn::pad` cache-hit bug still exists 
https://github.com/tenstorrent/tt-metal/pull/44601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-conv3d-prepare-weights-44565)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-conv3d-prepare-weights-44565)