### PR TITLE
[Feature] Add resolve_id() to DFBAccessor for Quasar LLK APIs

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
@@ -7,11 +7,11 @@
 #include "api/debug/dprint.h"
 #include "experimental/kernel_args.h"
 
-// Quick check that DFBAccessor implicitly converts to uint32_t.
+// Quick check that DFBAccessor implicitly converts to uint32_t at compile time.
 // This is a shim to enable DFB to work with WH/BH LLK compute APIs that expect raw CB ids.
+// If implicit conversion (or its constexpr-ness) regressed, this line would fail to compile.
 // NOTE: This check is piggybacking along on an unrelated test kernel.
-constexpr uint32_t implicit_id = dfb::in;  // copy-init invokes the conversion
-static_assert(implicit_id == dfb::in.id, "DFBAccessor must implicitly convert to its underlying uint32_t id");
+[[maybe_unused]] constexpr uint32_t implicit_id = dfb::in;
 
 void kernel_main() {
     constexpr uint32_t num_entries = get_arg(args::num_entries);

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -38,46 +38,29 @@
 //
 // Here my_dfb_name is a constexpr DFBAccessor, auto-included in kernel_bindings_generated.h.
 //
-// Currently, DFBAccessor is backed by a compile-time ID, baked into the kernel binary.
-// On Gen2 (Quasar) we reserve the right to switch to a runtime-backed ID
-// (e.g., dispatch-populated slot) without changing kernel-side syntax. The two
-// extraction paths below have intentionally different futureproofing contracts —
-// see their per-member comments.
 struct DFBAccessor {
     explicit constexpr DFBAccessor(uint16_t id) noexcept : id_(id) {}
 
-    // Implicit conversion to uint32_t — lets a Metal 2.0 kernel pass a
-    // DFBAccessor directly to Gen1 (WH/BH) LLK compute APIs that expect a raw CB id.
-    //
-    // This conversion is constexpr, which means callers may use it in constexpr
-    // contexts (template parameters, static_asserts, address computations). That
-    // permanently commits Gen1 to CTA-based DFB ids, and we have accepted that
-    // commitment: a survey of the TTNN kernel library found that every CB id
-    // already reaches the kernel via a compile-time path (CTA or hardcoded
-    // CBIndex enum), with zero RTA-backed cases. The Gen1 LLK macro architecture
-    // depends on constexpr CB ids and is not going to change.
+    // Constexpr behavior for ID extraction:
+    //  - On WH/BH, DFBAccessor is always constexpr. It's backed by a compile-time ID.
+    //  - On Quasar, we reserve the right to switch to a runtime-backed ID.
+    //    (Future-proofing workaround to a future problem with DM assignments.)
+
+    // Implicit conversion to uint32_t:
+    // This lets a Metal 2.0 kernel pass a DFBAccessor directly to Gen1 (WH/BH) LLK
+    // compute APIs that expect a raw CB id.
+    // This conversion is constexpr; it's intended for Gen1 use only.
     constexpr operator uint32_t() const noexcept { return id_; }
 
-    // Non-constexpr accessor — the blessed extraction path for Gen2 (Quasar) LLK
-    // APIs that accept DFBAccessor directly.
-    //
-    // Intentionally NOT constexpr. If we ever switch Gen2 DFB ids from implicit
-    // CTA to a runtime mechanism (RTA/CRTA), this method's body flips to a
-    // runtime load; marking it constexpr today would lock in a promise we'd
-    // later have to break. Keeping it non-constexpr preserves the seam.
-    //
-    // Gen2 LLK contract — OPEN QUESTION for the LLK team:
-    // Can we get away with this being non-constexpr, or does that break LLK
-    // APIs? If we want to leave open the possibility of future RTA-ification,
-    // the rule is: don't use the extracted value in any context that requires
-    // it to be a compile-time constant — no template non-type parameters, no
-    // constexpr variables, no array sizes, no static_asserts.
-    // If that constraint doesn't work for LLK, we can discard the futureproof
-    // attempt.
+    // Explicit ID accessor:
+    // This meant only for Quasar LLK APIs, which accept DFBAccessor directly.
+    // Intentionally NOT constexpr; since body could become an RTA retrieval.
+    // (If constexpr is needed by LLK, we could fix that for compute kernels.)
     uint16_t resolve_id() const noexcept { return id_; }
 
 private:
     uint16_t id_;
+    // uint32_t rta_idx; // future-proofing option
 };
 
 class DataflowBuffer {

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -39,20 +39,45 @@
 // Here my_dfb_name is a constexpr DFBAccessor, auto-included in kernel_bindings_generated.h.
 //
 // Currently, DFBAccessor is backed by a compile-time ID, baked into the kernel binary.
-// If we want to switch to using an implicit CRTA mechanism, the implementation of
-// DFBAccessor can be transparently modified (kernel-side syntax stays unchanged).
+// On Gen2 (Quasar) we reserve the right to switch to a runtime-backed ID
+// (e.g., dispatch-populated slot) without changing kernel-side syntax. The two
+// extraction paths below have intentionally different futureproofing contracts —
+// see their per-member comments.
 struct DFBAccessor {
-    explicit constexpr DFBAccessor(uint16_t id) noexcept : id(id) {}
+    explicit constexpr DFBAccessor(uint16_t id) noexcept : id_(id) {}
 
-    // DFBAccessor is implicitly convertible to uint32_t.
-    // On WH/BH, this allows a Metal 2.0 user to pass a DFBAccessor directly to
-    // LLK compute APIs that expect a raw CB id.
+    // Implicit conversion to uint32_t — lets a Metal 2.0 kernel pass a
+    // DFBAccessor directly to Gen1 (WH/BH) LLK compute APIs that expect a raw CB id.
     //
-    // NOTE: If we ever want to switch DFBAccessor from implicit CTA to implicit
-    // CRTA or RTA, we can update the conversion adaptor without affecting any
-    // kernel code that's passing DFBAccessors into LLK APIs.
-    constexpr operator uint32_t() const noexcept { return id; }
-    uint16_t id;
+    // This conversion is constexpr, which means callers may use it in constexpr
+    // contexts (template parameters, static_asserts, address computations). That
+    // permanently commits Gen1 to CTA-based DFB ids, and we have accepted that
+    // commitment: a survey of the TTNN kernel library found that every CB id
+    // already reaches the kernel via a compile-time path (CTA or hardcoded
+    // CBIndex enum), with zero RTA-backed cases. The Gen1 LLK macro architecture
+    // depends on constexpr CB ids and is not going to change.
+    constexpr operator uint32_t() const noexcept { return id_; }
+
+    // Non-constexpr accessor — the blessed extraction path for Gen2 (Quasar) LLK
+    // APIs that accept DFBAccessor directly.
+    //
+    // Intentionally NOT constexpr. If we ever switch Gen2 DFB ids from implicit
+    // CTA to a runtime mechanism (RTA/CRTA), this method's body flips to a
+    // runtime load; marking it constexpr today would lock in a promise we'd
+    // later have to break. Keeping it non-constexpr preserves the seam.
+    //
+    // Gen2 LLK contract — OPEN QUESTION for the LLK team:
+    // Can we get away with this being non-constexpr, or does that break LLK
+    // APIs? If we want to leave open the possibility of future RTA-ification,
+    // the rule is: don't use the extracted value in any context that requires
+    // it to be a compile-time constant — no template non-type parameters, no
+    // constexpr variables, no array sizes, no static_asserts.
+    // If that constraint doesn't work for LLK, we can discard the futureproof
+    // attempt.
+    uint16_t resolve_id() const noexcept { return id_; }
+
+private:
+    uint16_t id_;
 };
 
 class DataflowBuffer {
@@ -66,7 +91,7 @@ public:
     // Preferred constructor for Metal 2.0 / ProgramSpec kernels.
     // Pass the named binding constant from kernel_bindings_generated.h:
     //   DataflowBuffer dfb(my_dfb_name);
-    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(accessor.id) {}
+    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(accessor.resolve_id()) {}
 
     // Low-level constructor: prefer DFBAccessor overload above for new kernel code.
     DataflowBuffer(uint16_t logical_dfb_id);


### PR DESCRIPTION
## PR Category
Feature 

## Summary
Adds a new method, `resolve_id()` to the `DFBAccessor` handle.

The purpose of the getter is to enable the Quasar LLK APIs to take a `DFBAccessor` instead of a raw `uint32_t` CB id. As discussed, this is fully backwards-compatible with WH/BH APIs because `DFBAccessor` is also implicitly `uint32_t` convertible.

## Notes for reviewers
I deliberately made the `resolve_id()` non-constexpr for future-proofing purposes. If this causes LLK any headaches, we can reconsider that choice.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/dfb-accessor-futureproofing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/dfb-accessor-futureproofing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/dfb-accessor-futureproofing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/dfb-accessor-futureproofing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/dfb-accessor-futureproofing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/dfb-accessor-futureproofing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/dfb-accessor-futureproofing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/dfb-accessor-futureproofing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/dfb-accessor-futureproofing)