### PR TITLE
Bug fix: Fix binary SFPU LLK perf dst output index

### DIFF
--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -210,8 +210,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                 block_tile, formats.math, formats.math);
                         }
 
-                        test_utils::call_binary_sfpu_operation<DST_SYNC_MODE, is_fp32_dest_acc_en, APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS>(
-                            block_tile, (block_tile + 1) % MAX_TILES_DEST, formats.math);
+                        test_utils::
+                            call_binary_sfpu_operation<DST_SYNC_MODE, is_fp32_dest_acc_en, APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS, formats.math>(
+                                block_tile, (block_tile + 1) % MAX_TILES_DEST, block_tile);
                     }
                 }
             }
@@ -236,8 +237,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             block_tile, formats.math, formats.math);
 
                         // Start SFPU binary operation
-                        test_utils::call_binary_sfpu_operation<DST_SYNC_MODE, is_fp32_dest_acc_en, APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS>(
-                            block_tile, (block_tile + 1) % MAX_TILES_DEST, formats.math);
+                        test_utils::
+                            call_binary_sfpu_operation<DST_SYNC_MODE, is_fp32_dest_acc_en, APPROX_MODE, SFPU_BINARY_OPERATION, ITERATIONS, formats.math>(
+                                block_tile, (block_tile + 1) % MAX_TILES_DEST, block_tile);
                     }
 
                     _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes the LLK binary SFPU perf kernel passing `formats.math` as the runtime `dst_index_out` argument. The format is now provided as the helper's template parameter, and `block_tile` is used as the output destination index, avoiding the Blackhole LLK_ASSERT in `llk_perf_blackhole group 1/5`.

### Notes for reviewers
Focus on the `MATH_ISOLATE` and `L1_TO_L1` binary SFPU perf call sites. Verified the five annotated failing cases with both producer compile and consumer hardware run after refreshing the LLK SFPI test environment.

Tested:
- `./setup_testing_env.sh`
- `pytest --speed-of-light --compile-producer -n 4 -m "perf" --timeout=60 --override-ini="addopts=-v" <5 annotated perf_eltwise_binary_sfpu cases>`
- `pytest --speed-of-light --compile-consumer -n 1 -x -m "perf" --timeout=60 --override-ini="addopts=-v" <5 annotated perf_eltwise_binary_sfpu cases>`

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_llk_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_llk_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_llk_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_llk_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_llk_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_llk_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_llk_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_llk_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_llk_perf_test)