### PR TITLE
Fix conditions for using llk bcast with float32 output in binary_ng program factory

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_bcast_fp32_dest_acc.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_bcast_fp32_dest_acc.py
@@ -18,6 +18,8 @@ import pytest
 import torch
 import ttnn
 
+from models.common.utility_functions import run_for_blackhole
+
 pytestmark = pytest.mark.use_module_device
 
 
@@ -85,3 +87,85 @@ def test_bcast_multiply_bf16_x_fp32_sizes(device, T, C):
         f"T={T} C={C}: max deviation across {N_ITERS} iters = {max_dev}; "
         f"expected uniform output of 1.0. Per-iter deviations: {deviations}"
     )
+
+
+# ─── BH: BF16→FP32 + COL bcast hang ────────────────────────────────────────
+# Regression coverage for a BH-specific LLK `unary_bcast` hang: COL bcast with
+# any BFLOAT16 inputs and fp32_dest_acc_en hangs the post-op Synchronize.
+# Fix lives in `is_llk_bcast`, gated to BH + COL (the only configuration tested).
+
+TILE_W = 32
+
+_OPS = {
+    "subtract": (ttnn.subtract, torch.subtract),
+    "add": (ttnn.add, torch.add),
+    "multiply": (ttnn.multiply, torch.multiply),
+}
+
+
+def _bf16_round(x: torch.Tensor) -> torch.Tensor:
+    """Round to BF16 precision and back to float32; matches ttnn storage."""
+    return x.to(torch.bfloat16).to(torch.float32)
+
+
+def _run_subtract_fp32_col_b(device, w_tiles, b=5, s=256):
+    """Canonical bf16 − bf16 → fp32 + COL_B-bcast on ones inputs; expects zeros."""
+    v = w_tiles * TILE_W
+    lhs = ttnn.from_torch(torch.ones(b, 1, s, v), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    rhs = ttnn.from_torch(torch.ones(b, 1, s, 1), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.subtract(lhs, rhs, dtype=ttnn.float32)
+    assert out.dtype == ttnn.float32
+    return ttnn.to_torch(out)
+
+
+@run_for_blackhole("BH-only LLK unary_bcast + fp32_dest_acc regression;")
+@pytest.mark.timeout(20)
+@pytest.mark.parametrize("w_tiles", [1, 2, 3, 4, 5, 6, 7, 8], ids=lambda w: f"W_{w}")
+def test_subtract_bf16_to_fp32_col_b_w_sweep(device, w_tiles):
+    """LLK #1338: full W sweep of the canonical hang case."""
+    out = _run_subtract_fp32_col_b(device, w_tiles)
+    assert torch.equal(out, torch.zeros_like(out)), f"W={w_tiles}: max abs = {out.abs().max()}"
+
+
+def _run_bcast_subword_in_fp32_out(device, ttnn_op, torch_op, bcast_input, w_tiles, b=5, s=256):
+    """Generic BF16→FP32 col-bcast op runner. bcast_input ∈ {'a','b'}."""
+    v = w_tiles * TILE_W
+    if bcast_input == "a":
+        lhs_torch = torch.full((b, 1, s, 1), 0.5, dtype=torch.float32)
+        rhs_torch = torch.full((b, 1, s, v), 1.0, dtype=torch.float32)
+    else:
+        lhs_torch = torch.full((b, 1, s, v), 1.0, dtype=torch.float32)
+        rhs_torch = torch.full((b, 1, s, 1), 0.5, dtype=torch.float32)
+    ref = torch_op(_bf16_round(lhs_torch), _bf16_round(rhs_torch)).expand(b, 1, s, v).contiguous()
+
+    lhs = ttnn.from_torch(lhs_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    rhs = ttnn.from_torch(rhs_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn_op(lhs, rhs, dtype=ttnn.float32)
+    assert out.dtype == ttnn.float32
+    return ttnn.to_torch(out), ref
+
+
+# Matrix covers subtract+COL_A and add/multiply for both COL_A and COL_B.
+# (subtract+COL_B is exercised separately by test_subtract_bf16_to_fp32_col_b_w_sweep.)
+_MATRIX_COMBOS = [
+    ("subtract", "a"),
+    ("add", "a"),
+    ("add", "b"),
+    ("multiply", "a"),
+    ("multiply", "b"),
+]
+
+
+@run_for_blackhole("BH-only LLK unary_bcast + fp32_dest_acc regression")
+@pytest.mark.timeout(20)
+@pytest.mark.parametrize("w_tiles", [1, 2, 3, 4, 5, 6, 7, 8], ids=lambda w: f"W_{w}")
+@pytest.mark.parametrize(
+    "op_name, bcast_input", _MATRIX_COMBOS, ids=[f"{op}_COL_{d.upper()}" for op, d in _MATRIX_COMBOS]
+)
+def test_binary_ng_bcast_bf16_in_fp32_out_matrix(device, op_name, bcast_input, w_tiles):
+    """LLK #1338: (op × bcast direction × W) matrix for BF16→FP32 col-bcast."""
+    ttnn_op, torch_op = _OPS[op_name]
+    out, ref = _run_bcast_subword_in_fp32_out(device, ttnn_op, torch_op, bcast_input, w_tiles)
+    assert torch.equal(
+        out, ref
+    ), f"{op_name} COL_{bcast_input.upper()} W={w_tiles}: max abs diff = {(out - ref).abs().max()}"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -312,11 +312,25 @@ void overwrite_compute_kernel_name_and_defines(
     }
 }
 
+// Returns true on the (arch, broadcast, dtype) tuple that hangs the LLK
+// `unary_bcast` path on Blackhole: COL bcast + BFLOAT16 input + fp32_dest_acc_en.
+bool hits_bh_col_bcast_bf16_to_fp32_hang(
+    SubtileBroadcastType subtile_broadcast_type, DataType a_dtype, DataType b_dtype, bool fp32_dest_acc_en) {
+    const bool is_col_bcast =
+        subtile_broadcast_type == SubtileBroadcastType::COL_A || subtile_broadcast_type == SubtileBroadcastType::COL_B;
+    const bool has_bf16_input = a_dtype == DataType::BFLOAT16 || b_dtype == DataType::BFLOAT16;
+    return tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE && is_col_bcast && fp32_dest_acc_en && has_bf16_input;
+}
+
 bool is_llk_bcast(
     const SubtileBroadcastType subtile_broadcast_type,
     const DataType a_dtype,
     const DataType b_dtype,
-    [[maybe_unused]] const DataType c_dtype) {
+    const bool fp32_dest_acc_en) {
+    if (hits_bh_col_bcast_bf16_to_fp32_hang(subtile_broadcast_type, a_dtype, b_dtype, fp32_dest_acc_en)) {
+        return false;
+    }
+
     auto all_match = [&](DataType dt) { return a_dtype == dt && b_dtype == dt; };
 
     if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
@@ -731,8 +745,8 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
 
     bool use_llk_bcast =
-        !inputs_row_major &&
-        CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(operation_attributes.subtile_broadcast_type, a_dtype, b_dtype, c_dtype);
+        !inputs_row_major && CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(
+                                 operation_attributes.subtile_broadcast_type, a_dtype, b_dtype, fp32_dest_acc_en);
 
     // The B2D broadcast path for BFP formats introduces rounding that EXP/EXP2
     // amplifies beyond acceptable tolerance.


### PR DESCRIPTION
### PR Category
Guard against an LLK bug (no LLK fix here)
### Summary
On Blackhole, the LLK `unary_bcast` path hangs (at the post-op `Synchronize`) when a COL subtile broadcast runs with a BFLOAT16 input and `fp32_dest_acc_en` enabled. Surfaced in tt-train's `vocab_parallel_cross_entropy_loss`, whose `fused_subtract_exp_fp32` helper calls `ttnn::subtract(a, b, /*output_dtype=*/FLOAT32, ..., post_activations)` with bf16 inputs and an `exp` SFPU post-activation — the bf16 − bf16 COL-bcast into an fp32 dest hits the broken path and hangs.
This PR does **not** fix the LLK bug. It adds a guard in `is_llk_bcast` so that on BH the COL_A/COL_B + BFLOAT16 input + fp32 dest accum combination falls back to the generic path. `is_llk_bcast` now takes `fp32_dest_acc_en` in place of the previously unused `c_dtype`. Other archs / broadcast types are unaffected.
### Notes for reviewers
- Guard is scoped narrowly to **BFLOAT16** — that's what was observed hanging and what the new tests cover. BFP8_B/BFP4_B may share the issue but are not exercised by the surfacing call site and are intentionally left on the LLK path.
- New regression coverage in `test_binary_ng_bcast_fp32_dest_acc.py`: canonical bf16 − bf16 → fp32 COL_B subtract over W = 1..8 (previously hung), plus a {subtract, add, multiply} × {COL_A, COL_B} × W = 1..8 numerical-equivalence matrix vs torch.
- Signature change to `is_llk_bcast` is internal to the binary_ng program factory; only one caller.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bklTT/fix_binary_upcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bklTT/fix_binary_upcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bklTT/fix_binary_upcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bklTT/fix_binary_upcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bklTT/fix_binary_upcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bklTT/fix_binary_upcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bklTT/fix_binary_upcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bklTT/fix_binary_upcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bklTT/fix_binary_upcast)