### PR TITLE
Bug fix: skip Tracy queue pushes from RT profiler when no viewer is connected

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -109,9 +109,6 @@ void enqueue_sanity_program(
 }
 
 TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
-    // Skipped due to issue #44657: real-time profiler is disabled by default
-    // (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
-    GTEST_SKIP() << "Real-time profiler disabled by default — see issue #44657";
     constexpr int kDeviceId = 0;
 
     auto mesh_device = distributed::MeshDevice::create_unit_mesh(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -147,9 +147,6 @@ distributed::MeshWorkload build_blank_kernel_workload(const std::shared_ptr<dist
 }
 
 TEST(RealtimeProfilerStress, RingBufferOverflowFromTrace) {
-    // Skipped due to issue #44657: real-time profiler is disabled by default
-    // (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
-    GTEST_SKIP() << "Real-time profiler disabled by default — see issue #44657";
     constexpr int kDeviceId = 0;
 
     auto mesh_device = distributed::MeshDevice::create_unit_mesh(

--- a/tests/ttnn/tracy/test_realtime_profiler.py
+++ b/tests/ttnn/tracy/test_realtime_profiler.py
@@ -49,11 +49,6 @@ from pathlib import Path
 import pytest
 
 
-# Skipped due to issue #44657: real-time profiler is disabled by default
-# (TT_METAL_ENABLE_REALTIME_PROFILER kill switch).
-pytestmark = pytest.mark.skip(reason="Real-time profiler disabled by default — see issue #44657")
-
-
 # ---------------------------------------------------------------------------
 # Common paths / constants
 # ---------------------------------------------------------------------------

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1382,8 +1382,7 @@ bool MeshDeviceImpl::initialize_impl(
 }
 
 void MeshDeviceImpl::init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device) {
-    static const bool enable_rt_profiler = tt::parse_env<bool>("TT_METAL_ENABLE_REALTIME_PROFILER", false);
-    if (!enable_rt_profiler || realtime_profiler_) {
+    if (realtime_profiler_) {
         return;
     }
     realtime_profiler_ = std::make_unique<RealtimeProfilerManager>(mesh_device);

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -765,6 +765,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 return false;
             }
 
+            // TODO: Uncomment this and apply a debug verbosity level when
+            // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
             // ZoneScopedN("ProcessPage");
             dev_state.socket->read(page_buf.data(), 1);
             uint32_t* read_ptr = page_buf.data();
@@ -789,6 +791,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             // Skip records with id==0 (non-GO dispatch commands like SET_NUM_WORKER_SEMS):
             // they have no valid program and may carry stale end timestamps.
             if (start_id != 0) {
+                // TODO: Uncomment this and apply a debug verbosity level when
+                // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
                 // ZoneScopedN("InvokeCallbacks");
                 tt::ProgramRealtimeRecord record;
                 record.program_id = start_id;
@@ -814,6 +818,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 continue;
             }
 
+            // TODO: Uncomment this and apply a debug verbosity level when
+            // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
             // ZoneScopedN("PollLoop");
             bool any_data = false;
 
@@ -832,6 +838,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             }
 
             if (!any_data) {
+                // TODO: Uncomment this and apply a debug verbosity level when
+                // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
                 // ZoneScopedN("Idle");
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
@@ -839,6 +847,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
 
         // Drain in-flight PCIe pages until all sockets stay empty for several rounds.
         {
+            // TODO: Uncomment this and apply a debug verbosity level when
+            // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
             // ZoneScopedN("DrainShutdown");
             constexpr uint32_t kDrainQuietRounds = 10;
             uint64_t drain_pages = 0;

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -765,7 +765,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 return false;
             }
 
-            ZoneScopedN("ProcessPage");
+            // ZoneScopedN("ProcessPage");
             dev_state.socket->read(page_buf.data(), 1);
             uint32_t* read_ptr = page_buf.data();
 
@@ -789,7 +789,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             // Skip records with id==0 (non-GO dispatch commands like SET_NUM_WORKER_SEMS):
             // they have no valid program and may carry stale end timestamps.
             if (start_id != 0) {
-                ZoneScopedN("InvokeCallbacks");
+                // ZoneScopedN("InvokeCallbacks");
                 tt::ProgramRealtimeRecord record;
                 record.program_id = start_id;
                 record.start_timestamp = start_time;
@@ -814,7 +814,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 continue;
             }
 
-            ZoneScopedN("PollLoop");
+            // ZoneScopedN("PollLoop");
             bool any_data = false;
 
             for (auto& dev_state : devices_) {
@@ -832,14 +832,14 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             }
 
             if (!any_data) {
-                ZoneScopedN("Idle");
+                // ZoneScopedN("Idle");
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
         }
 
         // Drain in-flight PCIe pages until all sockets stay empty for several rounds.
         {
-            ZoneScopedN("DrainShutdown");
+            // ZoneScopedN("DrainShutdown");
             constexpr uint32_t kDrainQuietRounds = 10;
             uint64_t drain_pages = 0;
             uint32_t quiet_rounds = 0;

--- a/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
+++ b/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
@@ -100,6 +100,9 @@ TracyTTCtx RealtimeProfilerTracyHandler::GetContext(uint32_t chip_id) {
 
 void RealtimeProfilerTracyHandler::HandleRecord([[maybe_unused]] const tt::ProgramRealtimeRecord& record) {
 #if defined(TRACY_ENABLE)
+    if (!tracy::GetProfiler().IsConnected()) {
+        return;
+    }
     TracyTTCtx ctx = GetContext(record.chip_id);
     if (!ctx) {
         return;
@@ -148,6 +151,9 @@ void RealtimeProfilerTracyHandler::HandleRecord([[maybe_unused]] const tt::Progr
 void RealtimeProfilerTracyHandler::PushSyncCheckMarker(
     [[maybe_unused]] uint32_t chip_id, [[maybe_unused]] uint64_t device_timestamp, [[maybe_unused]] double frequency) {
 #if defined(TRACY_ENABLE)
+    if (!tracy::GetProfiler().IsConnected()) {
+        return;
+    }
     TracyTTCtx ctx = GetContext(chip_id);
     if (!ctx) {
         return;
@@ -188,6 +194,9 @@ void RealtimeProfilerTracyHandler::CalibrateDevice(
     [[maybe_unused]] uint64_t device_timestamp,
     [[maybe_unused]] double frequency) {
 #if defined(TRACY_ENABLE)
+    if (!tracy::GetProfiler().IsConnected()) {
+        return;
+    }
     TracyTTCtx ctx = GetContext(chip_id);
     if (!ctx) {
         return;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes Tracy's internal queue growing unboundedly when the RT profiler runs without a connected Tracy viewer (#44657). Tracy buffers events until a viewer drains them, so every push from the RT profiler accumulated forever in disconnected runs.

Fix: guard Tracy pushes in [realtime_profiler_tracy_handler.cpp](tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp) with `tracy::GetProfiler().IsConnected()`, and comment out the `ZoneScopedN` markers in [realtime_profiler_manager.cpp](tt_metal/distributed/realtime_profiler_manager.cpp).

With this fixed, we also revert #44658: drops the `TT_METAL_ENABLE_REALTIME_PROFILER` kill switch and re-enables the three skipped tests.

Fixes #44657

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/profiler-ci-selector.yaml/badge.svg?branch=ybashi/rt-profiler-tracy-disconnected-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/profiler-ci-selector.yaml?query=branch:ybashi/rt-profiler-tracy-disconnected-leak)