### PR TITLE
[Bug fix] Use `uintptr_t` for device-side pointer casts

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -327,7 +327,7 @@ extern "C" uint32_t _start1() {
                 int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
                 WAYPOINT("R");
                 if (enables & (1u << index)) {
-                    uint32_t kernel_lma =
+                    uintptr_t kernel_lma =
                         (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
                     asm("FENCE.i");
                     uint32_t* kernel_ptr = reinterpret_cast<uint32_t*>(kernel_lma);
@@ -404,7 +404,7 @@ extern "C" uint32_t _start1() {
         uintptr_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
         int index = hartid;
 
-        uint32_t kernel_lma = kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index];
+        uintptr_t kernel_lma = kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index];
 
         uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
                                                                 launch_msg->kernel_config.local_cb_offset);

--- a/tt_metal/hw/firmware/src/tt-2xx/quasar/noc_address_translation_tables.cpp
+++ b/tt_metal/hw/firmware/src/tt-2xx/quasar/noc_address_translation_tables.cpp
@@ -12,8 +12,8 @@
 
 #else
 
-#define NOC_WRITE_REG(addr, val) ((*((volatile uint32_t*)(addr))) = (val))
-#define NOC_READ_REG(addr) (*((volatile uint32_t*)(addr)))
+#define NOC_WRITE_REG(addr, val) ((*((volatile uint32_t*)(uintptr_t)(addr))) = (val))
+#define NOC_READ_REG(addr) (*((volatile uint32_t*)(uintptr_t)(addr)))
 
 #endif
 

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -149,8 +149,7 @@ extern "C" uint32_t _start1() {
         uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
         launch_msg_t* launch_msg = &(mailboxes->launch[launch_msg_rd_ptr]);
 
-        uint32_t kernel_config_base = launch_msg->kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
-
+        uintptr_t kernel_config_base = launch_msg->kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
         uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
@@ -197,7 +196,7 @@ extern "C" uint32_t _start1() {
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
 
         WAYPOINT("R");
-        uint32_t kernel_lma =
+        uintptr_t kernel_lma =
             (kernel_config_base +
              launch_msg->kernel_config.kernel_text_offset[hartid]);  // TODO verify if depends on kernel
         auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2315,7 +2315,7 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
     // Posting heartbeat at this address is only needed for Wormhole
 #if !defined(ARCH_BLACKHOLE)
     invalidate_l1_cache();
-    volatile uint32_t* ptr = (volatile uint32_t*)(0x1C);
+    volatile uint32_t* ptr = (volatile uint32_t*)(uintptr_t)(0x1C);
     heartbeat++;
     ptr[0] = 0xAABB0000 | (heartbeat & 0xFFFF);
 #endif

--- a/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
@@ -234,7 +234,7 @@ FORCE_INLINE
 void eth_send_payload_complete_signal_over_channel(uint32_t channel, uint32_t num_bytes) {
     erisc_info->channels[channel].bytes_sent = num_bytes;
     erisc_info->channels[channel].receiver_ack = 0;
-    uint32_t addr = ((uint32_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4;
+    uint32_t addr = ((uint32_t)(uintptr_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4;
     internal_::eth_send_packet(0, addr, addr, 1);
 }
 
@@ -255,7 +255,7 @@ void eth_send_bytes_over_channel(
     }
     erisc_info->channels[channel].bytes_sent = num_bytes;
     erisc_info->channels[channel].receiver_ack = 0;
-    uint32_t addr = ((uint32_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4;
+    uint32_t addr = ((uint32_t)(uintptr_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4;
     internal_::eth_send_packet(0, addr, addr, 1);
 }
 
@@ -290,8 +290,8 @@ void eth_wait_for_receiver_done(uint32_t wait_min = 0) {
     internal_::eth_send_packet(
         0,
 
-        ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
-        ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+        ((uint32_t)(uintptr_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+        ((uint32_t)(uintptr_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
         1);
     uint32_t count = 0;
     while (erisc_info->channels[0].bytes_sent != 0) {
@@ -499,8 +499,8 @@ void eth_receiver_done() {
     erisc_info->channels[0].bytes_sent = 0;
     internal_::eth_send_packet(
         0,
-        ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
-        ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+        ((uint32_t)(uintptr_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+        ((uint32_t)(uintptr_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
         1);
 }
 
@@ -524,7 +524,10 @@ void send_eth_receiver_channel_done(volatile eth_channel_sync_t* channel_sync) {
     channel_sync->bytes_sent = 0;
     channel_sync->receiver_ack = 0;
     internal_::eth_send_packet(
-        0, ((uint32_t)(&(channel_sync->bytes_sent))) >> 4, ((uint32_t)(&(channel_sync->bytes_sent))) >> 4, 1);
+        0,
+        ((uint32_t)(uintptr_t)(&(channel_sync->bytes_sent))) >> 4,
+        ((uint32_t)(uintptr_t)(&(channel_sync->bytes_sent))) >> 4,
+        1);
 }
 
 FORCE_INLINE
@@ -577,9 +580,13 @@ void eth_receiver_channel_ack(uint32_t channel, uint32_t eth_transaction_ack_wor
     ASSERT(reinterpret_cast<volatile uint32_t*>(eth_transaction_ack_word_addr)[0] == 1);
     reinterpret_cast<volatile uint32_t*>(eth_transaction_ack_word_addr)[1] = 1;
     // Make sure we don't alias the erisc_info eth_channel_sync_t
-    ASSERT(eth_transaction_ack_word_addr != ((uint32_t)(&(erisc_info->channels[channel].receiver_ack))) >> 4);
+    ASSERT(
+        eth_transaction_ack_word_addr != ((uint32_t)(uintptr_t)(&(erisc_info->channels[channel].receiver_ack))) >> 4);
     internal_::eth_send_packet(
-        0, eth_transaction_ack_word_addr >> 4, ((uint32_t)(&(erisc_info->channels[channel].receiver_ack))) >> 4, 1);
+        0,
+        eth_transaction_ack_word_addr >> 4,
+        ((uint32_t)(uintptr_t)(&(erisc_info->channels[channel].receiver_ack))) >> 4,
+        1);
 }
 
 /*
@@ -596,8 +603,8 @@ void eth_receiver_acknowledge(uint8_t channel = 0) {
     erisc_info->channels[channel].bytes_sent = 1;
     internal_::eth_send_packet(
         0,
-        ((uint32_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4,
-        ((uint32_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4,
+        ((uint32_t)(uintptr_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4,
+        ((uint32_t)(uintptr_t)(&(erisc_info->channels[channel].bytes_sent))) >> 4,
         1);
 }
 

--- a/tt_metal/hw/inc/internal/ethernet/erisc.h
+++ b/tt_metal/hw/inc/internal/ethernet/erisc.h
@@ -13,7 +13,7 @@ inline void (*toggle_macpcs_ptr)(uint32_t);
 #if defined(ARCH_BLACKHOLE)
 volatile inline uint32_t* flag_disable = (uint32_t*)(GET_MAILBOX_ADDRESS_DEV(aerisc_run_flag));
 #else
-volatile inline uint32_t* flag_disable = (uint32_t*)(eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG);
+volatile inline uint32_t* flag_disable = (uint32_t*)(uintptr_t)(eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG);
 #endif
 
 namespace internal_ {

--- a/tt_metal/hw/inc/internal/ethernet/tt_eth_api.h
+++ b/tt_metal/hw/inc/internal/ethernet/tt_eth_api.h
@@ -9,8 +9,8 @@
 
 #include "tt_eth_ss_regs.h"
 
-#define ETH_WRITE_REG(addr, val) ((*((volatile uint32_t*)((addr)))) = (val))
-#define ETH_READ_REG(addr) (*((volatile uint32_t*)((addr))))
+#define ETH_WRITE_REG(addr, val) ((*((volatile uint32_t*)(uintptr_t)((addr)))) = (val))
+#define ETH_READ_REG(addr) (*((volatile uint32_t*)(uintptr_t)((addr))))
 
 #define ETH_WORD_SIZE_BYTES 16
 #define BYTES_TO_ETH_WORD_SHIFT 4

--- a/tt_metal/hw/inc/internal/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/internal/ethernet/tunneling.h
@@ -12,17 +12,17 @@
 #include "tt_eth_ss_regs.h"
 #include "internal/ethernet/tt_eth_api.h"
 inline void RISC_POST_STATUS(uint32_t status) {
-    volatile uint32_t* ptr = (volatile uint32_t*)(NOC_CFG(ROUTER_CFG_2));
+    volatile uint32_t* ptr = (volatile uint32_t*)(uintptr_t)(NOC_CFG(ROUTER_CFG_2));
     ptr[0] = status;
 }
 
 static volatile uint32_t* const fabric_postcode_ptr =
-    reinterpret_cast<volatile uint32_t*>(eth_l1_mem::address_map::AERISC_FABRIC_POSTCODES_BASE);
+    reinterpret_cast<volatile uint32_t*>(static_cast<uintptr_t>(eth_l1_mem::address_map::AERISC_FABRIC_POSTCODES_BASE));
 
 #define POSTCODE(status) (*fabric_postcode_ptr = static_cast<uint32_t>(status))
 
 static volatile uint32_t* const fabric_scratch_ptr =
-    reinterpret_cast<volatile uint32_t*>(eth_l1_mem::address_map::AERISC_FABRIC_SCRATCH_BASE);
+    reinterpret_cast<volatile uint32_t*>(static_cast<uintptr_t>(eth_l1_mem::address_map::AERISC_FABRIC_SCRATCH_BASE));
 
 #define ROUTER_SCRATCH_WRITE(id, val) (fabric_scratch_ptr[id]) = val;
 
@@ -55,11 +55,12 @@ struct erisc_info_t {
         channels[eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS];  // user_buffer_bytes_sent
 };
 
-erisc_info_t* erisc_info = (erisc_info_t*)(eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);
-routing_info_t* routing_info = (routing_info_t*)(eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE);
+erisc_info_t* erisc_info = (erisc_info_t*)(uintptr_t)(eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);
+routing_info_t* routing_info = (routing_info_t*)(uintptr_t)(eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE);
 
 // Context Switch Config
-tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE);
+tt_l1_ptr mailboxes_t* const mailboxes =
+    (tt_l1_ptr mailboxes_t*)(uintptr_t)(eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE);
 
 extern uint32_t __erisc_jump_table;
 volatile uint32_t* RtosTable =

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_overlay_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_overlay_parameters.h
@@ -67,8 +67,8 @@ extern "C" {
 #else
 
 #define NOC_STREAM_WRITE_REG(stream_id, reg_id, val) \
-    ((*((volatile uint32_t*)(STREAM_REG_ADDR(stream_id, reg_id)))) = (val))
-#define NOC_STREAM_READ_REG(stream_id, reg_id) (*((volatile uint32_t*)(STREAM_REG_ADDR(stream_id, reg_id))))
+    ((*((volatile uint32_t*)(uintptr_t)(STREAM_REG_ADDR(stream_id, reg_id)))) = (val))
+#define NOC_STREAM_READ_REG(stream_id, reg_id) (*((volatile uint32_t*)(uintptr_t)(STREAM_REG_ADDR(stream_id, reg_id))))
 
 #define NOC_STREAM_WRITE_REG_FIELD(stream_id, reg_id, field, val)                 \
     (NOC_STREAM_WRITE_REG(                                                        \
@@ -79,8 +79,8 @@ extern "C" {
 #define NOC_STREAM_READ_REG_FIELD(stream_id, reg_id, field) \
     ((NOC_STREAM_READ_REG(stream_id, reg_id) >> (field)) & ((1 << field##_WIDTH) - 1))
 
-#define NOC_WRITE_REG(addr, val) ((*((volatile uint32_t*)(addr)))) = (val)
-#define NOC_READ_REG(addr) (*((volatile uint32_t*)(addr)))
+#define NOC_WRITE_REG(addr, val) ((*((volatile uint32_t*)(uintptr_t)(addr)))) = (val)
+#define NOC_READ_REG(addr) (*((volatile uint32_t*)(uintptr_t)(addr)))
 
 #endif
 

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -33,8 +33,10 @@ struct CQWriteInterface {
 
 constexpr ProgrammableCoreType fd_core_type = static_cast<ProgrammableCoreType>(FD_CORE_TYPE);
 
-FORCE_INLINE
-uint32_t round_up_pow2(uint32_t v, uint32_t pow2_size) { return (v + (pow2_size - 1)) & ~(pow2_size - 1); }
+template <typename T>
+FORCE_INLINE T round_up_pow2(T v, uint32_t pow2_size) {
+    return (v + (pow2_size - 1)) & ~static_cast<T>(pow2_size - 1);
+}
 
 FORCE_INLINE
 uint32_t div_up(uint32_t n, uint32_t d) { return (n + d - 1) / d; }
@@ -190,12 +192,12 @@ FORCE_INLINE void cq_noc_inline_dw_write_with_state(
     uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF, uint8_t noc = noc_index) {
 #if defined(ARCH_BLACKHOLE)
     noc_async_writes_flushed();  // ensure inline_l1_src_addr is not overwritten
-    uint32_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc, dst_addr);
+    uintptr_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc, dst_addr);
     volatile tt_l1_ptr uint32_t* inline_l1_src_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inline_l1_src_addr);
     *inline_l1_src_addr_ptr = val;
     cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_WAIT, CQ_NOC_SEND, NCRISC_WR_REG_CMD_BUF>(
-        inline_l1_src_addr, dst_addr, 4);
+        static_cast<uint32_t>(inline_l1_src_addr), dst_addr, 4);
 #else
     if constexpr (wait) {
         WAYPOINT("NISW");
@@ -221,7 +223,7 @@ FORCE_INLINE void cq_noc_inline_dw_write_init_state(
 #if defined(ARCH_BLACKHOLE)
     // On Blackhole inline writes are disabled so use cq_noc_async_write_init_state with inline write cmd buf
     // See comment in `noc_inline_dw_write` for more details
-    uint32_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc, dst_addr);
+    uintptr_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc, dst_addr);
     volatile tt_l1_ptr uint32_t* inline_l1_src_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inline_l1_src_addr);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, NCRISC_WR_REG_CMD_BUF>(0, dst_addr, 0);
@@ -398,7 +400,7 @@ public:
 
     // Return available space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
     // wrap around.
-    uint32_t available_bytes(uint32_t data_ptr) const { return cb_fence_ - data_ptr; }
+    uint32_t available_bytes(uintptr_t data_ptr) const { return static_cast<uint32_t>(cb_fence_ - data_ptr); }
 
 protected:
     FORCE_INLINE void init() {
@@ -436,7 +438,7 @@ protected:
         }
 
         // Set a fence to limit how much is processed at once
-        uint32_t limit = (block_next_start_addr_[rd_block_idx_] - cb_fence_) >> cb_log_page_size;
+        uint32_t limit = static_cast<uint32_t>((block_next_start_addr_[rd_block_idx_] - cb_fence_) >> cb_log_page_size);
         uint32_t available = upstream_count_ - local_count_;
         uint32_t usable = (available > limit) ? limit : available;
 
@@ -447,9 +449,9 @@ protected:
     }
 
     // Byte address fence delimiting the end of currently usable data (do not process beyond this address).
-    uint32_t cb_fence_{0};
+    uintptr_t cb_fence_{0};
     // Byte addresses of the start of the next block for each block index; used to cap processing per block and wrap.
-    uint32_t block_next_start_addr_[cb_blocks]{};
+    uintptr_t block_next_start_addr_[cb_blocks]{};
     // Current read block index within the circular buffer.
     uint32_t rd_block_idx_{0};
 
@@ -484,7 +486,7 @@ public:
     // If this function doesn't return sufficient data, there are two options:
     // 1. Process all the available data and then call this function again.
     // 2. Call get_cb_page_and_release_pages to attempt to get more data.
-    FORCE_INLINE uint32_t wait_for_available_data_and_release_old_pages(uint32_t& cmd_ptr) {
+    FORCE_INLINE uint32_t wait_for_available_data_and_release_old_pages(uintptr_t& cmd_ptr) {
         if (this->available_bytes(cmd_ptr) == 0) {
             if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {
                 if (this->rd_block_idx_ == cb_blocks - 1) {
@@ -505,7 +507,7 @@ public:
     // cmd_ptr is set to the base address after on_boundary is called).
     // noc_increment_nonposted_writes_issued() must be called before on_boundary returns.
     template <typename OnBoundaryFn>
-    FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
+    FORCE_INLINE uint32_t get_cb_page_and_release_pages(uintptr_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {
             const bool will_wrap = (this->rd_block_idx_ == cb_blocks - 1);
             on_boundary(will_wrap);
@@ -518,10 +520,10 @@ public:
         return this->acquire_pages();
     }
 
-    FORCE_INLINE void release_all_pages(uint32_t curr_ptr) {
+    FORCE_INLINE void release_all_pages(uintptr_t curr_ptr) {
         release_block_pages();
-        uint32_t pages_to_release =
-            cb_pages_per_block - ((this->block_next_start_addr_[this->rd_block_idx_] - curr_ptr) >> cb_log_page_size);
+        uint32_t pages_to_release = static_cast<uint32_t>(
+            cb_pages_per_block - ((this->block_next_start_addr_[this->rd_block_idx_] - curr_ptr) >> cb_log_page_size));
         if (pages_to_release != 0) {
             ReleasePolicy::template release<noc_idx, noc_xy, sem_id>(pages_to_release);
         }
@@ -569,7 +571,7 @@ public:
 
     // Get a new CB page. Will update cmd_ptr on wrap-around. Returns the number of pages acquired. Will not release
     // pages to writer.
-    FORCE_INLINE uint32_t get_cb_page(uint32_t& cmd_ptr) {
+    FORCE_INLINE uint32_t get_cb_page(uintptr_t& cmd_ptr) {
         // Strided past the data that has arrived, get the next page
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {
             if (this->rd_block_idx_ == cb_blocks - 1) {
@@ -583,7 +585,7 @@ public:
     }
 
     // Returns how much data is available. Will block until data is available.
-    FORCE_INLINE uint32_t wait_for_available_data(uint32_t& cmd_ptr) {
+    FORCE_INLINE uint32_t wait_for_available_data(uintptr_t& cmd_ptr) {
         if (this->available_bytes(cmd_ptr) == 0) {
             get_cb_page(cmd_ptr);
         }
@@ -591,11 +593,11 @@ public:
     }
 
     // Advance cmd_ptr by length. If we wrap around, wrap the fence (should only happen if we hit the end exactly).
-    FORCE_INLINE void consumed_data(uint32_t& cmd_ptr, uint32_t length) {
+    FORCE_INLINE void consumed_data(uintptr_t& cmd_ptr, uint32_t length) {
         // This is ugly: get_cb_page code can wrap and this can wrap
         // They peacefully coexist because we won't wrap there and here at once
         if (cmd_ptr + length >= cb_end) {
-            length -= cb_end - cmd_ptr;
+            length -= static_cast<uint32_t>(cb_end - cmd_ptr);
             cmd_ptr = cb_base;
             if (this->cb_fence_ == cb_end) {
                 // We hit the nail on the head, wrap the fence

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -24,7 +24,7 @@
 
 CQWriteInterface cq_write_interface;
 
-constexpr uint32_t dispatch_cb_base = DISPATCH_CB_BASE;
+constexpr uintptr_t dispatch_cb_base = DISPATCH_CB_BASE;
 constexpr uint32_t dispatch_cb_log_page_size = DISPATCH_CB_LOG_PAGE_SIZE;
 constexpr uint32_t dispatch_cb_pages = DISPATCH_CB_PAGES;
 constexpr uint32_t my_dispatch_cb_sem_id = MY_DISPATCH_CB_SEM_ID;
@@ -45,7 +45,7 @@ constexpr uint32_t prefetch_h_local_downstream_sem_addr = PREFETCH_H_LOCAL_DOWNS
 constexpr uint32_t prefetch_h_max_credits = PREFETCH_H_MAX_CREDITS;
 constexpr uint32_t packed_write_max_unicast_sub_cmds =
     PACKED_WRITE_MAX_UNICAST_SUB_CMDS;  // Number of cores in compute grid
-constexpr uint32_t dispatch_s_sync_sem_base_addr = DISPATCH_S_SYNC_SEM_BASE_ADDR;
+constexpr uintptr_t dispatch_s_sync_sem_base_addr = DISPATCH_S_SYNC_SEM_BASE_ADDR;
 constexpr uint32_t max_num_worker_sems = MAX_NUM_WORKER_SEMS;  // maximum number of worker semaphores
 constexpr uint32_t max_num_go_signal_noc_data_entries =
     MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES;  // maximum number of go signal data words
@@ -53,9 +53,9 @@ constexpr uint32_t mcast_go_signal_addr = MCAST_GO_SIGNAL_ADDR;
 constexpr uint32_t unicast_go_signal_addr = UNICAST_GO_SIGNAL_ADDR;
 constexpr uint32_t distributed_dispatcher = DISTRIBUTED_DISPATCHER;
 constexpr uint32_t host_completion_q_wr_ptr = HOST_COMPLETION_Q_WR_PTR;
-constexpr uint32_t dev_completion_q_wr_ptr = DEV_COMPLETION_Q_WR_PTR;
-constexpr uint32_t dev_completion_q_rd_ptr = DEV_COMPLETION_Q_RD_PTR;
-constexpr uint32_t dev_dispatch_progress_ptr = DEV_DISPATCH_PROGRESS_PTR;
+constexpr uintptr_t dev_completion_q_wr_ptr = DEV_COMPLETION_Q_WR_PTR;
+constexpr uintptr_t dev_completion_q_rd_ptr = DEV_COMPLETION_Q_RD_PTR;
+constexpr uintptr_t dev_dispatch_progress_ptr = DEV_DISPATCH_PROGRESS_PTR;
 
 constexpr uint32_t first_stream_used = FIRST_STREAM_USED;
 
@@ -118,7 +118,7 @@ constexpr uint32_t completion_queue_page_size_16B = completion_queue_page_size >
 constexpr uint32_t completion_queue_end_addr_16B = completion_queue_end_addr >> 4;
 constexpr uint32_t completion_queue_base_addr_16B = completion_queue_base_addr >> 4;
 constexpr uint32_t dispatch_cb_size = dispatch_cb_page_size * dispatch_cb_pages;
-constexpr uint32_t dispatch_cb_end = dispatch_cb_base + dispatch_cb_size;
+constexpr uintptr_t dispatch_cb_end = dispatch_cb_base + dispatch_cb_size;
 constexpr uint32_t downstream_cb_end = downstream_cb_base + downstream_cb_size;
 constexpr uint32_t fd_core_type_idx = static_cast<uint32_t>(fd_core_type);
 
@@ -140,7 +140,7 @@ constexpr uint32_t dispatch_cb_pages_per_block = dispatch_cb_pages / dispatch_cb
 volatile tt_l1_ptr realtime_profiler_msg_t* rt_profiler_msg =
     reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(REALTIME_PROFILER_MSG_ADDR);
 
-static uint32_t cmd_ptr;   // walks through pages in cb cmd by cmd
+static uintptr_t cmd_ptr;  // walks through pages in cb cmd by cmd
 static uint32_t downstream_cb_data_ptr = downstream_cb_base;
 
 static uint32_t write_offset[CQ_DISPATCH_MAX_WRITE_OFFSETS];  // added to write address on non-host writes
@@ -276,9 +276,10 @@ void notify_host_of_completion_queue_write_pointer() {
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
     uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-    noc_async_write(dev_completion_q_wr_ptr, pcie_noc_xy | completion_queue_write_ptr_addr, 4);
+    noc_async_write(static_cast<uint32_t>(dev_completion_q_wr_ptr), pcie_noc_xy | completion_queue_write_ptr_addr, 4);
 #else
-    cq_noc_async_write_with_state<CQ_NOC_SnDL>(dev_completion_q_wr_ptr, completion_queue_write_ptr_addr, 4);
+    cq_noc_async_write_with_state<CQ_NOC_SnDL>(
+        static_cast<uint32_t>(dev_completion_q_wr_ptr), completion_queue_write_ptr_addr, 4);
 #endif
 }
 
@@ -309,7 +310,7 @@ void process_write_host_h() {
     bool is_event = cmd->write_linear_host.is_event;
     // DPRINT << "process_write_host_h: " << length << ENDL();
     // DEVICE_PRINT("process_write_host_h: length {}\n", length);
-    uint32_t data_ptr = cmd_ptr;
+    uintptr_t data_ptr = cmd_ptr;
 #if !defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
     uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
@@ -339,9 +340,11 @@ void process_write_host_h() {
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
                 uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-                noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
+                noc_async_write(
+                    static_cast<uint32_t>(data_ptr), pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
 #else
-                cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, last_chunk_size);
+                cq_noc_async_write_with_state_any_len(
+                    static_cast<uint32_t>(data_ptr), completion_queue_write_addr, last_chunk_size);
                 uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
                 noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
                 noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
@@ -355,9 +358,10 @@ void process_write_host_h() {
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
             uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-            noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, xfer_size);
+            noc_async_write(static_cast<uint32_t>(data_ptr), pcie_noc_xy | completion_queue_write_addr, xfer_size);
 #else
-            cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, xfer_size);
+            cq_noc_async_write_with_state_any_len(
+                static_cast<uint32_t>(data_ptr), completion_queue_write_addr, xfer_size);
             // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets
             // written
             uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
@@ -384,7 +388,9 @@ void process_exec_buf_end_h() {
             get_semaphore<fd_core_type>(prefetch_h_local_downstream_sem_addr));
 
         noc_semaphore_inc(
-            get_noc_addr_helper(prefetch_h_noc_xy, (uint32_t)sem_addr), prefetch_h_max_credits, noc_index);
+            get_noc_addr_helper(prefetch_h_noc_xy, static_cast<uint32_t>(reinterpret_cast<uintptr_t>(sem_addr))),
+            prefetch_h_max_credits,
+            noc_index);
     }
 
     cmd_ptr += sizeof(CQDispatchCmd);
@@ -395,7 +401,7 @@ CBWriter<my_downstream_cb_sem_id, 0, 0, 0> dispatch_h_cb_writer{};
 // Relay, potentially through the mux/dmux/tunneller path
 // Code below sends 1 page worth of data except at the end of a cmd
 // This means the downstream buffers are always page aligned, simplifies wrap handling
-void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
+void relay_to_next_cb(uintptr_t data_ptr, uint64_t wlength) {
     // DPRINT << "relay_to_next_cb: " << data_ptr << " " << dispatch_cb_reader.cb_fence << " " << wlength << ENDL();
     // DEVICE_PRINT("relay_to_next_cb: data_ptr {} dispatch_cb_reader.cb_fence {} wlength {}\n", data_ptr,
     // dispatch_cb_reader.cb_fence, wlength);
@@ -478,7 +484,7 @@ void process_write_host_d() {
     volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
     // Remember: host transfer command includes the command in the payload, don't add it here
     uint64_t length = cmd->write_linear_host.length;
-    uint32_t data_ptr = cmd_ptr;
+    uintptr_t data_ptr = cmd_ptr;
 
     relay_to_next_cb(data_ptr, length);
 }
@@ -486,7 +492,7 @@ void process_write_host_d() {
 void relay_write_h() {
     volatile tt_l1_ptr CQDispatchCmdLarge* cmd = (volatile tt_l1_ptr CQDispatchCmdLarge*)cmd_ptr;
     uint64_t length = sizeof(CQDispatchCmdLarge) + cmd->write_linear.length;
-    uint32_t data_ptr = cmd_ptr;
+    uintptr_t data_ptr = cmd_ptr;
 
     relay_to_next_cb(data_ptr, length);
 }
@@ -506,7 +512,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
     uint32_t write_offset_index = cmd->write_linear.write_offset_index;
     uint64_t dst_addr = cmd->write_linear.addr + write_offset[write_offset_index];
     uint64_t length = cmd->write_linear.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmdLarge);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmdLarge);
     // DPRINT << "process_write_linear noc_xy:0x" << HEX() << dst_noc << ", write_offset:" << write_offset_index << ",
     // dst_addr:0x" << dst_addr << ", length:0x" << length << ", data_ptr:0x" << data_ptr << DEC() << ENDL();
     // DEVICE_PRINT("process_write_linear noc_xy:0x{:x} write_offset:{} dst_addr:0x{08x} length:{} data_ptr:0x{08x}\n",
@@ -538,7 +544,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
         uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
         uint32_t xfer_size = length > available_data ? available_data : length;
 #endif
-        cq_noc_async_write_with_state_any_len(data_ptr, dst_addr, xfer_size, num_mcast_dests);
+        cq_noc_async_write_with_state_any_len(static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_mcast_dests);
         // Increment counters based on the number of packets that were written
         uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE);
         noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
@@ -565,7 +571,7 @@ void process_write_paged() {
     uint32_t base_addr = cmd->write_paged.base_addr;
     uint32_t page_size = cmd->write_paged.page_size;
     uint32_t pages = cmd->write_paged.pages;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
     uint32_t write_length = pages * page_size;
     auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
     uint32_t dst_addr_offset = 0;  // Offset into page.
@@ -585,7 +591,7 @@ void process_write_paged() {
         xfer_size = xfer_size > NOC_MAX_BURST_SIZE ? NOC_MAX_BURST_SIZE : xfer_size;
         uint64_t dst = addr_gen.get_noc_addr(page_id, dst_addr_offset);
 
-        noc_async_write<NOC_MAX_BURST_SIZE>(data_ptr, dst, xfer_size);
+        noc_async_write<NOC_MAX_BURST_SIZE>(static_cast<uint32_t>(data_ptr), dst, xfer_size);
         // If paged write is not completed for a page (dispatch_cb_page_size < page_size) then add offset, otherwise
         // incr page_id.
         if (xfer_size < remaining_page_size) {
@@ -635,7 +641,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
 
     ASSERT(xfer_size <= dispatch_cb_page_size);
 
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(WritePackedSubCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(WritePackedSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
     uint32_t stride =
         (flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE) ? 0 : round_up_pow2(xfer_size, L1_ALIGNMENT);
@@ -680,7 +686,8 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
                 orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
                 if (orphan_size != 0) {
                     wait_for_barrier();
-                    cq_noc_async_write_with_state<CQ_NOC_SNdL>(data_ptr, dst, orphan_size, num_dests);
+                    cq_noc_async_write_with_state<CQ_NOC_SNdL>(
+                        static_cast<uint32_t>(data_ptr), dst, orphan_size, num_dests);
                     writes++;
                     mcasts += num_dests;
                     if (!will_wrap) {
@@ -703,7 +710,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
                 uint32_t remainder_dst_addr = dst_addr + orphan_size;
                 wait_for_barrier();
                 cq_noc_async_write_with_state<CQ_NOC_SnDL>(
-                    data_ptr, remainder_dst_addr, remainder_xfer_size, num_dests);
+                    static_cast<uint32_t>(data_ptr), remainder_dst_addr, remainder_xfer_size, num_dests);
                 // Reset values expected below
                 cq_noc_async_write_with_state<CQ_NOC_snDL, CQ_NOC_WAIT, CQ_NOC_send>(0, dst, xfer_size);
                 writes++;
@@ -717,7 +724,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
         }
 
         wait_for_barrier();
-        cq_noc_async_write_with_state<CQ_NOC_SNdl>(data_ptr, dst, xfer_size, num_dests);
+        cq_noc_async_write_with_state<CQ_NOC_SNdl>(static_cast<uint32_t>(data_ptr), dst, xfer_size, num_dests);
         writes++;
         mcasts += num_dests;
 
@@ -753,7 +760,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
     uint32_t alignment = cmd->write_packed_large.alignment;
     uint32_t write_offset_index = cmd->write_packed_large.write_offset_index;
     uint32_t local_write_offset = write_offset[write_offset_index];
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeSubCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
     constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeSubCmd);
@@ -821,24 +828,28 @@ void process_write_packed_large(uint32_t* l1_cache) {
             if (length > available_data) {
                 xfer_size = available_data;
                 wait_for_barrier();
-                cq_noc_async_write_with_state_any_len(data_ptr, dst_addr, xfer_size, num_dests);
+                cq_noc_async_write_with_state_any_len(static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
                 must_barrier = false;
             } else {
                 xfer_size = length;
                 if (unlink) {
                     wait_for_barrier();
-                    uint32_t rem_xfer_size =
-                        cq_noc_async_write_with_state_any_len<false>(data_ptr, dst_addr, xfer_size, num_dests);
+                    uint32_t rem_xfer_size = cq_noc_async_write_with_state_any_len<false>(
+                        static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
                     // Unset Link flag
                     cq_noc_async_write_init_state<CQ_NOC_sndl, true, false>(0, 0, 0);
                     uint32_t data_offset = xfer_size - rem_xfer_size;
                     cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_wait>(
-                        data_ptr + data_offset, dst_addr + data_offset, rem_xfer_size, num_dests);
+                        static_cast<uint32_t>(data_ptr + data_offset),
+                        dst_addr + data_offset,
+                        rem_xfer_size,
+                        num_dests);
                     // Later writes must barrier, but the `must_barrier = true` in the `if (init_state)` block above
                     // will see to that.
                 } else {
                     wait_for_barrier();
-                    cq_noc_async_write_with_state_any_len(data_ptr, dst_addr, xfer_size, num_dests);
+                    cq_noc_async_write_with_state_any_len(
+                        static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
                     must_barrier = false;
                 }
             }
@@ -881,7 +892,7 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
     uint32_t alignment = cmd->write_packed_large_unicast.alignment;
     uint32_t write_offset_index = cmd->write_packed_large_unicast.write_offset_index;
     uint32_t local_write_offset = write_offset[write_offset_index];
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
     constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
@@ -912,7 +923,7 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
                 // Transfer size is min(remaining_length, data_available_in_cb)
                 uint32_t xfer_size = (length > available_data) ? available_data : length;
 
-                noc_async_write(data_ptr, get_noc_addr_helper(dst_noc, dst_addr), xfer_size);
+                noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(dst_noc, dst_addr), xfer_size);
 
                 length -= xfer_size;
                 data_ptr += xfer_size;
@@ -949,7 +960,7 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
     cmd_ptr = data_ptr;
 }
 
-static uint32_t process_debug_cmd(uint32_t cmd_ptr) {
+static uintptr_t process_debug_cmd(uintptr_t cmd_ptr) {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
     return cmd_ptr + cmd->debug.stride;
 }
@@ -988,7 +999,7 @@ static void process_wait() {
     WAYPOINT("PWW");
     uint32_t heartbeat = 0;
     if (wait_memory) {
-        uint32_t addr = cmd->wait.addr;
+        uintptr_t addr = cmd->wait.addr;
         volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
         // DPRINT << " DISPATCH WAIT " << HEX() << addr << DEC() << " count " << count << ENDL();
         // DEVICE_PRINT("DISPATCH WAIT 0x{:08x} count {}\n", addr, count);
@@ -1001,7 +1012,7 @@ static void process_wait() {
         last_wait_count = count;
         last_wait_stream = stream;
         volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
-            STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX));
+            static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
         // DPRINT << " DISPATCH WAIT STREAM " << HEX() << stream << DEC() << " count " << count << ENDL();
         // DEVICE_PRINT("DISPATCH WAIT STREAM 0x{:08x} count {}\n", stream, count);
         do {
@@ -1012,7 +1023,7 @@ static void process_wait() {
 
     if (clear_stream) {
         volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
-            STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX));
+            static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
         uint32_t neg_sem_val = -(*sem_addr);
         NOC_STREAM_WRITE_REG(
             stream,
@@ -1061,7 +1072,9 @@ void process_go_signal_mcast_cmd() {
         aligned_go_signal_storage[storage_offset] = go_signal_value;
 
         cq_noc_async_write_init_state<CQ_NOC_SNDL, true>(
-            (uint32_t)&aligned_go_signal_storage[storage_offset], dst_noc_addr_multicast, sizeof(uint32_t));
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&aligned_go_signal_storage[storage_offset])),
+            dst_noc_addr_multicast,
+            sizeof(uint32_t));
         noc_nonposted_writes_acked[noc_index] += num_dests;
 
         WAYPOINT("WCW");
@@ -1101,7 +1114,8 @@ void process_go_signal_mcast_cmd() {
 
     for (uint32_t i = 0; i < num_unicasts; ++i) {
         uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
-        noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
+        noc_async_write_one_packet(
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(aligned_go_signal_storage)), dst, sizeof(uint32_t));
     }
 
     cmd_ptr += sizeof(CQDispatchCmd);
@@ -1125,10 +1139,11 @@ void process_notify_dispatch_s_go_signal_cmd() {
 
     while (index_bitmask != 0) {
         uint32_t set_index = __builtin_ctz(index_bitmask);
-        uint32_t dispatch_s_sync_sem_addr = dispatch_s_sync_sem_base_addr + set_index * L1_ALIGNMENT;
+        uintptr_t dispatch_s_sync_sem_addr = dispatch_s_sync_sem_base_addr + set_index * L1_ALIGNMENT;
         if constexpr (distributed_dispatcher) {
             static uint32_t num_go_signals_safe_to_send[max_num_worker_sems] = {0};
-            uint64_t dispatch_s_notify_addr = get_noc_addr_helper(dispatch_s_noc_xy, dispatch_s_sync_sem_addr);
+            uint64_t dispatch_s_notify_addr =
+                get_noc_addr_helper(dispatch_s_noc_xy, static_cast<uint32_t>(dispatch_s_sync_sem_addr));
             num_go_signals_safe_to_send[set_index]++;
             noc_inline_dw_write(dispatch_s_notify_addr, num_go_signals_safe_to_send[set_index]);
         } else {
@@ -1151,10 +1166,10 @@ void set_go_signal_noc_data() {
     for (uint32_t i = 0; i < num_words; ++i) {
         go_signal_noc_data[i] = *(data_ptr++);
     }
-    cmd_ptr = round_up_pow2((uint32_t)data_ptr, L1_ALIGNMENT);
+    cmd_ptr = round_up_pow2(reinterpret_cast<uintptr_t>(data_ptr), L1_ALIGNMENT);
 }
 
-static inline bool process_cmd_d(uint32_t& cmd_ptr, uint32_t* l1_cache) {
+static inline bool process_cmd_d(uintptr_t& cmd_ptr, uint32_t* l1_cache) {
     bool done = false;
 re_run_command:
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
@@ -1348,7 +1363,7 @@ re_run_command:
     return done;
 }
 
-static inline bool process_cmd_h(uint32_t& cmd_ptr) {
+static inline bool process_cmd_h(uintptr_t& cmd_ptr) {
     bool done = false;
 
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
@@ -1478,7 +1493,9 @@ void kernel_main() {
     router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
 
     // Initialize local state of any additional nocs used instead of the default
+#ifndef ARCH_QUASAR
     static_assert(my_noc_index != upstream_noc_index);
+#endif
     if constexpr (my_noc_index != upstream_noc_index) {
         noc_local_state_init(upstream_noc_index);
     }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1493,9 +1493,7 @@ void kernel_main() {
     router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
 
     // Initialize local state of any additional nocs used instead of the default
-#ifndef ARCH_QUASAR
     static_assert(my_noc_index != upstream_noc_index);
-#endif
     if constexpr (my_noc_index != upstream_noc_index) {
         noc_local_state_init(upstream_noc_index);
     }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -27,13 +27,13 @@
 // Reads cannot be issued by dispatch_s.
 constexpr uint32_t DISPATCH_S_WR_REG_CMD_BUF = 1;
 constexpr uint32_t DISPATCH_S_ATOMIC_CMD_BUF = 2;
-constexpr uint32_t cb_base = CB_BASE;
+constexpr uintptr_t cb_base = CB_BASE;
 constexpr uint32_t cb_log_page_size = CB_LOG_PAGE_SIZE;
 constexpr uint32_t cb_size = CB_SIZE;
 constexpr uint32_t my_dispatch_cb_sem_id = MY_DISPATCH_CB_SEM_ID;
 constexpr uint32_t upstream_dispatch_cb_sem_id = UPSTREAM_DISPATCH_CB_SEM_ID;
 constexpr uint32_t dispatch_d_shutdown_sem_id = DISPATCH_D_SHUTDOWN_SEM_ID;
-constexpr uint32_t dispatch_s_sync_sem_base_addr = DISPATCH_S_SYNC_SEM_BASE_ADDR;
+constexpr uintptr_t dispatch_s_sync_sem_base_addr = DISPATCH_S_SYNC_SEM_BASE_ADDR;
 constexpr uint32_t mcast_go_signal_addr = MCAST_GO_SIGNAL_ADDR;
 constexpr uint32_t unicast_go_signal_addr = UNICAST_GO_SIGNAL_ADDR;
 constexpr uint32_t distributed_dispatcher =
@@ -54,7 +54,7 @@ constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 constexpr uint8_t my_noc_index = NOC_INDEX;
 
 constexpr uint32_t cb_page_size = 1 << cb_log_page_size;
-constexpr uint32_t cb_end = cb_base + cb_size;
+constexpr uintptr_t cb_end = cb_base + cb_size;
 
 // Dispatch-core-local L1 region assigned by DispatchMemMap via
 // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG. Address comes from host through the
@@ -67,7 +67,7 @@ static bool rt_profiler_enabled = false;
 
 static uint32_t num_pages_acquired = 0;
 static uint32_t num_mcasts_sent[max_num_worker_sems] = {0};
-static uint32_t cmd_ptr;
+static uintptr_t cmd_ptr;
 
 extern "C" {
 // These variables are used by triage to help report dispatcher state.
@@ -169,8 +169,8 @@ void wait_for_workers(uint32_t wait_count, uint32_t wait_stream) {
     WAYPOINT("WCW");
     last_wait_count = wait_count;
     last_wait_stream = wait_stream;
-    volatile uint32_t* worker_sem =
-        (volatile uint32_t*)STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    volatile uint32_t* worker_sem = reinterpret_cast<volatile uint32_t*>(
+        static_cast<uintptr_t>(STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
     while (stream_wrap_gt(wait_count, *worker_sem)) {
         if (rt_profiler_enabled) {
             record_realtime_timestamp(rt_profiler_msg, false);
@@ -270,7 +270,9 @@ void process_go_signal_mcast_cmd() {
         aligned_go_signal_storage[storage_offset] = go_signal_value;
 
         cq_noc_async_write_init_state<CQ_NOC_SNDL, true>(
-            (uint32_t)&aligned_go_signal_storage[storage_offset], dst_noc_addr_multicast, sizeof(uint32_t));
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&aligned_go_signal_storage[storage_offset])),
+            dst_noc_addr_multicast,
+            sizeof(uint32_t));
 
         // Multicast write accounting: increment counters for num_dests acks and one issued transaction.
         noc_increment_nonposted_writes_acked(noc_index, num_dests);
@@ -304,7 +306,8 @@ void process_go_signal_mcast_cmd() {
 
     for (uint32_t i = 0; i < num_unicasts; ++i) {
         uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
-        noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
+        noc_async_write_one_packet(
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(aligned_go_signal_storage)), dst, sizeof(uint32_t));
     }
 
     update_worker_completion_count_on_dispatch_d();
@@ -321,8 +324,8 @@ void process_dispatch_s_wait_cmd() {
         distributed_dispatcher);
     uint32_t stream = cmd->wait.stream;
     uint32_t index = stream - first_stream_used;
-    volatile uint32_t* worker_sem =
-        (volatile uint32_t*)STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    volatile uint32_t* worker_sem = reinterpret_cast<volatile uint32_t*>(
+        static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
 
     // Wait for workers to complete
     while (stream_wrap_gt(cmd->wait.count, *worker_sem)) {
@@ -356,7 +359,7 @@ void set_go_signal_noc_data() {
     for (uint32_t i = 0; i < num_words; ++i) {
         go_signal_noc_data[i] = *(data_ptr++);
     }
-    cmd_ptr = round_up_pow2((uint32_t)data_ptr, L1_ALIGNMENT);
+    cmd_ptr = round_up_pow2(reinterpret_cast<uintptr_t>(data_ptr), L1_ALIGNMENT);
 }
 
 // When dispatch_d runs on the same core, it issues transactions on dispatch_s's dedicated NOC
@@ -475,7 +478,7 @@ void kernel_main() {
                 ASSERT(0);
         }
         // Dispatch s only supports single page commands for now
-        ASSERT(cmd_ptr <= ((uint32_t)cmd + cb_page_size));
+        ASSERT(cmd_ptr <= (reinterpret_cast<uintptr_t>(cmd) + cb_page_size));
         cmd_ptr = round_up_pow2(cmd_ptr, cb_page_size);
         // Release a single page to prefetcher. Assumption is that all dispatch_s commands fit inside a single page for
         // now.

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -2403,7 +2403,7 @@ uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstre
 // This function is only valid when called on the H variant
 // It expects the NoC async write state to be initialized to point to the downstream
 static uintptr_t process_relay_inline_all(uintptr_t data_ptr, uintptr_t fence, bool is_exec_buf) {
-    uint32_t length = fence - data_ptr;
+    uint32_t length = static_cast<uint32_t>(fence - data_ptr);
     // Downstream doesn't have FetchQ to tell it how much data to process
     // This packet header just contains the length
     volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr = (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -59,12 +59,12 @@ constexpr uint32_t downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
 // unused for prefetch_d
 constexpr uint32_t pcie_base = PCIE_BASE;
 constexpr uint32_t pcie_size = PCIE_SIZE;
-constexpr uint32_t prefetch_q_base = PREFETCH_Q_BASE;
+constexpr uintptr_t prefetch_q_base = PREFETCH_Q_BASE;
 constexpr uint32_t prefetch_q_size = PREFETCH_Q_SIZE;
-constexpr uint32_t prefetch_q_rd_ptr_addr = PREFETCH_Q_RD_PTR_ADDR;
-constexpr uint32_t prefetch_q_pcie_rd_ptr_addr = PREFETCH_Q_PCIE_RD_PTR_ADDR;
+constexpr uintptr_t prefetch_q_rd_ptr_addr = PREFETCH_Q_RD_PTR_ADDR;
+constexpr uintptr_t prefetch_q_pcie_rd_ptr_addr = PREFETCH_Q_PCIE_RD_PTR_ADDR;
 
-constexpr uint32_t cmddat_q_base = CMDDAT_Q_BASE;
+constexpr uintptr_t cmddat_q_base = CMDDAT_Q_BASE;
 constexpr uint32_t cmddat_q_size = CMDDAT_Q_SIZE;
 
 // unused for prefetch_h
@@ -120,8 +120,8 @@ constexpr bool is_2d_fabric = FABRIC_2D;
 constexpr uint32_t is_d_variant = IS_D_VARIANT;
 constexpr uint32_t is_h_variant = IS_H_VARIANT;
 
-constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
-constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;
+constexpr uintptr_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
+constexpr uintptr_t cmddat_q_end = cmddat_q_base + cmddat_q_size;
 constexpr uint32_t scratch_db_end = scratch_db_base + scratch_db_size;
 constexpr uint32_t ringbuffer_end = scratch_db_base + ringbuffer_size;
 
@@ -238,7 +238,7 @@ struct PrefetchExecBufState {
     uint32_t prefetch_length;
 };
 
-uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr);
+uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr);
 
 // Global Variables
 static uint32_t pcie_read_ptr = pcie_base;
@@ -265,7 +265,7 @@ static_assert((downstream_cb_base & (downstream_cb_page_size - 1)) == 0);
 
 template <bool cmddat_wrap_enable, bool exec_buf>
 bool process_cmd(
-    uint32_t& cmd_ptr,
+    uintptr_t& cmd_ptr,
     uint32_t& downstream_data_ptr,
     uint32_t& stride,
     uint32_t* l1_cache,
@@ -273,7 +273,7 @@ bool process_cmd(
 
 template <uint32_t downstream_cb_base_addr, uint32_t downstream_cmd_buf>
 FORCE_INLINE void write_downstream(
-    uint32_t& data_ptr,
+    uintptr_t& data_ptr,
     uint32_t& local_downstream_data_ptr,
     uint32_t length,
     uint32_t downstream_end,
@@ -283,10 +283,14 @@ FORCE_INLINE void write_downstream(
         if (remaining > 0) {
 #if defined(FABRIC_RELAY)
             noc_async_write(
-                data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), remaining);
+                static_cast<uint32_t>(data_ptr),
+                get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
+                remaining);
 #else
             cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
-                data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), remaining);
+                static_cast<uint32_t>(data_ptr),
+                get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
+                remaining);
 #endif
             data_ptr += remaining;
             length -= remaining;
@@ -295,10 +299,15 @@ FORCE_INLINE void write_downstream(
     }
 
 #if defined(FABRIC_RELAY)
-    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), length);
+    noc_async_write(
+        static_cast<uint32_t>(data_ptr),
+        get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
+        length);
 #else
     cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
-        data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), length);
+        static_cast<uint32_t>(data_ptr),
+        get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
+        length);
 #endif
     local_downstream_data_ptr += length;
 }
@@ -319,9 +328,9 @@ FORCE_INLINE void write_downstream(
 template <uint32_t preamble_size>
 FORCE_INLINE uint32_t read_from_pcie(
     volatile tt_l1_ptr prefetch_q_entry_type*& prefetch_q_rd_ptr,
-    uint32_t& fence,
+    uintptr_t& fence,
     uint32_t& pcie_read_ptr,
-    const uint32_t cmd_ptr,
+    const uintptr_t cmd_ptr,
     const uint32_t size,
     const uint32_t trid,
     const bool queue_empty) {
@@ -428,7 +437,7 @@ FORCE_INLINE uint32_t read_from_pcie(
 #endif
 
     const uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
-    const uint32_t dst_addr = fence + preamble_size;
+    const uint32_t dst_addr = static_cast<uint32_t>(fence + preamble_size);
 #if ENABLE_PREFETCH_DPRINTS
     DPRINT << "read_from_pcie: ISSUE_READ trid=" << trid << " host_src_addr=" << host_src_addr
            << " dst_addr=" << dst_addr << " size=" << size << ENDL();
@@ -491,7 +500,7 @@ FORCE_INLINE uint32_t read_from_pcie(
 //   - If no commands are available, retire exactly one oldest in-flight read per iteration to make progress; if nothing
 //     is in-flight and PrefetchQ is empty, spin until host posts work.
 template <uint32_t preamble_size>
-void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_ptr) {
+void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_ptr) {
     static constexpr uint32_t INFLIGHT_MASK = tt::tt_metal::PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS - 1U;
     enum class InflightFlags : uint32_t { NOSTALL = 0x0U, STALL_AFTER = 0x1U };
     struct InflightRead {
@@ -523,7 +532,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
 
     // End of reserved (possibly-not-yet-committed) region in cmddat_q for issued reads.
     // `fence` remains the committed boundary used for cmd_ready checks.
-    static uint32_t issue_fence = cmddat_q_base;
+    static uintptr_t issue_fence = cmddat_q_base;
     static volatile tt_l1_ptr prefetch_q_entry_type* prefetch_q_rd_ptr =
         (volatile tt_l1_ptr prefetch_q_entry_type*)prefetch_q_base;
     static constexpr uint32_t prefetch_q_msb_mask = 1u << (sizeof(prefetch_q_entry_type) * CHAR_BIT - 1U);
@@ -792,16 +801,16 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
     }
 }
 
-uint32_t process_debug_cmd(uint32_t cmd_ptr) {
+uint32_t process_debug_cmd(uintptr_t cmd_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     return cmd->debug.stride;
 }
 
 template <bool cmddat_wrap_enable, typename RelayInlineState>
-static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downstream_data_ptr) {
+static uint32_t process_relay_inline_cmd(uintptr_t cmd_ptr, uint32_t& local_downstream_data_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
     uint32_t npages =
         (length + RelayInlineState::downstream_page_size - 1) >> RelayInlineState::downstream_log_page_size;
@@ -841,11 +850,11 @@ static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downs
 // That means this command is stateful, incorrect use will be...bad
 // NOTE: this routine assumes we're sending a command header and that is LESS THAN A PAGE
 template <bool cmddat_wrap_enable>
-static uint32_t process_relay_inline_noflush_cmd(uint32_t cmd_ptr, uint32_t& dispatch_data_ptr) {
+static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& dispatch_data_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
 
     uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
     DispatchRelayInlineState::cb_writer.acquire_pages(1);
     if (dispatch_data_ptr == downstream_cb_end) {
@@ -854,12 +863,13 @@ static uint32_t process_relay_inline_noflush_cmd(uint32_t cmd_ptr, uint32_t& dis
     uint32_t remaining = cmddat_q_end - data_ptr;
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
-        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+        noc_async_write(
+            static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
         dispatch_data_ptr += remaining;
         length -= remaining;
         data_ptr = cmddat_q_base;
     }
-    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+    noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
     dispatch_data_ptr += length;
 
     return cmd->relay_inline.stride;
@@ -911,7 +921,7 @@ static uint32_t write_pages_to_dispatcher(
 // In the future, break them down into smaller pages...
 template <bool is_dram>
 uint32_t process_relay_paged_cmd_large(
-    uint32_t cmd_ptr,
+    uintptr_t cmd_ptr,
     uint32_t& downstream__data_ptr,
     uint32_t page_id,
     uint32_t base_addr,
@@ -1034,7 +1044,7 @@ uint32_t process_relay_paged_cmd_large(
 // With larger pages we'll get closer to a bandwidth match
 // The dispatch buffer is a ring buffer.
 template <bool is_dram>
-uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t page_id) {
+uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t page_id) {
     // This ensures that a previous cmd using the scratch buf has finished
     noc_async_writes_flushed();
 
@@ -1245,7 +1255,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cac
 }
 
 template <bool cmddat_wrap_enable>
-uint32_t process_relay_paged_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
+uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t total_length = cmd->relay_paged_packed.total_length;
     uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
@@ -1254,7 +1264,7 @@ uint32_t process_relay_paged_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream__
     // DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
     // DEVICE_PRINT("paged_packed: total_length={} stride={}\n", total_length, cmd->relay_paged_packed.stride);
 
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
     uint32_t remaining = cmddat_q_end - data_ptr;
     uint32_t* l1_cache_pos = l1_cache;
     if (cmddat_wrap_enable && sub_cmds_length > remaining) {
@@ -1314,7 +1324,7 @@ void noc_read_64bit_any_len(uint32_t src_noc_addr, uint64_t src_addr, uint32_t d
         noc_index, 0, src_addr, dst_addr, size);
 }
 
-uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
+uint32_t process_relay_linear_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr) {
     // This ensures that a previous cmd using the scratch buf has finished
     noc_async_writes_flushed();
 
@@ -1388,7 +1398,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_pt
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-uint32_t process_stall(uint32_t cmd_ptr) {
+uint32_t process_stall(uintptr_t cmd_ptr) {
     static uint32_t count = 0;
 
     count++;
@@ -1412,7 +1422,7 @@ uint32_t process_stall(uint32_t cmd_ptr) {
 // All fetching from DRAM stops at the end of cmddat_q until the cmddat_q are
 // processed.  Then it repeats again. Note: exec_buf_state struct must be
 // initialized to start using this function.
-void paged_read_into_cmddat_q(uint32_t& cmd_ptr, PrefetchExecBufState& exec_buf_state) {
+void paged_read_into_cmddat_q(uintptr_t& cmd_ptr, PrefetchExecBufState& exec_buf_state) {
     uint32_t page_id = exec_buf_state.page_id;
     uint32_t base_addr = exec_buf_state.base_addr;
     uint32_t log_page_size = exec_buf_state.log_page_size;
@@ -1522,11 +1532,11 @@ void paged_read_into_cmddat_q(uint32_t& cmd_ptr, PrefetchExecBufState& exec_buf_
 // Separate implementation that fetches more data from exec buf when cmd has been split
 template <typename RelayInlineState>
 FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
-    uint32_t& cmd_ptr, uint32_t& local_downstream_data_ptr, PrefetchExecBufState& exec_buf_state) {
+    uintptr_t& cmd_ptr, uint32_t& local_downstream_data_ptr, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint8_t dispatcher_type = cmd->relay_inline.dispatcher_type;
     uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
     // DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
     // DEVICE_PRINT("relay_inline_exec_buf_cmd: length={}\n", length);
@@ -1581,11 +1591,11 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
 // NOTE: this routine assumes we're sending a command header and that is LESS THAN A PAGE
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_inline_noflush_cmd(
-    uint32_t& cmd_ptr, uint32_t& dispatch_data_ptr, PrefetchExecBufState& exec_buf_state) {
+    uintptr_t& cmd_ptr, uint32_t& dispatch_data_ptr, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
 
     uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
     uint32_t stride = cmd->relay_inline.stride;
 
@@ -1598,10 +1608,11 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     while (length > remaining) {
         // wrap cmddat
 #if defined(FABRIC_RELAY)
-        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+        noc_async_write(
+            static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
 #else
         cq_noc_async_write_with_state_any_len<true, true>(
-            data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+            static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
 #endif
         dispatch_data_ptr += remaining;
         length -= remaining;
@@ -1618,10 +1629,10 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     }
 
 #if defined(FABRIC_RELAY)
-    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+    noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
 #else
     cq_noc_async_write_with_state_any_len<true, true>(
-        data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+        static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
 #endif
     dispatch_data_ptr += length;
 
@@ -1630,7 +1641,7 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
 
 template <uint32_t cmd_header_size = sizeof(CQPrefetchCmd)>
 void* copy_into_l1_cache(
-    uint32_t& cmd_ptr,
+    uintptr_t& cmd_ptr,
     uint32_t sub_cmds_length,
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state,
@@ -1671,7 +1682,7 @@ void* copy_into_l1_cache(
 
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_paged_packed_cmd(
-    uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t total_length = cmd->relay_paged_packed.total_length;
     uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
@@ -1690,7 +1701,7 @@ static uint32_t process_exec_buf_relay_paged_packed_cmd(
 }
 
 uint32_t process_exec_buf_cmd(
-    uint32_t cmd_ptr_outer, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    uintptr_t cmd_ptr_outer, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     // dispatch on eth cores is memory constrained, so exec_buf reuses the cmddat_q
     // prefetch_h stalls upon issuing an exec_buf to prevent conflicting use of the cmddat_q,
     // the exec_buf contains the release commands
@@ -1704,7 +1715,7 @@ uint32_t process_exec_buf_cmd(
     exec_buf_state.length = 0;
     exec_buf_state.read_ptr = cmddat_q_base;
     exec_buf_state.prefetch_length = 0;
-    uint32_t cmd_ptr = cmddat_q_base;
+    uintptr_t cmd_ptr = cmddat_q_base;
 
     bool done = false;
     while (!done) {
@@ -1726,7 +1737,7 @@ uint32_t process_exec_buf_cmd(
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-uint32_t process_paged_to_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr) {
+uint32_t process_paged_to_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr) {
     // This ensures that a previous cmd using the ringbuffer have completed.
     noc_async_writes_flushed();
 
@@ -1775,7 +1786,7 @@ uint32_t process_paged_to_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream_
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-uint32_t process_set_ringbuffer_offset(uint32_t cmd_ptr) {
+uint32_t process_set_ringbuffer_offset(uintptr_t cmd_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t offset = cmd->set_ringbuffer_offset.offset;
 
@@ -1815,7 +1826,7 @@ void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
 }
 
 template <bool cmddat_wrap_enable>
-uint32_t process_relay_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
+uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t count = cmd->relay_ringbuffer.count;
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
@@ -1823,7 +1834,7 @@ uint32_t process_relay_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__da
     // DPRINT << "relay_ringbuffer: " << count << " " << cmd->relay_ringbuffer.stride << ENDL();
     // DEVICE_PRINT("relay_ringbuffer: count={} stride={}\n", count, cmd->relay_ringbuffer.stride);
 
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
     uint32_t remaining = cmddat_q_end - data_ptr;
     uint32_t* l1_cache_pos = l1_cache;
     if (cmddat_wrap_enable && sub_cmds_length > remaining) {
@@ -1853,7 +1864,7 @@ uint32_t process_relay_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__da
 
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_ringbuffer_cmd(
-    uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t count = cmd->relay_ringbuffer.count;
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
@@ -1948,7 +1959,7 @@ void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_l
 }
 
 template <bool cmddat_wrap_enable>
-uint32_t process_relay_linear_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
+uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
     uint32_t total_length = cmd->relay_linear_packed.total_length;
@@ -1958,7 +1969,7 @@ uint32_t process_relay_linear_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream_
     // DPRINT << "linear_packed: " << total_length << " " << cmd->relay_linear_packed.stride << ENDL();
     // DEVICE_PRINT("linear_packed: {} {}\n", total_length, cmd->relay_linear_packed.stride);
 
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
     uint32_t remaining = cmddat_q_end - data_ptr;
     uint32_t* l1_cache_pos = l1_cache;
     if (cmddat_wrap_enable && sub_cmds_length > remaining) {
@@ -1988,7 +1999,7 @@ uint32_t process_relay_linear_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream_
 
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_linear_packed_cmd(
-    uint32_t& cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    uintptr_t& cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
     uint32_t total_length = cmd->relay_linear_packed.total_length;
@@ -2002,7 +2013,7 @@ static uint32_t process_exec_buf_relay_linear_packed_cmd(
 
 template <bool cmddat_wrap_enable, bool exec_buf>
 bool process_cmd(
-    uint32_t& cmd_ptr,
+    uintptr_t& cmd_ptr,
     uint32_t& downstream_data_ptr,
     uint32_t& stride,
     uint32_t* l1_cache,
@@ -2205,7 +2216,7 @@ static void relay_linear_to_downstream(
 }
 
 // Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
-uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
+uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr) {
     volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
     cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
     uint64_t wlength = cmd->relay_linear_h.length;
@@ -2213,7 +2224,7 @@ uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_
     constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
     // kernel_h must relay user data from pinned buffer to downstream (kernel_d's cmddatq)
     volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
-        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;
+        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)static_cast<uintptr_t>(scratch_read_addr);
     dptr->header.length = wlength + sizeof(CQPrefetchHToPrefetchDHeader);
     dptr->header.raw_copy = true;
     scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
@@ -2290,7 +2301,7 @@ uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_
 
 // Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_H command.
 // Combines packed linear reads (multiple sub-commands) with H-variant relay to remote device.
-uint32_t process_relay_linear_packed_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
+uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd =
         (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
     uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
@@ -2300,7 +2311,7 @@ uint32_t process_relay_linear_packed_h_cmd(uint32_t cmd_ptr, uint32_t& downstrea
     ASSERT(total_length > 0);
 
     // Copy sub-commands into L1 cache (same pattern as process_relay_linear_packed_cmd)
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader) + sizeof(CQPrefetchCmd);
+    uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader) + sizeof(CQPrefetchCmd);
     uint32_t amt = sub_cmds_length / sizeof(uint32_t);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
         (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache);
@@ -2310,7 +2321,7 @@ uint32_t process_relay_linear_packed_h_cmd(uint32_t cmd_ptr, uint32_t& downstrea
     constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
     // kernel_h must relay user data to downstream (kernel_d's cmddatq)
     volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
-        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;
+        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)static_cast<uintptr_t>(scratch_read_addr);
     dptr->header.length = total_length + sizeof(CQPrefetchHToPrefetchDHeader);
     dptr->header.raw_copy = true;
     scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
@@ -2391,7 +2402,7 @@ uint32_t process_relay_linear_packed_h_cmd(uint32_t cmd_ptr, uint32_t& downstrea
 
 // This function is only valid when called on the H variant
 // It expects the NoC async write state to be initialized to point to the downstream
-static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool is_exec_buf) {
+static uintptr_t process_relay_inline_all(uintptr_t data_ptr, uintptr_t fence, bool is_exec_buf) {
     uint32_t length = fence - data_ptr;
     // Downstream doesn't have FetchQ to tell it how much data to process
     // This packet header just contains the length
@@ -2421,14 +2432,19 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
         // WAIT is not needed here because previous writes were flushed at the end of the loop in the caller (kernel_h)
         relay_client
             .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, false, NCRISC_WR_CMD_BUF>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), length, npages);
+                static_cast<uint32_t>(data_ptr),
+                get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr),
+                length,
+                npages);
         downstream_data_ptr += npages * downstream_cb_page_size;
     } else {
         uint32_t tail_pages = npages - downstream_pages_left;
         uint32_t available = downstream_pages_left * downstream_cb_page_size;
         if (available > 0) {
             relay_client.write_any_len<my_noc_index, false, NCRISC_WR_CMD_BUF, true>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), available);
+                static_cast<uint32_t>(data_ptr),
+                get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr),
+                available);
             data_ptr += available;
             length -= available;
         }
@@ -2438,7 +2454,10 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
         // busy at this point
         relay_client
             .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), length, npages);
+                static_cast<uint32_t>(data_ptr),
+                get_noc_addr_helper(downstream_noc_xy, downstream_cb_base),
+                length,
+                npages);
 
         downstream_data_ptr = downstream_cb_base + tail_pages * downstream_cb_page_size;
     }
@@ -2459,7 +2478,7 @@ CBReaderWithManualRelease<
     h_cmddat_q_reader;
 
 // Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
-inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
+inline void relay_raw_data_to_downstream(uintptr_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
     // In initial return, we return the header bytes as well
     uint32_t initial_data_to_return = sizeof(CQPrefetchHToPrefetchDHeader);
     data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
@@ -2534,7 +2553,7 @@ inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, u
 // This grabs whole (possibly sets of if multiple in a page) commands.
 // In the case raw_copy is set in the header, that data will be copied to the downstream, and this function will loop
 // until commands are received.
-inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_ptr) {
+inline uint32_t relay_cb_get_cmds(uintptr_t& data_ptr, uint32_t& downstream_data_ptr) {
     while (true) {
         // DPRINT << "get_commands: data_ptr:0x" << HEX() << data_ptr << ", fence:0x" << fence << ",
         // downstream_data_ptr:0x" << downstream_data_ptr << ENDL();
@@ -2556,7 +2575,7 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
             int32_t pages_pending = pages_needed - pages_ready;
             int32_t npages = 0;
 
-            uint32_t dummy_data_ptr = data_ptr;
+            uintptr_t dummy_data_ptr = data_ptr;
             while (npages < pages_pending) {
                 npages += h_cmddat_q_reader.get_cb_page(dummy_data_ptr);
                 IDLE_ERISC_RETURN(length - sizeof(CQPrefetchHToPrefetchDHeader));
@@ -2569,8 +2588,8 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
 }
 
 void kernel_main_h() {
-    uint32_t cmd_ptr = cmddat_q_base;
-    uint32_t fence = cmddat_q_base;
+    uintptr_t cmd_ptr = cmddat_q_base;
+    uintptr_t fence = cmddat_q_base;
     bool done = false;
     uint32_t heartbeat = 0;
     uint32_t l1_cache[l1_cache_elements_rounded];
@@ -2629,7 +2648,7 @@ void kernel_main_d() {
     PrefetchExecBufState exec_buf_state;
 
     h_cmddat_q_reader.init();
-    uint32_t cmd_ptr = cmddat_q_base;
+    uintptr_t cmd_ptr = cmddat_q_base;
 
     bool done = false;
     uint32_t heartbeat = 0;
@@ -2705,8 +2724,8 @@ void kernel_main_d() {
 }
 
 void kernel_main_hd() {
-    uint32_t cmd_ptr = cmddat_q_base;
-    uint32_t fence = cmddat_q_base;
+    uintptr_t cmd_ptr = cmddat_q_base;
+    uintptr_t fence = cmddat_q_base;
     bool done = false;
     uint32_t heartbeat = 0;
     uint32_t l1_cache[l1_cache_elements_rounded];


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
In Quasar, DM processors are 64-bit, so any variable that gets cast to a pointer on the device side needs to be a `uintptr_t` instead of `uint32_t` in order to avoid cast errors during JIT build. Pointer/integer cast warnings don't show up on WH/BH or QSR compute processors because these are 32-bit.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/fd_uintptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/fd_uintptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/fd_uintptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/fd_uintptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/fd_uintptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/fd_uintptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/fd_uintptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/fd_uintptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/fd_uintptr)