### PR TITLE
Fix DeepSeek device sampling parameter formatting

### DIFF
--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -3,11 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 import ttnn
 from models.common.sampling import SamplingGenerator, SamplingParams, format_sampling_params
+from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, make_deepseek_sampling_args
 
 
@@ -56,6 +59,53 @@ def _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params):
     ttnn.deallocate(tt_tokens)
     ttnn.deallocate(tt_input)
     return device_tokens
+
+
+class _FakeSeedManager:
+    def __init__(self):
+        self.reset_calls = []
+
+    def reset_seed(self, seeds, user_ids):
+        self.reset_calls.append((seeds, user_ids))
+
+
+class _FakeSamplingGenerator:
+    def __init__(self):
+        self.tt_sampling = SimpleNamespace(_sampling_dp=2)
+        self.seed_manager = _FakeSeedManager()
+        self.decode_state_calls = []
+
+    def apply_decode_state(self, sampling_param_chunks, **kwargs):
+        self.decode_state_calls.append((sampling_param_chunks, kwargs))
+
+
+def test_deepseek_reset_sampling_state_does_not_preformat_sampling_params():
+    batch_size = 64
+    batch_size_per_row = 32
+    sampling_generator = _FakeSamplingGenerator()
+    generator = SimpleNamespace(sampling_generator=sampling_generator)
+    sampling_params = SamplingParams(
+        temperature=[0.6] * batch_size,
+        top_k=[32] * batch_size,
+        top_p=[0.95] * batch_size,
+        seed=[1234] * batch_size,
+    )
+
+    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, batch_size_per_row)
+
+    [(sampling_param_chunks, kwargs)] = sampling_generator.decode_state_calls
+    assert len(sampling_param_chunks) == 2
+    assert sampling_param_chunks[0].temperature[0] == 0.6
+    assert sampling_param_chunks[1].temperature[0] == 0.6
+    first_chunk_temperature = format_sampling_params(
+        sampling_param_chunks[0], max_batch_size=batch_size_per_row
+    ).temperature[0]
+    assert first_chunk_temperature == pytest.approx(1 / 0.6)
+    assert kwargs["reset_batch"] is True
+    assert kwargs["prompt_tokens"].shape == (batch_size_per_row, 1)
+    assert kwargs["output_tokens"].shape == (batch_size_per_row, 1)
+    [seed_reset] = sampling_generator.seed_manager.reset_calls
+    assert seed_reset == ([1234] * batch_size, list(range(batch_size)))
 
 
 @torch.no_grad()

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -875,10 +875,12 @@ class DeepseekGenerator(WarmupForwardMixin):
 
     def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
         # TODO(vllm): Thread prompt/output token state into sampling resets for penalty correctness.
-        sampling_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         sampling_dp = self.sampling_generator.tt_sampling._sampling_dp
         sampling_param_chunks = chunk_sampling_params(sampling_params, sampling_dp)
-        seed = getattr(sampling_params, "seed", None)
+        # apply_decode_state() formats user-facing params for TT sampling. Keep
+        # the chunks raw here, and only format a copy to preserve seed padding.
+        seed_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
+        seed = getattr(seed_params, "seed", None)
         if seed is not None:
             user_ids = list(range(batch_size))
             self.sampling_generator.seed_manager.reset_seed(seed, user_ids)


### PR DESCRIPTION
## Problem
DeepSeek on-device sampling was using the wrong effective temperature. `_reset_sampling_state()` formatted sampling params before calling `SamplingGenerator.apply_decode_state()`, and `apply_decode_state()` formats them again.

That matters because `format_sampling_params()` converts user-facing temperature into the inverse scale expected by the TT sampling kernel. With the default `T=0.6`, the first format produced `1 / 0.6 = 1.67`, then the second format converted that back to `0.6`. The kernel interpreted `0.6` as inverse temperature, so device sampling behaved like `T ~= 1.67` while host sampling used `T=0.6`. That flattens the sampled distribution and directly explains much worse stochastic eval accuracy with on-device sampling.

## Fix
- Pass raw user-facing sampling params from DeepSeek into `apply_decode_state()`, so TT sampling formats them exactly once.
- Keep a separately formatted copy only for padded seed reset state.
- Add a regression test that verifies `_reset_sampling_state()` passes raw temperature into `apply_decode_state()`.

## Testing
- `python -m py_compile models/demos/deepseek_v3/tt/generator.py models/demos/deepseek_v3/tests/test_sampling.py`
- `git diff --check HEAD~1..HEAD`
- Triggered `(Galaxy) DeepSeek tests` with `test-type=module`: https://github.com/tenstorrent/tt-metal/actions/runs/26096319090
- `pytest` was not available in the local interpreter; hardware-backed DeepSeek sampling tests were not run locally.

## CI Badge
[![(Galaxy) DeepSeek tests (yieldthought/deepseek-device-sampling-format-ds-rc1)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fdeepseek-device-sampling-format-ds-rc1)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2Fdeepseek-device-sampling-format-ds-rc1)
