### PR TITLE
Fix no-MOP matmul DEST sync

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -347,6 +347,24 @@ inline void _llk_math_matmul_uninit_no_mop_()
     // No state to restore - all states are transient or default
 }
 
+template <MathFidelity math_fidelity>
+inline void matmul_set_dst_write_addr_for_replay_no_mop(const std::uint32_t tile_index)
+{
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(tile_index);
+    if constexpr (math_fidelity == MathFidelity::HiFi4)
+    {
+        // Resolves a HiFi4 race with issuing REPLAY; address properly under tt-metal#44693.
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+    }
+}
+
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void _llk_math_matmul_no_mop_(std::uint32_t dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1)
 {
@@ -371,7 +389,7 @@ inline void _llk_math_matmul_no_mop_(std::uint32_t dst_index, const std::uint32_
     {
         for (std::uint32_t rut = 0; rut < rut_dim; rut++)
         {
-            math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + (reuse_a ? ct_dim * t + rut : t + rut * ct_dim));
+            matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + (reuse_a ? ct_dim * t + rut : t + rut * ct_dim));
 
             if constexpr (THROTTLE_LEVEL > 0)
             {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -170,6 +170,24 @@ inline void matmul_load_replay_no_mop(const std::uint32_t ct_dim, const std::uin
 }
 
 template <MathFidelity math_fidelity>
+inline void matmul_set_dst_write_addr_for_replay_no_mop(const std::uint32_t tile_index)
+{
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(tile_index);
+    if constexpr (math_fidelity == MathFidelity::HiFi4)
+    {
+        // Resolves a HiFi4 race with issuing REPLAY; address properly under tt-metal#44693.
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+        TTI_NOP;
+    }
+}
+
+template <MathFidelity math_fidelity>
 inline void matmul_execute_replay_no_mop(const std::uint32_t replay_buf_len, const bool reuse_a, const std::uint32_t t_dim)
 {
     if constexpr (!is_high_fidelity(math_fidelity))
@@ -206,11 +224,11 @@ inline void matmul_run_no_mop_tdim1_reuse_a(const std::uint32_t dst_index, const
 {
     for (std::uint32_t rut = 0; (rut + 1) < rut_dim; rut++)
     {
-        math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + rut);
+        matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + rut);
         matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, true, 1);
     }
 
-    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + rut_dim - 1);
+    matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + rut_dim - 1);
     matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, true, 1);
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
 }
@@ -221,11 +239,11 @@ inline void matmul_run_no_mop_tdim1_reuse_b(
 {
     for (std::uint32_t rut = 0; (rut + 1) < rut_dim; rut++)
     {
-        math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + rut * ct_dim);
+        matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + rut * ct_dim);
         matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, false, 1);
     }
 
-    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + (rut_dim - 1) * ct_dim);
+    matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + (rut_dim - 1) * ct_dim);
     matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, false, 1);
     TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
 }
@@ -241,13 +259,13 @@ inline void matmul_run_no_mop_tdim_gt1_reuse_a(
     {
         for (std::uint32_t rut = 0; (rut + 1) < rut_dim; rut++)
         {
-            math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + ct_dim * t + rut);
+            matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + ct_dim * t + rut);
             matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, true, t_dim);
 
             if ((t + 1) < t_dim)
             {
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-                math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + ct_dim * (t + 1) + rut);
+                matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + ct_dim * (t + 1) + rut);
                 matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, true, t_dim);
             }
 
@@ -255,13 +273,13 @@ inline void matmul_run_no_mop_tdim_gt1_reuse_a(
         }
 
         const std::uint32_t rut = rut_dim - 1;
-        math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + ct_dim * t + rut);
+        matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + ct_dim * t + rut);
         matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, true, t_dim);
 
         if ((t + 1) < t_dim)
         {
             TTI_CLEARDVALID(p_setrwc::CLR_B, 0);
-            math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + ct_dim * (t + 1) + rut);
+            matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + ct_dim * (t + 1) + rut);
             matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, true, t_dim);
         }
 
@@ -281,13 +299,13 @@ inline void matmul_run_no_mop_tdim_gt1_reuse_b(
     {
         for (std::uint32_t rut = 0; (rut + 1) < rut_dim; rut++)
         {
-            math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + t + rut * ct_dim);
+            matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + t + rut * ct_dim);
             matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, false, t_dim);
 
             if ((t + 1) < t_dim)
             {
                 TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
-                math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + t + 1 + rut * ct_dim);
+                matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + t + 1 + rut * ct_dim);
                 matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, false, t_dim);
             }
 
@@ -295,13 +313,13 @@ inline void matmul_run_no_mop_tdim_gt1_reuse_b(
         }
 
         const std::uint32_t rut = rut_dim - 1;
-        math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + t + rut * ct_dim);
+        matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + t + rut * ct_dim);
         matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, false, t_dim);
 
         if ((t + 1) < t_dim)
         {
             TTI_CLEARDVALID(p_setrwc::CLR_A, 0);
-            math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + t + 1 + rut * ct_dim);
+            matmul_set_dst_write_addr_for_replay_no_mop<math_fidelity>(dst_index + t + 1 + rut * ct_dim);
             matmul_execute_replay_no_mop<math_fidelity>(replay_buf_len, false, t_dim);
         }
 


### PR DESCRIPTION
## Summary
- Replace the earlier `mop_sync()` workaround with a no-MOP matmul helper that inserts a short fixed issue gap after programming the DEST target and before direct `REPLAY`.
- Limit the temporary issue gap to `HiFi4`, which covers the MLA mismatch path while leaving the `HiFi2` SDPA perf path unchanged.
- Apply the helper to the Blackhole no-MOP path and to all Wormhole no-MOP direct replay call sites.
- Keep this PR scoped to LLK kernel behavior; there are no Python test threshold changes in the PR diff.

## Context
This came out of the SDPA zigzag work in https://github.com/tenstorrent/tt-metal/pull/44480, specifically the discussion at https://github.com/tenstorrent/tt-metal/pull/44480#discussion_r3248247552.

`matmul_block_no_mop` bypasses the regular `ckernel_template`/MOP execution path and issues `lltt::replay()` directly after updating the math DEST target. The failing MLA path is sensitive to that ordering. Experiments showed that both `mop_sync()` and plain NOP spacing can hide the mismatch; using a fixed issue gap avoids the math-draining cost of `TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH)`.

This should still be treated as a targeted mitigation, not the complete root-cause fix for the no-MOP replay race. The underlying behavior should be investigated properly under https://github.com/tenstorrent/tt-metal/issues/44693.

## Testing
- `SDPA_PERF_CHECKS=1 pytest "tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check[wan2_2_1xGLX_analog-q288-k512]"`
  - Passed locally: duration `2.169 ms`, math util `69.65%`, expected band `[69.51, 70.49]`.
- `pytest tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_prefill_chunked_vs_not.py`
  - Passed locally: `4 passed`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-no-mop-matmul-dest-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-no-mop-matmul-dest-sync)