### PR TITLE
#38973: gelu_bw (tanh) - dst[8] out of bounds in DST SyncHalf

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
         copy_tile(cb_grad_out, 0, 0);
         copy_tile(cb_input, 0, 1);
         copy_tile(cb_input, 0, 2);  // tile[2] = x
-        copy_tile(cb_input, 0, 8);  // tile[8] = x
+        copy_tile(cb_input, 0, 5);  // tile[5] = x
 
         // tile[1] = x^3
         square_tile(1);
@@ -93,7 +93,7 @@ void kernel_main() {
         mul_binary_tile(2, 3, 2);
 
         // tile[2] = x * pdf term
-        copy_dest_values(8, 3);
+        copy_dest_values(5, 3);
         mul_binary_tile(2, 3, 2);
 
         // result: tile[1] = grad * (cdf_term + x * pdf_term)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Relates to #38973 


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
- Earlier PR #44338 fixed a bug related to the eltwise_bw_gelu_approx_tanh.cpp kernel. tile_regs_wait(); was misplaced in the tanh kernel and updated infra
- This fix exposed another bug on the Nightly debug run with LLK Assert - https://github.com/tenstorrent/tt-metal/actions/runs/26138745876/job/76889661135
- SyncHalf mode has (0 - 7) dst registers available but the kernel in `experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp` uses dst[8] which was caught by LLK Assert
- CI run with fix https://github.com/tenstorrent/tt-metal/actions/runs/26148698256
