### PR TITLE
Performance: Integrate `deepseek_moe_fast_reduce_nc_fused` into model

### DIFF
--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py
@@ -1,0 +1,646 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit test for deepseek_moe_fast_reduce_nc_fused — a single fused kernel that
+replaces the four-op chain:
+    permute(scores, (3,1,0,2)) → to_layout(TILE) → mul(activation, scores)
+    → deepseek_moe_fast_reduce_nc
+
+Runs on a single Tenstorrent device. Emulates the 16×8 mesh (128 devices)
+by 128 sequential iterations (same pattern as test_deepseek_moe_fast_reduce_nc_single.py).
+"""
+
+import random
+
+import pytest
+import torch
+from loguru import logger
+from tracy import signpost
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.perf.benchmarking_utils import BenchmarkProfiler
+
+
+def _bf16_to_float(bf16):
+    """Convert a torch.bfloat16 scalar or tensor to float32 using numpy reinterpretation"""
+    import numpy as np
+
+    if isinstance(bf16, float):
+        return float(bf16)
+    # Convert torch tensor to numpy uint16, upcast to uint32 << 16
+    arr = bf16.detach().cpu().numpy().astype(np.uint16)
+    arr32 = arr.astype(np.uint32) << 16
+    return arr32.view(np.float32)
+
+
+def _torch_golden_scale_and_fast_reduce_nc(
+    torch_unsqueezed_global,
+    torch_expert_scores_global,
+    *,
+    num_replicated_devices,
+):
+    """Reference: permute + broadcast mul + split-width sum along expert dim (dim 0)."""
+    topk_experts_weights = torch_expert_scores_global.permute(3, 1, 0, 2)
+    scaled = torch_unsqueezed_global * topk_experts_weights
+    hidden_size = scaled.shape[-1]
+    split_size = hidden_size // num_replicated_devices
+    assert hidden_size % split_size == 0
+    num_chunks = hidden_size // split_size
+    goldens = []
+    for i in range(num_chunks):
+        chunk = scaled[:, :, :, i * split_size : (i + 1) * split_size]
+        goldens.append(chunk.sum(dim=0, keepdim=True))
+    return goldens
+
+
+def _gen_expert_mapping_linearized(experts, num_devices):
+    """Convention-B mapping: shape [1, experts], cell value = linearized device id owning that expert.
+
+    Distributes experts evenly across devices in contiguous blocks (device d owns
+    [d*E, (d+1)*E) where E = experts/num_devices). Matches the format
+    `MoEOptimized.create_shared_state` constructs (pre-`map_shared_experts`).
+    The one-hot variant from `tests/nightly/t3000/ccl/test_all_to_all_dispatch.py:gen_expert_mapping`
+    is intentionally not used — this op expects the linearized-device-id encoding.
+    """
+    assert experts % num_devices == 0
+    experts_per_device = experts // num_devices
+    mapping = torch.empty((1, experts), dtype=torch.int32)
+    for e in range(experts):
+        mapping[0, e] = e // experts_per_device
+    return mapping
+
+
+def _get_expert_indices(batch, experts, selected_experts_k, seq_len):
+    """Per-token random distinct expert ids. Shape [batch, 1, seq_len, k], int32.
+
+    Trimmed from the `random` scheme of
+    `tests/nightly/t3000/ccl/test_all_to_all_dispatch.py:get_expert_indices`
+    (dropped the avg_perf / worst_perf / congestion variants that aren't relevant here).
+    """
+    indices = torch.empty((batch, 1, seq_len, selected_experts_k), dtype=torch.int32)
+    for b in range(batch):
+        for s in range(seq_len):
+            picks = random.sample(range(experts), selected_experts_k)
+            for k, e in enumerate(picks):
+                indices[b, 0, s, k] = e
+    return indices
+
+
+def _on_axis_mask(indices_local, mapping, mesh_shape, mesh_coord, cluster_axis):
+    """Per (token, k) bool mask: True iff the expert routed for that slot lives on this device's
+    cluster axis. Matches the kernel's compute_on_axis(t, k) predicate.
+
+    Args:
+        indices_local: [tokens, 1, seq, k] int — this device's slice of expert_indices.
+        mapping:       [1, experts] int — global expert→owning-device map (linearized).
+        mesh_shape:    (rows, cols) of the emulated mesh.
+        mesh_coord:    (row, col) of the device we're emulating.
+        cluster_axis:  0 ⇒ cluster is a column; 1 ⇒ cluster is a row.
+    """
+    owner_device = mapping[0, indices_local.long()]  # [tokens, 1, seq, k]
+    owner_row = owner_device // mesh_shape[1]
+    owner_col = owner_device % mesh_shape[1]
+    if cluster_axis == 0:
+        return owner_col == mesh_coord[1]
+    return owner_row == mesh_coord[0]
+
+
+def _torch_golden_gated(
+    u_local,
+    s_local,
+    ind_local,
+    mapping,
+    mesh_shape,
+    mesh_coord,
+    cluster_axis,
+    num_replicated_devices,
+    num_shared_experts,
+    shared_expert_scale_bf16,
+):
+    """Per-device golden with shared-expert support.
+
+    Activation layout: ``u_local`` has effective_k = select_experts_k + num_shared_experts entries
+    along the reduction dim (dim 0). The first select_experts_k are routed experts (multiplied by
+    on-axis-gated scores); the trailing num_shared_experts are shared experts (multiplied by a
+    constant BF16 scale, no per-token gating — matches the kernel which writes
+    shared_expert_scale_bf16 unconditionally into those score-tile slots).
+    """
+    select_experts_k = s_local.shape[-1]
+    effective_k = u_local.shape[0]
+    assert effective_k == select_experts_k + num_shared_experts
+
+    # Routed contribution: gate off-axis scores to zero, then permute/mul/split-sum.
+    on_axis = _on_axis_mask(ind_local, mapping, mesh_shape, mesh_coord, cluster_axis)
+    gated_scores = torch.where(on_axis, s_local, torch.zeros_like(s_local))
+    routed_u = u_local[:select_experts_k]
+    routed_weights = gated_scores.permute(3, 1, 0, 2)
+    routed_scaled = routed_u * routed_weights
+
+    # Shared-expert contribution: constant BF16 scale, no per-token gating.
+    shared_u = u_local[select_experts_k:]
+    shared_scaled = shared_u * shared_expert_scale_bf16
+
+    scaled = torch.cat([routed_scaled, shared_scaled], dim=0)
+    hidden_size = scaled.shape[-1]
+    split_size = hidden_size // num_replicated_devices
+    assert hidden_size % split_size == 0
+    num_chunks = hidden_size // split_size
+    return [scaled[:, :, :, i * split_size : (i + 1) * split_size].sum(dim=0, keepdim=True) for i in range(num_chunks)]
+
+
+PCC_THRESHOLD = 0.999
+
+
+@pytest.mark.parametrize(
+    "num_shared_experts, shared_expert_scale",
+    [
+        pytest.param(0, 1.0, id="no_shared"),
+        pytest.param(1, 0.5, id="1_shared_scale_0p5"),
+        pytest.param(2, 0.25, id="2_shared_scale_0p25"),
+    ],
+)
+@pytest.mark.parametrize("batch_per_device", [32, 8, 3, 1])
+@pytest.mark.parametrize("select_experts_k", [8])
+@pytest.mark.parametrize("seq", [1])
+@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.parametrize("experts_per_device", [2])
+@pytest.mark.parametrize(
+    "mesh_shape, mesh_device",
+    [
+        pytest.param((4, 8), (4, 8), id="16x8_grid"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+def test_deepseek_moe_fast_reduce_nc_fused(
+    mesh_device,
+    mesh_shape,
+    batch_per_device,
+    select_experts_k,
+    seq,
+    hidden_size,
+    experts_per_device,
+    cluster_axis,
+    num_shared_experts,
+    shared_expert_scale,
+):
+    torch.manual_seed(2005)
+    random.seed(2005)
+
+    num_devices = mesh_shape[0] * mesh_shape[1]
+    num_dispatch_devices = mesh_shape[cluster_axis]
+    num_replicated_devices = mesh_shape[1 - cluster_axis]
+    batch = batch_per_device * num_dispatch_devices
+    experts = experts_per_device * num_devices
+
+    # Activation's reduction dim covers routed experts + trailing shared-expert slots.
+    # The kernel treats indices [select_experts_k, effective_select_experts_k) as shared experts,
+    # multiplying those activation slices by ``shared_expert_scale_bf16`` (no per-token gating).
+    effective_select_experts_k = select_experts_k + num_shared_experts
+    # Pre-quantize the scale through BF16 so the golden mirrors the kernel's BF16 storage.
+    shared_expert_scale_bf16 = torch.tensor(shared_expert_scale, dtype=torch.bfloat16)
+
+    # Memory configs (identical to test_deepseek_moe_fast_reduce_nc_single.py)
+    activation_memory_config = ttnn.L1_MEMORY_CONFIG
+
+    fast_reduce_output_memory_config = ttnn.MemoryConfig(
+        ttnn.BufferType.L1,
+        ttnn.NdShardSpec(
+            ttnn.Shape([1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                ]
+            ),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+        ),
+    )
+
+    replicate_mapper = ttnn.replicate_tensor_to_mesh_mapper(mesh_device)
+
+    # Global tensors. Activation reduction dim now spans routed + shared expert slots.
+    torch_unsqueezed_global = (
+        torch.rand((effective_select_experts_k, 1, batch, hidden_size), dtype=torch.bfloat16) - 0.5
+    )
+
+    # Scores tensor only carries the routed scores; the kernel synthesizes shared-expert "scores"
+    torch_expert_scores_global = torch.rand((batch, 1, seq, select_experts_k), dtype=torch.bfloat16)
+
+    torch_expert_scores_global = torch_expert_scores_global / torch_expert_scores_global.sum(dim=-1, keepdim=True)
+
+    # New: per-token expert routing + global expert→owning-device map.
+    torch_expert_indices_global = _get_expert_indices(batch, experts, select_experts_k, seq)
+    torch_expert_mapping = _gen_expert_mapping_linearized(experts, num_devices)
+
+    per_device_goldens = []
+    for m0 in range(mesh_shape[0]):
+        for m1 in range(mesh_shape[1]):
+            mesh_coord = (m0, m1)
+
+            t0 = (m1 if cluster_axis == 1 else m0) * batch_per_device
+            t1 = t0 + batch_per_device
+
+            u_slice = torch_unsqueezed_global[:, :, t0:t1, :].contiguous()
+            s_slice = torch_expert_scores_global[t0:t1, :, :, :].contiguous()
+            ind_slice = torch_expert_indices_global[t0:t1, :, :, :].contiguous()
+
+            # Per-device golden — gated routed contribution + constant-scale shared contribution.
+            per_device_goldens.append(
+                _torch_golden_gated(
+                    u_slice,
+                    s_slice,
+                    ind_slice,
+                    torch_expert_mapping,
+                    mesh_shape,
+                    mesh_coord,
+                    cluster_axis,
+                    num_replicated_devices,
+                    num_shared_experts,
+                    shared_expert_scale_bf16,
+                )
+            )
+
+    def _shard_dims(dim):
+        return (dim, None) if cluster_axis == 0 else (None, dim)
+
+    # Activation: TILE layout, L1 — same as unsqueezed_output in unfused path
+    tt_activation = ttnn.from_torch(
+        torch_unsqueezed_global,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=activation_memory_config,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape, dims=_shard_dims(2)),
+    )
+
+    # Scores: ROW_MAJOR layout, DRAM — passed directly (no permute/tilize in Python)
+    tt_scores_dram = ttnn.from_torch(
+        torch_expert_scores_global,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape, dims=_shard_dims(0)),
+    )
+
+    # New: expert_indices and expert_mapping — uint16, ROW_MAJOR, DRAM, replicated.
+    tt_expert_indices = ttnn.from_torch(
+        torch_expert_indices_global,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape, dims=_shard_dims(0)),
+    )
+    tt_expert_mapping = ttnn.from_torch(
+        torch_expert_mapping,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=replicate_mapper,
+    )
+
+    # Single fused call replacing permute + to_layout + mul + deepseek_moe_fast_reduce_nc.
+    # Performs per-(t, k) on-axis gating using the expert_indices / expert_mapping tensors and
+    # cluster_axis (off-axis scores are zeroed). The trailing ``num_shared_experts`` slots along
+    # the activation's reduction dim are multiplied by ``shared_expert_scale`` (no gating) and
+    # summed into the output.
+    tt_fused_outputs = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+        tt_activation,
+        tt_expert_indices,
+        tt_expert_mapping,
+        reduce_dim=0,
+        split_size=int(hidden_size // num_replicated_devices),
+        cluster_axis=cluster_axis,
+        output_memory_config=fast_reduce_output_memory_config,
+        scores_tensor=tt_scores_dram,
+        num_shared_experts=num_shared_experts,
+        shared_expert_scale=shared_expert_scale,
+    )
+
+    for cidx, tt_out_list in enumerate(tt_fused_outputs):
+        for didx, tt_out in enumerate(ttnn.get_device_tensors(tt_out_list)):
+            tt_host = ttnn.to_torch(tt_out, dtype=torch.bfloat16)
+
+            ref = per_device_goldens[didx][cidx]
+
+            ok, msg = comp_pcc(ref, tt_host, pcc=PCC_THRESHOLD)
+            logger.info(f"virtual_dev={didx} mesh_coord={mesh_coord} chunk={cidx}: {msg}")
+            assert ok, f"virtual_dev={didx} mesh_coord={mesh_coord} chunk={cidx} failed: {msg}"
+
+    ttnn.deallocate(tt_activation)
+    ttnn.deallocate(tt_scores_dram)
+    ttnn.deallocate(tt_expert_indices)
+    ttnn.deallocate(tt_expert_mapping)
+    for t in tt_fused_outputs:
+        ttnn.deallocate(t)
+
+
+def _run_op_with_trace(num_iters, op_func, mesh_device, profiler, label):
+    """Compile + warmup-trace + perf-trace runner.
+
+    Mirrors the pattern in tests/nightly/tg/ccl/moe/test_selective_combine_6U.py:
+    1. one eager compile call so program-cache is populated;
+    2. a warmup trace of ``num_iters // 4`` iterations whose execution time is subtracted from
+       the perf-trace execution time (removes fixed trace-launch overhead);
+    3. the full-length perf trace, measured via ``BenchmarkProfiler``.
+    """
+    logger.info(f"{label}: compile run")
+    op_func(1)
+    ttnn.synchronize_device(mesh_device)
+
+    warmup_iters = max(1, num_iters // 4)
+    logger.info(f"{label}: capturing warmup trace ({warmup_iters} iters)")
+    trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    op_func(warmup_iters)
+    ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    logger.info(f"{label}: capturing perf trace ({num_iters} iters)")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    tt_out = op_func(num_iters)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    profiler.start(f"{label}-trace-warmup")
+    ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id_warmup)
+    ttnn.synchronize_device(mesh_device)
+    profiler.end(f"{label}-trace-warmup")
+
+    signpost("start")
+    profiler.start(f"{label}-trace")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+    profiler.end(f"{label}-trace")
+    signpost("stop")
+
+    elapsed_s = profiler.get_duration(f"{label}-trace") - profiler.get_duration(f"{label}-trace-warmup")
+    per_iter_us = elapsed_s / num_iters * 1e6
+    logger.info(f"{label}: {per_iter_us:.2f} us/iter (over {num_iters} iters)")
+
+    return tt_out
+
+
+def _build_perf_input_set(
+    *,
+    mesh_device,
+    mesh_shape,
+    cluster_axis,
+    batch,
+    seq,
+    hidden_size,
+    experts,
+    select_experts_k,
+    effective_select_experts_k,
+    num_devices,
+    activation_memory_config,
+    replicate_mapper,
+    shard_dims,
+):
+    """Allocate one (activation, scores, indices, mapping) ttnn tuple with fresh random data.
+
+    Returns ``(tt_tensors, torch_sources)`` so the caller can rebuild a golden later for the
+    iteration whose results are still resident after the trace finishes.
+    """
+    torch_act = torch.rand((effective_select_experts_k, 1, batch, hidden_size), dtype=torch.bfloat16) - 0.5
+    torch_scores = torch.rand((batch, 1, seq, select_experts_k), dtype=torch.bfloat16)
+    torch_scores = torch_scores / torch_scores.sum(dim=-1, keepdim=True)
+    torch_indices = _get_expert_indices(batch, experts, select_experts_k, seq)
+    torch_mapping = _gen_expert_mapping_linearized(experts, num_devices)
+
+    tt_activation = ttnn.from_torch(
+        torch_act,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=activation_memory_config,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape, dims=shard_dims(2)),
+    )
+    tt_scores = ttnn.from_torch(
+        torch_scores,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape, dims=shard_dims(0)),
+    )
+    tt_indices = ttnn.from_torch(
+        torch_indices,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape, dims=shard_dims(0)),
+    )
+    tt_mapping = ttnn.from_torch(
+        torch_mapping,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=replicate_mapper,
+    )
+    tt_tensors = (tt_activation, tt_scores, tt_indices, tt_mapping)
+    torch_sources = {
+        "activation": torch_act,
+        "scores": torch_scores,
+        "indices": torch_indices,
+        "mapping": torch_mapping,
+    }
+    return tt_tensors, torch_sources
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [pytest.param({"trace_region_size": 500000}, id="trace_region=500k")],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "num_shared_experts, shared_expert_scale",
+    [
+        pytest.param(0, 1.0, id="no_shared"),
+        pytest.param(2, 0.25, id="2_shared_scale_0p25"),
+    ],
+)
+@pytest.mark.parametrize("batch_per_device", [32])
+@pytest.mark.parametrize("select_experts_k", [8])
+@pytest.mark.parametrize("seq", [1])
+@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.parametrize("experts_per_device", [2])
+@pytest.mark.parametrize(
+    "mesh_shape, mesh_device",
+    [
+        pytest.param((4, 8), (4, 8), id="16x8_grid"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("num_test_iters", [40])
+@pytest.mark.parametrize("num_input_sets", [4])
+def test_deepseek_moe_fast_reduce_nc_fused_perf(
+    mesh_device,
+    mesh_shape,
+    batch_per_device,
+    select_experts_k,
+    seq,
+    hidden_size,
+    experts_per_device,
+    cluster_axis,
+    num_shared_experts,
+    shared_expert_scale,
+    num_test_iters,
+    num_input_sets,
+):
+    """Trace-mode perf benchmark for ``deepseek_moe_fast_reduce_nc_fused``.
+
+    Pre-allocates ``num_input_sets`` independent input tuples (activation / scores / expert
+    indices / expert mapping). Each captured trace iteration is bound to a different tuple so
+    the trace records distinct DRAM addresses across launches — this exercises the
+    override_runtime_arguments path and gives a more realistic per-iter latency than reusing
+    a single set. Reports microseconds per iter via ``BenchmarkProfiler`` and ``tracy.signpost``.
+    """
+    torch.manual_seed(2005)
+    random.seed(2005)
+
+    num_devices = mesh_shape[0] * mesh_shape[1]
+    num_dispatch_devices = mesh_shape[cluster_axis]
+    num_replicated_devices = mesh_shape[1 - cluster_axis]
+    batch = batch_per_device * num_dispatch_devices
+    experts = experts_per_device * num_devices
+    effective_select_experts_k = select_experts_k + num_shared_experts
+
+    activation_memory_config = ttnn.L1_MEMORY_CONFIG
+    fast_reduce_output_memory_config = ttnn.MemoryConfig(
+        ttnn.BufferType.L1,
+        ttnn.NdShardSpec(
+            ttnn.Shape([1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                ]
+            ),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+        ),
+    )
+    replicate_mapper = ttnn.replicate_tensor_to_mesh_mapper(mesh_device)
+
+    def _shard_dims(dim):
+        return (dim, None) if cluster_axis == 0 else (None, dim)
+
+    input_sets = []
+    torch_sources_per_set = []
+    for _ in range(num_input_sets):
+        tt_tuple, torch_sources = _build_perf_input_set(
+            mesh_device=mesh_device,
+            mesh_shape=mesh_shape,
+            cluster_axis=cluster_axis,
+            batch=batch,
+            seq=seq,
+            hidden_size=hidden_size,
+            experts=experts,
+            select_experts_k=select_experts_k,
+            effective_select_experts_k=effective_select_experts_k,
+            num_devices=num_devices,
+            activation_memory_config=activation_memory_config,
+            replicate_mapper=replicate_mapper,
+            shard_dims=_shard_dims,
+        )
+        input_sets.append(tt_tuple)
+        torch_sources_per_set.append(torch_sources)
+
+    split_size = int(hidden_size // num_replicated_devices)
+
+    def _run_op(num_iters):
+        tt_out = None
+        for i in range(num_iters):
+            tt_act, tt_scores, tt_idx, tt_map = input_sets[i % num_input_sets]
+            tt_out = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+                tt_act,
+                tt_idx,
+                tt_map,
+                reduce_dim=0,
+                split_size=split_size,
+                cluster_axis=cluster_axis,
+                output_memory_config=fast_reduce_output_memory_config,
+                scores_tensor=tt_scores,
+                num_shared_experts=num_shared_experts,
+                shared_expert_scale=shared_expert_scale,
+            )
+        return tt_out
+
+    profiler = BenchmarkProfiler()
+    tt_out = _run_op_with_trace(
+        num_test_iters,
+        _run_op,
+        mesh_device,
+        profiler,
+        label="deepseek-moe-fast-reduce-nc-fused",
+    )
+
+    # Validate the final outputs only — earlier iterations' L1 has already been reused.
+    # The final iteration's input set is the one captured at i = num_test_iters - 1.
+    final_set_idx = (num_test_iters - 1) % num_input_sets
+    final_sources = torch_sources_per_set[final_set_idx]
+    shared_expert_scale_bf16 = torch.tensor(shared_expert_scale, dtype=torch.bfloat16)
+
+    per_device_goldens = []
+    for m0 in range(mesh_shape[0]):
+        for m1 in range(mesh_shape[1]):
+            mesh_coord = (m0, m1)
+            t0 = (m1 if cluster_axis == 1 else m0) * batch_per_device
+            t1 = t0 + batch_per_device
+            u_slice = final_sources["activation"][:, :, t0:t1, :].contiguous()
+            s_slice = final_sources["scores"][t0:t1, :, :, :].contiguous()
+            ind_slice = final_sources["indices"][t0:t1, :, :, :].contiguous()
+            per_device_goldens.append(
+                _torch_golden_gated(
+                    u_slice,
+                    s_slice,
+                    ind_slice,
+                    final_sources["mapping"],
+                    mesh_shape,
+                    mesh_coord,
+                    cluster_axis,
+                    num_replicated_devices,
+                    num_shared_experts,
+                    shared_expert_scale_bf16,
+                )
+            )
+
+    assert tt_out is not None, "trace produced no output tensors"
+    for cidx, tt_out_list in enumerate(tt_out):
+        for didx, tt_dev_out in enumerate(ttnn.get_device_tensors(tt_out_list)):
+            tt_host = ttnn.to_torch(tt_dev_out, dtype=torch.bfloat16)
+            tt_host_slice = tt_host[:, :, 0:batch_per_device, :]
+            ref = per_device_goldens[didx][cidx]
+            ok, msg = comp_pcc(ref, tt_host_slice, pcc=PCC_THRESHOLD)
+            logger.info(f"perf-final virtual_dev={didx} chunk={cidx}: {msg}")
+            assert ok, f"perf-final virtual_dev={didx} chunk={cidx} failed: {msg}"
+
+    for t in tt_out:
+        ttnn.deallocate(t)
+    for tt_act, tt_scores, tt_idx, tt_map in input_sets:
+        ttnn.deallocate(tt_act)
+        ttnn.deallocate(tt_scores)
+        ttnn.deallocate(tt_idx)
+        ttnn.deallocate(tt_map)

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -400,6 +400,7 @@ def gen_combine_golden(
     torch_dispatch_input_expert_indices = torch_dispatch_input_expert_indices.repeat([num_replicated_devices, 1, 1, 1])
 
     torch_combine_ref_tensor = torch.zeros(select_experts_k, batch * num_replicated_devices, hidden_size).bfloat16()
+    valid_mask = torch.zeros(select_experts_k, batch * num_replicated_devices, dtype=torch.bool)
     batch_rep_idxr = get_batch_cluster_idxr(cluster_axis, batch, batches_per_device)
     for m0, m1, d in device_mesh_iterator(mesh_shape):
         if cluster_axis == 0:
@@ -420,29 +421,43 @@ def gen_combine_golden(
                 if e >= first_expert_on_cluster and e <= last_expert_on_cluster:
                     contrib = gen_matmul_golden(token, torch_w0_tensors[e], torch_w1_tensors[e], torch_w2_tensors[e])
                     torch_combine_ref_tensor[k, global_b, :] = contrib[0, 0, 0, :]
+                    valid_mask[k, global_b] = True
 
-    # [select_experts_k, batch * num_replicated_devices, hidden_size]
-    return torch_combine_ref_tensor
+    # [select_experts_k, batch * num_replicated_devices, hidden_size], [select_experts_k, batch * num_replicated_devices]
+    return torch_combine_ref_tensor, valid_mask
 
 
 def _add_shared_experts_to_combine_golden(
-    batch, torch_combine_golden, torch_dispatch_input_tensor, shared_id_to_w0, shared_id_to_w1, shared_id_to_w2
+    batch,
+    torch_combine_golden,
+    torch_combine_valid_mask,
+    torch_dispatch_input_tensor,
+    shared_id_to_w0,
+    shared_id_to_w1,
+    shared_id_to_w2,
 ):
     combine_output_shape = torch_combine_golden.shape
 
     shared_expert_contrib_shape = [len(shared_id_to_w0)] + list(combine_output_shape)[1:]
     shared_expert_contribs = torch.zeros(shared_expert_contrib_shape, dtype=torch_combine_golden.dtype)
+    shared_valid_mask = torch.zeros(len(shared_id_to_w0), torch_combine_valid_mask.shape[1], dtype=torch.bool)
 
     for e, (w0, w1, w2) in enumerate(zip(shared_id_to_w0.values(), shared_id_to_w1.values(), shared_id_to_w2.values())):
         for b in range(batch):
             token = torch_dispatch_input_tensor[b, :, :, :]
             contrib = gen_matmul_golden(token, w0, w1, w2)
             shared_expert_contribs[e, b, :] = contrib[0, 0, 0, :]
+            shared_valid_mask[e, b] = True
 
-    return torch.cat([torch_combine_golden, shared_expert_contribs], dim=0)
+    return (
+        torch.cat([torch_combine_golden, shared_expert_contribs], dim=0),
+        torch.cat([torch_combine_valid_mask, shared_valid_mask], dim=0),
+    )
 
 
-def verify_combine(iteration, mesh_device, mesh_shape, cluster_axis, tt_combine_tensor, torch_combine_golden):
+def verify_combine(
+    iteration, mesh_device, mesh_shape, cluster_axis, tt_combine_tensor, torch_combine_golden, torch_combine_valid_mask
+):
     PCC_THRESHOLD = 0.988
     ATOL_THRESHOLD = 700.0
 
@@ -463,22 +478,26 @@ def verify_combine(iteration, mesh_device, mesh_shape, cluster_axis, tt_combine_
             tt_combine_tensor, dtype=torch.bfloat16, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1)
         )
 
+    # only compare slots where the golden has a computed contribution — invalid slots
+    # (assigned expert not on this cluster) carry undefined data on the TT side.
+    valid_outputs = torch_combine_output[torch_combine_valid_mask]
+    valid_goldens = torch_combine_golden[torch_combine_valid_mask]
+
     # check pcc
-    pcc_passed, pcc_output = comp_pcc(torch_combine_output, torch_combine_golden, pcc=PCC_THRESHOLD)
+    pcc_passed, pcc_output = comp_pcc(valid_outputs, valid_goldens, pcc=PCC_THRESHOLD)
     logger.info(f"Combine Output - Iteration: {iteration} - PCC: {pcc_output}")
     if not pcc_passed:
         logger.warning(f"FAILED Combine Output - Iteration: {iteration} - PCC: {pcc_output}")
 
     # check allclose
-    allclose_passed, allclose_output = comp_allclose(
-        torch_combine_golden, torch_combine_output, atol=ATOL_THRESHOLD, rtol=0
-    )
+    allclose_passed, allclose_output = comp_allclose(valid_goldens, valid_outputs, atol=ATOL_THRESHOLD, rtol=0)
     logger.info(f"Combine Output - Iteration: {iteration} - AllClose: {allclose_output}")
     if not allclose_passed:
         logger.warning(f"FAILED Combine Output - Iteration: {iteration} - AllClose: {allclose_output}")
-        mask = (torch_combine_output - torch_combine_golden).abs() > ATOL_THRESHOLD
+        delta_mask = (valid_outputs - valid_goldens).abs() > ATOL_THRESHOLD
         logger.warning(
-            f"Elements out of bounds: {torch_combine_output[mask]} ref: {torch_combine_golden[mask]} idx: {mask.nonzero(as_tuple=True)}"
+            f"Elements out of bounds: {valid_outputs[delta_mask]} ref: {valid_goldens[delta_mask]} "
+            f"({int(delta_mask.sum())} of {valid_outputs.numel()})"
         )
 
     return pcc_passed and allclose_passed
@@ -568,6 +587,10 @@ def verify_output(iteration, mesh_device, mesh_shape, tt_output_tensor, output_r
     logger.info(f"Final Output - Iteration: {iteration} - AllClose: {allclose_output}")
     if not allclose_passed:
         logger.warning(f"FAILED Final Output - Iteration: {iteration} - AllClose: {allclose_output}")
+        mask = (tt_output_tensor - output_reference_tensor).abs() > ATOL_THRESHOLD
+        logger.warning(
+            f"Elements out of bounds: {tt_output_tensor[mask]} ref: {output_reference_tensor[mask]} idx: {mask.nonzero(as_tuple=True)}"
+        )
 
     return pcc_passed and allclose_passed
 
@@ -611,7 +634,7 @@ def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
 )
 @pytest.mark.parametrize("cluster_axis", [0])
 @pytest.mark.parametrize("layer_id, num_layers", [(0, 1)])
-@pytest.mark.parametrize("batches_per_device", [3, 8, 16, 32])
+@pytest.mark.parametrize("batches_per_device", [3, 8, 32])
 @pytest.mark.parametrize("shard_dim", [0])
 @pytest.mark.parametrize("routed_experts_per_device", [2])
 @pytest.mark.parametrize("select_experts_k", [8])
@@ -624,7 +647,6 @@ def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
 @pytest.mark.parametrize("compute_output_width_shard_dim", [4])
 @pytest.mark.parametrize("combine_mux_core_range", [((1, 1), (3, 3))])
 @pytest.mark.parametrize("combine_token_parallel_core_dim", [4])
-@pytest.mark.parametrize("combine_data_parallel_core_dim", [4])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize("num_iterations", [3])
 @pytest.mark.parametrize(
@@ -659,18 +681,16 @@ def test_optimized_moe_decode_block(
     compute_output_width_shard_dim,
     combine_mux_core_range,
     combine_token_parallel_core_dim,
-    combine_data_parallel_core_dim,
     enable_trace,
     num_iterations,
-    dispatch_persistent_buffers,
     shared_expert_mode,
 ):
     ############################################
     # initial setup
     ############################################
 
-    torch.manual_seed(42)
-    random.seed(42)
+    torch.manual_seed(2005)
+    random.seed(2005)
 
     num_devices = mesh_shape[0] * mesh_shape[1]
     num_dispatch_devices = mesh_shape[cluster_axis]
@@ -741,21 +761,13 @@ def test_optimized_moe_decode_block(
         expert_mapping_dtype,
     )
 
+    shared_expert_score = 1 / 2.5
     if shared_expert_ids_to_devices is not None:
         torch_expert_mapping = map_shared_experts(
             torch_expert_mapping, shared_expert_ids_to_devices, mesh_shape, cluster_axis
         )
         # the inverse of the routed scaling factor
-        torch_shared_expert_scores = torch.full([batch, 1, seq, num_shared_experts], 1 / 2.5)
-        tt_shared_expert_scores = ttnn.from_torch(
-            torch_shared_expert_scores,
-            device=mesh_device,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            dtype=dispatch_input_expert_scores_dtype,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=shard_dims, mesh_shape=mesh_shape),
-        )
-    else:
-        tt_shared_expert_scores = None
+        torch_shared_expert_scores = torch.full([batch, 1, seq, num_shared_experts], shared_expert_score)
 
     tt_expert_mapping = ttnn.from_torch(
         torch_expert_mapping,
@@ -933,6 +945,7 @@ def test_optimized_moe_decode_block(
     tt_dispatch_input_expert_scores_tensors = []
 
     torch_combine_goldens = []
+    torch_combine_valid_masks = []
     torch_output_goldens = []
     for iteration in range(num_iterations):
         dispatch_input_dtype = ttnn.bfloat16
@@ -990,7 +1003,7 @@ def test_optimized_moe_decode_block(
         tt_dispatch_input_expert_scores_tensors.append(tt_dispatch_input_expert_scores_tensor)
 
         # Initial golden is just routed experts
-        torch_combine_golden = gen_combine_golden(
+        torch_combine_golden, torch_combine_valid_mask = gen_combine_golden(
             mesh_shape,
             cluster_axis,
             num_devices,
@@ -1009,9 +1022,10 @@ def test_optimized_moe_decode_block(
         )
         # append shared experts if necessary
         if shared_expert_ids_to_devices is not None:
-            torch_combine_golden = _add_shared_experts_to_combine_golden(
+            torch_combine_golden, torch_combine_valid_mask = _add_shared_experts_to_combine_golden(
                 batch,
                 torch_combine_golden,
+                torch_combine_valid_mask,
                 torch_dispatch_input_tensor,
                 shared_id_to_w0,
                 shared_id_to_w1,
@@ -1019,6 +1033,7 @@ def test_optimized_moe_decode_block(
             )
 
         torch_combine_goldens.append(torch_combine_golden)
+        torch_combine_valid_masks.append(torch_combine_valid_mask)
 
         torch_output_golden = gen_output_golden(
             torch_dispatch_input_tensor,
@@ -1117,18 +1132,36 @@ def test_optimized_moe_decode_block(
         else None
     )
 
-    logger.info(f"Done creating persistent dispatch output tensors")
+    # one preallocated combine output per iteration — the buffer is reused by the op, so sharing across
+    # iterations would let verification compare against the last iteration's data instead of its own.
+    tt_preallocated_combine_outputs = [
+        ttnn.from_torch(
+            torch.zeros(
+                [effective_experts_k, tokens_per_device, hidden_size],
+                dtype=tt_to_torch_dtype(dispatch_output_sparse_buffer_dtype),
+            ),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=dispatch_output_sparse_buffer_dtype,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        for _ in range(num_iterations)
+    ]
+
+    logger.info(f"Done creating persistent CCL output tensors")
 
     ############################################
     # set post combine memory configs
     ############################################
+
     post_combine_tilize_output_memory_config = ttnn.MemoryConfig(
         buffer_type=ttnn.BufferType.L1,
         nd_shard_spec=ttnn.NdShardSpec(
             shard_shape=[32, 1024],
             grid=ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 7)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, effective_experts_k - 1)),
                 }
             ),
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -1195,14 +1228,16 @@ def test_optimized_moe_decode_block(
         # runtime since it needs to be a zeroed out tensor (for each layer)
         # allocated before dispatch, as dispatch serves as the barrier to ensure the tensor is allocated on all devices
         # [effective_experts_k (includes shared experts), tokens_per_device, hidden_size] per device
-        tt_preallocated_combine_output = ttnn.moreh_full(
-            shape=[effective_experts_k, tokens_per_device, hidden_size],
-            fill_value=0,
-            device=mesh_device,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            dtype=ttnn.bfloat16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
+
+        #         # TODO (AM) REMOVE ME ONCE TESTED ON QUAD
+        #         tt_preallocated_combine_output = ttnn.moreh_full(
+        #             shape=[effective_experts_k, tokens_per_device, hidden_size],
+        #             fill_value=0,
+        #             device=mesh_device,
+        #             layout=ttnn.ROW_MAJOR_LAYOUT,
+        #             dtype=ttnn.bfloat16,
+        #             memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        #         )
 
         (
             tt_dispatch_output_sparse_buffer,
@@ -1229,7 +1264,6 @@ def test_optimized_moe_decode_block(
         # - deallocate inputs to dispatch that are allocated in L1
         # - needed since compute uses just about all of L1
         ttnn.deallocate(tt_dispatch_input_tensor)
-        ttnn.deallocate(tt_dispatch_input_expert_indices_tensor)
         ttnn.deallocate(tt_dispatch_input_expert_scores_tensor)
 
         (
@@ -1251,7 +1285,7 @@ def test_optimized_moe_decode_block(
             output_width_shard_dim=compute_output_width_shard_dim,
             cluster_axis=cluster_axis,
             mux_core_range_set=combine_mux_cores,
-            optional_output_tensor=tt_preallocated_combine_output,
+            optional_output_tensor=tt_preallocated_combine_outputs[iteration],
             optional_cross_device_semaphore=combine_global_semaphore,
         )
 
@@ -1275,32 +1309,23 @@ def test_optimized_moe_decode_block(
                 memory_config=post_combine_tilize_output_memory_config,
             )
 
-        # scale with scores
-        # [tokens_per_device, 1, seq, select_experts_k] -> [select_experts_k, 1, tokens_per_device, seq]
-        # TODO (AFM) this is a kludge
-        if shared_expert_ids_to_devices is not None:
-            topk_experts_weights = ttnn.concat(
-                [tt_dispatch_input_expert_scores_tensors[iteration], tt_shared_expert_scores], dim=3
-            )
-        else:
-            topk_experts_weights = tt_dispatch_input_expert_scores_tensors[iteration]
+        topk_experts_weights = tt_dispatch_input_expert_scores_tensors[iteration]
 
-        topk_experts_weights = ttnn.permute(
-            topk_experts_weights, (3, 1, 0, 2), memory_config=scaled_output_memory_config
-        )
-        topk_experts_weights = ttnn.to_layout(
-            topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=scaled_output_memory_config
-        )
-        tt_scaled_output = ttnn.mul(
-            tt_tilized_compute_output, topk_experts_weights, memory_config=scaled_output_memory_config
-        )
-
-        tt_fast_reduce_output_tensors = ttnn.experimental.deepseek_moe_fast_reduce_nc(
-            tt_scaled_output,
-            dim=0,
-            split_size=int(tt_scaled_output.shape[-1] // num_replicated_devices),
+        # scale with scores and accumulate
+        tt_fast_reduce_output_tensors = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+            tt_tilized_compute_output,
+            tt_dispatch_input_expert_indices_tensor,
+            tt_expert_mapping,
+            reduce_dim=0,
+            cluster_axis=cluster_axis,
+            split_size=int(tt_tilized_compute_output.shape[-1] // num_replicated_devices),
             output_memory_config=fast_reduce_output_memory_config,
+            scores_tensor=topk_experts_weights,
+            num_shared_experts=num_shared_experts,
+            shared_expert_scale=shared_expert_score,
         )
+
+        ttnn.deallocate(tt_dispatch_input_expert_indices_tensor)
 
         # [select_experts_k, tokens_per_device, hidden_size // num_replicated_devices] final per device shape
         if mesh_shape[1 - cluster_axis] == 8:
@@ -1368,6 +1393,7 @@ def test_optimized_moe_decode_block(
             cluster_axis,
             tt_combine_tensors[iteration],
             torch_combine_goldens[iteration],
+            torch_combine_valid_masks[iteration],
         ):
             all_iterations_passed = False
 

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -162,8 +162,9 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         # SharedExpert now always expects collective ops to be handled by caller
         shared_expert_out = SharedExpert.forward_prefill(x_gathered, cfg["shared_expert"])
 
-        mlp_out = ttnn.sum(mlp_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"])
-        combined_out = ttnn.add(mlp_out, shared_expert_out)
+        combined_out = ttnn.add(
+            mlp_out, shared_expert_out, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
+        )
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)
 
@@ -212,7 +213,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
             fabric_config=cfg["moe"]["fabric_config"],
             mesh_device=cfg["moe"]["mesh_device"],
         )
-        mlp_out = moe_cls.forward_decode(x_gathered, cfg["moe"])
+        mlp_out, tt_moe_indices_rm, tt_moe_scores_rm = moe_cls.forward_decode(x_gathered, cfg["moe"])
         # SharedExpert now always expects collective ops to be handled by caller
         shared_expert_out = SharedExpert.forward_decode(x_gathered, cfg["shared_expert"])
 
@@ -229,28 +230,31 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         if x_dim == hidden_size // tp_size:
             # Single reduce_scatter on combined output using MoE's config for consistency
 
+            summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+                combined_out,
+                tt_moe_indices_rm,
+                cfg["moe"]["expert_mapping_tensor"],
+                reduce_dim=0,
+                cluster_axis=0,
+                split_size=combined_out.shape[-1] // tp_size,
+                output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
+                scores_tensor=tt_moe_scores_rm,
+                num_shared_experts=1,
+            )
+            ttnn.deallocate(combined_out)
+            ttnn.deallocate(tt_moe_scores_rm)
+            ttnn.deallocate(tt_moe_indices_rm)
+
             if (
                 cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING
                 and tp_size == 8
                 and num_tokens_per_row == ttnn.TILE_SIZE
             ):
-                summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
-                    combined_out,
-                    dim=0,
-                    split_size=combined_out.shape[-1] // tp_size,
-                    output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
-                )
-                ttnn.deallocate(combined_out)
                 output = ttnn.experimental.deepseek_moe_reduce_scatter(
                     summed_experts, **cfg["moe"]["ring_final_output_reduce_scatter"]
                 )
             else:
                 ccl_moe = cfg["moe"]["ccl"]
-
-                summed_experts = ttnn.sum(
-                    combined_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
-                )
-                ttnn.deallocate(combined_out)
                 output = ttnn.experimental.reduce_scatter_minimal_async(
                     summed_experts,
                     **ccl_moe.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),

--- a/models/demos/deepseek_v3/tt/moe_optimized.py
+++ b/models/demos/deepseek_v3/tt/moe_optimized.py
@@ -330,7 +330,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
         )
 
     @classmethod
-    def _forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
+    def _forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         return cls._forward_impl(x, cfg, "decode")
 
     @classmethod
@@ -364,7 +364,9 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
         return output
 
     @classmethod
-    def _forward_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, mode: str) -> ttnn.Tensor:
+    def _forward_impl(
+        cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, mode: str
+    ) -> ttnn.Tensor | tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         # Validate input dimensions
         hidden_size = cfg["hidden_size"]
         mesh_device = cfg.get("mesh_device")
@@ -392,7 +394,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
 
         # MOE
         if mode == "decode":
-            post_combine_output_tensor = cls._fwd_decode_moe(
+            return cls._fwd_decode_moe(
                 x,
                 topk_experts_indices,
                 topk_experts_weights,
@@ -400,9 +402,9 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 batch_size_per_device,
                 batch_size,
                 seq_len,
-            )
+            )  # also returns topk_experts_indices_rm, topk_experts_weights_rm
         else:
-            post_combine_output_tensor = cls._fwd_prefill_moe(
+            return cls._fwd_prefill_moe(
                 x,
                 topk_experts_indices,
                 topk_experts_weights,
@@ -411,9 +413,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 batch_size,
                 seq_len,
             )
-
-        # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
-        return post_combine_output_tensor
 
     @classmethod
     def _fwd_moe_gate(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
@@ -458,7 +457,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             topk_experts_weights_rm,
         )
 
-        return post_combine_output_tensor
+        return post_combine_output_tensor, topk_experts_indices_rm, topk_experts_weights_rm
 
     @classmethod
     def _fwd_prefill_moe(
@@ -549,7 +548,17 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 [cfg["num_experts_per_tok"], 1, batch_chunk, cfg["hidden_size"]],
             )
 
-            output_chunks.append(post_combine_output_tensor)
+            summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+                post_combine_output_tensor,
+                topk_experts_indices_rm_chunk,
+                cfg["expert_mapping_tensor"],
+                reduce_dim=0,
+                cluster_axis=0,
+                split_size=1,
+                scores_tensor=topk_experts_weights_rm_chunk,
+            )
+
+            output_chunks.append(summed_experts[0])
 
         ttnn.deallocate(topk_experts_indices_rm)
         ttnn.deallocate(topk_experts_weights_rm)
@@ -582,21 +591,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             topk_experts_weights_rm,
             memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
         )
-
-        # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
-        # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-        topk_experts_weights_for_scaling = ttnn.permute(
-            topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
-        )
-        topk_experts_weights_for_scaling = ttnn.to_layout(
-            topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
-        )
-
-        ttnn.deallocate(topk_experts_indices_rm)
-        ttnn.deallocate(topk_experts_weights_rm)
-
-        # NOTE: needs to run prior to all_to_all_dispatch_metadata
-        preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
 
         # TODO: #41009
         (
@@ -632,7 +626,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             cfg["expert_mapping_tensor"],
             cfg["moe_experts"]["quad_ring_w0_w1_experts"]["input_tensor_b"],
             cfg["moe_experts"]["quad_ring_w2_experts"]["input_tensor_b"],
-            optional_output_tensor=preallocated_combine_output,
             layer_id=0,  # each layer is composed of distinct tensors, as apposed to all layers fused together
             **cfg["quad_ring_moe_compute"],
         )
@@ -658,10 +651,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 pad_value=0.0,
                 memory_config=cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]["output_memory_config"],
             )
-
-        post_combine_output_tensor = ttnn.mul(
-            combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
-        )
 
         ttnn.deallocate(combine_output)
         return post_combine_output_tensor
@@ -700,7 +689,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             x = cls._fwd_all_gather(x, cfg)
 
         # Run the forward pass
-        output = cls._forward_decode(x, cfg)
+        output, indices_rm, weights_rm = cls._forward_decode(x, cfg)
 
         # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
@@ -721,7 +710,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
                 output = cls._fwd_reduce_scatter(output, cfg, ccl)
 
-        return output
+        return output, indices_rm, weights_rm
 
     @classmethod
     def forward_prefill(

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -302,6 +302,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/deepseek_moe_fast_reduce_nc_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reshape/view_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/slice_write/slice_write_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/padded_slice/padded_slice_nanobind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/experimental/conv3d/conv3d_nanobind.hpp"
 #include "ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.hpp"
 #include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/deepseek_moe_fast_reduce_nc_nanobind.hpp"
+#include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.hpp"
 #include "ttnn/operations/experimental/reduction/integral_image/intimg_nanobind.hpp"
 #include "ttnn/operations/experimental/reduction/deepseek_grouped_gate/deepseek_grouped_gate_nanobind.hpp"
 #include "ttnn/operations/experimental/slice_write/slice_write_nanobind.hpp"
@@ -103,6 +104,7 @@ void py_module(nb::module_& mod) {
 
     reduction::detail::bind_fast_reduce_nc(mod);
     reduction::detail::bind_deepseek_moe_fast_reduce_nc(mod);
+    reduction::detail::bind_deepseek_moe_fast_reduce_nc_fused(mod);
     reduction::detail::bind_reduction_intimg_operation(mod);
     reduction::detail::bind_deepseek_grouped_gate(mod);
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/CMakeLists.txt
@@ -15,6 +15,7 @@ file(
     GLOB_RECURSE kernels
     deepseek_grouped_gate/device/kernels/*
     deepseek_moe_fast_reduce_nc/device/kernels/*
+    deepseek_moe_fast_reduce_nc_fused/device/kernels/*
     fast_reduce_nc/device/kernels/*
     integral_image/device/kernels/*
 )
@@ -37,6 +38,9 @@ target_sources(
         deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_device_operation.cpp
         deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_program_factory.cpp
         deepseek_moe_fast_reduce_nc/deepseek_moe_fast_reduce_nc.cpp
+        deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.cpp
+        deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
+        deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.cpp
         integral_image/device/intimg_device_operation.cpp
         integral_image/device/intimg_program_factory.cpp
         integral_image/intimg.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/deepseek_moe_fast_reduce_nc.hpp"
+#include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.hpp"
+#include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::experimental::reduction {
+
+std::vector<ttnn::Tensor> deepseek_moe_fast_reduce_nc_fused(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& expert_indices_tensor,
+    const ttnn::Tensor& expert_mapping_tensor,
+    int32_t reduce_dim,
+    uint64_t split_size,
+    uint32_t cluster_axis,
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    const std::optional<ttnn::Tensor>& scores_tensor,
+    uint32_t num_shared_experts,
+    float shared_expert_scale,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    if (!scores_tensor.has_value()) {
+        // Fallback path: expert_indices / expert_mapping / cluster_axis are unused without scores.
+        return deepseek_moe_fast_reduce_nc(
+            input_tensor, reduce_dim, split_size, output_memory_config, compute_kernel_config);
+    }
+
+    ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(init_device_compute_kernel_config(
+        input_tensor.device()->arch(),
+        std::nullopt,
+        tt::tt_metal::MathFidelity::HiFi4,
+        /* default_approx_mode */ false,
+        /* default_fp32_acc */ true));
+
+    uint32_t rank = input_tensor.padded_shape().rank();
+    uint32_t normalized_dim = (reduce_dim < 0) ? reduce_dim + rank : (uint32_t)reduce_dim;
+    return ttnn::prim::deepseek_moe_fast_reduce_nc_fused(
+        input_tensor,
+        scores_tensor.value(),
+        expert_indices_tensor,
+        expert_mapping_tensor,
+        normalized_dim,
+        split_size,
+        cluster_axis,
+        output_memory_config,
+        num_shared_experts,
+        shared_expert_scale,
+        config);
+}
+
+}  // namespace ttnn::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.cpp
@@ -36,7 +36,7 @@ std::vector<ttnn::Tensor> deepseek_moe_fast_reduce_nc_fused(
     ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(init_device_compute_kernel_config(
         input_tensor.device()->arch(),
         std::nullopt,
-        tt::tt_metal::MathFidelity::HiFi4,
+        MathFidelity::HiFi4,
         /* default_approx_mode */ false,
         /* default_fp32_acc */ true));
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::reduction {
+
+// Fused operation: permute(scores) + tilize + mul(activation, scores) + reduce_nc
+// all in a single kernel launch, eliminating the large intermediate activation tensor.
+//
+// input_tensor          : [experts_k, 1, tokens, hidden_size]  TILE layout, L1
+// expert_indices_tensor : per-token expert indices (matches all_to_all_dispatch convention)
+// expert_mapping_tensor : expert-to-device mapping (matches all_to_all_dispatch convention)
+// scores_tensor         : optional [tokens, 1, seq, experts_k] ROW_MAJOR layout, DRAM.
+//                         If std::nullopt, delegates to deepseek_moe_fast_reduce_nc
+//                         (no fused score multiply). In that fallback the expert_indices /
+//                         expert_mapping / cluster_axis arguments are ignored.
+// cluster_axis          : mesh axis (0 or 1) along which the expert mapping is laid out.
+//
+// Returns split_size-wide output slices [1, 1, tokens, split_size] × (hidden_size/split_size)
+std::vector<ttnn::Tensor> deepseek_moe_fast_reduce_nc_fused(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& expert_indices_tensor,
+    const ttnn::Tensor& expert_mapping_tensor,
+    int32_t reduce_dim,
+    uint64_t split_size,
+    uint32_t cluster_axis,
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    const std::optional<ttnn::Tensor>& scores_tensor,
+    uint32_t num_shared_experts = 0,
+    float shared_expert_scale = 1.0f,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+
+}  // namespace ttnn::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "deepseek_moe_fast_reduce_nc_fused_nanobind.hpp"
+#include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+
+namespace ttnn::operations::experimental::reduction::detail {
+
+void bind_deepseek_moe_fast_reduce_nc_fused(nb::module_& mod) {
+    ttnn::bind_function<"deepseek_moe_fast_reduce_nc_fused", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        Fused operation combining permute + tilize + mul(activation, expert_scores) + deepseek_moe_fast_reduce_nc
+        into a single kernel launch.
+
+        The operation eliminates the large intermediate scaled-activation tensor by applying the
+        per-expert score scale inside the reduce loop using a hardware multiply-accumulate (MAC)
+        instruction with BroadcastType::COL.
+
+        Args:
+            input_tensor (ttnn.Tensor): activation tensor [experts_k, 1, tokens, hidden_size],
+                TILE layout, L1.
+            expert_indices_tensor (ttnn.Tensor): per-token expert indices
+                (matches all_to_all_dispatch convention).
+            expert_mapping_tensor (ttnn.Tensor): expert-to-device mapping
+                (matches all_to_all_dispatch convention).
+            reduce_dim (int): dimension along which to reduce (typically 0 for experts_k).
+
+        Keyword Args:
+            split_size (int): size of last dim of each output split tensor
+                (typically hidden_size // num_replicated_devices).
+            cluster_axis (int): mesh axis (0 or 1) along which the expert mapping is laid out.
+            output_memory_config (ttnn.MemoryConfig): output memory configuration.
+                Supports both interleaved and sharded (NdShardSpec) layouts.
+            scores_tensor (ttnn.Tensor, optional): expert scores [tokens, 1, seq, experts_k],
+                ROW_MAJOR layout, DRAM. If omitted, calls :func:`~ttnn.experimental.deepseek_moe_fast_reduce_nc`
+                instead (no fused multiply by scores). The expert_indices_tensor /
+                expert_mapping_tensor / cluster_axis arguments are ignored on that fallback path.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig): optional compute config.
+
+        Returns:
+            list of ttnn.Tensor: (hidden_size // split_size) output tensors, each with shape
+                [1, 1, tokens, split_size].
+        )doc",
+        &ttnn::experimental::reduction::deepseek_moe_fast_reduce_nc_fused,
+        nb::arg("input_tensor"),
+        nb::arg("expert_indices_tensor"),
+        nb::arg("expert_mapping_tensor"),
+        nb::arg("reduce_dim"),
+        nb::kw_only(),
+        nb::arg("split_size"),
+        nb::arg("cluster_axis"),
+        nb::arg("output_memory_config").noconvert() = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        nb::arg("scores_tensor") = nb::none(),
+        nb::arg("num_shared_experts") = 0,
+        nb::arg("shared_expert_scale") = 1.0f,
+        nb::arg("compute_kernel_config").noconvert() = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::reduction::detail {
+namespace nb = nanobind;
+void bind_deepseek_moe_fast_reduce_nc_fused(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.hpp"
+
+#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::prim {
+
+DeepseekMoEFastReduceNCFusedDeviceOperation::program_factory_t
+DeepseekMoEFastReduceNCFusedDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return DeepseekMoEFastReduceNCFusedMeshWorkloadFactory{};
+}
+
+void DeepseekMoEFastReduceNCFusedDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must have a buffer");
+
+    const ttnn::Tensor& scores_tensor = tensor_args.scores_tensor;
+    TT_FATAL(scores_tensor.storage_type() == StorageType::DEVICE, "Scores tensor must be on device");
+    TT_FATAL(scores_tensor.buffer() != nullptr, "Scores tensor must have a buffer");
+
+    const ttnn::Tensor& expert_indices_tensor = tensor_args.expert_indices_tensor;
+    TT_FATAL(expert_indices_tensor.storage_type() == StorageType::DEVICE, "Expert indices tensor must be on device");
+    TT_FATAL(expert_indices_tensor.buffer() != nullptr, "Expert indices tensor must have a buffer");
+
+    const ttnn::Tensor& expert_mapping_tensor = tensor_args.expert_mapping_tensor;
+    TT_FATAL(expert_mapping_tensor.storage_type() == StorageType::DEVICE, "Expert mapping tensor must be on device");
+    TT_FATAL(expert_mapping_tensor.buffer() != nullptr, "Expert mapping tensor must have a buffer");
+
+    TT_FATAL(
+        operation_attributes.cluster_axis <= 1,
+        "cluster_axis must be 0 or 1 (got {})",
+        operation_attributes.cluster_axis);
+}
+
+void DeepseekMoEFastReduceNCFusedDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_hit(operation_attributes, tensor_args);
+
+    const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
+    const auto& input_shape = input_tensor.padded_shape();
+    const uint32_t input_rank = input_shape.rank();
+    const uint32_t reduction_dim = operation_attributes.reduce_dim;
+
+    const uint32_t num_output_tensors = input_shape[-1] / operation_attributes.split_size;
+    const uint32_t split_dim = input_rank - 1;
+
+    // validate tensor
+    operations::check_tensor(
+        input_tensor, "DeepseekMoEFastReduceNCFused", "input", {DataType::BFLOAT16, DataType::BFLOAT8_B});
+    TT_FATAL(input_tensor.layout() == ttnn::Layout::TILE, "input tensor must be tiled");
+
+    // validate rank
+    TT_FATAL(input_rank > 2, "input tensor rank must be greater than 2, but has {}", input_rank);
+
+    // validate reduction dim
+    TT_FATAL(
+        reduction_dim <= input_rank - 3,
+        "reduction dim must be between 0 and {}, but has {}",
+        input_rank - 3,
+        reduction_dim);
+
+    // validate split dim
+    uint32_t split_dim_size = input_shape[split_dim];
+    TT_FATAL(
+        split_dim_size % (num_output_tensors * tt::constants::TILE_WIDTH) == 0,
+        "input tensor width must be divisible by {}",
+        num_output_tensors * tt::constants::TILE_WIDTH);
+
+    // validate tensor layout
+    const ttnn::Tensor& scores_tensor = tensor_args.scores_tensor;
+    operations::check_tensor(
+        scores_tensor, "DeepseekMoEFastReduceNCFused", "scores", {DataType::BFLOAT16}, ttnn::Layout::ROW_MAJOR);
+
+    // scores shape: [tokens, 1, seq, experts_k] where experts_k == reduction_dim_size
+    const auto& scores_shape = scores_tensor.logical_shape();
+    const uint32_t scores_rank = scores_shape.rank();
+    TT_FATAL(scores_rank == 4, "scores tensor must be rank 4, but has {}", scores_rank);
+    TT_FATAL(input_rank == 4, "input tensor must be rank 4, but has {}", input_rank);
+
+    const uint32_t reduction_dim_size = input_shape[reduction_dim];
+    const uint32_t num_shared_experts_val = operation_attributes.num_shared_experts;
+    TT_FATAL(
+        num_shared_experts_val <= reduction_dim_size,
+        "num_shared_experts ({}) must not exceed reduction dim size ({})",
+        num_shared_experts_val,
+        reduction_dim_size);
+    const uint32_t num_routed_experts = reduction_dim_size - num_shared_experts_val;
+    TT_FATAL(
+        scores_shape[-1] == num_routed_experts,
+        "scores last dim ({}) must equal num_routed_experts ({} = reduction_dim_size {} - num_shared_experts {})",
+        scores_shape[-1],
+        num_routed_experts,
+        reduction_dim_size,
+        num_shared_experts_val);
+
+    const uint32_t num_tokens = input_shape[-2];
+    TT_FATAL(
+        (scores_shape[0] > num_tokens - tt::constants::TILE_WIDTH) && (scores_shape[0] <= num_tokens),
+        "scores dim 0 (tokens in slice = {}) must be between {} and {} for the current fused kernel",
+        scores_shape[0],
+        num_tokens - tt::constants::TILE_WIDTH + 1,
+        num_tokens);
+}
+
+ttnn::TensorSpec DeepseekMoEFastReduceNCFusedDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const uint32_t reduction_dim = operation_attributes.reduce_dim;
+    const tt::tt_metal::MemoryConfig& output_memory_config = operation_attributes.output_memory_config;
+    const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
+    const auto& input_shape = input_tensor.logical_shape();
+
+    const uint32_t num_output_tensors = input_shape[-1] / operation_attributes.split_size;
+    const uint32_t split_dim = input_shape.rank() - 1;
+
+    auto output_shape = input_tensor.logical_shape();
+    output_shape[reduction_dim] = 1;  // keepdim = true
+    output_shape[split_dim] /= num_output_tensors;
+
+    return TensorSpec(
+        output_shape,
+        operations::TensorLayout(input_tensor.dtype(), tt::tt_metal::PageConfig(Layout::TILE), output_memory_config));
+}
+
+std::vector<ttnn::Tensor> DeepseekMoEFastReduceNCFusedDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
+
+    const ttnn::TensorSpec& output_tensor_spec = compute_output_specs(operation_attributes, tensor_args);
+
+    const uint32_t num_output_tensors = input_tensor.logical_shape()[-1] / operation_attributes.split_size;
+    std::vector<ttnn::Tensor> output_tensors(num_output_tensors);
+    for (uint32_t i = 0; i < num_output_tensors; ++i) {
+        output_tensors[i] = create_device_tensor(output_tensor_spec, input_tensor.device());
+    }
+
+    return output_tensors;
+}
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+std::vector<ttnn::Tensor> deepseek_moe_fast_reduce_nc_fused(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& scores_tensor,
+    const ttnn::Tensor& expert_indices_tensor,
+    const ttnn::Tensor& expert_mapping_tensor,
+    uint32_t reduce_dim,
+    uint64_t split_size,
+    uint32_t cluster_axis,
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    uint32_t num_shared_experts,
+    float shared_expert_scale,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config) {
+    using OperationType = ttnn::experimental::prim::DeepseekMoEFastReduceNCFusedDeviceOperation;
+
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            reduce_dim,
+            split_size,
+            cluster_axis,
+            output_memory_config,
+            num_shared_experts,
+            shared_expert_scale,
+            compute_kernel_config},
+        OperationType::tensor_args_t{input_tensor, scores_tensor, expert_indices_tensor, expert_mapping_tensor});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "deepseek_moe_fast_reduce_nc_fused_device_operation_types.hpp"
+#include "deepseek_moe_fast_reduce_nc_fused_program_factory.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct DeepseekMoEFastReduceNCFusedDeviceOperation {
+    using operation_attributes_t = DeepseekMoEFastReduceNCFusedParams;
+    using tensor_args_t = DeepseekMoEFastReduceNCFusedInputs;
+    using spec_return_value_t = ttnn::TensorSpec;
+    using tensor_return_value_t = std::vector<ttnn::Tensor>;
+    using program_factory_t = std::variant<DeepseekMoEFastReduceNCFusedMeshWorkloadFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+std::vector<ttnn::Tensor> deepseek_moe_fast_reduce_nc_fused(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& scores_tensor,
+    const ttnn::Tensor& expert_indices_tensor,
+    const ttnn::Tensor& expert_mapping_tensor,
+    uint32_t reduce_dim,
+    uint64_t split_size,
+    uint32_t cluster_axis,
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    uint32_t num_shared_experts,
+    float shared_expert_scale,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation_types.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct DeepseekMoEFastReduceNCFusedParams {
+    uint32_t reduce_dim;
+    uint64_t split_size;
+    uint32_t cluster_axis;
+    tt::tt_metal::MemoryConfig output_memory_config;
+    uint32_t num_shared_experts;
+    float shared_expert_scale;
+    ttnn::DeviceComputeKernelConfig compute_kernel_config;
+};
+
+// Input tensors:
+//   input_tensor           - activations [experts_k, 1, tokens, hidden], TILE layout, L1
+//   scores_tensor          - expert scores [tokens, 1, seq, experts_k], ROW_MAJOR layout, DRAM
+//   expert_indices_tensor  - per-token expert indices (matches all_to_all_dispatch convention)
+//   expert_mapping_tensor  - expert-to-device mapping (matches all_to_all_dispatch convention)
+struct DeepseekMoEFastReduceNCFusedInputs {
+    ttnn::Tensor input_tensor;
+    ttnn::Tensor scores_tensor;
+    ttnn::Tensor expert_indices_tensor;
+    ttnn::Tensor expert_mapping_tensor;
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
@@ -1,0 +1,486 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+
+#include "ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.hpp"
+
+using namespace tt;
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Matches compile-time arg order in deepseek_moe_fast_reduce_nc_fused_reader.cpp (get_compile_time_arg_val 0..26).
+struct DeepseekMoeFastReduceNcFusedReaderCtArgs {
+    uint32_t cb_in_act_id{};
+    uint32_t cb_scores_id{};
+    uint32_t cb_scores_rm_id{};
+    uint32_t act_page_size{};
+    uint32_t scores_buf_page_size{};
+    uint32_t scores_tile_size{};
+    uint32_t num_cores{};
+    uint32_t input_granularity{};
+    uint32_t reduction_dim{};
+    uint32_t reduction_dim_size{};
+    uint32_t inner_num_tiles{};
+    uint32_t reduction_num_tiles{};
+    uint32_t num_tokens{};
+    uint32_t num_tokens_x32{};
+    uint32_t scores_cb_rm_page_size{};
+    uint32_t expert_indices_page_size{};
+    uint32_t expert_mapping_page_size{};
+    uint32_t cluster_axis{};
+    uint32_t cb_expert_indices_id{};
+    uint32_t cb_expert_mapping_id{};
+    uint32_t expert_indices_cb_page_size{};
+    uint32_t expert_mapping_cb_page_size{};
+    uint32_t expert_indices_num_pages{};
+    uint32_t expert_mapping_num_pages{};
+    uint32_t mesh_cols{};  // mesh_shape[1]; lets the kernel decode linearized device ids into (row, col)
+    uint32_t num_shared_experts{};
+    uint32_t shared_expert_scale_bf16{};  // BF16 bit pattern in low 16 bits (upper 16 bits of float32)
+};
+
+std::vector<uint32_t> to_reader_ct_arg_vector(const DeepseekMoeFastReduceNcFusedReaderCtArgs& ct) {
+    return {
+        ct.cb_in_act_id,
+        ct.cb_scores_id,
+        ct.cb_scores_rm_id,
+        ct.act_page_size,
+        ct.scores_buf_page_size,  // DRAM page size
+        ct.scores_tile_size,
+        ct.num_cores,
+        ct.input_granularity,
+        ct.reduction_dim,
+        ct.reduction_dim_size,   // experts_k
+        ct.inner_num_tiles,      // the number of tiles in the inner dimensions: [reduction_dim+1,...,rank-1]
+        ct.reduction_num_tiles,  // the number of tiles in the reduction dimension: inner_num_tiles * reduction_dim_size
+        ct.num_tokens,
+        ct.num_tokens_x32,
+        ct.scores_cb_rm_page_size,    // cb_scores_rm_id page size: one page = one token row
+        ct.expert_indices_page_size,  // DRAM page size for expert_indices_tensor
+        ct.expert_mapping_page_size,  // DRAM page size for expert_mapping_tensor
+        ct.cluster_axis,
+        ct.cb_expert_indices_id,
+        ct.cb_expert_mapping_id,
+        ct.expert_indices_cb_page_size,  // L1-aligned CB stride for expert_indices
+        ct.expert_mapping_cb_page_size,  // L1-aligned CB stride for expert_mapping
+        ct.expert_indices_num_pages,
+        ct.expert_mapping_num_pages,
+        ct.mesh_cols,
+        ct.num_shared_experts,
+        ct.shared_expert_scale_bf16,
+    };
+}
+
+}  // namespace
+
+namespace ttnn::experimental::prim {
+
+ttnn::device_operation::CachedProgram<DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::shared_variables_t>
+DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
+    const DeepseekMoEFastReduceNCFusedParams& operation_attributes,
+    const ttnn::MeshCoordinate& mesh_coordinate,
+    const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto* device = tensor_args.input_tensor.device();
+    const uint32_t mesh_cols = device->get_view().num_cols();
+    auto program = Program();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
+    const ttnn::Tensor& scores_tensor = tensor_args.scores_tensor;
+    const ttnn::Tensor& expert_indices_tensor = tensor_args.expert_indices_tensor;
+    const ttnn::Tensor& expert_mapping_tensor = tensor_args.expert_mapping_tensor;
+    const auto& input_shape = input_tensor.padded_shape();
+    const uint32_t input_rank = input_shape.rank();
+
+    const std::vector<ttnn::Tensor>& output_tensors = tensor_return_value;
+
+    const uint32_t reduction_dim = operation_attributes.reduce_dim;
+
+    const uint32_t num_tile_elements = tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH;
+    const uint32_t input_tensor_Wt = input_shape[-1] / tt::constants::TILE_WIDTH;
+    const uint32_t slice_Wt = input_tensor_Wt / output_tensors.size();
+
+    uint32_t inner_dims_product = 1;
+    for (uint32_t dim = reduction_dim + 1; dim < input_rank; ++dim) {
+        inner_dims_product *= input_shape[dim];
+    }
+
+    const uint32_t reduction_dim_size = input_shape[reduction_dim];  // experts_k
+    const uint32_t inner_num_tiles = inner_dims_product / num_tile_elements;
+    const uint32_t reduction_num_tiles = inner_num_tiles * reduction_dim_size;
+
+    // scores shape: [tokens, 1, seq, experts_k] (ROW_MAJOR)
+    const uint32_t num_tokens = scores_tensor.logical_shape()[0];  // tokens_per_device
+    const uint32_t num_tokens_x32 = round_up(num_tokens, 32);
+
+    // Choose granularity as the largest factor of num_reduce_input_tile that is less than or equal to 8.
+    // Helps with locality and increases work unit for better performance.
+    uint32_t input_granularity;
+    for (input_granularity = 8; input_granularity > 1; --input_granularity) {
+        if (reduction_dim_size % input_granularity == 0) {
+            break;
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const uint32_t num_output_tiles = input_tensor.physical_volume() / num_tile_elements / reduction_dim_size;
+
+    auto grid = device->compute_with_storage_grid_size();
+    const auto
+        [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(grid, num_output_tiles, /*row_wise=*/true);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto input_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    const auto scores_data_format = datatype_to_dataformat_converter(scores_tensor.dtype());
+    const auto output_data_format = datatype_to_dataformat_converter(output_tensors.at(0).dtype());
+
+    const uint32_t input_page_size = input_tensor.buffer()->page_size();
+    const uint32_t output_page_size = output_tensors.at(0).buffer()->page_size();
+    const uint32_t scores_page_size = scores_tensor.buffer()->page_size();
+    const uint32_t scores_cb_rm_page_size =
+        round_up(scores_tensor.buffer()->aligned_page_size(), hal::get_l1_alignment());
+    const uint32_t expert_indices_page_size = expert_indices_tensor.buffer()->page_size();
+    const uint32_t expert_mapping_page_size = expert_mapping_tensor.buffer()->page_size();
+    const uint32_t expert_indices_cb_page_size =
+        round_up(expert_indices_tensor.buffer()->aligned_page_size(), hal::get_l1_alignment());
+    const uint32_t expert_mapping_cb_page_size =
+        round_up(expert_mapping_tensor.buffer()->aligned_page_size(), hal::get_l1_alignment());
+    const uint32_t expert_indices_num_pages = expert_indices_tensor.buffer()->num_pages();
+    const uint32_t expert_mapping_num_pages = expert_mapping_tensor.buffer()->num_pages();
+
+    const auto expert_indices_data_format = datatype_to_dataformat_converter(expert_indices_tensor.dtype());
+    const auto expert_mapping_data_format = datatype_to_dataformat_converter(expert_mapping_tensor.dtype());
+
+    const uint32_t scores_rm_cb_num_pages = num_tokens;
+    const uint32_t scores_tile_size = tt::tile_size(scores_data_format);
+
+    const uint32_t input_tensor_buffer_factor = input_granularity * 2;
+    const uint32_t output_tensor_buffer_factor = 2;
+
+    // CB c_0: activation tiles (double-buffered)
+    uint32_t cb_in_act_id = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig cb_in_act_config =
+        tt::tt_metal::CircularBufferConfig(
+            input_tensor_buffer_factor * input_page_size, {{cb_in_act_id, input_data_format}})
+            .set_page_size(cb_in_act_id, input_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_in_act_config);
+
+    // CB c_1: pre-processed score tiles (one per expert), held resident during compute
+    uint32_t cb_scores_id = tt::CBIndex::c_1;
+    tt::tt_metal::CircularBufferConfig cb_scores_config =
+        tt::tt_metal::CircularBufferConfig(reduction_dim_size * scores_tile_size, {{cb_scores_id, scores_data_format}})
+            .set_page_size(cb_scores_id, scores_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scores_config);
+
+    // CB c_2: scratch for reading raw RM scores from DRAM (one page = one token row)
+    uint32_t cb_scores_rm_id = tt::CBIndex::c_2;
+    tt::tt_metal::CircularBufferConfig cb_scores_rm_config =
+        tt::tt_metal::CircularBufferConfig(
+            scores_rm_cb_num_pages * scores_cb_rm_page_size, {{cb_scores_rm_id, scores_data_format}})
+            .set_page_size(cb_scores_rm_id, scores_cb_rm_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scores_rm_config);
+
+    // CB c_3: full expert_indices_tensor mirrored in L1. Sized to hold every page once;
+    // the reader loads all pages up front before the score-tilization prologue.
+    uint32_t cb_expert_indices_id = tt::CBIndex::c_3;
+    tt::tt_metal::CircularBufferConfig cb_expert_indices_config =
+        tt::tt_metal::CircularBufferConfig(
+            expert_indices_num_pages * expert_indices_cb_page_size,
+            {{cb_expert_indices_id, expert_indices_data_format}})
+            .set_page_size(cb_expert_indices_id, expert_indices_cb_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_expert_indices_config);
+
+    // CB c_4: full expert_mapping_tensor mirrored in L1, same loading pattern as c_3.
+    uint32_t cb_expert_mapping_id = tt::CBIndex::c_4;
+    tt::tt_metal::CircularBufferConfig cb_expert_mapping_config =
+        tt::tt_metal::CircularBufferConfig(
+            expert_mapping_num_pages * expert_mapping_cb_page_size,
+            {{cb_expert_mapping_id, expert_mapping_data_format}})
+            .set_page_size(cb_expert_mapping_id, expert_mapping_cb_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_expert_mapping_config);
+
+    // CB c_16: output tiles (double-buffered)
+    uint32_t cb_out_id = tt::CBIndex::c_16;
+    tt::tt_metal::CircularBufferConfig cb_out_config =
+        tt::tt_metal::CircularBufferConfig(
+            output_tensor_buffer_factor * output_page_size, {{cb_out_id, output_data_format}})
+            .set_page_size(cb_out_id, output_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    // Reader CT args: fields 0..26 = DeepseekMoeFastReduceNcFusedReaderCtArgs; then four
+    // TensorAccessorArgs (input, scores, expert_indices, expert_mapping) appended in that order.
+    // Convert the host-side float32 scale to BF16 by taking the upper 16 bits of its IEEE-754
+    // representation (truncation, matching the BF16 layout used elsewhere on device).
+    uint32_t shared_expert_scale_f32_bits = 0;
+    const float shared_expert_scale_value = operation_attributes.shared_expert_scale;
+    std::memcpy(&shared_expert_scale_f32_bits, &shared_expert_scale_value, sizeof(uint32_t));
+    const uint32_t shared_expert_scale_bf16 = shared_expert_scale_f32_bits >> 16;
+
+    const DeepseekMoeFastReduceNcFusedReaderCtArgs reader_ct_named{
+        .cb_in_act_id = cb_in_act_id,
+        .cb_scores_id = cb_scores_id,
+        .cb_scores_rm_id = cb_scores_rm_id,
+        .act_page_size = input_page_size,
+        .scores_buf_page_size = scores_page_size,
+        .scores_tile_size = scores_tile_size,
+        .num_cores = num_cores,
+        .input_granularity = input_granularity,
+        .reduction_dim = reduction_dim,
+        .reduction_dim_size = reduction_dim_size,
+        .inner_num_tiles = inner_num_tiles,
+        .reduction_num_tiles = reduction_num_tiles,
+        .num_tokens = num_tokens,
+        .num_tokens_x32 = num_tokens_x32,
+        .scores_cb_rm_page_size = scores_cb_rm_page_size,
+        .expert_indices_page_size = expert_indices_page_size,
+        .expert_mapping_page_size = expert_mapping_page_size,
+        .cluster_axis = operation_attributes.cluster_axis,
+        .cb_expert_indices_id = cb_expert_indices_id,
+        .cb_expert_mapping_id = cb_expert_mapping_id,
+        .expert_indices_cb_page_size = expert_indices_cb_page_size,
+        .expert_mapping_cb_page_size = expert_mapping_cb_page_size,
+        .expert_indices_num_pages = expert_indices_num_pages,
+        .expert_mapping_num_pages = expert_mapping_num_pages,
+        .mesh_cols = mesh_cols,
+        .num_shared_experts = operation_attributes.num_shared_experts,
+        .shared_expert_scale_bf16 = shared_expert_scale_bf16,
+    };
+    std::vector<uint32_t> reader_ct_args = to_reader_ct_arg_vector(reader_ct_named);
+    TensorAccessorArgs(input_tensor.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(scores_tensor.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(expert_indices_tensor.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(expert_mapping_tensor.buffer()).append_to(reader_ct_args);
+
+    std::vector<uint32_t> writer_ct_args = {
+        cb_out_id,
+        output_page_size,
+        num_cores,
+        input_tensor_Wt,
+        slice_Wt,
+        static_cast<uint32_t>(output_tensors.size())};
+    for (uint32_t i = 0; i < output_tensors.size(); ++i) {
+        writer_ct_args.push_back(output_page_size);
+    }
+    for (const ttnn::Tensor& output_tensor : output_tensors) {
+        TensorAccessorArgs(output_tensor.buffer()).append_to(writer_ct_args);
+    }
+
+    const auto* const reader_kernel_file =
+        "ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/"
+        "deepseek_moe_fast_reduce_nc_fused_reader.cpp";
+    const auto* const writer_kernel_file =
+        "ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/"
+        "deepseek_moe_fast_reduce_nc_writer.cpp";
+
+    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+        program, reader_kernel_file, all_cores, tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+
+    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
+        program, writer_kernel_file, all_cores, tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
+
+    std::map<std::string, std::string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    const auto* const compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/"
+        "deepseek_moe_fast_reduce_nc_fused_compute.cpp";
+
+    std::vector<uint32_t> compute_ct_args_group_1 = {
+        num_cols_per_core_group_1,
+        reduction_dim_size,
+        input_granularity,
+        cb_in_act_id,
+        cb_scores_id,
+        cb_out_id,
+    };
+    tt::tt_metal::CreateKernel(
+        program,
+        compute_kernel_file,
+        core_group_1,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_ct_args_group_1,
+            .defines = compute_defines});
+
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_ct_args_group_2 = {
+            num_cols_per_core_group_2,
+            reduction_dim_size,
+            input_granularity,
+            cb_in_act_id,
+            cb_scores_id,
+            cb_out_id,
+        };
+        tt::tt_metal::CreateKernel(
+            program,
+            compute_kernel_file,
+            core_group_2,
+            tt_metal::ComputeConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = compute_ct_args_group_2,
+                .defines = compute_defines});
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    // Each core is assigned an output work unit in a row wise round robin
+    // fashion. For a given core, the first index is i, and all subsequent
+    // indices are increments of num_cores. The total number of
+    // units is num_tiles_per_group times num_cores.
+    // For example, with 130 output tiles to be processed on an 8x8 grid
+    // - the increment is 64
+    // - the first 2 cores will have num_tiles_per_core 3 and the rest 2
+    // - core x=0,y=0 will process output tiles 0, 64, and 128
+    // - core x=1,y=0 will process output tiles 1, 65, and 129
+    // - core x=2,y=0 will process output tiles 2 and 66
+    // - core x=3,y=0 will process output tiles 3 and 67
+    // - etc
+    // The first tile that needs to be reduced has the same as the output tile.
+    // That is the starting point for the reader, which then processes all
+    // subsequent tiles to be reduced. The increment for the input indices is
+    // the size of the inner dimensions in tiles (inner_num_tiles). The number
+    // of tiles to process is the size of the reduce dimension in tiles
+    // (reduction_num_tiles).
+    TT_FATAL(
+        core_group_2.ranges().empty() || num_cols_per_core_group_1 >= num_cols_per_core_group_2,
+        "num_cols_per_core_group_1 must be greater than or equal to num_cols_per_core_group_2");
+
+    const auto core_groups = {core_group_1, core_group_2};
+
+    uint32_t start_tiles_read = 0;
+    for (const auto& core_group : core_groups) {
+        if (core_group.ranges().empty()) {
+            continue;
+        }
+
+        uint32_t num_tiles_per_core =
+            core_group_1.contains(core_group.ranges().at(0)) ? num_cols_per_core_group_1 : num_cols_per_core_group_2;
+        uint32_t page_id_range_length = num_tiles_per_core * num_cores;
+
+        for (const auto& core : corerange_to_cores(core_group)) {
+            uint32_t start_tiles_to_read = start_tiles_read + page_id_range_length;
+
+            uint32_t start_slice_row_offset = (start_tiles_read / input_tensor_Wt) * slice_Wt;
+            uint32_t start_pages_read_in_row = start_tiles_read % input_tensor_Wt;
+
+            // Reader RT args layout:
+            //   [0] input addr
+            //   [1] scores addr
+            //   [2] start_tiles_read
+            //   [3] start_tiles_to_read
+            //   [4] mesh_coord_row
+            //   [5] mesh_coord_col
+            //   [6] expert_indices addr
+            //   [7] expert_mapping addr
+            TT_FATAL(
+                mesh_coordinate.dims() == 2,
+                "deepseek_moe_fast_reduce_nc_fused expects a 2D mesh coordinate, got {}D",
+                mesh_coordinate.dims());
+            const uint32_t mesh_coord_row = mesh_coordinate[0];
+            const uint32_t mesh_coord_col = mesh_coordinate[1];
+            std::vector<uint32_t> reader_rt_args = {
+                input_tensor.buffer()->address(),
+                scores_tensor.buffer()->address(),
+                start_tiles_read,
+                start_tiles_to_read,
+                mesh_coord_row,
+                mesh_coord_col,
+                expert_indices_tensor.buffer()->address(),
+                expert_mapping_tensor.buffer()->address()};
+            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
+
+            std::vector<uint32_t> writer_rt_args = {
+                start_tiles_read, start_tiles_to_read, start_slice_row_offset, start_pages_read_in_row};
+            for (const ttnn::Tensor& output_tensor : output_tensors) {
+                writer_rt_args.push_back(output_tensor.buffer()->address());
+            }
+            tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_rt_args);
+
+            start_tiles_read++;
+        }
+    }
+
+    return ttnn::device_operation::CachedProgram<DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::shared_variables_t>{
+        std::move(program), {reader_kernel_id, writer_kernel_id, corerange_to_cores(all_cores), num_cores}};
+}
+
+void DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const DeepseekMoEFastReduceNCFusedParams&,
+    const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
+    const ttnn::Tensor& scores_tensor = tensor_args.scores_tensor;
+    const ttnn::Tensor& expert_indices_tensor = tensor_args.expert_indices_tensor;
+    const ttnn::Tensor& expert_mapping_tensor = tensor_args.expert_mapping_tensor;
+    const std::vector<ttnn::Tensor>& output_tensors = tensor_return_value;
+
+    // Mesh coords and cluster_axis are tied to the device/launch and don't change between
+    // launches with the same cache key, so we only refresh tensor addresses here.
+    // Reader RT arg layout (set in create_at):
+    //   [0] input addr, [1] scores addr, [2..3] work range,
+    //   [4..5] mesh (row, col), [6] expert_indices addr, [7] expert_mapping addr.
+    for (auto& [range, program] : cached_workload.workload.get_programs()) {
+        const auto& shared_variables = cached_workload.shared_variables.at(range);
+        const tt::tt_metal::KernelHandle& reader_kernel_id = shared_variables.reader_kernel_id;
+        const tt::tt_metal::KernelHandle& writer_kernel_id = shared_variables.writer_kernel_id;
+        const auto& all_cores = shared_variables.all_cores;
+        const uint32_t ncores = shared_variables.ncores;
+
+        for (uint32_t i = 0; i < ncores; ++i) {
+            const auto& core = all_cores[i];
+            auto& reader_rt_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            reader_rt_args[0] = input_tensor.buffer()->address();
+            reader_rt_args[1] = scores_tensor.buffer()->address();
+            reader_rt_args[6] = expert_indices_tensor.buffer()->address();
+            reader_rt_args[7] = expert_mapping_tensor.buffer()->address();
+
+            auto& writer_rt_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            const uint32_t output_tensor_start_idx = 4;
+            for (unsigned j = 0; j < output_tensors.size(); ++j) {
+                writer_rt_args[output_tensor_start_idx + j] = output_tensors.at(j).buffer()->address();
+            }
+        }
+    }
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "deepseek_moe_fast_reduce_nc_fused_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct DeepseekMoEFastReduceNCFusedMeshWorkloadFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id;
+        tt::tt_metal::KernelHandle writer_kernel_id;
+        std::vector<tt::tt_metal::CoreCoord> all_cores;
+        uint32_t ncores;
+    };
+
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    // Per-device program construction. The framework iterates the mesh's coordinate range set and
+    // assembles the MeshWorkload by calling this for each coordinate.
+    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
+        const DeepseekMoEFastReduceNCFusedParams& operation_attributes,
+        const ttnn::MeshCoordinate& mesh_coordinate,
+        const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const DeepseekMoEFastReduceNCFusedParams& operation_attributes,
+        const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Fused compute kernel: multiply-accumulate using hardware MAC.
+//
+// For each output tile we iterate over reduction_dim_size experts and sum:
+//   dst0 += act_tile[e] * score_col[e]   (hardware MAC with col-broadcast)
+//
+// Each score tile has expert scores in column 0 (broadcast to all columns).
+// The reader pre-loads all reduction_dim_size score tiles before signalling compute_scores.
+// Score tiles are kept resident and accessed by index throughout the loop.
+//
+// Initialization:
+//   init_bcast<ELWMUL, COL> handles PACK + UNPACK + hw_configure.
+//   We then override the MATH init with acc_to_dest=1 so that every
+//   mul_tiles_bcast_cols call accumulates into dst rather than replacing it.
+//
+// After tile_regs_acquire(), dst0 is zero-initialized by hardware, so the
+// first MAC (expert 0) correctly seeds the accumulator.
+
+#include "api/compute/bcast.h"
+
+using namespace ckernel;
+
+constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+constexpr uint32_t reduction_dim_size = get_compile_time_arg_val(1);
+constexpr uint32_t input_granularity = get_compile_time_arg_val(2);
+constexpr uint32_t compute_input_cb_id_0 = get_compile_time_arg_val(3);
+constexpr uint32_t compute_input_cb_id_1 = get_compile_time_arg_val(4);
+constexpr uint32_t compute_output_cb_id = get_compile_time_arg_val(5);
+
+void kernel_main() {
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t one_tile = 1;
+    constexpr uint32_t num_input_tiles_iter = reduction_dim_size / input_granularity;
+
+    // Full PACK + UNPACK + hw_configure init for ELWMUL + COL-broadcast
+    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::COL>(
+        compute_input_cb_id_0, compute_input_cb_id_1, compute_output_cb_id);
+
+    // Override MATH init to enable acc_to_dest=1 (hardware accumulate mode)
+    // This makes each mul_tiles_bcast_cols call do: dst0 += act * score  (MAC)
+    MATH((llk_math_eltwise_binary_init_with_operands<EltwiseBinaryType::ELWMUL, BroadcastType::COL, MATH_FIDELITY>(
+        compute_input_cb_id_0, compute_input_cb_id_1, 1 /*acc_to_dest*/)));
+
+    reconfig_data_format(compute_input_cb_id_0, compute_input_cb_id_1);
+
+    // Wait for all score tiles — they are pre-loaded once by the reader prologue
+    // and remain resident for the entire kernel invocation.
+    cb_wait_front(compute_input_cb_id_1, reduction_dim_size);
+    for (uint32_t i = 0; i < num_output_tiles; ++i) {
+        tile_regs_acquire();
+
+        for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
+            cb_wait_front(compute_input_cb_id_0, input_granularity);
+
+            for (uint32_t k = 0; k < input_granularity; ++k) {
+                // expert_tile = linear expert index for this tile
+                const uint32_t expert_tile = j * input_granularity + k;
+                // dst0 += act_tile[k] * score_col[expert_tile]  (single MAC)
+                mul_tiles_bcast_cols(compute_input_cb_id_0, compute_input_cb_id_1, k, expert_tile, dst0);
+            }
+            cb_pop_front(compute_input_cb_id_0, input_granularity);
+        }
+
+        tile_regs_commit();
+        cb_reserve_back(compute_output_cb_id, one_tile);
+        pack_reconfig_data_format(compute_output_cb_id);
+        tile_regs_wait();
+        pack_tile(dst0, compute_output_cb_id);
+        tile_regs_release();
+        cb_push_back(compute_output_cb_id, one_tile);
+    }
+
+    // Release all score tiles
+    cb_pop_front(compute_input_cb_id_1, reduction_dim_size);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint_pages.h"
+
+// Compile-time args
+constexpr uint32_t cb_in_act_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_scores_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_scores_rm_id = get_compile_time_arg_val(2);
+constexpr uint32_t act_page_size = get_compile_time_arg_val(3);
+constexpr uint32_t scores_page_size = get_compile_time_arg_val(4);
+constexpr uint32_t scores_tile_size = get_compile_time_arg_val(5);  // BF16 CB tile = 2048 bytes
+constexpr uint32_t num_cores_to_be_used = get_compile_time_arg_val(6);
+constexpr uint32_t input_granularity = get_compile_time_arg_val(7);
+constexpr uint32_t reduction_dim = get_compile_time_arg_val(8);
+constexpr uint32_t reduction_dim_size = get_compile_time_arg_val(9);  // expert_k
+constexpr uint32_t inner_num_tiles = get_compile_time_arg_val(10);
+constexpr uint32_t reduction_num_tiles = get_compile_time_arg_val(11);
+constexpr uint32_t num_tokens = get_compile_time_arg_val(12);
+constexpr uint32_t num_tokens_x32 = get_compile_time_arg_val(13);          // tokens per device == TILE_HEIGHT
+constexpr uint32_t cb_scores_rm_page_size = get_compile_time_arg_val(14);  // RM CB page (one token row)
+constexpr uint32_t expert_indices_page_size = get_compile_time_arg_val(15);
+constexpr uint32_t expert_mapping_page_size = get_compile_time_arg_val(16);
+constexpr uint32_t cluster_axis = get_compile_time_arg_val(17);
+constexpr uint32_t cb_expert_indices_id = get_compile_time_arg_val(18);
+constexpr uint32_t cb_expert_mapping_id = get_compile_time_arg_val(19);
+constexpr uint32_t expert_indices_cb_page_size = get_compile_time_arg_val(20);  // L1-aligned CB stride
+constexpr uint32_t expert_mapping_cb_page_size = get_compile_time_arg_val(21);  // L1-aligned CB stride
+constexpr uint32_t expert_indices_num_pages = get_compile_time_arg_val(22);
+constexpr uint32_t expert_mapping_num_pages = get_compile_time_arg_val(23);
+constexpr uint32_t mesh_cols = get_compile_time_arg_val(24);  // mesh_shape[1]; needed to decode linearized device ids
+constexpr uint32_t num_shared_experts = get_compile_time_arg_val(25);
+// Host packs the BF16 scale (upper 16 bits of float32) into the low 16 bits of this CT arg.
+constexpr uint16_t shared_expert_scale_bf16 = static_cast<uint16_t>(get_compile_time_arg_val(26) & 0xFFFF);
+
+constexpr uint32_t num_routed_experts = reduction_dim_size - num_shared_experts;
+
+constexpr uint32_t face2_offset = 512;  // face 2 starts 512 elements into tile
+
+// TensorAccessor CT args, chained:
+//   activation @ 27, scores @ next, expert_indices @ next, expert_mapping @ next.
+constexpr uint32_t initial_ct_idx_act = 27;
+constexpr uint32_t initial_ct_idx_scores = TensorAccessorArgs<initial_ct_idx_act>::next_compile_time_args_offset();
+constexpr uint32_t initial_ct_idx_expert_indices =
+    TensorAccessorArgs<initial_ct_idx_scores>::next_compile_time_args_offset();
+constexpr uint32_t initial_ct_idx_expert_mapping =
+    TensorAccessorArgs<initial_ct_idx_expert_indices>::next_compile_time_args_offset();
+
+void kernel_main() {
+    uint32_t arg_idx = 0;
+    const uint32_t input_address = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t scores_address = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    // Mesh coordinate of the executing device (row, col). Used together with cluster_axis to
+    // decide, per (token, k), whether the expert routed for that slot lives on this device's
+    // cluster axis (same column when cluster_axis==0, same row when cluster_axis==1).
+    const uint32_t mesh_coord_row = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mesh_coord_col = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t expert_indices_address = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t expert_mapping_address = get_arg_val<uint32_t>(arg_idx++);
+
+    // TensorAccessors
+    constexpr auto act_tensor_args = TensorAccessorArgs<initial_ct_idx_act>();
+    constexpr auto scores_tensor_args = TensorAccessorArgs<initial_ct_idx_scores>();
+    constexpr auto expert_indices_tensor_args = TensorAccessorArgs<initial_ct_idx_expert_indices>();
+    constexpr auto expert_mapping_tensor_args = TensorAccessorArgs<initial_ct_idx_expert_mapping>();
+    auto act_accessor = TensorAccessor(act_tensor_args, input_address, act_page_size);
+    // scores_accessor: each "page" = one token row (reduction_dim_size BF16 scores)
+    auto scores_accessor = TensorAccessor(scores_tensor_args, scores_address, scores_page_size);
+    auto expert_indices_accessor =
+        TensorAccessor(expert_indices_tensor_args, expert_indices_address, expert_indices_page_size);
+    auto expert_mapping_accessor =
+        TensorAccessor(expert_mapping_tensor_args, expert_mapping_address, expert_mapping_page_size);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Prologue 0: Mirror the full expert_indices_tensor and expert_mapping_tensor
+    // into their dedicated L1 CBs. Both tensors are small enough to fit entirely;
+    // pulling the data up front lets downstream consumers index them without
+    // re-issuing DRAM reads on the hot path. Each CB is single-buffered with one
+    // slot per DRAM page (host-side sizing in the program factory).
+    ////////////////////////////////////////////////////////////////////////////
+
+    cb_reserve_back(cb_expert_indices_id, expert_indices_num_pages);
+    uint32_t expert_indices_ptr = get_write_ptr(cb_expert_indices_id);
+    for (uint32_t p = 0; p < expert_indices_num_pages; ++p) {
+        noc_async_read_page(p, expert_indices_accessor, expert_indices_ptr + p * expert_indices_cb_page_size);
+    }
+
+    cb_reserve_back(cb_expert_mapping_id, expert_mapping_num_pages);
+    uint32_t expert_mapping_ptr = get_write_ptr(cb_expert_mapping_id);
+    for (uint32_t p = 0; p < expert_mapping_num_pages; ++p) {
+        noc_async_read_page(p, expert_mapping_accessor, expert_mapping_ptr + p * expert_mapping_cb_page_size);
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_expert_indices_id, expert_indices_num_pages);
+    cb_push_back(cb_expert_mapping_id, expert_mapping_num_pages);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Prologue: Load all raw RM scores into scratch CB, then build
+    // BF16 score tiles in cb_scores using BroadcastType::COL format.
+    //
+    // scores layout (ROW_MAJOR): [tokens, 1, seq, reduction_dim_size]
+    // One page = one token row of reduction_dim_size BF16 scores (= cb_scores_rm_page_size bytes)
+    //
+    // Target: cb_scores holds reduction_dim_size tiles (one per expert e).
+    // Each tile[e]: column 0 contains score[t, e] for token rows t=0..num_tokens-1.
+    //               All other columns = 0 (required by BroadcastType::COL).
+    //
+    // BF16 32x32 tile face layout (4 faces, each 16x16):
+    //   Face 0 (rows  0-15, cols  0-15): base offset 0   (uint16 index)
+    //   Face 1 (rows  0-15, cols 16-31): base offset 256
+    //   Face 2 (rows 16-31, cols  0-15): base offset 512
+    //   Face 3 (rows 16-31, cols 16-31): base offset 768
+    // Within a face, element at (row r, col c): index = r * 16 + c
+    // So column-0 of row t:
+    //   t < 16  → face 0 → uint16 index: t * 16
+    //   t >= 16 → face 2 → uint16 index: 512 + (t-16) * 16
+    ////////////////////////////////////////////////////////////////////////////
+
+    // Step 1: Read all token rows from DRAM into scratch staging buffer
+    cb_reserve_back(cb_scores_rm_id, num_tokens);
+    uint32_t scores_rm_ptr = get_write_ptr(cb_scores_rm_id);
+    for (uint32_t t = 0; t < num_tokens; ++t) {
+        noc_async_read_page(t, scores_accessor, scores_rm_ptr + t * cb_scores_rm_page_size);
+    }
+    noc_async_read_barrier();
+
+    // Step 2: Permute and to_layout scores; rm [token][expert] in uint16 units, row stride = reduction_dim_size
+    cb_reserve_back(cb_scores_id, reduction_dim_size);
+    uint32_t scores_write_ptr = get_write_ptr(cb_scores_id);
+
+    volatile tt_l1_ptr uint16_t* scores_rm_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scores_rm_ptr);
+    volatile tt_l1_ptr uint16_t* scores_tile_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scores_write_ptr);
+    volatile tt_l1_ptr uint16_t* expert_indices_u16 =
+        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(expert_indices_ptr);
+    volatile tt_l1_ptr uint16_t* expert_mapping_u16 =
+        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(expert_mapping_ptr);
+    const uint32_t tile_u16_stride = scores_tile_size / sizeof(uint16_t);  // 1024 uint16 per tile
+
+    // ---- On-axis predicate setup --------------------------------------------------------------
+    // For each (token, k) the prologue checks whether the expert this slot routes to lives on
+    // this device's cluster axis. If it doesn't, the score is zeroed so the compute kernel's
+    // weighted sum drops the contribution; otherwise the original score is written through.
+    //
+    // expert_id    = expert_indices_u16[t * indices_stride + k]
+    // owner_device = expert_mapping_u16[mapping_row * mapping_stride + expert_id]   (linearized)
+    // owner_row    = owner_device / mesh_cols
+    // owner_col    = owner_device % mesh_cols
+    // cluster_axis == 0: cluster is a column → on_axis iff owner_col == mesh_coord_col
+    // cluster_axis == 1: cluster is a row    → on_axis iff owner_row == mesh_coord_row
+    //
+    // Note on the zero literal: the score tiles hold BF16 values addressed as uint16. BF16 +0.0
+    // is bit pattern 0x0000, so writing static_cast<uint16_t>(0) is bit-identical to BF16 zero.
+    constexpr uint16_t bf16_zero = 0x0000;
+    const uint32_t indices_page_stride_u16 = expert_indices_cb_page_size / sizeof(uint16_t);
+    const uint32_t mapping_page_stride_u16 = expert_mapping_cb_page_size / sizeof(uint16_t);
+    const uint32_t local_device_idx = mesh_coord_row * mesh_cols + mesh_coord_col;
+    // If the mapping was supplied as a single replicated page (shape [1, experts]) every device
+    // sees the same row, so just read row 0. If it was supplied per dispatch-device (shape
+    // [devices, experts] from map_shared_experts) read this device's row.
+    const uint32_t mapping_row = (expert_mapping_num_pages == 1) ? 0u : local_device_idx;
+    volatile tt_l1_ptr uint16_t* mapping_row_base = expert_mapping_u16 + mapping_row * mapping_page_stride_u16;
+
+    auto compute_on_axis = [&](uint32_t t, uint32_t k) -> bool {
+        const uint16_t expert_id = expert_indices_u16[t * indices_page_stride_u16 + k];
+        const uint32_t owner_device = mapping_row_base[expert_id];
+        if constexpr (cluster_axis == 0) {
+            return (owner_device % mesh_cols) == mesh_coord_col;
+        } else {
+            return (owner_device / mesh_cols) == mesh_coord_row;
+        }
+    };
+
+    // [token][1][s=1][k] -> [k][1][t][s_padded=32]
+    for (uint32_t k = 0; k < reduction_dim_size; ++k) {
+        volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + k * tile_u16_stride;
+        const bool is_shared_expert = (k >= num_routed_experts);
+
+        // Fill Face 0 (rows 0-15, col 0) for tokens t = 0..15
+        for (uint32_t t = 0; t < 16 && t < num_tokens; ++t) {
+            if (is_shared_expert) {
+                expert_tile[t * 16] = shared_expert_scale_bf16;
+            } else {
+                // score location in RM: t * (cb_scores_rm_page_size / 2) + k
+                const uint16_t score = scores_rm_u16[t * (cb_scores_rm_page_size / 2) + k];
+                expert_tile[t * 16] = compute_on_axis(t, k) ? score : bf16_zero;
+            }
+        }
+        // Fill Face 2 (rows 16-31, col 0) for tokens t = 16..num_tokens-1
+        if (num_tokens > 16) {
+            for (uint32_t t = 16; t < num_tokens; ++t) {
+                if (is_shared_expert) {
+                    expert_tile[face2_offset + (t - 16) * 16] = shared_expert_scale_bf16;
+                } else {
+                    const uint16_t score = scores_rm_u16[t * (cb_scores_rm_page_size / 2) + k];
+                    expert_tile[face2_offset + (t - 16) * 16] = compute_on_axis(t, k) ? score : bf16_zero;
+                }
+            }
+        }
+    }
+    if ((num_tokens < num_tokens_x32) && (num_tokens < 16)) {
+        // Fill remaining Face 0 with BF16 +0.0 (bit pattern 0x0000).
+        for (uint32_t k = 0; k < reduction_dim_size; ++k) {
+            volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + k * tile_u16_stride;
+            for (uint32_t t = num_tokens; t < 16; ++t) {
+                expert_tile[t * 16] = bf16_zero;
+            }
+        }
+    }
+    if (num_tokens < num_tokens_x32) {
+        // Fill remaining Face 2 with BF16 +0.0. Clamp the start to 16 so that the
+        // (t - 16) row offset cannot underflow for num_tokens < 16 cases.
+        const uint32_t face_2_start = num_tokens < 16 ? 16 : num_tokens;
+        for (uint32_t k = 0; k < reduction_dim_size; ++k) {
+            volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + k * tile_u16_stride;
+            for (uint32_t t = face_2_start; t < 32; ++t) {
+                expert_tile[face2_offset + (t - 16) * 16] = bf16_zero;
+            }
+        }
+    }
+
+    // Step 3: Release scores to compute kernel
+    cb_push_back(cb_scores_id, reduction_dim_size);
+    cb_push_back(cb_scores_rm_id, num_tokens);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Main loop: stream activation tiles into cb_in_act (same as original op)
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t l1_write_addr;
+    uint32_t input_granularity_index = 0;
+
+    for (uint32_t tiles_read = start_tiles_read; tiles_read < start_tiles_to_read; tiles_read += num_cores_to_be_used) {
+        uint32_t read_tile_id;
+        if constexpr (reduction_dim == 0) {
+            read_tile_id = tiles_read;
+        } else {
+            read_tile_id = ((tiles_read / inner_num_tiles) * reduction_num_tiles) + (tiles_read % inner_num_tiles);
+        }
+
+        // Now reduce all tiles in the reduction dim. The first index is the
+        // same as the output index. After that need to increment by the
+        // size of the inner dimensions in tiles. E.g. for 130 tiles,
+        // the increment is 130. If 4 tiles need to be reduced, then the
+        // first core would access tiles at indices 0, 130, 260, 390, 64,
+        // 64+130, 64+260, 64+390, 128, 128+130, 128+260, and 128+390.
+        for (uint32_t j = 0; j < reduction_dim_size; ++j) {
+            if (input_granularity_index == 0) {
+                cb_reserve_back(cb_in_act_id, input_granularity);
+                l1_write_addr = get_write_ptr(cb_in_act_id);
+            }
+            noc_async_read_page(read_tile_id, act_accessor, l1_write_addr);
+
+            l1_write_addr += act_page_size;
+            read_tile_id += inner_num_tiles;
+            input_granularity_index++;
+
+            if (input_granularity_index == input_granularity) {
+                noc_async_read_barrier();
+                cb_push_back(cb_in_act_id, input_granularity);
+                input_granularity_index = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Where appropriate, replace reductions over K and expert score scaling with the fused op
- Also allows us to remove the `moreh_full` from decode

### Notes for reviewers
- 1a9a3a1cec22435280edaa648c7faa138ccb7f57 has already been reviewed and merged into main, only upper commits need to be reviewed.
- Note: the code paths are slightly different for prefill and decode due to the chunking structure 