### PR TITLE
[GraphTracker] Make processors and hook thread_local to fix concurrent-access race

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -35,6 +35,7 @@ set(UNIT_TESTS_API_SOURCES
     test_banked.cpp
     test_bit_utils.cpp
     test_filesystem_utils.cpp
+    test_graph_tracking.cpp
     test_buffer_region.cpp
     test_compile_time_args.cpp
     test_compile_defines.cpp

--- a/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
+++ b/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
@@ -73,7 +73,7 @@ TEST(GraphTrackerThreading, ProcessorsAreIsolatedPerThread) {
     std::atomic<int> ready_count{0};
     std::atomic<bool> go{false};
 
-    auto run_one_thread = [&](std::shared_ptr<CountingProcessor> proc) {
+    auto run_one_thread = [&](const std::shared_ptr<CountingProcessor>& proc) {
         auto& tracker = GraphTracker::instance();
         tracker.clear();
         tracker.push_processor(proc);

--- a/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
+++ b/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
@@ -29,14 +29,12 @@ public:
 
     void track_function_start(
         std::string_view /*function_name*/, std::span<TrackedArgument> /*input_parameters*/) override {
-        function_starts.fetch_add(1, std::memory_order_relaxed);
+        function_starts.fetch_add(1);
     }
 
-    void track_function_end() override { function_ends.fetch_add(1, std::memory_order_relaxed); }
+    void track_function_end() override { function_ends.fetch_add(1); }
 
-    void track_function_end(const std::any& /*output_tensors*/) override {
-        function_ends.fetch_add(1, std::memory_order_relaxed);
-    }
+    void track_function_end(const std::any& /*output_tensors*/) override { function_ends.fetch_add(1); }
 };
 
 }  // namespace
@@ -78,8 +76,8 @@ TEST(GraphTrackerThreading, ProcessorsAreIsolatedPerThread) {
         tracker.clear();
         tracker.push_processor(proc);
 
-        ready_count.fetch_add(1, std::memory_order_acq_rel);
-        while (!go.load(std::memory_order_acquire)) {
+        ready_count.fetch_add(1);
+        while (!go.load()) {
             std::this_thread::yield();
         }
 
@@ -96,10 +94,10 @@ TEST(GraphTrackerThreading, ProcessorsAreIsolatedPerThread) {
     std::thread t_a(run_one_thread, proc_a);
     std::thread t_b(run_one_thread, proc_b);
 
-    while (ready_count.load(std::memory_order_acquire) < kNumThreads) {
+    while (ready_count.load() < kNumThreads) {
         std::this_thread::yield();
     }
-    go.store(true, std::memory_order_release);
+    go.store(true);
 
     t_a.join();
     t_b.join();
@@ -116,11 +114,12 @@ TEST(GraphTrackerThreading, ConcurrentPushPopAndTrackDoNotRace) {
     constexpr auto kDuration = std::chrono::milliseconds(200);
 
     std::atomic<bool> stop{false};
+    std::atomic<bool> dispatcher_ran{false};
 
     std::thread mutator([&] {
         auto& tracker = GraphTracker::instance();
         tracker.clear();
-        while (!stop.load(std::memory_order_relaxed)) {
+        while (!stop.load()) {
             tracker.push_processor(std::make_shared<CountingProcessor>());
             tracker.pop_processor();
         }
@@ -131,20 +130,23 @@ TEST(GraphTrackerThreading, ConcurrentPushPopAndTrackDoNotRace) {
         auto& tracker = GraphTracker::instance();
         tracker.clear();
         tracker.push_processor(dispatcher_proc);
-        while (!stop.load(std::memory_order_relaxed)) {
+        while (!stop.load()) {
             tracker.track_function_start("op");
             tracker.track_function_end();
+            dispatcher_ran.store(true);
         }
         tracker.pop_processor();
     });
 
     std::this_thread::sleep_for(kDuration);
-    stop.store(true, std::memory_order_relaxed);
+    stop.store(true);
 
     mutator.join();
     dispatcher.join();
 
-    EXPECT_GT(dispatcher_proc->function_starts.load(), 0);
+    if (dispatcher_ran.load()) {
+        EXPECT_GT(dispatcher_proc->function_starts.load(), 0);
+    }
     EXPECT_EQ(dispatcher_proc->function_starts.load(), dispatcher_proc->function_ends.load());
 }
 

--- a/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
+++ b/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Host-only tests for tt::tt_metal::GraphTracker focused on its multi-threading
+// contract: `processors` and `hook` are thread_local, so a graph capture pushed
+// on thread A only observes ops dispatched on thread A, and concurrent
+// push/pop on another thread cannot race with the dispatch hot path.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <span>
+#include <string_view>
+#include <thread>
+
+#include <tt-metalium/graph_tracking.hpp>
+
+namespace tt::tt_metal::graph_tracking_test {
+
+namespace {
+
+class CountingProcessor : public IGraphProcessor {
+public:
+    std::atomic<int> function_starts{0};
+    std::atomic<int> function_ends{0};
+
+    void track_function_start(
+        std::string_view /*function_name*/, std::span<TrackedArgument> /*input_parameters*/) override {
+        function_starts.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void track_function_end() override { function_ends.fetch_add(1, std::memory_order_relaxed); }
+
+    void track_function_end(const std::any& /*output_tensors*/) override {
+        function_ends.fetch_add(1, std::memory_order_relaxed);
+    }
+};
+
+}  // namespace
+
+TEST(GraphTrackerThreading, SingleThreadCapturesEachEventOnce) {
+    auto& tracker = GraphTracker::instance();
+    tracker.clear();
+
+    auto processor = std::make_shared<CountingProcessor>();
+    tracker.push_processor(processor);
+
+    constexpr int kIterations = 100;
+    for (int i = 0; i < kIterations; ++i) {
+        tracker.track_function_start("op");
+        tracker.track_function_end();
+    }
+
+    tracker.pop_processor();
+
+    EXPECT_EQ(processor->function_starts.load(), kIterations);
+    EXPECT_EQ(processor->function_ends.load(), kIterations);
+    EXPECT_TRUE(tracker.get_processors().empty());
+}
+
+// Per-thread storage means a processor pushed on thread A only sees ops
+// dispatched on thread A — never on thread B firing in parallel. Each thread
+// pushes its processor before either starts dispatching (via a barrier), so
+// if storage were shared both threads would iterate both processors and each
+// would see 2 * kIterations events.
+TEST(GraphTrackerThreading, ProcessorsAreIsolatedPerThread) {
+    constexpr int kIterations = 1000;
+    constexpr int kNumThreads = 2;
+
+    std::atomic<int> ready_count{0};
+    std::atomic<bool> go{false};
+
+    auto run_one_thread = [&](std::shared_ptr<CountingProcessor> proc) {
+        auto& tracker = GraphTracker::instance();
+        tracker.clear();
+        tracker.push_processor(proc);
+
+        ready_count.fetch_add(1, std::memory_order_acq_rel);
+        while (!go.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+
+        for (int i = 0; i < kIterations; ++i) {
+            tracker.track_function_start("op");
+            tracker.track_function_end();
+        }
+        tracker.pop_processor();
+    };
+
+    auto proc_a = std::make_shared<CountingProcessor>();
+    auto proc_b = std::make_shared<CountingProcessor>();
+
+    std::thread t_a(run_one_thread, proc_a);
+    std::thread t_b(run_one_thread, proc_b);
+
+    while (ready_count.load(std::memory_order_acquire) < kNumThreads) {
+        std::this_thread::yield();
+    }
+    go.store(true, std::memory_order_release);
+
+    t_a.join();
+    t_b.join();
+
+    EXPECT_EQ(proc_a->function_starts.load(), kIterations);
+    EXPECT_EQ(proc_a->function_ends.load(), kIterations);
+    EXPECT_EQ(proc_b->function_starts.load(), kIterations);
+    EXPECT_EQ(proc_b->function_ends.load(), kIterations);
+}
+
+// Reproduces the race from tt-mlir#8302. One thread spins push/pop_processor
+// while another spins track_function_start.
+TEST(GraphTrackerThreading, ConcurrentPushPopAndTrackDoNotRace) {
+    constexpr auto kDuration = std::chrono::milliseconds(200);
+
+    std::atomic<bool> stop{false};
+
+    std::thread mutator([&] {
+        auto& tracker = GraphTracker::instance();
+        tracker.clear();
+        while (!stop.load(std::memory_order_relaxed)) {
+            tracker.push_processor(std::make_shared<CountingProcessor>());
+            tracker.pop_processor();
+        }
+    });
+
+    auto dispatcher_proc = std::make_shared<CountingProcessor>();
+    std::thread dispatcher([&] {
+        auto& tracker = GraphTracker::instance();
+        tracker.clear();
+        tracker.push_processor(dispatcher_proc);
+        while (!stop.load(std::memory_order_relaxed)) {
+            tracker.track_function_start("op");
+            tracker.track_function_end();
+        }
+        tracker.pop_processor();
+    });
+
+    std::this_thread::sleep_for(kDuration);
+    stop.store(true, std::memory_order_relaxed);
+
+    mutator.join();
+    dispatcher.join();
+
+    EXPECT_GT(dispatcher_proc->function_starts.load(), 0);
+    EXPECT_EQ(dispatcher_proc->function_starts.load(), dispatcher_proc->function_ends.load());
+}
+
+}  // namespace tt::tt_metal::graph_tracking_test

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -102,6 +102,18 @@ public:
     virtual ~IGraphHooks() = default;
 };
 
+// Process-wide singleton that fans out op-dispatch events to registered
+// processors and consults an optional hook to intercept buffer / program
+// operations.
+//
+// Threading contract:
+//   * The processor stack (`processors`) and `hook` are *per-thread*. A
+//     `push_processor` / capture / `pop_processor` sequence is scoped to the
+//     calling thread; ops dispatched on other threads are not observed by
+//     that capture.
+//   * `hooked_buffers` is process-wide and guarded by `hooked_buffers_mutex`.
+//     This is the only piece of GraphTracker state that is shared across
+//     threads.
 class GraphTracker {
 public:
     GraphTracker(const GraphTracker&) = delete;
@@ -191,16 +203,8 @@ private:
     GraphTracker() = default;
     ~GraphTracker() = default;
 
-    // Per-thread storage for the processor stack and hook so graph
-    // tracking is safe under multi-threaded use. The push -> run -> pop
-    // sequence is inherently scoped to the thread that performs the
-    // push; the calling thread is the only one whose dispatched ops
-    // should be observed by that capture. Per-thread storage matches
-    // that contract and lets the hot path stay lock-free: callers
-    // without a pushed processor / installed hook see empty state and
-    // return immediately.
+    // Per-thread state. See the class-level threading contract above.
     static thread_local std::vector<std::shared_ptr<IGraphProcessor>> processors;
-
     static thread_local std::shared_ptr<IGraphHooks> hook;
 
     std::mutex hooked_buffers_mutex;

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -191,9 +191,17 @@ private:
     GraphTracker() = default;
     ~GraphTracker() = default;
 
-    std::vector<std::shared_ptr<IGraphProcessor>> processors;
+    // Per-thread storage for the processor stack and hook so graph
+    // tracking is safe under multi-threaded use. The push -> run -> pop
+    // sequence is inherently scoped to the thread that performs the
+    // push; the calling thread is the only one whose dispatched ops
+    // should be observed by that capture. Per-thread storage matches
+    // that contract and lets the hot path stay lock-free: callers
+    // without a pushed processor / installed hook see empty state and
+    // return immediately.
+    static thread_local std::vector<std::shared_ptr<IGraphProcessor>> processors;
 
-    std::shared_ptr<IGraphHooks> hook;
+    static thread_local std::shared_ptr<IGraphHooks> hook;
 
     std::mutex hooked_buffers_mutex;
     std::unordered_set<const Buffer*> hooked_buffers;

--- a/tt_metal/impl/graph/graph_tracking.cpp
+++ b/tt_metal/impl/graph/graph_tracking.cpp
@@ -170,7 +170,10 @@ void GraphTracker::clear() {
 }
 
 void GraphTracker::clear_hook() {
-    hooked_buffers.clear();
+    {
+        std::lock_guard<std::mutex> lock(hooked_buffers_mutex);
+        hooked_buffers.clear();
+    }
     hook = nullptr;
 }
 

--- a/tt_metal/impl/graph/graph_tracking.cpp
+++ b/tt_metal/impl/graph/graph_tracking.cpp
@@ -10,6 +10,9 @@
 
 namespace tt::tt_metal {
 
+thread_local std::vector<std::shared_ptr<IGraphProcessor>> GraphTracker::processors;
+thread_local std::shared_ptr<IGraphHooks> GraphTracker::hook;
+
 nlohmann::json IGraphProcessor::end_capture() { return nullptr; }
 
 GraphTracker& GraphTracker::instance() {


### PR DESCRIPTION
## Summary

`tt::tt_metal::GraphTracker::processors` (and `hook`) are process-wide singleton members with no synchronization. When two threads concurrently drive graph tracking — one pushing/popping processors, another dispatching ops that fire `track_function_start` / `track_*` callbacks — the dispatching thread can iterate `processors` while the other thread is mid-`push_processor` / `pop_processor`, dereferencing stale `shared_ptr` storage.

Full context, repro, and root cause: tt-mlir issue [#8302](https://github.com/tenstorrent/tt-mlir/issues/8302).

## Crash signature

```
[ 1] ttnn::graph::GraphProcessor::track_function_start(...)
[ 2] tt::tt_metal::Tensor::deallocate_impl
[ 3] tt::tt_metal::Tensor::~Tensor
```

Faulting near-null address inside `track_function_start` after `processors` was mutated by a concurrent push/pop on another thread.

## Why `thread_local` is the right shape

Graph capture is already scoped to a single execution path by construction: a processor pushed by thread A is intended to observe the ops dispatched by thread A, not by arbitrary other threads. Per-thread storage matches that contract, lets the hot path keep returning on `processors.empty()` with zero overhead, and needs no locks.

## Repro

Lives in tt-mlir on branch [`rpavlovic/graph-tracker-race-repro`](https://github.com/tenstorrent/tt-mlir/tree/rpavlovic/graph-tracker-race-repro). Two threads share a process and the `GraphTracker` singleton: one driving graph captures (push/pop processors), another dispatching ops (which fire `track_*` callbacks). Crashes within seconds in Release; TSan flags the race on `processors` deterministically.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rpavlovic/graph-tracker-thread-local-processors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/graph-tracker-thread-local-processors)