### PR TITLE
Fix DeepSeek device sampling slot mapping

### DIFF
--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -3,11 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 import ttnn
 from models.common.sampling import SamplingGenerator, SamplingParams, format_sampling_params
+from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, make_deepseek_sampling_args
 
 
@@ -56,6 +59,62 @@ def _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params):
     ttnn.deallocate(tt_tokens)
     ttnn.deallocate(tt_input)
     return device_tokens
+
+
+class _FakeSeedManager:
+    def __init__(self, max_batch_size):
+        self.max_batch_size = max_batch_size
+        self.reset_calls = []
+        self.new_value_calls = []
+
+    def reset_seed(self, seeds, user_ids):
+        self.reset_calls.append((seeds, user_ids))
+
+    def get_new_values(self, user_slots):
+        self.new_value_calls.append(user_slots)
+
+
+class _FakeSamplingGenerator:
+    def __init__(self, *, padded_batch_size=32, sampling_dp=2):
+        self.tt_sampling = SimpleNamespace(max_batch_size=padded_batch_size, _sampling_dp=sampling_dp)
+        self.seed_manager = _FakeSeedManager(padded_batch_size * sampling_dp)
+        self.decode_state_calls = []
+
+    def apply_decode_state(self, sampling_param_chunks, **kwargs):
+        self.decode_state_calls.append((sampling_param_chunks, kwargs))
+
+
+def _fake_deepseek_generator(*, batch_size_per_row=8, sampling_dp=2):
+    return SimpleNamespace(
+        batch_size_per_row=batch_size_per_row,
+        sampling_generator=_FakeSamplingGenerator(padded_batch_size=32, sampling_dp=sampling_dp),
+    )
+
+
+def test_deepseek_sampling_user_slots_map_to_row_padded_device_slots():
+    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=3)
+
+    assert DeepseekGenerator._sampling_device_slots(generator, [0, 7, 8, 15, 16, 23]) == [0, 7, 32, 39, 64, 71]
+
+
+def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
+    batch_size = 16
+    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.0] * batch_size,
+        top_k=[1] * batch_size,
+        top_p=[1.0] * batch_size,
+        seed=list(range(100, 100 + batch_size)),
+    )
+
+    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, generator.batch_size_per_row)
+
+    [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
+    assert user_ids == list(range(64))
+    assert seeds[:8] == list(range(100, 108))
+    assert seeds[8:32] == [None] * 24
+    assert seeds[32:40] == list(range(108, 116))
+    assert seeds[40:] == [None] * 24
 
 
 @torch.no_grad()

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -880,14 +880,39 @@ class DeepseekGenerator(WarmupForwardMixin):
         sampling_param_chunks = chunk_sampling_params(sampling_params, sampling_dp)
         seed = getattr(sampling_params, "seed", None)
         if seed is not None:
-            user_ids = list(range(batch_size))
-            self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
+            seed_slots = self._sampling_device_seed_slots(seed, batch_size)
+            self.sampling_generator.seed_manager.reset_seed(seed_slots, list(range(len(seed_slots))))
         self.sampling_generator.apply_decode_state(
             sampling_param_chunks,
             reset_batch=True,
             prompt_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
             output_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
         )
+
+    def _sampling_device_slot(self, user_id: int) -> int:
+        row = int(user_id) // self.batch_size_per_row
+        local_user_id = int(user_id) % self.batch_size_per_row
+        sampling_batch_size = self.sampling_generator.tt_sampling.max_batch_size
+        sampling_dp = self.sampling_generator.tt_sampling._sampling_dp
+        if row < 0 or row >= sampling_dp:
+            raise ValueError(f"Sampling user id {user_id} maps to row {row}, outside sampling dp {sampling_dp}")
+        if local_user_id >= sampling_batch_size:
+            raise ValueError(
+                f"Sampling local user id {local_user_id} exceeds padded sampling batch size {sampling_batch_size}"
+            )
+        return row * sampling_batch_size + local_user_id
+
+    def _sampling_device_slots(self, user_slots: list[int] | None) -> list[int] | None:
+        if user_slots is None:
+            return None
+        return [self._sampling_device_slot(user_id) for user_id in user_slots]
+
+    def _sampling_device_seed_slots(self, seeds: list[int | None], batch_size: int) -> list[int | None]:
+        seed_slot_count = self.sampling_generator.seed_manager.max_batch_size
+        seed_slots = [None] * seed_slot_count
+        for user_id in range(batch_size):
+            seed_slots[self._sampling_device_slot(user_id)] = seeds[user_id]
+        return seed_slots
 
     def _sample_tokens_device(
         self,
@@ -936,7 +961,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             else:
                 sampling_logits = padded_logits
 
-        self.sampling_generator.seed_manager.get_new_values(user_slots)
+        self.sampling_generator.seed_manager.get_new_values(self._sampling_device_slots(user_slots))
         self.sampling_generator.enable_internal_trace = enable_trace
         try:
             tt_out = self.sampling_generator.sample(sampling_logits, enable_trace=enable_trace)
@@ -2059,9 +2084,11 @@ class DeepseekGenerator(WarmupForwardMixin):
                                 prefill_logits, user_slots=[user_id]
                             )
                             prefill_logits_sampled_host = self._tokens_from_device(
-                                prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
+                                prefill_logits_sampled_device,
+                                self.mesh_device,
+                                batch_size_per_row=self.batch_size_per_row,
                             )
-                            pred_token = int(prefill_logits_sampled_host[0].item())
+                            pred_token = int(prefill_logits_sampled_host[user_id].item())
                             ttnn.deallocate(prefill_logits)
                             ttnn.deallocate(prefill_logits_sampled_device)
                         else:

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -146,10 +146,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len, expand_to_batch=True)
                 prefill_logits_sampled_device = self._sample_tokens_device(prefill_logits, user_slots=[user_id])
                 prefill_logits_sampled_host = self._tokens_from_device(
-                    prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
+                    prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=self.batch_size_per_row
                 )
                 # Device-sampling path emits token ids.
-                user_output = prefill_logits_sampled_host[0].to(torch.int64)
+                user_output = prefill_logits_sampled_host[user_id].to(torch.int64)
             else:
                 assert isinstance(prefill_logits, torch.Tensor), "prefill_logits should be a torch.Tensor on host"
                 user_logits = prefill_logits.squeeze(0).squeeze(0)  # [1, 1, S, V] -> [S, V]


### PR DESCRIPTION
## Problem
DeepSeek on-device prefill sampling has two row/slot mapping bugs in multi-user and 8-upr style runs:

- Prefill samples the requested logical user, but then reads sampled token slot 0. For `user_id != 0`, this can feed the wrong first generated token into decode.
- Seed state uses compact logical user IDs, while TT sampling pads each mesh row to 32 device slots. With `max_users_per_row < 32`, rows after row 0 can consume the wrong seeded RNG stream.

These mostly affect seeded/per-user stochastic sampling and first-token correctness after prefill; they are separate from the temperature double-formatting fix in #44696.

## Fix
- Map compact logical user IDs to row-padded TT sampling slots before resetting or advancing seed state.
- Read the sampled prefill token for the requested logical user instead of always reading slot 0.
- Apply the same prefill token selection fix in the vLLM wrapper.
- Add focused tests for compact-to-row-padded slot and seed mapping.

## Testing
- `python -m py_compile models/demos/deepseek_v3/tt/generator.py models/demos/deepseek_v3/tt/generator_vllm.py models/demos/deepseek_v3/tests/test_sampling.py`
- `git diff --check`
- Local `pytest` not run: this interpreter does not have `pytest` installed.
