### PR TITLE
[MeshTensor Integration] Reduction op family

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -46,18 +46,16 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
     using namespace tt;
     using namespace tt::tt_metal;
 
-    const auto& input_tensor{tensor_args.input_tensor};
+    const auto& input_tensor{tensor_args.input_tensor.mesh_tensor()};
     auto& output_tensor{tensor_return_value};
+    const MeshTensor& dst_tensor = output_tensor.mesh_tensor();
     const auto& input_shape{input_tensor.padded_shape()};
 
     ProgramDescriptor desc;
 
-    IDevice* device{input_tensor.device()};
+    IDevice* device{&input_tensor.device_mut()};
 
-    auto* src_buffer{input_tensor.buffer()};
-    auto* dst_buffer{output_tensor.buffer()};
-
-    const auto dst_cb_data_format{datatype_to_dataformat_converter(output_tensor.dtype())};
+    const auto dst_cb_data_format{datatype_to_dataformat_converter(dst_tensor.dtype())};
 
     const uint32_t input_rank{input_tensor.padded_shape().rank()};
 
@@ -93,14 +91,14 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
     constexpr uint32_t acc_tiles = 1;
     constexpr uint32_t out_tiles = 4;
 
-    auto acc_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
+    auto acc_dataformat = datatype_to_dataformat_converter(dst_tensor.dtype());
     if (!is_integer_format(acc_dataformat)) {
         acc_dataformat = DataFormat::Float32;
     }
     auto acc_dataformat_name = fmt::format("DataFormat::{}", acc_dataformat);
 
     const auto input_dataformat = datatype_to_dataformat_converter(input_tensor.dtype());
-    const auto output_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
+    const auto output_dataformat = datatype_to_dataformat_converter(dst_tensor.dtype());
 
     auto push_cb = [&](const tt::DataFormat& data_format,
                        AccumulationProgramFactory::AccumulationCB accumulation_cb,
@@ -163,13 +161,13 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
     // fp32_dest_acc_en will be True for FLOAT32 inputs (set below), so use HiFi3 as default on Wormhole B0.
     const auto is_wormhole = device->arch() == tt::ARCH::WORMHOLE_B0;
     const auto default_math_fidelity =
-        (is_wormhole && output_tensor.dtype() == DataType::FLOAT32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+        (is_wormhole && dst_tensor.dtype() == DataType::FLOAT32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
 
     std::vector<uint32_t> reader_compile_time_args;
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args;
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dst_tensor).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = AccumulationProgramFactory::KERNEL_PATHS[0];
@@ -233,7 +231,7 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
 
         reader_desc.emplace_runtime_args(
             core,
-            {src_buffer,
+            {input_tensor,
              num_tiles_per_core,
              tiles_per_row,
              input_tile_offset,
@@ -244,7 +242,7 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
 
         writer_desc.emplace_runtime_args(
             core,
-            {dst_buffer,
+            {dst_tensor,
              num_tiles_per_core,
              tiles_per_row,
              input_tile_offset,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -47,7 +47,7 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
     using namespace tt::tt_metal;
 
     const auto& input_tensor{tensor_args.input_tensor.mesh_tensor()};
-    const MeshTensor& output_tensor{tensor_return_value.mesh_tensor()};
+    const auto& output_tensor{tensor_return_value.mesh_tensor()};
     const auto& input_shape{input_tensor.padded_shape()};
 
     ProgramDescriptor desc;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -47,15 +47,14 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
     using namespace tt::tt_metal;
 
     const auto& input_tensor{tensor_args.input_tensor.mesh_tensor()};
-    auto& output_tensor{tensor_return_value};
-    const MeshTensor& dst_tensor = output_tensor.mesh_tensor();
+    const MeshTensor& output_tensor{tensor_return_value.mesh_tensor()};
     const auto& input_shape{input_tensor.padded_shape()};
 
     ProgramDescriptor desc;
 
     IDevice* device{&input_tensor.device_mut()};
 
-    const auto dst_cb_data_format{datatype_to_dataformat_converter(dst_tensor.dtype())};
+    const auto dst_cb_data_format{datatype_to_dataformat_converter(output_tensor.dtype())};
 
     const uint32_t input_rank{input_tensor.padded_shape().rank()};
 
@@ -85,20 +84,20 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
         "Accumulation (cumsum/cumprod) requires at least one worker core; num_rows_total={}",
         num_rows_total);
 
-    validate_reduce_op_program_grid("Accumulation", all_cores, grid, nullptr, true, {{&output_tensor, "output"}});
+    validate_reduce_op_program_grid("Accumulation", all_cores, grid, nullptr, true, {{&tensor_return_value, "output"}});
 
     constexpr uint32_t in_tiles = 4;
     constexpr uint32_t acc_tiles = 1;
     constexpr uint32_t out_tiles = 4;
 
-    auto acc_dataformat = datatype_to_dataformat_converter(dst_tensor.dtype());
+    auto acc_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
     if (!is_integer_format(acc_dataformat)) {
         acc_dataformat = DataFormat::Float32;
     }
     auto acc_dataformat_name = fmt::format("DataFormat::{}", acc_dataformat);
 
     const auto input_dataformat = datatype_to_dataformat_converter(input_tensor.dtype());
-    const auto output_dataformat = datatype_to_dataformat_converter(dst_tensor.dtype());
+    const auto output_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
 
     auto push_cb = [&](const tt::DataFormat& data_format,
                        AccumulationProgramFactory::AccumulationCB accumulation_cb,
@@ -161,13 +160,13 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
     // fp32_dest_acc_en will be True for FLOAT32 inputs (set below), so use HiFi3 as default on Wormhole B0.
     const auto is_wormhole = device->arch() == tt::ARCH::WORMHOLE_B0;
     const auto default_math_fidelity =
-        (is_wormhole && dst_tensor.dtype() == DataType::FLOAT32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+        (is_wormhole && output_tensor.dtype() == DataType::FLOAT32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
 
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args;
-    tt::tt_metal::TensorAccessorArgs(dst_tensor).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output_tensor).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = AccumulationProgramFactory::KERNEL_PATHS[0];
@@ -242,7 +241,7 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
 
         writer_desc.emplace_runtime_args(
             core,
-            {dst_tensor,
+            {output_tensor,
              num_tiles_per_core,
              tiles_per_row,
              input_tile_offset,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -52,7 +52,7 @@ tt::tt_metal::ProgramDescriptor AccumulationProgramFactory::create_descriptor(
 
     ProgramDescriptor desc;
 
-    IDevice* device{&input_tensor.device_mut()};
+    IDevice* device{&input_tensor.mutable_device()};
 
     const auto dst_cb_data_format{datatype_to_dataformat_converter(output_tensor.dtype())};
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
@@ -20,9 +20,9 @@ constexpr auto ema_buffer_depth = 2;
 
 tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_descriptor(
     const EmaParams& operation_attributes, const EmaInputs& tensor_args, Tensor& tensor_return_value) {
-    const auto& input = tensor_args.input;
+    const auto& input = tensor_args.input.mesh_tensor();
     auto& output = tensor_return_value;
-    IDevice* device = input.device();
+    IDevice* device = &input.device_mut();
 
     // Grid sizing
     // -----------
@@ -80,10 +80,11 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
     constexpr auto prev_cb_index = tt::CBIndex::c_2;
 
     auto src_data_format = datatype_to_dataformat_converter(input.dtype());
-    auto dst_data_format = datatype_to_dataformat_converter(output.dtype());
+    const auto& output_mesh = output.mesh_tensor();
+    auto dst_data_format = datatype_to_dataformat_converter(output_mesh.dtype());
 
     auto src_tile_size = input.tensor_spec().tile().get_tile_size(src_data_format);
-    auto dst_tile_size = output.tensor_spec().tile().get_tile_size(dst_data_format);
+    auto dst_tile_size = output_mesh.tensor_spec().tile().get_tile_size(dst_data_format);
 
     auto src_cb_size = src_tile_size * ema_buffer_depth;
     auto dst_cb_size = dst_tile_size * ema_buffer_depth;
@@ -122,10 +123,10 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
     // Compile time args for the kernels
     // ---------------------------------
     std::vector<uint32_t> reader_compile_args = {total_tiles_per_core};
-    TensorAccessorArgs(input.buffer()).append_to(reader_compile_args);
+    TensorAccessorArgs(input).append_to(reader_compile_args);
 
     std::vector<uint32_t> writer_compile_args = {total_tiles_per_core};
-    TensorAccessorArgs(output.buffer()).append_to(writer_compile_args);
+    TensorAccessorArgs(output_mesh).append_to(writer_compile_args);
 
     std::vector<uint32_t> compute_compile_args = {
         total_batch_channel_tiles_per_core,
@@ -176,15 +177,13 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
 
     // Set runtime args
     // ---------------
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
 
     uint32_t src_start_tile = 0;
     uint32_t dst_start_tile = 0;
     for (const auto& range : all_cores.ranges()) {
         for (const auto& core : range) {
-            reader_desc.emplace_runtime_args(core, {src_buffer, src_start_tile});
-            writer_desc.emplace_runtime_args(core, {dst_buffer, dst_start_tile});
+            reader_desc.emplace_runtime_args(core, {input, src_start_tile});
+            writer_desc.emplace_runtime_args(core, {output_mesh, dst_start_tile});
             src_start_tile += total_tiles_per_core;
             dst_start_tile += total_tiles_per_core;
         }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
@@ -22,7 +22,7 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
     const EmaParams& operation_attributes, const EmaInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input.mesh_tensor();
     const MeshTensor& output = tensor_return_value.mesh_tensor();
-    IDevice* device = &input.device_mut();
+    IDevice* device = &input.mutable_device();
 
     // Grid sizing
     // -----------

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
@@ -21,7 +21,7 @@ constexpr auto ema_buffer_depth = 2;
 tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_descriptor(
     const EmaParams& operation_attributes, const EmaInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input.mesh_tensor();
-    auto& output = tensor_return_value;
+    const MeshTensor& output = tensor_return_value.mesh_tensor();
     IDevice* device = &input.device_mut();
 
     // Grid sizing
@@ -52,7 +52,7 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
     auto all_cores = CoreRangeSet(grid_to_cores(num_cores, grid_size.x, grid_size.y, false));
 
     validate_reduce_op_program_grid(
-        "EMA", all_cores, device->compute_with_storage_grid_size(), nullptr, false, {{&output, "output"}});
+        "EMA", all_cores, device->compute_with_storage_grid_size(), nullptr, false, {{&tensor_return_value, "output"}});
     log_debug(
         tt::LogOp,
         "EmaProgramFactory: grid_size=({}, {}), num_cores={}, total_batch_channel_tiles={}",
@@ -80,11 +80,10 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
     constexpr auto prev_cb_index = tt::CBIndex::c_2;
 
     auto src_data_format = datatype_to_dataformat_converter(input.dtype());
-    const auto& output_mesh = output.mesh_tensor();
-    auto dst_data_format = datatype_to_dataformat_converter(output_mesh.dtype());
+    auto dst_data_format = datatype_to_dataformat_converter(output.dtype());
 
     auto src_tile_size = input.tensor_spec().tile().get_tile_size(src_data_format);
-    auto dst_tile_size = output_mesh.tensor_spec().tile().get_tile_size(dst_data_format);
+    auto dst_tile_size = output.tensor_spec().tile().get_tile_size(dst_data_format);
 
     auto src_cb_size = src_tile_size * ema_buffer_depth;
     auto dst_cb_size = dst_tile_size * ema_buffer_depth;
@@ -126,7 +125,7 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
     TensorAccessorArgs(input).append_to(reader_compile_args);
 
     std::vector<uint32_t> writer_compile_args = {total_tiles_per_core};
-    TensorAccessorArgs(output_mesh).append_to(writer_compile_args);
+    TensorAccessorArgs(output).append_to(writer_compile_args);
 
     std::vector<uint32_t> compute_compile_args = {
         total_batch_channel_tiles_per_core,
@@ -183,7 +182,7 @@ tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_de
     for (const auto& range : all_cores.ranges()) {
         for (const auto& core : range) {
             reader_desc.emplace_runtime_args(core, {input, src_start_tile});
-            writer_desc.emplace_runtime_args(core, {output_mesh, dst_start_tile});
+            writer_desc.emplace_runtime_args(core, {output, dst_start_tile});
             src_start_tile += total_tiles_per_core;
             dst_start_tile += total_tiles_per_core;
         }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
@@ -21,7 +21,7 @@ constexpr auto ema_buffer_depth = 2;
 tt::tt_metal::ProgramDescriptor EmaDeviceOperation::EmaProgramFactory::create_descriptor(
     const EmaParams& operation_attributes, const EmaInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input.mesh_tensor();
-    const MeshTensor& output = tensor_return_value.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
     IDevice* device = &input.mutable_device();
 
     // Grid sizing

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
@@ -158,8 +158,8 @@ static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uin
  */
 ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
     const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
-    const auto& input = tensor_args.input;
-    const auto& output = tensor_return_value;
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
     const auto& dim = operation_attributes.dim;
     const bool keepdim = operation_attributes.keepdim;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
@@ -181,11 +181,9 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
     // Last dimension in output i.e. the dim left after reduction
     const auto output_last_dim = reduce_all or keepdim or (rank < 2) ? 1 : input_shape[rank - 2];
 
-    const tt::tt_metal::IDevice* device = output.device();
+    const tt::tt_metal::IDevice* device = &output.device_mut();
 
-    auto* const src_buffer = input.buffer();
-    auto* const dst_buffer = output.buffer();
-    const auto src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    const auto src_is_dram = input.mesh_buffer().device_local_config().buffer_type == tt::tt_metal::BufferType::DRAM;
 
     // NOC transactions need to be aligned.
     // So, for bfloat16 dtype, we need at least 16/32 units per core (depending on alignment) to avoid unaligned
@@ -372,8 +370,8 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
         start_sem_idx,
         done_sem_idx,
     };
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_args);
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(reader_compile_args);
+    tt::tt_metal::TensorAccessorArgs(input).append_to(reader_compile_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(reader_compile_args);
 
     KernelDescriptor reader_desc0;
     reader_desc0.kernel_source =
@@ -395,12 +393,12 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
         const CoreCoord& core = cores_coords0.at(i);
         reader_desc0.emplace_runtime_args(
             core,
-            {src_buffer,
-             dst_buffer,
+            {input,
+             output,
              i,
-             i * src_read_size0,
+             static_cast<uint32_t>(i * src_read_size0),
              i * red_dim_units0,
-             (i == num_cores0 - 1) ? src_read_size_last0 : src_read_size0,
+             static_cast<uint32_t>((i == num_cores0 - 1) ? src_read_size_last0 : src_read_size0),
              (i == num_cores0 - 1) ? red_dim_units_last0 : red_dim_units0});
     }
 
@@ -425,12 +423,12 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
             const CoreCoord& core = cores_coords1.at(i);
             reader_desc1.emplace_runtime_args(
                 core,
-                {src_buffer,
-                 dst_buffer,
+                {input,
+                 output,
                  static_cast<uint32_t>(num_cores0 + i),
-                 src_offset1 + (i * src_read_size1),
+                 static_cast<uint32_t>(src_offset1 + (i * src_read_size1)),
                  red_dim_offset1 + (i * red_dim_units1),
-                 (i == num_cores1 - 1) ? src_read_size_last1 : src_read_size1,
+                 static_cast<uint32_t>((i == num_cores1 - 1) ? src_read_size_last1 : src_read_size1),
                  (i == num_cores1 - 1) ? red_dim_units_last1 : red_dim_units1});
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
@@ -181,7 +181,7 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
     // Last dimension in output i.e. the dim left after reduction
     const auto output_last_dim = reduce_all or keepdim or (rank < 2) ? 1 : input_shape[rank - 2];
 
-    const tt::tt_metal::IDevice* device = &output.device_mut();
+    const tt::tt_metal::IDevice* device = &output.mutable_device();
 
     const auto src_is_dram = input.mesh_buffer().device_local_config().buffer_type == tt::tt_metal::BufferType::DRAM;
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
@@ -114,7 +114,8 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     const bool keepdim = operation_attributes.keepdim;
 
     ProgramDescriptor desc;
-    const tt::tt_metal::IDevice* device = output.device();
+    const auto& dst_mesh = output.mesh_tensor();
+    const tt::tt_metal::IDevice* device = &dst_mesh.device_mut();
     const bool reduce_all = not dim.has_value();
 
     // Circular buffers
@@ -130,8 +131,9 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     validate_reduce_op_program_grid(
         "Argmax single-core", all_cores, device->compute_with_storage_grid_size(), nullptr, true, {});
 
-    const tt::DataFormat input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    const tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto& src_mesh = input.mesh_tensor();
+    const tt::DataFormat input_data_format = tt::tt_metal::datatype_to_dataformat_converter(src_mesh.dtype());
+    const tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(dst_mesh.dtype());
     const auto [src_page_size, dst_page_size] = get_page_sizes_single_core(input, output, keepdim, reduce_all);
 
     // Create input CB
@@ -160,14 +162,12 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     std::vector<uint32_t> ctime_args = get_ctime_args_single_core(
         input, src_page_size, dst_page_size, src_cb_index, dst_cb_index, keepdim, reduce_all);
 
-    auto* const src_buffer = input.buffer();
-    auto* const dst_buffer = output.buffer();
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(ctime_args);
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(ctime_args);
+    tt::tt_metal::TensorAccessorArgs(src_mesh).append_to(ctime_args);
+    tt::tt_metal::TensorAccessorArgs(dst_mesh).append_to(ctime_args);
 
     // Kernel
     std::string kernel_path =
-        input.layout() == Layout::ROW_MAJOR
+        src_mesh.layout() == Layout::ROW_MAJOR
             ? "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp"
             : "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout.cpp";
 
@@ -181,7 +181,7 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     // Runtime args
     const auto cores = grid_to_cores(num_cores, grid_size.x, grid_size.y, false);
     for (const auto& core : cores) {
-        reader_desc.emplace_runtime_args(core, {src_buffer, dst_buffer});
+        reader_desc.emplace_runtime_args(core, {src_mesh, dst_mesh});
     }
 
     desc.kernels.push_back(std::move(reader_desc));

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
@@ -14,7 +14,7 @@ namespace ttnn::prim {
 using namespace tt::tt_metal;
 
 static std::tuple<uint32_t, uint32_t> get_page_sizes_single_core(
-    const Tensor& input, const Tensor& output, bool keepdim, bool reduce_all) {
+    const MeshTensor& input, const MeshTensor& output, bool keepdim, bool reduce_all) {
     const auto& input_shape = input.padded_shape();
     const uint32_t rank = input_shape.size();
 
@@ -44,7 +44,7 @@ static std::tuple<uint32_t, uint32_t> get_page_sizes_single_core(
 }
 
 static std::vector<uint32_t> get_ctime_args_single_core(
-    const Tensor& input,
+    const MeshTensor& input,
     uint32_t src_page_size,
     uint32_t dst_page_size,
     uint32_t src_cb_index,
@@ -108,14 +108,13 @@ static std::vector<uint32_t> get_ctime_args_single_core(
 
 ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
-    const auto& input = tensor_args.input;
-    const auto& output = tensor_return_value;
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
     const auto& dim = operation_attributes.dim;
     const bool keepdim = operation_attributes.keepdim;
 
     ProgramDescriptor desc;
-    const auto& dst_mesh = output.mesh_tensor();
-    const tt::tt_metal::IDevice* device = &dst_mesh.mutable_device();
+    const tt::tt_metal::IDevice* device = &output.mutable_device();
     const bool reduce_all = not dim.has_value();
 
     // Circular buffers
@@ -131,9 +130,8 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     validate_reduce_op_program_grid(
         "Argmax single-core", all_cores, device->compute_with_storage_grid_size(), nullptr, true, {});
 
-    const auto& src_mesh = input.mesh_tensor();
-    const tt::DataFormat input_data_format = tt::tt_metal::datatype_to_dataformat_converter(src_mesh.dtype());
-    const tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(dst_mesh.dtype());
+    const tt::DataFormat input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     const auto [src_page_size, dst_page_size] = get_page_sizes_single_core(input, output, keepdim, reduce_all);
 
     // Create input CB
@@ -162,12 +160,12 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     std::vector<uint32_t> ctime_args = get_ctime_args_single_core(
         input, src_page_size, dst_page_size, src_cb_index, dst_cb_index, keepdim, reduce_all);
 
-    tt::tt_metal::TensorAccessorArgs(src_mesh).append_to(ctime_args);
-    tt::tt_metal::TensorAccessorArgs(dst_mesh).append_to(ctime_args);
+    tt::tt_metal::TensorAccessorArgs(input).append_to(ctime_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(ctime_args);
 
     // Kernel
     std::string kernel_path =
-        src_mesh.layout() == Layout::ROW_MAJOR
+        input.layout() == Layout::ROW_MAJOR
             ? "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp"
             : "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout.cpp";
 
@@ -181,7 +179,7 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     // Runtime args
     const auto cores = grid_to_cores(num_cores, grid_size.x, grid_size.y, false);
     for (const auto& core : cores) {
-        reader_desc.emplace_runtime_args(core, {src_mesh, dst_mesh});
+        reader_desc.emplace_runtime_args(core, {input, output});
     }
 
     desc.kernels.push_back(std::move(reader_desc));

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
@@ -115,7 +115,7 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
 
     ProgramDescriptor desc;
     const auto& dst_mesh = output.mesh_tensor();
-    const tt::tt_metal::IDevice* device = &dst_mesh.device_mut();
+    const tt::tt_metal::IDevice* device = &dst_mesh.mutable_device();
     const bool reduce_all = not dim.has_value();
 
     // Circular buffers

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -22,8 +22,8 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
-    const auto& a = tensor_args;
-    auto& output = tensor_return_value;
+    const auto& a = tensor_args.mesh_tensor();
+    auto& output = tensor_return_value.mesh_tensor();
     const auto& shape = a.padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();
@@ -35,7 +35,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     uint32_t HtWt = Ht * Wt;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.device_mut().arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -45,7 +45,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    tt_metal::IDevice* device = a.device();
+    tt_metal::IDevice* device = &a.device_mut();
 
     bool use_width_sharding = a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
                               output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
@@ -108,7 +108,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
                 .data_format = src0_cb_data_format,
                 .page_size = src0_single_tile_size,
             }}},
-            .buffer = a.buffer(),
+            .tensor = &a,
         });
     } else {
         uint32_t num_input_tiles = operation_attributes.negate ? chunk_size : 2;
@@ -145,7 +145,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
                 .data_format = dst_cb_data_format,
                 .page_size = dst_single_tile_size,
             }}},
-            .buffer = output.buffer(),
+            .tensor = &output,
         });
     } else {
         uint32_t num_output_tiles = operation_attributes.negate ? chunk_size : 2;
@@ -159,7 +159,6 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
             }}},
         });
     }
-    tt_metal::Buffer* src0_buffer = a.buffer();
     uint32_t scaler_bits = std::bit_cast<uint32_t>(operation_attributes.scaler);
     // Packed fp32 scalar passed to the compute kernel for mul_unary_tile post-reduction scaling.
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
@@ -280,7 +279,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         reader_desc.defines = {reader_defines.begin(), reader_defines.end()};
     } else {
         std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, scaler_bits, /*use_welford=*/0};
-        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+        TensorAccessorArgs(a).append_to(reader_compile_time_args);
 
         // Pass DEST config so reader can compute DEST_AUTO_LIMIT
         std::map<std::string, std::string> reader_defines;
@@ -294,8 +293,6 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         reader_desc.compile_time_args = reader_compile_time_args;
         reader_desc.defines = {reader_defines.begin(), reader_defines.end()};
     }
-
-    tt_metal::Buffer* dst_buffer = output.buffer();
 
     KernelDescriptor writer_desc;
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
@@ -311,7 +308,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         writer_desc.compile_time_args = writer_ct_args;
     } else {
         std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
-        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+        TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
@@ -416,16 +413,12 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
                 TT_THROW("Core not in specified core ranges");
             }
             reader_desc.emplace_runtime_args(
-                core,
-                {a.buffer(),
-                 (num_cols_read / Wt * HtWt) + (num_cols_read % Wt),
-                 num_cols_read % Wt,
-                 num_cols_per_core});
+                core, {a, (num_cols_read / Wt * HtWt) + (num_cols_read % Wt), num_cols_read % Wt, num_cols_per_core});
 
             writer_desc.emplace_runtime_args(
                 core,
                 {
-                    output.buffer(),
+                    output,
                     num_cols_per_core,  // number of tiles to write
                     num_cols_read       // output tile start index
                 });

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -23,7 +23,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     using namespace tt;
     using namespace tt::tt_metal;
     const auto& a = tensor_args.mesh_tensor();
-    auto& output = tensor_return_value.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
     const auto& shape = a.padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -35,7 +35,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     uint32_t HtWt = Ht * Wt;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.device_mut().arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.mutable_device().arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -45,7 +45,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    tt_metal::IDevice* device = &a.device_mut();
+    tt_metal::IDevice* device = &a.mutable_device();
 
     bool use_width_sharding = a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
                               output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -35,7 +35,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     uint32_t HtWt = Ht * Wt;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.mutable_device().arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.device().arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -20,8 +20,8 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
-    const auto& a = tensor_args;
-    auto& output = tensor_return_value;
+    const auto& a = tensor_args.mesh_tensor();
+    auto& output = tensor_return_value.mesh_tensor();
     const auto& shape = a.padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();
@@ -31,7 +31,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     uint32_t Ht = H / tile_height;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.device_mut().arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -42,7 +42,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    tt_metal::IDevice* device = a.device();
+    tt_metal::IDevice* device = &a.device_mut();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto num_rows = NC * Ht;
@@ -102,12 +102,10 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
-    tt_metal::Buffer* src_buffer = a.buffer();
     std::vector<uint32_t> reader_compile_time_args = {std::bit_cast<uint32_t>(operation_attributes.scaler)};
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-    tt_metal::Buffer* dst_buffer = output.buffer();
+    TensorAccessorArgs(a).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     if (operation_attributes.negate) {
         uint32_t acc_cb_index = tt::CBIndex::c_4;
@@ -235,7 +233,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         reader_desc.emplace_runtime_args(
             core,
             {
-                a.buffer(),
+                a,
                 num_tensor_tiles_per_core,
                 num_tiles_read  // tile index of row to start reading from
             });
@@ -243,7 +241,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         writer_desc.emplace_runtime_args(
             core,
             {
-                output.buffer(),
+                output,
                 num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
                 num_tiles_read / out_dim_divider              // output tile start index
             });

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -31,7 +31,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     uint32_t Ht = H / tile_height;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.mutable_device().arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.device().arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -31,7 +31,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     uint32_t Ht = H / tile_height;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.device_mut().arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.mutable_device().arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -42,7 +42,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    tt_metal::IDevice* device = &a.device_mut();
+    tt_metal::IDevice* device = &a.mutable_device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto num_rows = NC * Ht;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -21,7 +21,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     using namespace tt;
     using namespace tt::tt_metal;
     const auto& a = tensor_args.mesh_tensor();
-    auto& output = tensor_return_value.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
     const auto& shape = a.padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -20,8 +20,8 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
-    const auto& a = tensor_args;
-    auto& output = tensor_return_value;
+    const auto& a = tensor_args.mesh_tensor();
+    auto& output = tensor_return_value.mesh_tensor();
     const auto& shape = a.padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();
@@ -29,7 +29,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     const uint32_t tile_hw = a.tensor_spec().tile().get_tile_hw();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.device_mut().arch(), operation_attributes.compute_kernel_config);
 
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
@@ -79,12 +79,6 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    tt_metal::Buffer* src0_buffer = a.buffer();
-
-    // This should allocate a DRAM buffer on the device
-    tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device");
-
     ProgramDescriptor desc;
 
     uint32_t src0_cb_index = 0;
@@ -128,7 +122,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
     std::vector<uint32_t> reader_compile_time_args = {std::bit_cast<uint32_t>(scaler)};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(a).append_to(reader_compile_time_args);
 
     if (operation_attributes.negate) {
         uint32_t acc_cb_index = tt::CBIndex::c_4;
@@ -157,7 +151,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     }
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, tt::tt_metal::ReduceOpDim::HW);
@@ -205,7 +199,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
         .fp32_dest_acc_en = fp32_dest_acc_en,
     };
 
-    reader_desc.emplace_runtime_args(selected_core_coord, {a.buffer(), num_tensor_tiles, 0u});
+    reader_desc.emplace_runtime_args(selected_core_coord, {a, num_tensor_tiles, 0u});
 
     TT_FATAL(Ht != 0 && Wt != 0, "Height and width in tiles must be non-zero (Ht={}, Wt={}, H={}, W={})", Ht, Wt, H, W);
     uint32_t out_dim_divider = Ht * Wt;
@@ -215,7 +209,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
         num_tensor_tiles,
         out_dim_divider);
 
-    writer_desc.emplace_runtime_args(selected_core_coord, {output.buffer(), num_tensor_tiles / out_dim_divider, 0u});
+    writer_desc.emplace_runtime_args(selected_core_coord, {output, num_tensor_tiles / out_dim_divider, 0u});
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -29,7 +29,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     const uint32_t tile_hw = a.tensor_spec().tile().get_tile_hw();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.mutable_device().arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.device().arch(), operation_attributes.compute_kernel_config);
 
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -29,7 +29,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     const uint32_t tile_hw = a.tensor_spec().tile().get_tile_hw();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(a.device_mut().arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(a.mutable_device().arch(), operation_attributes.compute_kernel_config);
 
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -21,7 +21,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
     using namespace tt;
     using namespace tt::tt_metal;
     const auto& a = tensor_args.mesh_tensor();
-    auto& output = tensor_return_value.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
     const auto& shape = a.padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -252,9 +252,6 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         });
     }
 
-    tt_metal::Buffer* input_buffer = tensor_arg.buffer();
-    tt_metal::Buffer* output_buffer = tensor_return_value.buffer();
-
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, operation_attributes.reduce_dim);
     reduce_defines["ENABLE_FP32_DEST_ACC"] = fp32_dest_acc_en ? "1" : "0";
@@ -274,7 +271,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         // mean/M2 state), so the reader must deliver tiles in strict column-major
         // order: all Ht tiles of column 0, then all Ht tiles of column 1, etc.
         std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, scaler_bits, /*use_welford=*/1};
-        TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
+        TensorAccessorArgs(tensor_arg.mesh_tensor()).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "reader_unary_transpose_wh_universal_input_cols_partitioned.cpp";
@@ -282,7 +279,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
     } else {
         // W-reduce: sequential reader reads tiles row by row.
         std::vector<uint32_t> reader_compile_time_args = {scaler_bits};
-        TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
+        TensorAccessorArgs(tensor_arg.mesh_tensor()).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "reader_unary_reduce_universal_start_id.cpp";
@@ -308,7 +305,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         // HW-reduce: custom writer that combines partial stats and constructs output tile.
         std::vector<uint32_t> writer_compile_time_args = {
             Wt, W, tile_width, H, static_cast<uint32_t>(operation_attributes.correction), reduce_batch_size};
-        TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
+        TensorAccessorArgs(tensor_return_value.mesh_tensor()).append_to(writer_compile_time_args);
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "writer_welford_hw.cpp";
@@ -317,7 +314,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
     } else {
         // W-reduce and H-reduce: generic tile writer.
         std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
-        TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
+        TensorAccessorArgs(tensor_return_value.mesh_tensor()).append_to(writer_compile_time_args);
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
         writer_desc.compile_time_args = writer_compile_time_args;
@@ -420,11 +417,12 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             }
             uint32_t num_input_tiles_per_core = num_work_units_per_core * Wt;
             uint32_t num_output_tiles_per_core = num_work_units_per_core;
-            reader_desc.emplace_runtime_args(core, {tensor_arg.buffer(), num_input_tiles_per_core, input_tiles_offset});
+            reader_desc.emplace_runtime_args(
+                core, {tensor_arg.mesh_tensor(), num_input_tiles_per_core, input_tiles_offset});
             (in_g1 ? compute_desc_g1 : *compute_desc_g2)
                 .runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_work_units_per_core});
             writer_desc.emplace_runtime_args(
-                core, {tensor_return_value.buffer(), num_output_tiles_per_core, output_tiles_offset});
+                core, {tensor_return_value.mesh_tensor(), num_output_tiles_per_core, output_tiles_offset});
             input_tiles_offset += num_input_tiles_per_core;
             output_tiles_offset += num_output_tiles_per_core;
         }
@@ -457,7 +455,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             uint32_t col_start_tile_id = nc_slice_offset * HtWt;
             reader_desc.emplace_runtime_args(
                 core,
-                {tensor_arg.buffer(),
+                {tensor_arg.mesh_tensor(),
                  col_start_tile_id,
                  /*curr_col_in_batch=*/0u,
                  num_cols});
@@ -467,7 +465,8 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             // Writer: runtime args are {dst_addr, NC_per_core, output_tile_start_id}.
             // NC_per_core is total NC slices; the writer uses reduce_batch_size
             // (compile-time) to determine how many to group per output.
-            writer_desc.emplace_runtime_args(core, {tensor_return_value.buffer(), nc_slices_per_core, output_offset});
+            writer_desc.emplace_runtime_args(
+                core, {tensor_return_value.mesh_tensor(), nc_slices_per_core, output_offset});
             nc_slice_offset += nc_slices_per_core;
             output_offset += num_outputs_per_core;
         }
@@ -489,13 +488,14 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             }
             reader_desc.emplace_runtime_args(
                 core,
-                {tensor_arg.buffer(),
+                {tensor_arg.mesh_tensor(),
                  (num_cols_read / Wt * HtWt) + (num_cols_read % Wt),
                  num_cols_read % Wt,
                  num_cols_per_core});
             (in_g1 ? compute_desc_g1 : *compute_desc_g2)
                 .runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_cols_per_core});
-            writer_desc.emplace_runtime_args(core, {tensor_return_value.buffer(), num_cols_per_core, num_cols_read});
+            writer_desc.emplace_runtime_args(
+                core, {tensor_return_value.mesh_tensor(), num_cols_per_core, num_cols_read});
             num_cols_read += num_cols_per_core;
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -252,6 +252,9 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         });
     }
 
+    const auto& input = tensor_arg.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
+
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, operation_attributes.reduce_dim);
     reduce_defines["ENABLE_FP32_DEST_ACC"] = fp32_dest_acc_en ? "1" : "0";
@@ -271,7 +274,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         // mean/M2 state), so the reader must deliver tiles in strict column-major
         // order: all Ht tiles of column 0, then all Ht tiles of column 1, etc.
         std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, scaler_bits, /*use_welford=*/1};
-        TensorAccessorArgs(tensor_arg.mesh_tensor()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(input).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "reader_unary_transpose_wh_universal_input_cols_partitioned.cpp";
@@ -279,7 +282,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
     } else {
         // W-reduce: sequential reader reads tiles row by row.
         std::vector<uint32_t> reader_compile_time_args = {scaler_bits};
-        TensorAccessorArgs(tensor_arg.mesh_tensor()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(input).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "reader_unary_reduce_universal_start_id.cpp";
@@ -305,7 +308,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         // HW-reduce: custom writer that combines partial stats and constructs output tile.
         std::vector<uint32_t> writer_compile_time_args = {
             Wt, W, tile_width, H, static_cast<uint32_t>(operation_attributes.correction), reduce_batch_size};
-        TensorAccessorArgs(tensor_return_value.mesh_tensor()).append_to(writer_compile_time_args);
+        TensorAccessorArgs(output).append_to(writer_compile_time_args);
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "writer_welford_hw.cpp";
@@ -314,7 +317,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
     } else {
         // W-reduce and H-reduce: generic tile writer.
         std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
-        TensorAccessorArgs(tensor_return_value.mesh_tensor()).append_to(writer_compile_time_args);
+        TensorAccessorArgs(output).append_to(writer_compile_time_args);
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
         writer_desc.compile_time_args = writer_compile_time_args;
@@ -417,12 +420,10 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             }
             uint32_t num_input_tiles_per_core = num_work_units_per_core * Wt;
             uint32_t num_output_tiles_per_core = num_work_units_per_core;
-            reader_desc.emplace_runtime_args(
-                core, {tensor_arg.mesh_tensor(), num_input_tiles_per_core, input_tiles_offset});
+            reader_desc.emplace_runtime_args(core, {input, num_input_tiles_per_core, input_tiles_offset});
             (in_g1 ? compute_desc_g1 : *compute_desc_g2)
                 .runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_work_units_per_core});
-            writer_desc.emplace_runtime_args(
-                core, {tensor_return_value.mesh_tensor(), num_output_tiles_per_core, output_tiles_offset});
+            writer_desc.emplace_runtime_args(core, {output, num_output_tiles_per_core, output_tiles_offset});
             input_tiles_offset += num_input_tiles_per_core;
             output_tiles_offset += num_output_tiles_per_core;
         }
@@ -455,7 +456,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             uint32_t col_start_tile_id = nc_slice_offset * HtWt;
             reader_desc.emplace_runtime_args(
                 core,
-                {tensor_arg.mesh_tensor(),
+                {input,
                  col_start_tile_id,
                  /*curr_col_in_batch=*/0u,
                  num_cols});
@@ -465,8 +466,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             // Writer: runtime args are {dst_addr, NC_per_core, output_tile_start_id}.
             // NC_per_core is total NC slices; the writer uses reduce_batch_size
             // (compile-time) to determine how many to group per output.
-            writer_desc.emplace_runtime_args(
-                core, {tensor_return_value.mesh_tensor(), nc_slices_per_core, output_offset});
+            writer_desc.emplace_runtime_args(core, {output, nc_slices_per_core, output_offset});
             nc_slice_offset += nc_slices_per_core;
             output_offset += num_outputs_per_core;
         }
@@ -488,14 +488,10 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
             }
             reader_desc.emplace_runtime_args(
                 core,
-                {tensor_arg.mesh_tensor(),
-                 (num_cols_read / Wt * HtWt) + (num_cols_read % Wt),
-                 num_cols_read % Wt,
-                 num_cols_per_core});
+                {input, (num_cols_read / Wt * HtWt) + (num_cols_read % Wt), num_cols_read % Wt, num_cols_per_core});
             (in_g1 ? compute_desc_g1 : *compute_desc_g2)
                 .runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_cols_per_core});
-            writer_desc.emplace_runtime_args(
-                core, {tensor_return_value.mesh_tensor(), num_cols_per_core, num_cols_read});
+            writer_desc.emplace_runtime_args(core, {output, num_cols_per_core, num_cols_read});
             num_cols_read += num_cols_per_core;
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
@@ -120,8 +120,8 @@ tt::tt_metal::ProgramDescriptor ManualSeedSingleSeedSetCoresProgramFactory::crea
 
     // Tensor config info
     const auto& user_ids_tensor = tensor_args.user_ids.value();
-    auto* const user_ids_tensor_buffer = user_ids_tensor.buffer();
-    const auto number_of_ids = static_cast<uint32_t>(user_ids_tensor.logical_volume());
+    const auto& user_ids_mesh = user_ids_tensor.mesh_tensor();
+    const auto number_of_ids = static_cast<uint32_t>(user_ids_mesh.logical_volume());
 
     // Create circular buffer for user_ids
     constexpr uint32_t user_ids_cb_index = tt::CBIndex::c_0;
@@ -140,7 +140,7 @@ tt::tt_metal::ProgramDescriptor ManualSeedSingleSeedSetCoresProgramFactory::crea
 
     // Create reader kernel
     std::vector<uint32_t> reader_compile_time_args = {user_ids_cb_index, kernel_communication_cb_index, number_of_ids};
-    TensorAccessorArgs(*user_ids_tensor_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(user_ids_mesh).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = reader_kernel_path;
@@ -154,7 +154,7 @@ tt::tt_metal::ProgramDescriptor ManualSeedSingleSeedSetCoresProgramFactory::crea
         const auto& core = cores[core_id];
 
         // Set runtime args for reader kernel
-        reader_desc.emplace_runtime_args(core, {user_ids_tensor_buffer, core_id});
+        reader_desc.emplace_runtime_args(core, {user_ids_mesh, core_id});
     }
     desc.kernels.push_back(std::move(reader_desc));
 
@@ -190,11 +190,11 @@ tt::tt_metal::ProgramDescriptor ManualSeedSetSeedsSetCoresProgramFactory::create
 
     // Tensor config info
     const auto& user_ids_tensor = tensor_args.user_ids.value();
-    auto* const user_ids_tensor_buffer = user_ids_tensor.buffer();
-    const auto number_of_ids = static_cast<uint32_t>(user_ids_tensor.logical_volume());
+    const auto& user_ids_mesh = user_ids_tensor.mesh_tensor();
+    const auto number_of_ids = static_cast<uint32_t>(user_ids_mesh.logical_volume());
 
     const auto& seeds_tensor = tensor_args.seeds.value();
-    auto* const seeds_tensor_buffer = seeds_tensor.buffer();
+    const auto& seeds_mesh = seeds_tensor.mesh_tensor();
 
     // Create circular buffers
     constexpr uint32_t user_ids_cb_index = tt::CBIndex::c_0;
@@ -217,8 +217,8 @@ tt::tt_metal::ProgramDescriptor ManualSeedSetSeedsSetCoresProgramFactory::create
     // Create reader kernel
     std::vector<uint32_t> reader_compile_time_args = {
         user_ids_cb_index, seeds_cb_index, kernel_communication_cb_index, number_of_ids};
-    TensorAccessorArgs(*user_ids_tensor_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*seeds_tensor_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(user_ids_mesh).append_to(reader_compile_time_args);
+    TensorAccessorArgs(seeds_mesh).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = reader_kernel_path;
@@ -232,7 +232,7 @@ tt::tt_metal::ProgramDescriptor ManualSeedSetSeedsSetCoresProgramFactory::create
         const auto& core = cores[core_id];
 
         // Set runtime args for reader kernel
-        reader_desc.emplace_runtime_args(core, {user_ids_tensor_buffer, seeds_tensor_buffer, core_id});
+        reader_desc.emplace_runtime_args(core, {user_ids_mesh, seeds_mesh, core_id});
     }
     desc.kernels.push_back(std::move(reader_desc));
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -17,9 +17,9 @@ namespace ttnn::prim {
 
 tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
     const MoeParams& operation_attributes, const MoeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& expert_mask_tensor = tensor_args.expert_mask;
-    const auto& topk_mask_tensor = tensor_args.topk_mask;
+    const auto& input_tensor = tensor_args.input.mesh_tensor();
+    const auto& expert_mask_tensor = tensor_args.expert_mask.mesh_tensor();
+    const auto& topk_mask_tensor = tensor_args.topk_mask.mesh_tensor();
 
     const auto k = operation_attributes.k;
 
@@ -30,7 +30,8 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
     tt::DataFormat topk_mask_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(topk_mask_tensor.dtype());
     tt::DataFormat expert_mask_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(expert_mask_tensor.dtype());
-    tt::DataFormat out_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+    const auto& out_tensor = output_tensor.mesh_tensor();
+    tt::DataFormat out_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(out_tensor.dtype());
     tt::DataFormat scalar_df =
         (input_tensor.dtype() == DataType::FLOAT32) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
@@ -44,15 +45,10 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
     uint32_t index_tile_size = tile_size(index_cb_data_format);
     uint32_t value_tile_size = tile_size(value_cb_data_format);
 
-    auto* input_buffer = input_tensor.buffer();
-    auto* topk_mask_buffer = topk_mask_tensor.buffer();
-    auto* expert_mask_buffer = expert_mask_tensor.buffer();
-    auto* out_buffer = output_tensor.buffer();
-
     const uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();
     const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
     const uint32_t tile_hw = input_tensor.tensor_spec().tile().get_tile_hw();
-    uint32_t num_out_tiles = output_tensor.physical_volume() / tile_hw;
+    uint32_t num_out_tiles = out_tensor.physical_volume() / tile_hw;
     uint32_t scale_tiles = 1;
 
     auto input_shape = input_tensor.padded_shape();
@@ -216,9 +212,9 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
 
     std::vector<uint32_t> reader_compile_time_args = {
         input_cb_index, index_cb_index, topk_mask_cb_index, expert_mask_cb_index, Ht, Wt, k};
-    tt::tt_metal::TensorAccessorArgs(input_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(topk_mask_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(expert_mask_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(topk_mask_tensor).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(expert_mask_tensor).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -230,13 +226,13 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
     reader_desc.emplace_runtime_args(
         core.start_coord,
         {
-            input_buffer,
-            topk_mask_buffer,
-            expert_mask_buffer,
+            input_tensor,
+            topk_mask_tensor,
+            expert_mask_tensor,
         });
 
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index, Ht, k};
-    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
@@ -248,7 +244,7 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
     writer_desc.emplace_runtime_args(
         core.start_coord,
         {
-            out_buffer,
+            out_tensor,
         });
 
     std::vector<uint32_t> compute_args = {

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -20,6 +20,7 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
     const auto& input_tensor = tensor_args.input.mesh_tensor();
     const auto& expert_mask_tensor = tensor_args.expert_mask.mesh_tensor();
     const auto& topk_mask_tensor = tensor_args.topk_mask.mesh_tensor();
+    const auto& out_tensor = output_tensor.mesh_tensor();
 
     const auto k = operation_attributes.k;
 
@@ -30,7 +31,6 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
     tt::DataFormat topk_mask_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(topk_mask_tensor.dtype());
     tt::DataFormat expert_mask_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(expert_mask_tensor.dtype());
-    const auto& out_tensor = output_tensor.mesh_tensor();
     tt::DataFormat out_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(out_tensor.dtype());
     tt::DataFormat scalar_df =
         (input_tensor.dtype() == DataType::FLOAT32) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -13,8 +13,8 @@ using namespace tt::tt_metal;
 
 ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descriptor(
     const ProdAllParams& /*operation_attributes*/, const ProdAllInputs& tensor_args, Tensor& tensor_return_value) {
-    const auto& input = tensor_args.input;
-    auto& output = tensor_return_value;
+    const auto& input = tensor_args.input.mesh_tensor();
+    auto& output = tensor_return_value.mesh_tensor();
 
     ProgramDescriptor desc;
 
@@ -61,13 +61,10 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
         }}},
     });
 
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(input).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -105,8 +102,8 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
     };
 
     CoreCoord core_coord = {0, 0};
-    reader_desc.emplace_runtime_args(core_coord, {src_buffer, num_tiles, 0u});
-    writer_desc.emplace_runtime_args(core_coord, {dst_buffer, /*num_tiles=*/1u, 0u});
+    reader_desc.emplace_runtime_args(core_coord, {input, num_tiles, 0u});
+    writer_desc.emplace_runtime_args(core_coord, {output, /*num_tiles=*/1u, 0u});
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -14,7 +14,7 @@ using namespace tt::tt_metal;
 ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descriptor(
     const ProdAllParams& /*operation_attributes*/, const ProdAllInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input.mesh_tensor();
-    auto& output = tensor_return_value.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
 
     ProgramDescriptor desc;
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -129,11 +129,11 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
     ////////////////////////////////////////////////////////////////////////////
 
     std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(dim)};
-    tt::tt_metal::TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input.mesh_tensor()).append_to(reader_compile_time_args);
 
     constexpr uint32_t cb_id_out = tt::CBIndex::c_3;
     std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(cb_id_out)};
-    tt::tt_metal::TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output.mesh_tensor()).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp";
@@ -195,7 +195,7 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
 
         reader_desc.emplace_runtime_args(
             core,
-            {input.buffer(),
+            {input.mesh_tensor(),
              num_reduce_input_tile,
              num_tiles_per_core,
              input_tile_offset,
@@ -206,7 +206,7 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
 
         writer_desc.emplace_runtime_args(
             core,
-            {output.buffer(),
+            {output.mesh_tensor(),
              num_tiles_per_core,
              tile_offset,
              static_cast<uint32_t>(ttnn::operations::is_dram(output))});

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -19,7 +19,7 @@ using namespace tt::tt_metal;
 tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::create_descriptor(
     const ProdNcParams& operation_attributes, const ProdNcInputs& tensor_args, Tensor& /*tensor_return_value*/) {
     const auto& input = tensor_args.input;
-    const auto& output = tensor_args.output;
+    const MeshTensor& output = tensor_args.output.mesh_tensor();
     const int64_t dim = operation_attributes.dim;
 
     TT_FATAL(dim == 0 || dim == 1, "Dimension ({}) must be either 0 or 1", dim);
@@ -82,7 +82,7 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
          num_cols_per_core_group_1,
          num_cols_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid, num_output_tiles);
 
-    validate_reduce_op_program_grid("Prod_nc", all_cores, grid, nullptr, true, {{&output, "output"}});
+    validate_reduce_op_program_grid("Prod_nc", all_cores, grid, nullptr, true, {{&tensor_args.output, "output"}});
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
@@ -133,7 +133,7 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
 
     constexpr uint32_t cb_id_out = tt::CBIndex::c_3;
     std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(cb_id_out)};
-    tt::tt_metal::TensorAccessorArgs(output.mesh_tensor()).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp";
@@ -206,10 +206,10 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
 
         writer_desc.emplace_runtime_args(
             core,
-            {output.mesh_tensor(),
+            {output,
              num_tiles_per_core,
              tile_offset,
-             static_cast<uint32_t>(ttnn::operations::is_dram(output))});
+             static_cast<uint32_t>(ttnn::operations::is_dram(tensor_args.output))});
 
         if (core_group_1.contains(core)) {
             compute_desc_1.emplace_runtime_args(core, {num_reduce_input_tile, num_tiles_per_core});

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -19,7 +19,7 @@ using namespace tt::tt_metal;
 tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::create_descriptor(
     const ProdNcParams& operation_attributes, const ProdNcInputs& tensor_args, Tensor& /*tensor_return_value*/) {
     const auto& input = tensor_args.input;
-    const MeshTensor& output = tensor_args.output.mesh_tensor();
+    const auto& output = tensor_args.output.mesh_tensor();
     const int64_t dim = operation_attributes.dim;
 
     TT_FATAL(dim == 0 || dim == 1, "Dimension ({}) must be either 0 or 1", dim);

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -21,11 +21,11 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     const SamplingParams& operation_attributes, const SamplingInputs& tensor_args, Tensor& output_tensor) {
     using namespace tt::tt_metal;
 
-    const auto& input_values_tensor = tensor_args.input_values;
-    const auto& input_indices_tensor = tensor_args.input_indices;
-    const auto& k = tensor_args.k;
-    const auto& p = tensor_args.p;
-    const auto& temp = tensor_args.temp;
+    const auto& input_values_tensor = tensor_args.input_values.mesh_tensor();
+    const auto& input_indices_tensor = tensor_args.input_indices.mesh_tensor();
+    const auto& k = tensor_args.k.mesh_tensor();
+    const auto& p = tensor_args.p.mesh_tensor();
+    const auto& temp = tensor_args.temp.mesh_tensor();
 
     const auto& seed = operation_attributes.seed;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
@@ -44,14 +44,9 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     uint32_t input_values_tile_size = tile_size(input_values_cb_data_format);
     uint32_t index_tile_size = tile_size(index_cb_data_format);
 
-    auto* input_values_buffer = input_values_tensor.buffer();
-    auto* input_indices_buffer = input_indices_tensor.buffer();
-    auto* k_buffer = k.buffer();
-    auto* p_buffer = p.buffer();
-    auto* temp_buffer = temp.buffer();
-    auto* output_buffer = output_tensor.buffer();
+    const auto& output_mesh = output_tensor.mesh_tensor();
 
-    auto* device = input_values_tensor.device();
+    auto* device = &input_values_tensor.device_mut();
 
     auto input_shape = input_values_tensor.logical_shape();
     const uint32_t tile_height = input_values_tensor.tensor_spec().tile().get_height();
@@ -262,7 +257,7 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     });
 
     // Output sampling indices
-    uint32_t output_unit_size = output_tensor.element_size();
+    uint32_t output_unit_size = output_mesh.element_size();
     uint32_t aligned_out0_unit_size = Ht * tile_height * output_unit_size;
     uint32_t output_cb_index = tt::CBIndex::c_13;
     desc.cbs.push_back(CBDescriptor{
@@ -326,8 +321,8 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         Wt,
         aligned_final_indices_rm_unit_size,
         tile_height};
-    tt::tt_metal::TensorAccessorArgs(input_values_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(input_indices_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_values_tensor).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_indices_tensor).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -341,8 +336,8 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         reader_desc.emplace_runtime_args(
             core,
             {
-                input_values_buffer,
-                input_indices_buffer,
+                input_values_tensor,
+                input_indices_tensor,
             });
     }
     desc.kernels.push_back(std::move(reader_desc));
@@ -352,10 +347,10 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         CoreRangeSet single_core{CoreRange(core, core)};
 
         std::vector<uint32_t> writer_compile_time_args;
-        tt::tt_metal::TensorAccessorArgs(output_buffer).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(temp_buffer).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(k_buffer).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(p_buffer).append_to(writer_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(output_mesh).append_to(writer_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(temp).append_to(writer_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(k).append_to(writer_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(p).append_to(writer_compile_time_args);
         writer_compile_time_args.insert(
             writer_compile_time_args.end(),
             {
@@ -384,7 +379,7 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         writer_desc.core_ranges = single_core;
         writer_desc.compile_time_args = writer_compile_time_args;
         writer_desc.config = WriterConfigDescriptor{};
-        writer_desc.emplace_runtime_args(core, {output_buffer, temp_buffer, k_buffer, p_buffer});
+        writer_desc.emplace_runtime_args(core, {output_mesh, temp, k, p});
         desc.kernels.push_back(std::move(writer_desc));
 
         std::vector<uint32_t> compute_args = {

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -46,7 +46,7 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
 
     const auto& output_mesh = output_tensor.mesh_tensor();
 
-    auto* device = &input_values_tensor.device_mut();
+    auto* device = &input_values_tensor.mutable_device();
 
     auto input_shape = input_values_tensor.logical_shape();
     const uint32_t tile_height = input_values_tensor.tensor_spec().tile().get_height();

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -69,10 +69,10 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     const auto& args = operation_attributes;
     auto& output_tensors = tensor_return_value;
     // Tensor references
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_indices_tensor = tensor_args.indices;
-    const auto& value_tensor = std::get<0>(output_tensors);
-    const auto& index_tensor = std::get<1>(output_tensors);
+    const auto& input_tensor = tensor_args.input.mesh_tensor();
+    const auto& input_indices_tensor = as_optional_mesh_tensor(tensor_args.indices);
+    const auto& value_tensor = std::get<0>(output_tensors).mesh_tensor();
+    const auto& index_tensor = std::get<1>(output_tensors).mesh_tensor();
 
     ProgramDescriptor desc;
 
@@ -99,13 +99,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     const uint32_t index_tile_size = tile_size(index_cb_data_format);
     const uint32_t compute_tile_size = tile_size(compute_cb_data_format);
 
-    // DRAM buffer pointers for kernel runtime arguments
-    auto* const input_buffer = input_tensor.buffer();
-    auto* const values_buffer = value_tensor.buffer();
-    auto* const index_buffer = index_tensor.buffer();
-    auto* const input_indices_buffer = input_indices_tensor.has_value() ? input_indices_tensor->buffer() : nullptr;
-
-    const auto* device = input_tensor.device();
+    const auto* device = &input_tensor.device_mut();
 
     const auto input_shape = input_tensor.padded_shape();
     const uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();
@@ -347,8 +341,8 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         Wt_local,                      // Width tiles per local core
         input_shape[-1] / tile_width,  // Total width tiles (Wt)
     };
-    tt::tt_metal::TensorAccessorArgs(input_buffer).append_to(reader_local_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(input_indices_buffer).append_to(reader_local_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_local_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_indices_tensor).append_to(reader_local_compile_time_args);
     const std::map<std::string, std::string> reader_specialization_defines_map = {
         {"GENERATE_INDICES", tensor_args.indices.has_value() ? "0" : "1"},
     };
@@ -425,8 +419,8 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         Ht,                   // Height tiles to write
         Kt                    // TopK tiles per height row
     };
-    tt::tt_metal::TensorAccessorArgs(values_buffer).append_to(writer_final_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(index_buffer).append_to(writer_final_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(value_tensor).append_to(writer_final_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(index_tensor).append_to(writer_final_compile_time_args);
 
     KernelDescriptor writer_final_desc;
     writer_final_desc.kernel_source =
@@ -503,11 +497,11 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         reader_local_desc.emplace_runtime_args(
             core,
             {
-                input_buffer,                          // DRAM address of input values tensor
+                input_tensor,                          // DRAM address of input values tensor
                 0u,                                    // Height offset (no height parallelism currently)
                 core_id * Wt_local,                    // Width offset for this core's chunk
                 static_cast<uint32_t>(is32_bit_data),  // Flag indicating if data is 32-bit
-                input_indices_tensor.has_value() ? input_indices_buffer->address()
+                input_indices_tensor.has_value() ? static_cast<uint32_t>(input_indices_tensor->address())
                                                  : 0u,  // DRAM address of input indices tensor (if provided)
             });
 
@@ -533,8 +527,8 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     writer_final_desc.emplace_runtime_args(
         final_core,
         {
-            values_buffer,  // DRAM address for TopK values output tensor
-            index_buffer,   // DRAM address for TopK indices output tensor
+            value_tensor,  // DRAM address for TopK values output tensor
+            index_tensor,  // DRAM address for TopK indices output tensor
         });
 
     desc.kernels.push_back(std::move(reader_local_desc));

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -9,6 +9,7 @@
 #include "tt_stl/assert.hpp"
 #include "ttnn/operations/reduction/topk/device/topk_utils.hpp"
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 
 #include <cmath>
 #include <map>

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -99,7 +99,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     const uint32_t index_tile_size = tile_size(index_cb_data_format);
     const uint32_t compute_tile_size = tile_size(compute_cb_data_format);
 
-    const auto* device = &input_tensor.device_mut();
+    const auto* device = &input_tensor.mutable_device();
 
     const auto input_shape = input_tensor.padded_shape();
     const uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -22,9 +22,9 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
     const auto& args = operation_attributes;
     auto& output_tensors = tensor_return_value;
     // Tensor references
-    const auto& input_tensor = tensor_args.input;
-    const auto& value_tensor = std::get<0>(output_tensors);
-    const auto& index_tensor = std::get<1>(output_tensors);
+    const auto& input_tensor = tensor_args.input.mesh_tensor();
+    const auto& value_tensor = std::get<0>(output_tensors).mesh_tensor();
+    const auto& index_tensor = std::get<1>(output_tensors).mesh_tensor();
 
     // Determine index output format based on dimension size constraints
     const ttnn::Shape input_shape = input_tensor.padded_shape();
@@ -52,11 +52,6 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
     const uint32_t value_tile_size = tile_size(output_val_cb_data_format);
     const uint32_t index_tile_size = tile_size(output_ind_cb_data_format);
     const uint32_t compute_tile_size = tile_size(compute_cb_data_format);
-
-    // Device memory buffer pointers for kernel runtime arguments
-    auto* const input_buffer = input_tensor.buffer();
-    auto* const values_buffer = value_tensor.buffer();
-    auto* const index_buffer = index_tensor.buffer();
 
     // Tensor shape and dimension calculations
     const uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();
@@ -196,9 +191,9 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
         total_number_of_cores,                // Total number of cores
         static_cast<uint32_t>(uint16_output)  // Index format flag
     };
-    tt::tt_metal::TensorAccessorArgs(input_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
     if (tensor_args.indices.has_value()) {
-        tt::tt_metal::TensorAccessorArgs(tensor_args.indices->buffer()).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(tensor_args.indices->mesh_tensor()).append_to(reader_compile_time_args);
     }
     const std::map<std::string, std::string> reader_defines_map = {
         {"GENERATE_INDICES", "1"},  // tensor_args.indices.has_value() ? "0" : "1" - GH issue: #36329
@@ -221,8 +216,8 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
         Ktiles,                // K value in tiles
         total_number_of_cores  // Total number of cores
     };
-    tt::tt_metal::TensorAccessorArgs(values_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(index_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(value_tensor).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(index_tensor).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
@@ -264,17 +259,18 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
                 reader_desc.emplace_runtime_args(
                     core,
                     {
-                        input_buffer,
+                        input_tensor,
                         id,
                         work_per_core,
-                        tensor_args.indices.has_value() ? tensor_args.indices->buffer()->address()
-                                                        : 0u,  // Optional indices tensor
+                        tensor_args.indices.has_value()
+                            ? static_cast<uint32_t>(tensor_args.indices->mesh_tensor().address())
+                            : 0u,  // Optional indices tensor
                     });
                 writer_desc.emplace_runtime_args(
                     core,
                     {
-                        values_buffer,
-                        index_buffer,
+                        value_tensor,
+                        index_tensor,
                         id,
                         work_per_core,
                     });


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Migration

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes https://github.com/tenstorrent/tt-metal/issues/44653 .

This PR migrates the reduction op family to use the new MeshTensor construct.

**Mechanically ported in this PR (15 program factories, build green):**
- reduction/accumulation
- reduction/accumulation/ema
- reduction/argmax (×2: multi-core, single-core)
- reduction/generic (×4: multi-core-h, multi-core-w, single-core-hw, welford)
- reduction/manual_seed
- reduction/moe
- reduction/prod (×2: prod-all, prod-nc)
- reduction/sampling
- reduction/topk (×2: multi-core, single-core)

The main goal of the migration is to:
- Make sure `TensorAccessorArgs` and `RuntimeArgs` are passed in with a `MeshTensor` instead of a `Buffer`.
This is one of the preparation for metal 2.0.

The side goal of the migration includes:
-  Removing unnecessary usage of single device buffer, this allows metal to see the true usage surface of the `Buffer` class.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

#### Runtime Tensor overview

Runtime Tensor is a recently introduced core runtime data structure. It
is closely modelled on `ttnn::Tensor` — the two share very similar
semantics and are designed to be drop-in interchangeable where
appropriate.

The motivation for Runtime Tensor is that it lets the runtime capture
the shape and sharding information of the true storage data structure.
That information is plumbed through `TensorAccessorArgs` and is
critical for the upcoming Metal 2.0 refactoring: gen 2 hardware needs
to understand the shape and sharding of device memory directly.

Runtime Tensor is not meant to replace `ttnn::Tensor` outright. This
PR replaces `ttnn::Tensor` usage in program factories specifically,
where Runtime Tensor is the most appropriate abstraction level.
(`MeshTensor` — the type you will see in the diff — is the
device-side part of Runtime Tensor.)

#### This refactoring

- **Primary goal:** ensure ops leverage Runtime Tensor so we no longer
  lose shape and sharding information when passing `Buffer` into
  runtime / compile arguments (notably into `TensorAccessorArgs`).
- **Secondary goal:** complete the migration away from single-device
  data classes now that the rest of our infrastructure is
  multi-device-aware (`Buffer` → `MeshTensor`).

#### Risk

This migration should carry minimal regression risk: it is a
type-substitution refactor, not a behavioural change. No control flow
or computational logic is modified.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mt-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-reduction)
