### PR TITLE
[Feature]: Allow experimental DFB to accept borrowed memory

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -1,0 +1,441 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
+
+#include "device_fixture.hpp"
+#include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
+
+namespace tt::tt_metal {
+
+namespace {
+
+static constexpr const char* PRODUCER_KERNEL =
+    "tests/tt_metal/tt_metal/test_kernels/dataflow/borrowed_dfb_producer.cpp";
+static constexpr const char* DM_CONSUMER_KERNEL =
+    "tests/tt_metal/tt_metal/test_kernels/dataflow/borrowed_dfb_consumer.cpp";
+static constexpr const char* TENSIX_CONSUMER_KERNEL =
+    "tests/tt_metal/tt_metal/test_kernels/compute/borrowed_dfb_tensix_consumer.cpp";
+
+struct BorrowedDFBTestConfig {
+    uint32_t num_entries        = 16;
+    uint32_t entry_size         = 256;  // bytes
+    uint32_t num_producers      = 1;
+    uint32_t num_consumers      = 1;
+    dfb::AccessPattern pap      = dfb::AccessPattern::STRIDED;
+    dfb::AccessPattern cap      = dfb::AccessPattern::STRIDED;
+    bool enable_implicit_sync   = false;
+    bool tensix_consumer        = false;
+    // When true, verify that output data == input data
+    bool verify_data            = false;
+};
+
+// Fills a vector with 0,1,2,...,n-1 (uint32_t).
+static std::vector<uint32_t> make_sequential(uint32_t n_words) {
+    std::vector<uint32_t> v(n_words);
+    std::iota(v.begin(), v.end(), 0u);
+    return v;
+}
+
+// Runs a single borrowed-memory DFB program on one core and asserts:
+//   1. The DFB was allocated at the borrowed L1 buffer address.
+//   2. (Optionally) output data matches input data.
+void run_borrowed_memory_dfb_program(
+    IDevice* device,
+    const CoreCoord& core,
+    const BorrowedDFBTestConfig& test_cfg) {
+
+    const bool is_all               = (test_cfg.cap == dfb::AccessPattern::ALL);
+    const uint32_t dfb_ring_size    = test_cfg.num_entries * test_cfg.entry_size;
+
+    // Per-RISC entry counts passed as compile-time args.
+    const uint32_t entries_per_producer =
+        (test_cfg.num_entries + test_cfg.num_producers - 1) / test_cfg.num_producers;
+    const uint32_t entries_per_consumer =
+        is_all ? test_cfg.num_entries
+               : (test_cfg.num_entries + test_cfg.num_consumers - 1) / test_cfg.num_consumers;
+
+    // Total bytes of input/output regions (rounded up per-RISC).
+    const uint32_t input_size  = test_cfg.num_producers * entries_per_producer * test_cfg.entry_size;
+    const uint32_t output_size = test_cfg.num_consumers * entries_per_consumer * test_cfg.entry_size;
+
+    // -----------------------------------------------------------------------
+    // 1. Allocate L1 buffers: DFB ring (borrowed), input, output.
+    // -----------------------------------------------------------------------
+    auto dfb_ring_buf = CreateBuffer(InterleavedBufferConfig{
+        .device    = device,
+        .size      = dfb_ring_size,
+        .page_size = dfb_ring_size,
+        .buffer_type = BufferType::L1});
+
+    auto input_buf = CreateBuffer(InterleavedBufferConfig{
+        .device    = device,
+        .size      = input_size,
+        .page_size = input_size,
+        .buffer_type = BufferType::L1});
+
+    std::shared_ptr<Buffer> output_buf;
+    if (!test_cfg.tensix_consumer) {
+        output_buf = CreateBuffer(InterleavedBufferConfig{
+            .device    = device,
+            .size      = output_size,
+            .page_size = output_size,
+            .buffer_type = BufferType::L1});
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Build DFB config with borrowed_buffer set BEFORE CreateDataflowBuffer.
+    // -----------------------------------------------------------------------
+    experimental::dfb::DataflowBufferConfig dfb_config{
+        .entry_size          = test_cfg.entry_size,
+        .num_entries         = test_cfg.num_entries,
+        .num_producers       = test_cfg.num_producers,
+        .pap                 = test_cfg.pap,
+        .num_consumers       = test_cfg.num_consumers,
+        .cap                 = test_cfg.cap,
+        .enable_implicit_sync = test_cfg.enable_implicit_sync,
+        .borrows_memory      = true,
+    };
+
+    // -----------------------------------------------------------------------
+    // 3. Create program and DFB.
+    // -----------------------------------------------------------------------
+    Program program = CreateProgram();
+    uint32_t dfb_id = experimental::dfb::CreateDataflowBuffer(program, core, dfb_config);
+
+    // -----------------------------------------------------------------------
+    // 4. Create kernels
+    // -----------------------------------------------------------------------
+    KernelHandle producer_handle{};
+    KernelHandle consumer_handle{};
+
+    const ARCH arch = device->arch();
+
+    if (arch == ARCH::QUASAR) {
+        producer_handle = experimental::quasar::CreateKernel(
+            program,
+            PRODUCER_KERNEL,
+            core,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = test_cfg.num_producers,
+                .compile_args = {entries_per_producer, test_cfg.entry_size}});
+
+        if (test_cfg.tensix_consumer) {
+            consumer_handle = experimental::quasar::CreateKernel(
+                program,
+                TENSIX_CONSUMER_KERNEL,
+                core,
+                experimental::quasar::QuasarComputeConfig{
+                    .num_threads_per_cluster = test_cfg.num_consumers,
+                    .compile_args = {entries_per_consumer}});
+        } else {
+            consumer_handle = experimental::quasar::CreateKernel(
+                program,
+                DM_CONSUMER_KERNEL,
+                core,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = test_cfg.num_consumers,
+                    .compile_args = {entries_per_consumer, test_cfg.entry_size}});
+        }
+    } else {
+        // WH / BH: BRISC = producer (RISCV_0), NCRISC / Compute = consumer.
+        producer_handle = CreateKernel(
+            program,
+            PRODUCER_KERNEL,
+            core,
+            DataMovementConfig{
+                .processor  = DataMovementProcessor::RISCV_0,
+                .compile_args = {entries_per_producer, test_cfg.entry_size}});
+
+        if (test_cfg.tensix_consumer) {
+            consumer_handle = CreateKernel(
+                program,
+                TENSIX_CONSUMER_KERNEL,
+                core,
+                ComputeConfig{.compile_args = {entries_per_consumer}});
+        } else {
+            consumer_handle = CreateKernel(
+                program,
+                DM_CONSUMER_KERNEL,
+                core,
+                DataMovementConfig{
+                    .processor  = DataMovementProcessor::RISCV_1,
+                    .compile_args = {entries_per_consumer, test_cfg.entry_size}});
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Bind DFB to producer and consumer kernels.
+    // -----------------------------------------------------------------------
+    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program, dfb_id, producer_handle, consumer_handle);
+
+    // -----------------------------------------------------------------------
+    // 6. Pre-fill input L1 region and set runtime args.
+    // -----------------------------------------------------------------------
+    auto input_words = make_sequential(input_size / sizeof(uint32_t));
+    detail::WriteToDeviceL1(device, core, static_cast<uint32_t>(input_buf->address()), input_words);
+
+    SetRuntimeArgs(program, producer_handle, core,
+                   {static_cast<uint32_t>(input_buf->address())});
+
+    if (!test_cfg.tensix_consumer) {
+        SetRuntimeArgs(program, consumer_handle, core,
+                       {static_cast<uint32_t>(output_buf->address())});
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. Set the borrowed buffer's address, then launch and wait.
+    // -----------------------------------------------------------------------
+    program.impl().get_dataflow_buffer(dfb_id)->set_borrowed_memory_base_addr(
+        static_cast<uint32_t>(dfb_ring_buf->address()));
+
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    // -----------------------------------------------------------------------
+    // 8. Assert the borrowed buffer address was used for the DFB ring.
+    // -----------------------------------------------------------------------
+    EXPECT_EQ(
+        program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
+        static_cast<uint32_t>(dfb_ring_buf->address()));
+
+    // -----------------------------------------------------------------------
+    // 9. Optionally verify round-trip data correctness
+    // -----------------------------------------------------------------------
+    if (test_cfg.verify_data && !test_cfg.tensix_consumer) {
+        std::vector<uint32_t> output;
+        detail::ReadFromDeviceL1(
+            device, core,
+            static_cast<uint32_t>(output_buf->address()),
+            output_size,
+            output);
+        EXPECT_EQ(input_words, output);
+    }
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// All-architecture tests (Quasar, Wormhole, Blackhole)
+// =============================================================================
+
+TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S) {
+    IDevice* device = devices_.at(0)->get_devices()[0];
+
+    BorrowedDFBTestConfig cfg{
+        .num_entries         = 16,
+        .entry_size          = 256,
+        .num_producers       = 1,
+        .num_consumers       = 1,
+        .pap                 = dfb::AccessPattern::STRIDED,
+        .cap                 = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .tensix_consumer     = false,
+        .verify_data         = true,
+    };
+
+    run_borrowed_memory_dfb_program(device, CoreCoord(0, 0), cfg);
+}
+
+TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S_UpdateAddress) {
+    IDevice* device = devices_.at(0)->get_devices()[0];
+    const CoreCoord core(0, 0);
+    const ARCH arch = device->arch();
+
+    constexpr uint32_t num_entries = 16;
+    constexpr uint32_t entry_size  = 256;
+    constexpr uint32_t dfb_size    = num_entries * entry_size;
+    constexpr uint32_t data_words  = dfb_size / sizeof(uint32_t);
+
+    auto ring_buf_a = CreateBuffer(InterleavedBufferConfig{
+        .device = device, .size = dfb_size, .page_size = dfb_size, .buffer_type = BufferType::L1});
+    auto ring_buf_b = CreateBuffer(InterleavedBufferConfig{
+        .device = device, .size = dfb_size, .page_size = dfb_size, .buffer_type = BufferType::L1});
+    auto input_buf = CreateBuffer(InterleavedBufferConfig{
+        .device = device, .size = dfb_size, .page_size = dfb_size, .buffer_type = BufferType::L1});
+    auto output_buf = CreateBuffer(InterleavedBufferConfig{
+        .device = device, .size = dfb_size, .page_size = dfb_size, .buffer_type = BufferType::L1});
+
+    experimental::dfb::DataflowBufferConfig dfb_cfg{
+        .entry_size    = entry_size,
+        .num_entries   = num_entries,
+        .num_producers = 1,
+        .pap           = dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap           = dfb::AccessPattern::STRIDED,
+        .borrows_memory = true,
+    };
+
+    Program program = CreateProgram();
+    uint32_t dfb_id = experimental::dfb::CreateDataflowBuffer(program, core, dfb_cfg);
+
+    KernelHandle producer_h{};
+    KernelHandle consumer_h{};
+    if (arch == ARCH::QUASAR) {
+        producer_h = experimental::quasar::CreateKernel(
+            program, PRODUCER_KERNEL, core,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1,
+                .compile_args = {num_entries, entry_size}});
+        consumer_h = experimental::quasar::CreateKernel(
+            program, DM_CONSUMER_KERNEL, core,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1,
+                .compile_args = {num_entries, entry_size}});
+    } else {
+        producer_h = CreateKernel(
+            program, PRODUCER_KERNEL, core,
+            DataMovementConfig{
+                .processor    = DataMovementProcessor::RISCV_0,
+                .compile_args = {num_entries, entry_size}});
+        consumer_h = CreateKernel(
+            program, DM_CONSUMER_KERNEL, core,
+            DataMovementConfig{
+                .processor    = DataMovementProcessor::RISCV_1,
+                .compile_args = {num_entries, entry_size}});
+    }
+
+    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program, dfb_id, producer_h, consumer_h);
+
+    SetRuntimeArgs(program, producer_h, core, {static_cast<uint32_t>(input_buf->address())});
+    SetRuntimeArgs(program, consumer_h, core, {static_cast<uint32_t>(output_buf->address())});
+
+    auto dfb = program.impl().get_dataflow_buffer(dfb_id);
+
+    // --- Run 1: DFB ring at ring_buf_a ---
+    std::vector<uint32_t> input_a(data_words);
+    std::iota(input_a.begin(), input_a.end(), 0u);
+    detail::WriteToDeviceL1(device, core, static_cast<uint32_t>(input_buf->address()), input_a);
+    dfb->set_borrowed_memory_base_addr(static_cast<uint32_t>(ring_buf_a->address()));
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    EXPECT_EQ(dfb->uniform_alloc_addr(), static_cast<uint32_t>(ring_buf_a->address()));
+    {
+        std::vector<uint32_t> output;
+        detail::ReadFromDeviceL1(
+            device, core, static_cast<uint32_t>(output_buf->address()), dfb_size, output);
+        EXPECT_EQ(input_a, output);
+    }
+
+    // --- Run 2: DFB ring redirected to ring_buf_b ---
+    std::vector<uint32_t> input_b(data_words);
+    std::iota(input_b.begin(), input_b.end(), data_words);  // distinct values from run 1
+    detail::WriteToDeviceL1(device, core, static_cast<uint32_t>(input_buf->address()), input_b);
+    dfb->set_borrowed_memory_base_addr(static_cast<uint32_t>(ring_buf_b->address()));
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    EXPECT_EQ(dfb->uniform_alloc_addr(), static_cast<uint32_t>(ring_buf_b->address()));
+    {
+        std::vector<uint32_t> output;
+        detail::ReadFromDeviceL1(
+            device, core, static_cast<uint32_t>(output_buf->address()), dfb_size, output);
+        EXPECT_EQ(input_b, output);
+    }
+}
+
+TEST_F(MeshDeviceFixture, BorrowedMemoryDMTensix1Sx1S) {
+    IDevice* device = devices_.at(0)->get_devices()[0];
+
+    BorrowedDFBTestConfig cfg{
+        .num_entries         = 16,
+        .entry_size          = 256,
+        .num_producers       = 1,
+        .num_consumers       = 1,
+        .pap                 = dfb::AccessPattern::STRIDED,
+        .cap                 = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .tensix_consumer     = true,
+        .verify_data         = true,
+    };
+
+    run_borrowed_memory_dfb_program(device, CoreCoord(0, 0), cfg);
+}
+
+// =============================================================================
+// Quasar-only tests (multi-producer / multi-consumer with implicit sync)
+// =============================================================================
+
+TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM2Sx4S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Multi-producer DFB with implicit sync requires Quasar";
+    }
+
+    IDevice* device = devices_.at(0)->get_devices()[0];
+
+    BorrowedDFBTestConfig cfg{
+        .num_entries         = 16,
+        .entry_size          = 256,
+        .num_producers       = 2,
+        .num_consumers       = 4,
+        .pap                 = dfb::AccessPattern::STRIDED,
+        .cap                 = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = true,
+        .tensix_consumer     = false,
+        .verify_data         = true,
+    };
+
+    run_borrowed_memory_dfb_program(device, CoreCoord(0, 0), cfg);
+}
+
+TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM4Sx2S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Multi-producer DFB with implicit sync requires Quasar";
+    }
+
+    IDevice* device = devices_.at(0)->get_devices()[0];
+
+    BorrowedDFBTestConfig cfg{
+        .num_entries         = 16,
+        .entry_size          = 256,
+        .num_producers       = 4,
+        .num_consumers       = 2,
+        .pap                 = dfb::AccessPattern::STRIDED,
+        .cap                 = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = true,
+        .tensix_consumer     = false,
+        .verify_data         = true,
+    };
+
+    run_borrowed_memory_dfb_program(device, CoreCoord(0, 0), cfg);
+}
+
+TEST_F(MeshDeviceFixture, BorrowedMemoryDMTensix2Sx4B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Multi-producer DFB with implicit sync requires Quasar";
+    }
+
+    IDevice* device = devices_.at(0)->get_devices()[0];
+
+    BorrowedDFBTestConfig cfg{
+        .num_entries         = 16,
+        .entry_size          = 256,
+        .num_producers       = 2,
+        .num_consumers       = 4,
+        .pap                 = dfb::AccessPattern::STRIDED,
+        .cap                 = dfb::AccessPattern::ALL,
+        .enable_implicit_sync = true,
+        .tensix_consumer     = true,
+        .verify_data         = false,
+    };
+
+    run_borrowed_memory_dfb_program(device, CoreCoord(0, 0), cfg);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -21,6 +21,7 @@ set(UNIT_TESTS_API_SOURCES
     core_coord/test_CoreRangeSet_merge.cpp
     dataflow_buffer/test_dataflow_buffer.cpp
     dataflow_buffer/test_dataflow_buffer_configs.cpp
+    dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
     metal2_host_api/test_program_spec.cpp
     metal2_host_api/test_program_spec_hw.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/compute/borrowed_dfb_tensix_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/borrowed_dfb_tensix_consumer.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tensix consumer kernel for borrowed-memory DFB tests.
+// Pops entries from the DFB ring so the DM producer's finish() can complete.
+// Host verifies the data by reading the borrowed L1 buffer directly.
+//
+// Compile-time args:
+//   CTA[0]: num_entries  - total number of entries to consume
+
+#include "api/dataflow/dataflow_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t num_entries = get_compile_time_arg_val(0);
+    DataflowBuffer dfb(0);
+
+    for (uint32_t i = 0; i < num_entries; i++) {
+        dfb.wait_front(1);
+        dfb.pop_front(1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/borrowed_dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/borrowed_dfb_consumer.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Simple DM consumer kernel for borrowed-memory DFB tests.
+// Reads from the DFB ring (borrowed L1 buffer) and writes to a separate L1 output region.
+//
+// Compile-time args:
+//   CTA[0]: num_entries_per_risc  - number of entries this RISC consumes
+//   CTA[1]: entry_size            - size of each entry in bytes
+//
+// Runtime args:
+//   RTA[0]: l1_dst_base_addr      - base address of L1 output region (host reads this back)
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/kernel_thread_globals.h"
+
+void kernel_main() {
+    constexpr uint32_t num_entries = get_compile_time_arg_val(0);
+    constexpr uint32_t entry_size = get_compile_time_arg_val(1);
+    const uint32_t l1_dst_base = get_arg_val<uint32_t>(0);
+
+    const uint32_t risc_idx = get_my_thread_id();
+    const uint32_t dst_base = l1_dst_base + risc_idx * num_entries * entry_size;
+
+    DataflowBuffer dfb(0);
+
+    for (uint32_t i = 0; i < num_entries; i++) {
+        dfb.wait_front(1);
+        const uint64_t dst_noc = get_noc_addr(dst_base + i * entry_size);
+        noc_async_write(dfb.get_read_ptr(), dst_noc, entry_size);
+        noc_async_write_barrier();
+        dfb.pop_front(1);
+    }
+
+    dfb.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/borrowed_dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/borrowed_dfb_producer.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Simple DM producer kernel for borrowed-memory DFB tests.
+// Reads from a pre-filled L1 input region into the DFB ring (which is the borrowed L1 buffer).
+//
+// Compile-time args:
+//   CTA[0]: num_entries_per_risc  - number of entries this RISC produces
+//   CTA[1]: entry_size            - size of each entry in bytes
+//
+// Runtime args:
+//   RTA[0]: l1_src_base_addr      - base address of L1 input region (host pre-fills this)
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/kernel_thread_globals.h"
+
+void kernel_main() {
+    constexpr uint32_t num_entries = get_compile_time_arg_val(0);
+    constexpr uint32_t entry_size = get_compile_time_arg_val(1);
+    const uint32_t l1_src_base = get_arg_val<uint32_t>(0);
+
+    const uint32_t risc_idx = get_my_thread_id();
+    const uint32_t src_base = l1_src_base + risc_idx * num_entries * entry_size;
+
+    DataflowBuffer dfb(0);
+
+    for (uint32_t i = 0; i < num_entries; i++) {
+        dfb.reserve_back(1);
+        const uint64_t src_noc = get_noc_addr(src_base + i * entry_size);
+        noc_async_read(src_noc, dfb.get_write_ptr(), entry_size);
+        noc_async_read_barrier();
+        dfb.push_back(1);
+    }
+
+    dfb.finish();
+}

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -17,6 +17,7 @@ namespace tt {
 enum class DataFormat : uint8_t;
 namespace tt_metal {
 class Program;
+class Buffer;
 }  // namespace tt_metal
 }  // namespace tt
 
@@ -45,6 +46,8 @@ struct DataflowBufferConfig {
     std::optional<Tile> tile = std::nullopt;
     // Set only when both producer and consumer are the same compute kernel
     std::optional<TensixScope> tensix_scope = std::nullopt;
+    // When set, the DFB borrows memory from this buffer instead of allocating its own L1 region.
+    const tt::tt_metal::Buffer* borrowed_buffer = nullptr;
 };
 
 // Note: This API and the DataflowBufferConfig are placeholder only, the final DataflowBuffer APIs will conform with

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -17,7 +17,6 @@ namespace tt {
 enum class DataFormat : uint8_t;
 namespace tt_metal {
 class Program;
-class Buffer;
 }  // namespace tt_metal
 }  // namespace tt
 
@@ -46,8 +45,10 @@ struct DataflowBufferConfig {
     std::optional<Tile> tile = std::nullopt;
     // Set only when both producer and consumer are the same compute kernel
     std::optional<TensixScope> tensix_scope = std::nullopt;
-    // When set, the DFB borrows memory from this buffer instead of allocating its own L1 region.
-    const tt::tt_metal::Buffer* borrowed_buffer = nullptr;
+    // When true, the DFB borrows L1 memory from an externally managed buffer
+    // instead of allocating its own L1 region. The actual base address must be
+    // supplied before launch via DataflowBufferImpl::set_borrowed_memory_base_addr.
+    bool borrows_memory = false;
 };
 
 // Note: This API and the DataflowBufferConfig are placeholder only, the final DataflowBuffer APIs will conform with

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -360,6 +360,10 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
         TT_FATAL(
             it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
         const uint32_t alloc_addr = it->second.second;
+        TT_FATAL(
+            !this->borrows_memory() || alloc_addr != 0,
+            "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
+            this->id);
 
         std::vector<uint8_t> data;
         data.reserve(4 * sizeof(uint32_t));
@@ -377,6 +381,10 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
     auto it = this->core_lookup_.find(core);
     TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
     const auto& [group_idx, alloc_addr] = it->second;
+    TT_FATAL(
+        !this->borrows_memory() || alloc_addr != 0,
+        "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
+        this->id);
     const DfbGroup* core_group = &this->groups[group_idx];
 
     const auto& hw_risc_configs = core_group->hw_risc_configs;
@@ -1346,7 +1354,9 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
     for (auto& dfb : this->dataflow_buffers_) {
         uint32_t alloc_addr;
         if (dfb->borrows_memory()) {
-            alloc_addr = static_cast<uint32_t>(dfb->config.borrowed_buffer->address());
+            // Address is not known at allocation time; caller must invoke
+            // set_borrowed_memory_base_addr() before launching the program.
+            alloc_addr = 0;
         } else {
             uint64_t computed_addr = base_dfb_address;
             for (const CoreRange& core_range : dfb->core_ranges.ranges()) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -646,7 +646,6 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
     dfb->core_ranges = core_range_set.merge_ranges();
     dfb->config = config;
-    dfb->borrowed_buffer = config.borrowed_buffer;
 
     dfb->entry_size = config.entry_size;
 
@@ -1349,7 +1348,7 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
     for (auto& dfb : this->dataflow_buffers_) {
         uint32_t alloc_addr;
         if (dfb->borrows_memory()) {
-            alloc_addr = static_cast<uint32_t>(dfb->borrowed_buffer->address());
+            alloc_addr = static_cast<uint32_t>(dfb->config.borrowed_buffer->address());
         } else {
             uint64_t computed_addr = base_dfb_address;
             for (const CoreRange& core_range : dfb->core_ranges.ranges()) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -1354,9 +1354,8 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
     for (auto& dfb : this->dataflow_buffers_) {
         uint32_t alloc_addr;
         if (dfb->borrows_memory()) {
-            // Address is not known at allocation time; caller must invoke
-            // set_borrowed_memory_base_addr() before launching the program.
-            alloc_addr = 0;
+            // Use the address latched by set_borrowed_memory_base_addr()
+            alloc_addr = dfb->borrowed_addr_;
         } else {
             uint64_t computed_addr = base_dfb_address;
             for (const CoreRange& core_range : dfb->core_ranges.ranges()) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -646,6 +646,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
     dfb->core_ranges = core_range_set.merge_ranges();
     dfb->config = config;
+    dfb->borrowed_buffer = config.borrowed_buffer;
 
     dfb->entry_size = config.entry_size;
 
@@ -705,7 +706,9 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
         }
     }
 
-    this->local_dataflow_buffer_allocation_needed_ = true;
+    if (!dfb->borrows_memory()) {
+        this->local_dataflow_buffer_allocation_needed_ = true;
+    }
 
     return dfb->id;
 }
@@ -1344,33 +1347,38 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
 
     uint64_t base_dfb_address = device->allocator()->get_base_allocator_addr(HalMemType::L1);
     for (auto& dfb : this->dataflow_buffers_) {
-        uint64_t computed_addr = base_dfb_address;
-        for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
-            // Need the max available address across all cores dataflow buffer is placed on
-            for (const CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
-                if (dfb_allocator.core_range == core_range) {
-                    computed_addr = std::max(computed_addr, dfb_allocator.get_cb_region_end());
-                    break;
-                }
-            }
-        }
-        computed_addr = align(computed_addr, device->allocator()->get_alignment(BufferType::DRAM));
-        for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
-            for (CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
-                if (dfb_allocator.core_range.intersects(core_range)) {
-                    if (dfb_allocator.core_range != core_range and computed_addr < dfb_allocator.get_cb_region_end()) {
-                        // Intersecting core range has already been marked to have allocation at this address. This
-                        // could have been marked by a dataflow buffer on a core range disjoint from current
-                        // `core_range` but also intersecting `dfb_allocator.core_range`
-                        continue;
+        uint32_t alloc_addr;
+        if (dfb->borrows_memory()) {
+            alloc_addr = static_cast<uint32_t>(dfb->borrowed_buffer->address());
+        } else {
+            uint64_t computed_addr = base_dfb_address;
+            for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
+                // Need the max available address across all cores dataflow buffer is placed on
+                for (const CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
+                    if (dfb_allocator.core_range == core_range) {
+                        computed_addr = std::max(computed_addr, dfb_allocator.get_cb_region_end());
+                        break;
                     }
-                    dfb_allocator.mark_address(computed_addr, dfb->total_size(), base_dfb_address);
                 }
             }
+            computed_addr = align(computed_addr, device->allocator()->get_alignment(BufferType::DRAM));
+            for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
+                for (CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
+                    if (dfb_allocator.core_range.intersects(core_range)) {
+                        if (dfb_allocator.core_range != core_range and computed_addr < dfb_allocator.get_cb_region_end()) {
+                            // Intersecting core range has already been marked to have allocation at this address. This
+                            // could have been marked by a dataflow buffer on a core range disjoint from current
+                            // `core_range` but also intersecting `dfb_allocator.core_range`
+                            continue;
+                        }
+                        dfb_allocator.mark_address(computed_addr, dfb->total_size(), base_dfb_address);
+                    }
+                }
+            }
+            alloc_addr = static_cast<uint32_t>(computed_addr);
         }
-        // Fill alloc_addr per core in each group.  All cores of a DFB get the same computed_addr so the L1 buffer is at a uniform
+        // Fill alloc_addr per core in each group.  All cores of a DFB get the same alloc_addr so the L1 buffer is at a uniform
         // absolute address on every physical core.
-        uint32_t alloc_addr = static_cast<uint32_t>(computed_addr);
         dfb->core_lookup_.clear();
         for (size_t gi = 0; gi < dfb->groups.size(); gi++) {
             for (auto& [core, addr] : dfb->groups[gi].l1_by_core) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -705,9 +705,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
         }
     }
 
-    if (!dfb->borrows_memory()) {
-        this->local_dataflow_buffer_allocation_needed_ = true;
-    }
+    this->local_dataflow_buffer_allocation_needed_ = true;
 
     return dfb->id;
 }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -15,7 +15,6 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
-#include <tt-metalium/buffer.hpp>
 
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 
@@ -78,12 +77,12 @@ struct DataflowBufferImpl {
     // Flag to track if this DFB uses remapper (set during finalization)
     bool use_remapper = false;
 
-    bool borrows_memory() const { return config.borrowed_buffer != nullptr; }
+    bool borrows_memory() const { return config.borrows_memory; }
 
-    // Redirects the DFB ring to a new base address without re-running allocation.
-    // This DFB must have been created with a borrowed_buffer.
-    void update_borrowed_memory_base_addr(uint32_t new_addr) {
-        TT_FATAL(borrows_memory(), "Cannot update address of DFB {} that does not borrow memory", id);
+    // Sets the L1 base address for a borrowed-memory DFB, updating all core entries.
+    // Must be called before launch whenever the DFB was configured with borrows_memory = true.
+    void set_borrowed_memory_base_addr(uint32_t new_addr) {
+        TT_FATAL(borrows_memory(), "Cannot set borrowed address on DFB {} that does not borrow memory", id);
         for (auto& group : groups) {
             for (auto& [core, addr] : group.l1_by_core) {
                 addr = new_addr;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -77,12 +77,16 @@ struct DataflowBufferImpl {
     // Flag to track if this DFB uses remapper (set during finalization)
     bool use_remapper = false;
 
+    // Set by set_borrowed_memory_base_addr()
+    uint32_t borrowed_addr_ = 0;
+
     bool borrows_memory() const { return config.borrows_memory; }
 
-    // Sets the L1 base address for a borrowed-memory DFB, updating all core entries.
-    // Must be called before launch whenever the DFB was configured with borrows_memory = true.
     void set_borrowed_memory_base_addr(uint32_t new_addr) {
         TT_FATAL(borrows_memory(), "Cannot set borrowed address on DFB {} that does not borrow memory", id);
+        borrowed_addr_ = new_addr;
+        // If allocate_dataflow_buffers() has already run, update the live tables so that
+        // a subsequent run picks up the new address.
         for (auto& group : groups) {
             for (auto& [core, addr] : group.l1_by_core) {
                 addr = new_addr;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -78,9 +78,21 @@ struct DataflowBufferImpl {
     // Flag to track if this DFB uses remapper (set during finalization)
     bool use_remapper = false;
 
-    // When non-null, the DFB borrows L1 memory from this buffer instead of allocating its own.
-    const tt::tt_metal::Buffer* borrowed_buffer = nullptr;
-    bool borrows_memory() const { return borrowed_buffer != nullptr; }
+    bool borrows_memory() const { return config.borrowed_buffer != nullptr; }
+
+    // Redirects the DFB ring to a new base address without re-running allocation.
+    // This DFB must have been created with a borrowed_buffer.
+    void update_borrowed_memory_base_addr(uint32_t new_addr) {
+        TT_FATAL(borrows_memory(), "Cannot update address of DFB {} that does not borrow memory", id);
+        for (auto& group : groups) {
+            for (auto& [core, addr] : group.l1_by_core) {
+                addr = new_addr;
+            }
+        }
+        for (auto& [core, pair] : core_lookup_) {
+            pair.second = new_addr;
+        }
+    }
 
     uint32_t total_size() const { return config.entry_size * config.num_entries; }
     uint32_t serialized_size() const;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -15,6 +15,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
+#include <tt-metalium/buffer.hpp>
 
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 
@@ -76,6 +77,10 @@ struct DataflowBufferImpl {
     bool configs_finalized = false;
     // Flag to track if this DFB uses remapper (set during finalization)
     bool use_remapper = false;
+
+    // When non-null, the DFB borrows L1 memory from this buffer instead of allocating its own.
+    const tt::tt_metal::Buffer* borrowed_buffer = nullptr;
+    bool borrows_memory() const { return borrowed_buffer != nullptr; }
 
     uint32_t total_size() const { return config.entry_size * config.num_entries; }
     uint32_t serialized_size() const;


### PR DESCRIPTION
### PR Category
Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-user-mem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-user-mem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-user-mem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-user-mem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-user-mem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-user-mem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-user-mem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-user-mem)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-user-mem)