### PR TITLE
Disabling zero_init for MoE

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -188,7 +188,7 @@ def run_combine_op(
         cluster_axis=sp_axis,
         num_links=1,
         topology=ttnn.Topology.Linear,
-        init_zeros=True,
+        init_zeros=False,
         use_l1_small_for_semaphores=use_l1_small,
     )
     ttnn.synchronize_device(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -239,7 +239,7 @@ def test_ttnn_combine(
         cluster_axis=sp_axis,
         num_links=num_links,
         topology=topology,
-        init_zeros=True,
+        init_zeros=False,
     )
 
     tt_output = tt_combine(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -457,7 +457,7 @@ def test_ttnn_dispatch_combine(
         cluster_axis=sp_axis,
         num_links=num_links,
         topology=topology,
-        init_zeros=True,
+        init_zeros=False,
     )
 
     tt_dispatched_buffer = ttnn.to_layout(tt_dispatched_buffer, layout=dispatched_buffer_layout)
@@ -727,7 +727,7 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
         cluster_axis=sp_axis,
         num_links=num_links,
         topology=topology,
-        init_zeros=True,
+        init_zeros=False,
     )
     logger.info(f"[overflow test / {overflow_mode}] Running combine...")
     tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts, tt_expert_region_offsets)

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -249,7 +249,7 @@ _COMBINE_PERF_PARAMS = [
         "combine", "test_prefill_combine.py", "test_ttnn_combine", "linear", 2, 4_121_973, "CombineDeviceOperation"
     ),
     _perf_param(
-        "combine", "test_prefill_combine.py", "test_ttnn_combine", "ring", 2, 3_177_159, "CombineDeviceOperation"
+        "combine", "test_prefill_combine.py", "test_ttnn_combine", "ring", 2, 2_769_700, "CombineDeviceOperation"
     ),
 ]
 
@@ -282,7 +282,7 @@ _COMBINE_PERF_PARAMS_FULL = [
         ("linear", 1, 5_767_986),
         ("linear", 2, 4_136_638),
         ("ring", 1, 4_968_952),
-        ("ring", 2, 3_136_810),
+        ("ring", 2, 2_769_700),
     ]
 ] + [
     _perf_param(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -323,7 +323,7 @@ class TtMoe(LightweightModule):
             cluster_axis=0,
             num_links=self.row_num_links,
             topology=self.row_topology,
-            init_zeros=True,
+            init_zeros=False,
         )
 
         # Build (group, chip, local_expert) -> global expert id table, sharded

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -711,6 +711,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
+    writer_defines["INIT_ZEROS"] = operation_attributes.init_zeros ? "1" : "0";
 
     // zero_init_writer kernel is launched whenever either:
     //   (a) init_zeros=True — it does the per-bank zero-init of the output tensor

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -712,6 +712,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
 
+    // zero_init_writer kernel is launched whenever either:
+    //   (a) init_zeros=True — it does the per-bank zero-init of the output tensor
+    //   (b) is_tile_layout — it runs the post-zero-init untilized-data send loop
+    //                        (consumes cb_untilize_id, writes back to the sender's c_18).
+    // With init_zeros=False on TILE_LAYOUT only (b) applies, so the zero-init CBs/semaphore
+    // are skipped and the kernel is compiled with INIT_ZEROS=0.
+    const bool create_zi_kernel = init_zeros || is_tile_layout;
+
     if (init_zeros) {
         uint32_t noc_max_burst_size;
         const auto arch = mesh_device->arch();
@@ -739,13 +747,17 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, zi_idle_cb_config);
 
         zi_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range_set, 0);
+    }
 
+    if (create_zi_kernel) {
         uint32_t output_aligned_page_size = detail::get_aligned_page_size(output_tensor);
         std::vector<uint32_t> zi_compile_time_args = {
             output_aligned_page_size,
-            num_cores,  // num_sender_cores = num_cores: each idle core signals all sender cores that its zero-init
-                        // portion is done and output pages are initializer with 0 for that chip
-            static_cast<uint32_t>(tt::CBIndex::c_6),
+            // num_sender_cores and cb_zero_buffer_id are only referenced inside the
+            // INIT_ZEROS-gated zero-init phase in the kernel; pass 0 when init_zeros=False
+            // (the c_6 CB is not created in that case so its index is meaningless).
+            init_zeros ? num_cores : 0u,
+            init_zeros ? static_cast<uint32_t>(tt::CBIndex::c_6) : 0u,
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);
 
@@ -765,6 +777,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
         std::map<std::string, std::string> zi_defines;
         zi_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
+        zi_defines["INIT_ZEROS"] = init_zeros ? "1" : "0";
 
         zero_init_kernel_id = tt::tt_metal::CreateKernel(
             program,
@@ -859,33 +872,37 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
     }
 
-    // Set runtime args for hybrid idle row cores
-    if (init_zeros) {
+    // Set runtime args for hybrid idle row cores.  Three layouts are possible:
+    //   init_zeros && tile_layout: [output_addr, page_start, page_end, zi_done_sem,
+    //                               (sender_noc_x, sender_noc_y) * num_cores,
+    //                               counter_ready_sem, owning_sender_noc_x, owning_sender_noc_y,
+    //                               data_ready_sem, start_sem, local_core_id]
+    //   init_zeros && row_major:   [output_addr, page_start, page_end, zi_done_sem,
+    //                               (sender_noc_x, sender_noc_y) * num_cores]
+    //   !init_zeros && tile_layout:[output_addr, counter_ready_sem, owning_sender_noc_x,
+    //                               owning_sender_noc_y, data_ready_sem, start_sem, local_core_id]
+    // The kernel guards the zero-init reads with #if INIT_ZEROS so the indices match.
+    if (create_zi_kernel) {
         for (uint32_t idle_idx = 0; idle_idx < num_idle_cores; idle_idx++) {
-            uint32_t row_idx = num_cores + idle_idx;
-            uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
-            uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
+            std::vector<uint32_t> zi_runtime_args = {output_tensor.buffer()->address()};
 
-            // Each idle core signals all sender cores
-            std::vector<uint32_t> zi_runtime_args = {
-                output_tensor.buffer()->address(),
-                page_start,
-                page_end,
-                zi_done_semaphore_id,
-            };
-            for (const auto& [noc_x, noc_y] : sender_noc_coords) {
-                zi_runtime_args.push_back(noc_x);
-                zi_runtime_args.push_back(noc_y);
+            if (init_zeros) {
+                uint32_t row_idx = num_cores + idle_idx;
+                uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
+                uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
+                zi_runtime_args.push_back(page_start);
+                zi_runtime_args.push_back(page_end);
+                zi_runtime_args.push_back(zi_done_semaphore_id);
+                // Each idle core signals all sender cores once its zero-init slice is done.
+                for (const auto& [noc_x, noc_y] : sender_noc_coords) {
+                    zi_runtime_args.push_back(noc_x);
+                    zi_runtime_args.push_back(noc_y);
+                }
             }
 
-            // TILE_LAYOUT: append owning-sender info so zero_init_writer can run its send loop
-            // + its c_9 address handshake.  In ROW_MAJOR the trailing args are ignored
-            // (kernel compiled with IS_TILE_LAYOUT=0).
             if (is_tile_layout) {
                 uint32_t s = idle_sender_map[idle_idx];
                 // core_id = this idle core's local index within sender s's group (0..k_s-1).
-                // Compute it by finding idle_idx's position in the sequential ordering of
-                // idle cores that belong to sender s.
                 uint32_t local_core_id = 0;
                 for (uint32_t j = 0; j < idle_idx; j++) {
                     if (idle_sender_map[j] == s) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -183,8 +183,7 @@ void kernel_main() {
     }
 #endif
 
-    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA START
-
+#if INIT_ZEROS
     // Signal writer that zero-init is complete
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
@@ -197,8 +196,7 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_barrier_address);
     noc_semaphore_wait(barrier_sem_ptr, num_cores);
     noc_semaphore_set(barrier_sem_ptr, 0);
-
-    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA END
+#endif
 
     // Read expert token counts
     const auto experts_tok_counter_addr_gen = TensorAccessor(experts_tok_counter_args, experts_tok_counter_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -183,6 +183,8 @@ void kernel_main() {
     }
 #endif
 
+    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA START
+
     // Signal writer that zero-init is complete
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
@@ -195,6 +197,8 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_barrier_address);
     noc_semaphore_wait(barrier_sem_ptr, num_cores);
     noc_semaphore_set(barrier_sem_ptr, 0);
+
+    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA END
 
     // Read expert token counts
     const auto experts_tok_counter_addr_gen = TensorAccessor(experts_tok_counter_args, experts_tok_counter_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -181,10 +181,13 @@ void kernel_main() {
     // Signal ALL readers that global init exchange is done.
     // Each writer increments every reader's barrier sem so each reader
     // collects num_cores signals before proceeding.
+
+    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA START
     for (uint32_t c = 0; c < num_cores; c++) {
         noc_semaphore_inc(all_core_barrier_noc_addrs[c], 1);
     }
     noc_async_atomic_barrier();
+    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA END
 
     const auto output_addr_gen = TensorAccessor(output_args, output_addr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -137,11 +137,13 @@ void kernel_main() {
     DPRINT_COMBINE << "Combine Writer: experts=[" << expert_start_idx << "," << expert_end_idx << ")"
                    << " linearized_mesh_coord=" << linearized_mesh_coord << ENDL();
 
+#if ZERO_INIT
     // Wait for reader to complete zero-init
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
     noc_semaphore_wait(zero_init_sem_ptr, 1);
     noc_semaphore_set(zero_init_sem_ptr, 0);
+#endif
 
 #ifdef DEST_CHIP_ID
     constexpr uint32_t total_mesh_devices = mesh_rows * mesh_cols;
@@ -178,16 +180,15 @@ void kernel_main() {
     DPRINT_COMBINE << "Fabric setup complete" << ENDL();
 #endif
 
+#if INIT_ZEROS
     // Signal ALL readers that global init exchange is done.
     // Each writer increments every reader's barrier sem so each reader
     // collects num_cores signals before proceeding.
-
-    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA START
     for (uint32_t c = 0; c < num_cores; c++) {
         noc_semaphore_inc(all_core_barrier_noc_addrs[c], 1);
     }
     noc_async_atomic_barrier();
-    // POTENCIJALNO SAMO ZA ZERO_INIT TREBA END
+#endif
 
     const auto output_addr_gen = TensorAccessor(output_args, output_addr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -31,8 +31,14 @@ void kernel_main() {
     constexpr auto output_args = TensorAccessorArgs<3>();
 
     // ===== Runtime args =====
+    // output_addr is always needed (the all-local send-loop path writes directly to output DRAM).
+    // The zero-init phase consumes additional runtime args (page range, zi-done sem, sender NOC
+    // coords), but they are only present when INIT_ZEROS=1 — the program factory omits them
+    // when init_zeros=False so the kernel can still run for TILE_LAYOUT's send-loop role.
     uint32_t rt_args_idx = 0;
     uint32_t output_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+#if INIT_ZEROS
     uint32_t page_start = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t page_end = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t zi_done_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
@@ -48,9 +54,11 @@ void kernel_main() {
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
         sender_sem_noc_addrs[c] = get_noc_addr(noc_x, noc_y, zi_done_sem_l1_offset);
     }
+#endif
 
     const auto output_addr_gen = TensorAccessor(output_args, output_addr);
 
+#if INIT_ZEROS
     fill_zero_buffer(cb_zero_buffer_id);
     uint32_t zero_buffer_addr = get_write_ptr(cb_zero_buffer_id);
 
@@ -62,6 +70,7 @@ void kernel_main() {
     }
 
     noc_async_atomic_barrier();
+#endif
 
 #if IS_TILE_LAYOUT
     // ===== Untilized-data send path (moved from reader_untilize.cpp steps 3-7) =====

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -213,5 +213,6 @@ void kernel_main() {
         // 7. Release untilize CB
         cb_pop_front(cb_untilize_id, read_batch_size);
     }
+    noc_semaphore_set(counter_ready_sem_ptr, 0);
 #endif
 }


### PR DESCRIPTION
### Problem description
Unnecessary `init_zeros=True` for **combine** inside `ttnn_moe.py`.

### What's changed
- Disabled `init_zeros` for combine operator for performance gain
- Fixed bug for hang when `init_zeros=False`

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/combine-zeroinit-removal)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/combine-zeroinit-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/combine-zeroinit-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/combine-zeroinit-removal)