### PR TITLE
sdxl: retune clip_encoder_1 blackhole baseline after unroll-pragma fix

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -141,7 +141,7 @@ DEVICE_PERF_EXPECTATIONS = {
     },
     "clip_encoder_1": {
         "wormhole": 40_479_595,  # Average of last 5 main CI runs (May 12-13, 2026); previous 40_995_000 was above observed range causing failures
-        "blackhole": 19_377_824,
+        "blackhole": 19_095_974,  # Average of 21 main CI runs (May 16-19, 2026)
     },
     "clip_encoder_2": {
         "wormhole": 125_300_000,


### PR DESCRIPTION
## Summary

`test_sdxl_perf_device[test_sdxl_clip_encoder_1]` on **P150 Blackhole** has been flaking on `(Single-card) Device perf regressions` (~14% failure rate over the last 21 runs) because the measured `AVG DEVICE KERNEL DURATION [ns]` now sits ~282k ns *faster* than the configured `expected_perf = 19_377_824`, hugging the ±1.5% lower bound of `19_087_157`.

This recenters the Blackhole expected value on the **post-improvement mean of 19,095,974 ns** (average across 21 main CI runs from 2026-05-16 → 05-19). New ±1.5% window: **(18,809,534, 19,382,413)** — the mean is dead center, the configured value of 19,377,824 still falls inside, and all observed measurements (min 19,081,490, max 19,110,913) sit comfortably within.

## Root cause: PR #43824

PR [#43824](https://github.com/tenstorrent/tt-metal/pull/43824) *"Fix unroll pragmas, warn on unknown pragma"* (commit [`acee3f82a66`](https://github.com/tenstorrent/tt-metal/commit/acee3f82a66), Nathan Sidwell, 2026-05-08) corrected two long-standing bugs:

1. **`tt_metal/jit_build/build.cpp`** — removed `-Wno-unknown-pragmas` from JIT kernel cflags.
2. **`ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp`** — replaced `#pragma unroll` (Clang/MSVC syntax, silently ignored by GCC) with `#pragma GCC unroll 32` on the inner tile-padding loops.

Before #43824, the `#pragma unroll` in `pad_tile.hpp` was a no-op under GCC and `-Wno-unknown-pragmas` was suppressing the warning that would have flagged it. After the fix, GCC actually unrolls the tile-padding loops used in the CLIP encoder compute path, recovering ~1.4% of kernel time. This is a **real perf improvement**, not a regression.

## Evidence — measurement step-change on 2026-05-08 → 09

| Date (UTC) | Run | sha | AVG DURATION [ns] | vs configured 19.378M |
|---|---|---|---:|---:|
| 2026-04-14 20:25 | [24421196208](https://github.com/tenstorrent/tt-metal/actions/runs/24421196208) | eddf933 | 19,394,218 | +16k (first run after threshold landed) |
| 2026-04-22 14:39 | [24784586408](https://github.com/tenstorrent/tt-metal/actions/runs/24784586408) | dce5fd4 | 19,372,532 | −5k |
| 2026-04-29 14:51 | [25116078116](https://github.com/tenstorrent/tt-metal/actions/runs/25116078116) | 9d4e0b0 | 19,355,739 | −22k |
| 2026-05-07 03:16 | [25474096622](https://github.com/tenstorrent/tt-metal/actions/runs/25474096622) | 0099c93 | 19,350,412 | −27k |
| **2026-05-08 23:25** | [25584443791](https://github.com/tenstorrent/tt-metal/actions/runs/25584443791) | c974edec | **19,363,088** | **−15k (last pre-drop)** |
| **2026-05-09 03:15** | [25590178093](https://github.com/tenstorrent/tt-metal/actions/runs/25590178093) | 8a5587c0 | **19,105,353** | **−272k (first post-drop)** |
| 2026-05-10 03:16 | [25618517284](https://github.com/tenstorrent/tt-metal/actions/runs/25618517284) | 3f39ff3 | 19,102,870 | −275k |
| 2026-05-15 23:24 | [25946146112](https://github.com/tenstorrent/tt-metal/actions/runs/25946146112) | 62d988b | 19,098,378 | −279k |
| 2026-05-19 03:17 | [26074026817](https://github.com/tenstorrent/tt-metal/actions/runs/26074026817) | 8e823c2 | 19,087,454 | −290k |

Commit `acee3f82a66` landed at 2026-05-08 23:35 UTC, perfectly between the last-pre-drop run (23:25 UTC) and the first-post-drop run (03:15 UTC the next day).

## Post-improvement distribution (last 21 main CI runs, 2026-05-16 → 05-19)

| Stat | Value |
|---|---|
| **Mean** | **19,095,974 ns** |
| Min | 19,081,490 ns |
| Max | 19,110,913 ns |
| Stdev | ~7,894 ns |
| Failures (too fast) | 3 / 21 (14%) |

All 21 observations fall within ±0.08% of the new center; min/max sit 286k/15k ns inside the new ±1.5% window.

## Relationship to #43996

[#43996](https://github.com/tenstorrent/tt-metal/pull/43996) (Janko Mitrovic, 2026-05-12) retuned **`clip_encoder_2` Blackhole** for the same root cause (#43824), but left **`clip_encoder_1` Blackhole** untouched — likely because encoder_1's measurement at that moment was still passing on the edge of the ±1.5% window. This PR is the natural follow-up that catches encoder_1 once continued run-to-run jitter started tripping the same lower bound.

## Test plan

- [ ] `(Single-card) Device perf regressions` passes the clip_encoder_1 BH check after merge
- [ ] Monitor next ~5 scheduled runs for flake regression

cc @mbezuljTT @pavlepopovic @ipotkonjak-tt @janko-mitrovic

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/sdxl-clip-encoder-1-bh-retune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/sdxl-clip-encoder-1-bh-retune)