### PR TITLE
#41662: Fix FP32 transpose RM sharded numerical regression

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1418,7 +1418,6 @@ def test_transpose_hc_mem_config(device, n, c, h, w):
     ids=["bfloat16", "float32", "int32", "bfloat8_b"],
 )
 def test_transpose_sharded(device, dim0, dim1, layout, input_sharding, output_sharding, dtype):
-    pytest.skip("https://github.com/tenstorrent/tt-metal/issues/41662")
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is only supported for TILE layout")
 
@@ -1459,5 +1458,56 @@ def test_transpose_sharded(device, dim0, dim1, layout, input_sharding, output_sh
         input_mem_config=input_memory_config,
         output_mem_config=output_memory_config,
         layout=layout,
+        input_dtype=dtype,
+    )
+
+
+# RM + WIDTH-sharded coverage. `test_transpose_sharded` above only parametrizes
+# the input/output strategies over {HEIGHT, BLOCK}, so the WIDTH-sharded path is
+# entirely uncovered for ROW_MAJOR layout. WIDTH-sharded RM buffers have
+# `pages_per_shard_width > 1`, i.e. a single logical row spans multiple sub-row
+# pages on potentially distinct banks, which is the exact code path that
+# requires the multi-page split in `tt::data_movement::common::noc_async_*_sharded`
+# (dropped during PR #42130 / device 2.0 port and tracked as a follow-up).
+_RM_WIDTH_SHARDED_COMBOS = [
+    pytest.param(ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.WIDTH, id="input_height-output_width"),
+    pytest.param(ttnn.ShardStrategy.BLOCK, ttnn.ShardStrategy.WIDTH, id="input_block-output_width"),
+    pytest.param(ttnn.ShardStrategy.WIDTH, ttnn.ShardStrategy.HEIGHT, id="input_width-output_height"),
+    pytest.param(ttnn.ShardStrategy.WIDTH, ttnn.ShardStrategy.BLOCK, id="input_width-output_block"),
+    pytest.param(ttnn.ShardStrategy.WIDTH, ttnn.ShardStrategy.WIDTH, id="input_width-output_width"),
+]
+
+
+@pytest.mark.parametrize(["dim0", "dim1"], [(2, 3), (2, 1), (0, 1)], ids=["wh", "hc", "cn"])
+@pytest.mark.parametrize(("input_sharding", "output_sharding"), _RM_WIDTH_SHARDED_COMBOS)
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.bfloat16, ttnn.float32, ttnn.int32],
+    ids=["bfloat16", "float32", "int32"],
+)
+def test_transpose_sharded_rm_width(device, dim0, dim1, input_sharding, output_sharding, dtype):
+    N = 1
+    C = 2
+    H = 256
+    W = 256
+
+    input_shape = (N, C, H, W)
+    output_shape = list(input_shape)
+    output_shape[dim0], output_shape[dim1] = input_shape[dim1], input_shape[dim0]
+
+    core_grid = ttnn.CoreGrid(x=2, y=4)
+    input_memory_config = ttnn.create_sharded_memory_config(input_shape, core_grid=core_grid, strategy=input_sharding)
+    output_memory_config = ttnn.create_sharded_memory_config(
+        output_shape, core_grid=core_grid, strategy=output_sharding
+    )
+
+    transpose(
+        input_shape,
+        device,
+        dim0=dim0,
+        dim1=dim1,
+        input_mem_config=input_memory_config,
+        output_mem_config=output_memory_config,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
         input_dtype=dtype,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
@@ -434,19 +434,22 @@ _RM = ttnn.ROW_MAJOR_LAYOUT
     ],
 )
 def test_transpose_universal_io_row_major(shape, dim0, dim1, input_factory, output_factory, dtype, device):
-    # Pre-existing LLK bug in `llk_math_transpose_dest` / `pack_untilize_dest` for fp32 DEST mode
-    # (issue #41662); not a regression of this PR, same class of op-side gap as the bfp8 HC skip above.
     in_mc = input_factory(device)
-    if dtype == ttnn.float32 and in_mc.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
-        pytest.xfail("RM HEIGHT_SHARDED WH transpose corrupts f32 elements (#41662)")
+    out_mc = output_factory(device)
+    # Interleaved → BLOCK/WIDTH-sharded RM: permute writer can't split rows across shards.
+    if in_mc.memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED and out_mc.memory_layout in (
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    ):
+        pytest.xfail("permute writer doesn't split sharded RM rows across cores (#32019)")
     run_transpose_test(
         shape,
         dim0,
         dim1,
         device,
         input_layout=_RM,
-        input_mem_config=input_factory(device),
-        output_mem_config=output_factory(device),
+        input_mem_config=in_mc,
+        output_mem_config=out_mc,
         dtype=dtype,
     )
 

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
@@ -436,12 +436,6 @@ _RM = ttnn.ROW_MAJOR_LAYOUT
 def test_transpose_universal_io_row_major(shape, dim0, dim1, input_factory, output_factory, dtype, device):
     in_mc = input_factory(device)
     out_mc = output_factory(device)
-    # Interleaved → BLOCK/WIDTH-sharded RM: permute writer can't split rows across shards.
-    if in_mc.memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED and out_mc.memory_layout in (
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-    ):
-        pytest.xfail("permute writer doesn't split sharded RM rows across cores (#32019)")
     run_transpose_test(
         shape,
         dim0,

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -224,55 +224,41 @@ struct ByteSizeAddressType<Size, typename std::enable_if<Size == 4>::type> {
     typedef uint32_t type;
 };
 
-// Split a logical-page transfer across shards when a BLOCK/WIDTH-sharded RM buffer's
-// row spans multiple cores. Falls through to a single noc_async_{read,write} for
-// interleaved buffers and shards that fit in one core. Supports both compile-time
-// and runtime tensor-shape TensorAccessors.
+// Split a logical-row transfer across shards when a BLOCK/WIDTH-sharded buffer's row
+// spans multiple cores. Falls through to a single noc_async_{read,write} for interleaved
+// buffers, HEIGHT-sharded RM (whole row stays on one core), and shards whose width covers
+// the full row.
+//
+// dest_id is a logical row index; pages_per_row converts it to the starting page index in
+// the destination buffer. pages_per_row is the last (W) axis of dspec.tensor_shape() after
+// squeeze — equivalent to (and now generalized from) the prior tensor_shape()[1] indexing,
+// which assumed a fully-squeezed 2D dspec and so misread the C dim for 4D NCHW inputs.
 template <typename AddrGenType>
 FORCE_INLINE void noc_async_write_sharded(
     uint32_t l1_addr, AddrGenType tensor, uint32_t dest_id, uint32_t offset, uint32_t size) {
     if constexpr (AddrGenType::DSpec::is_interleaved) {
-        // Interleaved buffers never need a multi-shard split.
-        uint64_t dst_noc_addr = tensor.get_noc_addr(dest_id, offset);
-        noc_async_write(l1_addr, dst_noc_addr, size);
-    } else if constexpr (AddrGenType::DSpec::tensor_shape_static) {
-        if constexpr ((tensor.dspec().rank() > 1) && (tensor.dspec().tensor_shape()[1] > 1)) {
-            constexpr uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
-            const uint32_t page_size = tensor.get_aligned_page_size();
-            uint32_t sharded_dest_id = dest_id * pages_per_shard_width + offset / page_size;
-            uint32_t sharded_offset = offset % page_size;
-            uint32_t num_pages = div_up(size + sharded_offset, page_size);
-            for (uint32_t i = 0; i < num_pages; i++) {
-                uint64_t dst_noc_addr = tensor.get_noc_addr(sharded_dest_id, sharded_offset);
-                uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
-                noc_async_write(l1_addr, dst_noc_addr, write_size);
-                sharded_dest_id++;
-                sharded_offset = 0;
-                l1_addr += write_size;
-            }
-        } else {
-            uint64_t dst_noc_addr = tensor.get_noc_addr(dest_id, offset);
-            noc_async_write(l1_addr, dst_noc_addr, size);
-        }
+        // Interleaved TensorAccessor lacks dspec() — keep this branch inside `if constexpr`
+        // so the sharded path below is never instantiated for the interleaved specialization.
+        noc_async_write(l1_addr, tensor.get_noc_addr(dest_id, offset), size);
     } else {
-        // Runtime tensor shape (ArgConfig::RuntimeTensorShape) — fields are non-constexpr.
-        if (tensor.dspec().rank() > 1 && tensor.dspec().tensor_shape()[1] > 1) {
-            const uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
-            const uint32_t page_size = tensor.get_aligned_page_size();
-            uint32_t sharded_dest_id = dest_id * pages_per_shard_width + offset / page_size;
-            uint32_t sharded_offset = offset % page_size;
-            uint32_t num_pages = div_up(size + sharded_offset, page_size);
-            for (uint32_t i = 0; i < num_pages; i++) {
-                uint64_t dst_noc_addr = tensor.get_noc_addr(sharded_dest_id, sharded_offset);
-                uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
-                noc_async_write(l1_addr, dst_noc_addr, write_size);
-                sharded_dest_id++;
-                sharded_offset = 0;
-                l1_addr += write_size;
-            }
-        } else {
-            uint64_t dst_noc_addr = tensor.get_noc_addr(dest_id, offset);
-            noc_async_write(l1_addr, dst_noc_addr, size);
+        const auto& dspec = tensor.dspec();
+        const uint32_t r = dspec.rank();
+        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
+        if (pages_per_row <= 1) {
+            noc_async_write(l1_addr, tensor.get_noc_addr(dest_id, offset), size);
+            return;
+        }
+        const uint32_t page_size = tensor.get_aligned_page_size();
+        uint32_t sharded_dest_id = dest_id * pages_per_row + offset / page_size;
+        uint32_t sharded_offset = offset % page_size;
+        uint32_t num_pages = div_up(size + sharded_offset, page_size);
+        for (uint32_t i = 0; i < num_pages; i++) {
+            uint64_t dst_noc_addr = tensor.get_noc_addr(sharded_dest_id, sharded_offset);
+            uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
+            noc_async_write(l1_addr, dst_noc_addr, write_size);
+            sharded_dest_id++;
+            sharded_offset = 0;
+            l1_addr += write_size;
         }
     }
 }
@@ -281,46 +267,26 @@ template <typename AddrGenType>
 FORCE_INLINE void noc_async_read_sharded(
     uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size) {
     if constexpr (AddrGenType::DSpec::is_interleaved) {
-        uint64_t src_noc_addr = tensor.get_noc_addr(src_id, offset);
-        noc_async_read(src_noc_addr, l1_addr, size);
-    } else if constexpr (AddrGenType::DSpec::tensor_shape_static) {
-        if constexpr ((tensor.dspec().rank() > 1) && (tensor.dspec().tensor_shape()[1] > 1)) {
-            constexpr uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
-            const uint32_t page_size = tensor.get_aligned_page_size();
-            uint32_t sharded_src_id = src_id * pages_per_shard_width + offset / page_size;
-            uint32_t sharded_offset = offset % page_size;
-            uint32_t num_pages = div_up(size + sharded_offset, page_size);
-            for (uint32_t i = 0; i < num_pages; i++) {
-                uint64_t src_noc_addr = tensor.get_noc_addr(sharded_src_id, sharded_offset);
-                uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
-                noc_async_read(src_noc_addr, l1_addr, read_size);
-                sharded_src_id++;
-                sharded_offset = 0;
-                l1_addr += read_size;
-            }
-        } else {
-            uint64_t src_noc_addr = tensor.get_noc_addr(src_id, offset);
-            noc_async_read(src_noc_addr, l1_addr, size);
-        }
+        noc_async_read(tensor.get_noc_addr(src_id, offset), l1_addr, size);
     } else {
-        // Runtime tensor shape (ArgConfig::RuntimeTensorShape) — fields are non-constexpr.
-        if (tensor.dspec().rank() > 1 && tensor.dspec().tensor_shape()[1] > 1) {
-            const uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
-            const uint32_t page_size = tensor.get_aligned_page_size();
-            uint32_t sharded_src_id = src_id * pages_per_shard_width + offset / page_size;
-            uint32_t sharded_offset = offset % page_size;
-            uint32_t num_pages = div_up(size + sharded_offset, page_size);
-            for (uint32_t i = 0; i < num_pages; i++) {
-                uint64_t src_noc_addr = tensor.get_noc_addr(sharded_src_id, sharded_offset);
-                uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
-                noc_async_read(src_noc_addr, l1_addr, read_size);
-                sharded_src_id++;
-                sharded_offset = 0;
-                l1_addr += read_size;
-            }
-        } else {
-            uint64_t src_noc_addr = tensor.get_noc_addr(src_id, offset);
-            noc_async_read(src_noc_addr, l1_addr, size);
+        const auto& dspec = tensor.dspec();
+        const uint32_t r = dspec.rank();
+        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
+        if (pages_per_row <= 1) {
+            noc_async_read(tensor.get_noc_addr(src_id, offset), l1_addr, size);
+            return;
+        }
+        const uint32_t page_size = tensor.get_aligned_page_size();
+        uint32_t sharded_src_id = src_id * pages_per_row + offset / page_size;
+        uint32_t sharded_offset = offset % page_size;
+        uint32_t num_pages = div_up(size + sharded_offset, page_size);
+        for (uint32_t i = 0; i < num_pages; i++) {
+            uint64_t src_noc_addr = tensor.get_noc_addr(sharded_src_id, sharded_offset);
+            uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
+            noc_async_read(src_noc_addr, l1_addr, read_size);
+            sharded_src_id++;
+            sharded_offset = 0;
+            l1_addr += read_size;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -224,10 +224,18 @@ struct ByteSizeAddressType<Size, typename std::enable_if<Size == 4>::type> {
     typedef uint32_t type;
 };
 
+// Split a logical-page transfer across shards when a BLOCK/WIDTH-sharded RM buffer's
+// row spans multiple cores. Falls through to a single noc_async_{read,write} for
+// interleaved buffers and shards that fit in one core. Supports both compile-time
+// and runtime tensor-shape TensorAccessors.
 template <typename AddrGenType>
 FORCE_INLINE void noc_async_write_sharded(
     uint32_t l1_addr, AddrGenType tensor, uint32_t dest_id, uint32_t offset, uint32_t size) {
-    if constexpr (AddrGenType::DSpec::tensor_shape_static) {
+    if constexpr (AddrGenType::DSpec::is_interleaved) {
+        // Interleaved buffers never need a multi-shard split.
+        uint64_t dst_noc_addr = tensor.get_noc_addr(dest_id, offset);
+        noc_async_write(l1_addr, dst_noc_addr, size);
+    } else if constexpr (AddrGenType::DSpec::tensor_shape_static) {
         if constexpr ((tensor.dspec().rank() > 1) && (tensor.dspec().tensor_shape()[1] > 1)) {
             constexpr uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
             const uint32_t page_size = tensor.get_aligned_page_size();
@@ -247,15 +255,35 @@ FORCE_INLINE void noc_async_write_sharded(
             noc_async_write(l1_addr, dst_noc_addr, size);
         }
     } else {
-        uint64_t dst_noc_addr = tensor.get_noc_addr(dest_id, offset);
-        noc_async_write(l1_addr, dst_noc_addr, size);
+        // Runtime tensor shape (ArgConfig::RuntimeTensorShape) — fields are non-constexpr.
+        if (tensor.dspec().rank() > 1 && tensor.dspec().tensor_shape()[1] > 1) {
+            const uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
+            const uint32_t page_size = tensor.get_aligned_page_size();
+            uint32_t sharded_dest_id = dest_id * pages_per_shard_width + offset / page_size;
+            uint32_t sharded_offset = offset % page_size;
+            uint32_t num_pages = div_up(size + sharded_offset, page_size);
+            for (uint32_t i = 0; i < num_pages; i++) {
+                uint64_t dst_noc_addr = tensor.get_noc_addr(sharded_dest_id, sharded_offset);
+                uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
+                noc_async_write(l1_addr, dst_noc_addr, write_size);
+                sharded_dest_id++;
+                sharded_offset = 0;
+                l1_addr += write_size;
+            }
+        } else {
+            uint64_t dst_noc_addr = tensor.get_noc_addr(dest_id, offset);
+            noc_async_write(l1_addr, dst_noc_addr, size);
+        }
     }
 }
 
 template <typename AddrGenType>
 FORCE_INLINE void noc_async_read_sharded(
     uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size) {
-    if constexpr (AddrGenType::DSpec::tensor_shape_static) {
+    if constexpr (AddrGenType::DSpec::is_interleaved) {
+        uint64_t src_noc_addr = tensor.get_noc_addr(src_id, offset);
+        noc_async_read(src_noc_addr, l1_addr, size);
+    } else if constexpr (AddrGenType::DSpec::tensor_shape_static) {
         if constexpr ((tensor.dspec().rank() > 1) && (tensor.dspec().tensor_shape()[1] > 1)) {
             constexpr uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
             const uint32_t page_size = tensor.get_aligned_page_size();
@@ -275,8 +303,25 @@ FORCE_INLINE void noc_async_read_sharded(
             noc_async_read(src_noc_addr, l1_addr, size);
         }
     } else {
-        uint64_t src_noc_addr = tensor.get_noc_addr(src_id, offset);
-        noc_async_read(src_noc_addr, l1_addr, size);
+        // Runtime tensor shape (ArgConfig::RuntimeTensorShape) — fields are non-constexpr.
+        if (tensor.dspec().rank() > 1 && tensor.dspec().tensor_shape()[1] > 1) {
+            const uint32_t pages_per_shard_width = tensor.dspec().tensor_shape()[1];
+            const uint32_t page_size = tensor.get_aligned_page_size();
+            uint32_t sharded_src_id = src_id * pages_per_shard_width + offset / page_size;
+            uint32_t sharded_offset = offset % page_size;
+            uint32_t num_pages = div_up(size + sharded_offset, page_size);
+            for (uint32_t i = 0; i < num_pages; i++) {
+                uint64_t src_noc_addr = tensor.get_noc_addr(sharded_src_id, sharded_offset);
+                uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
+                noc_async_read(src_noc_addr, l1_addr, read_size);
+                sharded_src_id++;
+                sharded_offset = 0;
+                l1_addr += read_size;
+            }
+        } else {
+            uint64_t src_noc_addr = tensor.get_noc_addr(src_id, offset);
+            noc_async_read(src_noc_addr, l1_addr, size);
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -112,8 +112,6 @@ void kernel_main() {
             uint64_t addr_offset = base_addr_offset + x * X_stride;
             uint64_t src_noc_addr = s0.get_noc_addr(addr_offset, w_offset);
 
-            // TODO(#32019): rows split across BLOCK/WIDTH-sharded cores need
-            // tt::data_movement::common::noc_async_read_sharded instead.
             noc_async_read(src_noc_addr, src_buffer_l1_addr + page_offset, w_read_size_bytes);
 
             // Advance output pointer by one page size for next row

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -112,7 +112,8 @@ void kernel_main() {
             uint64_t addr_offset = base_addr_offset + x * X_stride;
             uint64_t src_noc_addr = s0.get_noc_addr(addr_offset, w_offset);
 
-            // Perform async read of the current line (w_block_len elements) into L1
+            // TODO(#32019): rows split across BLOCK/WIDTH-sharded cores need
+            // tt::data_movement::common::noc_async_read_sharded instead.
             noc_async_read(src_noc_addr, src_buffer_l1_addr + page_offset, w_read_size_bytes);
 
             // Advance output pointer by one page size for next row

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -156,7 +156,8 @@ void kernel_main() {
             // Compute the L1 address from which to write (offset by W-block pages)
             uint32_t l1_addr = transposed_buffer_read_addr + (w - w_start) * output_cb_page_size;
 
-            // Perform an asynchronous write of the X-block to the destination
+            // TODO(#32019): rows split across BLOCK/WIDTH-sharded cores need
+            // tt::data_movement::common::noc_async_write_sharded instead.
             noc_async_write(l1_addr, dst_noc_addr, x_read_size_bytes);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -156,8 +156,6 @@ void kernel_main() {
             // Compute the L1 address from which to write (offset by W-block pages)
             uint32_t l1_addr = transposed_buffer_read_addr + (w - w_start) * output_cb_page_size;
 
-            // TODO(#32019): rows split across BLOCK/WIDTH-sharded cores need
-            // tt::data_movement::common::noc_async_write_sharded instead.
             noc_async_write(l1_addr, dst_noc_addr, x_read_size_bytes);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -53,8 +53,6 @@ void kernel_main() {
         cb.wait_front(1);
         uint32_t l1_read_addr = cb.get_read_ptr();
         uint64_t dst_noc_addr = s0.get_noc_addr(dest_linear_idx);
-        // TODO(#32019): rows split across BLOCK/WIDTH-sharded cores need
-        // tt::data_movement::common::noc_async_write_sharded instead.
         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
         noc_async_write_barrier();
         cb.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -53,6 +53,8 @@ void kernel_main() {
         cb.wait_front(1);
         uint32_t l1_read_addr = cb.get_read_ptr();
         uint64_t dst_noc_addr = s0.get_noc_addr(dest_linear_idx);
+        // TODO(#32019): rows split across BLOCK/WIDTH-sharded cores need
+        // tt::data_movement::common::noc_async_write_sharded instead.
         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
         noc_async_write_barrier();
         cb.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -140,14 +140,17 @@ void kernel_main() {
     unary_op_init_common(cb_in, cb_out_idx);
 
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
-        // Tilize input with activation pattern (Ht rows × Wt tiles)
+        // Tilize input (Ht rows × Wt tiles). Fp32Mode::Lossless keeps the full
+        // Float32 mantissa through tilization; the default Fast mode would
+        // collapse it to tf32 precision before the transpose ever runs.
         compute_kernel_lib::tilize<
             Wt,
             cb_in,
             cb_tilize,
             compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
             compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
-            compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(Ht);
+            compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+            compute_kernel_lib::tilize_config::Fp32Mode::Lossless>(Ht);
 
         // transpose
         cb_tilize_buf.wait_front(HtWt);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -39,7 +39,12 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_pages; ++i) {
         cb.reserve_back(onepage);
 #ifdef CN_RM
-        noc.async_read(s, cb, read_size, {.page_id = page_idx, .offset_bytes = 0}, {.offset_bytes = 0});
+        // Restored native sharded multi-page split (see common.hpp helper).
+        // RM-only: the helper splits a logical "row page" across multiple shards laterally
+        // when the buffer is BLOCK/WIDTH-sharded. TILE-layout path below must keep the
+        // original single-page transfer since each tile is one indivisible NOC unit.
+        const uint32_t cb_write_ptr = cb.get_write_ptr();
+        tt::data_movement::common::noc_async_read_sharded(cb_write_ptr, s, page_idx, 0, read_size);
 #else
         noc.async_read(s, cb, page_size, {.page_id = page_idx}, {.offset_bytes = 0});
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -38,11 +38,13 @@ void kernel_main() {
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
         cb.reserve_back(num_read_per_barrier);
+        const uint32_t cb_write_ptr = cb.get_write_ptr();
         uint32_t l1_write_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
-            noc.async_read(
-                s, cb, stick_size_bytes, {.page_id = i_stick, .offset_bytes = 0}, {.offset_bytes = l1_write_offset});
+            // Restored native sharded multi-page split (see common.hpp helper).
+            tt::data_movement::common::noc_async_read_sharded(
+                cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
             l1_write_offset += stick_size_bytes;
 
             curr_c++;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -36,18 +36,20 @@ void kernel_main() {
     uint32_t i_stick = start_id;
 
     // this reader will read a NHW tensor in NWH order
+    // Uses tt::data_movement::common::noc_async_read_sharded to restore the multi-page
+    // split that BLOCK/WIDTH-sharded RM buffers need (a logical row can span multiple
+    // shards laterally). PR #42130 had replaced these helpers with the
+    // single-NOC-transfer experimental::Noc::async_read primitive, which silently
+    // dropped the split logic for BLOCK/WIDTH-sharded RM inputs (24+ test cases).
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t h = 0; h < Ht; ++h) {
             cb.reserve_back(Wt);
+            const uint32_t cb_write_ptr = cb.get_write_ptr();
             uint32_t l1_write_offset = 0;
             uint32_t H_curr = h == Ht - 1 ? H_per_tile_last : H_per_tile;
             for (uint32_t h_datum = 0; h_datum < H_curr; ++h_datum) {
-                noc.async_read(
-                    s,
-                    cb,
-                    stick_size_bytes,
-                    {.page_id = i_stick, .offset_bytes = 0},
-                    {.offset_bytes = l1_write_offset});
+                tt::data_movement::common::noc_async_read_sharded(
+                    cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
                 l1_write_offset += l1_write_offset_bytes;
                 i_stick += 1;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
@@ -28,11 +28,13 @@ void kernel_main() {
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb.wait_front(onepage);
 #ifdef CN_RM
-        noc.async_write(cb, s, write_size, {.offset_bytes = 0}, {.page_id = i, .offset_bytes = 0});
+        // Restored native sharded multi-page split (see common.hpp helper).
+        // RM-only: see reader kernel for rationale; TILE-layout below uses original API.
+        const uint32_t cb_read_ptr = cb.get_read_ptr();
+        tt::data_movement::common::noc_async_write_sharded(cb_read_ptr, s, i, 0, write_size);
 #else
         noc.async_write(cb, s, page_size, {.offset_bytes = 0}, {.page_id = i});
 #endif
-
         noc.async_write_barrier();
         cb.pop_front(onepage);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -28,11 +28,13 @@ void kernel_main() {
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
         cb.wait_front(num_read_per_barrier);
+        const uint32_t cb_read_ptr = cb.get_read_ptr();
         uint32_t l1_read_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
-            noc.async_write(
-                cb, s, stick_size_bytes, {.offset_bytes = l1_read_offset}, {.page_id = i_stick, .offset_bytes = 0});
+            // Restored native sharded multi-page split (see common.hpp helper).
+            tt::data_movement::common::noc_async_write_sharded(
+                cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
             l1_read_offset += stick_size_bytes;
             i_stick += 1;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -34,15 +34,18 @@ void kernel_main() {
 
     uint32_t i_stick = start_id;
 
+    // Uses tt::data_movement::common::noc_async_write_sharded for BLOCK/WIDTH-sharded
+    // RM outputs (see reader kernel comment). PR #42130 dropped this on the writer side
+    // too, silently regressing the same 24+ test cases for output sharding.
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t w = 0; w < Wt; ++w) {
             cb.wait_front(Ht);
+            const uint32_t cb_read_ptr = cb.get_read_ptr();
             uint32_t l1_read_offset = 0;
             uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
             for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
-                noc.async_write(
-                    cb, s, stick_size_bytes, {.offset_bytes = l1_read_offset}, {.page_id = i_stick, .offset_bytes = 0});
-
+                tt::data_movement::common::noc_async_write_sharded(
+                    cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
                 l1_read_offset += l1_read_offset_bytes;
                 i_stick += 1;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_wh_program_factory.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_wh_program_factory.hpp"
@@ -282,6 +282,9 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (src0_cb_data_format == tt::DataFormat::Float32) {
+        // Keep the source CB in full Float32 on the unpack-to-dest path. In
+        // the row-major kernel, the tile-formatted intermediate (c_24) also
+        // feeds the transpose, so it needs the same treatment.
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         if (row_major) {
             unpack_to_dest_mode[static_cast<std::size_t>(tt::CBIndex::c_24)] =

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -224,6 +224,10 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (src0_cb_data_format == tt::DataFormat::Float32) {
+        // Keep both the tilize input (c_24) and its output (c_25, which feeds
+        // the transpose) in full Float32 on the unpack-to-dest path; otherwise
+        // the unpacker falls back to tf32 and drops the low mantissa bits.
+        unpack_to_dest_mode[in_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode[im_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -175,14 +175,6 @@ ttnn::Tensor transpose_nd(
     return ttnn::permute(input_tensor, permutation, memory_config_arg, pad_value);
 }
 
-// Composite-fallback guard: RM + BLOCK/WIDTH sharded I/O is reshard-hopped through L1 interleaved
-// because pages span cores and local readers/writers would race. (RM HEIGHT_SHARDED is handled by
-// is_native_transpose_sharding via the interleaved TensorAccessor path — pages stay on one core.)
-inline bool is_block_or_width_sharded_mc(const tt::tt_metal::MemoryConfig& mc) {
-    return mc.is_sharded() && (mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
-                               mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
-}
-
 }  // namespace detail
 
 ttnn::Tensor transpose_impl(
@@ -191,32 +183,6 @@ ttnn::Tensor transpose_impl(
     int64_t dim2,
     const std::optional<MemoryConfig>& memory_config_arg,
     float pad_value = 0.0f) {
-    {
-        const bool rm = input_tensor.layout() == Layout::ROW_MAJOR;
-        const bool in_bad = rm && detail::is_block_or_width_sharded_mc(input_tensor.memory_config());
-        const bool out_bad =
-            rm && memory_config_arg.has_value() && detail::is_block_or_width_sharded_mc(memory_config_arg.value());
-        if (in_bad || out_bad) {
-            const auto interleaved_l1 =
-                tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
-            Tensor x = in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
-            const std::optional<MemoryConfig> intermediate_mc =
-                out_bad ? std::optional<MemoryConfig>(interleaved_l1) : memory_config_arg;
-            Tensor result = transpose_impl(x, dim1, dim2, intermediate_mc, pad_value);
-            if (out_bad) {
-                // Synthesize a shard_spec for shard-spec-less sharded outputs so to_memory_config
-                // gets a fully-specified destination.
-                MemoryConfig final_mc = memory_config_arg.value();
-                if (!final_mc.shard_spec().has_value()) {
-                    auto shard_spec = operations::data_movement::transpose::generate_transpose_shard_spec(
-                        result, result.padded_shape(), final_mc.memory_layout());
-                    final_mc = final_mc.with_shard_spec(shard_spec);
-                }
-                result = ttnn::to_memory_config(result, final_mc, std::nullopt);
-            }
-            return result;
-        }
-    }
     const auto& input_shape = input_tensor.logical_shape();
     uint32_t normalized_dim1 = input_shape.get_normalized_index(dim1);
     uint32_t normalized_dim2 = input_shape.get_normalized_index(dim2);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -175,6 +175,11 @@ ttnn::Tensor transpose_nd(
     return ttnn::permute(input_tensor, permutation, memory_config_arg, pad_value);
 }
 
+inline bool is_block_or_width_sharded_mc(const tt::tt_metal::MemoryConfig& mc) {
+    return mc.is_sharded() && (mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+                               mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+}
+
 }  // namespace detail
 
 ttnn::Tensor transpose_impl(
@@ -183,6 +188,43 @@ ttnn::Tensor transpose_impl(
     int64_t dim2,
     const std::optional<MemoryConfig>& memory_config_arg,
     float pad_value = 0.0f) {
+    {
+        // Two temporary L1-interleaved hops for RM + BLOCK/WIDTH-sharded endpoints:
+        //   out_bad (interleaved → sharded): permute writer can't split a row across shards
+        //                                    (#32019). Remove once permute handles sharded RM
+        //                                    outputs.
+        //   in_bad  (sharded → anything, irregular only): noc_async_*_sharded helpers misread
+        //                                                 pages_per_shard for irregular RM
+        //                                                 geometries → data corruption. Regular
+        //                                                 shapes go native. Remove once the
+        //                                                 sharded helpers handle irregular RM.
+        const bool rm = input_tensor.layout() == Layout::ROW_MAJOR;
+        const bool in_sharded = detail::is_block_or_width_sharded_mc(input_tensor.memory_config());
+        const auto& input_logical = input_tensor.logical_shape();
+        const bool irregular_hw = input_logical.rank() >= 2 && (input_logical[-1] % tt::constants::TILE_WIDTH != 0 ||
+                                                                input_logical[-2] % tt::constants::TILE_HEIGHT != 0);
+        const bool in_bad = rm && in_sharded && irregular_hw;
+        const bool out_bad = rm && !in_sharded && memory_config_arg.has_value() &&
+                             detail::is_block_or_width_sharded_mc(memory_config_arg.value());
+        if (in_bad || out_bad) {
+            const auto interleaved_l1 =
+                tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+            Tensor x = in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
+            const std::optional<MemoryConfig> intermediate_mc =
+                out_bad ? std::optional<MemoryConfig>(interleaved_l1) : memory_config_arg;
+            Tensor result = transpose_impl(x, dim1, dim2, intermediate_mc, pad_value);
+            if (out_bad) {
+                MemoryConfig final_mc = memory_config_arg.value();
+                if (!final_mc.shard_spec().has_value()) {
+                    auto shard_spec = operations::data_movement::transpose::generate_transpose_shard_spec(
+                        result, result.padded_shape(), final_mc.memory_layout());
+                    final_mc = final_mc.with_shard_spec(shard_spec);
+                }
+                result = ttnn::to_memory_config(result, final_mc, std::nullopt);
+            }
+            return result;
+        }
+    }
     const auto& input_shape = input_tensor.logical_shape();
     uint32_t normalized_dim1 = input_shape.get_normalized_index(dim1);
     uint32_t normalized_dim2 = input_shape.get_normalized_index(dim2);


### PR DESCRIPTION
### Ticket
Link to GitHub Issue #41662

### Problem
`ttnn::transpose` produced numerically corrupt outputs (PCC ≈ 0) for **FP32, ROW_MAJOR + sharded** 4D inputs after a chain of changes to the transpose/permute stack and the LLK. Root cause was a combination of host-side mis-configuration, an LLK rewrite (now fixed upstream), and dropped data-movement helpers. See timeline below.

In addition, two RM + BLOCK/WIDTH-sharded correctness gaps that pre-date this PR also surface once FP32 starts running:
- `ttnn::prim::permute`'s writer can't split a logical row across shards (#32019), so `interleaved RM → BLOCK/WIDTH-sharded RM` corrupts at the writer.
- The native sharded data-movement helpers (`noc_async_*_sharded`) misread `pages_per_shard` for **irregular** RM geometries (e.g. `(1, 1, 65, 97)`), producing `ULP=inf` data corruption inside the kernel itself.

### Timeline of PRs that shaped this bug

| # | Date | PR | What it did | Effect |
|---|------|----|-------------|--------|
| 1 | Feb 27 | **#37362** (Ilia) | Added native sharded RM transpose. Introduced the `noc_async_*_sharded` helpers with multi-page splitting for BLOCK/WIDTH-sharded RM buffers. | Baseline — FP32 + RM + sharded worked end-to-end. |
| 2 | Mar 18 | **#39294** | Tilize/Untilize helpers integration — replaced the manual `tilize_init`/`tilize_block`/`tilize_uninit` calls in `transpose_wh_rm.cpp` with `compute_kernel_lib::tilize<>()`. Default template param is `Fp32Mode::Fast` (lossy bf16-class precision). | Latent — `Fp32Mode::Fast` didn't yet visibly regress at this LLK pin, but the silent lossy default became a trap. |
| 3 | Apr 02 | **#41007** | Extended `ttnn.sort` for FP32. Side-effects in the transpose factory: (a) added `c_24 = UnpackToDestFp32` in the RM branch even though `ttnn.sort` itself runs in TILE; (b) added an `enable_unpack_to_dest` gate that promoted FP32 from the legacy unpack-time transpose to the dest-resident transpose path. | First commit where FP32 + RM + WH tests go red — `c_24` mis-flag + lossy default tilize collide. |
| 4 | Apr 02 | **#41199** (LLK pin bump) | Bumped the LLK submodule pin (later vendored in-tree by #41932). The new pin rewrote the `is_32bit` branch of `_llk_math_transpose_dest_` to a MOVB2A/MOVD2B/TRNSPSRCB sequence, correct for INT32, broken for FP32. | Same-day partner of #41007 — explains why a tt-metal-only host fix is necessary but not sufficient on `main` (Bug A.2). |
| 5 | Apr 13 | **#41615** | Added `pytest.skip("…/issues/41662")` at the top of `test_transpose_sharded` so CI would stay green while a real fix was investigated. | Hid the regression from CI for the next ~9 months and inadvertently masked all subsequent regressions in the same test. |
| 6 | Apr 21 | **#42130** | Ported transpose/permute kernels to the device-2.0 API. **Dropped** the calls to `noc_async_*_sharded` from 6 RM kernels. | Silently regressed BLOCK/WIDTH-sharded RM data movement (orthogonal to #41662). Invisible because of #41615's blanket skip. |
| 7 | May 08 | **#42155** | Universal input support for transpose. Added the `is_block_or_width_sharded_mc` composite fallback that reshards BLOCK/WIDTH RM cases through L1 interleaved. | Masked #42130's regression. Didn't touch #41615's skip. |
| 8 | May 19 | **#43757** (amahmudTT) | "Remove dependency on debug bit 11 for transpose_dest" — replaced the broken `is_32bit` branch of `_llk_math_transpose_dest_` with a new `transpose_dest_32b<>` helper that uses SrcA format-switching (`Float16_b` → `Tf32` → `Float32`), making the 32-bit DEST transpose FP32-safe unconditionally. Also enabled Float32 coverage with exact-equality assertions in `test_zzz_transpose_dest.py`. | ✅ Closes Bug A.2 upstream. Earlier revisions of this PR carried a parallel branch-local LLK fix (`is_fp32` template param plumbed through `transpose_wh.h` → LLK); after rebasing onto a `main` that contains #43757 that plumbing is no longer needed and has been dropped from this PR. |

Two bug families fall out of that timeline:
- **A — FP32 RM WH compute corruption** (#41662): host-side mis-flag + lossy tilize default (PR #41007 + #39294) on top of an LLK rewrite (PR #41199). **A.1** (host-side) is fixed in this PR via Fix A (drop `c_24` mis-flag handling) + Fix C (`Fp32Mode::Lossless`). **A.2** (LLK rewrite) is fixed upstream by PR #43757; nothing LLK-side ships in this PR.
- **B — BLOCK/WIDTH-sharded RM data movement** (#42130): the helpers and their multi-page-split logic were stripped; this PR restores them so regular BLOCK/WIDTH RM goes native, and routes the irregular-shape residue through a narrow temporary fallback (see `in_bad` below) pending a kernel-side follow-up.

### Silent-drop behaviour pre-fix

Before this PR, when a caller asked for `interleaved RM input → BLOCK/WIDTH-sharded RM output` **without supplying a shard_spec**, the old `transpose.cpp` quietly downgraded the request: `output_mem_constructed = a.memory_config()` produced an *interleaved* output, the user's BLOCK/WIDTH layout was discarded, and the assertion-blind PCC against torch still came out clean. The native sharded writer was never exercised by that input pattern, so the kernel-side bug stayed hidden. This PR keeps the user's requested layout and routes through a temporary L1-interleaved fallback to deliver the correct output **in the requested memory layout**. The fallback goes away once `ttnn::prim::permute` gains universal I/O (sharded RM outputs with cross-shard row-splitting, #32019).

### What this PR does

- **Host-side compute-kernel fixes for Bug A.1.** `transpose_wh_rm.cpp` now sets `Fp32Mode::Lossless` for the in-DEST WH transpose (Fix C); `transpose_wh_program_factory.cpp` and `transpose_wh_sharded_rm_program_factory.cpp` mark both the source CB and the `c_24` intermediate as `UnpackToDestFp32` when running with FP32 inputs (Fix A). No LLK changes — Bug A.2 is closed upstream by PR #43757.
- **`noc_async_*_sharded` helper fix.** Refactored the helpers in `ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp` to (1) gate the sharded multi-page split inside `if constexpr (!DSpec::is_interleaved)` so the interleaved `TensorAccessor` specialization no longer fails to compile, and (2) compute `pages_per_row` from `dspec.tensor_shape()[r - 1]` (the W axis, regardless of rank) so 4D NCHW shapes index the right dim. Regular RM BLOCK/WIDTH-sharded inputs now flow through the native path.
- **Host-side synth fix (`derive_effective_output_memory_config`).** When the device op has to synthesize an output shard spec (sharded output requested without a spec), `generate_transpose_shard_spec` is now fed the OUTPUT's logical shape (TILE-rounded for TILE layout) instead of `transposed_shapes().padded`. The padded variant silently inherits the INPUT's shard-width rounding (e.g. RM input shard_width=25 → input padded W=100 for logical W=97), which leaks into the output and produces a shard whose height doesn't match the output's actual physical height (the `Shard height 100 must match physical height 97` class of `TT_FATAL`s). Using the logical shape makes the synthesized spec consistent with the `(logical, default-alignment)` math `TensorSpec` runs downstream. This change is permanent.
- **Composite-fallback guard (narrowed).** Reintroduced a small RM-only guard in `transpose.cpp` that hops through L1 interleaved + reshard for the two known-broken RM + BLOCK/WIDTH-sharded cases:
  - **`out_bad`** — `interleaved RM input → BLOCK/WIDTH-sharded RM output`: unconditional fallback. Permute writer can't split rows across shards (#32019). **Remove once `ttnn::prim::permute` supports universal I/O.**
  - **`in_bad`** — `BLOCK/WIDTH-sharded RM input → anything`, gated on `irregular_hw` (input's `logical[-1]` or `logical[-2]` not a tile multiple): falls back **only** for irregular geometries. Regular shapes go fully native through the restored `noc_async_*_sharded` helpers. The irregular-geometry path still hits a kernel-side `pages_per_shard` misread that produces `ULP=inf` data corruption. **Remove once the `noc_async_*_sharded` helpers handle irregular RM (the kernel-side follow-up).**
- **Output-spec helpers promoted out of the anonymous namespace.** `transposed_shapes`, `adjust_shard_spec_to_shape`, `generate_transpose_shard_spec`, and `derive_effective_output_memory_config` now live in `transpose_utils.{hpp,cpp}` so the device op (`select_program_factory` / `compute_output_specs`) and the `transpose.cpp` fallback guard share the same shape arithmetic. Removed the earlier `native_transpose_can_produce_valid_output_spec` validator (it disagreed with the device-op path because of a stale seed and masked both the host-side TT_FATAL family — now fixed by the synth change above — and the kernel-side `pages_per_shard` data corruption, still gated by `irregular_hw`).
- **Permute TODO breadcrumbs.** Added 3-line `TODO(#32019)` comments next to the `noc_async_read`/`noc_async_write` call sites in `reader_permute_interleaved_rm_blocked_generic.cpp`, `writer_permute_interleaved_rm_blocked_generic.cpp`, and `writer_permute_interleaved_rm_row_invariant.cpp` so the next person to look at permute knows where the cross-shard split needs to land.
- **Tests.** Removed `#41662`-scoped `pytest.skip` markers for cases the fix now passes; dropped the dead `#32019`-scoped xfail block in `test_transpose_universal_io_row_major` (those cases now pass via the narrowed fallback). Existing `test_transpose_irregular_shapes_sharded` continues to cover the irregular-shape path (now via `in_bad` fallback for RM block/width).

### Routing summary (post-fix, RM only — TILE inputs always go native)

| Input | Output | Shape | Path |
|-------|--------|-------|------|
| interleaved | interleaved / HEIGHT-sharded | any | native |
| interleaved | BLOCK / WIDTH-sharded | any | **fallback** (`out_bad`, permute writer #32019) |
| HEIGHT-sharded | any | any | native |
| BLOCK / WIDTH-sharded | any | **regular** (last-2 dims tile-aligned) | **native** (regular flow via restored `noc_async_*_sharded`) |
| BLOCK / WIDTH-sharded | any | **irregular** (last-2 dims not tile-aligned) | **fallback** (`in_bad`, kernel `pages_per_shard` misread) |

### Verification (local, full clean build on WH N150)

- `test_transpose_sharded[float32-*-rm-wh]` (the canonical #41662 regression, 4 cases) — **4 / 4 PASS, PCC = 1.0, ATOL = 0.0**.
- Full `test_transpose_sharded` (96 cases) — **80 passed / 16 skipped (legit: bfloat8_b restrictions) / 0 fail** — identical numbers to the PR #37362 (Feb 2026) baseline.
- Full `test_transpose_universal_io.py` (141 cases) — **139 passed / 2 skipped (legit) / 0 fail**, including all 52 irregular-shape sub-tests.

### Notes for Reviewers

- Both fallback arms are *temporary* and tagged in the inline comment with their exit conditions:
  - `out_bad` — removed when `ttnn::prim::permute` supports universal I/O for sharded RM outputs (#32019).
  - `in_bad` — removed when `noc_async_*_sharded` correctly handles irregular RM geometries (kernel-side follow-up).
- The `irregular_hw` gate (`logical[-1] % TILE_WIDTH != 0 || logical[-2] % TILE_HEIGHT != 0`) is the minimum-surface guard: every irregular case in `test_transpose_irregular_shapes_sharded` hits it; every regular RM block/width case in `test_transpose_universal_io_row_major` skips it and goes native (verified — `WH_RM_block_to_block`, `WH_RM_block_to_interleaved`, `WH_RM_width_to_interleaved`, etc. all pass without entering the fallback).
- Permute-side fixes and the kernel-side `noc_async_*_sharded` irregular-shape fix are intentionally **not** included here. The fallback is the right unblock for transpose; permute and the kernel helper will each get their own pass. The 3 TODO breadcrumbs in the permute writers point at #32019.
- The full investigation log (per-PR genealogy, empirical bisect tables, LLK pin walk for Bug A.2, the PR #43757 resolution) lives in [this doc](https://docs.google.com/document/d/12PqkcunOWSXofLfDs_s7Ev-yaZX_KzpmYq-VNueH_P4/edit?usp=sharing) for reviewers who want the long form.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/transpose_fp32_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/transpose_fp32_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/transpose_fp32_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/transpose_fp32_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/transpose_fp32_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/transpose_fp32_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/transpose_fp32_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/transpose_fp32_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/transpose_fp32_bug)
