### PR TITLE
[Feature]: Support for aliased dfbs

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -1,0 +1,658 @@
+// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+using namespace experimental;
+using namespace experimental::metal2_host_api;
+
+constexpr const char* ALIAS_PRODUCER_KERNEL =
+    "tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp";
+constexpr const char* ALIAS_CONSUMER_KERNEL =
+    "tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp";
+
+inline TensorSpec make_alias_dram_tensor_spec(uint32_t entry_size, uint32_t num_entries) {
+    const uint32_t words = entry_size / sizeof(uint32_t);
+    return TensorSpec(
+        Shape{num_entries, words},
+        TensorLayout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR),
+                     MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM}));
+}
+
+inline TensorSpec make_alias_l1_tensor_spec(uint32_t entry_size, uint32_t num_entries) {
+    const uint32_t total_words = num_entries * entry_size / sizeof(uint32_t);
+    return TensorSpec(
+        Shape{1, total_words},
+        TensorLayout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR),
+                     MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1}));
+}
+
+// Build a DataflowBufferConfig for direct-API tests (no kernel compilation).
+// producer = DM RISC 0, consumer = DM RISC 1 (valid on WH/BH and Quasar).
+inline dfb::DataflowBufferConfig make_1sx1s_config(uint32_t entry_size, uint32_t num_entries) {
+    return dfb::DataflowBufferConfig{
+        .entry_size         = entry_size,
+        .num_entries        = num_entries,
+        .producer_risc_mask = 0x1,
+        .num_producers      = 1,
+        .pap                = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x2,
+        .num_consumers      = 1,
+        .cap                = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+    };
+}
+
+struct AliasDFBProgramComponents {
+    ProgramSpec       spec;
+    MeshTensor        in_a;
+    MeshTensor        in_b;
+    MeshTensor        out_a;
+    MeshTensor        out_b;
+};
+
+AliasDFBProgramComponents make_alias_dfb_program_spec(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const NodeCoord& node,
+    uint32_t entry_size_a,
+    uint32_t num_entries_a,
+    uint32_t entry_size_b,
+    uint32_t num_entries_b,
+    uint8_t  num_producers,
+    uint8_t  num_consumers) {
+
+    const uint32_t epp_a = (num_entries_a + num_producers - 1) / num_producers;
+    const uint32_t epp_b = (num_entries_b + num_producers - 1) / num_producers;
+    const uint32_t epc_a = (num_entries_a + num_consumers - 1) / num_consumers;
+    const uint32_t epc_b = (num_entries_b + num_consumers - 1) / num_consumers;
+
+    MeshTensor in_a  = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size_a, num_entries_a), TensorTopology{});
+    MeshTensor in_b  = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size_b, num_entries_b), TensorTopology{});
+    MeshTensor out_a = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size_a, num_entries_a), TensorTopology{});
+    MeshTensor out_b = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size_b, num_entries_b), TensorTopology{});
+
+    // DM kernel configs (Gen1 + Gen2 variants so the same spec runs everywhere).
+    const DataMovementConfiguration producer_cfg{
+        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0},
+        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+    };
+    const DataMovementConfiguration consumer_cfg{
+        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1},
+        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+    };
+
+    DataflowBufferSpec dfb_a{
+        .unique_id        = "dfb_a",
+        .entry_size       = entry_size_a,
+        .num_entries      = num_entries_a,
+        .data_format_metadata = tt::DataFormat::Float16_b,
+        .alias_with       = {"dfb_b"},
+        .disable_implicit_sync = true,
+    };
+    DataflowBufferSpec dfb_b{
+        .unique_id        = "dfb_b",
+        .entry_size       = entry_size_b,
+        .num_entries      = num_entries_b,
+        .data_format_metadata = tt::DataFormat::Float16_b,
+        .alias_with       = {"dfb_a"},
+        .disable_implicit_sync = true,
+    };
+
+    KernelSpec producer{
+        .unique_id   = "producer",
+        .source      = KernelSpec::SourceFilePath{ALIAS_PRODUCER_KERNEL},
+        .num_threads = num_producers,
+        .dfb_bindings = {
+            {.dfb_spec_name = "dfb_a", .local_accessor_name = "out_a",
+             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+            {.dfb_spec_name = "dfb_b", .local_accessor_name = "out_b",
+             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+        },
+        .tensor_bindings = {
+            {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
+            {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
+        },
+        .compile_time_arg_bindings = {
+            {"num_entries_per_producer_a", epp_a},
+            {"num_entries_per_producer_b", epp_b},
+            {"num_producers",              static_cast<uint32_t>(num_producers)},
+        },
+        .runtime_arguments_schema = {.named_runtime_args =
+            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .config_spec = producer_cfg,
+    };
+
+    KernelSpec consumer{
+        .unique_id   = "consumer",
+        .source      = KernelSpec::SourceFilePath{ALIAS_CONSUMER_KERNEL},
+        .num_threads = num_consumers,
+        .dfb_bindings = {
+            {.dfb_spec_name = "dfb_a", .local_accessor_name = "in_a",
+             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+            {.dfb_spec_name = "dfb_b", .local_accessor_name = "in_b",
+             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+        },
+        .tensor_bindings = {
+            {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
+            {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
+        },
+        .compile_time_arg_bindings = {
+            {"num_entries_per_consumer_a", epc_a},
+            {"num_entries_per_consumer_b", epc_b},
+            {"num_consumers",              static_cast<uint32_t>(num_consumers)},
+        },
+        .runtime_arguments_schema = {.named_runtime_args =
+            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .config_spec = consumer_cfg,
+    };
+
+    ProgramSpec spec{
+        .program_id       = "alias_dfb",
+        .kernels          = {producer, consumer},
+        .dataflow_buffers = {dfb_a, dfb_b},
+        .tensor_parameters = {
+            {.unique_id = "in_tensor_a",  .spec = in_a.tensor_spec()},
+            {.unique_id = "in_tensor_b",  .spec = in_b.tensor_spec()},
+            {.unique_id = "out_tensor_a", .spec = out_a.tensor_spec()},
+            {.unique_id = "out_tensor_b", .spec = out_b.tensor_spec()},
+        },
+        .work_units = {WorkUnitSpec{
+            .unique_id    = "wu",
+            .kernels      = {"producer", "consumer"},
+            .target_nodes = node,
+        }},
+    };
+
+    return {std::move(spec), std::move(in_a), std::move(in_b), std::move(out_a), std::move(out_b)};
+}
+
+void run_alias_dfb_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const NodeCoord& node,
+    uint32_t entry_size_a,
+    uint32_t num_entries_a,
+    uint32_t entry_size_b,
+    uint32_t num_entries_b,
+    uint8_t  num_producers = 1,
+    uint8_t  num_consumers = 1) {
+
+    auto [spec, in_a, in_b, out_a, out_b] = make_alias_dfb_program_spec(
+        mesh_device, node,
+        entry_size_a, num_entries_a,
+        entry_size_b, num_entries_b,
+        num_producers, num_consumers);
+
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    auto rtas = [&](uint32_t epc_a, uint32_t epc_b) {
+        return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+            node,
+            {{"chunk_offset_a",     0u},
+             {"chunk_offset_b",     0u},
+             {"entries_per_core_a", epc_a},
+             {"entries_per_core_b", epc_b}}}};
+    };
+
+    ProgramRunParams run_params;
+    run_params.kernel_run_params = {
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "producer",
+            .named_runtime_args = rtas(num_entries_a, num_entries_b)},
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "consumer",
+            .named_runtime_args = rtas(num_entries_a, num_entries_b)},
+    };
+    run_params.tensor_args = {
+        {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
+        {.tensor_parameter_name = "in_tensor_b",  .tensor = std::cref(in_b)},
+        {.tensor_parameter_name = "out_tensor_a", .tensor = std::cref(out_a)},
+        {.tensor_parameter_name = "out_tensor_b", .tensor = std::cref(out_b)},
+    };
+    SetProgramRunParameters(program, run_params);
+
+    // Generate random inputs.
+    const uint32_t words_a = num_entries_a * entry_size_a / sizeof(uint32_t);
+    const uint32_t words_b = num_entries_b * entry_size_b / sizeof(uint32_t);
+    auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_a);
+    auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
+
+    detail::WriteToBuffer(*in_a.mesh_buffer().get_reference_buffer(), input_a);
+    detail::WriteToBuffer(*in_b.mesh_buffer().get_reference_buffer(), input_b);
+
+    if (mesh_device->get_devices()[0]->arch() == ARCH::QUASAR) {
+        // TODO #38042: barrier for Quasar DRAM write visibility.
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    IDevice* device = mesh_device->get_devices()[0];
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    std::vector<uint32_t> result_a, result_b;
+    detail::ReadFromBuffer(*out_a.mesh_buffer().get_reference_buffer(), result_a);
+    detail::ReadFromBuffer(*out_b.mesh_buffer().get_reference_buffer(), result_b);
+
+    EXPECT_EQ(result_a, input_a)
+        << "Phase A output mismatch: DFB_A data did not round-trip correctly";
+    EXPECT_EQ(result_b, input_b)
+        << "Phase B output mismatch: DFB_B (alias) data did not round-trip correctly";
+}
+
+struct AliasBorrowedDFBComponents {
+    ProgramSpec  spec;
+    MeshTensor   in_a;
+    MeshTensor   in_b;
+    MeshTensor   out_a;
+    MeshTensor   out_b;
+    MeshTensor   ring_tensor;  // L1 tensor that backs dfb
+};
+
+AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const NodeCoord& node,
+    uint32_t entry_size,
+    uint32_t num_entries) {
+
+    const uint32_t epp = num_entries;
+    const uint32_t epc = num_entries;
+
+    MeshTensor in_a  = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries), TensorTopology{});
+    MeshTensor in_b  = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries), TensorTopology{});
+    MeshTensor out_a = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries), TensorTopology{});
+    MeshTensor out_b = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries), TensorTopology{});
+    MeshTensor ring  = MeshTensor::allocate_on_device(
+        *mesh_device, make_alias_l1_tensor_spec(entry_size, num_entries), TensorTopology{});
+
+    const DataMovementConfiguration producer_cfg{
+        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0},
+        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+    };
+    const DataMovementConfiguration consumer_cfg{
+        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1},
+        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+    };
+
+    // dfb_borrowed: backed by ring_tensor (L1)
+    DataflowBufferSpec dfb_borrowed{
+        .unique_id             = "dfb_borrowed",
+        .entry_size            = entry_size,
+        .num_entries           = num_entries,
+        .data_format_metadata  = tt::DataFormat::Float16_b,
+        .borrowed_from         = "ring_tensor",
+        .alias_with            = {"dfb_alias"},
+        .disable_implicit_sync = true,
+    };
+    DataflowBufferSpec dfb_alias_spec{
+        .unique_id             = "dfb_alias",
+        .entry_size            = entry_size,
+        .num_entries           = num_entries,
+        .data_format_metadata  = tt::DataFormat::Float16_b,
+        .borrowed_from         = "ring_tensor",
+        .alias_with            = {"dfb_borrowed"},
+        .disable_implicit_sync = true,
+    };
+
+    KernelSpec producer{
+        .unique_id   = "producer",
+        .source      = KernelSpec::SourceFilePath{ALIAS_PRODUCER_KERNEL},
+        .num_threads = 1,
+        .dfb_bindings = {
+            {.dfb_spec_name = "dfb_borrowed", .local_accessor_name = "out_a",
+             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+            {.dfb_spec_name = "dfb_alias", .local_accessor_name = "out_b",
+             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+        },
+        .tensor_bindings = {
+            {.tensor_parameter_name = "in_tensor_a",  .accessor_name = "src_a"},
+            {.tensor_parameter_name = "in_tensor_b",  .accessor_name = "src_b"},
+            // ring_tensor must be bound to at least one kernel even though the
+            // kernel doesn't access it directly (required by TensorParameter rules).
+            {.tensor_parameter_name = "ring_tensor",  .accessor_name = "ring"},
+        },
+        .compile_time_arg_bindings = {
+            {"num_entries_per_producer_a", epp},
+            {"num_entries_per_producer_b", epp},
+            {"num_producers",              1u},
+        },
+        .runtime_arguments_schema = {.named_runtime_args =
+            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .config_spec = producer_cfg,
+    };
+
+    KernelSpec consumer{
+        .unique_id   = "consumer",
+        .source      = KernelSpec::SourceFilePath{ALIAS_CONSUMER_KERNEL},
+        .num_threads = 1,
+        .dfb_bindings = {
+            {.dfb_spec_name = "dfb_borrowed", .local_accessor_name = "in_a",
+             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+            {.dfb_spec_name = "dfb_alias", .local_accessor_name = "in_b",
+             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+             .access_pattern = DFBAccessPattern::STRIDED},
+        },
+        .tensor_bindings = {
+            {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
+            {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
+        },
+        .compile_time_arg_bindings = {
+            {"num_entries_per_consumer_a", epc},
+            {"num_entries_per_consumer_b", epc},
+            {"num_consumers",              1u},
+        },
+        .runtime_arguments_schema = {.named_runtime_args =
+            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .config_spec = consumer_cfg,
+    };
+
+    ProgramSpec spec{
+        .program_id        = "alias_borrowed_dfb",
+        .kernels           = {producer, consumer},
+        .dataflow_buffers  = {dfb_borrowed, dfb_alias_spec},
+        .tensor_parameters = {
+            {.unique_id = "in_tensor_a",  .spec = in_a.tensor_spec()},
+            {.unique_id = "in_tensor_b",  .spec = in_b.tensor_spec()},
+            {.unique_id = "out_tensor_a", .spec = out_a.tensor_spec()},
+            {.unique_id = "out_tensor_b", .spec = out_b.tensor_spec()},
+            {.unique_id = "ring_tensor",  .spec = ring.tensor_spec()},
+        },
+        .work_units = {WorkUnitSpec{
+            .unique_id    = "wu",
+            .kernels      = {"producer", "consumer"},
+            .target_nodes = node,
+        }},
+    };
+
+    return {std::move(spec), std::move(in_a), std::move(in_b), std::move(out_a), std::move(out_b), std::move(ring)};
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBAddressEquality1Sx1S) {
+    const NodeCoord node{0, 0};
+
+    // make these variables
+    auto [spec, in_a, in_b, out_a, out_b] = make_alias_dfb_program_spec(
+        devices_.at(0), node, 512, 8, 256, 16, 1, 1);
+
+    Program program = MakeProgramFromSpec(*devices_.at(0), spec);
+
+    IDevice* device = devices_.at(0)->get_devices()[0];
+    detail::CompileProgram(device, program);
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(device);
+
+    const uint32_t id_a = program.impl().get_dfb_handle("dfb_a");
+    const uint32_t id_b = program.impl().get_dfb_handle("dfb_b");
+
+    const uint32_t addr_a = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
+    const uint32_t addr_b = program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr();
+
+    EXPECT_EQ(addr_a, addr_b) << "Aliased DFBs must share the same L1 base address";
+
+    log_info(
+        tt::LogTest,
+        "AliasDFB_AddressEquality_1Sx1S: addr_a=0x{:x}  addr_b=0x{:x}",
+        addr_a, addr_b);
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBDataFlow1Sx1S) {
+    run_alias_dfb_program(
+        devices_.at(0), NodeCoord{0, 0},
+        /*entry_size_a=*/512, /*num_entries_a=*/8,
+        /*entry_size_b=*/256, /*num_entries_b=*/16);
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBDataFlow2Sx4S) {
+    if (devices_.at(0)->get_devices()[0]->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Multi-producer DFB requires Quasar TC hardware";
+    }
+    run_alias_dfb_program(
+        devices_.at(0), NodeCoord{0, 0},
+        /*entry_size_a=*/512, /*num_entries_a=*/8,
+        /*entry_size_b=*/256, /*num_entries_b=*/16,
+        /*num_producers=*/2, /*num_consumers=*/4);
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBDataFlow4Sx2S) {
+    if (devices_.at(0)->get_devices()[0]->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Multi-producer DFB requires Quasar TC hardware";
+    }
+    run_alias_dfb_program(
+        devices_.at(0), NodeCoord{0, 0},
+        /*entry_size_a=*/512, /*num_entries_a=*/8,
+        /*entry_size_b=*/256, /*num_entries_b=*/16,
+        /*num_producers=*/4, /*num_consumers=*/2);
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBAllocSecondarySkipped) {
+    IDevice* device = devices_.at(0)->get_devices()[0];
+    const CoreCoord core{0, 0};
+
+    const auto cfg_a = make_1sx1s_config(512, 8);
+    const auto cfg_b = make_1sx1s_config(256, 16);
+    const auto cfg_c = make_1sx1s_config(512, 4);
+
+    Program program = CreateProgram();
+    const uint32_t id_a = dfb::CreateDataflowBuffer(program, core, cfg_a);
+    const uint32_t id_b = dfb::CreateDataflowBuffer(program, core, cfg_b);
+    const uint32_t id_c = dfb::CreateDataflowBuffer(program, core, cfg_c);
+
+    program.impl().set_dfb_alias(id_a, id_b);
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(device);
+
+    const uint32_t addr_a = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
+    const uint32_t addr_b = program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr();
+    const uint32_t addr_c = program.impl().get_dataflow_buffer(id_c)->uniform_alloc_addr();
+
+    EXPECT_EQ(addr_a, addr_b) << "Aliased DFBs must share L1 address";
+
+    // addr_c must follow the primary's footprint, not the secondary's.
+    const uint32_t group_end = addr_a + cfg_a.entry_size * cfg_a.num_entries;
+    EXPECT_GE(addr_c, group_end)
+        << "Non-aliased DFB_C must start after the alias group";
+    EXPECT_LT(addr_c, group_end + cfg_b.entry_size * cfg_b.num_entries)
+        << "Allocator double-counted the secondary: addr_c is too far";
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBAlloc3Way) {
+    IDevice* device = devices_.at(0)->get_devices()[0];
+    const CoreCoord core{0, 0};
+
+    const auto cfg_a = make_1sx1s_config(512,  8);
+    const auto cfg_b = make_1sx1s_config(256,  16);
+    const auto cfg_c = make_1sx1s_config(1024, 4);
+
+    Program program = CreateProgram();
+    const uint32_t id_a = dfb::CreateDataflowBuffer(program, core, cfg_a);
+    const uint32_t id_b = dfb::CreateDataflowBuffer(program, core, cfg_b);
+    const uint32_t id_c = dfb::CreateDataflowBuffer(program, core, cfg_c);
+
+    program.impl().set_dfb_alias(id_a, id_b);
+    program.impl().set_dfb_alias(id_a, id_c);
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(device);
+
+    const uint32_t addr_a = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
+    const uint32_t addr_b = program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr();
+    const uint32_t addr_c = program.impl().get_dataflow_buffer(id_c)->uniform_alloc_addr();
+
+    EXPECT_EQ(addr_a, addr_b) << "DFB_B must share DFB_A's address";
+    EXPECT_EQ(addr_a, addr_c) << "DFB_C must share DFB_A's address";
+
+    log_info(
+        tt::LogTest,
+        "AliasDFB_Alloc_3Way: addr_a=0x{:x}  addr_b=0x{:x}  addr_c=0x{:x}",
+        addr_a, addr_b, addr_c);
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
+    const NodeCoord node{0, 0};
+    constexpr uint32_t kEntrySize   = 512;
+    constexpr uint32_t kNumEntries  = 8;
+
+    auto [spec, in_a, in_b, out_a, out_b, ring] = make_alias_borrowed_dfb_program_spec(
+        devices_.at(0), node, kEntrySize, kNumEntries);
+
+    Program program = MakeProgramFromSpec(*devices_.at(0), spec);
+
+    IDevice* device = devices_.at(0)->get_devices()[0];
+    detail::CompileProgram(device, program);
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(device);
+
+    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    auto rtas = [&]() {
+        return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+            node,
+            {{"chunk_offset_a",     0u},
+             {"chunk_offset_b",     0u},
+             {"entries_per_core_a", kNumEntries},
+             {"entries_per_core_b", kNumEntries}}}};
+    };
+    ProgramRunParams run_params;
+    run_params.kernel_run_params = {
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .named_runtime_args = rtas()},
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .named_runtime_args = rtas()},
+    };
+    run_params.tensor_args = {
+        {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
+        {.tensor_parameter_name = "in_tensor_b",  .tensor = std::cref(in_b)},
+        {.tensor_parameter_name = "out_tensor_a", .tensor = std::cref(out_a)},
+        {.tensor_parameter_name = "out_tensor_b", .tensor = std::cref(out_b)},
+        {.tensor_parameter_name = "ring_tensor",  .tensor = std::cref(ring)},
+    };
+    SetProgramRunParameters(program, run_params);
+
+    const uint32_t id_borrowed = program.impl().get_dfb_handle("dfb_borrowed");
+    const uint32_t id_alias    = program.impl().get_dfb_handle("dfb_alias");
+
+    const uint32_t addr_borrowed = program.impl().get_dataflow_buffer(id_borrowed)->uniform_alloc_addr();
+    const uint32_t addr_alias    = program.impl().get_dataflow_buffer(id_alias)->uniform_alloc_addr();
+    const uint32_t ring_addr     =
+        static_cast<uint32_t>(ring.mesh_buffer().get_reference_buffer()->address());
+
+    EXPECT_EQ(addr_borrowed, ring_addr)
+        << "dfb_borrowed must resolve to the ring tensor's L1 address";
+    EXPECT_EQ(addr_alias, ring_addr)
+        << "dfb_alias must inherit the ring tensor's L1 address via alias propagation";
+
+    log_info(
+        tt::LogTest,
+        "AliasDFB_BorrowedMemory_AddressEquality: addr_borrowed=0x{:x}  addr_alias=0x{:x}  ring=0x{:x}",
+        addr_borrowed, addr_alias, ring_addr);
+}
+
+TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
+    const NodeCoord node{0, 0};
+    constexpr uint32_t kEntrySize  = 512;
+    constexpr uint32_t kNumEntries = 8;
+
+    auto [spec, in_a, in_b, out_a, out_b, ring] = make_alias_borrowed_dfb_program_spec(
+        devices_.at(0), node, kEntrySize, kNumEntries);
+
+    Program program = MakeProgramFromSpec(*devices_.at(0), spec);
+
+    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    auto rtas = [&]() {
+        return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+            node,
+            {{"chunk_offset_a",     0u},
+             {"chunk_offset_b",     0u},
+             {"entries_per_core_a", kNumEntries},
+             {"entries_per_core_b", kNumEntries}}}};
+    };
+    ProgramRunParams run_params;
+    run_params.kernel_run_params = {
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .named_runtime_args = rtas()},
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .named_runtime_args = rtas()},
+    };
+    run_params.tensor_args = {
+        {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
+        {.tensor_parameter_name = "in_tensor_b",  .tensor = std::cref(in_b)},
+        {.tensor_parameter_name = "out_tensor_a", .tensor = std::cref(out_a)},
+        {.tensor_parameter_name = "out_tensor_b", .tensor = std::cref(out_b)},
+        {.tensor_parameter_name = "ring_tensor",  .tensor = std::cref(ring)},
+    };
+    SetProgramRunParameters(program, run_params);
+
+    const uint32_t words = kNumEntries * kEntrySize / sizeof(uint32_t);
+    auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words);
+    auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words);
+
+    detail::WriteToBuffer(*in_a.mesh_buffer().get_reference_buffer(), input_a);
+    detail::WriteToBuffer(*in_b.mesh_buffer().get_reference_buffer(), input_b);
+
+    if (devices_.at(0)->get_devices()[0]->arch() == ARCH::QUASAR) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    IDevice* device = devices_.at(0)->get_devices()[0];
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    std::vector<uint32_t> result_a, result_b;
+    detail::ReadFromBuffer(*out_a.mesh_buffer().get_reference_buffer(), result_a);
+    detail::ReadFromBuffer(*out_b.mesh_buffer().get_reference_buffer(), result_b);
+
+    EXPECT_EQ(result_a, input_a)
+        << "Phase A (dfb_borrowed) data did not round-trip correctly";
+    EXPECT_EQ(result_b, input_b)
+        << "Phase B (dfb_alias via borrowed L1) data did not round-trip correctly";
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -424,8 +424,7 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
 TEST_F(MeshDeviceFixture, AliasDFBAddressEquality1Sx1S) {
     const NodeCoord node{0, 0};
 
-    // make these variables
-    auto [spec, in_a, in_b, out_a, out_b] = make_alias_dfb_program_spec(
+    [[maybe_unused]] auto [spec, in_a, in_b, out_a, out_b] = make_alias_dfb_program_spec(
         devices_.at(0), node, 512, 8, 256, 16, 1, 1);
 
     Program program = MakeProgramFromSpec(*devices_.at(0), spec);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -91,7 +91,7 @@ void validate_dfb_tile_counters(
             uint8_t expected_tensix_id = (risc_id - 8) % 4;
             for (uint8_t tc = 0; tc < rc->config.num_tcs_to_rr; tc++) {
                 auto ptc = rc->config.packed_tile_counter[tc];
-                uint8_t actual_tensix_id = dfb::get_tensix_id(ptc);
+                uint8_t actual_tensix_id = ::dfb::get_tensix_id(ptc);
                 EXPECT_EQ(actual_tensix_id, expected_tensix_id)
                     << "Tensix producer RISC " << (int)risc_id << " TC[" << (int)tc
                     << "] must use tensix_id=" << (int)expected_tensix_id << " but has " << (int)actual_tensix_id;
@@ -105,7 +105,7 @@ void validate_dfb_tile_counters(
             uint8_t expected_tensix_id = (risc_id - 8) % 4;
             for (uint8_t tc = 0; tc < rc->config.num_tcs_to_rr; tc++) {
                 auto ptc = rc->config.packed_tile_counter[tc];
-                uint8_t actual_tensix_id = dfb::get_tensix_id(ptc);
+                uint8_t actual_tensix_id = ::dfb::get_tensix_id(ptc);
                 EXPECT_EQ(actual_tensix_id, expected_tensix_id)
                     << "Tensix consumer RISC " << (int)risc_id << " TC[" << (int)tc
                     << "] must use tensix_id=" << (int)expected_tensix_id << " but has " << (int)actual_tensix_id;
@@ -160,7 +160,7 @@ void validate_dfb_tile_counters(
                 // For ALL mode, consumer TCs are different from producer TC (remapper-based)
                 // Accumulate the consumer TC IDs into expected_consumer_tcs
                 if (consumer_idx < 4) {
-                    uint8_t consumer_tc_id = dfb::get_counter_id(consumer_ptc);
+                    uint8_t consumer_tc_id = ::dfb::get_counter_id(consumer_ptc);
                     expected_consumer_tcs |= (consumer_tc_id & 0x1F) << (consumer_idx * 5);
                     consumer_idx++;
                 }
@@ -170,21 +170,21 @@ void validate_dfb_tile_counters(
                     "ALL: Producer {} TC[{}]=(tensix:{}, tc:{}) -> Consumer {} TC[{}]=(tensix:{}, tc:{})",
                     producer_risc_id,
                     producer_tc_slot,
-                    dfb::get_tensix_id(producer_ptc),
-                    dfb::get_counter_id(producer_ptc),
+                    ::dfb::get_tensix_id(producer_ptc),
+                    ::dfb::get_counter_id(producer_ptc),
                     consumer_risc_id,
                     consumer_tc_slot,
-                    dfb::get_tensix_id(consumer_ptc),
-                    dfb::get_counter_id(consumer_ptc));
+                    ::dfb::get_tensix_id(consumer_ptc),
+                    ::dfb::get_counter_id(consumer_ptc));
             } else {
                 // For STRIDED mode, producer and consumer should share the exact same TC
                 EXPECT_EQ(producer_ptc, consumer_ptc)
                     << "STRIDED: Producer " << (int)producer_risc_id << " TC[" << (int)producer_tc_slot
                     << "] should share TC with Consumer " << (int)consumer_risc_id << " TC[" << (int)consumer_tc_slot
-                    << "]. Producer has (tensix:" << (int)dfb::get_tensix_id(producer_ptc)
-                    << ", tc:" << (int)dfb::get_counter_id(producer_ptc)
-                    << "), Consumer has (tensix:" << (int)dfb::get_tensix_id(consumer_ptc)
-                    << ", tc:" << (int)dfb::get_counter_id(consumer_ptc) << ")";
+                    << "]. Producer has (tensix:" << (int)::dfb::get_tensix_id(producer_ptc)
+                    << ", tc:" << (int)::dfb::get_counter_id(producer_ptc)
+                    << "), Consumer has (tensix:" << (int)::dfb::get_tensix_id(consumer_ptc)
+                    << ", tc:" << (int)::dfb::get_counter_id(consumer_ptc) << ")";
 
                 log_info(
                     tt::LogTest,
@@ -193,8 +193,8 @@ void validate_dfb_tile_counters(
                     producer_tc_slot,
                     consumer_risc_id,
                     consumer_tc_slot,
-                    dfb::get_tensix_id(producer_ptc),
-                    dfb::get_counter_id(producer_ptc));
+                    ::dfb::get_tensix_id(producer_ptc),
+                    ::dfb::get_counter_id(producer_ptc));
             }
         }
 
@@ -782,7 +782,7 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync) {
                 for (const auto& rc : found_grp->hw_risc_configs) {
                     for (uint8_t tc = 0; tc < rc.config.num_tcs_to_rr; tc++) {
                         auto ptc = rc.config.packed_tile_counter[tc];
-                        EXPECT_EQ(dfb::get_counter_id(ptc), tc)
+                        EXPECT_EQ(::dfb::get_counter_id(ptc), tc)
                             << "Core (" << x << "," << y << ") RISC " << (int)rc.risc_id
                             << " TC[" << (int)tc << "] should have counter_id=" << (int)tc;
                     }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -857,32 +857,6 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOversizedFails) {
             ::testing::HasSubstr("is larger than its borrowed TensorParameter")));
 }
 
-// Remove once implemented
-TEST_F(ProgramSpecTestQuasar, DFBAliasingFails) {
-    // DFB aliasing is not yet implemented
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.program_id = "test_program";
-
-    auto producer = MakeMinimalDMKernel("producer");
-    auto consumer = MakeMinimalDMKernel("consumer");
-    auto dfb = MakeMinimalDFB("dfb");
-    dfb.alias_with = std::vector<DFBSpecName>{"other_dfb"};  // Not supported yet!
-
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
-
-    spec.kernels = {producer, consumer};
-    spec.dataflow_buffers = {dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("DFB 'dfb' has a non-empty alias_with, but DFB aliasing is not yet implemented")));
-}
-
 TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
@@ -3038,6 +3012,102 @@ TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
     const auto built_compute_variant = built_compute->config();
     const auto& built_compute_config = std::get<ComputeConfig>(built_compute_variant);
     EXPECT_EQ(built_compute_config.compiler_include_paths, compute_paths);
+}
+
+// ============================================================================
+// DFB alias validation — negative tests
+// ============================================================================
+
+// Helper: build a minimal 1-producer / 1-consumer ProgramSpec with a single
+// DFB, reusing the Quasar fixture's node coordinate.
+namespace {
+ProgramSpec MakeAliasProgramSpec(
+    const NodeCoord& node,
+    DataflowBufferSpec dfb_a,
+    DataflowBufferSpec dfb_b,
+    const std::optional<std::string>& second_kernel_source = std::nullopt) {
+    ProgramSpec spec;
+
+    KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
+    KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
+
+    BindDFBToKernel(producer, dfb_a.unique_id, "out_a", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, dfb_a.unique_id, "in_a", KernelSpec::DFBEndpointType::CONSUMER);
+
+    BindDFBToKernel(producer, dfb_b.unique_id, "out_b", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, dfb_b.unique_id, "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb_a, dfb_b};
+    spec.work_units = {MakeMinimalWorkUnit("wu", node, {"producer_kernel", "consumer_kernel"})};
+    return spec;
+}
+}  // anonymous namespace
+
+TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnMismatchedTotalSize) {
+    // DFB_A: 512 * 8 = 4096 bytes, DFB_B: 256 * 8 = 2048 bytes — different totals → TT_FATAL
+    auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/8);
+    dfb_a.alias_with = {"dfb_b"};
+    dfb_b.alias_with = {"dfb_a"};
+
+    const NodeCoord node{0, 0};
+    auto spec = MakeAliasProgramSpec(node, dfb_a, dfb_b);
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("different total sizes")));
+}
+
+TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnNonMutualDeclaration) {
+    // DFB_A lists DFB_B but DFB_B does not list DFB_A → TT_FATAL
+    auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
+    dfb_a.alias_with = {"dfb_b"};
+    // dfb_b.alias_with intentionally left empty
+
+    const NodeCoord node{0, 0};
+    auto spec = MakeAliasProgramSpec(node, dfb_a, dfb_b);
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("alias_with must be mutual")));
+}
+
+TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentKernelBindings) {
+    // DFB_A and DFB_B have the same total size but are bound to different kernels → TT_FATAL
+    const NodeCoord node{0, 0};
+
+    auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
+    dfb_a.alias_with = {"dfb_b"};
+    dfb_b.alias_with = {"dfb_a"};
+
+    // Bind dfb_a to producer_kernel / consumer_kernel as usual
+    KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
+    KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
+    // A third kernel that will be the only consumer of dfb_b
+    KernelSpec other = MakeMinimalDMKernel("other_kernel");
+
+    BindDFBToKernel(producer, "dfb_a", "out_a", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb_a", "in_a", KernelSpec::DFBEndpointType::CONSUMER);
+
+    // dfb_b bound to producer_kernel but consumed by a *different* kernel
+    BindDFBToKernel(producer, "dfb_b", "out_b", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(other, "dfb_b", "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+
+    ProgramSpec spec;
+    spec.kernels = {producer, consumer, other};
+    spec.dataflow_buffers = {dfb_a, dfb_b};
+    spec.work_units = {
+        MakeMinimalWorkUnit("wu", node, {"producer_kernel", "consumer_kernel", "other_kernel"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("different producer/consumer kernels")));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3023,9 +3023,8 @@ TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
 namespace {
 ProgramSpec MakeAliasProgramSpec(
     const NodeCoord& node,
-    DataflowBufferSpec dfb_a,
-    DataflowBufferSpec dfb_b,
-    const std::optional<std::string>& second_kernel_source = std::nullopt) {
+    const DataflowBufferSpec& dfb_a,
+    const DataflowBufferSpec& dfb_b) {
     ProgramSpec spec;
 
     KernelSpec producer = MakeMinimalDMKernel("producer_kernel");

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -19,6 +19,7 @@ set(UNIT_TESTS_API_SOURCES
     core_coord/test_CoreRangeSet_contains.cpp
     core_coord/test_CoreRangeSet_intersects.cpp
     core_coord/test_CoreRangeSet_merge.cpp
+    dataflow_buffer/test_alias_dataflow_buffer.cpp
     dataflow_buffer/test_dataflow_buffer.cpp
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+#include "api/kernel_thread_globals.h"
+
+void kernel_main() {
+    constexpr uint32_t num_entries_per_consumer_a = get_arg(args::num_entries_per_consumer_a);
+    constexpr uint32_t num_entries_per_consumer_b = get_arg(args::num_entries_per_consumer_b);
+    constexpr uint32_t num_consumers              = get_arg(args::num_consumers);
+
+    const uint32_t chunk_offset_a     = get_arg(args::chunk_offset_a);
+    const uint32_t chunk_offset_b     = get_arg(args::chunk_offset_b);
+    const uint32_t entries_per_core_a = get_arg(args::entries_per_core_a);
+    const uint32_t entries_per_core_b = get_arg(args::entries_per_core_b);
+
+    const uint32_t consumer_idx = get_my_thread_id();
+
+    DataflowBuffer dfb_a(dfb::in_a);
+    DataflowBuffer dfb_b(dfb::in_b);
+    Noc noc;
+
+    const uint32_t entry_size_a = dfb_a.get_entry_size();
+    const uint32_t entry_size_b = dfb_b.get_entry_size();
+
+    const auto dst_a = TensorAccessor(ta::dst_a);
+    const auto dst_b = TensorAccessor(ta::dst_b);
+
+    for (uint32_t tile = 0; tile < num_entries_per_consumer_a; tile++) {
+        const uint32_t page_id = chunk_offset_a + tile * num_consumers + consumer_idx;
+        if (page_id >= chunk_offset_a + entries_per_core_a) {
+            break;
+        }
+        dfb_a.wait_front(1);
+        noc.async_write(dfb_a, dst_a, entry_size_a, {}, {.page_id = page_id});
+        noc.async_write_barrier();
+        dfb_a.pop_front(1);
+    }
+    dfb_a.finish();
+    dfb_a.write_barrier(noc);
+
+    for (uint32_t tile = 0; tile < num_entries_per_consumer_b; tile++) {
+        const uint32_t page_id = chunk_offset_b + tile * num_consumers + consumer_idx;
+        if (page_id >= chunk_offset_b + entries_per_core_b) {
+            break;
+        }
+        dfb_b.wait_front(1);
+        noc.async_write(dfb_b, dst_b, entry_size_b, {}, {.page_id = page_id});
+        noc.async_write_barrier();
+        dfb_b.pop_front(1);
+    }
+    dfb_b.finish();
+    dfb_b.write_barrier(noc);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+#include "api/kernel_thread_globals.h"
+
+void kernel_main() {
+    constexpr uint32_t num_entries_per_producer_a = get_arg(args::num_entries_per_producer_a);
+    constexpr uint32_t num_entries_per_producer_b = get_arg(args::num_entries_per_producer_b);
+    constexpr uint32_t num_producers              = get_arg(args::num_producers);
+
+    const uint32_t chunk_offset_a    = get_arg(args::chunk_offset_a);
+    const uint32_t chunk_offset_b    = get_arg(args::chunk_offset_b);
+    const uint32_t entries_per_core_a = get_arg(args::entries_per_core_a);
+    const uint32_t entries_per_core_b = get_arg(args::entries_per_core_b);
+
+    const uint32_t producer_idx = get_my_thread_id();
+
+    DataflowBuffer dfb_a(dfb::out_a);
+    DataflowBuffer dfb_b(dfb::out_b);
+    Noc noc;
+
+    const uint32_t entry_size_a = dfb_a.get_entry_size();
+    const uint32_t entry_size_b = dfb_b.get_entry_size();
+
+    const auto src_a = TensorAccessor(ta::src_a);
+    const auto src_b = TensorAccessor(ta::src_b);
+
+    for (uint32_t tile = 0; tile < num_entries_per_producer_a; tile++) {
+        const uint32_t page_id = chunk_offset_a + tile * num_producers + producer_idx;
+        if (page_id >= chunk_offset_a + entries_per_core_a) {
+            break;
+        }
+        dfb_a.reserve_back(1);
+        noc.async_read(src_a, dfb_a, entry_size_a, {.page_id = page_id}, {});
+        noc.async_read_barrier();
+        dfb_a.push_back(1);
+    }
+    dfb_a.finish();
+
+    for (uint32_t tile = 0; tile < num_entries_per_producer_b; tile++) {
+        const uint32_t page_id = chunk_offset_b + tile * num_producers + producer_idx;
+        if (page_id >= chunk_offset_b + entries_per_core_b) {
+            break;
+        }
+        dfb_b.reserve_back(1);
+        noc.async_read(src_b, dfb_b, entry_size_b, {.page_id = page_id}, {});
+        noc.async_read_barrier();
+        dfb_b.push_back(1);
+    }
+    dfb_b.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -1352,6 +1352,12 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
 
     uint64_t base_dfb_address = device->allocator()->get_base_allocator_addr(HalMemType::L1);
     for (auto& dfb : this->dataflow_buffers_) {
+        // Alias secondaries share the primary's L1 address; skip allocation here
+        // and propagate the address inline after the primary is processed below.
+        if (dfb->alias_primary_id.has_value()) {
+            continue;
+        }
+
         uint32_t alloc_addr;
         if (dfb->borrows_memory()) {
             // Use the address latched by set_borrowed_memory_base_addr()
@@ -1390,6 +1396,19 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
             for (auto& [core, addr] : dfb->groups[gi].l1_by_core) {
                 addr = alloc_addr;
                 dfb->core_lookup_.emplace(core, std::make_pair(gi, alloc_addr));
+            }
+        }
+
+        // Propagate this primary's address to all alias secondaries immediately,
+        // so they share the same L1 region without an additional allocator call.
+        for (uint32_t sec_id : dfb->alias_secondary_ids) {
+            auto& sec = this->dataflow_buffers_[sec_id];
+            sec->core_lookup_.clear();
+            for (size_t gi = 0; gi < sec->groups.size(); gi++) {
+                for (auto& [core, addr] : sec->groups[gi].l1_by_core) {
+                    addr = alloc_addr;
+                    sec->core_lookup_.emplace(core, std::make_pair(gi, alloc_addr));
+                }
             }
         }
     }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -80,6 +80,13 @@ struct DataflowBufferImpl {
     // Set by set_borrowed_memory_base_addr()
     uint32_t borrowed_addr_ = 0;
 
+    // Aliased DFBs share the same L1 data-buffer
+    // alias_primary_id: set on secondaries; holds the primary's DFB id.
+    // alias_secondary_ids: set on the primary; lists all secondary DFB ids.
+    // The choice of a primary is arbitrary
+    std::optional<uint32_t> alias_primary_id;
+    std::vector<uint32_t>   alias_secondary_ids;
+
     bool borrows_memory() const { return config.borrows_memory; }
 
     void set_borrowed_memory_base_addr(uint32_t new_addr) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1112,12 +1112,75 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             tensor_bytes);
     }
 
-    // DFB aliasing is not supported yet
-    for (const auto& dfb : spec.dataflow_buffers) {
-        TT_FATAL(
-            dfb.alias_with.empty(),
-            "DFB '{}' has a non-empty alias_with, but DFB aliasing is not yet implemented",
-            dfb.unique_id);
+    // Validate DFB alias groups.
+    // Rules:
+    //  1. Mutual declaration: if A lists B, B must list A.
+    //  2. Same total size: entry_size * num_entries must match within a group.
+    //  3. Same kernel bindings: each DFB in the group must be bound to the same
+    //     set of producer and consumer KernelSpec unique_ids.
+    {
+        // Build a name -> spec lookup for convenience.
+        std::unordered_map<DFBSpecName, const DataflowBufferSpec*> dfb_spec_by_name;
+        for (const auto& dfb : spec.dataflow_buffers) {
+            dfb_spec_by_name[dfb.unique_id] = &dfb;
+        }
+
+        auto kernel_ids_for_dfb = [&](const DFBSpecName& name) {
+            std::pair<std::vector<std::string>, std::vector<std::string>> result;
+            for (const auto& rec : collected.dfb_endpoints.at(name).producers) {
+                result.first.push_back(rec.kernel->unique_id);
+            }
+            for (const auto& rec : collected.dfb_endpoints.at(name).consumers) {
+                result.second.push_back(rec.kernel->unique_id);
+            }
+            std::sort(result.first.begin(), result.first.end());
+            std::sort(result.second.begin(), result.second.end());
+            return result;
+        };
+
+        for (const auto& dfb : spec.dataflow_buffers) {
+            if (dfb.alias_with.empty()) {
+                continue;
+            }
+            const uint32_t total_size_a = dfb.entry_size * dfb.num_entries;
+            const auto bindings_a = kernel_ids_for_dfb(dfb.unique_id);
+
+            for (const auto& alias_name : dfb.alias_with) {
+                TT_FATAL(
+                    dfb_spec_by_name.contains(alias_name),
+                    "DFB '{}' lists unknown alias '{}' in alias_with",
+                    dfb.unique_id,
+                    alias_name);
+
+                const DataflowBufferSpec* alias_spec = dfb_spec_by_name.at(alias_name);
+
+                // Rule 1: mutual declaration
+                const bool mutual = std::find(
+                    alias_spec->alias_with.begin(),
+                    alias_spec->alias_with.end(),
+                    dfb.unique_id) != alias_spec->alias_with.end();
+                TT_FATAL(
+                    mutual,
+                    "DFB '{}' lists '{}' as an alias, but '{}' does not list '{}' — alias_with must be mutual",
+                    dfb.unique_id, alias_name, alias_name, dfb.unique_id);
+
+                // Rule 2: same total size
+                const uint32_t total_size_b = alias_spec->entry_size * alias_spec->num_entries;
+                TT_FATAL(
+                    total_size_a == total_size_b,
+                    "Aliased DFBs '{}' and '{}' have different total sizes ({} vs {} bytes). "
+                    "Aliased DFBs must have the same total size (entry_size * num_entries).",
+                    dfb.unique_id, alias_name, total_size_a, total_size_b);
+
+                // Rule 3: same kernel bindings
+                const auto bindings_b = kernel_ids_for_dfb(alias_name);
+                TT_FATAL(
+                    bindings_a == bindings_b,
+                    "Aliased DFBs '{}' and '{}' are bound to different producer/consumer kernels. "
+                    "Aliased DFBs must be bound to the same kernel specs.",
+                    dfb.unique_id, alias_name);
+            }
+        }
     }
 
     // Data format metadata (optional param) MUST be specified for a DFB with a compute endpoint
@@ -2222,6 +2285,31 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // at runtime (analog of dynamic CB's UpdateDynamicCircularBufferAddress).
         if (dfb_spec.borrowed_from.has_value()) {
             program_impl->register_dfb_borrowed_binding(dfb_id, *dfb_spec.borrowed_from);
+        }
+    }
+
+    // Wire alias groups: for each DFB that has alias_with entries, make the first
+    // encountered DFB in the group the primary and call set_dfb_alias for each secondary.
+    // handled_as_secondary prevents a DFB from being treated as a primary when it was
+    // already registered as a secondary by an earlier DFB in the group (mutual declaration).
+    {
+        std::unordered_set<DFBSpecName> handled_as_secondary;
+        for (const auto& dfb_spec : spec.dataflow_buffers) {
+            if (handled_as_secondary.count(dfb_spec.unique_id)) {
+                continue;
+            }
+            if (dfb_spec.alias_with.empty()) {
+                continue;
+            }
+            const uint32_t primary_id = dfb_name_to_id.at(dfb_spec.unique_id);
+            for (const auto& alias_name : dfb_spec.alias_with) {
+                if (handled_as_secondary.count(alias_name)) {
+                    continue;
+                }
+                const uint32_t secondary_id = dfb_name_to_id.at(alias_name);
+                program_impl->set_dfb_alias(primary_id, secondary_id);
+                handled_as_secondary.insert(alias_name);
+            }
         }
     }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1142,7 +1142,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (dfb.alias_with.empty()) {
                 continue;
             }
-            const uint32_t total_size_a = dfb.entry_size * dfb.num_entries;
+            const size_t total_size_a = dfb.entry_size * dfb.num_entries;
             const auto bindings_a = kernel_ids_for_dfb(dfb.unique_id);
 
             for (const auto& alias_name : dfb.alias_with) {
@@ -2295,7 +2295,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     {
         std::unordered_set<DFBSpecName> handled_as_secondary;
         for (const auto& dfb_spec : spec.dataflow_buffers) {
-            if (handled_as_secondary.count(dfb_spec.unique_id)) {
+            if (handled_as_secondary.contains(dfb_spec.unique_id)) {
                 continue;
             }
             if (dfb_spec.alias_with.empty()) {
@@ -2303,7 +2303,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
             }
             const uint32_t primary_id = dfb_name_to_id.at(dfb_spec.unique_id);
             for (const auto& alias_name : dfb_spec.alias_with) {
-                if (handled_as_secondary.count(alias_name)) {
+                if (handled_as_secondary.contains(alias_name)) {
                     continue;
                 }
                 const uint32_t secondary_id = dfb_name_to_id.at(alias_name);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -471,6 +471,23 @@ void ProgramImpl::register_kernel_spec_name(const KernelSpecName& name, KernelHa
     TT_FATAL(inserted, "Duplicate kernel spec name: {}", name);
 }
 
+void ProgramImpl::set_dfb_alias(uint32_t primary_id, uint32_t secondary_id) {
+    TT_FATAL(
+        primary_id < dataflow_buffers_.size(),
+        "set_dfb_alias: primary DFB id {} has not been created yet (only {} DFBs exist). "
+        "Both DFBs must be created via add_dataflow_buffer before aliasing.",
+        primary_id,
+        dataflow_buffers_.size());
+    TT_FATAL(
+        secondary_id < dataflow_buffers_.size(),
+        "set_dfb_alias: secondary DFB id {} has not been created yet (only {} DFBs exist). "
+        "Both DFBs must be created via add_dataflow_buffer before aliasing.",
+        secondary_id,
+        dataflow_buffers_.size());
+    dataflow_buffers_[primary_id]->alias_secondary_ids.push_back(secondary_id);
+    dataflow_buffers_[secondary_id]->alias_primary_id = primary_id;
+}
+
 void ProgramImpl::register_dfb_spec_name(const DFBSpecName& name, uint32_t dfb_id) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -484,6 +484,23 @@ void ProgramImpl::set_dfb_alias(uint32_t primary_id, uint32_t secondary_id) {
         "Both DFBs must be created via add_dataflow_buffer before aliasing.",
         secondary_id,
         dataflow_buffers_.size());
+    TT_FATAL(primary_id != secondary_id, "set_dfb_alias: cannot alias a DFB with itself. Primary and secondary DFB IDs must be different");
+
+    auto& primary_dfb = dataflow_buffers_[primary_id];
+    auto& secondary_dfb = dataflow_buffers_[secondary_id];
+
+    TT_FATAL(
+        !primary_dfb->alias_primary_id.has_value(),
+        "set_dfb_alias: primary DFB id {} is already a secondary of DFB id {}. Alias chains are not allowed.",
+        primary_id,
+        primary_dfb->alias_primary_id.value());
+    TT_FATAL(
+        !secondary_dfb->alias_primary_id.has_value(),
+        "set_dfb_alias: secondary DFB id {} is already aliased to primary DFB id {}.",
+        secondary_id,
+        secondary_dfb->alias_primary_id.value());
+
+
     dataflow_buffers_[primary_id]->alias_secondary_ids.push_back(secondary_id);
     dataflow_buffers_[secondary_id]->alias_primary_id = primary_id;
 }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -286,6 +286,9 @@ public:
     uint32_t add_dataflow_buffer(
         const CoreRangeSet& core_range_set, const experimental::dfb::DataflowBufferConfig& config);
 
+    // Declare an alias relationship: secondary shares primary's L1 address.
+    void set_dfb_alias(uint32_t primary_id, uint32_t secondary_id);
+
     // Allocates TCs and remapper configs, cannot be done on creation because we need to determine if a set of DFBs on a
     // core require remapper being enabled
     void finalize_dataflow_buffer_configs();


### PR DESCRIPTION
### Summary
Continuation of DFB <-> CB feature parity. Aliased DFBs all share the same backing memory (this memory may be borrowed). Aliases have unique DFB ids, handles, hw resources and state tracking. 

Kernels are responsible for ensuring they don't corrupt this shared memory.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/alias-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/alias-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/alias-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/alias-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=abhullar/alias-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:abhullar/alias-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/alias-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/alias-dfb)