### PR TITLE
Migrate matmul/factory/matmul_multicore_reuse to ProgramDescriptor

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.cpp
@@ -2,288 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <map>
-#include <string>
-
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.hpp"
-#include "ttnn/operations/compute_throttle_utils.hpp"
-#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 
 using namespace tt::constants;
 using namespace tt;
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+using tt::tt_metal::ReaderConfigDescriptor;
+using tt::tt_metal::WriterConfigDescriptor;
 
 namespace ttnn::prim {
 
-static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
-    tt_metal::IDevice* device,
-    tt::DataFormat in0_cb_data_format,
-    tt::DataFormat in1_cb_data_format,
-    tt::DataFormat out_cb_data_format,
-    MathFidelity math_fidelity,
-    bool dst_full_sync_en,
-    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
-    uint32_t num_cores_x,
-    uint32_t B,
-    uint32_t M,
-    uint32_t N,
-    uint32_t K,
-    bool bcast_batch,
-    uint32_t in0_block_w,
-    uint32_t out_subblock_h,
-    uint32_t out_subblock_w,
-    uint32_t per_core_M,
-    uint32_t per_core_N,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* out_buffer) {
-    tt_metal::Program program{};
-
-    uint32_t in0_single_tile_size = tt::tile_size(in0_cb_data_format);
-    uint32_t in1_single_tile_size = tt::tile_size(in1_cb_data_format);
-    uint32_t out_single_tile_size = tt::tile_size(out_cb_data_format);
-
-    uint32_t in0_block_tiles = per_core_M * in0_block_w;
-    uint32_t in0_CB_tiles = in0_block_tiles * 2;  // double buffer
-    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
-    uint32_t in1_block_tiles = per_core_N * in0_block_w;
-    uint32_t in1_CB_tiles = in1_block_tiles * 2;  // double buffer
-    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
-    uint32_t out_block_tiles = per_core_M * per_core_N;
-    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
-    uint32_t out_CB_size = out_CB_tiles * out_single_tile_size;
-
-    // Compute kernel compile time args
-    uint32_t num_blocks = (K / in0_block_w);
-
-    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
-    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
-    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
-
-    uint32_t in1_num_subblocks = (per_core_N / out_subblock_w);
-    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
-    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
-
-    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
-
-    std::vector<uint32_t> compute_kernel_args = {
-        in0_block_w,             // in0_block_w
-        in0_num_subblocks,       // in0_num_subblocks
-        in0_block_num_tiles,     // in0_block_num_tiles
-        in0_subblock_num_tiles,  // in0_subblock_num_tiles
-
-        in1_num_subblocks,    // in1_num_subblocks
-        in1_block_num_tiles,  // in1_block_num_tiles
-        in1_per_core_w,       // in1_per_core_w
-
-        num_blocks,  // num_blocks
-
-        out_subblock_h,          // out_subblock_h
-        out_subblock_w,          // out_subblock_w
-        out_subblock_num_tiles,  // out_subblock_num_tiles
-        B                        // batch
-    };
-
-    uint32_t num_blocks_read = 0;
-    uint32_t num_blocks_y = M / per_core_M;
-    uint32_t num_blocks_x = N / per_core_N;
-
-    CoreRangeSet all_cores(tt::tt_metal::num_cores_to_corerangeset(
-        num_blocks_x * num_blocks_y, device->compute_with_storage_grid_size(), true));
-
-    // Create circular buffers
-    uint32_t src0_cb_index = 0;
-    tt_metal::CircularBufferConfig src0_cb_config =
-        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_cb_data_format}})
-            .set_page_size(src0_cb_index, in0_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
-
-    uint32_t src1_cb_index = 1;
-    tt_metal::CircularBufferConfig src1_cb_config =
-        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_cb_data_format}})
-            .set_page_size(src1_cb_index, in1_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
-
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t interm0_cb_index = 24;
-    std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
-        {output_cb_index, out_cb_data_format}, {interm0_cb_index, out_cb_data_format}};
-    tt_metal::CircularBufferConfig output_cb_config =
-        tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-            .set_page_size(output_cb_index, out_single_tile_size)
-            .set_page_size(interm0_cb_index, out_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
-
-    std::vector<uint32_t> reader_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(reader_compile_time_args);
-
-    std::vector<uint32_t> writer_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(writer_compile_time_args);
-
-    // Create reader and writer kernels per core
-    auto mm_reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args, {}, {{"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}}));
-
-    auto unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, {{"cb_out", tt::CBIndex::c_16}}));
-
-    // Create compute kernel
-    std::map<std::string, std::string> mm_kernel_defines;
-    const uint32_t num_cores = all_cores.num_cores();
-    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
-        device->arch(), num_cores, mm_kernel_defines);
-    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
-        device->arch(), num_cores, mm_kernel_defines, throttle_level);
-
-    tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .dst_full_sync_en = dst_full_sync_en,
-            .compile_args = compute_kernel_args,
-            .defines = mm_kernel_defines,
-            .named_compile_args = {
-                {"cb_in0", tt::CBIndex::c_0},
-                {"cb_in1", tt::CBIndex::c_1},
-                {"cb_out", tt::CBIndex::c_16},
-                {"cb_intermed0", (uint32_t)24}}});
-
-    for (int output_idx_y = 0; output_idx_y < num_blocks_y; output_idx_y++) {
-        for (int output_idx_x = 0; output_idx_x < num_blocks_x; output_idx_x++) {
-            int core_idx_x = num_blocks_read % num_cores_x;
-            int core_idx_y = num_blocks_read / num_cores_x;
-            CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
-
-            // Write runtime args to device
-            std::vector<uint32_t> mm_reader_args = {
-                (std::uint32_t)in0_buffer->address(),          // in0_tensor_addr
-                (std::uint32_t)K * per_core_M * output_idx_y,  // in0_tensor_start_tile_id
-                (std::uint32_t)1,                              // in0_tensor_stride_w
-                (std::uint32_t)K,                              // in0_tensor_stride_h
-                (std::uint32_t)in0_block_w,                    // in0_tensor_next_block_stride
-
-                (std::uint32_t)in0_block_w,               // in0_block_w
-                (std::uint32_t)per_core_M,                // in0_block_h
-                (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
-
-                (std::uint32_t)in1_buffer->address(),      // in1_tensor_addr
-                (std::uint32_t)per_core_N * output_idx_x,  // in1_tensor_start_tile_id
-                (std::uint32_t)1,                          // in1_tensor_stride_w
-                (std::uint32_t)N,                          // in1_tensor_stride_h
-                (std::uint32_t)in0_block_w * N,            // in1_tensor_next_block_stride
-
-                (std::uint32_t)per_core_N,                // in1_block_w
-                (std::uint32_t)in0_block_w,               // in1_block_h
-                (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
-
-                (std::uint32_t)K / in0_block_w,  // num_blocks
-
-                (std::uint32_t)M * K,       // MtKt
-                (std::uint32_t)K * N,       // KtNt
-                (std::uint32_t)B,           // batch
-                (std::uint32_t)bcast_batch  // bcast_B
-            };
-
-            std::vector<uint32_t> writer_args = {
-                (std::uint32_t)out_buffer->address(),  // out_tensor_addr
-                ((std::uint32_t)output_idx_x * per_core_N) +
-                    (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
-                (std::uint32_t)1,                     // out_tensor_stride_w
-                (std::uint32_t)N,                     // out_tensor_stride_h
-                (std::uint32_t)out_subblock_w,        // out_tensor_next_subblock_stride_w
-                (std::uint32_t)out_subblock_h * N,    // out_tensor_next_subblock_stride_h
-
-                (std::uint32_t)out_subblock_w,                     // out_subblock_w
-                (std::uint32_t)out_subblock_h,                     // out_subblock_h
-                (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
-                (std::uint32_t)(per_core_N / out_subblock_w),      // out_num_subblocks_w
-                (std::uint32_t)(per_core_M / out_subblock_h),      // out_num_subblocks_h
-
-                (std::uint32_t)M * N,  // MtNt
-                (std::uint32_t)B       // batch
-            };
-
-            tt_metal::SetRuntimeArgs(program, mm_reader_kernel_id, core, mm_reader_args);
-            tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_args);
-
-            num_blocks_read++;
-        }
-    }
-
-    return {std::move(program), {mm_reader_kernel_id, unary_writer_kernel_id, num_cores_x, num_blocks_y, num_blocks_x}};
-}
-
-void MatmulMultiCoreReuseProgramFactory::override_runtime_arguments(
-    MatmulMultiCoreReuseProgramFactory::cached_program_t& cached_program,
-    const ttnn::prim::MatmulParams& /*operation_attributes*/,
-    const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
-    constexpr uint32_t per_core_M = 16;
-    constexpr uint32_t per_core_N = 16;
-
-    const auto& input_tensors = tensor_args.input_tensors;
-    const auto& output_tensors = tensor_return_value;
-
-    const auto& ashape = input_tensors.at(0).padded_shape();
-    const auto& bshape = input_tensors.at(1).padded_shape();
-    uint32_t M = ashape[-2] / TILE_HEIGHT;
-    uint32_t N = bshape[-1] / TILE_WIDTH;
-
-    uint32_t num_cores_x = cached_program.shared_variables.num_cores_x;
-
-    uint32_t num_blocks_y = M / per_core_M;
-    uint32_t num_blocks_x = N / per_core_N;
-
-    auto* src_dram_buffer_a = input_tensors.at(0).buffer();
-    auto* src_dram_buffer_b = input_tensors.at(1).buffer();
-
-    auto* dst_dram_buffer = output_tensors.at(0).buffer();
-
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-
-    uint32_t num_blocks_read = 0;
-    for (int output_idx_y = 0; output_idx_y < num_blocks_y; output_idx_y++) {
-        for (int output_idx_x = 0; output_idx_x < num_blocks_x; output_idx_x++) {
-            int core_idx_x = num_blocks_read % num_cores_x;
-            int core_idx_y = num_blocks_read / num_cores_x;
-            CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
-
-            {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer_a->address();
-                runtime_args[8] = src_dram_buffer_b->address();
-            }
-
-            {
-                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer->address();
-            }
-            num_blocks_read++;
-        }
-    }
-}
-
-MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgramFactory::create(
+ProgramDescriptor MatmulMultiCoreReuseProgramFactory::create_descriptor(
     const ttnn::prim::MatmulParams& operation_attributes,
     const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     bool bcast_batch = operation_attributes.bcast_batch.value();
 
@@ -320,7 +64,6 @@ MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgram
     TT_FATAL(Nt % per_core_N == 0, "Nt ({}) must be divisible by per_core_N ({})", Nt, per_core_N);
     TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
-    // This should allocate a DRAM buffer on the device
     tt_metal::IDevice* device = a.device();
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -342,65 +85,207 @@ MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgram
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
+    uint32_t in0_single_tile_size = tt::tile_size(in0_cb_data_format);
+    uint32_t in1_single_tile_size = tt::tile_size(in1_cb_data_format);
+    uint32_t out_single_tile_size = tt::tile_size(out_cb_data_format);
 
-    return create_program(
-        device,
-        in0_cb_data_format,
-        in1_cb_data_format,
-        out_cb_data_format,
-        math_fidelity,
-        ttnn::get_dst_full_sync_en(operation_attributes.compute_kernel_config),
-        ttnn::get_throttle_level(operation_attributes.compute_kernel_config),
-        num_cores_x,
-        B,
-        Mt,
-        Nt,
-        Kt,
-        bcast_batch,
-        in0_block_w,
-        out_subblock_h,
-        out_subblock_w,
-        per_core_M,
-        per_core_N,
-        in0_buffer,
-        in1_buffer,
-        out_buffer);
-}
+    uint32_t in0_block_tiles = per_core_M * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles * 2;  // double buffer
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+    uint32_t in1_block_tiles = per_core_N * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles * 2;  // double buffer
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t out_CB_size = out_CB_tiles * out_single_tile_size;
 
-////////////////////////////////////////////////////////////////////////////
-//                      Mesh Workload Setup
-////////////////////////////////////////////////////////////////////////////
+    // Compute kernel compile time args
+    uint32_t num_blocks = (Kt / in0_block_w);
 
-MatmulMeshWorkloadMultiCoreReuseFactory::cached_mesh_workload_t
-MatmulMeshWorkloadMultiCoreReuseFactory::create_mesh_workload(
-    const ttnn::prim::MatmulParams& attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& output) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-        for (const auto& mesh_coord : mesh_coord_range) {
-            const ttnn::MeshCoordinateRange mesh_coord_range{mesh_coord, mesh_coord};
-            auto single_device_program = MatmulMultiCoreReuseProgramFactory::create(attributes, tensor_args, output);
-            shared_variables[mesh_coord_range] = single_device_program.shared_variables;
-            workload.add_program(mesh_coord_range, std::move(single_device_program.program));
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (per_core_N / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,  // num_blocks
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B                        // batch
+    };
+
+    uint32_t num_blocks_y = Mt / per_core_M;
+    uint32_t num_blocks_x = Nt / per_core_N;
+
+    CoreRangeSet all_cores(tt::tt_metal::num_cores_to_corerangeset(
+        num_blocks_x * num_blocks_y, device->compute_with_storage_grid_size(), true));
+
+    ProgramDescriptor desc;
+
+    // Create circular buffers
+    constexpr uint8_t src0_cb_index = 0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_CB_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = in0_cb_data_format,
+            .page_size = in0_single_tile_size,
+        }}},
+    });
+
+    constexpr uint8_t src1_cb_index = 1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_CB_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src1_cb_index,
+            .data_format = in1_cb_data_format,
+            .page_size = in1_single_tile_size,
+        }}},
+    });
+
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    constexpr uint8_t interm0_cb_index = 24;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out_CB_size,
+        .core_ranges = all_cores,
+        .format_descriptors =
+            {{CBFormatDescriptor{
+                  .buffer_index = output_cb_index,
+                  .data_format = out_cb_data_format,
+                  .page_size = out_single_tile_size,
+              },
+              CBFormatDescriptor{
+                  .buffer_index = interm0_cb_index,
+                  .data_format = out_cb_data_format,
+                  .page_size = out_single_tile_size,
+              }}},
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {};
+    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {};
+    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(writer_compile_time_args);
+
+    // Create reader and writer kernels per core
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.named_compile_time_args = {{"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}};
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.named_compile_time_args = {{"cb_out", tt::CBIndex::c_16}};
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Create compute kernel
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = compute_kernel_args;
+    compute_desc.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_out", tt::CBIndex::c_16},
+        {"cb_intermed0", (uint32_t)24}};
+    compute_desc.config = ComputeConfigDescriptor{.math_fidelity = math_fidelity};
+
+    // Per-core runtime args for reader and writer
+    uint32_t num_blocks_read = 0;
+    for (int output_idx_y = 0; output_idx_y < num_blocks_y; output_idx_y++) {
+        for (int output_idx_x = 0; output_idx_x < num_blocks_x; output_idx_x++) {
+            int core_idx_x = num_blocks_read % num_cores_x;
+            int core_idx_y = num_blocks_read / num_cores_x;
+            CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
+
+            // Write runtime args to device
+            reader_desc.emplace_runtime_args(
+                core,
+                {
+                    in0_buffer,                                     // in0_tensor_addr
+                    (std::uint32_t)Kt * per_core_M * output_idx_y,  // in0_tensor_start_tile_id
+                    (std::uint32_t)1,                               // in0_tensor_stride_w
+                    (std::uint32_t)Kt,                              // in0_tensor_stride_h
+                    (std::uint32_t)in0_block_w,                     // in0_tensor_next_block_stride
+
+                    (std::uint32_t)in0_block_w,               // in0_block_w
+                    (std::uint32_t)per_core_M,                // in0_block_h
+                    (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
+
+                    in1_buffer,                                // in1_tensor_addr
+                    (std::uint32_t)per_core_N * output_idx_x,  // in1_tensor_start_tile_id
+                    (std::uint32_t)1,                          // in1_tensor_stride_w
+                    (std::uint32_t)Nt,                         // in1_tensor_stride_h
+                    (std::uint32_t)in0_block_w * Nt,           // in1_tensor_next_block_stride
+
+                    (std::uint32_t)per_core_N,                // in1_block_w
+                    (std::uint32_t)in0_block_w,               // in1_block_h
+                    (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
+
+                    (std::uint32_t)Kt / in0_block_w,  // num_blocks
+
+                    (std::uint32_t)Mt * Kt,     // MtKt
+                    (std::uint32_t)Kt * Nt,     // KtNt
+                    (std::uint32_t)B,           // batch
+                    (std::uint32_t)bcast_batch  // bcast_B
+                });
+
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    out_buffer,  // out_tensor_addr
+                    ((std::uint32_t)output_idx_x * per_core_N) +
+                        (output_idx_y * per_core_M * Nt),  // out_tensor_start_tile_id
+                    (std::uint32_t)1,                      // out_tensor_stride_w
+                    (std::uint32_t)Nt,                     // out_tensor_stride_h
+                    (std::uint32_t)out_subblock_w,         // out_tensor_next_subblock_stride_w
+                    (std::uint32_t)out_subblock_h * Nt,    // out_tensor_next_subblock_stride_h
+
+                    (std::uint32_t)out_subblock_w,                     // out_subblock_w
+                    (std::uint32_t)out_subblock_h,                     // out_subblock_h
+                    (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+                    (std::uint32_t)(per_core_N / out_subblock_w),      // out_num_subblocks_w
+                    (std::uint32_t)(per_core_M / out_subblock_h),      // out_num_subblocks_h
+
+                    (std::uint32_t)Mt * Nt,  // MtNt
+                    (std::uint32_t)B         // batch
+                });
+
+            num_blocks_read++;
         }
     }
-    return {std::move(workload), std::move(shared_variables)};
-}
 
-void MatmulMeshWorkloadMultiCoreReuseFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const ttnn::prim::MatmulParams& attributes,
-    const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
-    for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
-        auto cached_program_proxy = MatmulMultiCoreReuseProgramFactory::cached_program_t::proxy(
-            program, cached_workload.shared_variables.at(mesh_coord_range));
-        MatmulMultiCoreReuseProgramFactory::override_runtime_arguments(
-            cached_program_proxy, attributes, tensor_args, tensor_return_value);
-    }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.hpp
@@ -6,47 +6,16 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct MatmulMultiCoreReuseProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        uint32_t num_cores_x{};
-        uint32_t num_blocks_y{};
-        uint32_t num_blocks_x{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ttnn::prim::MatmulParams& operation_attributes,
         const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ttnn::prim::MatmulParams& operation_attributes,
-        const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value);
-};
-
-struct MatmulMeshWorkloadMultiCoreReuseFactory {
-    using shared_variables_t = MatmulMultiCoreReuseProgramFactory::shared_variables_t;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const ttnn::prim::MatmulParams& attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& output);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
-        const ttnn::prim::MatmulParams& operation_attributes,
-        const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value);
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
_Replaces closed PR #44406 (auto-closed during a force-push rebase; branch content unchanged)._

Last remaining factory in `matmul/device/factory/` on the legacy `CachedProgram` pattern after the matmul descriptor migration (#43578) covered the rest of the family.

Drops `shared_variables_t` / `cached_program_t` / `create()` / `override_runtime_arguments()`; exposes a single `static create_descriptor` returning `ProgramDescriptor`. The legacy `MatmulMeshWorkloadMultiCoreReuseFactory` inner struct (a dead legacy sibling) is also dropped.

Note: this factory is currently dead code — no `select_program_factory` branch returns `MatmulMultiCoreReuseProgramFactory` and no external consumer references it. Migrating now to keep the family on a single architecture; deletion of the factory entirely is an open question for follow-up.

Defers: `MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory` (gather_in0 path) uses `MeshWorkload` / `AdaptedCachedMeshWorkload`, which the descriptor framework does not yet support per-workload-level allocation hooks for.

Contributes to #42193, #42338, #42205.

## Performance

Host dispatch (cache hit, WH B0 single device, N=20, 5 trials, warm cache):
- matmul 2x16x384x64 @ 2x16x64x128 bf8 (multicore_reuse): 25634 ns ± 399 ns vs main 29944 ns ± 427 ns (−14.4%) — fast cache-hit patching via emplace_runtime_args(Buffer*)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-matmul-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-matmul-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-matmul-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-matmul-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-matmul-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-matmul-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-matmul-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-matmul-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-matmul-reuse)

