### PR TITLE
[tt-triage] Save LLM friendly output artifact in CI

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -148,11 +148,13 @@ runs:
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"
         TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH=/work/generated/debug_bus_signal_groups.json
         TT_TRIAGE_OUTPUT_PATH=/work/generated/triage_output.txt
+        TT_TRIAGE_LLM_OUTPUT_PATH=/work/generated/triage_llm_output.txt
         HANG_REPORT="/opt/venv/bin/python3 $(pwd)/.github/scripts/utils/hang_report.py"
-        TRIAGE="/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress --path=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH --triage-summary-path=generated/triage_summary.txt"
+        TRIAGE="/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress --path=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH --triage-summary-path=generated/triage_summary.txt --llm-output-path=$TT_TRIAGE_LLM_OUTPUT_PATH"
         echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=$HANG_REPORT; mkdir -p generated; $TRIAGE 2>&1 | tee $TT_TRIAGE_OUTPUT_PATH 1>&2; $HANG_REPORT --update" >> $GITHUB_ENV
         echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
         echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1" >> $GITHUB_ENV
         echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
         echo "TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH" >> $GITHUB_ENV
+        echo "TT_TRIAGE_LLM_OUTPUT_PATH=$TT_TRIAGE_LLM_OUTPUT_PATH" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/upload-artifact-with-job-uuid/action.yml
+++ b/.github/actions/upload-artifact-with-job-uuid/action.yml
@@ -40,3 +40,11 @@ runs:
         name: "triage_output_${{ job.check_run_id }}"
         path: /work/generated/triage_output.txt
         if-no-files-found: ignore
+
+    - name: Upload triage LLM output
+      if: ${{ env.TT_TRIAGE_LLM_OUTPUT_PATH != '' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: "triage_llm_output_${{ job.check_run_id }}"
+        path: ${{ env.TT_TRIAGE_LLM_OUTPUT_PATH }}
+        if-no-files-found: ignore


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Enables the new LLM friendly triage output to be saved in CI as an artifact for easier analysis. File size is 50+% smaller than the original triage output file.

Closes https://github.com/tenstorrent/tt-exalens/issues/1028

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-llm-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-llm-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/triage-llm-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-llm-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-llm-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-llm-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-llm-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-llm-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-llm-ci)