### PR TITLE
ds_prefill(gate_refactor) - split TtMoERoutingSetup out of TtMoEGatePrefill

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, create_gate_weights, get_sp_mesh_composer
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_gate_weights, get_sp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_testing, get_input_mem_config
@@ -80,15 +80,6 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     gate_w = gate_weights_dict["weight"]
     gate_b = gate_weights_dict["e_score_correction_bias"]
 
-    # Create dispatch table
-    n_sp_devices = mesh_device.shape[0]
-    n_tp_devices = mesh_device.shape[1]
-    dispatch_table = ExpertMapping.create_dispatch_table(
-        num_routed_experts=config.n_routed_experts,
-        dispatch_group_size=n_sp_devices,
-        num_dispatch_groups=n_tp_devices,
-    )
-
     # Create input (SP+TP sharded)
     x = create_gate_input(config, mesh_device)
 
@@ -100,18 +91,15 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         return ttnn.to_torch(tt_tensor, mesh_composer=sp_composer)
 
     # === Path 1: From Weights ===
-    experts_per_chip = config.n_routed_experts // (n_sp_devices * n_tp_devices)
     gate_from_weights = TtMoEGatePrefill(
         config,
         mesh_device,
-        dispatch_table,
-        experts_per_chip=experts_per_chip,
         weight=gate_w,
         bias=gate_b,
         fallback_mode=gate_mode,
         weight_cache_path=None,  # No caching
     )
-    scores1, indices1, logits1, offsets1, counts1, regions1 = gate_from_weights(x)
+    scores1, indices1, logits1 = gate_from_weights(x)
     output1 = to_torch_gate(scores1)
 
     # === Path 2: Cold Cache (build + load) ===
@@ -145,8 +133,6 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     gate_cold = TtMoEGatePrefill(
         config,
         mesh_device,
-        dispatch_table,
-        experts_per_chip=experts_per_chip,
         weight=None,
         bias=None,  # Cache-only mode
         fallback_mode=gate_mode,
@@ -154,7 +140,7 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         cache_name_prefix="gate",
     )
     profiler.end("cold_load")
-    scores2, indices2, logits2, offsets2, counts2, regions2 = gate_cold(x)
+    scores2, indices2, logits2 = gate_cold(x)
     output2 = to_torch_gate(scores2)
 
     # === Path 3: Warm Cache (reuse existing cache) ===
@@ -162,8 +148,6 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     gate_warm = TtMoEGatePrefill(
         config,
         mesh_device,
-        dispatch_table,
-        experts_per_chip=experts_per_chip,
         weight=None,
         bias=None,
         fallback_mode=gate_mode,
@@ -171,7 +155,7 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         cache_name_prefix="gate",
     )
     profiler.end("warm_load")
-    scores3, indices3, logits3, offsets3, counts3, regions3 = gate_warm(x)
+    scores3, indices3, logits3 = gate_warm(x)
     output3 = to_torch_gate(scores3)
 
     # === Validation ===

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -14,11 +14,8 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    ExpertMapping,
     create_fabric_router_config,
     create_gate_weights,
-    get_ep_mesh_composer,
-    get_gate_outputs,
     get_max_payload_size,
     get_sp_mesh_composer,
     load_gate_weights_from_hf,
@@ -26,7 +23,6 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
 from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     ValidationResult,
-    compare_exact,
     compare_pcc,
     compare_recall,
     validate_composed,
@@ -209,32 +205,16 @@ def test_forward_pass(
     # Create TT gate
     n_sp_devices = mesh_device.shape[0]
     n_tp_devices = mesh_device.shape[1]
-    n_routed_experts = config.n_routed_experts
 
-    dispatch_table = ExpertMapping.create_dispatch_table(
-        num_routed_experts=n_routed_experts,
-        dispatch_group_size=n_sp_devices,
-        num_dispatch_groups=n_tp_devices,
-    )
-    experts_per_chip = n_routed_experts // (n_sp_devices * n_tp_devices)
     tt_model = TtMoEGatePrefill(
         config,
         mesh_device,
-        dispatch_table=dispatch_table,
-        experts_per_chip=experts_per_chip,
         weight=gate_w["weight"],
         bias=gate_w["e_score_correction_bias"],
         fallback_mode=gate_fallback_mode,
     )
     # TT forward pass
-    (
-        tt_topk_scores,
-        tt_topk_indices,
-        tt_logits,
-        tt_dispatch_offsets,
-        tt_total_counts_per_expert,
-        _,
-    ) = tt_model(tt_input)
+    tt_topk_scores, tt_topk_indices, tt_logits = tt_model(tt_input)
 
     # Validation thresholds depend on gate compute mode
     if gate_fallback_mode == GateComputeMode.HOST_ALL:
@@ -294,51 +274,6 @@ def test_forward_pass(
 
     all_results = [recall_topk_indices, pcc_logits, pcc_scores]
 
-    # EP-sharded exact checks only make sense when the gate runs on host
-    if gate_fallback_mode == GateComputeMode.HOST_ALL:
-        experts_per_chip = n_routed_experts // (n_sp_devices * n_tp_devices)
-        ref_dispatch_offsets, ref_expert_token_counts, _, _ = get_gate_outputs(
-            indices=reference_topk_indices.view(n_sp_devices, seq_len_per_device, -1).int(),
-            dispatch_group_size=n_sp_devices,
-            num_routed_experts=n_routed_experts,
-            experts_per_chip=experts_per_chip,
-            seq_len_per_chip=seq_len_per_device,
-            num_experts_per_tok=config.n_activated_experts,
-            expert_dispatch_table=dispatch_table,
-        )
-
-        ep_composer = get_ep_mesh_composer(mesh_device)
-
-        tt_dispatch_offsets = ttnn.unsqueeze_to_4D(tt_dispatch_offsets)
-        host_dispatch_offsets = ttnn.to_torch(tt_dispatch_offsets, mesh_composer=ep_composer).squeeze(2).long()
-
-        exact_dispatch_offsets = validate_composed(
-            host_dispatch_offsets,
-            ref_dispatch_offsets.long(),
-            n_tp_devices,
-            n_sp_devices,
-            compare_exact,
-            name="dispatch_offsets",
-        )
-
-        tt_total_counts_per_expert = ttnn.unsqueeze_to_4D(tt_total_counts_per_expert)
-        host_tt_total_counts_per_expert = (
-            ttnn.to_torch(tt_total_counts_per_expert, mesh_composer=ep_composer).squeeze(2).long()
-        )
-        ref_expert_token_counts = ref_expert_token_counts[:, 0, :].unsqueeze(1).expand(-1, n_sp_devices, -1).long()
-
-        expert_token_counts = validate_composed(
-            host_tt_total_counts_per_expert,
-            ref_expert_token_counts,
-            n_tp_devices,
-            n_sp_devices,
-            compare_exact,
-            name="expert_token_counts",
-        )
-
-        all_results.extend([exact_dispatch_offsets, expert_token_counts])
-    else:
-        logger.info("Skipping dispatch_offsets and expert_token_counts exact checks (device gate mode)")
     for res in all_results:
         res.log_mismatches()
     log_validation_results(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -30,6 +30,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_intermediates import TtMoEIntermediates
+from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_routing_setup import TtMoERoutingSetup
 from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
@@ -237,13 +238,18 @@ class TtMoe(LightweightModule):
         self.gate = TtMoEGatePrefill(
             gate_config,
             mesh_device,
-            dispatch_table=expert_dispatch_table,
-            experts_per_chip=experts_per_chip,
             weight=gate_weight,
             bias=gate_bias,
             fallback_mode=gate_fallback_mode,
             weight_cache_path=weight_cache_path,
             cache_name_prefix=f"layer_{layer_idx}.gate",
+        )
+
+        self.routing_setup = TtMoERoutingSetup(
+            mesh_device,
+            expert_dispatch_table,
+            num_links=gate_config.ccl_config["NUM_LINKS"],
+            experts_per_chip=experts_per_chip,
         )
         logger.debug(f"Initializing TtMoe")
         logger.debug(f"  mesh_device.shape={mesh_device.shape}")
@@ -419,9 +425,16 @@ class TtMoe(LightweightModule):
         # ========================================
         # Reshape 3D -> 2D for gate: (batch, seq, emb) -> (batch*seq, emb)
 
-        scores, indices, gate_logits, tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets = self.gate(
-            ttnn.view(x, (x.shape[0] * x.shape[1], x.shape[2]))
+        scores, indices, gate_logits = self.gate(ttnn.view(x, (x.shape[0] * x.shape[1], x.shape[2])))
+
+        signpost(header="moe_gate_calculate_dispatch_offsets")
+        tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = self.routing_setup(
+            ttnn_top_k_experts_indices=indices,
+            num_routed_experts=self.num_routed_experts,
+            seq_len_per_chip=self.seq_len_per_chip,
+            num_experts_per_tok=self.num_experts_per_tok,
         )
+        signpost(header="moe_gate_calculate_dispatch_offsets")
         gate_logits = (
             ttnn.to_memory_config(gate_logits, ttnn.DRAM_MEMORY_CONFIG)
             if return_intermediates

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -17,7 +17,6 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
-from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_routing_setup import TtMoERoutingSetup
 
 
 class GateComputeMode(Enum):
@@ -220,8 +219,6 @@ class TtMoEGatePrefill(LightweightModule):
         self,
         config,
         mesh_device,
-        dispatch_table: torch.Tensor,
-        experts_per_chip: int,
         weight: torch.Tensor = None,
         bias: torch.Tensor = None,
         fallback_mode: GateComputeMode = GateComputeMode.DEVICE,
@@ -232,7 +229,6 @@ class TtMoEGatePrefill(LightweightModule):
         Args:
             weight: Gate weight in HF convention: (n_routed_experts, dim).
                     Transposed internally to (dim, n_routed_experts) for the TTNN matmul path.
-            experts_per_chip: Number of experts per chip (for expert region offset grouping in offset_cumsum).
         """
         self.config = config
         self.mesh_device = mesh_device
@@ -272,10 +268,6 @@ class TtMoEGatePrefill(LightweightModule):
             dtype=ttnn.bfloat16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.TILE_LAYOUT,
-        )
-
-        self.routing_setup = TtMoERoutingSetup(
-            mesh_device, dispatch_table, num_links=config.ccl_config["NUM_LINKS"], experts_per_chip=experts_per_chip
         )
 
         # Torch copies for host fallback paths — keep in HF convention (n_experts, dim)
@@ -463,7 +455,7 @@ class TtMoEGatePrefill(LightweightModule):
     # Forward
     # ------------------------------------------------------------------
 
-    def forward(self, x: ttnn.Tensor) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    def forward(self, x: ttnn.Tensor) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         mode = self.fallback_mode
         logger.debug(f"[MoeGate] fallback_mode={mode.value}")
 
@@ -500,23 +492,8 @@ class TtMoEGatePrefill(LightweightModule):
             logits = self._host_logits_to_device(host_logits)
         signpost(header="moe_gate_grouped_gate")
 
-        # ---- Phase 3: Routing setup ----
-        signpost(header="moe_gate_calculate_dispatch_offsets")
-        ttnn_top_k_experts_indices = ttnn.to_layout(ttnn_top_k_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
-
-        dispatch_offsets, total_counts_per_expert, expert_region_offsets, _ = self.routing_setup(
-            ttnn_top_k_experts_indices=ttnn_top_k_experts_indices,
-            num_routed_experts=self.config.n_routed_experts,
-            seq_len_per_chip=self.config.sp_dim,
-            num_experts_per_tok=self.config.n_activated_experts,
-        )
-        signpost(header="moe_gate_calculate_dispatch_offsets")
-
         return (
             ttnn_scores,
             ttnn_top_k_experts_indices,
             logits,
-            dispatch_offsets,
-            total_counts_per_expert,
-            expert_region_offsets,
         )


### PR DESCRIPTION
## Summary
- Decouple `TtMoERoutingSetup` from `TtMoEGatePrefill` so `TtMoe` manages both as peer modules
- `TtMoEGatePrefill` no longer owns routing setup; it returns only `(scores, indices, logits)` instead of 6 values
- `TtMoe` now creates `TtMoERoutingSetup` directly and calls it after the gate in `forward()`
- Simplify gate tests (`test_moe_gate_prefill2d.py`, `test_gate_cache.py`) to match the reduced 3-value return

## Test plan
- `/deepseek-pipelines` (all 4 CI workflows)

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/split-routing-setup-from-gate) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/split-routing-setup-from-gate) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/split-routing-setup-from-gate) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/split-routing-setup-from-gate) Blackhole ⚠️ irrelevant tests failing

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/split-routing-setup-from-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/split-routing-setup-from-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/split-routing-setup-from-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/split-routing-setup-from-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/split-routing-setup-from-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/split-routing-setup-from-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/split-routing-setup-from-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/split-routing-setup-from-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/split-routing-setup-from-gate)