### PR TITLE
gpt-oss: serialize trace iters in row_sharded_batched_prefill (#44746)

### DIFF
--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -824,6 +824,13 @@ class Model:
                 )
                 ho = self.prepare_inputs_prefill(ti, page_table=pi, trace_enabled=True, batched_prefill=True)
                 hi = (ho[0], ho[3], ho[4])
+                # Wait for the previous iter's trace to finish reading the
+                # shared trace input tensors before overwriting them with this
+                # iter's payload. Without this sync, copy_host_to_device on
+                # iter N+1 can clobber inputs that iter N's still-running
+                # async execute_trace is consuming, corrupting per-user KV
+                # writes. See tenstorrent/tt-metal#44746.
+                ttnn.synchronize_device(mesh_device)
                 copy_host_to_device(hi, device_tensors=tc_inputs[trace_key], mesh_device=mesh_device)
                 ttnn.execute_trace(mesh_device, tc_ids[trace_key], cq_id=0, blocking=False)
                 if not skip_lm:


### PR DESCRIPTION
## Summary

Serialise the iteration loop in `row_sharded_batched_prefill` so the next iter's host-side `copy_host_to_device` doesn't clobber shared trace input device tensors while the previous iter's `execute_trace(..., blocking=False)` is still consuming them.

This is part of the investigation into tenstorrent/tt-metal#44746 (gpt-oss-120b per-user KV-cache corruption under `sample_on_device_mode=all`). It fixes the **iter-loop async-trace race** specifically; the deeper bug in the same area is still being investigated and will land separately.

## The race

`row_sharded_batched_prefill` runs `num_iters = users_per_row_total / upr` iterations of the same captured trace, each with a different page table / token batch:

```python
for iter_idx in range(num_iters):
    ti, pi, li, ui = self.prepare_row_sharded_prefill_iter(...)
    ho = self.prepare_inputs_prefill(ti, page_table=pi, trace_enabled=True, batched_prefill=True)
    hi = (ho[0], ho[3], ho[4])
    copy_host_to_device(hi, device_tensors=tc_inputs[trace_key], mesh_device=mesh_device)
    ttnn.execute_trace(mesh_device, tc_ids[trace_key], cq_id=0, blocking=False)
    ...
ttnn.synchronize_device(mesh_device)  # only at end of loop
```

`ttnn.execute_trace(..., blocking=False)` is async — the call returns while the trace is still running on device, reading from the device tensors at `tc_inputs[trace_key]`. The next iter's `copy_host_to_device` writes to those same device tensors. With no sync between iters, iter N+1's host copy can land while iter N's trace is mid-read, corrupting iter N's input → wrong per-user KV writes.

## Fix

```diff
                 ho = self.prepare_inputs_prefill(ti, page_table=pi, trace_enabled=True, batched_prefill=True)
                 hi = (ho[0], ho[3], ho[4])
+                # Wait for the previous iter's trace to finish reading the
+                # shared trace input tensors before overwriting them with this
+                # iter's payload.
+                ttnn.synchronize_device(mesh_device)
                 copy_host_to_device(hi, device_tensors=tc_inputs[trace_key], mesh_device=mesh_device)
                 ttnn.execute_trace(mesh_device, tc_ids[trace_key], cq_id=0, blocking=False)
```

## Test plan

Measured on gpt-oss-120b on Galaxy 4x8 (DP=4), `sample_on_device_mode=all`, with [tenstorrent/vllm#396](https://github.com/tenstorrent/vllm/pull/396) applied:

**Same-prompt concurrency probe** — 16 identical reasoning prompts at `temperature=1.0`, `reasoning_effort=high`:

| Build | NULL responses |
|---|---|
| Before this PR | 7 / 16 |
| **After this PR** | **3 / 16** |

The remaining 3/16 NULL is **bug #2** that this PR does not address (tracked in #44746 along with the diagnostic test that pins it).

**Greedy probe** — same prompt × 16 users × `temperature=0`, which removes sampling variance and should produce 16 identical outputs if batched prefill is correct:

| Build | NULL | Distinct content heads |
|---|---|---|
| Before this PR | 13 / 16 | 3 |
| After this PR | 12 / 16 | 3 |

So this PR alone is not enough at greedy. With temp=1.0 (the user-facing workload) the improvement is significant. Greedy stays broken because of the deeper state-management bug we're investigating separately.

- [x] Race confirmed by adding sync → 4/16 fewer NULLs at temp=1.0 (causal evidence)
- [x] Sync placement isolated to the offending tensor write (`copy_host_to_device` immediately follows)
- [ ] Greenfield CI run (this PR only touches the gpt-oss demo; covered by existing gpt-oss tests)
- [ ] End-to-end AIME25 retest with this PR + #44746 fix (deferred until #44746 fix lands)

## Performance

The fix waits for each iter's trace to drain before kicking off the next. `num_iters` is typically small (4 at batch_size=16 with `upr=1`), and each trace already takes most of the iteration time, so the host idle overhead added by the sync is well within the noise of the prefill compute itself. No measurable TTFT regression on the AIME25 workload above.

## Related

- tenstorrent/tt-metal#44746 — parent issue with full investigation, candidate areas for the remaining bug, and a diagnostic KV-diff test skeleton
- tenstorrent/vllm#395 — the original DP async-decode race (different bug, vllm side)
- tenstorrent/vllm#396 — vllm-side fix for #395; works with `decode_only` today; will work with `all` once #44746 fully lands.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/fix-row-sharded-batched-prefill-iter-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/fix-row-sharded-batched-prefill-iter-sync)