### PR TITLE
dispatch: non-temporal store path for memcpy_to_device on non-x86 targets

### DIFF
--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -13,7 +13,6 @@
 
 #if defined(__x86_64__) || defined(__i386__)
 #include <emmintrin.h>
-#endif
 
 #define LOAD_STREAM_32()                                                               \
     do {                                                                               \
@@ -44,6 +43,8 @@
         src8 += sizeof(int32_t);                  \
         dst8 += sizeof(int32_t);                  \
     } while (0)
+
+#endif  // x86
 
 namespace tt::tt_metal {
 
@@ -148,9 +149,79 @@ void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n
         tt_driver_atomics::sfence();
     }
 }
+
+#elif __has_builtin(__builtin_nontemporal_store)
+
+// Generic non-temporal store path for compilers that support the builtin (Clang; GCC does not).
+// __builtin_nontemporal_store generates the best non-temporal store the target supports
+// (e.g. STNP on AArch64) without requiring arch-specific headers.
+// 32-byte vector chunks: on AArch64 the compiler pairs two Q-registers → STNP Q0, Q1, [addr].
+typedef uint8_t __attribute__((vector_size(32), aligned(1))) nt_v256;
+typedef uint8_t __attribute__((vector_size(16), aligned(1))) nt_v128;
+
+template <bool debug_sync = false>
+void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n) {
+    const auto* src8 = static_cast<const uint8_t*>(src);
+    auto* dst8 = static_cast<uint8_t*>(dst);
+
+    constexpr uint32_t inner_loop = 8;
+    constexpr uint32_t inner_blk_size = inner_loop * 32;  // 256 bytes
+
+    size_t num_lines = n / inner_blk_size;
+    for (size_t i = 0; i < num_lines; ++i) {
+        for (size_t j = 0; j < inner_loop; ++j) {
+            nt_v256 chunk;
+            __builtin_memcpy(&chunk, src8, 32);
+            __builtin_nontemporal_store(chunk, (nt_v256*)dst8);
+            src8 += 32;
+            dst8 += 32;
+        }
+        n -= inner_blk_size;
+    }
+
+    num_lines = n / 32;
+    for (size_t i = 0; i < num_lines; ++i) {
+        nt_v256 chunk;
+        __builtin_memcpy(&chunk, src8, 32);
+        __builtin_nontemporal_store(chunk, (nt_v256*)dst8);
+        src8 += 32;
+        dst8 += 32;
+    }
+    n -= num_lines * 32;
+
+    num_lines = n / 16;
+    for (size_t i = 0; i < num_lines; ++i) {
+        nt_v128 chunk;
+        __builtin_memcpy(&chunk, src8, 16);
+        __builtin_nontemporal_store(chunk, (nt_v128*)dst8);
+        src8 += 16;
+        dst8 += 16;
+    }
+    n -= num_lines * 16;
+
+    num_lines = n / 4;
+    for (size_t i = 0; i < num_lines; ++i) {
+        uint32_t chunk;
+        __builtin_memcpy(&chunk, src8, 4);
+        __builtin_nontemporal_store(chunk, (uint32_t*)dst8);
+        src8 += 4;
+        dst8 += 4;
+    }
+    n -= num_lines * 4;
+
+    if (n > 0) {
+        uint32_t val = 0;
+        __builtin_memcpy(&val, src8, n);
+        __builtin_nontemporal_store(val, (uint32_t*)dst8);
+    }
+
+    if constexpr (debug_sync) {
+        tt_driver_atomics::sfence();
+    }
+}
+
 #else
-// Fallback implementation for non-x86 architectures
-// Uses standard memcpy since SIMD optimizations aren't available
+// Fallback for other architectures
 template <bool debug_sync = false>
 __attribute((nonnull(1, 2))) static inline void memcpy_to_device(
     void* __restrict dst, const void* __restrict src, size_t n) {
@@ -163,7 +234,9 @@ __attribute((nonnull(1, 2))) static inline void memcpy_to_device(
 
 }  // namespace tt::tt_metal
 
+#if defined(__x86_64__) || defined(__i386__)
 #undef LOAD_STREAM_32
 #undef LOAD_STREAM_16
 #undef LOAD_STREAM_4
 #undef LOAD_STREAM_4_UNALIGNED
+#endif


### PR DESCRIPTION
## Summary

- On AArch64 (and any other non-x86 Clang target) the previous `memcpy_to_device` fallback used plain `memcpy`, which pulls the source data into the CPU cache even though it is immediately DMA'd to the device and never read back.
- Add a `__builtin_nontemporal_store` path using GCC vector-extension types (`nt_v256` / `nt_v128`), structured in the same 256-byte block loop as the existing x86 AVX2 path.
- On AArch64 the compiler lowers 32-byte chunks to a single `STNP Q0, Q1, [addr]` (store non-temporal pair), bypassing the data cache.
- Guard is `__has_builtin(__builtin_nontemporal_store)` rather than an arch or compiler macro, so GCC (which lacks the builtin) correctly falls through to the `memcpy` fallback without a compile error.
- x86 macros (`LOAD_STREAM_*`) are now properly guarded and `#undef`'d inside their own `#if` block.

## Performance (Blackhole AArch64, ResNet-50 trace+2CQ, batch=16)

| | Avg iteration | fps |
|---|---|---|
| Before (plain `memcpy`) | 1.774 ms | 9 018 |
| After (`__builtin_nontemporal_store`) | 1.680 ms | 9 523 |
| **Delta** | **−94 µs** | **+5.6 %** |

CPU-side staging-buffer write bandwidth (4.7 MB, Clang 20, `-O2 -march=native`):
- plain `memcpy`: 20.78 GB/s
- NT store: 22.28 GB/s (+7 %)

## Test plan

- [x] Builds cleanly with Clang 20 (the project's default compiler) on AArch64
- [x] `clang-format` pre-commit hook passes
- [x] `test_perf_trace_2cqs[16-0.0018-30-device_params0]` PASSED (1.680 ms < 1.8 ms threshold)
- [ ] CI on x86 — no functional change to the x86 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)