### PR TITLE
SDPA: global Q scheduling for single-chip path

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -2109,6 +2109,13 @@ void sdpa_inner_loop(
         if (q_per_core > 1 || is_last_ring_iter) {
             cb_pop_front(cb_q_in, q_chunk_tiles);
         }
+
+        // Under global Q scheduling the reader pushes one cb_attention_sink slot per Q iter,
+        // so we must drain matching slots inside this loop. Pre-PR the push/pop pair was
+        // 1:1 outside the loop; the new cadence is 1:1 per iter.
+        if constexpr (use_attention_sink) {
+            cb_pop_front(cb_attention_sink, Sq_chunk_t);
+        }
     }
 
     if constexpr (sdpa_type == RING) {
@@ -2118,10 +2125,6 @@ void sdpa_inner_loop(
             cb_pop_front(cb_k_in, k_chunk_tiles);
             cb_pop_front(cb_v_in, v_chunk_tiles);
         }
-    }
-
-    if constexpr (use_attention_sink) {
-        cb_pop_front(cb_attention_sink, Sq_chunk_t);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1738,7 +1738,9 @@ void sdpa_inner_loop(
         uint32_t causal_k_limit = 0;  // RING: K-chunk index beyond which all K is above the diagonal
         if constexpr (sdpa_type == STANDARD) {
             const uint32_t linear_q_chunk = local_q_start + (q_iter - iter_q_start);
-            uint32_t q_chunk = remap_q_index(linear_q_chunk, q_num_chunks, use_zigzag_balancing);
+            // Mod is a no-op when the input is per-head ([0, q_num_chunks)) and extracts the
+            // per-head q_chunk when it's a flat global index (global Q scheduling spans heads).
+            uint32_t q_chunk = remap_q_index(linear_q_chunk, q_num_chunks, use_zigzag_balancing) % q_num_chunks;
             // Get Q chunk
             if constexpr (is_chunked) {
                 q_chunk = chunked_q_chunk_offset + q_chunk;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1313,8 +1313,10 @@ void sdpa_standard_v2(
         uint32_t k_loop_end = k_num_chunks;
         if constexpr (is_causal_sdpa) {
             // Reader and writer apply the same remap; compute must agree or causal
-            // masks and output positions desync.
-            q_chunk_local = remap_q_index(q_chunk_local, q_num_chunks, use_zigzag_balancing);
+            // masks and output positions desync. The mod is a no-op when the input is per-head
+            // ([0, q_num_chunks)) and extracts the per-head q_chunk when it's a flat global index
+            // (global Q scheduling iterates across batches and heads).
+            q_chunk_local = remap_q_index(q_chunk_local, q_num_chunks, use_zigzag_balancing) % q_num_chunks;
             // q_chunk_global is the absolute Q chunk index (used for the diagonal);
             // chunked-prefill shifts this via chunked_q_chunk_offset.
             const uint32_t q_chunk_global = q_chunk_local + chunked_q_chunk_offset;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -49,25 +49,21 @@ void kernel_main() {
     constexpr uint32_t valid_Skt = get_compile_time_arg_val(31);
     constexpr bool uniform_dataformat = get_compile_time_arg_val(32) == 1;
     constexpr uint32_t k_partial_col = get_compile_time_arg_val(33);
+    // Zigzag remap flag drives the external remap_q_index call on the flat B*NQH*q_num_chunks range.
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(34) == 1;
 
     const uint32_t core_id = get_arg_val<uint32_t>(0);
-    const uint32_t local_batch_start = get_arg_val<uint32_t>(1);
-    const uint32_t local_batch_end = get_arg_val<uint32_t>(2);
-    const uint32_t local_nh_start = get_arg_val<uint32_t>(3);
-    const uint32_t local_nh_end = get_arg_val<uint32_t>(4);
-    const uint32_t local_q_start = get_arg_val<uint32_t>(5);
-    const uint32_t local_q_end = get_arg_val<uint32_t>(6);
-    // const uint32_t chunked_q_chunk_offset = get_arg_val<uint32_t>(7);
-    const uint32_t num_phases = get_arg_val<uint32_t>(7);
-    const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(8);
-    uint32_t chunked_q_chunk_offset_phase_1 = get_arg_val<uint32_t>(9);
+    const uint32_t num_phases = get_arg_val<uint32_t>(1);
+    const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(2);
+    uint32_t chunked_q_chunk_offset_phase_1 = get_arg_val<uint32_t>(3);
     uint32_t chunked_q_chunk_offset_phase_2 = 0;
     if (num_phases == 2) {
-        chunked_q_chunk_offset_phase_2 = get_arg_val<uint32_t>(10);
+        chunked_q_chunk_offset_phase_2 = get_arg_val<uint32_t>(4);
     }
 
-    const uint32_t q_chunks_per_core = local_q_end - local_q_start;
+    // Global Q scheduling args follow phase_2 slot.
+    const uint32_t global_q_start = get_arg_val<uint32_t>(5);
+    const uint32_t global_q_count = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
@@ -139,51 +135,47 @@ void kernel_main() {
             cb_wait_front(cb_mask_in, 2);
         }
 
-        for (uint32_t phase = 0; phase < num_phases; ++phase) {
-            const uint32_t phase_chunked_offset =
-                (phase == 0) ? chunked_q_chunk_offset_phase_1 : chunked_q_chunk_offset_phase_2;
-            for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-                for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
-                    sdpa_standard_v2<
-                        Sq_chunk_t,
-                        Sk_chunk_t,
-                        valid_Skt,
-                        DHt,
-                        vDHt,
-                        scale_fp32,
-                        qk_subblock_h,
-                        qk_subblock_w,
-                        out_subblock_h,
-                        out_subblock_w,
-                        use_padded_mask,
-                        cb_q_in,
-                        cb_k_in,
-                        cb_v_in,
-                        cb_qk_im,
-                        cb_identity_scale_in,
-                        cb_exp_max_diff,
-                        cb_col_identity,
-                        cb_recip_scratch,
-                        cb_out,  // normalized output goes directly to output CB
-                        cb_mask_in,
-                        uniform_dataformat,
-                        is_causal>(
-                        q_chunks_per_core,
-                        k_num_chunks,
-                        cb_out_im_A,
-                        cb_out_im_B,
-                        cb_max_A,
-                        cb_max_B,
-                        cb_sum_A,
-                        cb_sum_B,
-                        local_q_start,
-                        phase_chunked_offset,
-                        lw_mask,
-                        q_num_chunks,
-                        use_zigzag_balancing);
-                }
-            }
-        }
+        // Global Q scheduling: sdpa_standard_v2 walks the per-core flat range over
+        // B*NQH*q_num_chunks chunks; the modulo inside its inner loop extracts the per-head q_chunk
+        // from each flat index. num_phases==1 is pinned for streaming, so the chunked offset comes
+        // from phase 1.
+        sdpa_standard_v2<
+            Sq_chunk_t,
+            Sk_chunk_t,
+            valid_Skt,
+            DHt,
+            vDHt,
+            scale_fp32,
+            qk_subblock_h,
+            qk_subblock_w,
+            out_subblock_h,
+            out_subblock_w,
+            use_padded_mask,
+            cb_q_in,
+            cb_k_in,
+            cb_v_in,
+            cb_qk_im,
+            cb_identity_scale_in,
+            cb_exp_max_diff,
+            cb_col_identity,
+            cb_recip_scratch,
+            cb_out,  // normalized output goes directly to output CB
+            cb_mask_in,
+            uniform_dataformat,
+            is_causal>(
+            global_q_count,
+            k_num_chunks,
+            cb_out_im_A,
+            cb_out_im_B,
+            cb_max_A,
+            cb_max_B,
+            cb_sum_A,
+            cb_sum_B,
+            global_q_start,
+            chunked_q_chunk_offset_phase_1,
+            lw_mask,
+            q_num_chunks,
+            use_zigzag_balancing);
     } else {
         // Standard SDPA path (causal, masked, chunked, etc.)
         constexpr bool use_lightweight_causal_mask = is_causal && !use_provided_mask && (sliding_window_size == 0);
@@ -203,65 +195,64 @@ void kernel_main() {
                 chunked_q_chunk_offset = chunked_q_chunk_offset_phase_2;
             }
 
-            for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-                for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
-                    sdpa_standard<
-                        cb_qk_im,
-                        cb_identity_scale_in,
-                        cb_attention_sink,
-                        Sq_chunk_t,
-                        Sk_chunk_t,
-                        DHt,
-                        vDHt,
-                        use_attention_sink,
-                        is_causal,
-                        use_provided_mask,
-                        use_padded_mask,
-                        is_chunked,
-                        scale_fp32,
-                        sliding_window_size,
-                        use_lightweight_causal_mask>(
-                        Skt,
-                        qk_in0_block_w,
-                        qk_subblock_w,
-                        qk_subblock_h,
-                        qk_in0_num_subblocks,
-                        qk_in1_num_subblocks,
-                        qk_num_blocks,
-                        out_in0_block_w,
-                        out_subblock_w,
-                        out_subblock_h,
-                        out_in0_num_subblocks,
-                        out_in1_num_subblocks,
-                        out_num_blocks,
-                        0,                  // iter_q_start
-                        q_chunks_per_core,  // iter_q_end
-                        q_num_chunks,
-                        local_q_start,
-                        chunked_q_chunk_offset,
-                        k_num_chunks,
-                        q_chunk_tiles,
-                        k_chunk_tiles,
-                        v_chunk_tiles,
-                        qk_chunk_tiles,
-                        out_chunk_tiles,
-                        cb_q_in,
-                        cb_k_in,
-                        cb_v_in,
-                        cb_mask_in,
-                        cb_col_identity,
-                        cb_out_im_A,
-                        cb_out_im_B,
-                        cb_max_A,
-                        cb_max_B,
-                        cb_sum_A,
-                        cb_sum_B,
-                        cb_exp_max_diff,
-                        cb_out,
-                        lw_mask,
-                        use_zigzag_balancing);
-                }
-            }
+            // Global Q scheduling: sdpa_standard walks the per-core flat range over
+            // B*NQH*q_num_chunks chunks; the modulo inside its inner loop extracts the per-head
+            // q_chunk from each flat index.
+            sdpa_standard<
+                cb_qk_im,
+                cb_identity_scale_in,
+                cb_attention_sink,
+                Sq_chunk_t,
+                Sk_chunk_t,
+                DHt,
+                vDHt,
+                use_attention_sink,
+                is_causal,
+                use_provided_mask,
+                use_padded_mask,
+                is_chunked,
+                scale_fp32,
+                sliding_window_size,
+                use_lightweight_causal_mask>(
+                Skt,
+                qk_in0_block_w,
+                qk_subblock_w,
+                qk_subblock_h,
+                qk_in0_num_subblocks,
+                qk_in1_num_subblocks,
+                qk_num_blocks,
+                out_in0_block_w,
+                out_subblock_w,
+                out_subblock_h,
+                out_in0_num_subblocks,
+                out_in1_num_subblocks,
+                out_num_blocks,
+                /*iter_q_start=*/0,
+                /*iter_q_end=*/global_q_count,
+                q_num_chunks,
+                /*local_q_start=*/global_q_start,
+                chunked_q_chunk_offset,
+                k_num_chunks,
+                q_chunk_tiles,
+                k_chunk_tiles,
+                v_chunk_tiles,
+                qk_chunk_tiles,
+                out_chunk_tiles,
+                cb_q_in,
+                cb_k_in,
+                cb_v_in,
+                cb_mask_in,
+                cb_col_identity,
+                cb_out_im_A,
+                cb_out_im_B,
+                cb_max_A,
+                cb_max_B,
+                cb_sum_A,
+                cb_sum_B,
+                cb_exp_max_diff,
+                cb_out,
+                lw_mask,
+                use_zigzag_balancing);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -95,12 +95,6 @@ void kernel_main() {
     const uint32_t attention_sink_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t chunk_start_idx_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t core_id = get_arg_val<uint32_t>(argidx++);
-    const uint32_t local_batch_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t local_batch_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t local_nh_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t local_nh_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t local_q_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t local_q_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t num_phases = get_arg_val<uint32_t>(argidx++);
     const uint32_t chunked_q_chunk_offset_phase_1 = get_arg_val<uint32_t>(argidx++);
     const uint32_t read_offset_phase_1 = get_arg_val<uint32_t>(argidx++);
@@ -113,7 +107,10 @@ void kernel_main() {
     uint32_t chunked_q_chunk_offset_phase_1_local = chunked_q_chunk_offset_phase_1;
     uint32_t chunked_q_chunk_offset_phase_2_local = chunked_q_chunk_offset_phase_2;
 
-    const uint32_t q_chunks_per_core = local_q_end - local_q_start;
+    // Global Q scheduling runtime args (parsed after chain metadata so the host-side ordering
+    // aligns for both causal and non-causal).
+    uint32_t global_q_start = 0;
+    uint32_t global_q_count = 0;
 
     // Parse chain metadata for KV forwarding (non-causal only)
     uint32_t is_chain_participant = 0;
@@ -188,6 +185,10 @@ void kernel_main() {
             }
         }
     }
+
+    // Global Q scheduling runtime args sit right after chain metadata.
+    global_q_start = get_arg_val<uint32_t>(argidx++);
+    global_q_count = get_arg_val<uint32_t>(argidx++);
 
     // When chunked: only process K/V up to (chunk_start_idx + Q_chunk_length) tokens.
     // valid_Skt_bound = min(offset_tiles + valid_Sqt, valid_Skt); cap at valid_Skt for callers that pass
@@ -283,370 +284,355 @@ void kernel_main() {
             valid_Skt_bound = valid_Skt + chunked_q_chunk_offset * Sq_chunk_t;
         }
 
-        for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-            if constexpr (is_chunked) {
-                // Chunked means that we have paged attention
-                cb_reserve_back(cb_id_page_table, 1);
-                page_table_ptr = read_page_table_for_batch(
-                    cb_id_page_table, nb, page_table_args, page_table_addr, page_table_stick_size);
-                cb_push_back(cb_id_page_table, 1);
-            }
-
-            // Calculate mask batch offset based on broadcasting (using unpadded mask dimensions):
-            // - If batch is broadcasted [1 x ...]: always use batch=0, so offset = 0
-            // - If batch is not broadcasted [b x ...]: use actual batch nb
-            uint32_t mask_batch_offset = 0;
-            if constexpr (!broadcast_provided_mask_batch) {
-                if constexpr (broadcast_provided_mask_heads) {
-                    // [b x 1 x s x s]: batch offset without head factor
-                    mask_batch_offset = nb * valid_Sqt * valid_Skt;
-                } else {
-                    // [b x h x s x s]: batch offset with all heads
-                    mask_batch_offset = nb * valid_Sqt * valid_Skt * NQH;
-                }
-            }
-            for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
-                // Read attention sink for this Q chunk if enabled
-                if constexpr (use_attention_sink) {
-                    cb_reserve_back(cb_attention_sink, Sq_chunk_t);
-                    uint32_t attention_sink_write_ptr = get_write_ptr(cb_attention_sink);
-
-                    // Attention sink has shape [1, NH, 1, 1] - single value per head
-                    // Read the single tile for this head into the first tile of the CB
-                    const uint32_t sink_tile_id =
-                        attention_sink_tile_shape.id_of(0, nq, 0, 0);  // batch=0 since shape is [1,NH,1,1]
-                    noc_async_read_tile(sink_tile_id, attention_sink_reader, attention_sink_write_ptr);
-                    noc_async_read_barrier();
-
-                    // Fill all Sq_chunk_t tiles in the CB by copying the first element of the source tile
-                    // to the first element of every row in each destination tile
-                    fill_attention_sink_tiles<attention_sink_tile_bytes>(
-                        cb_attention_sink, Sq_chunk_t, attention_sink_write_ptr);
-
-                    cb_push_back(cb_attention_sink, Sq_chunk_t);
-                }
-                for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
-                    /*
-                    Read a chunk of Q. Zigzag balancing remaps the flat per-head Q
-                    index in causal mode so light and heavy causal chunks interleave.
-                    When chunked, we must treat Q as offset by some factor.
-                    When causal, we set up the bounds such that we only read the lower triangle of K and V.
-                    When non-causal, read all of K and V.
-                    */
-                    uint32_t q_chunk = remap_q_index(local_q_start + q_iter, q_num_chunks, use_zigzag_balancing);
-                    /*
-                    Determine how many rows of Q will be read. Both start and end rows are
-                    capped by valid_Sqt, since Sq padding is independent of Sk padding.
-                    */
-                    const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
-                    const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
-                    const uint32_t q_row_tile_count = q_row_end_tile - q_row_start_tile;
-                    uint32_t q_read_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
-
-                    // Q read is deferred into the K loop (k_chunk==0) for subblock interleaving.
-                    // When use_q_subblock_push is false, Q is read in full before the K loop (original behavior).
-                    if constexpr (!use_q_subblock_push) {
-                        read_chunk_with_padding<q_tile_bytes>(
-                            q_reader,
-                            cb_q_in,
-                            q_read_tile_id,
-                            q_row_tile_count,
-                            DHt,
-                            Sq_chunk_t,
-                            DHt,
-                            barrier_threshold);
-                    }
-
-                    q_chunk = chunked_q_chunk_offset + q_chunk;
-                    uint32_t q_low_idx =
-                        q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
-                    uint32_t q_high_idx;
-                    if constexpr (is_causal) {
-                        // Clamp to total K-tile extent (Skt = k_num_chunks * Sk_chunk_t). Without
-                        // this, when Q-chunk extends past K (e.g., Sq_chunk_t > k_num_chunks*Sk_chunk_t),
-                        // the K-loop pushes more chunks than compute consumes → CB deadlock.
-                        const uint32_t q_high_unclamped = q_low_idx + Sq_chunk_t;
-                        q_high_idx = q_high_unclamped < Skt ? q_high_unclamped : Skt;
+        // Global Q scheduling: iterate over a linear range of B*NQH*q_num_chunks chunks.
+        // - per_head_q_iter resets on (nb, nq) transition: chain forwarding's
+        //   `q_iter < next_core_q_chunks` gate expects this (chains are non-causal only).
+        // - is_chunked: page-table read on nb transition, single-entry CB rotated forward.
+        // - use_attention_sink: pushed every iter, since compute pops Sq_chunk_t per
+        //   sdpa_inner_loop call and under global_q each iter is exactly one call.
+        uint32_t prev_nb = static_cast<uint32_t>(-1);
+        uint32_t prev_nq = static_cast<uint32_t>(-1);
+        uint32_t per_head_q_iter = 0;
+        uint32_t mask_batch_offset = 0;
+        for (uint32_t global_q_iter = 0; global_q_iter < global_q_count; ++global_q_iter) {
+            const auto decoded =
+                decompose_global_q_index(global_q_start + global_q_iter, q_num_chunks, NQH, use_zigzag_balancing);
+            if (decoded.nb != prev_nb) {
+                if constexpr (!broadcast_provided_mask_batch) {
+                    if constexpr (broadcast_provided_mask_heads) {
+                        mask_batch_offset = decoded.nb * valid_Sqt * valid_Skt;
                     } else {
-                        q_high_idx = Skt;
+                        mask_batch_offset = decoded.nb * valid_Sqt * valid_Skt * NQH;
                     }
-
-                    const uint32_t k_head = nq / q_heads_per_k;
-                    const uint32_t v_head = nq / q_heads_per_v;
-
-                    // Chain forwarding conditions are loop-invariant — compute once
-                    bool should_forward = false;
-                    bool should_receive = false;
-                    if constexpr (!is_causal) {
-                        should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
-                                         (q_iter < next_core_q_chunks);
-                        should_receive =
-                            is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
+                }
+                if constexpr (is_chunked) {
+                    if (prev_nb != static_cast<uint32_t>(-1)) {
+                        cb_pop_front(cb_id_page_table, 1);
                     }
+                    cb_reserve_back(cb_id_page_table, 1);
+                    page_table_ptr = read_page_table_for_batch(
+                        cb_id_page_table, decoded.nb, page_table_args, page_table_addr, page_table_stick_size);
+                    cb_push_back(cb_id_page_table, 1);
+                }
+            }
+            if (decoded.nb != prev_nb || decoded.nq != prev_nq) {
+                per_head_q_iter = 0;
+                prev_nb = decoded.nb;
+                prev_nq = decoded.nq;
+            }
+            if constexpr (use_attention_sink) {
+                cb_reserve_back(cb_attention_sink, Sq_chunk_t);
+                uint32_t attention_sink_write_ptr = get_write_ptr(cb_attention_sink);
+                const uint32_t sink_tile_id = attention_sink_tile_shape.id_of(0, decoded.nq, 0, 0);
+                noc_async_read_tile(sink_tile_id, attention_sink_reader, attention_sink_write_ptr);
+                noc_async_read_barrier();
+                fill_attention_sink_tiles<attention_sink_tile_bytes>(
+                    cb_attention_sink, Sq_chunk_t, attention_sink_write_ptr);
+                cb_push_back(cb_attention_sink, Sq_chunk_t);
+            }
 
-                    // loop while k_low < q_high
-                    for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
-                        const uint32_t kv_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
-                        const uint32_t kv_row_end_tile = std::min(kv_row_start_tile + Sk_chunk_t, valid_Skt_bound);
-                        const uint32_t kv_row_tile_count = kv_row_end_tile - kv_row_start_tile;
-                        const uint32_t k_start_tile_id = k_tile_shape.id_of(nb, k_head, kv_row_start_tile, 0);
-                        const uint32_t v_start_tile_id = v_tile_shape.id_of(nb, v_head, kv_row_start_tile, 0);
+            const uint32_t nb = decoded.nb;
+            const uint32_t nq = decoded.nq;
+            uint32_t q_chunk = decoded.q_chunk;
+            const uint32_t q_iter = per_head_q_iter;
+            ++per_head_q_iter;
 
-                        // K: either read locally (injector or not participant) or receive from previous core
-                        uint32_t cb_k_start_address = 0;
+            /*
+            Determine how many rows of Q will be read. Both start and end rows are
+            capped by valid_Sqt, since Sq padding is independent of Sk padding.
+            */
+            const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
+            const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
+            const uint32_t q_row_tile_count = q_row_end_tile - q_row_start_tile;
+            uint32_t q_read_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
 
-                        if (should_receive) {
-                            // Receive forwarded K chunk from previous core
+            // Q read is deferred into the K loop (k_chunk==0) for subblock interleaving.
+            // When use_q_subblock_push is false, Q is read in full before the K loop (original behavior).
+            if constexpr (!use_q_subblock_push) {
+                read_chunk_with_padding<q_tile_bytes>(
+                    q_reader, cb_q_in, q_read_tile_id, q_row_tile_count, DHt, Sq_chunk_t, DHt, barrier_threshold);
+            }
+
+            q_chunk = chunked_q_chunk_offset + q_chunk;
+            uint32_t q_low_idx = q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
+            uint32_t q_high_idx;
+            if constexpr (is_causal) {
+                // Clamp to total K-tile extent (Skt = k_num_chunks * Sk_chunk_t). Without
+                // this, when Q-chunk extends past K (e.g., Sq_chunk_t > k_num_chunks*Sk_chunk_t),
+                // the K-loop pushes more chunks than compute consumes → CB deadlock.
+                const uint32_t q_high_unclamped = q_low_idx + Sq_chunk_t;
+                q_high_idx = q_high_unclamped < Skt ? q_high_unclamped : Skt;
+            } else {
+                q_high_idx = Skt;
+            }
+
+            const uint32_t k_head = nq / q_heads_per_k;
+            const uint32_t v_head = nq / q_heads_per_v;
+
+            // Chain forwarding conditions are loop-invariant — compute once
+            bool should_forward = false;
+            bool should_receive = false;
+            if constexpr (!is_causal) {
+                should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
+                                 (q_iter < next_core_q_chunks);
+                should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
+            }
+
+            // loop while k_low < q_high
+            for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
+                const uint32_t kv_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
+                const uint32_t kv_row_end_tile = std::min(kv_row_start_tile + Sk_chunk_t, valid_Skt_bound);
+                const uint32_t kv_row_tile_count = kv_row_end_tile - kv_row_start_tile;
+                const uint32_t k_start_tile_id = k_tile_shape.id_of(nb, k_head, kv_row_start_tile, 0);
+                const uint32_t v_start_tile_id = v_tile_shape.id_of(nb, v_head, kv_row_start_tile, 0);
+
+                // K: either read locally (injector or not participant) or receive from previous core
+                uint32_t cb_k_start_address = 0;
+
+                if (should_receive) {
+                    // Receive forwarded K chunk from previous core
+                    cb_reserve_back(cb_k_in, k_chunk_tiles);
+                    cb_k_start_address = get_write_ptr(cb_k_in);
+                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
+                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                    cb_push_back(cb_k_in, k_chunk_tiles);
+                } else {
+                    // Read K chunk from DRAM
+                    if constexpr (is_chunked) {
+                        // Use page table to read K chunk (forwarding not supported for paged mode)
+                        const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                        read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
+                            k_reader,
+                            cb_k_in,
+                            k_head,
+                            k_chunk_start_row_num,
+                            kv_row_tile_count,
+                            DHt,
+                            Sk_chunk_t,
+                            DHt,
+                            k_tile_bytes,
+                            barrier_threshold,
+                            page_table_ptr,
+                            true  // transpose=true for K reads
+                        );
+                    } else {
+                        if (should_forward) {
                             cb_reserve_back(cb_k_in, k_chunk_tiles);
                             cb_k_start_address = get_write_ptr(cb_k_in);
-                            noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                            noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                            noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                            cb_push_back(cb_k_in, k_chunk_tiles);
+                            read_chunk_for_forwarding<k_tile_bytes, true>(
+                                k_reader, cb_k_start_address, k_start_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
                         } else {
-                            // Read K chunk from DRAM
-                            if constexpr (is_chunked) {
-                                // Use page table to read K chunk (forwarding not supported for paged mode)
-                                const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                                read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
-                                    k_reader,
-                                    cb_k_in,
-                                    k_head,
-                                    k_chunk_start_row_num,
-                                    kv_row_tile_count,
-                                    DHt,
-                                    Sk_chunk_t,
-                                    DHt,
-                                    k_tile_bytes,
-                                    barrier_threshold,
-                                    page_table_ptr,
-                                    true  // transpose=true for K reads
-                                );
-                            } else {
-                                if (should_forward) {
-                                    cb_reserve_back(cb_k_in, k_chunk_tiles);
-                                    cb_k_start_address = get_write_ptr(cb_k_in);
-                                    read_chunk_for_forwarding<k_tile_bytes, true>(
-                                        k_reader,
-                                        cb_k_start_address,
-                                        k_start_tile_id,
-                                        kv_row_tile_count,
-                                        DHt,
-                                        Sk_chunk_t,
-                                        DHt);
-                                } else {
-                                    read_chunk_with_padding<k_tile_bytes>(
-                                        k_reader,
-                                        cb_k_in,
-                                        k_start_tile_id,
-                                        kv_row_tile_count,
-                                        DHt,
-                                        Sk_chunk_t,
-                                        DHt,
-                                        barrier_threshold,
-                                        true  // transpose=true for K reads
-                                    );
-                                }
-                            }
-                        }
-
-                        // Forward K chunk to next core(s): initiate async write (NOC write channel)
-                        // For mcast: send linked data + companion semaphore back-to-back.
-                        // The companion must be issued immediately after the linked write —
-                        // any noc_async_read_barrier() between them deadlocks (the read barrier
-                        // blocks while a linked write awaits its companion).
-                        if (should_forward) {
-                            noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                            noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                            if constexpr (mcast_enabled) {
-                                uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
-                                noc_async_write_multicast(
-                                    cb_k_start_address,
-                                    k_mcast_addr,
-                                    k_chunk_tiles * k_tile_bytes,
-                                    mcast_num_dests,
-                                    true /* linked: semaphore mcast follows */);
-                                noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                                noc_async_writes_flushed();
-                                if (!should_receive) {
-                                    cb_push_back(cb_k_in, k_chunk_tiles);
-                                }
-                            } else {
-                                uint64_t k_unicast_data_addr =
-                                    get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                                noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
-                            }
-                        }
-
-                        // Mask read — safe after linked write pair is complete
-                        if constexpr (use_provided_mask) {
-                            cb_reserve_back(cb_mask_in, mask_chunk_tiles);
-                            uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
-                            uint32_t barrier_count = 0;
-
-                            uint32_t mask_row_start = mask_batch_offset + q_chunk * Sq_chunk_t * valid_Skt;
-                            if constexpr (!broadcast_provided_mask_heads) {
-                                mask_row_start += nq * valid_Sqt * valid_Skt;
-                            }
-
-                            uint32_t tile_idx = 0;
-                            for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
-                                const uint32_t global_q_tile = q_chunk * Sq_chunk_t + row;
-                                const bool q_valid = !use_padded_mask || (global_q_tile < valid_Sqt);
-                                for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
-                                    const uint32_t global_k_tile = k_chunk * Sk_chunk_t + col;
-                                    const bool k_valid = !use_padded_mask || (global_k_tile < valid_Skt);
-                                    if (q_valid && k_valid) {
-                                        noc_async_read_tile(
-                                            mask_row_start + global_k_tile, mask_reader, mask_write_ptr);
-                                    } else {
-                                        fill_neginf_tile<mask_tile_bytes>(cb_mask_in, tile_idx);
-                                    }
-                                    mask_write_ptr += mask_tile_bytes;
-                                    tile_idx++;
-                                    if (++barrier_count == barrier_threshold) {
-                                        noc_async_read_barrier();
-                                        barrier_count = 0;
-                                    }
-                                }
-                                if (q_valid) {
-                                    mask_row_start += valid_Skt;
-                                }
-                            }
-                            noc_async_read_barrier();
-                            cb_push_back(cb_mask_in, mask_chunk_tiles);
-                        }
-
-                        // Complete K forward: flush write and signal receiver(s)
-                        // (mcast path already completed above — companion sent with linked write)
-                        if (should_forward) {
-                            if constexpr (!mcast_enabled) {
-                                noc_async_writes_flushed();
-                                if (!should_receive) {
-                                    cb_push_back(cb_k_in, k_chunk_tiles);
-                                }
-                                noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
-                            }
-                        }
-
-                        // Q subblock push: K is fully forwarded, now push Q one subblock at
-                        // a time. Compute waits for K first (cb_wait_front(cb_k_in, K*N)),
-                        // then waits for Q subblocks incrementally (accumulating cb_wait_front).
-                        // Each push unblocks the next QK subblock computation.
-                        // Placed after K forward complete so no outstanding NOC writes remain
-                        // (noc_async_read_barrier inside read_q_subblock deadlocks on BH
-                        // when NOC writes are in-flight).
-                        if constexpr (use_q_subblock_push) {
-                            if (k_chunk == 0) {
-                                for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
-                                    read_q_subblock<q_tile_bytes>(
-                                        q_reader,
-                                        cb_q_in,
-                                        q_read_tile_id,
-                                        q_sub * qk_subblock_h,
-                                        qk_subblock_h,
-                                        q_row_tile_count,
-                                        DHt,
-                                        DHt,
-                                        barrier_threshold);
-                                }
-                            }
-                        }
-
-                        // V: either read locally (injector or not participant) or receive from previous core
-                        uint32_t cb_v_start_address = 0;
-
-                        if (should_receive) {
-                            // Receive forwarded V chunk from previous core
-                            cb_reserve_back(cb_v_in, v_chunk_tiles);
-                            cb_v_start_address = get_write_ptr(cb_v_in);
-                            noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                            noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                            noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                            cb_push_back(cb_v_in, v_chunk_tiles);
-                        } else {
-                            // Read V chunk from DRAM
-                            if constexpr (is_chunked) {
-                                // Use page table to read V chunk (forwarding not supported for paged mode)
-                                const uint32_t kv_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                                constexpr uint32_t head_dim = (use_mla && !mla_kv_overlap) ? vDHt : DHt;
-                                read_paged_chunk_with_padding<NVH, block_size_t, head_dim>(
-                                    v_reader,
-                                    cb_v_in,
-                                    v_head,
-                                    kv_chunk_start_row_num,
-                                    kv_row_tile_count,
-                                    vDHt,
-                                    Sk_chunk_t,
-                                    vDHt,
-                                    v_tile_bytes,
-                                    barrier_threshold,
-                                    page_table_ptr,
-                                    false,
-                                    skip_src_cols);
-                            } else {
-                                if (should_forward) {
-                                    cb_reserve_back(cb_v_in, v_chunk_tiles);
-                                    cb_v_start_address = get_write_ptr(cb_v_in);
-                                    read_chunk_for_forwarding<v_tile_bytes, false>(
-                                        v_reader,
-                                        cb_v_start_address,
-                                        v_start_tile_id,
-                                        kv_row_tile_count,
-                                        vDHt,
-                                        Sk_chunk_t,
-                                        vDHt,
-                                        skip_src_cols);
-                                } else {
-                                    read_chunk_with_padding<v_tile_bytes>(
-                                        v_reader,
-                                        cb_v_in,
-                                        v_start_tile_id,
-                                        kv_row_tile_count,
-                                        vDHt,
-                                        Sk_chunk_t,
-                                        vDHt,
-                                        barrier_threshold,
-                                        false,
-                                        skip_src_cols);
-                                }
-                            }
-                        }
-
-                        // Forward V chunk to next core(s) before push_back — prevents compute from
-                        // popping the buffer while the mcast is still reading from it.
-                        if (should_forward) {
-                            noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                            noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                            if constexpr (mcast_enabled) {
-                                uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
-                                noc_async_write_multicast(
-                                    cb_v_start_address,
-                                    v_mcast_addr,
-                                    v_chunk_tiles * v_tile_bytes,
-                                    mcast_num_dests,
-                                    true /* linked: semaphore mcast follows */);
-                                noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                            } else {
-                                uint64_t v_unicast_data_addr =
-                                    get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
-                                noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
-                            }
-                            noc_async_writes_flushed();
-                            if constexpr (!mcast_enabled) {
-                                noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
-                            }
-                            if (!should_receive) {
-                                cb_push_back(cb_v_in, v_chunk_tiles);
-                            }
+                            read_chunk_with_padding<k_tile_bytes>(
+                                k_reader,
+                                cb_k_in,
+                                k_start_tile_id,
+                                kv_row_tile_count,
+                                DHt,
+                                Sk_chunk_t,
+                                DHt,
+                                barrier_threshold,
+                                true  // transpose=true for K reads
+                            );
                         }
                     }
                 }
-            }
 
-            if constexpr (is_chunked) {
+                // Forward K chunk to next core(s): initiate async write (NOC write channel)
+                // For mcast: send linked data + companion semaphore back-to-back.
+                // The companion must be issued immediately after the linked write —
+                // any noc_async_read_barrier() between them deadlocks (the read barrier
+                // blocks while a linked write awaits its companion).
+                if (should_forward) {
+                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
+                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                    if constexpr (mcast_enabled) {
+                        uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
+                        noc_async_write_multicast(
+                            cb_k_start_address,
+                            k_mcast_addr,
+                            k_chunk_tiles * k_tile_bytes,
+                            mcast_num_dests,
+                            true /* linked: semaphore mcast follows */);
+                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                        noc_async_writes_flushed();
+                        if (!should_receive) {
+                            cb_push_back(cb_k_in, k_chunk_tiles);
+                        }
+                    } else {
+                        uint64_t k_unicast_data_addr =
+                            get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
+                        noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
+                    }
+                }
+
+                // Mask read — safe after linked write pair is complete
+                if constexpr (use_provided_mask) {
+                    cb_reserve_back(cb_mask_in, mask_chunk_tiles);
+                    uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
+                    uint32_t barrier_count = 0;
+
+                    uint32_t mask_row_start = mask_batch_offset + q_chunk * Sq_chunk_t * valid_Skt;
+                    if constexpr (!broadcast_provided_mask_heads) {
+                        mask_row_start += nq * valid_Sqt * valid_Skt;
+                    }
+
+                    uint32_t tile_idx = 0;
+                    for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
+                        const uint32_t global_q_tile = q_chunk * Sq_chunk_t + row;
+                        const bool q_valid = !use_padded_mask || (global_q_tile < valid_Sqt);
+                        for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
+                            const uint32_t global_k_tile = k_chunk * Sk_chunk_t + col;
+                            const bool k_valid = !use_padded_mask || (global_k_tile < valid_Skt);
+                            if (q_valid && k_valid) {
+                                noc_async_read_tile(mask_row_start + global_k_tile, mask_reader, mask_write_ptr);
+                            } else {
+                                fill_neginf_tile<mask_tile_bytes>(cb_mask_in, tile_idx);
+                            }
+                            mask_write_ptr += mask_tile_bytes;
+                            tile_idx++;
+                            if (++barrier_count == barrier_threshold) {
+                                noc_async_read_barrier();
+                                barrier_count = 0;
+                            }
+                        }
+                        if (q_valid) {
+                            mask_row_start += valid_Skt;
+                        }
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(cb_mask_in, mask_chunk_tiles);
+                }
+
+                // Complete K forward: flush write and signal receiver(s)
+                // (mcast path already completed above — companion sent with linked write)
+                if (should_forward) {
+                    if constexpr (!mcast_enabled) {
+                        noc_async_writes_flushed();
+                        if (!should_receive) {
+                            cb_push_back(cb_k_in, k_chunk_tiles);
+                        }
+                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                    }
+                }
+
+                // Q subblock push: K is fully forwarded, now push Q one subblock at
+                // a time. Compute waits for K first (cb_wait_front(cb_k_in, K*N)),
+                // then waits for Q subblocks incrementally (accumulating cb_wait_front).
+                // Each push unblocks the next QK subblock computation.
+                // Placed after K forward complete so no outstanding NOC writes remain
+                // (noc_async_read_barrier inside read_q_subblock deadlocks on BH
+                // when NOC writes are in-flight).
+                if constexpr (use_q_subblock_push) {
+                    if (k_chunk == 0) {
+                        for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
+                            read_q_subblock<q_tile_bytes>(
+                                q_reader,
+                                cb_q_in,
+                                q_read_tile_id,
+                                q_sub * qk_subblock_h,
+                                qk_subblock_h,
+                                q_row_tile_count,
+                                DHt,
+                                DHt,
+                                barrier_threshold);
+                        }
+                    }
+                }
+
+                // V: either read locally (injector or not participant) or receive from previous core
+                uint32_t cb_v_start_address = 0;
+
+                if (should_receive) {
+                    // Receive forwarded V chunk from previous core
+                    cb_reserve_back(cb_v_in, v_chunk_tiles);
+                    cb_v_start_address = get_write_ptr(cb_v_in);
+                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
+                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                    cb_push_back(cb_v_in, v_chunk_tiles);
+                } else {
+                    // Read V chunk from DRAM
+                    if constexpr (is_chunked) {
+                        // Use page table to read V chunk (forwarding not supported for paged mode)
+                        const uint32_t kv_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                        constexpr uint32_t head_dim = (use_mla && !mla_kv_overlap) ? vDHt : DHt;
+                        read_paged_chunk_with_padding<NVH, block_size_t, head_dim>(
+                            v_reader,
+                            cb_v_in,
+                            v_head,
+                            kv_chunk_start_row_num,
+                            kv_row_tile_count,
+                            vDHt,
+                            Sk_chunk_t,
+                            vDHt,
+                            v_tile_bytes,
+                            barrier_threshold,
+                            page_table_ptr,
+                            false,
+                            skip_src_cols);
+                    } else {
+                        if (should_forward) {
+                            cb_reserve_back(cb_v_in, v_chunk_tiles);
+                            cb_v_start_address = get_write_ptr(cb_v_in);
+                            read_chunk_for_forwarding<v_tile_bytes, false>(
+                                v_reader,
+                                cb_v_start_address,
+                                v_start_tile_id,
+                                kv_row_tile_count,
+                                vDHt,
+                                Sk_chunk_t,
+                                vDHt,
+                                skip_src_cols);
+                        } else {
+                            read_chunk_with_padding<v_tile_bytes>(
+                                v_reader,
+                                cb_v_in,
+                                v_start_tile_id,
+                                kv_row_tile_count,
+                                vDHt,
+                                Sk_chunk_t,
+                                vDHt,
+                                barrier_threshold,
+                                false,
+                                skip_src_cols);
+                        }
+                    }
+                }
+
+                // Forward V chunk to next core(s) before push_back — prevents compute from
+                // popping the buffer while the mcast is still reading from it.
+                if (should_forward) {
+                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
+                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                    if constexpr (mcast_enabled) {
+                        uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
+                        noc_async_write_multicast(
+                            cb_v_start_address,
+                            v_mcast_addr,
+                            v_chunk_tiles * v_tile_bytes,
+                            mcast_num_dests,
+                            true /* linked: semaphore mcast follows */);
+                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                    } else {
+                        uint64_t v_unicast_data_addr =
+                            get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
+                        noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
+                    }
+                    noc_async_writes_flushed();
+                    if constexpr (!mcast_enabled) {
+                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                    }
+                    if (!should_receive) {
+                        cb_push_back(cb_v_in, v_chunk_tiles);
+                    }
+                }
+            }  // close k_chunk
+        }  // close global_q_iter
+        if constexpr (is_chunked) {
+            if (prev_nb != static_cast<uint32_t>(-1)) {
                 cb_pop_front(cb_id_page_table, 1);
             }
         }
-    }
+    }  // close phase
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -38,24 +38,20 @@ void kernel_main() {
 
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
-    const uint32_t local_batch_start = get_arg_val<uint32_t>(2);
-    const uint32_t local_batch_end = get_arg_val<uint32_t>(3);
-    const uint32_t local_nh_start = get_arg_val<uint32_t>(4);
-    const uint32_t local_nh_end = get_arg_val<uint32_t>(5);
-    const uint32_t local_q_start = get_arg_val<uint32_t>(6);
-    const uint32_t local_q_end = get_arg_val<uint32_t>(7);
-    const uint32_t num_phases = get_arg_val<uint32_t>(8);
-    const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(9);
-    uint32_t chunk_start_t_in_q_chunks_phase_1 = get_arg_val<uint32_t>(10);
-    const uint32_t write_offset_phase_1 = get_arg_val<uint32_t>(11);
+    const uint32_t num_phases = get_arg_val<uint32_t>(2);
+    const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(3);
+    uint32_t chunk_start_t_in_q_chunks_phase_1 = get_arg_val<uint32_t>(4);
+    const uint32_t write_offset_phase_1 = get_arg_val<uint32_t>(5);
     uint32_t chunk_start_t_in_q_chunks_phase_2 = 0;
     uint32_t write_offset_phase_2 = 0;
     if (num_phases == 2) {
-        chunk_start_t_in_q_chunks_phase_2 = get_arg_val<uint32_t>(12);
-        write_offset_phase_2 = get_arg_val<uint32_t>(13);
+        chunk_start_t_in_q_chunks_phase_2 = get_arg_val<uint32_t>(6);
+        write_offset_phase_2 = get_arg_val<uint32_t>(7);
     }
 
-    const uint32_t q_chunks_per_core = local_q_end - local_q_start;
+    // Global Q scheduling args follow phase_2 args.
+    const uint32_t global_q_start = get_arg_val<uint32_t>(8);
+    const uint32_t global_q_count = get_arg_val<uint32_t>(9);
 
     constexpr uint32_t mask_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;  // non-streaming drain only
@@ -115,63 +111,51 @@ void kernel_main() {
             chunk_start_t_in_q_chunks = chunk_start_t_in_q_chunks_phase_2;
             write_offset = write_offset_phase_2;
         }
-        for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-            const uint32_t q_batch_offset = nb * NQH * Sqt * DHt;
-            for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
-                for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
-                    uint32_t q_chunk = remap_q_index(local_q_start + q_iter, q_num_chunks, use_zigzag_balancing);
+        for (uint32_t global_q_iter = 0; global_q_iter < global_q_count; ++global_q_iter) {
+            const auto decoded =
+                decompose_global_q_index(global_q_start + global_q_iter, q_num_chunks, NQH, use_zigzag_balancing);
+            const uint32_t nb = decoded.nb;
+            const uint32_t nq = decoded.nq;
+            const uint32_t q_chunk = decoded.q_chunk;
 
-                    // Generate mask only when user didn't provide one.
-                    // Lightweight path already has a single -inf tile fronted — skip generate_mask.
-                    if constexpr (!use_provided_mask && !use_lightweight_mask) {
-                        generate_mask<is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
-                            Sq_chunk_t,
-                            Sk_chunk_t,
-                            q_chunk,
-                            chunk_start_t_in_q_chunks,
-                            true,
-                            false,
-                            unpadded_Sk,
-                            0,
-                            is_causal);
-                    }
+            // Generate mask only when user didn't provide one.
+            // Lightweight path already has a single -inf tile fronted — skip generate_mask.
+            if constexpr (!use_provided_mask && !use_lightweight_mask) {
+                generate_mask<is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
+                    Sq_chunk_t, Sk_chunk_t, q_chunk, chunk_start_t_in_q_chunks, true, false, unpadded_Sk, 0, is_causal);
+            }
 
-                    // Wait for compute to deliver output chunk
-                    /*
-                      Determine how many rows of OUT will be written. Both start and end rows are
-                      capped by valid_Sqt, since Sq padding is independent of Sk padding.
-                    */
-                    const uint32_t out_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
-                    const uint32_t out_row_end_tile = std::min(out_row_start_tile + Sq_chunk_t, valid_Sqt);
-                    const uint32_t out_row_tile_count = out_row_end_tile - out_row_start_tile;
-                    uint32_t out_tile_id = out_tile_shape.id_of(nb, nq, write_offset + out_row_start_tile, 0);
-                    if constexpr (use_streaming_compute) {
-                        // Streaming: drain per row-group (cb_out is a 2-slot ping-pong).
-                        // Compute always pushes Sq_chunk_t rows; rows past out_row_tile_count
-                        // are padding and get popped without being written.
-                        write_block_row_grouped(
-                            out_writer,
-                            cb_out,
-                            Sq_chunk_t,
-                            out_row_tile_count,
-                            vDHt,
-                            out_tile_id,
-                            tile_bytes,
-                            out_subblock_h,
-                            barrier_threshold);
-                    } else {
-                        write_block(
-                            out_writer,
-                            cb_out,
-                            out_chunk_tiles,
-                            out_row_tile_count,
-                            vDHt,
-                            out_tile_id,
-                            tile_bytes,
-                            barrier_threshold);
-                    }
-                }
+            // Determine how many rows of OUT will be written. Both start and end rows are
+            // capped by valid_Sqt, since Sq padding is independent of Sk padding.
+            const uint32_t out_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
+            const uint32_t out_row_end_tile = std::min(out_row_start_tile + Sq_chunk_t, valid_Sqt);
+            const uint32_t out_row_tile_count = out_row_end_tile - out_row_start_tile;
+            uint32_t out_tile_id = out_tile_shape.id_of(nb, nq, write_offset + out_row_start_tile, 0);
+            if constexpr (use_streaming_compute) {
+                // Streaming: drain per row-group (cb_out is a 2-slot ping-pong).
+                // Compute always pushes Sq_chunk_t rows; rows past out_row_tile_count
+                // are padding and get popped without being written.
+                write_block_row_grouped(
+                    out_writer,
+                    cb_out,
+                    Sq_chunk_t,
+                    out_row_tile_count,
+                    vDHt,
+                    out_tile_id,
+                    tile_bytes,
+                    out_subblock_h,
+                    barrier_threshold);
+            } else {
+                write_block(
+                    out_writer,
+                    cb_out,
+                    out_chunk_tiles,
+                    out_row_tile_count,
+                    vDHt,
+                    out_tile_id,
+                    tile_bytes,
+                    barrier_threshold);
             }
         }
-    }
+    }  // close phase
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp
@@ -57,3 +57,32 @@ FORCE_INLINE uint32_t remap_q_index(uint32_t linear_index, uint32_t num_q_chunks
     }
     return linear_index;
 }
+
+/**
+ * Result of decomposing a global Q index into (batch, head, q_chunk) coordinates.
+ */
+struct GlobalQIndex {
+    uint32_t nb;
+    uint32_t nq;
+    uint32_t q_chunk;
+};
+
+/**
+ * Decompose a linear global Q index in [0, B*NQH*num_q_chunks) into (nb, nq, q_chunk).
+ *
+ * Applies the remap (linear or zigzag) first, then splits the remapped index as:
+ *   nb      = idx / (NQH * num_q_chunks)
+ *   nq      = (idx / num_q_chunks) % NQH
+ *   q_chunk = idx % num_q_chunks
+ *
+ * Used by SDPA reader/writer kernels under global Q scheduling to fetch the right
+ * Q/K/V and write outputs for each (batch, head, q_chunk) triple a core is assigned.
+ */
+FORCE_INLINE GlobalQIndex decompose_global_q_index(uint32_t idx, uint32_t num_q_chunks, uint32_t NQH, bool use_zigzag) {
+    const uint32_t remapped = remap_q_index(idx, num_q_chunks, use_zigzag);
+    return {
+        /*nb=*/remapped / (NQH * num_q_chunks),
+        /*nq=*/(remapped / num_q_chunks) % NQH,
+        /*q_chunk=*/remapped % num_q_chunks,
+    };
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -138,16 +138,25 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         chunked_q_chunk_offset_phase_2 += chunk_start_idx.value() / q_chunk_size;
     }
 
-    // Parallelization scheme
-    // We will choose parallelization factors for batch, num_heads, and q_seq_len in that order
-    uint32_t batch_parallel_factor = std::min(B, num_cores);
-    uint32_t nh_parallel_factor = std::min(num_cores / batch_parallel_factor, NQH);
-    uint32_t q_parallel_factor = std::min(num_cores / (batch_parallel_factor * nh_parallel_factor), q_num_chunks);
-
-    // Ceiling divide to allow for non-perfect divisions
-    const uint32_t batch_per_core = (B + batch_parallel_factor - 1) / batch_parallel_factor;
-    const uint32_t nh_per_core = (NQH + nh_parallel_factor - 1) / nh_parallel_factor;
-    const uint32_t q_per_core = (q_num_chunks + q_parallel_factor - 1) / q_parallel_factor;
+    // Global Q scheduling: distribute the flat B*NQH*q_num_chunks Q-chunk space evenly across cores
+    // (one linear range per core). Ring is always causal, so pair-distribute when q_num_chunks is
+    // even — that keeps the shared zigzag remap balancing light/heavy work across cores. The same
+    // (global_q_start, global_q_count) range is walked once per ring phase (num_phases=2 below).
+    const uint32_t total_q_chunks = B * NQH * q_num_chunks;
+    const bool global_q_pair_distribute = (q_num_chunks % 2 == 0);
+    uint32_t global_q_base_chunks_per_core = 0;
+    uint32_t global_q_cores_doing_extra = 0;
+    uint32_t global_q_extra_chunks_per_core = 0;
+    if (global_q_pair_distribute) {
+        const uint32_t total_pairs = total_q_chunks / 2;
+        global_q_base_chunks_per_core = (total_pairs / num_cores) * 2;
+        global_q_cores_doing_extra = total_pairs % num_cores;
+        global_q_extra_chunks_per_core = 2;
+    } else {
+        global_q_base_chunks_per_core = total_q_chunks / num_cores;
+        global_q_cores_doing_extra = total_q_chunks % num_cores;
+        global_q_extra_chunks_per_core = 1;
+    }
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * 2;
@@ -273,7 +282,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         0,      // arg 21: use_streaming_compute — always false for ring distributed (causal)
         0,      // arg 22: out_subblock_h — unused when streaming is off
         0,      // arg 23: k_partial_col — non-streaming, no partial mask emitted
-        static_cast<uint32_t>(use_zigzag_balancing),  // arg 24
+        static_cast<uint32_t>(use_zigzag_balancing),  // arg 24: unified zigzag remap
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
@@ -311,9 +320,9 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         0,          //(std::uint32_t)use_attention_sink,
         0,          //(std::uint32_t)use_streaming_compute — always false for ring distributed (causal)
         valid_Skt,  // arg 31: unpadded K tiles for streaming padded_k_tiles
-        0,          // arg 32: uniform_dataformat — unused when streaming is off
-        0,          // arg 33: k_partial_col — non-streaming, no partial mask emitted
-        static_cast<uint32_t>(use_zigzag_balancing),  // arg 34
+        0u,         // arg 32: uniform_dataformat — unused on ring's non-streaming path
+        0u,         // arg 33: k_partial_col — unused on ring's non-streaming path
+        static_cast<uint32_t>(use_zigzag_balancing),  // arg 34: unified zigzag remap
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
 
@@ -463,27 +472,23 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     // Set reader rt args
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
-        uint32_t core_id = i;
 
         uint32_t read_offset_phase_1 = chunk_1 * Sqt;
         uint32_t read_offset_phase_2 = chunk_2 * Sqt;
         uint32_t write_offset_phase_1 = 0;
         uint32_t write_offset_phase_2 = Sqt;
 
-        uint32_t local_batch_start = (core_id / (nh_parallel_factor * q_parallel_factor)) * batch_per_core;
-        uint32_t local_batch_end = local_batch_start + batch_per_core;
-        uint32_t local_nh_start = ((core_id / q_parallel_factor) % nh_parallel_factor) * nh_per_core;
-        uint32_t local_nh_end = local_nh_start + nh_per_core;
-        uint32_t local_q_start = (core_id % q_parallel_factor) * q_per_core;
-        uint32_t local_q_end = local_q_start + q_per_core;
-
-        // clamp all to max values for non-even partitioning
-        local_batch_start = std::min(local_batch_start, B);
-        local_batch_end = std::min(local_batch_end, B);
-        local_nh_start = std::min(local_nh_start, NQH);
-        local_nh_end = std::min(local_nh_end, NQH);
-        local_q_start = std::min(local_q_start, q_num_chunks);
-        local_q_end = std::min(local_q_end, q_num_chunks);
+        // Per-core slice of the flat B*NQH*q_num_chunks Q-chunk space (walked once per phase).
+        uint32_t global_q_start = i * global_q_base_chunks_per_core +
+                                  std::min(i, global_q_cores_doing_extra) * global_q_extra_chunks_per_core;
+        uint32_t global_q_count =
+            global_q_base_chunks_per_core + ((i < global_q_cores_doing_extra) ? global_q_extra_chunks_per_core : 0u);
+        if (global_q_start >= total_q_chunks) {
+            global_q_start = total_q_chunks;
+            global_q_count = 0;
+        } else if (global_q_start + global_q_count > total_q_chunks) {
+            global_q_count = total_q_chunks - global_q_start;
+        }
 
         uint32_t page_table_addr = page_table.has_value() ? page_table->buffer()->address() : 0;
         SetRuntimeArgs(
@@ -498,50 +503,38 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
              0,  // attention_sink_addr,
              0,  // chunk_start_idx_addr (ring has no chunk_start_idx_tensor)
              i,
-             local_batch_start,
-             local_batch_end,
-             local_nh_start,
-             local_nh_end,
-             local_q_start,
-             local_q_end,
              2,
              chunked_q_chunk_offset_phase_1,
              read_offset_phase_1,
              chunked_q_chunk_offset_phase_2,
-             read_offset_phase_2});
+             read_offset_phase_2,
+             global_q_start,
+             global_q_count});
         SetRuntimeArgs(
             program,
             writer_kernels_id,
             core,
             {out_addr,
              i,
-             local_batch_start,
-             local_batch_end,
-             local_nh_start,
-             local_nh_end,
-             local_q_start,
-             local_q_end,
              2,
              0,  // use_chunk_start_idx_tensor (ring has no chunk_start_idx_tensor)
              chunked_q_chunk_offset_phase_1,
              write_offset_phase_1,
              chunked_q_chunk_offset_phase_2,
-             write_offset_phase_2});
+             write_offset_phase_2,
+             global_q_start,
+             global_q_count});
         SetRuntimeArgs(
             program,
             compute_kernels_id,
             core,
             {i,
-             local_batch_start,
-             local_batch_end,
-             local_nh_start,
-             local_nh_end,
-             local_q_start,
-             local_q_end,
              2,
              0,  // use_chunk_start_idx_tensor (ring has no chunk_start_idx_tensor)
              chunked_q_chunk_offset_phase_1,
-             chunked_q_chunk_offset_phase_2});
+             chunked_q_chunk_offset_phase_2,
+             global_q_start,
+             global_q_count});
     }
 
     return cached_program_t(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -332,31 +332,30 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         num_cores,
         device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y);
 
-    // Parallelization scheme
-    // We will choose parallelization factors for batch, num_heads, and q_seq_len in that order
-    uint32_t batch_parallel_factor = std::min(B, num_cores);
-    uint32_t nh_parallel_factor = std::min(num_cores / batch_parallel_factor, NQH);
-    uint32_t q_parallel_factor = std::min(num_cores / (batch_parallel_factor * nh_parallel_factor), q_num_chunks);
+    TT_FATAL(num_cores > 0, "SDPA requires a non-empty core grid; got num_cores=0.");
 
-    TT_FATAL(
-        batch_parallel_factor * nh_parallel_factor * q_parallel_factor <= num_cores,
-        "Parallelism must not exceed number of cores. Got {}, expected at most {}.",
-        batch_parallel_factor * nh_parallel_factor * q_parallel_factor,
-        num_cores);
+    // Global Q scheduling is the single-chip default: distribute the flat B*NQH*q_num_chunks
+    // Q-chunk space evenly across cores. Pair-distribute when causal + even q_num_chunks so every
+    // core gets balanced light/heavy work after the shared zigzag remap (CT 31/24/34 to kernels).
+    const uint32_t total_q_chunks = B * NQH * q_num_chunks;
+    const bool global_q_pair_distribute = is_causal && (q_num_chunks % 2 == 0);
+    uint32_t global_q_base_chunks_per_core = 0;
+    uint32_t global_q_cores_doing_extra = 0;
+    uint32_t global_q_extra_chunks_per_core = 0;
+    if (global_q_pair_distribute) {
+        const uint32_t total_pairs = total_q_chunks / 2;
+        global_q_base_chunks_per_core = (total_pairs / num_cores) * 2;
+        global_q_cores_doing_extra = total_pairs % num_cores;
+        global_q_extra_chunks_per_core = 2;
+    } else {
+        global_q_base_chunks_per_core = total_q_chunks / num_cores;
+        global_q_cores_doing_extra = total_q_chunks % num_cores;
+        global_q_extra_chunks_per_core = 1;
+    }
+    const uint32_t max_global_q_chunks_per_core =
+        global_q_base_chunks_per_core + (global_q_cores_doing_extra > 0 ? global_q_extra_chunks_per_core : 0);
 
-    log_debug(tt::LogOp, "Parallelization scheme:");
-    log_debug(tt::LogOp, "batch_parallel_factor: {}", batch_parallel_factor);
-    log_debug(tt::LogOp, "nh_parallel_factor: {}", nh_parallel_factor);
-    log_debug(tt::LogOp, "q_parallel_factor: {}", q_parallel_factor);
-
-    // Ceiling divide to allow for non-perfect divisions
-    const uint32_t batch_per_core = (B + batch_parallel_factor - 1) / batch_parallel_factor;
-    const uint32_t nh_per_core = (NQH + nh_parallel_factor - 1) / nh_parallel_factor;
-    const uint32_t q_per_core = (q_num_chunks + q_parallel_factor - 1) / q_parallel_factor;
-
-    const uint32_t q_buffer_factor = (q_per_core > 1) ? 2 : 1;
-
-    log_debug(tt::LogOp, "q_per_core: {}", q_per_core);
+    const uint32_t q_buffer_factor = (max_global_q_chunks_per_core > 1) ? 2 : 1;
 
     // Host code is responsible for determining matmul configuration
     const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
@@ -467,6 +466,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     const bool use_zigzag_balancing = is_causal;
 
+    // Reader CT layout: ... arg 27..30 = sema/mcast placeholders, arg 31 = use_zigzag_balancing,
+    // then TensorAccessorArgs from 32.
     std::vector<uint32_t> reader_compile_time_args = {// interleaved accessor args
                                                       B,
                                                       NQH,
@@ -539,6 +540,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             valid_semaphore_id);
     }
 
+    // Writer CT layout: ... arg 24 = use_zigzag_balancing, then TensorAccessorArgs from 25.
     std::vector<uint32_t> writer_compile_time_args = {
         // interleaved accessor args
         B,
@@ -565,7 +567,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         (std::uint32_t)(use_streaming_compute),       // arg 21: row-grouped cb_out drain
         out_out_subblock_h,                           // arg 22: drain group height
         k_partial_col,                                // arg 23: K partial-tile col (0 = no partial)
-        static_cast<uint32_t>(use_zigzag_balancing),  // arg 24
+        static_cast<uint32_t>(use_zigzag_balancing),  // arg 24: unified zigzag remap
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -609,7 +611,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         valid_Skt,                                    // arg 31: unpadded K tile count for streaming padded_k_tiles
         (std::uint32_t)uniform_dataformat,            // arg 32: skip reconfig when all formats match
         k_partial_col,                                // arg 33: K partial-tile col (0 = no partial)
-        static_cast<uint32_t>(use_zigzag_balancing),  // arg 34
+        static_cast<uint32_t>(use_zigzag_balancing),  // arg 34: unified zigzag remap
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
@@ -623,6 +625,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     defines["EXP_APPROX_MODE"] = std::to_string(exp_approx_mode);
 
     log_debug(tt::LogOp, "use_zigzag_balancing: {}", use_zigzag_balancing);
+    log_debug(tt::LogOp, "global_q_pair_distribute: {}", global_q_pair_distribute);
 
     // NOTE: CreateKernel calls are deferred until after chain construction so that
     // the mcast_enabled compile-time arg can be determined first.
@@ -794,6 +797,12 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     uint32_t read_offset = 0;
     uint32_t write_offset = 0;
 
+    // Defense-in-depth: kernels place global_q runtime args past the max phase_2 slot,
+    // but the host-side compute/writer arg packing only zeros the phase_2 slots when
+    // num_phases==1. Any future change that raises num_phases on this path must rethink
+    // the layout — assert early so the failure is loud rather than a slot reinterpretation.
+    TT_FATAL(num_phases == 1, "Single-chip SDPA assumes num_phases == 1 under global Q scheduling");
+
     // Build chain topology for KV forwarding (non-causal only)
     std::vector<CoreWork> core_work(num_cores);
     std::vector<CoreChainInfo> core_chain_info(num_cores);
@@ -801,6 +810,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     std::vector<std::vector<HeadSegmentRef>> head_segments;
     uint32_t mcast_chains = 0;
 
+    // KV chain forwarding applies to non-causal, non-chunked workloads. Each core's linear global
+    // range is decomposed into (nb, nq, q_chunk_range) segments below to build per-head chains.
     if (!is_causal && !is_chunked) {
         head_segments.resize(total_heads);
 
@@ -813,44 +824,54 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         for (uint32_t i = 0; i < num_cores; ++i) {
             CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
-            uint32_t local_batch_start = (i / (nh_parallel_factor * q_parallel_factor)) * batch_per_core;
-            uint32_t local_batch_end = local_batch_start + batch_per_core;
-            uint32_t local_nh_start = ((i / q_parallel_factor) % nh_parallel_factor) * nh_per_core;
-            uint32_t local_nh_end = local_nh_start + nh_per_core;
-            uint32_t local_q_start = (i % q_parallel_factor) * q_per_core;
-            uint32_t local_q_end = local_q_start + q_per_core;
-
-            // Clamp to max values
-            local_batch_start = std::min(local_batch_start, B);
-            local_batch_end = std::min(local_batch_end, B);
-            local_nh_start = std::min(local_nh_start, NQH);
-            local_nh_end = std::min(local_nh_end, NQH);
-            local_q_start = std::min(local_q_start, q_num_chunks);
-            local_q_end = std::min(local_q_end, q_num_chunks);
-
             auto& work = core_work[i];
             work.logical_core = core;
             work.physical_core = device->worker_core_from_logical_core(core);
 
-            // Track each (batch, head, q_chunk_range) this core handles
-            for (uint32_t b = local_batch_start; b < local_batch_end; ++b) {
-                for (uint32_t h = local_nh_start; h < local_nh_end; ++h) {
-                    uint32_t q_count = local_q_end - local_q_start;
-                    if (q_count > 0) {
-                        work.head_work.push_back(CoreHeadWork{
-                            .batch = b,
-                            .head = h,
-                            .q_chunk_start = local_q_start,
-                            .q_chunk_count = q_count,
-                        });
-
-                        uint32_t head_id = (b * NQH) + h;
-                        if (head_id < head_segments.size()) {
-                            head_segments[head_id].push_back(HeadSegmentRef{
-                                .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
-                        }
-                    }
+            auto push_head_work = [&](uint32_t nb, uint32_t nh, uint32_t q_start, uint32_t q_count) {
+                if (q_count == 0) {
+                    return;
                 }
+                work.head_work.push_back(CoreHeadWork{
+                    .batch = nb,
+                    .head = nh,
+                    .q_chunk_start = q_start,
+                    .q_chunk_count = q_count,
+                });
+                const uint32_t head_id = (nb * NQH) + nh;
+                if (head_id < head_segments.size()) {
+                    head_segments[head_id].push_back(HeadSegmentRef{
+                        .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
+                }
+            };
+
+            // Walk the core's [g_start, g_start + g_count) linear range and split into
+            // contiguous (nb, nq, q_chunk_range) segments. Non-causal here (chain section is
+            // !is_causal), so the zigzag remap is off and the decompose is identity.
+            uint32_t g_start = i * global_q_base_chunks_per_core +
+                               std::min(i, global_q_cores_doing_extra) * global_q_extra_chunks_per_core;
+            uint32_t g_count = global_q_base_chunks_per_core +
+                               ((i < global_q_cores_doing_extra) ? global_q_extra_chunks_per_core : 0u);
+            if (g_start >= total_q_chunks) {
+                g_start = total_q_chunks;
+                g_count = 0;
+            } else if (g_start + g_count > total_q_chunks) {
+                g_count = total_q_chunks - g_start;
+            }
+            work.global_q_start = g_start;
+            work.global_q_count = g_count;
+
+            uint32_t cursor = g_start;
+            const uint32_t g_end = g_start + g_count;
+            while (cursor < g_end) {
+                const uint32_t nb = cursor / (NQH * q_num_chunks);
+                const uint32_t nq = (cursor / q_num_chunks) % NQH;
+                const uint32_t q_in_head = cursor % q_num_chunks;
+                const uint32_t remaining_in_head = q_num_chunks - q_in_head;
+                const uint32_t remaining_in_range = g_end - cursor;
+                const uint32_t span = std::min(remaining_in_head, remaining_in_range);
+                push_head_work(nb, nq, q_in_head, span);
+                cursor += span;
             }
 
             if (!work.head_work.empty()) {
@@ -1285,31 +1306,26 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
-        // log_debug(tt::LogOp, "core: {} getting runtime args for idx {i}", core, i);
-        uint32_t local_batch_start = (i / (nh_parallel_factor * q_parallel_factor)) * batch_per_core;
-        uint32_t local_batch_end = local_batch_start + batch_per_core;
-        uint32_t local_nh_start = ((i / q_parallel_factor) % nh_parallel_factor) * nh_per_core;
-        uint32_t local_nh_end = local_nh_start + nh_per_core;
-        uint32_t local_q_start = (i % q_parallel_factor) * q_per_core;
-        uint32_t local_q_end = local_q_start + q_per_core;
+        // Global Q scheduling per-core range: contiguous slice of the flat (B, NQH, q_num_chunks) space.
+        uint32_t global_q_start = i * global_q_base_chunks_per_core +
+                                  std::min(i, global_q_cores_doing_extra) * global_q_extra_chunks_per_core;
+        uint32_t global_q_count =
+            global_q_base_chunks_per_core + ((i < global_q_cores_doing_extra) ? global_q_extra_chunks_per_core : 0u);
+        if (global_q_start >= total_q_chunks) {
+            global_q_start = total_q_chunks;
+            global_q_count = 0;
+        } else if (global_q_start + global_q_count > total_q_chunks) {
+            global_q_count = total_q_chunks - global_q_start;
+        }
 
-        // clamp all to max values for non-even partitioning
-        local_batch_start = std::min(local_batch_start, B);
-        local_batch_end = std::min(local_batch_end, B);
-        local_nh_start = std::min(local_nh_start, NQH);
-        local_nh_end = std::min(local_nh_end, NQH);
-        local_q_start = std::min(local_q_start, q_num_chunks);
-        local_q_end = std::min(local_q_end, q_num_chunks);
-
-        // log the above
-        log_debug(tt::LogOp, "core: {}", i);
-        log_debug(tt::LogOp, "x={},y={}", core.x, core.y);
-        log_debug(tt::LogOp, "local_batch_start: {}", local_batch_start);
-        log_debug(tt::LogOp, "local_batch_end: {}", local_batch_end);
-        log_debug(tt::LogOp, "local_nh_start: {}", local_nh_start);
-        log_debug(tt::LogOp, "local_nh_end: {}", local_nh_end);
-        log_debug(tt::LogOp, "local_q_start: {}", local_q_start);
-        log_debug(tt::LogOp, "local_q_end: {}", local_q_end);
+        log_debug(
+            tt::LogOp,
+            "core: {} x={} y={} global_q_start={} global_q_count={}",
+            i,
+            core.x,
+            core.y,
+            global_q_start,
+            global_q_count);
 
         // Get chain info for this core
         const auto& chain = core_chain_info[i];
@@ -1323,12 +1339,6 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             attention_sink_addr,
             flexible_chunked ? operation_attributes.chunk_start_idx_tensor.value().buffer()->address() : 0,
             i,
-            local_batch_start,
-            local_batch_end,
-            local_nh_start,
-            local_nh_end,
-            local_q_start,
-            local_q_end,
             num_phases,
             chunked_q_chunk_offset,
             read_offset  // read_offset
@@ -1352,37 +1362,33 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             reader_args.push_back(chain.mcast_sender_wait);
         }
 
+        reader_args.push_back(global_q_start);
+        reader_args.push_back(global_q_count);
+
         SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
-        SetRuntimeArgs(
-            program,
-            writer_kernels_id,
-            core,
-            {out_addr,
-             i,
-             local_batch_start,
-             local_batch_end,
-             local_nh_start,
-             local_nh_end,
-             local_q_start,
-             local_q_end,
-             num_phases,
-             static_cast<uint32_t>(flexible_chunked ? 1 : 0),
-             chunked_q_chunk_offset,
-             write_offset});  // write_offset
-        SetRuntimeArgs(
-            program,
-            compute_kernels_id,
-            core,
-            {i,
-             local_batch_start,
-             local_batch_end,
-             local_nh_start,
-             local_nh_end,
-             local_q_start,
-             local_q_end,
-             num_phases,
-             static_cast<uint32_t>(flexible_chunked ? 1 : 0),
-             chunked_q_chunk_offset});
+        std::vector<uint32_t> writer_args = {
+            out_addr,
+            i,
+            num_phases,                                       // 2
+            static_cast<uint32_t>(flexible_chunked ? 1 : 0),  // 3
+            chunked_q_chunk_offset,                           // 4: phase_1
+            write_offset,                                     // 5
+            0u,                                               // 6: phase_2 chunk_start (unused, num_phases==1)
+            0u,                                               // 7: phase_2 write_offset (unused, num_phases==1)
+            global_q_start,                                   // 8
+            global_q_count,                                   // 9
+        };
+        SetRuntimeArgs(program, writer_kernels_id, core, writer_args);
+        std::vector<uint32_t> compute_args = {
+            i,
+            num_phases,                                       // 1
+            static_cast<uint32_t>(flexible_chunked ? 1 : 0),  // 2
+            chunked_q_chunk_offset,                           // 3: phase_1
+            0u,                                               // 4: phase_2 chunked offset (unused, num_phases==1)
+            global_q_start,                                   // 5
+            global_q_count,                                   // 6
+        };
+        SetRuntimeArgs(program, compute_kernels_id, core, compute_args);
     }
 
     return cached_program_t{
@@ -1462,14 +1468,14 @@ void SDPAProgramFactory::override_runtime_arguments(
         reader_args[4] = page_table_addr;
         reader_args[5] = attention_sink_addr;
         reader_args[6] = chunk_start_idx_addr;
-        reader_args[15] = chunked_q_chunk_offset;
+        reader_args[9] = chunked_q_chunk_offset;
 
         writer_args[0] = out_addr;
-        writer_args[9] = use_chunk_start_idx_tensor;
-        writer_args[10] = chunked_q_chunk_offset;
+        writer_args[3] = use_chunk_start_idx_tensor;
+        writer_args[4] = chunked_q_chunk_offset;
 
-        compute_args[8] = use_chunk_start_idx_tensor;
-        compute_args[9] = chunked_q_chunk_offset;
+        compute_args[2] = use_chunk_start_idx_tensor;
+        compute_args[3] = chunked_q_chunk_offset;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -161,6 +161,7 @@ ChunkedParams compute_chunked_params(
 
 }  // namespace
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const SDPAParams& operation_attributes, const SDPAInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor_q = tensor_args.q;


### PR DESCRIPTION
## Summary

Adds **global Q scheduling** to single-chip and ring-distributed SDPA: the `B * NQH * q_num_chunks` Q-chunk space is laid out flat and distributed evenly across cores (one linear range per core), replacing the hierarchical batch → heads → q_chunks split.

The zigzag remap (#44480 — merged on main) is reused as the unified balancing flag, with pair-distribution when causal + even `q_num_chunks` so cores get balanced light/heavy work.

After this PR, **single-chip SDPA and ring-joint SDPA share the same Q distribution scheme** (ring-distributed too).

## Result

- Better core utilization on low batch/head-count workloads
- Single-chip, ring-distributed, and ring-joint SDPA aligned on one scheduling pattern

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26176978946)
- [x] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26176983729) (sdpa only)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26176981320)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26171201879)
- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26171204620) (ops perf tests only)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26171207143)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26171209917)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/runs/26171212631) (deepseek_prefill only)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sdpa-global-q-scheduling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-global-q-scheduling)
