### PR TITLE
Fix DeepSeek device sampling slot and RNG state

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -558,10 +558,18 @@ class SeedManager:
         self.tt_sampling = tt_sampling
         # True when at least one user slot has a non-None seed.
         self._seed_active = False
-        # Set to True by reset_seed() so the next get_new_values() knows it
-        # must push seeds (or SKIP values) to the device at least once after a
-        # prefill. Cleared after the first push.
+        # Set to True by reset_seed() so the next get_new_values() pushes
+        # fresh values to the device.  When _seed_active is True this pushes
+        # RNG-derived seeds; when False it pushes random per-user values to
+        # diversify the device RNG state (state 1 in the three-state machine
+        # described in get_new_values).  Cleared after the push.
         self._reseted = False
+        # When True, the next get_new_values() must push MAX_UINT32 (SKIP) so
+        # the device transitions from rand_tile_init to rand_tile (advance).
+        # This is needed after pushing random seeds for unseeded slots during
+        # prefill — without it the device would re-init from the same values
+        # every decode step instead of advancing.
+        self._needs_skip = False
         # Mesh mapper for sharding seeds across rows when sampling_dp > 1
         if tt_sampling._sampling_dp > 1:
             self._seed_mapper = ttnn.ShardTensor2dMesh(
@@ -588,26 +596,55 @@ class SeedManager:
     def get_new_values(self, empty_slots=None, replicate_seeds=False):
         """Generate and push new seed values to the device.
 
-        When no seeds are active (``_seed_active=False``):
-          - On the first call after reset (``_reseted=True``), pushes SKIP
-            values (MAX_UINT32) so the device's ``rand_tile_init`` is skipped.
-          - On subsequent decode calls (``_reseted=False``), returns early
-            without any device copy — this is the main optimisation.
+        **Seeded path** (``_seed_active=True``):
+        Advances each slot's host-side RNG and copies the new values to the
+        device every step.  The device calls ``rand_tile_init`` with each
+        user's value, then ``rand_tile`` to produce the sampling tile.
 
-        When seeds are active, advances each user's RNG and copies the new
-        seed tensor to the device as before.
+        **Unseeded path** (``_seed_active=False``):
+        Uses a three-state machine to ensure each user gets a unique device
+        RNG state without redundant host-to-device copies during decode:
+
+          State 1 — **init** (``_reseted=True``):
+            Push random per-user values.  The device calls ``rand_tile_init``
+            for every user, giving each one a unique RNG seed.  This prevents
+            stale identical tiles left over from a previous batch (e.g. a
+            replicated seed during an earlier prefill).
+
+          State 2 — **transition** (``_needs_skip=True``):
+            Push MAX_UINT32 (SKIP).  The device skips ``rand_tile_init`` and
+            calls only ``rand_tile``, advancing each user's RNG from the
+            varied state established in state 1.  Without this step the
+            device would re-run ``rand_tile_init`` with the same values
+            every decode step, producing identical tiles.
+
+          State 3 — **steady** (both flags clear):
+            Early-return with no device copy.  The device continues to call
+            ``rand_tile`` each step, advancing the per-user RNG
+            independently.  No host interaction needed.
+
+        ``reset_seed`` always sets ``_reseted=True``, so any new prefill
+        re-enters state 1 to refresh the device RNG.
         """
         if empty_slots is None:
             empty_slots = range(self.max_batch_size)
 
         if not self._seed_active:
-            if not self._reseted:
-                # No active seeds and already pushed SKIP values — nothing to do.
+            if self._reseted:
+                # State 1 (init): must take precedence over a pending
+                # transition so a new prefill always refreshes the device
+                # RNG with varied per-user values.
+                new_seeds = [random.randint(0, 1000000) for _ in range(self.max_batch_size)]
+                self._needs_skip = True
+            elif self._needs_skip:
+                # State 2 (transition): push SKIP so the device stops calling
+                # rand_tile_init and starts advancing via rand_tile().
+                new_seeds = [MAX_UINT32] * self.max_batch_size
+                self._needs_skip = False
+            else:
+                # State 3 (steady): device already has SKIP, rand_tile
+                # advances on its own — no host-to-device copy needed.
                 return
-            # First call after reset with no active seeds: push SKIP (MAX_UINT32)
-            # so the device skips rand_tile_init. All following decode steps will
-            # early-return above until the next reset_seed().
-            new_seeds = [MAX_UINT32] * self.max_batch_size
         else:
             # Advance RNG for each user in empty_slots; non-active slots get MAX_UINT32.
             new_seeds = [rng.randint(0, 1000000) if i in empty_slots else MAX_UINT32 for i, rng in enumerate(self.rngs)]

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -62,28 +62,47 @@ def _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params):
 
 
 class _FakeSeedManager:
-    def __init__(self):
+    def __init__(self, max_batch_size):
+        self.max_batch_size = max_batch_size
         self.reset_calls = []
+        self.new_value_calls = []
 
     def reset_seed(self, seeds, user_ids):
         self.reset_calls.append((seeds, user_ids))
 
+    def get_new_values(self, user_slots):
+        self.new_value_calls.append(user_slots)
+
 
 class _FakeSamplingGenerator:
-    def __init__(self):
-        self.tt_sampling = SimpleNamespace(_sampling_dp=2)
-        self.seed_manager = _FakeSeedManager()
+    def __init__(self, *, padded_batch_size=32, sampling_dp=2):
+        self.tt_sampling = SimpleNamespace(max_batch_size=padded_batch_size, _sampling_dp=sampling_dp)
+        self.seed_manager = _FakeSeedManager(padded_batch_size * sampling_dp)
         self.decode_state_calls = []
 
     def apply_decode_state(self, sampling_param_chunks, **kwargs):
         self.decode_state_calls.append((sampling_param_chunks, kwargs))
 
 
+def _fake_deepseek_generator(*, batch_size_per_row=8, sampling_dp=2):
+    class _FakeDeepseekGenerator:
+        _reset_sampling_state = DeepseekGenerator._reset_sampling_state
+        _sampling_device_slot = DeepseekGenerator._sampling_device_slot
+        _sampling_device_slots = DeepseekGenerator._sampling_device_slots
+        _sampling_device_seed_slots = DeepseekGenerator._sampling_device_seed_slots
+
+        def __init__(self):
+            self.batch_size_per_row = batch_size_per_row
+            self.sampling_generator = _FakeSamplingGenerator(padded_batch_size=32, sampling_dp=sampling_dp)
+
+    return _FakeDeepseekGenerator()
+
+
 def test_deepseek_reset_sampling_state_does_not_preformat_sampling_params():
     batch_size = 64
     batch_size_per_row = 32
-    sampling_generator = _FakeSamplingGenerator()
-    generator = SimpleNamespace(sampling_generator=sampling_generator)
+    generator = _fake_deepseek_generator(batch_size_per_row=batch_size_per_row, sampling_dp=2)
+    sampling_generator = generator.sampling_generator
     sampling_params = SamplingParams(
         temperature=[0.6] * batch_size,
         top_k=[32] * batch_size,
@@ -106,6 +125,36 @@ def test_deepseek_reset_sampling_state_does_not_preformat_sampling_params():
     assert kwargs["output_tokens"].shape == (batch_size_per_row, 1)
     [seed_reset] = sampling_generator.seed_manager.reset_calls
     assert seed_reset == ([1234] * batch_size, list(range(batch_size)))
+
+
+def test_deepseek_sampling_user_slots_map_to_row_padded_device_slots():
+    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=3)
+
+    assert DeepseekGenerator._sampling_device_slots(generator, [0, 7, 8, 15, 16, 23]) == [0, 7, 32, 39, 64, 71]
+
+
+def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=4)
+    sampling_params = SamplingParams(
+        temperature=[0.0] * batch_size,
+        top_k=[1] * batch_size,
+        top_p=[1.0] * batch_size,
+        seed=list(range(100, 100 + batch_size)),
+    )
+
+    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, generator.batch_size_per_row)
+
+    [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
+    assert user_ids == list(range(128))
+    assert seeds[:8] == list(range(100, 108))
+    assert seeds[8:32] == [None] * 24
+    assert seeds[32:40] == list(range(108, 116))
+    assert seeds[40:64] == [None] * 24
+    assert seeds[64:72] == list(range(116, 124))
+    assert seeds[72:96] == [None] * 24
+    assert seeds[96:104] == list(range(124, 132))
+    assert seeds[104:] == [None] * 24
 
 
 @torch.no_grad()

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -892,14 +892,39 @@ class DeepseekGenerator(WarmupForwardMixin):
         seed_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         seed = getattr(seed_params, "seed", None)
         if seed is not None:
-            user_ids = list(range(batch_size))
-            self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
+            seed_slots = self._sampling_device_seed_slots(seed, batch_size)
+            self.sampling_generator.seed_manager.reset_seed(seed_slots, list(range(len(seed_slots))))
         self.sampling_generator.apply_decode_state(
             sampling_param_chunks,
             reset_batch=True,
             prompt_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
             output_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
         )
+
+    def _sampling_device_slot(self, user_id: int) -> int:
+        row = int(user_id) // self.batch_size_per_row
+        local_user_id = int(user_id) % self.batch_size_per_row
+        sampling_batch_size = self.sampling_generator.tt_sampling.max_batch_size
+        sampling_dp = self.sampling_generator.tt_sampling._sampling_dp
+        if row < 0 or row >= sampling_dp:
+            raise ValueError(f"Sampling user id {user_id} maps to row {row}, outside sampling dp {sampling_dp}")
+        if local_user_id >= sampling_batch_size:
+            raise ValueError(
+                f"Sampling local user id {local_user_id} exceeds padded sampling batch size {sampling_batch_size}"
+            )
+        return row * sampling_batch_size + local_user_id
+
+    def _sampling_device_slots(self, user_slots: list[int] | None) -> list[int] | None:
+        if user_slots is None:
+            return None
+        return [self._sampling_device_slot(user_id) for user_id in user_slots]
+
+    def _sampling_device_seed_slots(self, seeds: list[int | None], batch_size: int) -> list[int | None]:
+        seed_slot_count = self.sampling_generator.seed_manager.max_batch_size
+        seed_slots = [None] * seed_slot_count
+        for user_id in range(batch_size):
+            seed_slots[self._sampling_device_slot(user_id)] = seeds[user_id]
+        return seed_slots
 
     def _sample_tokens_device(
         self,
@@ -948,7 +973,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             else:
                 sampling_logits = padded_logits
 
-        self.sampling_generator.seed_manager.get_new_values(user_slots)
+        self.sampling_generator.seed_manager.get_new_values(self._sampling_device_slots(user_slots))
         self.sampling_generator.enable_internal_trace = enable_trace
         try:
             tt_out = self.sampling_generator.sample(sampling_logits, enable_trace=enable_trace)
@@ -2068,9 +2093,11 @@ class DeepseekGenerator(WarmupForwardMixin):
                                 prefill_logits, user_slots=[user_id]
                             )
                             prefill_logits_sampled_host = self._tokens_from_device(
-                                prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
+                                prefill_logits_sampled_device,
+                                self.mesh_device,
+                                batch_size_per_row=self.batch_size_per_row,
                             )
-                            pred_token = int(prefill_logits_sampled_host[0].item())
+                            pred_token = int(prefill_logits_sampled_host[user_id].item())
                             ttnn.deallocate(prefill_logits)
                             ttnn.deallocate(prefill_logits_sampled_device)
                         else:

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -146,10 +146,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len, expand_to_batch=True)
                 prefill_logits_sampled_device = self._sample_tokens_device(prefill_logits, user_slots=[user_id])
                 prefill_logits_sampled_host = self._tokens_from_device(
-                    prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
+                    prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=self.batch_size_per_row
                 )
                 # Device-sampling path emits token ids.
-                user_output = prefill_logits_sampled_host[0].to(torch.int64)
+                user_output = prefill_logits_sampled_host[user_id].to(torch.int64)
             else:
                 assert isinstance(prefill_logits, torch.Tensor), "prefill_logits should be a torch.Tensor on host"
                 user_logits = prefill_logits.squeeze(0).squeeze(0)  # [1, 1, S, V] -> [S, V]


### PR DESCRIPTION
Summary
- Map DeepSeek device-sampling state through the row-padded sampling slots used by the device sampler.
- Fix prefill device-sampling extraction for padded rows.
- Include the stale unseeded RNG fix so unseeded random sampling initializes device RNG state instead of skipping it.
- Add CPU coverage for sampling params and row-padded seed slots.

Validation
- python -m py_compile models/common/sampling/generator.py models/demos/deepseek_v3/tt/generator.py models/demos/deepseek_v3/tt/generator_vllm.py models/demos/deepseek_v3/tests/test_sampling.py
- python -m pytest models/demos/deepseek_v3/tests/test_sampling.py -q -k "reset_sampling_state or sampling_user_slots or sampling_seed_reset"
- Full AIME24 32k device-sampling run, 8 users/row, trace on, K=64, no cache: 24/30 normalized boxed-int correct, 4/30 no-boxed, 2/30 boxed wrong, exit_status=0. Final perf reported 6.44-6.45 decode tokens/sec/user. Run dir: /data/moconnor/tt-metal/generated/artifacts/aime24_demo_32k_8upr_trace_on_k64_device_sampling_combined_fixes_20260520T023957Z

Stacking note
- This PR targets moconnor/deepseek-generator-warmup-sampling-fix-20260519 so the diff stays focused on the device-sampling fixes.