### PR TITLE
WIP: single-galaxy 2-mesh cross-mesh socket smoke + ETH HAL bump

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pipeline/README.md
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/README.md
@@ -1,0 +1,251 @@
+# Cross-mesh socket smoke + perf
+
+A 2-rank test that drives `H2D socket → cross-mesh D2D socket → D2H socket` on
+either:
+
+- **One Blackhole galaxy** carved into two `(2, 4)` meshes (whole UBB trays).
+- **Two Blackhole galaxies** as two `(4, 8)` meshes connected by inter-galaxy
+  ethernet.
+
+Same Python test runs in both modes; only the rank-binding YAML and the
+launcher differ.
+
+The test verifies (a) cross-mesh `MeshSocket` data exchange is bit-exact and
+(b) measures end-to-end bandwidth for a configurable tensor shape (default
+`640×1792 bf16` = 2,293,760 bytes).
+
+It exists to validate the cross-mesh fabric path the production decode demo
+relies on, and as a building block for prefill→decode KV migration tests.
+
+
+## What's in here
+
+```
+test_cross_mesh_socket_smoke.py        — pytest (smoke + perf variants)
+runme_cross_mesh_smoke.sh              — single-galaxy launcher
+runme_2galaxy_cross_mesh_smoke.sh      — 2-galaxy launcher
+run_2galaxy_end_to_end.sh              — 2-galaxy launcher with recovery
+dual_tray_2x4_rank_bindings.yaml       — single-galaxy 2-rank binding (trays 1+2)
+dual_galaxy_rank_bindings.yaml         — 2-galaxy 2-rank binding (1 rank per host)
+bh_galaxy_dual_2x1_minimal.textproto   — (kept for reference; not viable)
+dual_2x1_minimal_rank_bindings.yaml    — (kept for reference; not viable)
+```
+
+The python test parametrizes on:
+
+- `mesh_device`: `(2, 4)` ids=`1galaxy`, `(4, 8)` ids=`2galaxy` — selected via `-k 1galaxy` or `-k 2galaxy`.
+- `page_size_bytes` (perf only): `256, 1024, 2048, 4096, 8192, 16384` — sweep
+  to map the bandwidth-vs-page-size curve.
+
+
+## Prerequisites
+
+### 1. tt-metal built with the ETH HAL bump
+
+Commit `7e1579142a3` on `jjovicic/socket-experiment` bumps
+`MEM_ERISC_KERNEL_CONFIG_SIZE` from 25 KB to 32 KB in
+`tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h`. The upstream 25 KB
+limit doesn't fit the current `FABRIC_2D` router program (~26000 B) for
+intra-galaxy cross-mesh paths with `assign_z_direction: true`.
+
+Verify the build picked it up:
+
+```bash
+grep MEM_ERISC_KERNEL_CONFIG_SIZE \
+    tt-metal/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+# Expect: #define MEM_ERISC_KERNEL_CONFIG_SIZE (32 * 1024)
+```
+
+If you see `(25 * 1024)`, `git checkout jjovicic/socket-experiment`, clear
+the kernel cache, and rebuild:
+
+```bash
+rm -rf ~/.cache/tt-metal-cache/
+./build_metal.sh --build-type RelWithDebInfo
+```
+
+### 2. (2-galaxy only) Inter-galaxy ETH PHYs trained
+
+A fresh galaxy reset via `tt-smi -glx_reset_auto` alone is **not** enough on
+this hardware — the inter-galaxy ethernet PHYs need to be trained by either a
+simultaneous-via-mpirun reset across all hosts and/or a traffic-sending
+cluster-validation pass.
+
+You can do this manually:
+
+```bash
+cd .../tt-metal
+./tools/scaleout/exabox/recover.sh --hosts <HOST_A>,<HOST_B> --num-iterations 10
+# Repeat 1-2 times if first run reports failures.
+```
+
+…or use the wrapper script:
+
+```bash
+./models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh \
+    --host-a bh-glx-d04u02 --host-b bh-glx-d04u08
+```
+
+`run_cluster_validation` (which `recover.sh` invokes) must be built. If it's
+missing under `build/tools/scaleout/`, rebuild tt-metal with the scaleout
+tools target.
+
+### 3. `TT_TCP_INTERFACE`
+
+The NIC name carrying inter-host traffic on your cluster. On the d04 hosts
+it's `ens5f0np0`. Find via:
+
+```bash
+ip -br addr | grep UP   # pick the one with a cluster-fabric IP
+```
+
+
+## Running
+
+
+### Single galaxy
+
+```bash
+cd /path/to/tt-blaze
+source env.sh
+bash tt-metal/models/demos/deepseek_v3_d_p/tests/pipeline/runme_cross_mesh_smoke.sh
+```
+
+`tt-run --bare --mpi-args "--oversubscribe"` packs both ranks onto the
+single allocated host. Rank 0 (mesh_id=0) gets tray 1 (chips 0–7); rank 1
+(mesh_id=1) gets tray 2 (chips 8–15). MGD is the in-tree
+`bh_galaxy_dual_2x4_intermesh.textproto` (4 intermesh channels with
+`assign_z_direction: true`, RELAXED policy).
+
+Smoke verifies 4 H2D→D2D→D2H iterations of a 64-byte `int32` tensor with
+bit-exact roundtrip. Perf sweep transfers a 640×1792 bf16 tensor 20× per
+page-size point, reports wall time + GB/s.
+
+
+### Two galaxies
+
+Easiest path is the wrapper:
+
+```bash
+cd /path/to/tt-blaze
+source env.sh
+bash tt-metal/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh \
+    --host-a bh-glx-d04u02 --host-b bh-glx-d04u08
+```
+
+Or run the two stages manually:
+
+```bash
+# 1. Train inter-galaxy ETH (repeat if needed)
+cd .../tt-metal
+./tools/scaleout/exabox/recover.sh --hosts bh-glx-d04u02,bh-glx-d04u08 --num-iterations 10
+
+# 2. Run the test (do NOT reset between training and this)
+cd /path/to/tt-blaze
+HOST_A=bh-glx-d04u02 HOST_B=bh-glx-d04u08 TT_TCP_INTERFACE=ens5f0np0 \
+    bash tt-metal/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_cross_mesh_smoke.sh
+```
+
+Both hosts must have:
+- `/data/jjovicic/...` on shared NFS (verified with `df -T`)
+- Passwordless SSH between them (`ssh-copy-id` once, both directions)
+- HAL-bumped tt-metal build (see prereq 1)
+
+The MGD is `dual_bh_galaxy_experimental_mesh_graph_descriptor.textproto`
+(2 `(4, 8)` meshes, 4 intermesh channels STRICT, `assign_z_direction: true`).
+
+
+## Expected results
+
+### Topology + setup
+
+```
+Inter-mesh mapping succeeded, found 2 mesh pair(s)
+[mesh_id=0] iter 0: write_tensor
+[mesh_id=1] iter 0: roundtrip OK
+...
+[rank with mesh_id={0,1}] smoke OK
+```
+
+### Perf (640×1792 bf16 = 2,293,760 bytes per logical tensor; 20 iters/point)
+
+Both single-galaxy and 2-galaxy land at the same numbers (±1%):
+
+```
+page_size  | per-tensor  | bandwidth
+-----------+-------------+--------------
+   256 B   | 10.7 ms     | 0.22 GB/s
+  1024 B   |  8.0 ms     | 0.29 GB/s
+  2048 B   |  7.8 ms     | 0.29 GB/s
+  4096 B   |  7.7 ms     | 0.30 GB/s
+  8192 B   |  7.6 ms     | 0.30 GB/s   ← plateau
+ 16384 B   |  7.6 ms     | 0.30 GB/s
+```
+
+The 0.30 GB/s plateau is the **single H2D writer / single D2H reader** ceiling
+for this socket path. Inter-galaxy DAC is fast enough that the bottleneck is
+elsewhere (per-page setup + single-channel pipeline depth, not the cable).
+
+
+## Troubleshooting
+
+
+### `TT_FATAL: Program size (X) too large for kernel config buffer (25600) on ACTIVE_ETH`
+
+You're on a build without the HAL bump (see prereq 1). Rebuild from
+`jjovicic/socket-experiment`.
+
+### `Inter-mesh mapping succeeded` then `Device N: Timeout (10000 ms) waiting for physical cores ... `
+
+Inter-galaxy ETH PHYs aren't trained. Run `recover.sh` (with validation, not
+`--skip-validation`) — see prereq 2. If one run isn't enough, run 2–3 times
+back-to-back with `--num-iterations 10`. Don't re-`tt-smi -glx_reset_auto`
+between recovery and the test.
+
+### `ETH_LIVE_STATUS: 0x0` on every chip via `tt-smi -s`
+
+Not a definitive "no link" signal — runtime fabric init is what trains the
+link, and the telemetry is misleading. Try running the test anyway and see
+whether device init succeeds.
+
+### `Permission denied (publickey)` from mpirun
+
+You need passwordless SSH between the two hosts.
+
+```bash
+[ -f ~/.ssh/id_ed25519 ] || ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519
+cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+# Repeat on the peer if ~/.ssh isn't on shared NFS.
+```
+
+### `All nodes which are allocated for this job are already filled.`
+
+SLURM allocated 1 task; you're trying to run 2 ranks. Already handled in the
+launchers via `--mpi-args "--oversubscribe"` (single-galaxy) or
+`--mpi-args "--host ${HOST_A}:1,${HOST_B}:1 ..."` (2-galaxy). If you write
+your own launcher, include `--oversubscribe`.
+
+
+## Why each MGD knob
+
+- **`assign_z_direction: true`** on the inter-mesh connection — instructs the
+  topology mapper to use **Z-direction physical ethernet ports** (the
+  inter-tray and inter-galaxy cables). Without this, the mapper would try
+  X/Y direction ports which don't reach another mesh.
+- **`channels { count: N policy: RELAXED|STRICT }`** — number of inter-mesh
+  ethernet channels the mapping requires. RELAXED accepts fewer if the
+  hardware doesn't provide all N (logged as a warning, not fatal); STRICT
+  must match exactly. The single-galaxy MGD asks for 8 in RELAXED mode and
+  uses the 4 the hardware actually has between trays.
+- **`device_topology { dims: [...] }`** must match the per-rank mesh shape:
+  `(2, 4)` for one tray, `(4, 8)` for one galaxy.
+
+
+## What it builds toward
+
+The cross-mesh socket path here is the same `SocketInterface` + cross-mesh
+`MeshSocket` machinery the production sp4 decode pipeline uses for inter-stage
+data. Confirming it works at the 2-rank level is the unit-test prerequisite
+for KV-cache migration between a prefill galaxy and a decode galaxy (step 3
+in the broader plan).

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/bh_galaxy_dual_2x1_minimal.textproto
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/bh_galaxy_dual_2x1_minimal.textproto
@@ -1,0 +1,37 @@
+# Black Hole galaxy: minimal dual-mesh MGD for the cross-mesh socket smoke.
+#
+# Two (2, 1) logical meshes (= 2 chips each) on one galaxy with a single
+# intermesh fabric channel between them. Simplest possible 2-mesh config that
+# still exercises cross-mesh D2D fabric.
+#
+# Channel count is 1 (vs 8 in bh_galaxy_dual_2x4_intermesh.textproto) so the
+# topology mapper only has to find ONE inter-tray ethernet link between the
+# two physical 2-chip regions.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 2, 1 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 1
+    policy: RELAXED
+  }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 1 policy: RELAXED }
+    directional: false
+    assign_z_direction: true
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/dual_2x1_minimal_rank_bindings.yaml
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/dual_2x1_minimal_rank_bindings.yaml
@@ -1,0 +1,24 @@
+# Minimal 2-rank single-galaxy rank binding for the cross-mesh socket smoke.
+#
+# rank 0 -> mesh_id=0, TT_VISIBLE_DEVICES=0,1 (tray 1, first 2 chips)
+# rank 1 -> mesh_id=1, TT_VISIBLE_DEVICES=8,9 (tray 2, first 2 chips)
+#
+# Each rank opens a (2, 1) MeshDevice with its 2 visible chips. The intermesh
+# fabric channel runs between tray 1 and tray 2 (adjacent UBB trays on the
+# galaxy backplane). Pairs with bh_galaxy_dual_2x1_minimal.textproto.
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1"
+      TT_METAL_SLOW_DISPATCH_MODE: "1"
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "8,9"
+      TT_METAL_SLOW_DISPATCH_MODE: "1"
+
+mesh_graph_desc_path: "models/demos/deepseek_v3_d_p/tests/pipeline/bh_galaxy_dual_2x1_minimal.textproto"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/dual_galaxy_rank_bindings.yaml
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/dual_galaxy_rank_bindings.yaml
@@ -1,0 +1,27 @@
+# Two-rank, two-host rank binding for the cross-mesh socket smoke on 2 galaxies.
+#
+# rank 0 -> mesh_id=0, runs on galaxy A (whole 32-chip galaxy as one (4, 8) mesh)
+# rank 1 -> mesh_id=1, runs on galaxy B (whole 32-chip galaxy as one (4, 8) mesh)
+#
+# Each rank takes its host's full galaxy. Intermesh fabric runs over the
+# inter-host network (configure --tcp-interface in runme_2galaxy_cross_mesh_smoke.sh
+# to whatever NIC carries fabric traffic on your cluster, e.g. ens5f0np0).
+#
+# Pairs with tt-metal's existing dual_bh_galaxy_experimental_mesh_graph_descriptor.textproto:
+#   - 2 meshes of (4, 8), 1 host each
+#   - 4 intermesh channels with assign_z_direction=true
+#   - RELAXED policy (so 1-of-N physical link mismatch becomes a warning, not fatal)
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides:
+      TT_METAL_SLOW_DISPATCH_MODE: "1"
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides:
+      TT_METAL_SLOW_DISPATCH_MODE: "1"
+
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_bh_galaxy_experimental_mesh_graph_descriptor.textproto"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/dual_galaxy_rank_bindings.yaml
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/dual_galaxy_rank_bindings.yaml
@@ -7,10 +7,13 @@
 # inter-host network (configure --tcp-interface in runme_2galaxy_cross_mesh_smoke.sh
 # to whatever NIC carries fabric traffic on your cluster, e.g. ens5f0np0).
 #
-# Pairs with tt-metal's existing dual_bh_galaxy_experimental_mesh_graph_descriptor.textproto:
+# Pairs with our forked bh_galaxy_dual_4x8_intermesh.textproto:
 #   - 2 meshes of (4, 8), 1 host each
-#   - 4 intermesh channels with assign_z_direction=true
-#   - RELAXED policy (so 1-of-N physical link mismatch becomes a warning, not fatal)
+#   - 2 intra-mesh channels per link, RELAXED
+#   - 8 inter-mesh channels (4 exit nodes × 2 channels), RELAXED, assign_z_direction
+# Channel counts match the physical BH-galaxy fabric topology so the socket
+# infra can route over all available channels (previously 4 STRICT, which
+# under-declared the available inter-galaxy bandwidth).
 
 rank_bindings:
   - rank: 0
@@ -24,4 +27,4 @@ rank_bindings:
     env_overrides:
       TT_METAL_SLOW_DISPATCH_MODE: "1"
 
-mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_bh_galaxy_experimental_mesh_graph_descriptor.textproto"
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_dual_4x8_intermesh.textproto"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/dual_tray_2x4_rank_bindings.yaml
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/dual_tray_2x4_rank_bindings.yaml
@@ -1,0 +1,29 @@
+# Two-rank single-galaxy rank binding using WHOLE trays per mesh.
+#
+# rank 0 -> mesh_id=0, TT_VISIBLE_DEVICES = tray 1 (chips 0..7)   — 2x4 mesh
+# rank 1 -> mesh_id=1, TT_VISIBLE_DEVICES = tray 2 (chips 8..15)  — 2x4 mesh
+#
+# Each tray is one UBB and naturally a 2×4 chip cluster, so the physical
+# layout matches the MGD's (2, 4) mesh_descriptor without scattering chips
+# across multiple trays. Intermesh fabric runs over the inter-tray backplane
+# ethernet links between trays 1 and 2 (Bus IDs 0x00 and 0x40).
+#
+# Reuses the existing bh_galaxy_dual_2x4_intermesh.textproto MGD (which
+# requires count: 8 intermesh channels). If 8 still doesn't fit physically,
+# we'd dial that down in a fork of the MGD.
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+      TT_METAL_SLOW_DISPATCH_MODE: "1"
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"
+      TT_METAL_SLOW_DISPATCH_MODE: "1"
+
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_dual_2x4_intermesh.textproto"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/dram_to_socket_sender.cpp
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/dram_to_socket_sender.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sender kernel for the pure-D2D pipeline test.
+//
+// Reads `data_size` bytes from a DRAM tensor (one page at a time, walked via
+// TensorAccessor) into a local L1 CB, then pushes each page into a cross-mesh
+// MeshSocket via single-link fabric writes. Companion: socket_to_dram_receiver.cpp.
+//
+// Modeled on tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp,
+// extended to walk DRAM pages via TensorAccessor (so the source lives in DRAM,
+// not L1).
+
+#include <cstdint>
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/socket_api.h"
+#include "api/tensor/tensor_accessor.h"
+
+void fabric_write_any_len(
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* data_packet_header_addr,
+    tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
+    uint32_t src_addr,
+    uint64_t dst_addr,
+    uint32_t xfer_size,
+    sender_downstream_encoding& downstream_enc) {
+    fabric_set_unicast_route(data_packet_header_addr, downstream_enc);
+    while (xfer_size > FABRIC_MAX_PACKET_SIZE) {
+        data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, FABRIC_MAX_PACKET_SIZE);
+        fabric_connection.wait_for_empty_write_slot();
+        fabric_connection.send_payload_without_header_non_blocking_from_address(src_addr, FABRIC_MAX_PACKET_SIZE);
+        fabric_connection.send_payload_flush_blocking_from_address(
+            (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+        dst_addr += FABRIC_MAX_PACKET_SIZE;
+        src_addr += FABRIC_MAX_PACKET_SIZE;
+        xfer_size -= FABRIC_MAX_PACKET_SIZE;
+    }
+    data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, xfer_size);
+    fabric_connection.wait_for_empty_write_slot();
+    fabric_connection.send_payload_without_header_non_blocking_from_address(src_addr, xfer_size);
+    fabric_connection.send_payload_flush_blocking_from_address(
+        (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+}
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+constexpr uint32_t data_cb_id = get_compile_time_arg_val(0);
+constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(1);
+constexpr uint32_t page_size = get_compile_time_arg_val(2);
+constexpr uint32_t num_pages = get_compile_time_arg_val(3);
+// TensorAccessor CT args for the DRAM source tensor start here.
+constexpr uint32_t input_args_cta_idx = 4;
+constexpr uint32_t input_args_crta_idx = 0;
+
+void kernel_main() {
+    size_t rt_args_idx = 0;
+    uint32_t input_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t socket_config_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+    tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
+        tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
+
+    auto input_addr_gen_args = TensorAccessorArgs<input_args_cta_idx, input_args_crta_idx>();
+    auto input_addr_gen = TensorAccessor(input_addr_gen_args, input_tensor_addr);
+
+    auto* data_packet_header_addr =
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+    auto* socket_packet_header_addr = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
+        get_write_ptr(fabric_packet_header_cb_id) + sizeof(PACKET_HEADER_TYPE));
+
+    fabric_connection.open();
+
+    SocketSenderInterface sender_socket = create_sender_socket_interface(socket_config_addr);
+    set_sender_socket_page_size(sender_socket, page_size);
+
+    for (uint32_t p = 0; p < num_pages; ++p) {
+        // Stage page p of the DRAM source into the L1 CB.
+        cb_reserve_back(data_cb_id, 1);
+        auto cb_addr = get_write_ptr(data_cb_id);
+        auto noc_read_addr = input_addr_gen.get_noc_addr(p);
+        noc_async_read<page_size>(noc_read_addr, cb_addr, page_size);
+        noc_async_read_barrier();
+        cb_push_back(data_cb_id, 1);
+
+        // Push page p across the fabric to the downstream socket FIFO.
+        socket_reserve_pages(sender_socket, 1);
+        uint32_t l1_read_addr = get_read_ptr(data_cb_id);
+        for (uint32_t i = 0; i < sender_socket.num_downstreams; ++i) {
+            sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
+            uint64_t receiver_noc_coord_addr = get_noc_addr(
+                downstream_enc.d2d.downstream_noc_x,
+                downstream_enc.d2d.downstream_noc_y,
+                sender_socket.write_ptr + sender_socket.downstream_fifo_addr);
+            fabric_write_any_len(
+                data_packet_header_addr,
+                fabric_connection,
+                l1_read_addr,
+                receiver_noc_coord_addr,
+                page_size,
+                downstream_enc);
+        }
+        socket_push_pages(sender_socket, 1);
+
+        fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);
+
+        cb_pop_front(data_cb_id, 1);
+    }
+
+    socket_barrier(sender_socket);
+    update_socket_config(sender_socket);
+    fabric_connection.close();
+}

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/dram_to_socket_sender.cpp
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/dram_to_socket_sender.cpp
@@ -5,11 +5,9 @@
 //
 // Reads `data_size` bytes from a DRAM tensor (one page at a time, walked via
 // TensorAccessor) into a local L1 CB, then pushes each page into a cross-mesh
-// MeshSocket via single-link fabric writes. Companion: socket_to_dram_receiver.cpp.
-//
-// Modeled on tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp,
-// extended to walk DRAM pages via TensorAccessor (so the source lives in DRAM,
-// not L1).
+// MeshSocket by splitting the page across TWO forward fabric links (matching
+// the production d2d_exchange.cpp pattern: num_fwd_links=2, num_bwd_links=1).
+// Companion: socket_to_dram_receiver.cpp.
 
 #include <cstdint>
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
@@ -17,6 +15,7 @@
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
 
+// Write `xfer_size` bytes on a single fabric link, breaking into FABRIC_MAX_PACKET_SIZE chunks.
 void fabric_write_any_len(
     volatile tt_l1_ptr PACKET_HEADER_TYPE* data_packet_header_addr,
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
@@ -50,38 +49,47 @@ constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(1);
 constexpr uint32_t page_size = get_compile_time_arg_val(2);
 constexpr uint32_t num_pages = get_compile_time_arg_val(3);
 // Toggles whether the sender waits for all pages to be acked before exiting.
-// Set to 0 in cross-host (2-galaxy) cases — see test_dram_to_dram_smoke.py for
-// why: receiver-side acks (`fabric_socket_notify_sender_stateful` inline writes)
-// don't reach the sender's `bytes_acked` counter over inter-host fabric, so the
-// barrier never returns. The data path itself is unaffected — bit-exact still
-// passes — but the FIFO-recycle bookkeeping that socket_barrier relies on does
-// not. With this disabled, num_pages must fit inside the socket FIFO since
-// pages won't be recycled.
+// See test_dram_to_dram_smoke.py for why this is a per-topology knob: cross-host
+// fabric acks have a credit-return gap that hangs the barrier; data path itself
+// is unaffected.
 constexpr uint32_t wait_for_acks = get_compile_time_arg_val(4);
 // TensorAccessor CT args for the DRAM source tensor start here.
 constexpr uint32_t input_args_cta_idx = 5;
 constexpr uint32_t input_args_crta_idx = 0;
+
+// Each page is split into 2 halves, one half per forward link. Page size must
+// be even.
+static_assert(page_size % 2 == 0, "page_size must be even — pages are split across 2 forward links");
 
 void kernel_main() {
     size_t rt_args_idx = 0;
     uint32_t input_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t socket_config_addr = get_arg_val<uint32_t>(rt_args_idx++);
 
-    tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
+    // Two forward fabric links (matches production d2d_exchange.cpp pattern).
+    tt::tt_fabric::WorkerToFabricEdmSender fabric_connection_0 =
+        tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
+    tt::tt_fabric::WorkerToFabricEdmSender fabric_connection_1 =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
     auto input_addr_gen_args = TensorAccessorArgs<input_args_cta_idx, input_args_crta_idx>();
     auto input_addr_gen = TensorAccessor(input_addr_gen_args, input_tensor_addr);
 
-    auto* data_packet_header_addr =
+    // Packet header CB layout: [data_link_0 | data_link_1 | socket_notify].
+    auto* data_packet_header_addr_0 =
         reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
-    auto* socket_packet_header_addr = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
+    auto* data_packet_header_addr_1 = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
         get_write_ptr(fabric_packet_header_cb_id) + sizeof(PACKET_HEADER_TYPE));
+    auto* socket_packet_header_addr = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
+        get_write_ptr(fabric_packet_header_cb_id) + 2 * sizeof(PACKET_HEADER_TYPE));
 
-    fabric_connection.open();
+    fabric_connection_0.open();
+    fabric_connection_1.open();
 
     SocketSenderInterface sender_socket = create_sender_socket_interface(socket_config_addr);
     set_sender_socket_page_size(sender_socket, page_size);
+
+    constexpr uint32_t half_page = page_size / 2;
 
     for (uint32_t p = 0; p < num_pages; ++p) {
         // Stage page p of the DRAM source into the L1 CB.
@@ -92,26 +100,38 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(data_cb_id, 1);
 
-        // Push page p across the fabric to the downstream socket FIFO.
+        // Push page p across the fabric — first half over link 0, second half
+        // over link 1. Receiver writes both halves contiguously into the socket
+        // FIFO at the downstream slot.
         socket_reserve_pages(sender_socket, 1);
         uint32_t l1_read_addr = get_read_ptr(data_cb_id);
         for (uint32_t i = 0; i < sender_socket.num_downstreams; ++i) {
             sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
-            uint64_t receiver_noc_coord_addr = get_noc_addr(
+            uint64_t receiver_noc_coord_addr_base = get_noc_addr(
                 downstream_enc.d2d.downstream_noc_x,
                 downstream_enc.d2d.downstream_noc_y,
                 sender_socket.write_ptr + sender_socket.downstream_fifo_addr);
             fabric_write_any_len(
-                data_packet_header_addr,
-                fabric_connection,
+                data_packet_header_addr_0,
+                fabric_connection_0,
                 l1_read_addr,
-                receiver_noc_coord_addr,
-                page_size,
+                receiver_noc_coord_addr_base,
+                half_page,
+                downstream_enc);
+            fabric_write_any_len(
+                data_packet_header_addr_1,
+                fabric_connection_1,
+                l1_read_addr + half_page,
+                receiver_noc_coord_addr_base + half_page,
+                half_page,
                 downstream_enc);
         }
         socket_push_pages(sender_socket, 1);
 
-        fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);
+        // Socket-notify goes on link 0 (the bwd-direction ack uses its own link
+        // on the receiver side, but the fwd-direction page-available notify
+        // shares one of the fwd links — same convention as production).
+        fabric_socket_notify_receiver(sender_socket, fabric_connection_0, socket_packet_header_addr);
 
         cb_pop_front(data_cb_id, 1);
     }
@@ -120,5 +140,6 @@ void kernel_main() {
         socket_barrier(sender_socket);
     }
     update_socket_config(sender_socket);
-    fabric_connection.close();
+    fabric_connection_0.close();
+    fabric_connection_1.close();
 }

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/dram_to_socket_sender.cpp
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/dram_to_socket_sender.cpp
@@ -49,8 +49,17 @@ constexpr uint32_t data_cb_id = get_compile_time_arg_val(0);
 constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(1);
 constexpr uint32_t page_size = get_compile_time_arg_val(2);
 constexpr uint32_t num_pages = get_compile_time_arg_val(3);
+// Toggles whether the sender waits for all pages to be acked before exiting.
+// Set to 0 in cross-host (2-galaxy) cases — see test_dram_to_dram_smoke.py for
+// why: receiver-side acks (`fabric_socket_notify_sender_stateful` inline writes)
+// don't reach the sender's `bytes_acked` counter over inter-host fabric, so the
+// barrier never returns. The data path itself is unaffected — bit-exact still
+// passes — but the FIFO-recycle bookkeeping that socket_barrier relies on does
+// not. With this disabled, num_pages must fit inside the socket FIFO since
+// pages won't be recycled.
+constexpr uint32_t wait_for_acks = get_compile_time_arg_val(4);
 // TensorAccessor CT args for the DRAM source tensor start here.
-constexpr uint32_t input_args_cta_idx = 4;
+constexpr uint32_t input_args_cta_idx = 5;
 constexpr uint32_t input_args_crta_idx = 0;
 
 void kernel_main() {
@@ -107,7 +116,9 @@ void kernel_main() {
         cb_pop_front(data_cb_id, 1);
     }
 
-    socket_barrier(sender_socket);
+    if constexpr (wait_for_acks) {
+        socket_barrier(sender_socket);
+    }
     update_socket_config(sender_socket);
     fabric_connection.close();
 }

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/socket_to_dram_receiver.cpp
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/socket_to_dram_receiver.cpp
@@ -47,13 +47,24 @@ void kernel_main() {
 
     fabric_connection.open_finish();
 
+    // Pre-compute the fabric unicast route + ack target NOC addr once, then use
+    // the _stateful notify variant inside the loop. This mirrors the production
+    // d2d_exchange.cpp pattern exactly; the non-stateful variant re-runs
+    // fabric_set_unicast_route on every call, which appears to leave the bwd
+    // path mis-routed on the cross-host fabric (sender's socket_barrier hangs
+    // because acks don't arrive).
+    fabric_set_unicast_route(socket_packet_header_addr, recv_socket);
+    uint64_t upstream_bytes_acked_noc_addr = get_noc_addr(
+        recv_socket.d2d.upstream_noc_x, recv_socket.d2d.upstream_noc_y, recv_socket.d2d.upstream_bytes_acked_addr);
+
     for (uint32_t p = 0; p < num_pages; ++p) {
         socket_wait_for_pages(recv_socket, 1);
         uint64_t dst_noc_addr = output_addr_gen.get_noc_addr(p);
         noc_async_write<page_size>(recv_socket.read_ptr, dst_noc_addr, page_size);
         noc_async_write_barrier();
         socket_pop_pages(recv_socket, 1);
-        fabric_socket_notify_sender(recv_socket, fabric_connection, socket_packet_header_addr);
+        fabric_socket_notify_sender_stateful(
+            recv_socket, fabric_connection, socket_packet_header_addr, upstream_bytes_acked_noc_addr);
     }
 
     update_socket_config(recv_socket);

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/socket_to_dram_receiver.cpp
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/kernels/socket_to_dram_receiver.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Receiver kernel for the pure-D2D pipeline test.
+//
+// For each of `num_pages` pages: wait for one page on the socket, `noc_async_write`
+// it from the socket FIFO straight into the DRAM destination tensor (walked via
+// TensorAccessor), pop the page, and ack the sender over the backward fabric link.
+//
+// Modeled on tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_receiver_worker.cpp,
+// changed to write to DRAM via TensorAccessor (so the destination lives in DRAM,
+// not L1).
+
+#include <cstdint>
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/socket_api.h"
+#include "api/tensor/tensor_accessor.h"
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(0);
+constexpr uint32_t page_size = get_compile_time_arg_val(1);
+constexpr uint32_t num_pages = get_compile_time_arg_val(2);
+// TensorAccessor CT args for the DRAM destination tensor start here.
+constexpr uint32_t output_args_cta_idx = 3;
+constexpr uint32_t output_args_crta_idx = 0;
+
+void kernel_main() {
+    size_t rt_args_idx = 0;
+    uint32_t recv_socket_config_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t output_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+    tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
+        tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
+
+    auto output_addr_gen_args = TensorAccessorArgs<output_args_cta_idx, output_args_crta_idx>();
+    auto output_addr_gen = TensorAccessor(output_addr_gen_args, output_tensor_addr);
+
+    fabric_connection.open_start();
+    auto* socket_packet_header_addr =
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+
+    SocketReceiverInterface recv_socket = create_receiver_socket_interface(recv_socket_config_addr);
+    set_receiver_socket_page_size(recv_socket, page_size);
+
+    fabric_connection.open_finish();
+
+    for (uint32_t p = 0; p < num_pages; ++p) {
+        socket_wait_for_pages(recv_socket, 1);
+        uint64_t dst_noc_addr = output_addr_gen.get_noc_addr(p);
+        noc_async_write<page_size>(recv_socket.read_ptr, dst_noc_addr, page_size);
+        noc_async_write_barrier();
+        socket_pop_pages(recv_socket, 1);
+        fabric_socket_notify_sender(recv_socket, fabric_connection, socket_packet_header_addr);
+    }
+
+    update_socket_config(recv_socket);
+    fabric_connection.close();
+}

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
@@ -142,4 +142,5 @@ source ./env.sh
 HOST_A="${HOST_A}" \
 HOST_B="${HOST_B}" \
 TT_TCP_INTERFACE="${TT_TCP_INTERFACE}" \
+K_FILTER="${K_FILTER:-2galaxy}" \
     bash "${RUNME}"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
@@ -94,15 +94,15 @@ if [[ "${SKIP_RECOVERY}" != true && ! -x "${VALIDATION_BIN}" ]]; then
 fi
 echo "[prereq] OK"
 
-echo "[prereq] checking SSH between hosts..."
+echo "[prereq] checking SSH to both hosts in BatchMode (mpirun's launcher path)..."
+# mpirun spawns remote MPI procs by ssh-ing from THIS host to each --host entry,
+# so what we need to verify is that this host can reach both A and B without
+# interactive prompts. We don't need to test "A reaching B" — mpirun never does
+# that (it launches from here to both, not via a hop).
 ssh -o BatchMode=yes -o ConnectTimeout=5 "${HOST_A}" hostname >/dev/null 2>&1 \
-    || { echo "ERROR: cannot SSH to ${HOST_A} without password" >&2; exit 1; }
+    || { echo "ERROR: cannot SSH to ${HOST_A} from here without password" >&2; exit 1; }
 ssh -o BatchMode=yes -o ConnectTimeout=5 "${HOST_B}" hostname >/dev/null 2>&1 \
-    || { echo "ERROR: cannot SSH to ${HOST_B} without password" >&2; exit 1; }
-# Cross-host hop (A reaching B) — mpirun needs this.
-ssh -o BatchMode=yes -o ConnectTimeout=5 "${HOST_A}" \
-    "ssh -o BatchMode=yes -o ConnectTimeout=5 ${HOST_B} hostname" >/dev/null 2>&1 \
-    || { echo "ERROR: cannot SSH from ${HOST_A} to ${HOST_B} without password" >&2; exit 1; }
+    || { echo "ERROR: cannot SSH to ${HOST_B} from here without password" >&2; exit 1; }
 echo "[prereq] OK"
 
 # --- Recovery -------------------------------------------------------------

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# End-to-end 2-galaxy cross-mesh socket smoke + perf.
+#
+# Does what you'd otherwise type by hand:
+#   1. Validate prerequisites (HAL bump, SSH, validation tool built)
+#   2. Run tools/scaleout/exabox/recover.sh N times back-to-back to train
+#      the inter-galaxy ETH PHYs (a single recover.sh call sometimes isn't
+#      enough — empirically 2 with --num-iterations 10 each is reliable).
+#   3. Launch runme_2galaxy_cross_mesh_smoke.sh on the trained fabric.
+#
+# Default hosts/interface match the d04 reservation; override via flags.
+
+set -eo pipefail
+
+HOST_A="bh-glx-d04u02"
+HOST_B="bh-glx-d04u08"
+TT_TCP_INTERFACE="ens5f0np0"
+NUM_RECOVERY_PASSES=2
+RECOVERY_ITERS=10
+SKIP_RECOVERY=false
+
+show_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+End-to-end 2-galaxy cross-mesh socket smoke + perf, including the
+inter-galaxy ETH PHY training step.
+
+Options:
+    --host-a HOST           First host (rank 0, mesh_id=0). Default: ${HOST_A}
+    --host-b HOST           Second host (rank 1, mesh_id=1). Default: ${HOST_B}
+    --tcp-interface IFACE   NIC for inter-host traffic. Default: ${TT_TCP_INTERFACE}
+    --recovery-passes N     Times to run recover.sh back-to-back. Default: ${NUM_RECOVERY_PASSES}
+    --recovery-iters N      --num-iterations passed to each recover.sh. Default: ${RECOVERY_ITERS}
+    --skip-recovery         Skip recovery (use only if you know links are trained)
+    -h, --help              Show this help
+
+Example:
+    $0 --host-a bh-glx-d04u02 --host-b bh-glx-d04u08
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host-a)           HOST_A="$2"; shift 2 ;;
+        --host-b)           HOST_B="$2"; shift 2 ;;
+        --tcp-interface)    TT_TCP_INTERFACE="$2"; shift 2 ;;
+        --recovery-passes)  NUM_RECOVERY_PASSES="$2"; shift 2 ;;
+        --recovery-iters)   RECOVERY_ITERS="$2"; shift 2 ;;
+        --skip-recovery)    SKIP_RECOVERY=true; shift ;;
+        -h|--help)          show_help; exit 0 ;;
+        *)                  echo "ERROR: unknown arg: $1" >&2; show_help >&2; exit 1 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TT_METAL_ROOT="$(cd "${SCRIPT_DIR}/../../../../../" && pwd)"
+TT_BLAZE_ROOT="$(cd "${TT_METAL_ROOT}/.." && pwd)"
+
+RUNME="${SCRIPT_DIR}/runme_2galaxy_cross_mesh_smoke.sh"
+RECOVER="${TT_METAL_ROOT}/tools/scaleout/exabox/recover.sh"
+VALIDATION_BIN="${TT_METAL_ROOT}/build/tools/scaleout/run_cluster_validation"
+HAL_HEADER="${TT_METAL_ROOT}/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h"
+
+echo "=========================================="
+echo "2-galaxy cross-mesh socket smoke (end-to-end)"
+echo "  HOST_A             = ${HOST_A}"
+echo "  HOST_B             = ${HOST_B}"
+echo "  TT_TCP_INTERFACE   = ${TT_TCP_INTERFACE}"
+echo "  recovery passes    = ${NUM_RECOVERY_PASSES} x --num-iterations=${RECOVERY_ITERS}"
+echo "  skip recovery      = ${SKIP_RECOVERY}"
+echo "  tt-metal root      = ${TT_METAL_ROOT}"
+echo "=========================================="
+echo ""
+
+# --- Prereqs ---------------------------------------------------------------
+
+echo "[prereq] checking HAL bump (MEM_ERISC_KERNEL_CONFIG_SIZE)..."
+if ! grep -q "MEM_ERISC_KERNEL_CONFIG_SIZE (32 \* 1024)" "${HAL_HEADER}"; then
+    echo "ERROR: ${HAL_HEADER} does not have the 32 KB bump." >&2
+    echo "       Check out jjovicic/socket-experiment and rebuild tt-metal." >&2
+    exit 1
+fi
+echo "[prereq] OK"
+
+echo "[prereq] checking launcher + recover.sh + validation tool..."
+[[ -f "${RUNME}" ]]          || { echo "ERROR: missing ${RUNME}" >&2; exit 1; }
+[[ -f "${RECOVER}" ]]        || { echo "ERROR: missing ${RECOVER}" >&2; exit 1; }
+if [[ "${SKIP_RECOVERY}" != true && ! -x "${VALIDATION_BIN}" ]]; then
+    echo "ERROR: ${VALIDATION_BIN} not built." >&2
+    echo "       Build it (scaleout tools must be enabled), or rerun with --skip-recovery" >&2
+    echo "       if you've trained the ETH PHYs another way." >&2
+    exit 1
+fi
+echo "[prereq] OK"
+
+echo "[prereq] checking SSH between hosts..."
+ssh -o BatchMode=yes -o ConnectTimeout=5 "${HOST_A}" hostname >/dev/null 2>&1 \
+    || { echo "ERROR: cannot SSH to ${HOST_A} without password" >&2; exit 1; }
+ssh -o BatchMode=yes -o ConnectTimeout=5 "${HOST_B}" hostname >/dev/null 2>&1 \
+    || { echo "ERROR: cannot SSH to ${HOST_B} without password" >&2; exit 1; }
+# Cross-host hop (A reaching B) — mpirun needs this.
+ssh -o BatchMode=yes -o ConnectTimeout=5 "${HOST_A}" \
+    "ssh -o BatchMode=yes -o ConnectTimeout=5 ${HOST_B} hostname" >/dev/null 2>&1 \
+    || { echo "ERROR: cannot SSH from ${HOST_A} to ${HOST_B} without password" >&2; exit 1; }
+echo "[prereq] OK"
+
+# --- Recovery -------------------------------------------------------------
+
+if [[ "${SKIP_RECOVERY}" == true ]]; then
+    echo ""
+    echo "[recovery] SKIPPED (--skip-recovery)"
+else
+    echo ""
+    echo "[recovery] Running recover.sh ${NUM_RECOVERY_PASSES} time(s) (each --num-iterations ${RECOVERY_ITERS})"
+    cd "${TT_METAL_ROOT}"
+    for pass in $(seq 1 "${NUM_RECOVERY_PASSES}"); do
+        echo ""
+        echo "[recovery] pass ${pass}/${NUM_RECOVERY_PASSES}"
+        echo "----------------------------------------------------------"
+        if ! "${RECOVER}" \
+                --hosts "${HOST_A},${HOST_B}" \
+                --num-iterations "${RECOVERY_ITERS}"; then
+            echo "[recovery] pass ${pass} reported failures — continuing to next pass" >&2
+        fi
+    done
+    echo ""
+    echo "[recovery] all passes done"
+fi
+
+# --- Test -----------------------------------------------------------------
+
+echo ""
+echo "[test] launching runme_2galaxy_cross_mesh_smoke.sh"
+echo "       NOTE: do not run tt-smi -glx_reset between this and recovery —"
+echo "       that would undo the ETH PHY training."
+echo "----------------------------------------------------------"
+
+cd "${TT_BLAZE_ROOT}"
+source ./env.sh
+
+HOST_A="${HOST_A}" \
+HOST_B="${HOST_B}" \
+TT_TCP_INTERFACE="${TT_TCP_INTERFACE}" \
+    bash "${RUNME}"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/run_2galaxy_end_to_end.sh
@@ -8,12 +8,12 @@
 #      enough — empirically 2 with --num-iterations 10 each is reliable).
 #   3. Launch runme_2galaxy_cross_mesh_smoke.sh on the trained fabric.
 #
-# Default hosts/interface match the d04 reservation; override via flags.
+# Default hosts/interface match the d03 reservation; override via flags.
 
 set -eo pipefail
 
-HOST_A="bh-glx-d04u02"
-HOST_B="bh-glx-d04u08"
+HOST_A="bh-glx-d03u02"
+HOST_B="bh-glx-d03u08"
 TT_TCP_INTERFACE="ens5f0np0"
 NUM_RECOVERY_PASSES=2
 RECOVERY_ITERS=10
@@ -36,7 +36,7 @@ Options:
     -h, --help              Show this help
 
 Example:
-    $0 --host-a bh-glx-d04u02 --host-b bh-glx-d04u08
+    $0 --host-a bh-glx-d03u02 --host-b bh-glx-d03u08
 EOF
 }
 

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_cross_mesh_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_cross_mesh_smoke.sh
@@ -53,4 +53,4 @@ tt-run \
     --tcp-interface "${TCP_INTERFACE}" \
     --rank-binding "${RANK_BINDING}" \
     --mpi-args "--host ${HOSTSP} --tag-output --allow-run-as-root --mca btl tcp,self --mca btl_tcp_if_include ${TCP_INTERFACE}" \
-    python -m pytest "${TEST_FILE}" -svv --no-header -k "4-8"
+    python -m pytest "${TEST_FILE}" -svv --no-header -k 2galaxy

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_cross_mesh_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_cross_mesh_smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Launcher for test_cross_mesh_socket_smoke.py on 2 galaxies (2 hosts).
+#
+# Same Python test as the single-galaxy variant — only the rank-binding YAML
+# and the host distribution change. Each rank takes a full galaxy as its
+# (4, 8) mesh; intermesh fabric runs over the inter-host network.
+#
+# Before running, set:
+#   HOST_A         hostname of galaxy A (gets rank 0, mesh_id=0)
+#   HOST_B         hostname of galaxy B (gets rank 1, mesh_id=1)
+#   TCP_INTERFACE  NIC name carrying inter-host fabric traffic (e.g. ens5f0np0)
+#
+# IMPORTANT:
+#   - Both hosts must have an up-to-date tt-metal build with the
+#     MEM_ERISC_KERNEL_CONFIG_SIZE bump (commit jjovicic/socket-experiment).
+#   - The test parametrize includes (4, 8); make sure the version of
+#     test_cross_mesh_socket_smoke.py on both hosts has that entry.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TT_METAL_ROOT="$(cd "${SCRIPT_DIR}/../../../../../" && pwd)"
+
+cd "${TT_METAL_ROOT}"
+
+export TT_METAL_HOME="${TT_METAL_HOME:-${TT_METAL_ROOT}}"
+export TT_METAL_SLOW_DISPATCH_MODE=1
+export PYTHONPATH="${TT_METAL_ROOT}:${PYTHONPATH:-}"
+
+# >>> Fill these in for your cluster <<<
+: "${HOST_A:?Set HOST_A to the hostname of galaxy A}"
+: "${HOST_B:?Set HOST_B to the hostname of galaxy B}"
+TCP_INTERFACE="${TT_TCP_INTERFACE:-ens5f0np0}"
+
+HOSTSP="${HOST_A}:1,${HOST_B}:1"
+
+RANK_BINDING="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/dual_galaxy_rank_bindings.yaml"
+TEST_FILE="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py"
+
+for f in "${RANK_BINDING}" "${TEST_FILE}"; do
+    [[ -f "$f" ]] || { echo "ERROR: missing file: $f" >&2; exit 1; }
+done
+
+echo "=== Cross-mesh socket smoke (2 galaxies) ==="
+echo "  HOST_A         = ${HOST_A}"
+echo "  HOST_B         = ${HOST_B}"
+echo "  TCP_INTERFACE  = ${TCP_INTERFACE}"
+echo "  rank-binding   = ${RANK_BINDING}"
+echo "  test           = ${TEST_FILE}"
+echo
+
+tt-run \
+    --tcp-interface "${TCP_INTERFACE}" \
+    --rank-binding "${RANK_BINDING}" \
+    --mpi-args "--host ${HOSTSP} --tag-output --allow-run-as-root --mca btl tcp,self --mca btl_tcp_if_include ${TCP_INTERFACE}" \
+    python -m pytest "${TEST_FILE}" -svv --no-header -k "4-8"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_cross_mesh_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_cross_mesh_smoke.sh
@@ -31,6 +31,7 @@ export PYTHONPATH="${TT_METAL_ROOT}:${PYTHONPATH:-}"
 : "${HOST_A:?Set HOST_A to the hostname of galaxy A}"
 : "${HOST_B:?Set HOST_B to the hostname of galaxy B}"
 TCP_INTERFACE="${TT_TCP_INTERFACE:-ens5f0np0}"
+K_FILTER="${K_FILTER:-2galaxy}"
 
 HOSTSP="${HOST_A}:1,${HOST_B}:1"
 
@@ -53,4 +54,4 @@ tt-run \
     --tcp-interface "${TCP_INTERFACE}" \
     --rank-binding "${RANK_BINDING}" \
     --mpi-args "--host ${HOSTSP} --tag-output --allow-run-as-root --mca btl tcp,self --mca btl_tcp_if_include ${TCP_INTERFACE}" \
-    python -m pytest "${TEST_FILE}" -svv --no-header -k 2galaxy
+    python -m pytest "${TEST_FILE}" -svv --no-header -k "${K_FILTER}"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_dram_to_dram_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_dram_to_dram_smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# 2-galaxy launcher for test_dram_to_dram_smoke.py.
+#
+# rank 0 = galaxy A (full 4x8 mesh, mesh_id=0), rank 1 = galaxy B (4x8, mesh_id=1).
+# Inter-galaxy fabric over the inter-host network (TT_TCP_INTERFACE).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TT_METAL_ROOT="$(cd "${SCRIPT_DIR}/../../../../../" && pwd)"
+
+cd "${TT_METAL_ROOT}"
+
+export TT_METAL_HOME="${TT_METAL_HOME:-${TT_METAL_ROOT}}"
+export TT_METAL_SLOW_DISPATCH_MODE=1
+export PYTHONPATH="${TT_METAL_ROOT}:${PYTHONPATH:-}"
+
+: "${HOST_A:?Set HOST_A to the hostname of galaxy A}"
+: "${HOST_B:?Set HOST_B to the hostname of galaxy B}"
+TCP_INTERFACE="${TT_TCP_INTERFACE:-ens5f0np0}"
+K_FILTER="${K_FILTER:-2galaxy}"
+
+HOSTSP="${HOST_A}:1,${HOST_B}:1"
+
+RANK_BINDING="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/dual_galaxy_rank_bindings.yaml"
+TEST_FILE="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py"
+
+for f in "${RANK_BINDING}" "${TEST_FILE}"; do
+    [[ -f "$f" ]] || { echo "ERROR: missing file: $f" >&2; exit 1; }
+done
+
+echo "=== DRAM→DRAM cross-mesh smoke (2 galaxies) ==="
+echo "  HOST_A         = ${HOST_A}"
+echo "  HOST_B         = ${HOST_B}"
+echo "  TCP_INTERFACE  = ${TCP_INTERFACE}"
+echo "  rank-binding   = ${RANK_BINDING}"
+echo "  test           = ${TEST_FILE}"
+echo
+
+tt-run \
+    --tcp-interface "${TCP_INTERFACE}" \
+    --rank-binding "${RANK_BINDING}" \
+    --mpi-args "--host ${HOSTSP} --tag-output --allow-run-as-root --mca btl tcp,self --mca btl_tcp_if_include ${TCP_INTERFACE}" \
+    python -m pytest "${TEST_FILE}" -svv --no-header -k "${K_FILTER}"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_dram_to_dram_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_2galaxy_dram_to_dram_smoke.sh
@@ -37,8 +37,15 @@ echo "  rank-binding   = ${RANK_BINDING}"
 echo "  test           = ${TEST_FILE}"
 echo
 
+# Forward TT_METAL_DPRINT_CORES to the remote rank via `mpirun -x VAR` so kernel
+# DPRINTs from both ranks reach this host's stdout.
+DPRINT_FWD=""
+if [[ -n "${TT_METAL_DPRINT_CORES:-}" ]]; then
+    DPRINT_FWD="-x TT_METAL_DPRINT_CORES"
+fi
+
 tt-run \
     --tcp-interface "${TCP_INTERFACE}" \
     --rank-binding "${RANK_BINDING}" \
-    --mpi-args "--host ${HOSTSP} --tag-output --allow-run-as-root --mca btl tcp,self --mca btl_tcp_if_include ${TCP_INTERFACE}" \
+    --mpi-args "--host ${HOSTSP} --tag-output --allow-run-as-root --mca btl tcp,self --mca btl_tcp_if_include ${TCP_INTERFACE} ${DPRINT_FWD}" \
     python -m pytest "${TEST_FILE}" -svv --no-header -k "${K_FILTER}"

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_cross_mesh_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_cross_mesh_smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Launcher for test_cross_mesh_socket_smoke.py.
+#
+# Runs 2 MPI ranks on this single SLURM-allocated host, each on its own
+# 2x4 submesh slice of one Blackhole galaxy, with cross-mesh fabric between
+# them. The rank-binding YAML pins:
+#   rank 0 -> mesh_id=0, chips 4,7,10,14,15,18,25,30
+#   rank 1 -> mesh_id=1, chips 0,2,3,6,8,21,28,31
+# MGD: bh_galaxy_dual_2x4_intermesh.textproto.
+#
+# Use --bare so tt-run doesn't force its `--mca btl self,tcp ...` defaults
+# (those broke intra-host comms in earlier runs).
+# Use --oversubscribe so OpenMPI ignores SLURM_TASKS_PER_NODE=1 and packs
+# both ranks onto the one allocated host.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TT_METAL_ROOT="$(cd "${SCRIPT_DIR}/../../../../../" && pwd)"
+
+cd "${TT_METAL_ROOT}"
+
+export TT_METAL_HOME="${TT_METAL_HOME:-${TT_METAL_ROOT}}"
+export TT_METAL_SLOW_DISPATCH_MODE=1
+export PYTHONPATH="${TT_METAL_ROOT}:${PYTHONPATH:-}"
+
+RANK_BINDING="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/dual_tray_2x4_rank_bindings.yaml"
+TEST_FILE="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py"
+
+for f in "${RANK_BINDING}" "${TEST_FILE}"; do
+    [[ -f "$f" ]] || { echo "ERROR: missing file: $f" >&2; exit 1; }
+done
+
+echo "=== Cross-mesh socket smoke ==="
+echo "  TT_METAL_HOME = ${TT_METAL_HOME}"
+echo "  rank-binding  = ${RANK_BINDING}"
+echo "  test          = ${TEST_FILE}"
+echo
+
+tt-run \
+    --bare \
+    --rank-binding "${RANK_BINDING}" \
+    --mpi-args "--oversubscribe" \
+    python -m pytest "${TEST_FILE}" -svv --no-header

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_cross_mesh_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_cross_mesh_smoke.sh
@@ -41,4 +41,4 @@ tt-run \
     --bare \
     --rank-binding "${RANK_BINDING}" \
     --mpi-args "--oversubscribe" \
-    python -m pytest "${TEST_FILE}" -svv --no-header
+    python -m pytest "${TEST_FILE}" -svv --no-header -k 1galaxy

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/runme_dram_to_dram_smoke.sh
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/runme_dram_to_dram_smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Single-galaxy launcher for test_dram_to_dram_smoke.py.
+#
+# Same 2-rank-on-1-galaxy setup as runme_cross_mesh_smoke.sh — rank 0 = tray 1
+# (mesh_id=0, 2x4 submesh), rank 1 = tray 2 (mesh_id=1, 2x4 submesh). Intermesh
+# fabric over the inter-tray backplane.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TT_METAL_ROOT="$(cd "${SCRIPT_DIR}/../../../../../" && pwd)"
+
+cd "${TT_METAL_ROOT}"
+
+export TT_METAL_HOME="${TT_METAL_HOME:-${TT_METAL_ROOT}}"
+export TT_METAL_SLOW_DISPATCH_MODE=1
+export PYTHONPATH="${TT_METAL_ROOT}:${PYTHONPATH:-}"
+
+RANK_BINDING="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/dual_tray_2x4_rank_bindings.yaml"
+TEST_FILE="${TT_METAL_ROOT}/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py"
+
+for f in "${RANK_BINDING}" "${TEST_FILE}"; do
+    [[ -f "$f" ]] || { echo "ERROR: missing file: $f" >&2; exit 1; }
+done
+
+echo "=== DRAM→DRAM cross-mesh smoke (1 galaxy, 2x4 submeshes) ==="
+echo "  TT_METAL_HOME = ${TT_METAL_HOME}"
+echo "  rank-binding  = ${RANK_BINDING}"
+echo "  test          = ${TEST_FILE}"
+echo
+
+tt-run \
+    --bare \
+    --rank-binding "${RANK_BINDING}" \
+    --mpi-args "--oversubscribe" \
+    python -m pytest "${TEST_FILE}" -svv --no-header -k 1galaxy

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
@@ -69,7 +69,14 @@ _FABRIC_ROUTER_MAX_PAYLOAD_BYTES = 2048
 )
 @pytest.mark.parametrize(
     "mesh_device",
-    [(2, 4)],
+    [
+        # Single-galaxy 2-mesh: rank 0 = tray 1, rank 1 = tray 2; each mesh is (2, 4).
+        # Pairs with dual_tray_2x4_rank_bindings.yaml.
+        (2, 4),
+        # Two-galaxy 2-mesh: rank 0 = galaxy A, rank 1 = galaxy B; each mesh is (4, 8).
+        # Pairs with dual_galaxy_rank_bindings.yaml + runme_2galaxy_cross_mesh_smoke.sh.
+        (4, 8),
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
@@ -538,13 +538,18 @@ def test_cross_mesh_socket_perf(
     # (num_channels, page_size_bytes, num_logical_tensors_per_channel)
     # Each channel transfers a 640×1792 bf16 (= 2,293,760 bytes) "logical tensor"
     # per iteration. Aggregate per iteration = num_channels × that.
+    #
+    # Iteration count is intentionally small (2 per channel) — early measurements
+    # showed that inter-galaxy per-channel bandwidth doesn't drop with N, so the
+    # full N-channel sweep would otherwise take ~10 min/point on 2 galaxies.
+    # Bump iters once we know the curve shape we want stable measurements over.
     "num_channels, page_size_bytes, num_logical_tensors_per_channel",
     [
-        (1, 4096, 20),
-        (4, 4096, 20),
-        (8, 4096, 20),
-        (16, 4096, 20),
-        (32, 4096, 20),
+        (1, 4096, 2),
+        (4, 4096, 2),
+        (8, 4096, 2),
+        (16, 4096, 2),
+        (32, 4096, 2),
     ],
     ids=["nc1", "nc4", "nc8", "nc16", "nc32"],
 )

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Single-galaxy 2-mesh cross-mesh socket smoke test.
+
+Goal
+----
+Verify that two submeshes carved out of one Blackhole galaxy can exchange
+a tensor end-to-end via the production socket stack:
+
+    host ──H2D──> chip on mesh_id=0 ──cross-mesh D2D (fabric)──> chip on mesh_id=1 ──D2H──> host
+
+This is the minimal cross-mesh fabric exercise. It's a 2-rank cut-down of
+``models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
+::test_multi_host_loopback_pipeline`` (currently @pytest.mark.skip per
+#43085) — one hop, no fabric loopback.
+
+If this passes on a single galaxy, the same Python test should also work
+on a 2-galaxy setup (step 2) by swapping the rank-binding YAML.
+If this hangs, the cross-mesh fabric path is the same bug area as #43079 /
+#43085 / our earlier HostIoDecoderStage hang.
+
+How to run
+----------
+See ``runme.sh`` next to this file. In short::
+
+    tt-run --bare \
+        --rank-binding tests/tt_metal/distributed/config/mock_galaxy_single_host_subcontext_b_rank_bindings.yaml \
+        --mpi-args "--oversubscribe" \
+        python -m pytest models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py -svv
+
+The rank-binding YAML pins:
+  - rank 0 → mesh_id=0, TT_VISIBLE_DEVICES=4,7,10,14,15,18,25,30 (galaxy slice 2)
+  - rank 1 → mesh_id=1, TT_VISIBLE_DEVICES=0,2,3,6,8,21,28,31 (galaxy slice 3)
+  mesh_graph_desc_path = bh_galaxy_dual_2x4_intermesh.textproto
+"""
+
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import MeshWrapper, SocketInterface
+from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
+
+# Production-shape fabric + L1 settings; mirrors test_multi_host_pipeline.py.
+# FABRIC_2D is the simpler 2D fabric (no torus). #43085 was specifically about
+# FABRIC_2D_TORUS_Y; FABRIC_2D gives us a control-knob to see if the bug
+# follows the fabric mode or is broader.
+_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_2D
+_FABRIC_ROUTER_MAX_PAYLOAD_BYTES = 2048
+
+
+@pytest.mark.parametrize(
+    "tensor_size_bytes, fifo_size, num_iterations",
+    [
+        (64, 256, 4),
+    ],
+)
+@pytest.mark.parametrize(
+    "h2d_mode",
+    [
+        ttnn.H2DMode.HOST_PUSH,
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(2, 4)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": _FABRIC_CONFIG,
+            "fabric_router_config": create_fabric_router_config(_FABRIC_ROUTER_MAX_PAYLOAD_BYTES),
+        }
+    ],
+    indirect=True,
+)
+def test_cross_mesh_socket_smoke(mesh_device, tensor_size_bytes, fifo_size, num_iterations, h2d_mode):
+    """One H2D → one cross-mesh D2D hop → one D2H, across 2 ranks on 1 galaxy.
+
+    Requires tt-run with the dual-2x4 intermesh rank-binding (2 procs total).
+    Each rank owns a (2, 4) submesh on a distinct mesh_id.
+
+    Rank 0 (sender, mesh_id=0):
+        - Builds H2DSocket on a local entry-node core.
+        - HostInterface forwards H2D bytes to a local "exit-node" core via a
+          core-to-core L1 socket.
+        - SocketInterface (sender side) sends from that exit-node core, across
+          the intermesh fabric, to rank 1's entry-node core (cross-mesh D2D).
+
+    Rank 1 (receiver, mesh_id=1):
+        - SocketInterface (receiver side) lands incoming bytes on a local
+          entry-node core.
+        - HostInterface forwards from there to a local exit-node core, where
+          D2HSocket pushes bytes back to host.
+
+    Per iteration:
+        rank 0 calls h2d_socket.write_tensor(input);
+        rank 1 calls d2h_socket.read_tensor(output);
+        rank 1 asserts output == input (rank 0's input is built deterministically
+        from the iteration index so rank 1 can reconstruct it).
+    """
+    if not is_slow_dispatch():
+        pytest.skip("Sockets require slow dispatch (set TT_METAL_SLOW_DISPATCH_MODE=1).")
+
+    num_procs = int(ttnn.distributed_context_get_size())
+    if num_procs != 2:
+        pytest.skip(f"This test runs with exactly 2 ranks; got num_procs={num_procs}")
+
+    my_mesh_id = mesh_device.get_system_mesh_id()
+    logger.info(
+        f"[rank with mesh_id={my_mesh_id}] starting cross-mesh socket smoke, "
+        f"tensor_size_bytes={tensor_size_bytes}, fifo_size={fifo_size}, iters={num_iterations}"
+    )
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    # Entry / exit "node" coords inside this rank's (2, 4) submesh — same convention
+    # as test_multi_host_pipeline.py (entry at (0,0), exit at (1,0)) so we hit two
+    # distinct chips within the mesh, exercising intra-mesh routing in addition to
+    # the cross-mesh hop.
+    entry_node_coord = ttnn.MeshCoordinate((0, 0))
+    exit_node_coord = ttnn.MeshCoordinate((1, 0))
+    pipeline_core_coord = ttnn.CoreCoord(0, 0)
+
+    tensor_size_datums = tensor_size_bytes // 4  # int32 datums
+
+    if my_mesh_id == 0:
+        # ---------- SENDER ----------
+        logger.info("[mesh_id=0] building H2D socket + sender SocketInterface")
+
+        h2d_socket = ttnn.H2DSocket(
+            mesh_device,
+            ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+            ttnn.BufferType.L1,
+            fifo_size,
+            h2d_mode,
+        )
+
+        # h2d_socket only; d2h_socket=None is allowed. HostInterface still wants a
+        # d2h_page_size value — pass the same size to keep validators happy.
+        host_io = HostInterface(
+            h2d_socket=h2d_socket,
+            d2h_socket=None,
+            h2d_page_size=tensor_size_bytes,
+            d2h_page_size=tensor_size_bytes,
+            core_to_core_socket_buffer_size=fifo_size,
+            h2d_downstream_core=ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+        )
+
+        # Cross-mesh D2D: my exit-node core ──fabric──> peer mesh_id=1's entry-node core.
+        exit_socket = SocketInterface(
+            page_size=tensor_size_bytes,
+            socket_fifo_size=fifo_size,
+            data_size_per_transfer=tensor_size_bytes,
+            send_core_coord=ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+            recv_core_coord=ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+            upstream_socket=host_io.get_downstream_socket(),
+            sender_mesh=MeshWrapper(mesh_device),
+            receiver_mesh=MeshWrapper(mesh_id=1),
+        )
+
+        host_io.run()
+        exit_socket.run()
+
+        logger.info("[mesh_id=0] waiting on barrier before send")
+        ttnn.distributed_context_barrier()
+
+        for i in range(num_iterations):
+            torch_input = torch.arange(i * tensor_size_datums, (i + 1) * tensor_size_datums, dtype=torch.int32).reshape(
+                1, tensor_size_datums
+            )
+            input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+            logger.info(
+                f"[mesh_id=0] iter {i}: write_tensor (range {i * tensor_size_datums}..{(i + 1) * tensor_size_datums})"
+            )
+            h2d_socket.write_tensor(input_tensor)
+
+        logger.info("[mesh_id=0] sent all iterations; barrier")
+        ttnn.distributed_context_barrier()
+
+        logger.info("[mesh_id=0] terminating")
+        host_io.terminate(False)
+        exit_socket.terminate(True)
+
+    else:
+        # ---------- RECEIVER (mesh_id == 1) ----------
+        logger.info("[mesh_id=1] building entry SocketInterface + D2H socket")
+
+        d2h_socket = ttnn.D2HSocket(
+            mesh_device,
+            ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+            fifo_size,
+        )
+
+        host_io = HostInterface(
+            h2d_socket=None,
+            d2h_socket=d2h_socket,
+            h2d_page_size=tensor_size_bytes,
+            d2h_page_size=tensor_size_bytes,
+            core_to_core_socket_buffer_size=fifo_size,
+            d2h_upstream_core=ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+        )
+
+        # Cross-mesh D2D receiver: rank 0's exit-node core ──fabric──> my entry-node core.
+        entry_socket = SocketInterface(
+            page_size=tensor_size_bytes,
+            socket_fifo_size=fifo_size,
+            data_size_per_transfer=tensor_size_bytes,
+            send_core_coord=ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+            recv_core_coord=ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+            downstream_socket=host_io.get_upstream_socket(),
+            sender_mesh=MeshWrapper(mesh_id=0),
+            receiver_mesh=MeshWrapper(mesh_device),
+        )
+
+        host_io.run()
+        entry_socket.run()
+
+        logger.info("[mesh_id=1] waiting on barrier before recv")
+        ttnn.distributed_context_barrier()
+
+        for i in range(num_iterations):
+            torch_output = torch.zeros(1, tensor_size_datums, dtype=torch.int32)
+            output_tensor = ttnn.from_torch(torch_output, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+            logger.info(f"[mesh_id=1] iter {i}: read_tensor")
+            d2h_socket.read_tensor(output_tensor)
+
+            result_torch = ttnn.to_torch(output_tensor).to(torch.int32)
+            expected_torch = torch.arange(
+                i * tensor_size_datums, (i + 1) * tensor_size_datums, dtype=torch.int32
+            ).reshape(1, tensor_size_datums)
+            match = torch.equal(expected_torch, result_torch)
+            assert match, (
+                f"[mesh_id=1] iter {i}: cross-mesh roundtrip mismatch.\n"
+                f"Expected: {expected_torch}\n"
+                f"Got:      {result_torch}"
+            )
+            logger.info(f"[mesh_id=1] iter {i}: roundtrip OK")
+
+        logger.info("[mesh_id=1] received all iterations; barrier")
+        ttnn.distributed_context_barrier()
+
+        logger.info("[mesh_id=1] terminating")
+        host_io.terminate(False)
+        entry_socket.terminate(True)
+
+    logger.info(f"[rank with mesh_id={my_mesh_id}] smoke OK")

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
@@ -37,6 +37,8 @@ The rank-binding YAML pins:
 """
 
 
+import time
+
 import pytest
 import torch
 from loguru import logger
@@ -77,6 +79,7 @@ _FABRIC_ROUTER_MAX_PAYLOAD_BYTES = 2048
         # Pairs with dual_galaxy_rank_bindings.yaml + runme_2galaxy_cross_mesh_smoke.sh.
         (4, 8),
     ],
+    ids=["1galaxy", "2galaxy"],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -262,3 +265,240 @@ def test_cross_mesh_socket_smoke(mesh_device, tensor_size_bytes, fifo_size, num_
         entry_socket.terminate(True)
 
     logger.info(f"[rank with mesh_id={my_mesh_id}] smoke OK")
+
+
+# ---------------------------------------------------------------------------
+# Perf variant — measures end-to-end wall time + bandwidth for shipping a
+# logical (rows × cols) bf16 tensor across the cross-mesh socket.
+#
+# The logical tensor is chunked into ``page_size_bytes``-sized H2D pages
+# because the H2D/D2H sockets transfer one page per ``write_tensor`` /
+# ``read_tensor`` call. fifo_size must be >= page_size; we set it 4×
+# page_size to allow pipelining (sender can buffer a few pages ahead while
+# the receiver is still draining).
+#
+# Two timing modes are measured for each (logical tensor shape, page_size):
+#   - Bit-exact pass (one iteration): asserts the bytes round-trip identically.
+#   - Hot loop (``num_logical_tensors`` iterations): no per-iter assertions,
+#     just write/read in a tight loop, timed across MPI barriers. Reports
+#     ms per logical-tensor transfer + GB/s.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    # (logical_rows, logical_cols, page_size_bytes, num_logical_tensors)
+    # 640 × 1792 bf16 = 2,293,760 bytes; page=4096 → 560 pages per logical tensor.
+    "logical_rows, logical_cols, page_size_bytes, num_logical_tensors",
+    [
+        (640, 1792, 4096, 20),
+    ],
+)
+@pytest.mark.parametrize("h2d_mode", [ttnn.H2DMode.HOST_PUSH])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (2, 4),
+        (4, 8),
+    ],
+    ids=["1galaxy", "2galaxy"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": _FABRIC_CONFIG,
+            "fabric_router_config": create_fabric_router_config(_FABRIC_ROUTER_MAX_PAYLOAD_BYTES),
+        }
+    ],
+    indirect=True,
+)
+def test_cross_mesh_socket_perf(
+    mesh_device, logical_rows, logical_cols, page_size_bytes, num_logical_tensors, h2d_mode
+):
+    """End-to-end perf of cross-mesh H2D→D2D→D2H for a (logical_rows, logical_cols) bf16 tensor.
+
+    Reports ms per logical-tensor transfer + effective bandwidth. The logical
+    tensor is chunked into ``page_size_bytes``-byte pages (one per write_tensor
+    call). Wall time is measured across MPI barriers so both ranks include the
+    same start/end points.
+    """
+    if not is_slow_dispatch():
+        pytest.skip("Sockets require slow dispatch (set TT_METAL_SLOW_DISPATCH_MODE=1).")
+
+    num_procs = int(ttnn.distributed_context_get_size())
+    if num_procs != 2:
+        pytest.skip(f"This test runs with exactly 2 ranks; got num_procs={num_procs}")
+
+    BF16_BYTES = 2
+    logical_tensor_bytes = logical_rows * logical_cols * BF16_BYTES
+    assert (
+        logical_tensor_bytes % page_size_bytes == 0
+    ), f"logical_tensor_bytes ({logical_tensor_bytes}) must be a multiple of page_size_bytes ({page_size_bytes})"
+    pages_per_logical_tensor = logical_tensor_bytes // page_size_bytes
+
+    # FIFO must be ≥ page_size; 4× pages of pipelining headroom.
+    fifo_size = page_size_bytes * 4
+    # Page size in uint32 datums (write_tensor takes a uint32 tensor).
+    page_size_datums = page_size_bytes // 4
+
+    my_mesh_id = mesh_device.get_system_mesh_id()
+    logger.info(
+        f"[mesh_id={my_mesh_id}] PERF setup: logical={logical_rows}x{logical_cols} bf16 "
+        f"({logical_tensor_bytes} bytes), page={page_size_bytes} B "
+        f"({pages_per_logical_tensor} pages/tensor), fifo={fifo_size} B, "
+        f"hot-loop iters={num_logical_tensors}"
+    )
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    entry_node_coord = ttnn.MeshCoordinate((0, 0))
+    exit_node_coord = ttnn.MeshCoordinate((1, 0))
+    pipeline_core_coord = ttnn.CoreCoord(0, 0)
+
+    # Build sender or receiver side identically to the smoke test.
+    if my_mesh_id == 0:
+        h2d_socket = ttnn.H2DSocket(
+            mesh_device,
+            ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+            ttnn.BufferType.L1,
+            fifo_size,
+            h2d_mode,
+        )
+        host_io = HostInterface(
+            h2d_socket=h2d_socket,
+            d2h_socket=None,
+            h2d_page_size=page_size_bytes,
+            d2h_page_size=page_size_bytes,
+            core_to_core_socket_buffer_size=fifo_size,
+            h2d_downstream_core=ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+        )
+        exit_socket = SocketInterface(
+            page_size=page_size_bytes,
+            socket_fifo_size=fifo_size,
+            data_size_per_transfer=page_size_bytes,
+            send_core_coord=ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+            recv_core_coord=ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+            upstream_socket=host_io.get_downstream_socket(),
+            sender_mesh=MeshWrapper(mesh_device),
+            receiver_mesh=MeshWrapper(mesh_id=1),
+        )
+        host_io.run()
+        exit_socket.run()
+
+        # Pre-build one full logical tensor of input pages. Bytes are arbitrary but
+        # deterministic so the receiver can verify the first iteration bit-exactly.
+        # Reused across the hot loop to keep the hot path free of per-iter alloc.
+        input_pages = [
+            ttnn.from_torch(
+                torch.arange(p * page_size_datums, (p + 1) * page_size_datums, dtype=torch.int32).reshape(
+                    1, page_size_datums
+                ),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+            for p in range(pages_per_logical_tensor)
+        ]
+
+        logger.info("[mesh_id=0] PERF: pre-built input pages; barrier before hot loop")
+        ttnn.distributed_context_barrier()
+
+        # --- hot loop (timed) ---
+        t0 = time.perf_counter()
+        for _t in range(num_logical_tensors):
+            for p in range(pages_per_logical_tensor):
+                h2d_socket.write_tensor(input_pages[p])
+        ttnn.distributed_context_barrier()
+        t1 = time.perf_counter()
+        # ---
+
+        elapsed_s = t1 - t0
+        total_bytes = num_logical_tensors * logical_tensor_bytes
+        ms_per_tensor = (elapsed_s / num_logical_tensors) * 1000.0
+        gbps = total_bytes / elapsed_s / 1e9
+        logger.info(
+            f"[mesh_id=0] PERF RESULT: shape={logical_rows}x{logical_cols} bf16  "
+            f"page={page_size_bytes}B  iters={num_logical_tensors}  "
+            f"total={total_bytes/1e6:.2f} MB  elapsed={elapsed_s:.3f}s  "
+            f"per-tensor={ms_per_tensor:.3f} ms  bw={gbps:.3f} GB/s"
+        )
+
+        host_io.terminate(False)
+        exit_socket.terminate(True)
+
+    else:
+        d2h_socket = ttnn.D2HSocket(
+            mesh_device,
+            ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+            fifo_size,
+        )
+        host_io = HostInterface(
+            h2d_socket=None,
+            d2h_socket=d2h_socket,
+            h2d_page_size=page_size_bytes,
+            d2h_page_size=page_size_bytes,
+            core_to_core_socket_buffer_size=fifo_size,
+            d2h_upstream_core=ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+        )
+        entry_socket = SocketInterface(
+            page_size=page_size_bytes,
+            socket_fifo_size=fifo_size,
+            data_size_per_transfer=page_size_bytes,
+            send_core_coord=ttnn.MeshCoreCoord(exit_node_coord, pipeline_core_coord),
+            recv_core_coord=ttnn.MeshCoreCoord(entry_node_coord, pipeline_core_coord),
+            downstream_socket=host_io.get_upstream_socket(),
+            sender_mesh=MeshWrapper(mesh_id=0),
+            receiver_mesh=MeshWrapper(mesh_device),
+        )
+        host_io.run()
+        entry_socket.run()
+
+        # One reusable output buffer; read_tensor overwrites it each call.
+        output_tensor = ttnn.from_torch(
+            torch.zeros(1, page_size_datums, dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+        logger.info("[mesh_id=1] PERF: ready; barrier before hot loop")
+        ttnn.distributed_context_barrier()
+
+        # --- hot loop (timed) ---
+        t0 = time.perf_counter()
+        verified_first = False
+        for _t in range(num_logical_tensors):
+            for p in range(pages_per_logical_tensor):
+                d2h_socket.read_tensor(output_tensor)
+                if not verified_first:
+                    # Bit-exact verify only the very first page to confirm the path
+                    # is healthy without slowing the hot loop on every iter.
+                    got = ttnn.to_torch(output_tensor).to(torch.int32)
+                    expected = torch.arange(
+                        p * page_size_datums, (p + 1) * page_size_datums, dtype=torch.int32
+                    ).reshape(1, page_size_datums)
+                    assert torch.equal(expected, got), (
+                        f"[mesh_id=1] first-page bit-exact check failed.\n"
+                        f"Expected: {expected[:, :8]}...\n"
+                        f"Got:      {got[:, :8]}..."
+                    )
+                    logger.info("[mesh_id=1] first page bit-exact OK; entering hot loop")
+                    verified_first = True
+        ttnn.distributed_context_barrier()
+        t1 = time.perf_counter()
+        # ---
+
+        elapsed_s = t1 - t0
+        total_bytes = num_logical_tensors * logical_tensor_bytes
+        ms_per_tensor = (elapsed_s / num_logical_tensors) * 1000.0
+        gbps = total_bytes / elapsed_s / 1e9
+        logger.info(
+            f"[mesh_id=1] PERF RESULT: shape={logical_rows}x{logical_cols} bf16  "
+            f"page={page_size_bytes}B  iters={num_logical_tensors}  "
+            f"total={total_bytes/1e6:.2f} MB  elapsed={elapsed_s:.3f}s  "
+            f"per-tensor={ms_per_tensor:.3f} ms  bw={gbps:.3f} GB/s"
+        )
+
+        host_io.terminate(False)
+        entry_socket.terminate(True)
+
+    logger.info(f"[rank with mesh_id={my_mesh_id}] PERF done")

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
@@ -287,11 +287,20 @@ def test_cross_mesh_socket_smoke(mesh_device, tensor_size_bytes, fifo_size, num_
 
 @pytest.mark.parametrize(
     # (logical_rows, logical_cols, page_size_bytes, num_logical_tensors)
-    # 640 × 1792 bf16 = 2,293,760 bytes; page=4096 → 560 pages per logical tensor.
+    # 640 × 1792 bf16 = 2,293,760 bytes per logical tensor. Sweep page sizes
+    # to map the bandwidth curve (per-call overhead vs L1 footprint).
+    # Constraint: logical_tensor_bytes % page_size_bytes == 0 (verified inline).
+    # Each point allocates fifo = 4 × page_size in L1.
     "logical_rows, logical_cols, page_size_bytes, num_logical_tensors",
     [
+        (640, 1792, 256, 20),
+        (640, 1792, 1024, 20),
+        (640, 1792, 2048, 20),
         (640, 1792, 4096, 20),
+        (640, 1792, 8192, 20),
+        (640, 1792, 16384, 20),
     ],
+    ids=["pg256", "pg1024", "pg2048", "pg4096", "pg8192", "pg16384"],
 )
 @pytest.mark.parametrize("h2d_mode", [ttnn.H2DMode.HOST_PUSH])
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_cross_mesh_socket_smoke.py
@@ -45,7 +45,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
-from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import MeshWrapper, SocketInterface
+from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import MeshWrapper, ParallelSocketInterface, SocketInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
 from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
 
@@ -511,3 +511,295 @@ def test_cross_mesh_socket_perf(
         entry_socket.terminate(True)
 
     logger.info(f"[rank with mesh_id={my_mesh_id}] PERF done")
+
+
+# ---------------------------------------------------------------------------
+# Parallel variant — N chip-pair sockets in parallel via ParallelSocketInterface.
+#
+# Per-channel layout (per chip):
+#   core (0,0) "entry"  — D2D recv core on receiver, sender's exit-node-recv on sender
+#   core (0,1) "exit"   — D2D send core on sender, receiver's entry-node-send on receiver
+#   core (0,2) "io"     — H2D socket on rank 0; D2H socket on rank 1
+#
+# Per chip on rank 0: H2D socket → HostInterface forwards to (0,1) exit core
+#                   → ParallelSocketInterface channel N → fabric → rank 1's chip N entry core
+# Per chip on rank 1: ParallelSocketInterface channel N delivers to (0,0) entry core
+#                   → HostInterface forwards to (0,2) → D2H socket back to host
+#
+# One ParallelSocketInterface per rank owns N channels (one per chip in the
+# mesh). All N sockets run in one kernel dispatch and can carry data
+# simultaneously across the inter-mesh fabric. This is the same machinery
+# the production decode pipeline uses for inter-stage data movement; we test
+# it at the unit level here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    # (num_channels, page_size_bytes, num_logical_tensors_per_channel)
+    # Each channel transfers a 640×1792 bf16 (= 2,293,760 bytes) "logical tensor"
+    # per iteration. Aggregate per iteration = num_channels × that.
+    "num_channels, page_size_bytes, num_logical_tensors_per_channel",
+    [
+        (1, 4096, 20),
+        (4, 4096, 20),
+        (8, 4096, 20),
+        (16, 4096, 20),
+        (32, 4096, 20),
+    ],
+    ids=["nc1", "nc4", "nc8", "nc16", "nc32"],
+)
+@pytest.mark.parametrize("h2d_mode", [ttnn.H2DMode.HOST_PUSH])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (2, 4),
+        (4, 8),
+    ],
+    ids=["1galaxy", "2galaxy"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": _FABRIC_CONFIG,
+            "fabric_router_config": create_fabric_router_config(_FABRIC_ROUTER_MAX_PAYLOAD_BYTES),
+        }
+    ],
+    indirect=True,
+)
+def test_cross_mesh_socket_parallel_perf(
+    mesh_device, num_channels, page_size_bytes, num_logical_tensors_per_channel, h2d_mode
+):
+    """N-channel parallel cross-mesh socket: one socket per chip-pair, all in flight at once.
+
+    Each channel ships a 640×1792 bf16 logical tensor per iteration (chunked into
+    page_size_bytes-sized H2D writes). Wall time is measured across MPI barriers;
+    aggregate bandwidth = (num_channels × logical_bytes_per_chan × iters) / elapsed.
+
+    Skipped when num_channels exceeds the available chip count for the chosen
+    mesh shape: max 8 for (2,4) single-galaxy, max 32 for (4,8) two-galaxy.
+
+    First page of channel 0 is bit-exact verified to confirm the path is healthy;
+    rest of the hot loop runs without per-iter asserts to keep timing honest.
+    """
+    if not is_slow_dispatch():
+        pytest.skip("Sockets require slow dispatch (set TT_METAL_SLOW_DISPATCH_MODE=1).")
+
+    num_procs = int(ttnn.distributed_context_get_size())
+    if num_procs != 2:
+        pytest.skip(f"This test runs with exactly 2 ranks; got num_procs={num_procs}")
+
+    mesh_rows, mesh_cols = mesh_device.shape
+    num_chips_in_mesh = int(mesh_rows) * int(mesh_cols)
+    if num_channels > num_chips_in_mesh:
+        pytest.skip(f"num_channels={num_channels} exceeds chips in this mesh ({num_chips_in_mesh})")
+
+    BF16_BYTES = 2
+    logical_rows = 640
+    logical_cols = 1792
+    logical_bytes_per_chan = logical_rows * logical_cols * BF16_BYTES  # 2,293,760
+    assert (
+        logical_bytes_per_chan % page_size_bytes == 0
+    ), f"logical_bytes_per_chan ({logical_bytes_per_chan}) must be a multiple of page_size_bytes ({page_size_bytes})"
+    pages_per_chan = logical_bytes_per_chan // page_size_bytes
+
+    fifo_size = page_size_bytes * 4
+    page_size_datums = page_size_bytes // 4
+
+    my_mesh_id = mesh_device.get_system_mesh_id()
+    peer_mesh_id = 1 if my_mesh_id == 0 else 0
+
+    # Pick the first num_channels chips in row-major order.
+    device_coords = [ttnn.MeshCoordinate((r, c)) for r in range(int(mesh_rows)) for c in range(int(mesh_cols))][
+        :num_channels
+    ]
+    core_entry = ttnn.CoreCoord(0, 0)
+    core_exit = ttnn.CoreCoord(0, 1)
+    core_io = ttnn.CoreCoord(0, 2)
+
+    logger.info(
+        f"[mesh_id={my_mesh_id}] PARALLEL setup: nc={num_channels} on mesh {mesh_rows}x{mesh_cols}, "
+        f"page={page_size_bytes} B ({pages_per_chan} pages/chan/iter), fifo={fifo_size} B, "
+        f"iters={num_logical_tensors_per_channel}, "
+        f"aggregate per logical_tensor = {num_channels * logical_bytes_per_chan / 1e6:.2f} MB"
+    )
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    if my_mesh_id == 0:
+        # ----------------- SENDER -----------------
+        h2d_sockets = []
+        host_ios = []
+        for dc in device_coords:
+            h2d = ttnn.H2DSocket(
+                mesh_device,
+                ttnn.MeshCoreCoord(dc, core_io),
+                ttnn.BufferType.L1,
+                fifo_size,
+                h2d_mode,
+            )
+            hio = HostInterface(
+                h2d_socket=h2d,
+                d2h_socket=None,
+                h2d_page_size=page_size_bytes,
+                d2h_page_size=page_size_bytes,
+                core_to_core_socket_buffer_size=fifo_size,
+                h2d_downstream_core=ttnn.MeshCoreCoord(dc, core_exit),
+            )
+            h2d_sockets.append(h2d)
+            host_ios.append(hio)
+
+        # Same chip on each side: send from chip's exit core, receive on
+        # corresponding chip's entry core in the peer mesh.
+        send_cores = [ttnn.MeshCoreCoord(dc, core_exit) for dc in device_coords]
+        recv_cores = [ttnn.MeshCoreCoord(dc, core_entry) for dc in device_coords]
+
+        parallel_socket = ParallelSocketInterface(
+            page_size=page_size_bytes,
+            socket_fifo_size=fifo_size,
+            send_core_coords=send_cores,
+            recv_core_coords=recv_cores,
+            upstream_sockets=[hio.get_downstream_socket() for hio in host_ios],
+            sender_mesh=MeshWrapper(mesh_device),
+            receiver_mesh=MeshWrapper(mesh_id=peer_mesh_id),
+        )
+
+        for hio in host_ios:
+            hio.run()
+        parallel_socket.run()
+
+        # Pre-build pages so the hot loop is free of host-side construction.
+        # All channels share the same input pages (channel 0's data is the
+        # bit-exact reference; other channels carry the same bytes — receiver
+        # will verify channel 0's first page).
+        input_pages = [
+            ttnn.from_torch(
+                torch.arange(p * page_size_datums, (p + 1) * page_size_datums, dtype=torch.int32).reshape(
+                    1, page_size_datums
+                ),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+            for p in range(pages_per_chan)
+        ]
+
+        logger.info(f"[mesh_id=0] PARALLEL: pages pre-built; barrier before hot loop")
+        ttnn.distributed_context_barrier()
+
+        # --- hot loop (timed) ---
+        t0 = time.perf_counter()
+        for _t in range(num_logical_tensors_per_channel):
+            for p in range(pages_per_chan):
+                # Push the same page into each channel's H2D socket. The
+                # parallel kernel drains all channels' FIFOs simultaneously.
+                for ch in range(num_channels):
+                    h2d_sockets[ch].write_tensor(input_pages[p])
+        ttnn.distributed_context_barrier()
+        t1 = time.perf_counter()
+        # ---
+
+        elapsed_s = t1 - t0
+        total_bytes = num_logical_tensors_per_channel * num_channels * logical_bytes_per_chan
+        per_logical_ms = (elapsed_s / num_logical_tensors_per_channel) * 1000.0
+        agg_gbps = total_bytes / elapsed_s / 1e9
+        per_chan_gbps = (total_bytes / num_channels) / elapsed_s / 1e9
+        logger.info(
+            f"[mesh_id=0] PARALLEL RESULT: nc={num_channels}  page={page_size_bytes}B  "
+            f"iters={num_logical_tensors_per_channel}  total={total_bytes/1e6:.2f} MB  "
+            f"elapsed={elapsed_s:.3f}s  per-logical-tensor={per_logical_ms:.3f} ms  "
+            f"aggregate_bw={agg_gbps:.3f} GB/s  per_channel_bw={per_chan_gbps:.3f} GB/s"
+        )
+
+        for hio in host_ios:
+            hio.terminate(False)
+        parallel_socket.terminate(True)
+
+    else:
+        # ----------------- RECEIVER -----------------
+        d2h_sockets = []
+        host_ios = []
+        for dc in device_coords:
+            d2h = ttnn.D2HSocket(
+                mesh_device,
+                ttnn.MeshCoreCoord(dc, core_io),
+                fifo_size,
+            )
+            hio = HostInterface(
+                h2d_socket=None,
+                d2h_socket=d2h,
+                h2d_page_size=page_size_bytes,
+                d2h_page_size=page_size_bytes,
+                core_to_core_socket_buffer_size=fifo_size,
+                d2h_upstream_core=ttnn.MeshCoreCoord(dc, core_entry),
+            )
+            d2h_sockets.append(d2h)
+            host_ios.append(hio)
+
+        # Mirror the sender's wiring: same chip pairs send/recv between the meshes.
+        send_cores = [ttnn.MeshCoreCoord(dc, core_exit) for dc in device_coords]
+        recv_cores = [ttnn.MeshCoreCoord(dc, core_entry) for dc in device_coords]
+
+        parallel_socket = ParallelSocketInterface(
+            page_size=page_size_bytes,
+            socket_fifo_size=fifo_size,
+            send_core_coords=send_cores,
+            recv_core_coords=recv_cores,
+            downstream_sockets=[hio.get_upstream_socket() for hio in host_ios],
+            sender_mesh=MeshWrapper(mesh_id=peer_mesh_id),
+            receiver_mesh=MeshWrapper(mesh_device),
+        )
+
+        for hio in host_ios:
+            hio.run()
+        parallel_socket.run()
+
+        # One reusable output tensor per channel (read_tensor overwrites in place).
+        output_tensors = [
+            ttnn.from_torch(
+                torch.zeros(1, page_size_datums, dtype=torch.int32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+            for _ in range(num_channels)
+        ]
+
+        logger.info(f"[mesh_id=1] PARALLEL: ready; barrier before hot loop")
+        ttnn.distributed_context_barrier()
+
+        # --- hot loop (timed) ---
+        verified_first = False
+        t0 = time.perf_counter()
+        for _t in range(num_logical_tensors_per_channel):
+            for p in range(pages_per_chan):
+                for ch in range(num_channels):
+                    d2h_sockets[ch].read_tensor(output_tensors[ch])
+                    if not verified_first:
+                        got = ttnn.to_torch(output_tensors[ch]).to(torch.int32)
+                        expected = torch.arange(
+                            p * page_size_datums, (p + 1) * page_size_datums, dtype=torch.int32
+                        ).reshape(1, page_size_datums)
+                        assert torch.equal(expected, got), f"[mesh_id=1] ch={ch} first-page bit-exact check failed."
+                        logger.info(f"[mesh_id=1] ch=0 first page bit-exact OK; entering hot loop")
+                        verified_first = True
+        ttnn.distributed_context_barrier()
+        t1 = time.perf_counter()
+        # ---
+
+        elapsed_s = t1 - t0
+        total_bytes = num_logical_tensors_per_channel * num_channels * logical_bytes_per_chan
+        per_logical_ms = (elapsed_s / num_logical_tensors_per_channel) * 1000.0
+        agg_gbps = total_bytes / elapsed_s / 1e9
+        per_chan_gbps = (total_bytes / num_channels) / elapsed_s / 1e9
+        logger.info(
+            f"[mesh_id=1] PARALLEL RESULT: nc={num_channels}  page={page_size_bytes}B  "
+            f"iters={num_logical_tensors_per_channel}  total={total_bytes/1e6:.2f} MB  "
+            f"elapsed={elapsed_s:.3f}s  per-logical-tensor={per_logical_ms:.3f} ms  "
+            f"aggregate_bw={agg_gbps:.3f} GB/s  per_channel_bw={per_chan_gbps:.3f} GB/s"
+        )
+
+        for hio in host_ios:
+            hio.terminate(False)
+        parallel_socket.terminate(True)
+
+    logger.info(f"[rank with mesh_id={my_mesh_id}] PARALLEL done")

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py
@@ -78,6 +78,12 @@ _FIFO_PAGES = 4  # FIFO sized to 4 pages (= 32 KB)
 # path; the 2-galaxy variant is the cross-host smoke and is FIFO-capped.
 _TOPOLOGY_CONFIG = {
     "1galaxy": {"num_pages": 256, "wait_for_acks": True},
+    # 2-galaxy: cross-host ack credit return is still broken even with the
+    # dual-fwd-link sender that matches production d2d_exchange.cpp's pattern.
+    # The data path is verified bit-exact, but `fabric_socket_notify_sender_stateful`
+    # inline writes from receiver → sender don't update the sender's L1
+    # bytes_acked. FIFO-cap to _FIFO_PAGES pages and skip socket_barrier until
+    # that's resolved.
     "2galaxy": {"num_pages": _FIFO_PAGES, "wait_for_acks": False},
 }
 
@@ -85,11 +91,12 @@ _DATA_CB_INDEX = 0
 _PACKET_HEADER_CB_INDEX = 1
 
 
-def _packet_header_cb(core_range_set):
-    """Two-slot CB for fabric packet headers (data header + socket-notify header)."""
+def _packet_header_cb(core_range_set, num_slots):
+    """N-slot CB for fabric packet headers. Sender uses 3 (2 data + 1 notify);
+    receiver uses 1 (just the ack notify header)."""
     packet_header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
     return ttnn.CBDescriptor(
-        total_size=2 * packet_header_size,
+        total_size=num_slots * packet_header_size,
         core_ranges=core_range_set,
         format_descriptors=[
             ttnn.CBFormatDescriptor(
@@ -141,21 +148,25 @@ def _build_sender_program(
         config=ttnn.WriterConfigDescriptor(),
     )
 
+    # 3-slot packet header CB: 2 for the dual-link data writes, 1 for the
+    # socket-notify-receiver write. Matches production d2d_exchange.cpp.
     program = ttnn.ProgramDescriptor(
         kernels=[sender_kernel],
         semaphores=[],
-        cbs=[_data_cb(core_range_set, page_size), _packet_header_cb(core_range_set)],
+        cbs=[_data_cb(core_range_set, page_size), _packet_header_cb(core_range_set, num_slots=3)],
     )
 
     cx, cy = send_core.core_coord.x, send_core.core_coord.y
     program.kernels[0].runtime_args[cx][cy] = [source_tensor.buffer_address(), mesh_socket.get_config_buffer_address()]
 
+    # Open 2 forward fabric links (matches production d2d_exchange num_fwd_links=2).
     sender_fabric_node_id = mesh_device.get_fabric_node_id(send_core.device_coord)
     recv_fabric_node_id = mesh_socket.get_fabric_node_id(ttnn.SocketEndpoint.RECEIVER, recv_core.device_coord)
-    fabric_args = ttnn.setup_fabric_connection(
-        sender_fabric_node_id, recv_fabric_node_id, 0, program, send_core.core_coord
-    )
-    program.kernels[0].runtime_args[cx][cy].extend(fabric_args)
+    for link_idx in range(2):
+        fabric_args = ttnn.setup_fabric_connection(
+            sender_fabric_node_id, recv_fabric_node_id, link_idx, program, send_core.core_coord
+        )
+        program.kernels[0].runtime_args[cx][cy].extend(fabric_args)
 
     return program
 
@@ -178,7 +189,7 @@ def _build_receiver_program(mesh_device, mesh_socket, send_core, recv_core, dest
     program = ttnn.ProgramDescriptor(
         kernels=[receiver_kernel],
         semaphores=[],
-        cbs=[_packet_header_cb(core_range_set)],
+        cbs=[_packet_header_cb(core_range_set, num_slots=1)],
     )
 
     cx, cy = recv_core.core_coord.x, recv_core.core_coord.y

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py
@@ -5,8 +5,8 @@
 Pure-D2D DRAM→fabric→DRAM cross-mesh smoke — host out of the data path.
 
 Single chip-pair, single cross-mesh socket. Ships one logical tensor of size
-``_NUM_ELEMS_PER_TENSOR`` (uint32) from a DRAM-resident source on rank 0's
-chip (0, 0) to a DRAM-resident destination on rank 1's chip (0, 0), then
+``num_pages × _PAGE_SIZE_BYTES`` uint32s from a DRAM-resident source on rank
+0's chip (0, 0) to a DRAM-resident destination on rank 1's chip (0, 0), then
 verifies the destination matches the source bit-exactly.
 
 Why this exists
@@ -29,6 +29,18 @@ Kernels
   chip's core (0, 0). Pulls each page from the socket FIFO and
   ``noc_async_write``s it into the DRAM destination via ``TensorAccessor``.
 
+Known cross-host (2-galaxy) limitation
+--------------------------------------
+On 2-galaxy the receiver's ``fabric_socket_notify_sender_stateful`` ack
+writes (inline NOC writes encoded in fabric packet headers) don't reach the
+sender's ``bytes_acked`` counter — the data path works fine, but the credit
+return path goes silent. Symptom: sender hangs in ``socket_barrier`` waiting
+for the last ack. The data transfer itself is correct (verified bit-exact
+end-to-end). Workaround: the sender kernel takes a ``wait_for_acks``
+compile-time arg; we set it to 0 for 2-galaxy. Consequence: ``num_pages``
+must fit inside the socket FIFO (no page recycling), so 2-galaxy is capped
+at ``fifo_size / page_size`` pages until the ack path is fixed.
+
 Once this smoke passes, scaling to all 32 chip-pairs in parallel is just
 "add 31 more SocketConnections + 31 more program dispatches."
 """
@@ -49,16 +61,25 @@ _RECEIVER_KERNEL = "models/demos/deepseek_v3_d_p/tests/pipeline/kernels/socket_t
 
 # Tensor sized so the per-page L1 footprint fits comfortably alongside the
 # socket FIFO + packet header CB + kernel binary on a single Tensix core
-# (~1.5 MB total L1 on Blackhole). 2 MB total / 8 KB pages = 256 pages.
+# (~1.5 MB total L1 on Blackhole). Shape is (NUM_PAGES, ELEMS_PER_PAGE) so a
+# ROW_MAJOR DRAM tensor's intrinsic page (one row) == our kernel's page,
+# letting TensorAccessor.get_noc_addr(p) walk real pages rather than past
+# the end of a single-row allocation.
 #
-# Shape is (NUM_PAGES, ELEMS_PER_PAGE) so a ROW_MAJOR DRAM tensor's intrinsic
-# page (one row) == our kernel's page (8 KB). TensorAccessor.get_noc_addr(p)
-# then walks 256 real tensor pages, not into uninitialized memory past the
-# end of a single-row allocation.
-_NUM_PAGES = 256
+# Per-topology page counts:
+#   - 1-galaxy: 256 pages (2 MB total). socket_barrier works intra-galaxy.
+#   - 2-galaxy: 4 pages (32 KB). The ack credit-return path is broken cross-
+#     host, so wait_for_acks is off and num_pages must fit in the FIFO.
 _ELEMS_PER_PAGE = 2048
-_NUM_ELEMS_PER_TENSOR = _NUM_PAGES * _ELEMS_PER_PAGE  # 512K uint32 = 2 MB
 _PAGE_SIZE_BYTES = _ELEMS_PER_PAGE * 4  # 8 KB
+_FIFO_PAGES = 4  # FIFO sized to 4 pages (= 32 KB)
+
+# Per-topology config. The 1-galaxy variant exercises the full intra-galaxy
+# path; the 2-galaxy variant is the cross-host smoke and is FIFO-capped.
+_TOPOLOGY_CONFIG = {
+    "1galaxy": {"num_pages": 256, "wait_for_acks": True},
+    "2galaxy": {"num_pages": _FIFO_PAGES, "wait_for_acks": False},
+}
 
 _DATA_CB_INDEX = 0
 _PACKET_HEADER_CB_INDEX = 1
@@ -95,12 +116,21 @@ def _data_cb(core_range_set, page_size_bytes):
     )
 
 
-def _build_sender_program(mesh_device, mesh_socket, send_core, recv_core, source_tensor, page_size, num_pages):
+def _build_sender_program(
+    mesh_device, mesh_socket, send_core, recv_core, source_tensor, page_size, num_pages, wait_for_acks
+):
     core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(send_core.core_coord, send_core.core_coord)])
 
     tensor_accessor_args = ttnn.TensorAccessorArgs(source_tensor).get_compile_time_args()
 
-    compile_time_args = [_DATA_CB_INDEX, _PACKET_HEADER_CB_INDEX, page_size, num_pages, *tensor_accessor_args]
+    compile_time_args = [
+        _DATA_CB_INDEX,
+        _PACKET_HEADER_CB_INDEX,
+        page_size,
+        num_pages,
+        1 if wait_for_acks else 0,
+        *tensor_accessor_args,
+    ]
 
     sender_kernel = ttnn.KernelDescriptor(
         kernel_source=_SENDER_KERNEL,
@@ -200,14 +230,16 @@ def test_dram_to_dram_smoke(mesh_device):
     if num_procs != 2:
         pytest.skip(f"This test runs with exactly 2 ranks; got num_procs={num_procs}")
 
-    total_bytes = _NUM_ELEMS_PER_TENSOR * 4  # uint32
-    assert (
-        total_bytes % _PAGE_SIZE_BYTES == 0
-    ), f"total_bytes ({total_bytes}) must be a multiple of page_size ({_PAGE_SIZE_BYTES})"
-    num_pages = total_bytes // _PAGE_SIZE_BYTES
+    # Topology-aware config: 2-galaxy is FIFO-capped (see module docstring).
+    mesh_shape = mesh_device.shape
+    topology_id = "1galaxy" if (int(mesh_shape[0]), int(mesh_shape[1])) == (2, 4) else "2galaxy"
+    cfg = _TOPOLOGY_CONFIG[topology_id]
+    num_pages = cfg["num_pages"]
+    wait_for_acks = cfg["wait_for_acks"]
+    num_elems_per_tensor = num_pages * _ELEMS_PER_PAGE
+    total_bytes = num_elems_per_tensor * 4
 
-    # 4 in-flight pages of headroom — same convention as the H2D-bound perf test.
-    fifo_size_bytes = _PAGE_SIZE_BYTES * 4
+    fifo_size_bytes = _PAGE_SIZE_BYTES * _FIFO_PAGES
 
     my_mesh_id = mesh_device.get_system_mesh_id()
     peer_mesh_id = 1 if my_mesh_id == 0 else 0
@@ -220,8 +252,9 @@ def test_dram_to_dram_smoke(mesh_device):
     recv_core = ttnn.MeshCoreCoord(receiver_device_coord, core_coord)
 
     logger.info(
-        f"[mesh_id={my_mesh_id}] DRAM smoke: total={total_bytes} B, "
-        f"page={_PAGE_SIZE_BYTES} B, num_pages={num_pages}, fifo={fifo_size_bytes} B"
+        f"[mesh_id={my_mesh_id}] DRAM smoke ({topology_id}): total={total_bytes} B, "
+        f"page={_PAGE_SIZE_BYTES} B, num_pages={num_pages}, fifo={fifo_size_bytes} B, "
+        f"wait_for_acks={wait_for_acks}"
     )
 
     ttnn.enable_asynchronous_slow_dispatch(mesh_device)
@@ -243,10 +276,10 @@ def test_dram_to_dram_smoke(mesh_device):
     # ReplicateTensorToMesh explicitly so read-back semantics are deterministic.
     if my_mesh_id == 0:
         torch_local = (
-            torch.arange(_NUM_ELEMS_PER_TENSOR, dtype=torch.int64).to(torch.int32).reshape(_NUM_PAGES, _ELEMS_PER_PAGE)
+            torch.arange(num_elems_per_tensor, dtype=torch.int64).to(torch.int32).reshape(num_pages, _ELEMS_PER_PAGE)
         )
     else:
-        torch_local = torch.zeros(_NUM_PAGES, _ELEMS_PER_PAGE, dtype=torch.int32)
+        torch_local = torch.zeros(num_pages, _ELEMS_PER_PAGE, dtype=torch.int32)
     local_tensor = ttnn.from_torch(
         torch_local,
         dtype=ttnn.uint32,
@@ -261,7 +294,7 @@ def test_dram_to_dram_smoke(mesh_device):
     # Build the right program for this rank.
     if my_mesh_id == 0:
         program = _build_sender_program(
-            mesh_device, mesh_socket, send_core, recv_core, local_tensor, _PAGE_SIZE_BYTES, num_pages
+            mesh_device, mesh_socket, send_core, recv_core, local_tensor, _PAGE_SIZE_BYTES, num_pages, wait_for_acks
         )
         my_device_coord = sender_device_coord
     else:
@@ -291,11 +324,11 @@ def test_dram_to_dram_smoke(mesh_device):
             ttnn.from_device(local_tensor),
             mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1),
         ).to(torch.int32)
-        # readback shape: (_NUM_PAGES, num_chips * _ELEMS_PER_PAGE) ROW_MAJOR.
+        # readback shape: (num_pages, num_chips * _ELEMS_PER_PAGE) ROW_MAJOR.
         # Chip (0, 0) is the first cols slice; flatten that to compare against arange.
-        first_chip = readback[:, :_ELEMS_PER_PAGE].reshape(-1)
+        first_chip = readback[:, :_ELEMS_PER_PAGE].reshape(-1)[:num_elems_per_tensor]
 
-        expected = torch.arange(_NUM_ELEMS_PER_TENSOR, dtype=torch.int64).to(torch.int32)
+        expected = torch.arange(num_elems_per_tensor, dtype=torch.int64).to(torch.int32)
         match = torch.equal(expected, first_chip)
         if not match:
             mismatches = (expected != first_chip).nonzero(as_tuple=True)[0]
@@ -309,6 +342,6 @@ def test_dram_to_dram_smoke(mesh_device):
                 f"  expected (8 elems from there): {sample_expected}\n"
                 f"  got      (8 elems from there): {sample_got}"
             )
-        logger.info(f"[mesh_id=1] DRAM→DRAM bit-exact: PASS ({_NUM_ELEMS_PER_TENSOR} uint32 elems = {total_bytes} B)")
+        logger.info(f"[mesh_id=1] DRAM→DRAM bit-exact: PASS ({num_elems_per_tensor} uint32 elems = {total_bytes} B)")
 
     logger.info(f"[mesh_id={my_mesh_id}] smoke OK")

--- a/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py
+++ b/models/demos/deepseek_v3_d_p/tests/pipeline/test_dram_to_dram_smoke.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pure-D2D DRAM→fabric→DRAM cross-mesh smoke — host out of the data path.
+
+Single chip-pair, single cross-mesh socket. Ships one logical tensor of size
+``_NUM_ELEMS_PER_TENSOR`` (uint32) from a DRAM-resident source on rank 0's
+chip (0, 0) to a DRAM-resident destination on rank 1's chip (0, 0), then
+verifies the destination matches the source bit-exactly.
+
+Why this exists
+---------------
+The companion ``test_cross_mesh_socket_perf`` is bottlenecked by PCIe H2D
+throughput (it calls ``h2d_socket.write_tensor`` in the timed loop). For the
+prefill pipeline design the activations live in DRAM on the sender, never
+touch host, and land in DRAM on the receiver. This test exercises that path
+end-to-end with the smallest possible scope: 1 chip-pair, 1 transfer, no
+hot loop, no perf timing — just "does the wiring work and is the tensor
+correct."
+
+Kernels
+-------
+* ``kernels/dram_to_socket_sender.cpp`` — Tensix worker on the sender chip's
+  core (0, 0). Walks pages of the DRAM source via ``TensorAccessor``, stages
+  each in a local L1 CB, and pushes via single-link fabric writes into the
+  cross-mesh MeshSocket data buffer.
+* ``kernels/socket_to_dram_receiver.cpp`` — Tensix worker on the receiver
+  chip's core (0, 0). Pulls each page from the socket FIFO and
+  ``noc_async_write``s it into the DRAM destination via ``TensorAccessor``.
+
+Once this smoke passes, scaling to all 32 chip-pairs in parallel is just
+"add 31 more SocketConnections + 31 more program dispatches."
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
+
+_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_2D
+_FABRIC_ROUTER_MAX_PAYLOAD_BYTES = 2048
+
+_SENDER_KERNEL = "models/demos/deepseek_v3_d_p/tests/pipeline/kernels/dram_to_socket_sender.cpp"
+_RECEIVER_KERNEL = "models/demos/deepseek_v3_d_p/tests/pipeline/kernels/socket_to_dram_receiver.cpp"
+
+# Tensor sized so the per-page L1 footprint fits comfortably alongside the
+# socket FIFO + packet header CB + kernel binary on a single Tensix core
+# (~1.5 MB total L1 on Blackhole). 2 MB total / 8 KB pages = 256 pages.
+#
+# Shape is (NUM_PAGES, ELEMS_PER_PAGE) so a ROW_MAJOR DRAM tensor's intrinsic
+# page (one row) == our kernel's page (8 KB). TensorAccessor.get_noc_addr(p)
+# then walks 256 real tensor pages, not into uninitialized memory past the
+# end of a single-row allocation.
+_NUM_PAGES = 256
+_ELEMS_PER_PAGE = 2048
+_NUM_ELEMS_PER_TENSOR = _NUM_PAGES * _ELEMS_PER_PAGE  # 512K uint32 = 2 MB
+_PAGE_SIZE_BYTES = _ELEMS_PER_PAGE * 4  # 8 KB
+
+_DATA_CB_INDEX = 0
+_PACKET_HEADER_CB_INDEX = 1
+
+
+def _packet_header_cb(core_range_set):
+    """Two-slot CB for fabric packet headers (data header + socket-notify header)."""
+    packet_header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
+    return ttnn.CBDescriptor(
+        total_size=2 * packet_header_size,
+        core_ranges=core_range_set,
+        format_descriptors=[
+            ttnn.CBFormatDescriptor(
+                buffer_index=_PACKET_HEADER_CB_INDEX,
+                data_format=ttnn.uint32,
+                page_size=packet_header_size,
+            )
+        ],
+    )
+
+
+def _data_cb(core_range_set, page_size_bytes):
+    """Single-page L1 CB used to stage each DRAM page before pushing it via fabric."""
+    return ttnn.CBDescriptor(
+        total_size=page_size_bytes,
+        core_ranges=core_range_set,
+        format_descriptors=[
+            ttnn.CBFormatDescriptor(
+                buffer_index=_DATA_CB_INDEX,
+                data_format=ttnn.uint32,
+                page_size=page_size_bytes,
+            )
+        ],
+    )
+
+
+def _build_sender_program(mesh_device, mesh_socket, send_core, recv_core, source_tensor, page_size, num_pages):
+    core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(send_core.core_coord, send_core.core_coord)])
+
+    tensor_accessor_args = ttnn.TensorAccessorArgs(source_tensor).get_compile_time_args()
+
+    compile_time_args = [_DATA_CB_INDEX, _PACKET_HEADER_CB_INDEX, page_size, num_pages, *tensor_accessor_args]
+
+    sender_kernel = ttnn.KernelDescriptor(
+        kernel_source=_SENDER_KERNEL,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_range_set,
+        compile_time_args=compile_time_args,
+        defines=[("FABRIC_MAX_PACKET_SIZE", str(ttnn.get_tt_fabric_max_payload_size_bytes()))],
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    program = ttnn.ProgramDescriptor(
+        kernels=[sender_kernel],
+        semaphores=[],
+        cbs=[_data_cb(core_range_set, page_size), _packet_header_cb(core_range_set)],
+    )
+
+    cx, cy = send_core.core_coord.x, send_core.core_coord.y
+    program.kernels[0].runtime_args[cx][cy] = [source_tensor.buffer_address(), mesh_socket.get_config_buffer_address()]
+
+    sender_fabric_node_id = mesh_device.get_fabric_node_id(send_core.device_coord)
+    recv_fabric_node_id = mesh_socket.get_fabric_node_id(ttnn.SocketEndpoint.RECEIVER, recv_core.device_coord)
+    fabric_args = ttnn.setup_fabric_connection(
+        sender_fabric_node_id, recv_fabric_node_id, 0, program, send_core.core_coord
+    )
+    program.kernels[0].runtime_args[cx][cy].extend(fabric_args)
+
+    return program
+
+
+def _build_receiver_program(mesh_device, mesh_socket, send_core, recv_core, dest_tensor, page_size, num_pages):
+    core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(recv_core.core_coord, recv_core.core_coord)])
+
+    tensor_accessor_args = ttnn.TensorAccessorArgs(dest_tensor).get_compile_time_args()
+
+    compile_time_args = [_PACKET_HEADER_CB_INDEX, page_size, num_pages, *tensor_accessor_args]
+
+    receiver_kernel = ttnn.KernelDescriptor(
+        kernel_source=_RECEIVER_KERNEL,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_range_set,
+        compile_time_args=compile_time_args,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    program = ttnn.ProgramDescriptor(
+        kernels=[receiver_kernel],
+        semaphores=[],
+        cbs=[_packet_header_cb(core_range_set)],
+    )
+
+    cx, cy = recv_core.core_coord.x, recv_core.core_coord.y
+    program.kernels[0].runtime_args[cx][cy] = [mesh_socket.get_config_buffer_address(), dest_tensor.buffer_address()]
+
+    recv_fabric_node_id = mesh_device.get_fabric_node_id(recv_core.device_coord)
+    sender_fabric_node_id = mesh_socket.get_fabric_node_id(ttnn.SocketEndpoint.SENDER, send_core.device_coord)
+    fabric_args = ttnn.setup_fabric_connection(
+        recv_fabric_node_id, sender_fabric_node_id, 0, program, recv_core.core_coord
+    )
+    program.kernels[0].runtime_args[cx][cy].extend(fabric_args)
+
+    return program
+
+
+def _dispatch(mesh_device, program, device_coord):
+    dummy_tensor = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([0, 0, 0, 0]), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, mesh_device
+    )
+    mesh_pd = ttnn.MeshProgramDescriptor()
+    mesh_pd[ttnn.MeshCoordinateRange(device_coord, device_coord)] = program
+    return ttnn.generic_op([dummy_tensor, dummy_tensor], mesh_pd)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (2, 4),
+        (4, 8),
+    ],
+    ids=["1galaxy", "2galaxy"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": _FABRIC_CONFIG,
+            "fabric_router_config": create_fabric_router_config(_FABRIC_ROUTER_MAX_PAYLOAD_BYTES),
+        }
+    ],
+    indirect=True,
+)
+def test_dram_to_dram_smoke(mesh_device):
+    if not is_slow_dispatch():
+        pytest.skip("Sockets require slow dispatch (set TT_METAL_SLOW_DISPATCH_MODE=1).")
+
+    num_procs = int(ttnn.distributed_context_get_size())
+    if num_procs != 2:
+        pytest.skip(f"This test runs with exactly 2 ranks; got num_procs={num_procs}")
+
+    total_bytes = _NUM_ELEMS_PER_TENSOR * 4  # uint32
+    assert (
+        total_bytes % _PAGE_SIZE_BYTES == 0
+    ), f"total_bytes ({total_bytes}) must be a multiple of page_size ({_PAGE_SIZE_BYTES})"
+    num_pages = total_bytes // _PAGE_SIZE_BYTES
+
+    # 4 in-flight pages of headroom — same convention as the H2D-bound perf test.
+    fifo_size_bytes = _PAGE_SIZE_BYTES * 4
+
+    my_mesh_id = mesh_device.get_system_mesh_id()
+    peer_mesh_id = 1 if my_mesh_id == 0 else 0
+
+    # Single chip-pair at coord (0, 0), single core (0, 0). Cross-mesh.
+    sender_device_coord = ttnn.MeshCoordinate((0, 0))
+    receiver_device_coord = ttnn.MeshCoordinate((0, 0))
+    core_coord = ttnn.CoreCoord(0, 0)
+    send_core = ttnn.MeshCoreCoord(sender_device_coord, core_coord)
+    recv_core = ttnn.MeshCoreCoord(receiver_device_coord, core_coord)
+
+    logger.info(
+        f"[mesh_id={my_mesh_id}] DRAM smoke: total={total_bytes} B, "
+        f"page={_PAGE_SIZE_BYTES} B, num_pages={num_pages}, fifo={fifo_size_bytes} B"
+    )
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    # Build the cross-mesh socket (mesh 0 sender ↔ mesh 1 receiver, both at (0,0)).
+    socket_connection = ttnn.SocketConnection(send_core, recv_core)
+    socket_mem_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, fifo_size_bytes)
+    socket_config = ttnn.SocketConfig(
+        connections=[socket_connection],
+        memory_config=socket_mem_config,
+        sender_mesh_id=0,
+        receiver_mesh_id=1,
+    )
+    mesh_socket = ttnn.MeshSocket(mesh_device, socket_config)
+
+    # Pre-fill source DRAM with a deterministic arange pattern; pre-zero the
+    # destination. Tensor shape is (NUM_PAGES, ELEMS_PER_PAGE) so that the
+    # ROW_MAJOR per-row page equals the kernel's page_size (8 KB). Use
+    # ReplicateTensorToMesh explicitly so read-back semantics are deterministic.
+    if my_mesh_id == 0:
+        torch_local = (
+            torch.arange(_NUM_ELEMS_PER_TENSOR, dtype=torch.int64).to(torch.int32).reshape(_NUM_PAGES, _ELEMS_PER_PAGE)
+        )
+    else:
+        torch_local = torch.zeros(_NUM_PAGES, _ELEMS_PER_PAGE, dtype=torch.int32)
+    local_tensor = ttnn.from_torch(
+        torch_local,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    logger.info(f"[mesh_id={my_mesh_id}] tensors allocated; buffer_address=0x{local_tensor.buffer_address():x}")
+
+    # Build the right program for this rank.
+    if my_mesh_id == 0:
+        program = _build_sender_program(
+            mesh_device, mesh_socket, send_core, recv_core, local_tensor, _PAGE_SIZE_BYTES, num_pages
+        )
+        my_device_coord = sender_device_coord
+    else:
+        program = _build_receiver_program(
+            mesh_device, mesh_socket, send_core, recv_core, local_tensor, _PAGE_SIZE_BYTES, num_pages
+        )
+        my_device_coord = receiver_device_coord
+
+    logger.info(f"[mesh_id={my_mesh_id}] program built; barrier before dispatch")
+    ttnn.distributed_context_barrier()
+
+    _dispatch(mesh_device, program, my_device_coord)
+    ttnn.synchronize_device(mesh_device)
+
+    logger.info(f"[mesh_id={my_mesh_id}] dispatch complete; barrier before readback")
+    ttnn.distributed_context_barrier()
+
+    # Bit-exact check on the receiver. Only chip (0, 0) of the receiver mesh
+    # actually got data; the rest still have the pre-kernel zeros. Use a
+    # ConcatMeshToTensor composer to deterministically lay out per-chip shards
+    # side-by-side; chip (0, 0) is the first shard.
+    if my_mesh_id == 1:
+        # Concat along the trailing dim — chip-(0, 0)'s rows sit at columns
+        # 0.._ELEMS_PER_PAGE on the concatenated readback; flatten and take
+        # the first _NUM_ELEMS_PER_TENSOR elements.
+        readback = ttnn.to_torch(
+            ttnn.from_device(local_tensor),
+            mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1),
+        ).to(torch.int32)
+        # readback shape: (_NUM_PAGES, num_chips * _ELEMS_PER_PAGE) ROW_MAJOR.
+        # Chip (0, 0) is the first cols slice; flatten that to compare against arange.
+        first_chip = readback[:, :_ELEMS_PER_PAGE].reshape(-1)
+
+        expected = torch.arange(_NUM_ELEMS_PER_TENSOR, dtype=torch.int64).to(torch.int32)
+        match = torch.equal(expected, first_chip)
+        if not match:
+            mismatches = (expected != first_chip).nonzero(as_tuple=True)[0]
+            n_mismatch = mismatches.numel()
+            first = mismatches[0].item() if n_mismatch else -1
+            sample_expected = expected[first : first + 8].tolist() if n_mismatch else []
+            sample_got = first_chip[first : first + 8].tolist() if n_mismatch else []
+            assert match, (
+                f"[mesh_id=1] DRAM→DRAM bit-exact mismatch: {n_mismatch} elements differ.\n"
+                f"  first mismatch at index {first}\n"
+                f"  expected (8 elems from there): {sample_expected}\n"
+                f"  got      (8 elems from there): {sample_got}"
+            )
+        logger.info(f"[mesh_id=1] DRAM→DRAM bit-exact: PASS ({_NUM_ELEMS_PER_TENSOR} uint32 elems = {total_bytes} B)")
+
+    logger.info(f"[mesh_id={my_mesh_id}] smoke OK")

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_dual_4x8_intermesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_dual_4x8_intermesh.textproto
@@ -1,0 +1,40 @@
+# Black Hole 2-galaxy MGD for the cross-mesh prefill pipeline tests.
+#
+# Two (4, 8) Blackhole meshes (one per galaxy), connected over the inter-mesh
+# fabric.
+#
+# Channel counts match the physical BH-galaxy fabric topology (per Aditya
+# Saigal):
+#   - Intra-mesh:  2 channels per ETH link
+#   - Inter-mesh:  8 channels (4 exit nodes per galaxy × 2 channels per chip)
+#
+# Forked from dual_bh_galaxy_experimental_mesh_graph_descriptor.textproto so
+# that the other fabric tests consuming the experimental MGD aren't disturbed.
+# The intra count is unchanged (was already 2 RELAXED); the inter count goes
+# from 4 STRICT → 8 RELAXED so the socket infra can route over all available
+# inter-galaxy channels.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 8 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+    directional: false
+    assign_z_direction: true
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -229,7 +229,13 @@
 #define MEM_ERISC_FABRIC_ROUTING_PATH_SIZE_2D COMPRESSED_ROUTING_PATH_SIZE_2D
 #define MEM_ERISC_FABRIC_ROUTING_PATH_SIZE MEM_ERISC_FABRIC_ROUTING_PATH_SIZE_2D  // Union size
 #define MEM_ERISC_MAILBOX_SIZE 12768
-#define MEM_ERISC_KERNEL_CONFIG_SIZE (25 * 1024)
+// LOCAL PATCH (jjovicic/socket-experiment): bumped 25K -> 32K to fit the current
+// FABRIC_2D router program (~26000 bytes) on ACTIVE_ETH cores. The upstream 25K
+// limit was set when the router was smaller; recent commits grew it past 25K
+// for our intra-galaxy cross-mesh path (bh_galaxy_dual_2x4_intermesh.textproto
+// with assign_z_direction=true). Production multi-galaxy paths happen to land
+// under 25K so don't trigger this. Tracked upstream as related to #43079/#43085.
+#define MEM_ERISC_KERNEL_CONFIG_SIZE (32 * 1024)
 #define MEM_ERISC_BASE 0
 
 // From the top of L1. Common.


### PR DESCRIPTION
Adds a minimal pytest that exercises the cross-mesh D2D socket path on one Blackhole galaxy carved into two 2x4 meshes (whole UBB trays per mesh), driving one H2D -> one D2D hop (intermesh fabric) -> one D2H.

Files under models/demos/deepseek_v3_d_p/tests/pipeline/:
  test_cross_mesh_socket_smoke.py   2-rank pytest, FABRIC_2D, mesh (2,4)
  runme_cross_mesh_smoke.sh         tt-run launcher (--bare, --oversubscribe)
  dual_tray_2x4_rank_bindings.yaml  whole-tray rank binding (chips 0-7 vs 8-15)
                                    pointing at upstream
                                    tests/tt_metal/tt_fabric/custom_mesh_descriptors/
                                    bh_galaxy_dual_2x4_intermesh.textproto
  dual_2x1_minimal_rank_bindings.yaml  + bh_galaxy_dual_2x1_minimal.textproto
                                       smaller (2,1)-per-mesh variant; kept for
                                       reference but rejected by topology mapper
                                       on this hardware.

What works now (with the HAL bump below):
  - topology mapper finds the 2-mesh layout (relaxed mode, 4 of 8 channels)
  - fabric router program now fits in ACTIVE_ETH kernel config buffer

HAL bump (tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h):
  MEM_ERISC_KERNEL_CONFIG_SIZE 25K -> 32K.
  Current FABRIC_2D router compiles to ~26000 bytes on ACTIVE_ETH; the
  25K limit was set when the router was smaller. Tensix workers can grow
  their kernel-config via worker_l1_size; ACTIVE_ETH does not have an
  equivalent knob, so the only path was the HAL constant. Same root cause
  family as #43079 / #43085 (skips in test_host_io.py /
  test_multi_host_pipeline.py covering Blackhole single-galaxy fabric).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/socket-experiment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/socket-experiment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/socket-experiment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/socket-experiment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/socket-experiment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/socket-experiment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/socket-experiment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/socket-experiment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/socket-experiment)