### PR TITLE
[skip ci] ci: add aarch64 native Ubuntu 24.04 build workflow

### DIFF
--- a/.github/workflows/build-aarch64-native.yaml
+++ b/.github/workflows/build-aarch64-native.yaml
@@ -1,0 +1,110 @@
+name: "Build tt-metal — aarch64 native Ubuntu 24.04"
+
+# Native (no Docker) compile check on a GitHub-hosted arm64 runner.
+# Validates that tt-metal builds cleanly on aarch64 Ubuntu 24.04.
+
+on:
+  schedule:
+    # Every 2 hours, offset by 7 minutes to spread GH runner load
+    - cron: "7 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      build-type:
+        required: false
+        type: choice
+        default: "Release"
+        options:
+          - "Release"
+          - "RelWithDebInfo"
+          - "Debug"
+        description: "CMake build type"
+
+jobs:
+  build-aarch64:
+    name: "🛠️ aarch64 Ubuntu 24.04 native build"
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
+
+    env:
+      BUILD_TYPE: ${{ inputs.build-type || 'Release' }}
+
+    steps:
+      - name: "⬇️ Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: "📦 Install system dependencies"
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            git \
+            build-essential \
+            cmake \
+            ninja-build \
+            pkg-config \
+            g++-14 \
+            pandoc \
+            xz-utils \
+            openssl \
+            libssl-dev \
+            python3-dev \
+            python3-pip \
+            python3-venv \
+            libhwloc-dev \
+            libnuma-dev \
+            libatomic1 \
+            libstdc++6 \
+            libtbb-dev \
+            libcapstone-dev \
+            wget \
+            curl \
+            xxd \
+            lsb-release \
+            software-properties-common \
+            gnupg \
+            ca-certificates
+
+      - name: "🔧 Install LLVM 20 (clang-20)"
+        run: |
+          set -euo pipefail
+          TEMP_DIR=$(mktemp -d)
+          wget -q -P "$TEMP_DIR" https://apt.llvm.org/llvm.sh
+          chmod u+x "$TEMP_DIR/llvm.sh"
+          sudo "$TEMP_DIR/llvm.sh" 20
+          rm -rf "$TEMP_DIR"
+          # Verify
+          clang-20 --version
+          clang++-20 --version
+
+      - name: "📦 Cache CPM source packages"
+        id: cpm-cache
+        uses: actions/cache@v4
+        with:
+          path: .cpmcache
+          key: cpm-aarch64-ubuntu2404-${{ hashFiles('third_party/CMakeLists.txt', 'tt_metal/third_party/umd/third_party/CMakeLists.txt') }}
+          restore-keys: cpm-aarch64-ubuntu2404-
+
+      - name: "⚙️ Configure ccache"
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ccache-aarch64-ubuntu2404-${{ env.BUILD_TYPE }}
+          max-size: "2G"
+          append-timestamp: false
+
+      - name: "🔧 Build tt-metal"
+        run: |
+          set -euo pipefail
+          ./build_metal.sh \
+            --toolchain-path cmake/aarch64-linux-clang-20-libstdcpp-toolchain.cmake \
+            --build-type "$BUILD_TYPE" \
+            --enable-ccache \
+            --without-distributed \
+            --without-python-bindings
+
+      - name: "📊 ccache statistics"
+        if: always()
+        run: ccache -s

--- a/.github/workflows/build-aarch64-native.yaml
+++ b/.github/workflows/build-aarch64-native.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: "⬇️ Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           fetch-depth: 0

--- a/cmake/aarch64-linux-clang-20-libstdcpp-toolchain.cmake
+++ b/cmake/aarch64-linux-clang-20-libstdcpp-toolchain.cmake
@@ -1,0 +1,19 @@
+set(CMAKE_SYSTEM_PROCESSOR "aarch64")
+
+set(CMAKE_C_COMPILER clang-20 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER clang++-20 CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+
+# Choose the fastest available linker
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld-20)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-aarch64-native.yaml` — a GitHub-hosted `ubuntu-24.04-arm` compile check with **no Docker dependency**
- Adds `cmake/aarch64-linux-clang-20-libstdcpp-toolchain.cmake` mirroring the existing x86_64 toolchain but targeting `aarch64`
- Scheduled every 2 hours (`7 */2 * * *`); also triggerable via `workflow_dispatch` with build-type choice
- Installs LLVM 20 from `apt.llvm.org` (same compiler as x86 CI)
- Builds with `--without-distributed` and `--without-python-bindings` for a clean compile check (no OpenMPI/Python complexity on arm64 yet)
- ccache enabled via `hendrikmuhs/ccache-action` for incremental build speed

## Test plan
- [ ] Trigger `workflow_dispatch` on this branch and confirm the job passes on `ubuntu-24.04-arm`
- [ ] Verify scheduled runs fire every 2 hours after merge

🤖 Generated with BrAIn (Claude Code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/aarch64-native-ubuntu2404-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/aarch64-native-ubuntu2404-build)