### PR TITLE
Re-enabling Real Time Profiler Tests

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -20,6 +20,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -109,9 +110,13 @@ void enqueue_sanity_program(
 }
 
 TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
-    // Skipped due to issue #44657: real-time profiler is disabled by default
-    // (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
-    GTEST_SKIP() << "Real-time profiler disabled by default — see issue #44657";
+    // Flip the RT-profiler kill switch on for this test (see issue #44657:
+    // RT profiler is gated off by default). The env var is consumed by a
+    // function-local static in MeshDeviceImpl::init_realtime_profiler_socket
+    // on first call, so this setenv only takes effect if no earlier test in
+    // the process has already opened a mesh device. In that fallback case
+    // the IsProgramRealtimeProfilerActive() check below will skip cleanly.
+    setenv("TT_METAL_ENABLE_REALTIME_PROFILER", "1", /*overwrite=*/1);
     constexpr int kDeviceId = 0;
 
     auto mesh_device = distributed::MeshDevice::create_unit_mesh(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -147,9 +148,13 @@ distributed::MeshWorkload build_blank_kernel_workload(const std::shared_ptr<dist
 }
 
 TEST(RealtimeProfilerStress, RingBufferOverflowFromTrace) {
-    // Skipped due to issue #44657: real-time profiler is disabled by default
-    // (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
-    GTEST_SKIP() << "Real-time profiler disabled by default — see issue #44657";
+    // Flip the RT-profiler kill switch on for this test (see issue #44657:
+    // RT profiler is gated off by default). The env var is consumed by a
+    // function-local static in MeshDeviceImpl::init_realtime_profiler_socket
+    // on first call, so this setenv only takes effect if no earlier test in
+    // the process has already opened a mesh device. In that fallback case
+    // the IsProgramRealtimeProfilerActive() check below will skip cleanly.
+    setenv("TT_METAL_ENABLE_REALTIME_PROFILER", "1", /*overwrite=*/1);
     constexpr int kDeviceId = 0;
 
     auto mesh_device = distributed::MeshDevice::create_unit_mesh(

--- a/tests/ttnn/tracy/test_realtime_profiler.py
+++ b/tests/ttnn/tracy/test_realtime_profiler.py
@@ -49,9 +49,14 @@ from pathlib import Path
 import pytest
 
 
-# Skipped due to issue #44657: real-time profiler is disabled by default
-# (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
-pytestmark = pytest.mark.skip(reason="Real-time profiler disabled by default — see issue #44657")
+# Flip the RT-profiler kill switch on for every subprocess workload spawned by
+# this module (see issue #44657: RT profiler is gated off by default). All
+# device-touching work runs in subprocesses that inherit env via
+# ``dict(os.environ)``, so setting it at module load time propagates into
+# every workload. Each subprocess is fresh, so the function-local static
+# in MeshDeviceImpl::init_realtime_profiler_socket sees a clean slate and
+# picks up this env var on its first mesh-device open.
+os.environ["TT_METAL_ENABLE_REALTIME_PROFILER"] = "1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### PR Category
Feature

Re-enabling Real Time Profiler tests on CI while issue https://github.com/tenstorrent/tt-metal/issues/44657 is worked on.
- [x] [Sanity Test](https://github.com/tenstorrent/tt-metal/actions/runs/26111468702)

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/re_enabling_rt_profiler_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/re_enabling_rt_profiler_tests)