### PR TITLE
[skip ci] Remove uv pip install ttnn from multihost runner

### DIFF
--- a/.github/workflows/demo-sp-multihost-impl.yaml
+++ b/.github/workflows/demo-sp-multihost-impl.yaml
@@ -211,7 +211,7 @@ jobs:
             ls -R /ci/artifacts
             exit 1
           fi
-          uv pip install "${ttnn_wheels[@]}"
+
           mpirun --pernode uv pip install "${ttnn_wheels[@]}"
 
       - name: Reset cards and validate cluster for ${{ matrix.test-group.name }}


### PR DESCRIPTION
As tt-metal is copied to multihost runner and tt-run is part of the image this is not needed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dpopov-remove-pip-install-multihost-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dpopov-remove-pip-install-multihost-runner)