### PR TITLE
[Feature] Implicit DFBAccessor → uint32_t for LLK compatibility

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
@@ -7,6 +7,16 @@
 #include "api/debug/dprint.h"
 #include "experimental/kernel_args.h"
 
+namespace {
+// Compile-time check that DFBAccessor implicitly converts to uint32_t in a copy-init context,
+// which is what makes `dfb::name` usable directly as the CB-id argument to LLK compute APIs
+// (reduce_init, pack_tile, etc.) without an intermediate DataflowBuffer.
+constexpr uint32_t take_cb_id(uint32_t v) { return v; }
+static_assert(
+    take_cb_id(dfb::in) == dfb::in.id,
+    "DFBAccessor must implicitly convert to its underlying uint32_t id for LLK compatibility");
+}  // namespace
+
 void kernel_main() {
     constexpr uint32_t num_entries = get_arg(args::num_entries);
     DataflowBuffer dfb_in(dfb::in);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
@@ -7,15 +7,11 @@
 #include "api/debug/dprint.h"
 #include "experimental/kernel_args.h"
 
-namespace {
-// Compile-time check that DFBAccessor implicitly converts to uint32_t in a copy-init context,
-// which is what makes `dfb::name` usable directly as the CB-id argument to LLK compute APIs
-// (reduce_init, pack_tile, etc.) without an intermediate DataflowBuffer.
-constexpr uint32_t take_cb_id(uint32_t v) { return v; }
-static_assert(
-    take_cb_id(dfb::in) == dfb::in.id,
-    "DFBAccessor must implicitly convert to its underlying uint32_t id for LLK compatibility");
-}  // namespace
+// Quick check that DFBAccessor implicitly converts to uint32_t.
+// This is a shim to enable DFB to work with WH/BH LLK compute APIs that expect raw CB ids.
+// NOTE: This check is piggybacking along on an unrelated test kernel.
+constexpr uint32_t implicit_id = dfb::in;  // copy-init invokes the conversion
+static_assert(implicit_id == dfb::in.id, "DFBAccessor must implicitly convert to its underlying uint32_t id");
 
 void kernel_main() {
     constexpr uint32_t num_entries = get_arg(args::num_entries);

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -43,11 +43,14 @@
 // DFBAccessor can be transparently modified (kernel-side syntax stays unchanged).
 struct DFBAccessor {
     explicit constexpr DFBAccessor(uint16_t id) noexcept : id(id) {}
-    // Implicit conversion to uint32_t: lets DFBAccessor flow into LLK compute APIs
-    // (reduce_init, pack_tile, etc.) that take a raw CB id. Interim measure while
-    // the LLK API surface migrates from CB-centric to DFB-centric vocabulary; if
-    // DFBAccessor's representation ever changes (e.g. moves to a CRTA), updating
-    // this single conversion is preferable to fixing every LLK wrapper.
+
+    // DFBAccessor is implicitly convertible to uint32_t.
+    // On WH/BH, this allows a Metal 2.0 user to pass a DFBAccessor directly to
+    // LLK compute APIs that expect a raw CB id.
+    //
+    // NOTE: If we ever want to switch DFBAccessor from implicit CTA to implicit
+    // CRTA or RTA, we can update the conversion adaptor without affecting any
+    // kernel code that's passing DFBAccessors into LLK APIs.
     constexpr operator uint32_t() const noexcept { return id; }
     uint16_t id;
 };

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -43,6 +43,12 @@
 // DFBAccessor can be transparently modified (kernel-side syntax stays unchanged).
 struct DFBAccessor {
     explicit constexpr DFBAccessor(uint16_t id) noexcept : id(id) {}
+    // Implicit conversion to uint32_t: lets DFBAccessor flow into LLK compute APIs
+    // (reduce_init, pack_tile, etc.) that take a raw CB id. Interim measure while
+    // the LLK API surface migrates from CB-centric to DFB-centric vocabulary; if
+    // DFBAccessor's representation ever changes (e.g. moves to a CRTA), updating
+    // this single conversion is preferable to fixing every LLK wrapper.
+    constexpr operator uint32_t() const noexcept { return id; }
     uint16_t id;
 };
 


### PR DESCRIPTION
## PR Category
Feature

## Summary

**Problem**: All ops will soon be ported to Metal 2.0 on WH/BH, in preparation for Quasar support. On WH/BH, the LLK APIs all want a CB id... a concept that doesn't exist in Metal 2.0 at all. This is leading to some very serious awkward grossness in the first AI op porting attempts. The _correct_ thing to pass into the LLK API, from a DFB, is its `DFBAccessor` opaque handle.

**_Best_ solution**: Overload all the LLK APIs that current want CB IDs to also accept `DFBAccessor`. Update the header documentation accordingly.

**Pragmatic, interim solution**: Provide an implicit converter from `DFBAccessor` to `uint32_t`. Tell the ops porting AI recipe to always pass the `DFBAccessor` in where the LLK asked for CB id.

### What I did

- Add an implicit `uint32_t` converter to`DFBAccessor` so `dfb::name` can flow directly into LLK compute APIs that take a raw `uint32_t` CB id.
- Adds a temporary "piggyback" test. `dfb_t6.cpp` is a compute kernel that several DFB tests use; now it's also got a static assert that the conversion works as intended. This is slightly ick, but can be removed once the tt-metal test migration to Metal 2.0 is done.

## Notes for reviewers
Do you agree this is the right approach to solve the LLK API DFB incompatibility on WH/BH?
I figure that down the road, when Metal 2.0 is more established, we could properly swap over (or overload) the LLK library.

## TODO!

Some Quasar LLKs are currently asking for CB ids, too! 
Any Quasar-specific LLK API should be natively DFB-aware.

## CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/dfb-accessor-implicit-conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/dfb-accessor-implicit-conv)