### PR TITLE
Add L1-safe defaults for paged SDPA decode

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -270,6 +270,44 @@ def test_sdpa_decode_paged_attention_regressions(
         )
 
 
+@pytest.mark.parametrize(
+    "kv_dtype, q_dtype",
+    [
+        [ttnn.bfloat8_b, ttnn.bfloat16],
+    ],
+    ids=[
+        "kv_bfp8_q_bf16",
+    ],
+)
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d, grid_size, cur_pos_tensor, sliding_window_size",
+    ([1, 8, 1, 1024, 512, (8, 8), True, None],),  # Gemma-style global attention; issue #44311
+    ids=["paged-default-config-l1-regr"],
+)
+@pytest.mark.parametrize("block_size", (32,), ids=["paged_32"])
+@pytest.mark.timeout(120)
+def test_sdpa_decode_paged_attention_default_config_regression(
+    device, b, nh, nkv, s, d, kv_dtype, grid_size, q_dtype, cur_pos_tensor, sliding_window_size, block_size, reset_seeds
+):
+    run_test_sdpa_decode_paged_attention(
+        device,
+        b,
+        nh,
+        nkv,
+        s,
+        d,
+        kv_dtype,
+        grid_size,
+        q_dtype,
+        cur_pos_tensor,
+        block_size=block_size,
+        sharded_in=True,
+        sharded_out=False,
+        sliding_window_size=sliding_window_size,
+        use_program_config=False,
+    )
+
+
 @pytest.mark.timeout(120)
 def test_sdpa_decode_tree_reduction_power_of_2_regression(device):
     """Regression test for issue #38521: tree-reduction round count off-by-one for power-of-2 core counts.

--- a/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
@@ -556,6 +556,7 @@ def run_test_sdpa_decode_paged_attention(
     sharded_in=True,
     sharded_out=True,
     sliding_window_size=None,
+    use_program_config=True,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -645,18 +646,21 @@ def run_test_sdpa_decode_paged_attention(
         scale = d**-0.5
         start_indices = np.linspace(max(max_start_idx - b, 0), max_start_idx, b, dtype=np.int32).tolist()
 
-        # Test when page_table does not contain blocks for full sequence length
-        k_chunk_size = get_chunk_size(max_start_idx + 1, s)
+        # Test when page_table does not contain blocks for full sequence length.
+        # The no-program-config decode default uses fixed 32-token chunks.
+        k_chunk_size = get_chunk_size(max_start_idx + 1, s) if use_program_config else 32
         padded_layer_len = nearest_n(max_start_idx + 1, n=k_chunk_size) if causal else s
 
         tt_page_table = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
-        program_config = ttnn.SDPAProgramConfig(
-            compute_with_storage_grid_size=grid_size,  # device.compute_with_storage_grid_size(),
-            q_chunk_size=padded_num_heads,
-            k_chunk_size=k_chunk_size,
-            exp_approx_mode=False,
-        )
+        program_config = None
+        if use_program_config:
+            program_config = ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=grid_size,  # device.compute_with_storage_grid_size(),
+                q_chunk_size=padded_num_heads,
+                k_chunk_size=k_chunk_size,
+                exp_approx_mode=False,
+            )
 
         # Test various sequence lengths
         logger.debug(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -4,8 +4,11 @@
 
 #include "sdpa_decode.hpp"
 
+#include <cstdint>
 #include <optional>
 #include <utility>
+
+#include <tt-logger/tt-logger.hpp>
 
 #include "device/sdpa_decode_device_operation.hpp"
 #include "ttnn/operation.hpp"
@@ -13,6 +16,9 @@
 using namespace tt::tt_metal;
 
 namespace {
+constexpr uint32_t kDefaultDecodeChunkSize = 32;
+constexpr uint32_t kDefaultMaxCoresPerHeadBatch = 1;
+
 inline uint32_t get_chunk_size(uint32_t s) {
     /*
     # find maximum power of 2 divisor of s
@@ -110,6 +116,25 @@ ttnn::Tensor paged_scaled_dot_product_attention_decode(
     [[maybe_unused]] auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
                                      ? input_tensor_q.device()->arch()
                                      : ttnn::GetDefaultDevice()->arch();
+
+    if (!program_config.has_value()) {
+        program_config = ttnn::operations::transformer::SDPAProgramConfig{
+            input_tensor_q.device()->compute_with_storage_grid_size(),
+            std::nullopt,
+            kDefaultDecodeChunkSize,
+            kDefaultDecodeChunkSize,
+            std::nullopt,
+            kDefaultMaxCoresPerHeadBatch};
+        log_debug(
+            tt::LogOp,
+            "Paged SDPA decode default config: grid={}x{}, q_chunk_size={}, k_chunk_size={}, "
+            "max_cores_per_head_batch={}",
+            program_config->compute_with_storage_grid_size.x,
+            program_config->compute_with_storage_grid_size.y,
+            program_config->q_chunk_size,
+            program_config->k_chunk_size,
+            program_config->max_cores_per_head_batch);
+    }
 
     // Use k_chunk_size as override; if k_chunk_size == 0, figure it out in kernels
     // uint32_t k_chunk_size = get_chunk_size(s);


### PR DESCRIPTION
Materialize a conservative SDPAProgramConfig when paged_scaled_dot_product_attention_decode is called without program_config. The default uses 32-token Q/K chunks and max_cores_per_head_batch=1 so wide-head paged decode shapes avoid the all-core L1-heavy schedule, while explicit user configs remain untouched.

Add nightly regression coverage for the Gemma-style no-config paged decode shape through the shared paged SDPA decode runner.

Fixes: https://github.com/tenstorrent/tt-metal/issues/44311

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/paged-sdpa-decode-l1-defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/paged-sdpa-decode-l1-defaults)