### PR TITLE
GPT-OSS: ensure L1 dispatch + harden unit tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -399,7 +399,7 @@ models/demos/deepseek_v3_b1 @tt-aho @TT-BrianLiu @sjameelTT @nardoTT @tt-asaigal
 models/demos/deepseek_v3_b1/demo @esmalTT @tt-aho @TT-BrianLiu @sjameelTT @nardoTT @tt-asaigal @tenstorrent/codeowner-bypass
 models/demos/deepseek_v3_b1/weights @esmalTT @tt-aho @TT-BrianLiu @sjameelTT @nardoTT @tt-asaigal @tenstorrent/codeowner-bypass
 models/demos/deepseek_v3_d_p @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
-models/demos/gpt_oss @uaydonat @mtairum @sraizada-tt @handrewsTT @tenstorrent/codeowner-bypass
+models/demos/gpt_oss @uaydonat @mtairum @sraizada-tt @djordje-tt @handrewsTT @tenstorrent/codeowner-bypass
 models/**/bert*/ @TT-BrianLiu @uaydonat @tenstorrent/codeowner-bypass
 models/demos/metal_BERT_large_11 @tt-aho @TT-BrianLiu @tenstorrent/codeowner-bypass
 models/**/distilbert/ @tt-aho @uaydonat @tenstorrent/codeowner-bypass

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -273,57 +273,20 @@ def run_throughput_experts_component(
         mesh_mapper=mesh_mapper,
     )
 
-    # Extract TT experts from decoder layer — retry once on catastrophic PCC (fabric corruption).
-    max_attempts = 2
-    for attempt in range(max_attempts):
-        tt_experts = decoder_layer.mlp.experts
-        tt_output = tt_experts(
-            hidden_states=tt_hidden_states,
-            topk_expert_indices=tt_router_indices,
-            topk_expert_weights=tt_routing_weights,
-            is_decode=is_decode,
-        )
+    tt_experts = decoder_layer.mlp.experts
+    tt_output = tt_experts(
+        hidden_states=tt_hidden_states,
+        topk_expert_indices=tt_router_indices,
+        topk_expert_weights=tt_routing_weights,
+        is_decode=is_decode,
+    )
 
-        mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
-        tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
-        passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
-        if passing:
-            logger.info(f"High Throughput Experts test passed. Output: {output}")
-            return
-
-        pcc_val = float(output) if isinstance(output, (int, float)) else 0.0
-        try:
-            pcc_val = float(output)
-        except (ValueError, TypeError):
-            pcc_val = 0.0
-        if attempt < max_attempts - 1 and pcc_val < 0.1:
-            logger.warning(
-                f"High Throughput Experts PCC={output} (attempt {attempt + 1}/{max_attempts}) — "
-                f"catastrophic, likely fabric data corruption. Synchronizing and retrying..."
-            )
-            ttnn.synchronize_device(mesh_device)
-            tt_hidden_states = ttnn.from_torch(
-                hidden_states,
-                device=mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                mesh_mapper=mesh_mapper,
-            )
-            tt_routing_weights = ttnn.from_torch(
-                topk_weights_dense,
-                device=mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                mesh_mapper=mesh_mapper,
-            )
-            tt_router_indices = ttnn.from_torch(
-                router_indices,
-                device=mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.uint16,
-                mesh_mapper=mesh_mapper,
-            )
-            continue
+    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
+    tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
+    passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
+    if passing:
+        logger.info(f"High Throughput Experts test passed. Output: {output}")
+    else:
         assert passing, f"High Throughput Experts test failed. Output: {output}"
 
 
@@ -443,14 +406,8 @@ def run_fused_throughput_experts_component(
         per_row = [ttnn.to_torch(dev_tensors[r * mesh_cols]) for r in range(mesh_rows)]
         tt_output_torch = torch.cat(per_row, dim=-2)[..., :hidden_size]
 
-        has_nan = torch.isnan(tt_output_torch).any().item()
-        has_inf = torch.isinf(tt_output_torch).any().item()
-        if has_nan or has_inf:
-            logger.warning(
-                f"Fused expert output has NaN={has_nan} Inf={has_inf} — likely fabric data corruption (flaky). "
-                f"Skipping PCC check."
-            )
-            return
+        assert not torch.isnan(tt_output_torch).any(), "NaN detected in fused expert output"
+        assert not torch.isinf(tt_output_torch).any(), "Inf detected in fused expert output"
 
         tt_flat = tt_output_torch.reshape(-1, hidden_size)[:num_tokens].float()
         ref_flat = reference_output.reshape(-1, hidden_size)[:num_tokens].float()

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -273,22 +273,57 @@ def run_throughput_experts_component(
         mesh_mapper=mesh_mapper,
     )
 
-    # Extract TT experts from decoder layer
-    tt_experts = decoder_layer.mlp.experts
-    tt_output = tt_experts(
-        hidden_states=tt_hidden_states,
-        topk_expert_indices=tt_router_indices,
-        topk_expert_weights=tt_routing_weights,
-        is_decode=is_decode,
-    )
+    # Extract TT experts from decoder layer — retry once on catastrophic PCC (fabric corruption).
+    max_attempts = 2
+    for attempt in range(max_attempts):
+        tt_experts = decoder_layer.mlp.experts
+        tt_output = tt_experts(
+            hidden_states=tt_hidden_states,
+            topk_expert_indices=tt_router_indices,
+            topk_expert_weights=tt_routing_weights,
+            is_decode=is_decode,
+        )
 
-    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
-    tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
-    # Compare outputs
-    passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
-    if passing:
-        logger.info(f"High Throughput Experts test passed. Output: {output}")
-    else:
+        mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
+        tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
+        passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
+        if passing:
+            logger.info(f"High Throughput Experts test passed. Output: {output}")
+            return
+
+        pcc_val = float(output) if isinstance(output, (int, float)) else 0.0
+        try:
+            pcc_val = float(output)
+        except (ValueError, TypeError):
+            pcc_val = 0.0
+        if attempt < max_attempts - 1 and pcc_val < 0.1:
+            logger.warning(
+                f"High Throughput Experts PCC={output} (attempt {attempt + 1}/{max_attempts}) — "
+                f"catastrophic, likely fabric data corruption. Synchronizing and retrying..."
+            )
+            ttnn.synchronize_device(mesh_device)
+            tt_hidden_states = ttnn.from_torch(
+                hidden_states,
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=mesh_mapper,
+            )
+            tt_routing_weights = ttnn.from_torch(
+                topk_weights_dense,
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=mesh_mapper,
+            )
+            tt_router_indices = ttnn.from_torch(
+                router_indices,
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.uint16,
+                mesh_mapper=mesh_mapper,
+            )
+            continue
         assert passing, f"High Throughput Experts test failed. Output: {output}"
 
 
@@ -403,15 +438,19 @@ def run_fused_throughput_experts_component(
             mesh_device=mesh_device,
         )
 
-        # After all_reduce across cols, all col devices in the same row have identical
-        # output [1, 1, M, H]. Pick col=0 from each row and concat tokens along dim -2.
         mesh_rows, mesh_cols = mesh_device.shape
         dev_tensors = ttnn.get_device_tensors(tt_output)
         per_row = [ttnn.to_torch(dev_tensors[r * mesh_cols]) for r in range(mesh_rows)]
         tt_output_torch = torch.cat(per_row, dim=-2)[..., :hidden_size]
-        assert not torch.isnan(tt_output_torch).any(), "NaN detected in fused expert output"
-        assert not torch.isinf(tt_output_torch).any(), "Inf detected in fused expert output"
-        # reference_output: [num_tokens, hidden_size]
+
+        has_nan = torch.isnan(tt_output_torch).any().item()
+        has_inf = torch.isinf(tt_output_torch).any().item()
+        if has_nan or has_inf:
+            logger.warning(
+                f"Fused expert output has NaN={has_nan} Inf={has_inf} — likely fabric data corruption (flaky). "
+                f"Skipping PCC check."
+            )
+            return
 
         tt_flat = tt_output_torch.reshape(-1, hidden_size)[:num_tokens].float()
         ref_flat = reference_output.reshape(-1, hidden_size)[:num_tokens].float()
@@ -422,8 +461,23 @@ def run_fused_throughput_experts_component(
             f"Output range: [{tt_flat.min():.4f}, {tt_flat.max():.4f}]."
         )
     finally:
-        # Always clean up fused config resources
-        pass
+        for attr in [
+            "dispatch_sparse",
+            "dispatch_indices",
+            "dispatch_scores",
+            "combine_preallocated",
+            "tt_dispatch_mapping",
+            "tt_moe_gpt_mapping",
+            "tt_w0_w1",
+            "tt_w2",
+        ]:
+            tensor = getattr(fused_config, attr, None)
+            if tensor is not None:
+                try:
+                    ttnn.deallocate(tensor)
+                except Exception:
+                    pass
+        ttnn.synchronize_device(mesh_device)
 
 
 def run_experts_component(mesh_device, hidden_shape, config, reference_layer, decoder_layer, is_decode, pcc_threshold):
@@ -779,7 +833,8 @@ def test_decoder(
 
     if should_test("experts"):
         if decoder_layer.mlp.use_throughput_experts:
-            logger.info(f"Testing High Throughput Experts (EP=32) for mesh shape {tuple(mesh_device.shape)}...")
+            logger.info(f"Testing High Throughput Experts (EP=32) for mesh shape {mesh_shape}...")
+            ttnn.synchronize_device(setup["mesh_device"])
             hidden_states_throughput_experts = hidden_states.reshape(1, 1, batch_size * seq_len, -1)
             run_throughput_experts_component(
                 setup["mesh_device"],

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -438,8 +438,8 @@ def run_fused_throughput_experts_component(
             if tensor is not None:
                 try:
                     ttnn.deallocate(tensor)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Failed to deallocate {attr}: {e}")
         ttnn.synchronize_device(mesh_device)
 
 

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -273,6 +273,7 @@ def run_throughput_experts_component(
         mesh_mapper=mesh_mapper,
     )
 
+    # Extract TT experts from decoder layer
     tt_experts = decoder_layer.mlp.experts
     tt_output = tt_experts(
         hidden_states=tt_hidden_states,
@@ -283,6 +284,7 @@ def run_throughput_experts_component(
 
     mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape))
     tt_output = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)[..., :num_tokens, :hidden_size]
+    # Compare outputs
     passing, output = compare_tensors(tt_output, reference_output, mesh_device, pcc_threshold=pcc_threshold)
     if passing:
         logger.info(f"High Throughput Experts test passed. Output: {output}")
@@ -307,6 +309,7 @@ def run_fused_throughput_experts_component(
     cluster_axis = 0
     tokens_per_device = num_tokens // mesh_device.shape[cluster_axis]  # e.g., 128 // 4 = 32
 
+    # Extract TT experts from decoder layer
     tt_experts = decoder_layer.mlp.experts
     tt_config = tt_experts.config
 
@@ -401,6 +404,8 @@ def run_fused_throughput_experts_component(
             mesh_device=mesh_device,
         )
 
+        # After all_reduce across cols, all col devices in the same row have identical
+        # output [1, 1, M, H]. Pick col=0 from each row and concat tokens along dim -2.
         mesh_rows, mesh_cols = mesh_device.shape
         dev_tensors = ttnn.get_device_tensors(tt_output)
         per_row = [ttnn.to_torch(dev_tensors[r * mesh_cols]) for r in range(mesh_rows)]
@@ -409,6 +414,7 @@ def run_fused_throughput_experts_component(
         assert not torch.isnan(tt_output_torch).any(), "NaN detected in fused expert output"
         assert not torch.isinf(tt_output_torch).any(), "Inf detected in fused expert output"
 
+        # reference_output: [num_tokens, hidden_size]
         tt_flat = tt_output_torch.reshape(-1, hidden_size)[:num_tokens].float()
         ref_flat = reference_output.reshape(-1, hidden_size)[:num_tokens].float()
 

--- a/models/demos/gpt_oss/tt/experts_throughput/fused_decode.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/fused_decode.py
@@ -102,6 +102,8 @@ def fused_decode_forward(
         ttnn.deallocate(topk_expert_indices)
     else:
         indices_rm = topk_expert_indices
+    if indices_rm.memory_config().buffer_type != ttnn.BufferType.L1:
+        indices_rm = ttnn.clone(indices_rm, memory_config=ttnn.L1_MEMORY_CONFIG)
     topk_expert_indices = ttnn.reshape(indices_rm, (tokens_per_device, 1, 1, K_sel))
 
     # Reshape scores for dispatch: same transformation
@@ -112,6 +114,8 @@ def fused_decode_forward(
         ttnn.deallocate(topk_expert_scores)
     else:
         scores_dispatch_rm = topk_expert_scores
+    if scores_dispatch_rm.memory_config().buffer_type != ttnn.BufferType.L1:
+        scores_dispatch_rm = ttnn.clone(scores_dispatch_rm, memory_config=ttnn.L1_MEMORY_CONFIG)
     topk_expert_scores = ttnn.reshape(scores_dispatch_rm, (tokens_per_device, 1, 1, K_sel))
 
     # Create zeroed combine output buffer before dispatch (dispatch is the cross-device barrier).


### PR DESCRIPTION
## Summary
- Ensure dispatch indices/scores are copied to L1 regardless of input memory config
- Harden unit tests against fabric state pollution between fused/non-fused test phases

Split from #44240 (model changes only).

## Changes

### Commit 1: L1 dispatch safety (fused_decode.py)
Dispatch metadata (indices/scores) must be in L1 for correct alignment. Added explicit `to_memory_config(L1)` to handle cases where inputs arrive in DRAM.

### Commits 2-3: Test cleanup (test_modules.py)
- Fused experts: deallocate all 8 `fused_config` tensors + `synchronize_device` in `finally` block
- `synchronize_device` barrier between fused and non-fused test phases in `test_decoder`
- Removed hack workarounds, kept only cleanup fixes

## Test plan
- [x] `test_modules.py` passes on 4x8 Galaxy
- [x] `test_gpt_oss_demo[batch128]` passes on 4x8 Galaxy
- [x] Galaxy CI 3/3 pass (from #44240)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/fix-gptoss-fused-decode-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/fix-gptoss-fused-decode-tests)