### PR TITLE
[ttnn] paged_fill_cache: allow asymmetric num_heads under HMA tensor sharing

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -85,6 +85,46 @@ def _permute_tile_grid(t, view_block_size, view_head_dim):
     return t.view(N, KV, view_block_size, view_head_dim)
 
 
+def _permute_view_general(t_alloc, view_kv, view_block_size, view_head_dim):
+    """Like ``_permute_tile_grid`` but also reinterprets the kv-heads dimension.
+
+    Per-block tiles are stored linearly in ``(kv_head, bs_tile, hd_tile)`` order; with
+    that linearization the kv-head axis is just the outermost factor of the per-block
+    tile count, so changing it is the same kind of regroup as changing block_size or
+    head_dim. ``_permute_tile_grid`` is the special case where alloc_kv == view_kv.
+
+    Used to verify HMA cross-group sharing where sliding and full layers see one
+    physical buffer through views with different ``num_kv_heads`` (e.g. Gemma4-26B-A4B
+    sliding kv=8 / full kv=2). The per-block element-count invariant
+    ``alloc_kv * alloc_bs * alloc_hd == view_kv * view_bs * view_hd`` must hold.
+    """
+    N, alloc_kv, alloc_block_size, alloc_head_dim = t_alloc.shape
+    TILE = 32
+    assert alloc_block_size % TILE == 0 and alloc_head_dim % TILE == 0, "alloc dims must be tile-aligned"
+    assert view_block_size % TILE == 0 and view_head_dim % TILE == 0, "view dims must be tile-aligned"
+    alloc_BR_t = alloc_block_size // TILE
+    alloc_Wt = alloc_head_dim // TILE
+    view_BR_t = view_block_size // TILE
+    view_Wt = view_head_dim // TILE
+    alloc_total_tiles = alloc_kv * alloc_BR_t * alloc_Wt
+    view_total_tiles = view_kv * view_BR_t * view_Wt
+    assert alloc_total_tiles == view_total_tiles, (
+        f"per-block tile count mismatch: alloc {alloc_kv}*{alloc_BR_t}*{alloc_Wt}={alloc_total_tiles} "
+        f"vs view {view_kv}*{view_BR_t}*{view_Wt}={view_total_tiles}"
+    )
+
+    # Alloc-view (N, KV, BR_t, TILE, Wt, TILE) → tile-grid major (N, KV, BR_t, Wt, TILE, TILE),
+    # then flatten (KV, BR_t, Wt) into a single per-block tile axis.
+    t = t_alloc.view(N, alloc_kv, alloc_BR_t, TILE, alloc_Wt, TILE)
+    t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
+    t = t.reshape(N, alloc_total_tiles, TILE, TILE)
+    # Repack under view layout: (N, view_KV, view_BR_t, view_Wt, TILE, TILE) tile-grid major,
+    # then back to (N, view_KV, view_block_size, view_head_dim).
+    t = t.reshape(N, view_kv, view_BR_t, view_Wt, TILE, TILE)
+    t = t.permute(0, 1, 2, 4, 3, 5).contiguous()
+    return t.reshape(N, view_kv, view_block_size, view_head_dim)
+
+
 # ── paged_update_cache tests ───────────────────────────────────────────────
 
 
@@ -519,6 +559,98 @@ def test_paged_fill_cache_negative_byte_count_mismatch(device):
     page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
     x = torch.randn([1, num_kv_heads, input_seq_len, view_head_dim]).bfloat16().float()
+    xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    with pytest.raises(RuntimeError, match="geometry mismatch"):
+        ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, batch_idx=0, block_size=view_block_size)
+
+
+def test_paged_fill_cache_asymmetric_num_heads_per_block_match(device):
+    """Cache allocated with one ``num_kv_heads``, input filled with a different
+    ``num_kv_heads`` — the canonical Gemma4-26B-A4B / 31B HMA cross-group case
+    where sliding (kv=8, hd=256) and full (kv=2, hd=512) layers share one
+    physical buffer via vLLM's hybrid kv-cache-groups manager.
+
+    Allocates the cache under sliding's spec, fills via the full view, then
+    round-trips through ``_permute_view_general`` (which also reinterprets the
+    kv-head dimension) to verify the kernel laid the writes out where the full
+    view would later read them. Guards the relaxation in
+    ``paged_fill_cache_device_operation.cpp``: the per-block element-count
+    invariant ``input_kv * eff_bs * input_hd == cache_kv * cache_bs * cache_hd``
+    is the real constraint, not the strict ``input_kv == cache_kv``.
+    """
+    torch.manual_seed(14)
+    num_users = 2
+    # Sliding spec (alloc): kv=8, bs=64, hd=256 → 131072 elems/block.
+    cache_kv = 8
+    alloc_block_size = 64
+    alloc_head_dim = 256
+    # Full spec (call view): kv=2, bs=128, hd=512 → also 131072 elems/block.
+    view_kv = 2
+    view_block_size = 128
+    view_head_dim = 512
+    input_seq_len = 128  # exactly one view block per user
+    assert cache_kv * alloc_block_size * alloc_head_dim == view_kv * view_block_size * view_head_dim
+
+    max_num_blocks_per_seq = input_seq_len // view_block_size
+    max_num_blocks = num_users * max_num_blocks_per_seq
+
+    cache_shape = [max_num_blocks, cache_kv, alloc_block_size, alloc_head_dim]
+    cache_torch_alloc = torch.randn(cache_shape).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch_alloc, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    # Reference cache in the view's coordinate system. Re-tile the alloc-layout
+    # randoms into the (view_kv, view_bs, view_hd) layout so the slots the kernel
+    # touches line up with where we expect them in the view.
+    cache_ref_view = _permute_view_general(cache_torch_alloc, view_kv, view_block_size, view_head_dim).clone()
+    for u in range(num_users):
+        x = torch.randn([1, view_kv, input_seq_len, view_head_dim]).bfloat16().float()
+        xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+        ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, batch_idx=u, block_size=view_block_size)
+        for t in range(input_seq_len):
+            vb = t // view_block_size
+            slot = t % view_block_size
+            physical_block = page_table[u, vb].item()
+            cache_ref_view[physical_block, 0:view_kv, slot : slot + 1, :] = x[0, :, t : t + 1, :]
+
+    got_alloc = _read_paged_cache(cache_tt)
+    got_view = _permute_view_general(got_alloc, view_kv, view_block_size, view_head_dim)
+
+    eq, msg = comp_equal(cache_ref_view, got_view)
+    assert eq, f"asymmetric num_heads fill cache round trip mismatch: {msg}"
+
+
+def test_paged_fill_cache_negative_asymmetric_num_heads_byte_count_mismatch(device):
+    """Different ``num_kv_heads`` between cache and input *without* the per-block
+    element count being preserved must still be rejected. Guards against the
+    relaxation accidentally allowing arbitrary mismatched-byte writes.
+    """
+    torch.manual_seed(15)
+    num_users = 2
+    # Cache: 8 * 64 * 256 = 131072 elems/block.
+    cache_kv = 8
+    alloc_block_size = 64
+    alloc_head_dim = 256
+    # Input: 4 * 128 * 512 = 262144 elems/block — twice the cache, mismatched.
+    view_kv = 4
+    view_block_size = 128
+    view_head_dim = 512
+    input_seq_len = 128
+    assert cache_kv * alloc_block_size * alloc_head_dim != view_kv * view_block_size * view_head_dim
+
+    max_num_blocks_per_seq = input_seq_len // view_block_size
+    max_num_blocks = num_users * max_num_blocks_per_seq
+
+    cache_torch = torch.randn([max_num_blocks, cache_kv, alloc_block_size, alloc_head_dim]).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    x = torch.randn([1, view_kv, input_seq_len, view_head_dim]).bfloat16().float()
     xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
 
     with pytest.raises(RuntimeError, match="geometry mismatch"):

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -50,39 +50,36 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
         args.batch_idx_fallback < page_table_shape[0],
         "Batch idx must be within the page_table batch size");
 
-    // The program factory reads num_heads from input.padded_shape[1] and bakes it into
-    // the kernel's per-block stride, so input and cache must agree on num_heads
-    // independently of the per-block byte-count check below.
+    // Per-block element-count consistency. The program factory reads num_heads,
+    // block_size, and head_dim from the *input* tensor and computes the kernel's
+    // per-block stride as input_num_heads * effective_block_size * input_head_dim.
+    // For each new physical block in the cache buffer the kernel jumps by that
+    // stride, so it must equal the cache's actual per-block element count.
+    // Allowing input_num_heads != cache_num_heads (as long as the per-block
+    // element count is preserved) enables HMA cross-group tensor sharing for
+    // models with asymmetric num_kv_heads per layer type (e.g. Gemma4 26B-A4B
+    // with sliding kv=8 and full kv=2). Trivially holds for legacy callers
+    // with no override and matching shapes.
     const uint32_t cache_num_heads = cache_shape[1];
     const uint32_t input_num_heads = input_shape[1];
-    TT_FATAL(
-        input_num_heads == cache_num_heads,
-        "paged_fill_cache num_heads mismatch: input has {} heads but cache has {}.",
-        input_num_heads,
-        cache_num_heads);
-
-    // Per-block byte-count consistency. When the caller reinterprets the cache with a
-    // different (block_size, head_dim) view via block_size_override, the kernel's
-    // per-block element stride (num_kv_heads * block_size * head_dim) must be preserved.
-    // Trivially holds for legacy callers (no override, matching head dims).
     const uint32_t cache_block_size = cache_shape[2];
     const uint32_t cache_head_dim = cache_shape[3];
     const uint32_t input_head_dim = input_shape[3];
     const uint32_t effective_block_size = args.block_size_override.value_or(cache_block_size);
     const uint64_t cache_elems_per_block = static_cast<uint64_t>(cache_num_heads) * cache_block_size * cache_head_dim;
     const uint64_t view_elems_per_block =
-        static_cast<uint64_t>(cache_num_heads) * effective_block_size * input_head_dim;
+        static_cast<uint64_t>(input_num_heads) * effective_block_size * input_head_dim;
     TT_FATAL(
         view_elems_per_block == cache_elems_per_block,
         "paged_fill_cache geometry mismatch: cache has {} elems/block "
-        "(kv_heads={}, block_size={}, head_dim={}) but call view is {} "
+        "(kv_heads={}, block_size={}, head_dim={}) but input view is {} "
         "(kv_heads={}, block_size={}, head_dim={}).",
         cache_elems_per_block,
         cache_num_heads,
         cache_block_size,
         cache_head_dim,
         view_elems_per_block,
-        cache_num_heads,
+        input_num_heads,
         effective_block_size,
         input_head_dim);
     TT_FATAL(


### PR DESCRIPTION
## Summary

- Relaxes `paged_fill_cache` validation so input and cache may have different `num_kv_heads` as long as per-block element counts match.
- Folds the old `input_num_heads == cache_num_heads` TT_FATAL into the existing per-block byte-count check by computing `view_elems_per_block` from `input_num_heads` instead of `cache_num_heads`.
- Kernel itself is unchanged — it already reads `num_heads`/`block_size`/`head_dim` from input via the program factory.

## Why

PR #44073 added `block_size_override` so one DRAM cache buffer could be reinterpreted with different `(block_size, head_dim)` views per layer, which is how vLLM's hybrid-kv-cache-groups manager enables HMA tensor sharing for models with mixed sliding/full attention.

That works when sliding and full have the *same* `num_kv_heads`. For Gemma4-26B-A4B (sliding kv=8, full kv=2) and Gemma4-31B (kv=16/4), the unifier produces matching per-block bytes via different `(num_kv_heads, block_size, head_dim)` triples — but the existing `input_num_heads == cache_num_heads` TT_FATAL rejects the HMA cross-group write at runtime:

> `TT_FATAL: paged_fill_cache num_heads mismatch: input has 2 heads but cache has 8.`

The kernel's `block_stride = num_heads * block_size_t * Wt` already derives those quantities from the input tensor (see `paged_fill_cache_program_factory.cpp:42,45,46`). The only real invariant is:

```
input_num_heads * effective_block_size * input_head_dim
  == cache_num_heads * cache_block_size * cache_head_dim
```

i.e., the kernel's per-block stride must equal the cache's actual per-block element count. The previous `view_elems_per_block` formula used `cache_num_heads` on both sides, so `num_heads` cancelled and only `effective_block_size * input_head_dim == cache_block_size * cache_head_dim` was enforced — the per-head dimension was unchecked, hence the separate strict equality. This commit puts `input_num_heads` in `view_elems_per_block` and drops the strict-equality TT_FATAL.

Under HMA cross-group sharing each layer is the sole writer *and* reader of its own block IDs (vLLM's block-pool guarantees disjoint allocations across groups), so the within-block reordering between sliding and full views is invisible at the model level.

## Compatibility

Legacy callers (no `block_size_override`, matching shapes) are unaffected — the equality reduces to true on identical `(kv_heads, block_size, head_dim)`. Verified `paged_fill_cache` callers across the tree all currently pass `input_num_heads == cache_num_heads`:

- `models/tt_transformers/tt/attention.py`
- `models/demos/llama3_70b_galaxy/tt/llama_attention.py`
- `models/demos/qwen3_vl/tt/attention.py`
- `models/demos/gpt_oss/tt/attention/prefill.py`
- `models/demos/gemma4/tt/attention/prefill.py` *(this is the caller that needs the relaxation for 26B-A4B / 31B)*
- `models/common/modules/attention/attention_1d.py`
- `models/demos/deepseek_v3/tt/mla/mla1d.py`

## Out of scope

`paged_update_cache` (decode counterpart) reads `num_heads` from `cache.padded_shape[1]` rather than input, so asymmetric HMA writes on the decode path remain unsupported. That needs a separate fix (kernel change to read `num_heads` from input, like `paged_fill_cache` does). The Gemma4 hybrid-KVC branch can be unblocked on the prefill / fill-cache path with this PR alone.

## Test plan

- [ ] Confirm the existing Gemma4 prefill smoke (`test_attention_prefill[blackhole-seq4096-global-1x*]` on E2B / E4B / Llama / etc. SKUs) still passes — covers the legacy `input_num_heads == cache_num_heads` path.
- [ ] Confirm Gemma4-26B-A4B / 31B `test_full_model_parity_uniform_vs_vllm` and `test_attention_paged_decode_via_harness` get past the previous `paged_fill_cache num_heads mismatch` TT_FATAL on the first `paged_fill_cache` call. (Decode-path failures remain expected until `paged_update_cache` is fixed in a follow-up.)
- [ ] Spot-check Llama 70B Galaxy and Qwen3 VL `paged_fill_cache` paths to confirm legacy callers see no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/paged-fill-cache-asymmetric-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/paged-fill-cache-asymmetric-heads)