### PR TITLE
feat(sim/multichip): rebase nkapreTT multichip support onto main

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -66,4 +66,5 @@ set(UNIT_TESTS_API_SOURCES
     test_duplicate_kernel.cpp
     test_core_local_mem_api.cpp
     disaggregation/test_kv_chunk_address_table.cpp
+    test_named_runtime_args.cpp
 )

--- a/tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for named args (CT and RT) with generated header.
+//
+// Verifies:
+// 1. Named common runtime args delivered via rt_args::get<>()
+// 2. Named per-core runtime args deliver different values per core
+// 3. Named compile-time args accessible via ct_args:: namespace
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "device_fixture.hpp"
+#include "multi_device_fixture.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+using NamedArgsTest = GenericMeshDeviceFixture;
+
+TEST_F(NamedArgsTest, TensixTestNamedCommonAndPerCoreRuntimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core0 = {0, 0};
+    CoreCoord core1 = {1, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core0, core1)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const uint32_t expected_marker = 0xCAFE;
+    const uint32_t core0_idx = 10;
+    const uint32_t core1_idx = 20;
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .named_compile_time_args = {{"my_kernel.param_a", 0}, {"my_kernel.param_b", 0}},
+        .defines = {{"WRITE_ADDRESS", std::to_string(write_addr)}},
+        .named_common_runtime_args = {{"my_kernel.marker", expected_marker}},
+        .named_per_core_runtime_args = {{"my_kernel.core_idx", {{core0, core0_idx}, {core1, core1_idx}}}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results_core0;
+    detail::ReadFromDeviceL1(device, core0, write_addr, 2 * sizeof(uint32_t), results_core0);
+    std::vector<uint32_t> results_core1;
+    detail::ReadFromDeviceL1(device, core1, write_addr, 2 * sizeof(uint32_t), results_core1);
+
+    EXPECT_EQ(results_core0[0], expected_marker) << "Core (0,0): marker should be 0xCAFE";
+    EXPECT_EQ(results_core1[0], expected_marker) << "Core (1,0): marker should be 0xCAFE";
+    EXPECT_EQ(results_core0[1], core0_idx) << "Core (0,0): core_idx should be 10";
+    EXPECT_EQ(results_core1[1], core1_idx) << "Core (1,0): core_idx should be 20";
+}
+
+TEST_F(NamedArgsTest, TensixTestNamedArrayRuntimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core = {0, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core, core)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const uint32_t prefix_val = 10;
+    const std::vector<uint32_t> array_data = {100, 200, 300, 400};
+    const uint32_t num_elements = static_cast<uint32_t>(array_data.size());
+
+    // Expected: prefix + sum(array_data) = 10 + 100 + 200 + 300 + 400 = 1010
+    uint32_t expected_sum = prefix_val;
+    for (auto v : array_data) {
+        expected_sum += v;
+    }
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_array_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .defines =
+            {
+                {"WRITE_ADDRESS", std::to_string(write_addr)},
+                {"NUM_ELEMENTS", std::to_string(num_elements)},
+            },
+        // Scalar named common RT arg
+        .named_common_runtime_args = {{"my_kernel.prefix", prefix_val}},
+        // Array named common RT arg
+        .named_common_runtime_arg_arrays = {{"my_kernel.data", array_data}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results;
+    detail::ReadFromDeviceL1(device, core, write_addr, sizeof(uint32_t), results);
+
+    EXPECT_EQ(results[0], expected_sum) << "Sum should be prefix(" << prefix_val << ") + sum(data) = " << expected_sum
+                                        << ", got " << results[0];
+}
+
+TEST_F(NamedArgsTest, TensixTestNamedCompileTimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core = {0, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core, core)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const uint32_t param_a = 42;
+    const uint32_t param_b = 0xBEEF;
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .named_compile_time_args = {{"my_kernel.param_a", param_a}, {"my_kernel.param_b", param_b}},
+        .defines = {{"WRITE_ADDRESS", std::to_string(write_addr)}},
+        .named_common_runtime_args = {{"my_kernel.marker", 0}},
+        .named_per_core_runtime_args = {{"my_kernel.core_idx", {{core, 0}}}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results;
+    detail::ReadFromDeviceL1(device, core, write_addr, 4 * sizeof(uint32_t), results);
+
+    EXPECT_EQ(results[2], param_a) << "ct_args::my_kernel::param_a should be 42";
+    EXPECT_EQ(results[3], param_b) << "ct_args::my_kernel::param_b should be 0xBEEF";
+}
+
+TEST_F(NamedArgsTest, TensixTestNamedPerCoreArrayRuntimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core0 = {0, 0};
+    CoreCoord core1 = {1, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core0, core1)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const std::vector<uint32_t> core0_weights = {10, 20, 30};
+    const std::vector<uint32_t> core1_weights = {100, 200, 300};
+    const uint32_t num_elements = static_cast<uint32_t>(core0_weights.size());
+
+    uint32_t expected_sum_core0 = 0;
+    for (auto v : core0_weights) {
+        expected_sum_core0 += v;
+    }
+    uint32_t expected_sum_core1 = 0;
+    for (auto v : core1_weights) {
+        expected_sum_core1 += v;
+    }
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_per_core_array_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .defines =
+            {
+                {"WRITE_ADDRESS", std::to_string(write_addr)},
+                {"NUM_ELEMENTS", std::to_string(num_elements)},
+            },
+        .named_per_core_runtime_arg_arrays = {{"my_kernel.weights", {{core0, core0_weights}, {core1, core1_weights}}}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results_core0;
+    detail::ReadFromDeviceL1(device, core0, write_addr, sizeof(uint32_t), results_core0);
+    std::vector<uint32_t> results_core1;
+    detail::ReadFromDeviceL1(device, core1, write_addr, sizeof(uint32_t), results_core1);
+
+    EXPECT_EQ(results_core0[0], expected_sum_core0)
+        << "Core (0,0): sum should be " << expected_sum_core0 << ", got " << results_core0[0];
+    EXPECT_EQ(results_core1[0], expected_sum_core1)
+        << "Core (1,0): sum should be " << expected_sum_core1 << ", got " << results_core1[0];
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/named_array_runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/named_array_runtime_args_kernel.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel for array named runtime args.
+// Reads a scalar Arg (prefix) and an ArrayArg (data[NUM_ELEMENTS]),
+// sums prefix + all data elements, writes the sum to L1 at WRITE_ADDRESS.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)WRITE_ADDRESS;
+
+    // Scalar named RT arg
+    uint32_t prefix = rt_args::get<rt_args::my_kernel::prefix>();
+
+    // Array named RT arg — read NUM_ELEMENTS values and sum them
+    uint32_t sum = prefix;
+    for (uint32_t i = 0; i < NUM_ELEMENTS; i++) {
+        sum += rt_args::get<rt_args::my_kernel::data>(i);
+    }
+
+    l1_ptr[0] = sum;
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/named_per_core_array_runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/named_per_core_array_runtime_args_kernel.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel for per-core array named runtime args.
+// Reads a per-core ArrayArg (weights[NUM_ELEMENTS]) with PER_CORE dispatch,
+// sums all elements, writes the sum to L1 at WRITE_ADDRESS.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)WRITE_ADDRESS;
+
+    // Per-core array named RT arg — each core receives its own array
+    uint32_t sum = 0;
+    for (uint32_t i = 0; i < NUM_ELEMENTS; i++) {
+        sum += rt_args::get<rt_args::my_kernel::weights>(i);
+    }
+
+    l1_ptr[0] = sum;
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel for named args (both CT and RT) with generated header.
+// Reads named compile-time and runtime args, writes them to L1
+// at WRITE_ADDRESS so the host can verify the values.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)WRITE_ADDRESS;
+
+    // Named runtime args — dispatch type hidden by rt_args::get<>()
+    l1_ptr[0] = rt_args::get<rt_args::my_kernel::marker>();
+    l1_ptr[1] = rt_args::get<rt_args::my_kernel::core_idx>();
+
+    // Named compile-time args — plain constexpr from ct_args:: namespace
+    l1_ptr[2] = ct_args::my_kernel::param_a;
+    l1_ptr[3] = ct_args::my_kernel::param_b;
+}

--- a/tests/ttnn/unit_tests/base_functionality/test_device_synchronize.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_device_synchronize.py
@@ -54,3 +54,28 @@ def test_read_write_cq_synchronize(device):
     output = ttnn.to_torch(output)
     eq = torch.equal(input, output)
     assert eq
+
+
+def test_cpu_blocking_false_discarded_return_no_uaf(device):
+    """Regression test for issue #43638.
+
+    Tensor.cpu(blocking=False) must keep the destination host buffer alive until
+    the async D2H read completes, even if the caller immediately discards the
+    returned tensor.  Without the fix, the DistributedHostBuffer is freed before
+    the NumaAwareExecutor reader thread finishes its memcpy → SIGSEGV in
+    libumd read_from_sysmem.
+
+    Use ~16 MB tensors so the async read is still in flight when CPython would
+    normally garbage-collect the unreferenced return value.
+    """
+    # Large enough that the async D2H is likely still in flight when the
+    # discarded tensor goes out of scope.
+    host = torch.randn(1024, 4096, dtype=torch.bfloat16)
+    dev_tensor = ttnn.from_torch(host, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    for _ in range(20):
+        # Deliberately discard the return value — the host buffer must remain
+        # pinned internally until synchronize_device() completes.
+        dev_tensor.cpu(blocking=False)
+        ttnn.synchronize_device(device)
+    # If we reach here without crashing, the fix is working.

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -121,6 +121,16 @@ public:
 
     uint32_t get_config_buffer_address() const { return config_buffer_address_; }
 
+    uint32_t get_fifo_size() const { return fifo_size_; }
+
+    bool has_space(std::optional<uint32_t> num_bytes_to_check);
+
+    // Cumulative bytes pushed into the FIFO (wraps modulo 2^32).
+    uint32_t get_bytes_sent() const { return bytes_sent_; }
+
+    // Returns true iff the device has acked past `watermark`.
+    bool acked_past(uint32_t watermark);
+
     void set_page_size(uint32_t page_size);
 
     void write(void* data, uint32_t num_pages);

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -140,9 +140,48 @@ struct KernelDescriptor {
     Defines defines;
 
     // vector of pairs, where runtime_args[i].first is the core coord and runtime_args[i].second is the vector of
+    // Named runtime args use "ns.field" convention (e.g. "demo.num_tiles").
+    // The name is split on '.' to produce namespace hierarchy in the generated header.
+    // Common: same value on all cores. Per-core: different value per core.
+    struct NamedCommonRuntimeArg {
+        std::string name;
+        uint32_t value;
+    };
+    using NamedCommonRuntimeArgs = std::vector<NamedCommonRuntimeArg>;
+    struct NamedPerCoreRuntimeArg {
+        std::string name;
+        std::vector<std::pair<CoreCoord, uint32_t>> core_values;
+    };
+    using NamedPerCoreRuntimeArgs = std::vector<NamedPerCoreRuntimeArg>;
+
+    // Array variant: named RT arg that occupies N contiguous slots.
+    // Generates ArrayArg (with length) in the kernel header instead of Arg.
+    struct NamedCommonRuntimeArgArray {
+        std::string name;
+        std::vector<uint32_t> values;
+    };
+    using NamedCommonRuntimeArgArrays = std::vector<NamedCommonRuntimeArgArray>;
+    // Per-core array variant: each core gets its own array of N contiguous RT arg slots.
+    struct NamedPerCoreRuntimeArgArray {
+        std::string name;
+        std::vector<std::pair<CoreCoord, std::vector<uint32_t>>> core_values;
+    };
+    using NamedPerCoreRuntimeArgArrays = std::vector<NamedPerCoreRuntimeArgArray>;
+
     // runtime args for that core
     RuntimeArgs runtime_args;
     CommonRuntimeArgs common_runtime_args;
+    // Named common runtime args: ordered (name, value) pairs.
+    // Names define the index mapping compiled into the kernel for compile-time resolution.
+    // Values are set as common runtime args (appended after any positional common_runtime_args).
+    NamedCommonRuntimeArgs named_common_runtime_args;
+    // Per-core named runtime args: each entry has a name and per-core values.
+    // Values are merged into runtime_args by program.cpp; indices auto-assigned by position.
+    NamedPerCoreRuntimeArgs named_per_core_runtime_args;
+    // Array variant: each entry occupies N contiguous common RT arg slots.
+    NamedCommonRuntimeArgArrays named_common_runtime_arg_arrays;
+    // Per-core array variant: each core gets its own array of N contiguous RT arg slots.
+    NamedPerCoreRuntimeArgArrays named_per_core_runtime_arg_arrays;
 
     std::optional<KernelBuildOptLevel> opt_level = std::nullopt;
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -94,6 +94,11 @@ struct MeshReadEventDescriptor {
 
 struct MeshBufferReadDescriptor {
     std::unordered_map<IDevice*, uint32_t> num_reads_per_dev;
+    // Keeps host-buffer memory alive until the reader thread finishes the async memcpy.
+    // Without this, a caller that discards the returned Tensor before synchronize_device()
+    // would free the destination buffer while the NumaAwareExecutor thread is still copying
+    // into it (use-after-free / SIGSEGV in libumd read_from_sysmem). See issue #43638.
+    std::vector<MemoryPin> memory_pins;
 };
 
 struct MeshCoreDataReadDescriptor {
@@ -678,9 +683,13 @@ void FDMeshCommandQueue::increment_num_entries_in_completion_queue() {
 }
 
 void FDMeshCommandQueue::submit_memcpy_request(
-    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) {
+    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
+    bool blocking,
+    std::vector<MemoryPin> memory_pins) {
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
-        std::in_place_type<MeshBufferReadDescriptor>, std::move(num_txns_per_device)));
+        std::in_place_type<MeshBufferReadDescriptor>,
+        std::move(num_txns_per_device),
+        std::move(memory_pins)));
 
     this->increment_num_entries_in_completion_queue();
 

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -196,7 +196,10 @@ protected:
         const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
-    void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;
+    void submit_memcpy_request(
+        std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
+        bool blocking,
+        std::vector<MemoryPin> memory_pins = {}) override;
     void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     MeshEvent enqueue_record_event_to_host_nolock(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -399,4 +399,29 @@ std::unique_ptr<H2DSocket> H2DSocket::connect(const std::string& socket_id, std:
     return socket;
 }
 
+bool H2DSocket::has_space(std::optional<uint32_t> num_bytes_to_check) {
+    TT_FATAL(page_size_ > 0, "Page size must be set before checking for data.");
+    uint32_t num_bytes = num_bytes_to_check.value_or(page_size_);
+    uint32_t bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
+    if (bytes_free >= num_bytes) {
+        return true;
+    }
+    tt_driver_atomics::mfence();
+    volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
+    bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_value);
+    bytes_acked_ = bytes_acked_value;
+    return bytes_free >= num_bytes;
+}
+
+bool H2DSocket::acked_past(uint32_t watermark) {
+    uint32_t bytes_since_watermark = bytes_sent_ - watermark;
+    if (bytes_sent_ - bytes_acked_ <= bytes_since_watermark) {
+        return true;
+    }
+    tt_driver_atomics::mfence();
+    volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
+    bytes_acked_ = bytes_acked_value;
+    return bytes_sent_ - bytes_acked_ <= bytes_since_watermark;
+}
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -320,7 +320,8 @@ void MeshCommandQueueBase::enqueue_write_with_core_filter(
 void MeshCommandQueueBase::enqueue_read_shards_nolock(
     const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
     const std::shared_ptr<MeshBuffer>& buffer,
-    bool blocking) {
+    bool blocking,
+    std::vector<MemoryPin> memory_pins) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     std::unordered_map<IDevice*, uint32_t> num_txns_per_device = {};
@@ -338,7 +339,7 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
                 num_txns_per_device);
         }
     }
-    this->submit_memcpy_request(num_txns_per_device, blocking);
+    this->submit_memcpy_request(num_txns_per_device, blocking, std::move(memory_pins));
 
     if (!blocking && has_pinned_memory) {
         auto event = this->enqueue_record_event_to_host_nolock();
@@ -368,6 +369,9 @@ void MeshCommandQueueBase::enqueue_read(
     bool blocking) {
     auto lock = lock_api_function_();
     std::vector<distributed::ShardDataTransfer> shard_data_transfers;
+    // Capture a MemoryPin for each shard so the host buffer stays alive until the
+    // async reader thread finishes the memcpy (fixes use-after-free, issue #43638).
+    std::vector<MemoryPin> memory_pins;
     for (const auto& coord : MeshCoordinateRange(buffer->device()->shape())) {
         if (shards.has_value() && !shards->contains(coord)) {
             continue;
@@ -375,13 +379,14 @@ void MeshCommandQueueBase::enqueue_read(
 
         auto buf = host_buffer.get_shard(coord);
         if (buf.has_value()) {
+            memory_pins.push_back(buf->pin());
             shard_data_transfers.push_back(distributed::ShardDataTransfer{coord}
                                                .host_data(buf->view_bytes().data())
                                                .region(BufferRegion(0, buf->view_bytes().size())));
         }
     }
 
-    this->enqueue_read_shards_nolock(shard_data_transfers, buffer, blocking);
+    this->enqueue_read_shards_nolock(shard_data_transfers, buffer, blocking, std::move(memory_pins));
 }
 
 void MeshCommandQueue::enqueue_write_shards(

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -40,7 +40,10 @@ protected:
         const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
-    virtual void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) = 0;
+    virtual void submit_memcpy_request(
+        std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
+        bool blocking,
+        std::vector<MemoryPin> memory_pins = {}) = 0;
     // Must be called with lock_api_function_() held.
     virtual void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual MeshEvent enqueue_record_event_to_host_nolock(
@@ -58,7 +61,8 @@ private:
     void enqueue_read_shards_nolock(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        bool blocking);
+        bool blocking,
+        std::vector<MemoryPin> memory_pins = {});
     // Must be called with lock_api_function_() held.
     void enqueue_write_shards_nolock(
         MeshBuffer& mesh_buffer,

--- a/tt_metal/hw/inc/api/compute/common.h
+++ b/tt_metal/hw/inc/api/compute/common.h
@@ -110,6 +110,22 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
     return *((tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }
 
+#include "api/rt_arg.h"
+
+// Unified accessor for named runtime args (works for both Arg and ArrayArg).
+// Scalar:  uint32_t n = rt_args::get<rt_args::my_op::num_tiles>();
+// Array:   uint32_t a = rt_args::get<rt_args::my_op::worker_sem_addr>(i);
+namespace rt_args {
+template <auto arg, typename T = uint32_t>
+FORCE_INLINE T get(uint32_t i = 0) {
+    if constexpr (arg.dispatch == Dispatch::COMMON) {
+        return get_common_arg_val<T>(arg.index + i);
+    } else {
+        return get_arg_val<T>(arg.index + i);
+    }
+}
+}  // namespace rt_args
+
 // clang-format off
 /**
  * Returns the absolute logical X coordinate value that this kernel is running on. The absolute coordinate

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -10,6 +10,7 @@
 #define DATA_FORMATS_DEFINED
 #endif
 
+#include <algorithm>
 #include <stdint.h>
 #include <tuple>
 #include <utility>
@@ -170,6 +171,22 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
     static_assert("Error: only 4B args are supported" && sizeof(T) == 4);
     return *((tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }
+
+#include "api/rt_arg.h"
+
+// Unified accessor for named runtime args (works for both Arg and ArrayArg).
+// Scalar:  uint32_t n = rt_args::get<rt_args::my_op::num_tiles>();
+// Array:   uint32_t a = rt_args::get<rt_args::my_op::worker_sem_addr>(i);
+namespace rt_args {
+template <auto arg, typename T = uint32_t>
+FORCE_INLINE T get(uint32_t i = 0) {
+    if constexpr (arg.dispatch == Dispatch::COMMON) {
+        return get_common_arg_val<T>(arg.index + i);
+    } else {
+        return get_arg_val<T>(arg.index + i);
+    }
+}
+}  // namespace rt_args
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/rt_arg.h
+++ b/tt_metal/hw/inc/api/rt_arg.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Named runtime arg types for device kernels.
+//
+// Defines rt_args::Dispatch and rt_args::Arg used by the JIT-generated header
+// (named_args_generated.h) and by rt_args::get<>() in the API headers.
+//
+// This file is safe to -include before any API headers because it only
+// defines types (no functions that depend on get_arg_val etc.).
+
+#pragma once
+
+#include <cstdint>
+
+namespace rt_args {
+
+enum class Dispatch : uint8_t { COMMON, PER_CORE };
+
+struct Arg {
+    uint32_t index;
+    Dispatch dispatch;
+};
+
+struct ArrayArg {
+    uint32_t index;
+    uint32_t length;
+    Dispatch dispatch;
+};
+
+}  // namespace rt_args

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -1,4 +1,5 @@
 set(HW_JIT_API_HEADERS
+    inc/api/rt_arg.h
     inc/api/alignment.h
     inc/api/compile_time_args.h
     inc/api/remote_circular_buffer.h

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -325,6 +325,18 @@ void Kernel::process_tensor_binding_handles(
     }
 }
 
+void Kernel::process_named_runtime_args(std::function<void(const NamedRuntimeArgNamespaces&)> fn) const {
+    if (!named_runtime_arg_namespaces_.empty()) {
+        fn(named_runtime_arg_namespaces_);
+    }
+}
+
+void Kernel::process_named_ct_arg_namespaces(std::function<void(const NamedCTArgNamespaces&)> fn) const {
+    if (!named_ct_arg_namespaces_.empty()) {
+        fn(named_ct_arg_namespaces_);
+    }
+}
+
 void Kernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
     // For FILE_PATH kernels, add the kernel source directory to the include path.
     // This enables relative includes (e.g., #include "foo.inc") to work when the kernel

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -178,6 +178,16 @@ public:
     bool is_metal2_kernel() const override { return is_metal2_kernel_; }
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
+    // Named runtime arg namespace support (ProgramDescriptor path).
+    void set_named_runtime_arg_namespaces(const NamedRuntimeArgNamespaces& ns) {
+        named_runtime_arg_namespaces_ = ns;
+    }
+    void set_named_ct_arg_namespaces(const NamedCTArgNamespaces& ns) { named_ct_arg_namespaces_ = ns; }
+    void process_named_runtime_args(
+        std::function<void(const NamedRuntimeArgNamespaces&)> fn) const override;
+    void process_named_ct_arg_namespaces(
+        std::function<void(const NamedCTArgNamespaces&)> fn) const override;
+
     void validate_runtime_args_size(
         size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const;
     void set_runtime_args(const CoreCoord& logical_core, stl::Span<const uint32_t> runtime_args);
@@ -266,7 +276,10 @@ protected:
     RuntimeArgsData common_runtime_args_data_{};
     std::set<CoreCoord> core_with_runtime_args_;
     std::size_t max_runtime_args_per_core_{0};  // For validation
-    CoreCoord core_with_max_runtime_args_;   // For validation
+    CoreCoord core_with_max_runtime_args_;       // For validation
+    // Named arg namespace maps, populated from ProgramDescriptor path.
+    NamedRuntimeArgNamespaces named_runtime_arg_namespaces_;
+    NamedCTArgNamespaces named_ct_arg_namespaces_;
     std::map<std::string, std::string>
         defines_;  // preprocessor defines. this is to be able to generate generic instances.
     const bool watcher_assert_enabled_;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -384,10 +384,146 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                 ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
                 : CreateKernelFromString(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
 
-        for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
-            SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);
+        // Set per-core runtime args: positional values followed by named values.
+        if (!kernel_descriptor.named_per_core_runtime_args.empty() ||
+            !kernel_descriptor.named_per_core_runtime_arg_arrays.empty()) {
+            // Start with positional args per core
+            std::map<CoreCoord, std::vector<uint32_t>> core_to_args;
+            for (const auto& [core, positional] : kernel_descriptor.runtime_args) {
+                core_to_args[core] = positional;
+            }
+            // Append named per-core scalar values in order (index = position)
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_args) {
+                for (const auto& [core, value] : arg.core_values) {
+                    core_to_args[core].push_back(value);
+                }
+            }
+            // Append named per-core array values (N contiguous slots per core)
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_arg_arrays) {
+                for (const auto& [core, values] : arg.core_values) {
+                    core_to_args[core].insert(core_to_args[core].end(), values.begin(), values.end());
+                }
+            }
+            for (const auto& [core, merged] : core_to_args) {
+                SetRuntimeArgs(*this, kernel_handle, core, merged);
+            }
+        } else {
+            for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
+                SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);
+            }
         }
-        SetCommonRuntimeArgs(*this, kernel_handle, kernel_descriptor.common_runtime_args);
+
+        // Set common runtime args: positional values followed by named scalars, then named arrays.
+        if (!kernel_descriptor.named_common_runtime_args.empty() ||
+            !kernel_descriptor.named_common_runtime_arg_arrays.empty()) {
+            std::vector<uint32_t> merged_common_rt_args;
+            merged_common_rt_args.insert(
+                merged_common_rt_args.end(),
+                kernel_descriptor.common_runtime_args.begin(),
+                kernel_descriptor.common_runtime_args.end());
+            for (const auto& arg : kernel_descriptor.named_common_runtime_args) {
+                merged_common_rt_args.push_back(arg.value);
+            }
+            for (const auto& arg : kernel_descriptor.named_common_runtime_arg_arrays) {
+                merged_common_rt_args.insert(
+                    merged_common_rt_args.end(), arg.values.begin(), arg.values.end());
+            }
+            SetCommonRuntimeArgs(*this, kernel_handle, merged_common_rt_args);
+        } else {
+            SetCommonRuntimeArgs(*this, kernel_handle, kernel_descriptor.common_runtime_args);
+        }
+
+        // Build namespace maps for JIT header generation.
+        // Names use "ns.field" convention — split on '.' to produce namespace hierarchy.
+        auto validate_identifier = [](const std::string& id, const std::string& context) {
+            TT_FATAL(
+                !id.empty() && (std::isalpha((unsigned char)id[0]) || id[0] == '_') &&
+                    std::all_of(id.begin(), id.end(), [](char c) { return std::isalnum((unsigned char)c) || c == '_'; }),
+                "Named arg {}: '{}' is not a valid C++ identifier",
+                context,
+                id);
+        };
+        auto split_name = [&validate_identifier](const std::string& name) -> std::pair<std::string, std::string> {
+            auto dot = name.find('.');
+            if (dot == std::string::npos) {
+                validate_identifier(name, "field");
+                return {"", name};
+            }
+            auto ns = name.substr(0, dot);
+            auto field = name.substr(dot + 1);
+            validate_identifier(ns, "namespace");
+            validate_identifier(field, "field");
+            return {ns, field};
+        };
+
+        auto kernel = internal_->get_kernel(kernel_handle);
+
+        // RT namespace map: rt_args::get<rt_args::ns::field>()
+        if (!kernel_descriptor.named_common_runtime_args.empty() ||
+            !kernel_descriptor.named_per_core_runtime_args.empty() ||
+            !kernel_descriptor.named_common_runtime_arg_arrays.empty() ||
+            !kernel_descriptor.named_per_core_runtime_arg_arrays.empty()) {
+            NamedRuntimeArgNamespaces rt_ns_map;
+
+            // Common scalars: one slot each
+            uint32_t common_index = static_cast<uint32_t>(kernel_descriptor.common_runtime_args.size());
+            for (const auto& arg : kernel_descriptor.named_common_runtime_args) {
+                auto [ns, field] = split_name(arg.name);
+                rt_ns_map[ns].push_back({field, common_index, 1, RuntimeArgDispatch::COMMON});
+                common_index += 1;
+            }
+            // Common arrays: N contiguous slots each
+            for (const auto& arg : kernel_descriptor.named_common_runtime_arg_arrays) {
+                auto [ns, field] = split_name(arg.name);
+                uint32_t len = static_cast<uint32_t>(arg.values.size());
+                rt_ns_map[ns].push_back({field, common_index, len, RuntimeArgDispatch::COMMON});
+                common_index += len;
+            }
+
+            // Per-core scalars: one slot each
+            uint32_t per_core_index = 0;
+            if (!kernel_descriptor.runtime_args.empty()) {
+                per_core_index = static_cast<uint32_t>(kernel_descriptor.runtime_args[0].second.size());
+            }
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_args) {
+                auto [ns, field] = split_name(arg.name);
+                rt_ns_map[ns].push_back({field, per_core_index, 1, RuntimeArgDispatch::PER_CORE});
+                per_core_index += 1;
+            }
+            // Per-core arrays: N contiguous slots each
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_arg_arrays) {
+                auto [ns, field] = split_name(arg.name);
+                uint32_t len = arg.core_values.empty() ? 0
+                                                        : static_cast<uint32_t>(arg.core_values[0].second.size());
+                rt_ns_map[ns].push_back({field, per_core_index, len, RuntimeArgDispatch::PER_CORE});
+                per_core_index += len;
+            }
+
+            kernel->set_named_runtime_arg_namespaces(rt_ns_map);
+        }
+
+        // CT namespace map: ct_args::ns::field (plain constexpr values)
+        if (!kernel_descriptor.named_compile_time_args.empty()) {
+            NamedCTArgNamespaces ct_ns_map;
+            std::unordered_map<std::string, uint32_t> seen_ct_args;
+            for (const auto& [name, value] : kernel_descriptor.named_compile_time_args) {
+                auto it = seen_ct_args.find(name);
+                if (it != seen_ct_args.end()) {
+                    TT_FATAL(
+                        it->second == value,
+                        "named_compile_time_arg '{}' is defined twice with conflicting values ({} vs {}). "
+                        "Each CT arg name must be unique across all sub-lists.",
+                        name,
+                        it->second,
+                        value);
+                    continue;  // same value — silently skip the duplicate
+                }
+                seen_ct_args.emplace(name, value);
+                auto [ns, field] = split_name(name);
+                ct_ns_map[ns].emplace_back(field, value);
+            }
+            kernel->set_named_ct_arg_namespaces(ct_ns_map);
+        }
     }
 }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -18,7 +18,9 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <map>
 #include <mutex>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -521,6 +523,80 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
                 ss << "\"";
                 defines += ss.str() + " ";
             });
+
+        // Generate named_args_generated.h: each namespace becomes a struct with
+        // both CT constexpr values and RT arg descriptors (rt_args::Arg/ArrayArg).
+        {
+            // Accumulate RT entries per namespace.
+            std::map<std::string, std::vector<NamedRuntimeArgEntry>> rt_by_ns;
+            settings->process_named_runtime_args([&rt_by_ns](const NamedRuntimeArgNamespaces& namespaces) {
+                for (const auto& [ns, entries] : namespaces) {
+                    rt_by_ns[ns].insert(rt_by_ns[ns].end(), entries.begin(), entries.end());
+                }
+            });
+
+            // Accumulate CT entries per namespace.
+            std::map<std::string, std::vector<std::pair<std::string, uint32_t>>> ct_by_ns;
+            settings->process_named_ct_arg_namespaces([&ct_by_ns](const NamedCTArgNamespaces& namespaces) {
+                for (const auto& [ns, entries] : namespaces) {
+                    ct_by_ns[ns].insert(ct_by_ns[ns].end(), entries.begin(), entries.end());
+                }
+            });
+
+            // Collect all non-empty namespaces from both CT and RT maps.
+            std::set<std::string> all_ns;
+            for (const auto& [ns, unused] : ct_by_ns) {
+                all_ns.insert(ns);
+            }
+            for (const auto& [ns, unused] : rt_by_ns) {
+                if (!ns.empty()) {
+                    all_ns.insert(ns);
+                }
+            }
+
+            // Emit one struct per namespace containing both CT fields and RT descriptors.
+            std::ostringstream header_ct;
+            for (const auto& ns : all_ns) {
+                if (!ns.empty()) {
+                    header_ct << "struct " << ns << " {\n";
+                }
+                // CT fields
+                if (auto it = ct_by_ns.find(ns); it != ct_by_ns.end()) {
+                    for (const auto& [field, value] : it->second) {
+                        header_ct << "    static constexpr uint32_t " << field << " = " << value << ";\n";
+                    }
+                }
+                // RT descriptors
+                if (auto it = rt_by_ns.find(ns); it != rt_by_ns.end()) {
+                    for (const auto& entry : it->second) {
+                        const char* dispatch_str = entry.dispatch == RuntimeArgDispatch::COMMON
+                                                       ? "rt_args::Dispatch::COMMON"
+                                                       : "rt_args::Dispatch::PER_CORE";
+                        if (entry.length > 1) {
+                            header_ct << "    static constexpr rt_args::ArrayArg " << entry.field << " = {"
+                                      << entry.index << ", " << entry.length << ", " << dispatch_str << "};\n";
+                        } else {
+                            header_ct << "    static constexpr rt_args::Arg " << entry.field << " = {" << entry.index
+                                      << ", " << dispatch_str << "};\n";
+                        }
+                    }
+                }
+                if (!ns.empty()) {
+                    header_ct << "};\n";
+                }
+            }
+
+            auto ct_str = header_ct.str();
+            if (!ct_str.empty()) {
+                std::string header_path = out_dir + "named_args_generated.h";
+                std::ostringstream content;
+                content << "#pragma once\n#include \"api/rt_arg.h\"\n\n";
+                content << "namespace ct_args {\n" << ct_str << "}\n";
+                std::ofstream f(header_path);
+                f << content.str();
+                defines += fmt::format("-include {} ", header_path);
+            }
+        }
 
         cmd += fmt::format("-{} ", settings->get_compiler_opt_level());
     } else {

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -6,12 +6,36 @@
 
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace tt::tt_metal {
+
+// Dispatch type for named runtime args — determines which device-side accessor to use.
+enum class RuntimeArgDispatch : uint8_t {
+    COMMON,   // get_common_arg_val (shared across all cores)
+    PER_CORE  // get_arg_val (unique per core)
+};
+
+// Entry in the named runtime arg namespace map.
+// length == 1: emits constexpr Arg (scalar).
+// length > 1:  emits constexpr ArrayArg (array of contiguous slots).
+struct NamedRuntimeArgEntry {
+    std::string field;
+    uint32_t index;
+    uint32_t length = 1;
+    RuntimeArgDispatch dispatch;
+};
+
+// Namespace → [entries] map for named runtime arg header generation.
+using NamedRuntimeArgNamespaces = std::map<std::string, std::vector<NamedRuntimeArgEntry>>;
+
+// Namespace → [(field, value)] map for named compile-time arg header generation.
+using NamedCTArgNamespaces = std::map<std::string, std::vector<std::pair<std::string, uint32_t>>>;
 
 // Abstract base class for kernel specialization
 // Higher levels of the SW derive from this and fill in build details not known to the build system
@@ -65,6 +89,11 @@ public:
         static const std::vector<std::string> k_empty;
         return k_empty;
     }
+
+    // Called to process named runtime arg namespaces for generated header (rt_args:: namespace)
+    virtual void process_named_runtime_args(std::function<void(const NamedRuntimeArgNamespaces&)>) const {}
+    // Called to process named compile-time arg namespaces for generated header (ct_args:: namespace)
+    virtual void process_named_ct_arg_namespaces(std::function<void(const NamedCTArgNamespaces&)>) const {}
 
     // Called to process additional include paths (e.g., kernel source directory for relative includes)
     virtual void process_include_paths(const std::function<void(const std::string& path)>&) const {}


### PR DESCRIPTION
## Summary

- Rebases unique additions from `nkapreTT/nkapre/multichip` onto `tenstorrent/tt-metal` main, resolving conflicts against all API changes since nkapreTT's fork
- Adds named runtime/compile-time arg infrastructure for kernel descriptors, enabling `rt_args::get<>()` and `ct_args::` accessor patterns in RISC-V kernels
- Adds H2D socket flow-control APIs (`has_space()`, `acked_past()`, `get_fifo_size()`, `get_bytes_sent()`) needed for craq-sim multichip socket tests
- Companion to: `tenstorrent/tt-umd` PR for `ridvan/nkapre-multichip-umd`

## Key changes

### Named runtime/compile-time arg system (`rt_args::` / `ct_args::`)
- `tt_metal/hw/inc/api/rt_arg.h` — new `rt_args::Arg`, `rt_args::ArrayArg`, `rt_args::Dispatch` types; `rt_args::get<arg>(i)` template accessor for kernels
- `tt_metal/jit_build/jit_build_settings.hpp` — `RuntimeArgDispatch`, `NamedRuntimeArgEntry`, `NamedRuntimeArgNamespaces`, `NamedCTArgNamespaces` types; `process_named_runtime_args()` and `process_named_ct_arg_namespaces()` virtuals
- `tt_metal/jit_build/build.cpp` — JIT header generation for `named_args_generated.h`; emits `ct_args::` namespace structs with both CT constexpr values and RT arg descriptors at compile time
- `tt_metal/api/tt-metalium/program_descriptors.hpp` — `NamedCommonRuntimeArg`, `NamedPerCoreRuntimeArg`, `NamedCommonRuntimeArgArray`, `NamedPerCoreRuntimeArgArray` descriptor types + fields on `KernelDescriptor`
- `tt_metal/impl/program/program.cpp` — processes named per-core and common RT args from `ProgramDescriptor`, builds namespace maps, populates kernel's named arg namespaces for JIT
- `tt_metal/impl/kernels/kernel.hpp/cpp` — `set_named_runtime_arg_namespaces()`, `set_named_ct_arg_namespaces()`, `process_named_*()` overrides

### H2D socket flow control
- `tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp` — `get_fifo_size()`, `has_space()`, `get_bytes_sent()`, `acked_past()` declarations
- `tt_metal/distributed/h2d_socket.cpp` — `has_space()` and `acked_past()` implementations

### Tests
- `tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp` — 4 end-to-end tests covering named common/per-core/array RT args and named CT args
- `tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp`
- `tests/tt_metal/tt_metal/test_kernels/misc/named_array_runtime_args_kernel.cpp`
- `tests/tt_metal/tt_metal/test_kernels/misc/named_per_core_array_runtime_args_kernel.cpp`

## Notes for reviewers

- `nkapreTT/nkapre/multichip` has no common ancestor with main (completely diverged fork since 2022 initial commit), so changes were identified via `git diff HEAD nkapreTT/nkapre/multichip -- <file>` and applied manually
- Infrastructure divergences (e.g. `StableHasher` → `FNV1a`, C++17 → C++20 flags) were intentionally NOT carried over — only semantic additions unique to nkapreTT were applied
- The `rt_args::get<>()` template uses C++20 NTTP (non-type template parameters) to dispatch to either `get_arg_val` (per-core) or `get_common_arg_val` (common) based on the `Dispatch` field at compile time
- The named_args_generated.h JIT header is only emitted when named args are present; kernels without named args are unaffected

## Test plan

- [ ] `tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp` — all 4 tests pass on BH hardware
- [ ] Existing `test_runtime_args.cpp`, `test_compile_time_args.cpp` unaffected
- [ ] craq-sim p150 Blaze test sweep — `test_named_runtime_args.py` passes
- [ ] LLK weekly/nightly still 100% clean (no regression in kernel compilation path)

## CI Status

| Workflow | Status |
|---|---|
| Merge Gate | ![merge-gate](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml/badge.svg?branch=ridvan/nkapre-multichip-metal) |
| Sanity Tests | ![sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/nkapre-multichip-metal) |