### PR TITLE
[Bug fix] Correctly unpack outputs of `Transform.prepare_inputs_prefill`.

### DIFF
--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -961,14 +961,20 @@ class Model:
         )
         return host_inputs
 
-    def transform_and_embed_prefill_inputs_device(self, tokens, tt_page_table, tt_chunk_page_table):
+    def transform_and_embed_prefill_inputs_device(
+        self,
+        tokens,
+        tt_page_table,
+        tt_chunk_page_table,
+        tt_chunk_start_idx=None,
+    ):
         """Transform and embed tokens on device"""
         tokens_embd = ttnn.embedding(tokens, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
         # Keep `tokens` allocated: trace replay updates this same device buffer via copy_host_to_device.
         # Deallocating it here breaks prefill trace replay with "Buffer must be allocated on device".
         if len(tokens_embd.shape) == 3:
             tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
-        return tokens_embd, tt_page_table, tt_chunk_page_table
+        return tokens_embd, tt_page_table, tt_chunk_page_table, tt_chunk_start_idx
 
     def prepare_inputs_prefill(
         self,
@@ -982,6 +988,8 @@ class Model:
         batch_size=1,
         user_id=0,
         batched_prefill=False,
+        chunk_start_idx=None,
+        **kwargs,
     ):
         """Prepare inputs for prefill mode
 
@@ -1079,12 +1087,23 @@ class Model:
                 chunk_page_table, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
             )
 
+        if chunk_start_idx is not None:
+            tt_chunk_start_idx = ttnn.from_torch(
+                torch.tensor([chunk_start_idx], dtype=torch.int32),
+                device=device,
+                dtype=ttnn.int32,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+        else:
+            tt_chunk_start_idx = None
+
         return (
             tokens if trace_enabled else tokens_embd,
             rot_mats_global,
             rot_mats_local,
             tt_page_table,
             tt_chunk_page_table,
+            tt_chunk_start_idx,
         )
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1148,7 +1148,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 user_id=user_id,
                 **kwargs,
             )
-            prefill_input, rot_mats_global_prefill, rot_mats_local_prefill, page_table_tt, _, _ = inputs
+            prefill_input, rot_mats_global_prefill, rot_mats_local_prefill, page_table_tt, *_ = inputs
 
             tt_logits = self.model[model_id].ttnn_prefill_forward(
                 prefill_input,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
[#43165](https://github.com/tenstorrent/tt-metal/pull/43165) introduced a regression on models that unpack prefill attributes with different number of variables. This PR changes unpacking from exactly 6 values to at least 5 in general and specifically, adds `chunk_start_idx` to GPT-OSS `prepare_inputs_prefill` (similar to changes to TT-transformers from the root PR) to resolve the bug referenced above.

### Notes for reviewers
* Originally alerted from here: https://github.com/tenstorrent/tt-metal/actions/runs/26156496239
* vLLM Nightly Tests: https://github.com/tenstorrent/tt-metal/actions/runs/26146707492

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanjaradylov/fix-prefill-input-unpacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanjaradylov/fix-prefill-input-unpacking)