### PR TITLE
[Feature] Tighten UnpackToDestMode legality checks in Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1101,29 +1101,11 @@ TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithUnpackToDestFp32ModeFails) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Kernel 'compute_kernel' unpack_to_dest_mode entry for non-FP32 DFB 'dfb_0' "
-                                 "specifies UnpackToDestFp32")));
+            ::testing::HasSubstr("specifies UnpackToDestFp32, but the DFB data format is not Float32")));
 }
 
-TEST_F(ProgramSpecTestQuasar, FP32DFBWithoutUnpackToDestModeEntryFails) {
-    // FP32 DFBs require an explicit unpack_to_dest_mode choice — no implicit default.
-    ProgramSpec spec = MakeMinimalValidProgramSpec();
-    for (auto& dfb : spec.dataflow_buffers) {
-        if (dfb.unique_id == "dfb_0") {
-            dfb.data_format_metadata = tt::DataFormat::Float32;
-        }
-    }
-    // Compute kernel intentionally has no unpack_to_dest_mode entry.
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
-            "Kernel 'compute_kernel' binds FP32 DFB 'dfb_0' but has no unpack_to_dest_mode entry for it")));
-}
-
-TEST_F(ProgramSpecTestQuasar, FP32DFBWithDefaultUnpackToDestModeSucceeds) {
-    // For an FP32 DFB the user must choose; Default is one valid choice (precision loss
-    // accepted in exchange for SRCA/B compatibility).
+TEST_F(ProgramSpecTestQuasar, FP32ConsumerWithFp32DestAccEnAndNoEntryFails) {
+    // The narrow case where a choice is required: CONSUMER + FP32 + fp32_dest_acc_en=true.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     for (auto& dfb : spec.dataflow_buffers) {
         if (dfb.unique_id == "dfb_0") {
@@ -1133,6 +1115,141 @@ TEST_F(ProgramSpecTestQuasar, FP32DFBWithDefaultUnpackToDestModeSucceeds) {
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            config.fp32_dest_acc_en = true;
+        }
+    }
+    // Compute kernel intentionally has no unpack_to_dest_mode entry.
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+            "Kernel 'compute_kernel' consumes FP32 DFB 'dfb_0' with fp32_dest_acc_en=true, but has no "
+            "unpack_to_dest_mode entry for it")));
+}
+
+TEST_F(ProgramSpecTestQuasar, FP32ConsumerWithoutFp32DestAccEnDoesNotRequireEntry) {
+    // Without fp32_dest_acc_en, UnpackToDestFp32 is incoherent (Dest is 16-bit), so there's
+    // no real choice — Default is the only valid value. No explicit entry required.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    for (auto& dfb : spec.dataflow_buffers) {
+        if (dfb.unique_id == "dfb_0") {
+            dfb.data_format_metadata = tt::DataFormat::Float32;
+        }
+    }
+    // fp32_dest_acc_en stays at its default (false). No unpack_to_dest_mode entry.
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, FP32ProducerOnlyBindingDoesNotRequireEntry) {
+    // A compute kernel that only PRODUCES an FP32 DFB never unpacks it, so the unpack mode
+    // is dead config — no explicit entry required regardless of fp32_dest_acc_en.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer_compute = MakeMinimalComputeKernel("producer_compute");
+    auto& producer_config = std::get<ComputeConfiguration>(producer_compute.config_spec);
+    producer_config.fp32_dest_acc_en = true;
+
+    auto consumer_dm = MakeMinimalDMKernel("consumer_dm");
+
+    auto dfb = MakeMinimalDFB("dfb_0");
+    dfb.data_format_metadata = tt::DataFormat::Float32;
+
+    BindDFBToKernel(producer_compute, "dfb_0", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer_dm, "dfb_0", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer_compute, consumer_dm};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer_compute", "consumer_dm"})};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32OnProducerBindingFails) {
+    // UnpackToDestFp32 on a producer-only binding is meaningless (producers don't unpack).
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer_compute = MakeMinimalComputeKernel("producer_compute");
+    auto& producer_config = std::get<ComputeConfiguration>(producer_compute.config_spec);
+    producer_config.fp32_dest_acc_en = true;
+    producer_config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::UnpackToDestFp32}};
+
+    auto consumer_dm = MakeMinimalDMKernel("consumer_dm");
+
+    auto dfb = MakeMinimalDFB("dfb_0");
+    dfb.data_format_metadata = tt::DataFormat::Float32;
+
+    BindDFBToKernel(producer_compute, "dfb_0", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer_dm, "dfb_0", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer_compute, consumer_dm};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer_compute", "consumer_dm"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("does not have a CONSUMER endpoint on this DFB")));
+}
+
+TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32WithoutFp32DestAccEnFails) {
+    // UnpackToDestFp32 requires fp32_dest_acc_en=true (Dest must be 32-bit-wide to hold FP32).
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    for (auto& dfb : spec.dataflow_buffers) {
+        if (dfb.unique_id == "dfb_0") {
+            dfb.data_format_metadata = tt::DataFormat::Float32;
+        }
+    }
+    for (auto& kernel : spec.kernels) {
+        if (kernel.is_compute_kernel()) {
+            auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            // fp32_dest_acc_en stays at its default (false).
+            config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::UnpackToDestFp32}};
+        }
+    }
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("specifies UnpackToDestFp32, but fp32_dest_acc_en is false")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DuplicateUnpackToDestModeEntriesFail) {
+    // Two entries for the same DFB is a user error; we reject rather than silently picking one.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    for (auto& kernel : spec.kernels) {
+        if (kernel.is_compute_kernel()) {
+            auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            config.unpack_to_dest_mode = {
+                {"dfb_0", UnpackToDestMode::Default},
+                {"dfb_0", UnpackToDestMode::Default},
+            };
+        }
+    }
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("has duplicate unpack_to_dest_mode entries for DFB 'dfb_0'")));
+}
+
+TEST_F(ProgramSpecTestQuasar, FP32DFBWithDefaultUnpackToDestModeSucceeds) {
+    // Default is always a valid value, even outside the (CONSUMER + FP32 + fp32_dest_acc_en) triple.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    for (auto& dfb : spec.dataflow_buffers) {
+        if (dfb.unique_id == "dfb_0") {
+            dfb.data_format_metadata = tt::DataFormat::Float32;
+        }
+    }
+    for (auto& kernel : spec.kernels) {
+        if (kernel.is_compute_kernel()) {
+            auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            config.fp32_dest_acc_en = true;
             config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::Default}};
         }
     }
@@ -1827,7 +1944,8 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigMathFidelitySucceeds) {
 TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
-    // Switch dfb_0 to FP32 so UnpackToDestFp32 is meaningful (it's the FP32-only mode).
+    // The full meaningfulness triple: FP32 DFB, consumed by a compute kernel with
+    // fp32_dest_acc_en=true. UnpackToDestFp32 is meaningful here.
     for (auto& dfb : spec.dataflow_buffers) {
         if (dfb.unique_id == "dfb_0") {
             dfb.data_format_metadata = tt::DataFormat::Float32;
@@ -1836,6 +1954,7 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeConfiguration>(kernel.config_spec);
+            config.fp32_dest_acc_en = true;
             config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::UnpackToDestFp32}};
         }
     }
@@ -1869,6 +1988,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
     BindDFBToKernel(consumer, "dfb_1", "in1", KernelSpec::DFBEndpointType::CONSUMER);
 
     auto& compute_config = std::get<ComputeConfiguration>(consumer.config_spec);
+    compute_config.fp32_dest_acc_en = true;
     compute_config.unpack_to_dest_mode = {{"dfb_1", UnpackToDestMode::UnpackToDestFp32}};
 
     spec.kernels = {producer, consumer};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -22,17 +22,54 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 struct ComputeConfiguration {
-    // Tensix hardware resource configuration (configured by compute kernels)
+    // Tensix hardware resource configuration for compute kernels.
     // Gen1 and Gen2 configurations are currently identical.
+    //
+    // Background: the Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack)
+    // driven by three concurrent TRISC threads. The FPU reads operands from the
+    // SrcA / SrcB register files (~19-bit elements) and writes to the Dest
+    // register file (16- or 32-bit elements, configurable). The SFPU runs SIMD
+    // transcendentals (exp, gelu, etc.) and can only see Dest. The fields below
+    // tune that pipeline.
 
+    // Number of multiply passes the FPU runs to use more mantissa bits.
+    // The FPU multipliers are 5b × 7b; full-precision multiply requires multiple
+    // passes accumulating different mantissa slices. Higher fidelity → lower throughput.
+    //   LoFi (1 pass) ... HiFi4 (4 passes).
     MathFidelity math_fidelity = MathFidelity::HiFi4;
+
+    // Configure the Dest register to hold 32-bit elements (and the FPU to accumulate
+    // in FP32) instead of the default 16-bit. Trade-off: half as many tiles fit in Dest.
+    // Prerequisite for using UnpackToDestMode::UnpackToDestFp32 below.
     bool fp32_dest_acc_en = false;
+
+    // Dest register sync mode.
+    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered).
+    //   true  (Full) — Dest is one buffer; twice the tile capacity, no math/pack overlap.
     bool dst_full_sync_en = false;
+
+    // Pack-side precision tweak for the Bfp8 block-float format.
+    // Affects how exponents are reconciled when converting Dest contents → Bfp8 in L1.
     bool bfp8_pack_precise = false;
+
+    // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
+    // (exp, gelu, sqrt, etc.). Only some SFPU ops respect this flag; the rest ignore it.
     bool math_approx_mode = false;
 
-    // "Unpack to dest" mode must be specified on a per-DFB basis
-    // unpack_to_dest_mode maps DFB identifier to UnpackToDestMode
+    // Per-DFB choice of how the unpacker delivers data into the math stage:
+    //   Default          — unpack via SrcA/B (limited to ~19-bit elements; full FPU access,
+    //                      including binary ops).
+    //   UnpackToDestFp32 — direct Unpacker0 → Dest path (full FP32 in Dest; SrcA/B-path ops
+    //                      on this DFB are disabled, so binary FPU ops cannot use it).
+    //
+    // The choice has a meaningful effect only when ALL of the following hold for the binding:
+    //   1. The kernel has a CONSUMER endpoint on the DFB (only consumers unpack).
+    //   2. The DFB's data format is Float32.
+    //   3. fp32_dest_acc_en is true (Dest must be 32-bit-wide to hold FP32).
+    // In that case, an explicit entry is REQUIRED — the two values have very different
+    // runtime semantics, and we want the choice surfaced in source. Outside that case,
+    // Default is silently assumed; supplying UnpackToDestFp32 is rejected as meaningless
+    // (non-consumer / non-FP32) or incoherent (fp32_dest_acc_en=false → Dest is 16-bit).
     using UnpackToDestModeEntry = std::pair<DFBSpecName, tt::tt_metal::UnpackToDestMode>;
     std::vector<UnpackToDestModeEntry> unpack_to_dest_mode;
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -27,7 +27,7 @@ struct ComputeConfiguration {
     //
     // The Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack).
     // There are two math engines:
-    //  - FPU reads operands from the SrcA / SrcB register files (~19 bit),
+    //  - FPU reads operands from the SrcA / SrcB register files (~19-bit),
     //    writes to the Dest register file (16- or 32-bit, configurable).
     //  - SFPU runs SIMD transcendentals. It can only access Dest.
     // The fields below configure this pipeline.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -23,53 +23,45 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 
 struct ComputeConfiguration {
     // Tensix hardware resource configuration for compute kernels.
-    // Gen1 and Gen2 configurations are currently identical.
+    // Gen1 and Gen2 configurations are identical.
     //
-    // Background: the Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack)
-    // driven by three concurrent TRISC threads. The FPU reads operands from the
-    // SrcA / SrcB register files (~19-bit elements) and writes to the Dest
-    // register file (16- or 32-bit elements, configurable). The SFPU runs SIMD
-    // transcendentals (exp, gelu, etc.) and can only see Dest. The fields below
-    // tune that pipeline.
+    // The Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack).
+    // There are two math engines:
+    //  - FPU reads operands from the SrcA / SrcB register files (~19 bit),
+    //    writes to the Dest register file (16- or 32-bit, configurable).
+    //  - SFPU runs SIMD transcendentals. It can only access Dest.
+    // The fields below configure this pipeline.
 
-    // Number of multiply passes the FPU runs to use more mantissa bits.
-    // The FPU multipliers are 5b × 7b; full-precision multiply requires multiple
-    // passes accumulating different mantissa slices. Higher fidelity → lower throughput.
-    //   LoFi (1 pass) ... HiFi4 (4 passes).
+    // Number of multiply passes the FPU runs to use more mantissa bits
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 
-    // Configure the Dest register to hold 32-bit elements (and the FPU to accumulate
-    // in FP32) instead of the default 16-bit. Trade-off: half as many tiles fit in Dest.
-    // Prerequisite for using UnpackToDestMode::UnpackToDestFp32 below.
+    // Configure Dest register to hold 32-bit elements (instead of the default 16-bit)
     bool fp32_dest_acc_en = false;
 
-    // Dest register sync mode.
-    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered).
-    //   true  (Full) — Dest is one buffer; twice the tile capacity, no math/pack overlap.
+    // Dest register sync mode:
+    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered)
+    //   true  (Full) — Dest is one buffer; twice the capacity, no math/pack overlap
     bool dst_full_sync_en = false;
 
     // Pack-side precision tweak for the Bfp8 block-float format.
-    // Affects how exponents are reconciled when converting Dest contents → Bfp8 in L1.
+    // (Affects how exponents are reconciled when converting Dest contents to Bfp8)
     bool bfp8_pack_precise = false;
 
     // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
-    // (exp, gelu, sqrt, etc.). Only some SFPU ops respect this flag; the rest ignore it.
     bool math_approx_mode = false;
 
     // Per-DFB choice of how the unpacker delivers data into the math stage:
-    //   Default          — unpack via SrcA/B (limited to ~19-bit elements; full FPU access,
-    //                      including binary ops).
-    //   UnpackToDestFp32 — direct Unpacker0 → Dest path (full FP32 in Dest; SrcA/B-path ops
-    //                      on this DFB are disabled, so binary FPU ops cannot use it).
+    //   Default          — unpack via SrcA/B regs (~19-bit elements; full FPU access)
+    //   UnpackToDestFp32 — unpack via Dest regs with full FP32 precision (SFPU only)
     //
-    // The choice has a meaningful effect only when ALL of the following hold for the binding:
-    //   1. The kernel has a CONSUMER endpoint on the DFB (only consumers unpack).
+    // This choice matters only when ALL of the following hold for the DFB binding:
+    //   1. The kernel is the consumer endpoint (unpacking data into the kernel)
     //   2. The DFB's data format is Float32.
     //   3. fp32_dest_acc_en is true (Dest must be 32-bit-wide to hold FP32).
-    // In that case, an explicit entry is REQUIRED — the two values have very different
-    // runtime semantics, and we want the choice surfaced in source. Outside that case,
-    // Default is silently assumed; supplying UnpackToDestFp32 is rejected as meaningless
-    // (non-consumer / non-FP32) or incoherent (fp32_dest_acc_en=false → Dest is 16-bit).
+    //
+    // You MUST provide an unpack_to_dest_mode entry for the DFB if these conditions hold;
+    // failing to do so will trigger an error. Otherwise, supplying an entry is optional
+    // and only Default is accepted.
     using UnpackToDestModeEntry = std::pair<DFBSpecName, tt::tt_metal::UnpackToDestMode>;
     std::vector<UnpackToDestModeEntry> unpack_to_dest_mode;
 };

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -722,29 +722,40 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     // Validate compute kernel unpack_to_dest_mode entries.
-    // Policy:
-    //   - Each entry must reference a DFB the kernel actually binds.
-    //   - For non-FP32 DFBs, the only meaningful mode is Default — UnpackToDestFp32
-    //     is specifically for unpacking Float32 data with full precision, and makes
-    //     no sense for other formats. We allow entries for non-FP32 DFBs only if
-    //     the value is Default (so existing code that spells it out keeps working;
-    //     pure-busywork specifications get flagged if they specify the wrong value).
-    //   - For FP32 DFBs, an entry is REQUIRED. The choice between Default and
-    //     UnpackToDestFp32 matters for FP32 data (precision vs SRCA/B compatibility),
-    //     so the user must make it explicitly.
+    //
+    // UnpackToDestMode only has a meaningful effect when the kernel CONSUMES the
+    // DFB (endpoint_type == CONSUMER), the DFB data format is Float32, and
+    // fp32_dest_acc_en is true. Only in that configuration is there a real choice:
+    //   - Default          → unpack via SrcA/B (~19-bit, full FPU access)
+    //   - UnpackToDestFp32 → direct Unpacker0 → Dest (full FP32, no SrcA/B for this DFB)
+    // Anywhere else, the value is dead config (non-consumer / non-FP32) or
+    // incoherent (UnpackToDestFp32 with fp32_dest_acc_en=false — Dest is 16-bit).
+    //
+    // Rules enforced:
+    //   - Every entry references a DFB the kernel binds.
+    //   - No duplicate entries for the same DFB.
+    //   - UnpackToDestFp32 is allowed only when the (CONSUMER + FP32 + fp32_dest_acc_en)
+    //     triple holds for that DFB binding.
+    //   - When the triple holds for a DFB, an explicit entry is REQUIRED — the two
+    //     values have very different runtime semantics, so we surface the choice in source.
+    //   - Default is silently assumed everywhere else (no entry required, no busywork).
     for (const auto& kernel : spec.kernels) {
         if (!kernel.is_compute_kernel()) {
             continue;
         }
         const auto& compute_config = std::get<ComputeConfiguration>(kernel.config_spec);
 
-        // Quick lookup of DFBs this kernel binds.
+        // Index the kernel's DFB bindings: which are bound, which are consumed.
         std::unordered_set<DFBSpecName> bound_dfbs;
+        std::unordered_set<DFBSpecName> consumed_dfbs;
         for (const auto& binding : kernel.dfb_bindings) {
             bound_dfbs.insert(binding.dfb_spec_name);
+            if (binding.endpoint_type == KernelSpec::DFBEndpointType::CONSUMER) {
+                consumed_dfbs.insert(binding.dfb_spec_name);
+            }
         }
 
-        // Check each user-supplied entry against the policy.
+        // Validate each user-supplied entry.
         std::unordered_set<DFBSpecName> entries_seen;
         for (const auto& [dfb_name, mode] : compute_config.unpack_to_dest_mode) {
             TT_FATAL(
@@ -752,38 +763,69 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 "Kernel '{}' unpack_to_dest_mode entry references DFB '{}', which the kernel does not bind",
                 kernel.unique_id,
                 dfb_name);
-            entries_seen.insert(dfb_name);
+            TT_FATAL(
+                entries_seen.insert(dfb_name).second,
+                "Kernel '{}' has duplicate unpack_to_dest_mode entries for DFB '{}'",
+                kernel.unique_id,
+                dfb_name);
 
-            const DataflowBufferSpec* dfb_spec = collected.dfb_by_name.at(dfb_name);
+            if (mode == UnpackToDestMode::Default) {
+                continue;  // Default is always allowed.
+            }
+            // mode == UnpackToDestFp32 — require the meaningfulness triple.
+            TT_FATAL(
+                consumed_dfbs.contains(dfb_name),
+                "Kernel '{}' unpack_to_dest_mode entry for DFB '{}' specifies UnpackToDestFp32, "
+                "but the kernel does not have a CONSUMER endpoint on this DFB. UnpackToDestFp32 "
+                "configures the unpack path, which is only exercised by consumer bindings. "
+                "Use Default or omit the entry.",
+                kernel.unique_id,
+                dfb_name);
             // If data_format_metadata isn't set, the separate "compute endpoint requires
             // data_format_metadata" check (below) will fail. Defer to that check.
+            const DataflowBufferSpec* dfb_spec = collected.dfb_by_name.at(dfb_name);
             if (!dfb_spec->data_format_metadata.has_value()) {
                 continue;
             }
-            const bool is_fp32 = (dfb_spec->data_format_metadata.value() == tt::DataFormat::Float32);
             TT_FATAL(
-                is_fp32 || mode == UnpackToDestMode::Default,
-                "Kernel '{}' unpack_to_dest_mode entry for non-FP32 DFB '{}' specifies UnpackToDestFp32. "
-                "UnpackToDestFp32 is only meaningful for FP32 data; non-FP32 DFBs must use Default "
-                "(or omit the entry — Default is the implicit value).",
+                dfb_spec->data_format_metadata.value() == tt::DataFormat::Float32,
+                "Kernel '{}' unpack_to_dest_mode entry for DFB '{}' specifies UnpackToDestFp32, "
+                "but the DFB data format is not Float32. UnpackToDestFp32 is only meaningful for "
+                "FP32 data. Use Default or omit the entry.",
+                kernel.unique_id,
+                dfb_name);
+            TT_FATAL(
+                compute_config.fp32_dest_acc_en,
+                "Kernel '{}' unpack_to_dest_mode entry for DFB '{}' specifies UnpackToDestFp32, "
+                "but fp32_dest_acc_en is false. Full-precision FP32 in the Dest register requires "
+                "fp32_dest_acc_en=true (otherwise Dest is 16-bit and the mode is incoherent).",
                 kernel.unique_id,
                 dfb_name);
         }
 
-        // Every FP32 DFB the kernel binds must have an explicit entry.
+        // Require an explicit entry where the choice is real:
+        // CONSUMER binding + FP32 data format + fp32_dest_acc_en=true.
+        if (!compute_config.fp32_dest_acc_en) {
+            continue;
+        }
         for (const auto& binding : kernel.dfb_bindings) {
+            if (binding.endpoint_type != KernelSpec::DFBEndpointType::CONSUMER) {
+                continue;
+            }
             const DataflowBufferSpec* dfb_spec = collected.dfb_by_name.at(binding.dfb_spec_name);
             if (!dfb_spec->data_format_metadata.has_value()) {
-                continue;  // Will be caught by the data_format-required check.
+                continue;  // Deferred to the data_format-required check.
             }
             if (dfb_spec->data_format_metadata.value() != tt::DataFormat::Float32) {
                 continue;
             }
             TT_FATAL(
                 entries_seen.contains(binding.dfb_spec_name),
-                "Kernel '{}' binds FP32 DFB '{}' but has no unpack_to_dest_mode entry for it. "
-                "FP32 DFBs require an explicit choice between UnpackToDestMode::Default and "
-                "UnpackToDestMode::UnpackToDestFp32.",
+                "Kernel '{}' consumes FP32 DFB '{}' with fp32_dest_acc_en=true, but has no "
+                "unpack_to_dest_mode entry for it. This configuration requires an explicit choice "
+                "between UnpackToDestMode::Default (unpack via SrcA/B — enables binary FPU ops, "
+                "precision reduced to ~19 bits) and UnpackToDestMode::UnpackToDestFp32 (unpack "
+                "direct to Dest — full FP32 precision, SrcA/B access disabled for this DFB).",
                 kernel.unique_id,
                 binding.dfb_spec_name);
         }


### PR DESCRIPTION
## PR Category
Feature(ish)

## Summary
The `unpack_to_dest_mode` might be the most confusing bit of configuration we expose. It's a frequent source of kernel bugs.

It would be nice if the runtime could auto-infer this setting for users. However, this currently isn't possible without kernel code introspection capabilities. However, we can do something _almost_ as good:
 - Only consider the value of `unpack_to_dest_mode` in the specific situation that requires it:
     1. endpoint_type == CONSUMER (only consumers unpack)
     2. DFB data format == Float32
     3. fp32_dest_acc_en == true (Dest must be 32-bit-wide to hold FP32)
 - Require an explicit `unpack_to_dest_mode` setting for _this specific situation_.

The idea: a kernel author (AI or human) who forgets to configure this will be notified by a noisy validation error, which will prompt him to read the comments in either `kernel_spec.hpp` or `base_types.hpp` and get the right compute config.
If the (i,ii,iii) above doesn't hold, the `unpack_to_dest_mode` value is dead config. If you set one of these to `DEFAULT`, Metal 2.0 ignores it, if you try to set it to a non-default, you get an informative error.

I also augmented the Metal 2.0 tensix engine config with some comments explaining the mystery knobs.

### Notes for reviewers
Legality check only change. API changes are comments-only.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/tighten-unpack-to-dest-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/tighten-unpack-to-dest-mode)