### PR TITLE
[skip ci] ttsim: skip test_tiled_concat on wormhole_b0

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -44,6 +44,11 @@ wormhole_b0:
   # https://github.com/tenstorrent/tt-metal/pull/42112
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
 
+  # MOVD2B failures (worker crash on 4D INT32/UINT32 concat). Passes on real
+  # wormhole silicon; already deselected for blackhole below for the same reason.
+  # https://github.com/tenstorrent/tt-metal/issues/43295
+  - tests/ttnn/unit_tests/operations/data_movement/test_concat.py::test_tiled_concat
+
 blackhole:
   # Job-level timeouts
   - tests/ttnn/unit_tests/operations/conv/test_conv2d.py

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -46,7 +46,7 @@ wormhole_b0:
 
   # MOVD2B failures (worker crash on 4D INT32/UINT32 concat). Passes on real
   # wormhole silicon; already deselected for blackhole below for the same reason.
-  # https://github.com/tenstorrent/tt-metal/issues/43295
+  # https://github.com/tenstorrent/tt-metal/issues/41286
   - tests/ttnn/unit_tests/operations/data_movement/test_concat.py::test_tiled_concat
 
 blackhole:


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The `ttsim-integration-tests / TTNN ttnn data movement group - wormhole_b0` sanity job has been red on main because `test_concat.py::test_tiled_concat` crashes pytest-xdist workers under ttsim wormhole_b0 for the 4D `INT32` / `UINT32` parametrizations:

```
[gw1] FAILED test_concat.py::test_tiled_concat[dtype=DataType.INT32-concat_spec=([[1, 1, 4, 4], [1, 1, 4, 4]], -1)]
[gw2] FAILED test_concat.py::test_tiled_concat[dtype=DataType.UINT32-concat_spec=([[1, 1, 4, 4], [1, 1, 4, 4]], -1)]
worker 'gw1' crashed ...
worker 'gw2' crashed ...
```

The same test:

- **Fails on ttsim wormhole_b0** on the most recent main commit (`94b84e17417`):
  [ttsim-integration-tests / TTNN ttnn data movement group - wormhole_b0 — job 76845697001](https://github.com/tenstorrent/tt-metal/actions/runs/26124220318/job/76845697001)
- **Passes on real wormhole silicon** on the same main commit. All six `test_tiled_concat` parametrizations (including the two that crash ttsim) execute and explicitly `PASSED`:
  [ttnn-unit-tests / ttnn data movement group [wh_n300_civ2] — job 76845695340](https://github.com/tenstorrent/tt-metal/actions/runs/26124220318/job/76845695340)
- **Is already deselected for blackhole ttsim** — see the existing entry under `blackhole:` in `tests/pipeline_reorg/ttsim-skip-list.yaml`.

This PR mirrors that blackhole skip entry under `wormhole_b0:`, unblocking sanity. No workflow changes, no schema changes — one YAML entry plus a comment block.

### Notes for reviewers

- **Hardware coverage is unaffected.** The hardware sanity job (`ttnn-post-commit.yaml`) reads the same `tests/pipeline_reorg/ttnn-tests.yaml` cmd but does **not** consult `ttsim-skip-list.yaml`, so `test_tiled_concat` continues to run on real silicon (`wh_n300_civ2`) and continues to pass.
- **Coverage loss on ttsim wormhole_b0** is broader than strictly necessary. The workflow's skip-list build joins entries with spaces (`SKIP_ARGS=$(yq … | sed 's/^/--deselect=/' | tr '\n' ' ')`), so YAML entries containing spaces (such as parametrized nodeids like `test_tiled_concat[dtype=DataType.INT32-concat_spec=([[1, 1, 4, 4], [1, 1, 4, 4]], -1)]`) would break shell parsing. Surgical deselection of just the failing parametrizations isn't possible without changing the skip-list build logic. Skipping the whole test matches the existing blackhole approach.
- **Stacking note**: this PR is independent of #44781 (the `PYTEST_ADDOPTS` fix). #44781 is needed for the `core ttnn unit test group` failures, which are a different `&&`-chain bug; the `ttnn data movement group` cmd is a single pytest invocation so deselect args have always reached it correctly. This PR works on main standalone.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/ttsim-skip-tiled-concat-wh-b0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/ttsim-skip-tiled-concat-wh-b0)