### PR TITLE
Adding Env Var to Disable Real Time Profiler

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -109,6 +109,9 @@ void enqueue_sanity_program(
 }
 
 TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
+    // Skipped due to issue #44657: real-time profiler is disabled by default
+    // (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
+    GTEST_SKIP() << "Real-time profiler disabled by default — see issue #44657";
     constexpr int kDeviceId = 0;
 
     auto mesh_device = distributed::MeshDevice::create_unit_mesh(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -147,6 +147,9 @@ distributed::MeshWorkload build_blank_kernel_workload(const std::shared_ptr<dist
 }
 
 TEST(RealtimeProfilerStress, RingBufferOverflowFromTrace) {
+    // Skipped due to issue #44657: real-time profiler is disabled by default
+    // (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
+    GTEST_SKIP() << "Real-time profiler disabled by default — see issue #44657";
     constexpr int kDeviceId = 0;
 
     auto mesh_device = distributed::MeshDevice::create_unit_mesh(

--- a/tests/ttnn/tracy/test_realtime_profiler.py
+++ b/tests/ttnn/tracy/test_realtime_profiler.py
@@ -49,6 +49,11 @@ from pathlib import Path
 import pytest
 
 
+# Skipped due to issue #44657: real-time profiler is disabled by default
+# (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
+pytestmark = pytest.mark.skip(reason="Real-time profiler disabled by default — see issue #44657")
+
+
 # ---------------------------------------------------------------------------
 # Common paths / constants
 # ---------------------------------------------------------------------------

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1381,8 +1381,8 @@ bool MeshDeviceImpl::initialize_impl(
 }
 
 void MeshDeviceImpl::init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device) {
-    static const bool disable_rt_profiler = tt::parse_env<bool>("DISABLE_REALTIME_PROFILER", false);
-    if (disable_rt_profiler || realtime_profiler_) {
+    static const bool enable_rt_profiler = tt::parse_env<bool>("ENABLE_REALTIME_PROFILER", false);
+    if (!enable_rt_profiler || realtime_profiler_) {
         return;
     }
     realtime_profiler_ = std::make_unique<RealtimeProfilerManager>(mesh_device);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1381,7 +1381,7 @@ bool MeshDeviceImpl::initialize_impl(
 }
 
 void MeshDeviceImpl::init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device) {
-    static const bool enable_rt_profiler = tt::parse_env<bool>("ENABLE_REALTIME_PROFILER", false);
+    static const bool enable_rt_profiler = tt::parse_env<bool>("TT_METAL_ENABLE_REALTIME_PROFILER", false);
     if (!enable_rt_profiler || realtime_profiler_) {
         return;
     }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1381,7 +1381,8 @@ bool MeshDeviceImpl::initialize_impl(
 }
 
 void MeshDeviceImpl::init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device) {
-    if (realtime_profiler_) {
+    static const bool disable_rt_profiler = tt::parse_env<bool>("DISABLE_REALTIME_PROFILER", false);
+    if (disable_rt_profiler || realtime_profiler_) {
         return;
     }
     realtime_profiler_ = std::make_unique<RealtimeProfilerManager>(mesh_device);


### PR DESCRIPTION
### PR Category
Bug Fix
### Summary
As per https://github.com/tenstorrent/tt-metal/issues/44657, the real time profiler is adding op profiling data to a host-side buffer without limit, causing programs to crash due to OOM. There is no way to disable it. This PR adds an env var to disable the real time profiler by default.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
- [x] [Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/runs/26072029906)
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/realtime_profiler_kill_switch_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/realtime_profiler_kill_switch_patch)