### PR TITLE
prefill_runner config loading and default iteration number

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -341,42 +341,31 @@ def _print_config() -> None:
     """Print all env var values at startup so the config is visible in logs."""
     UNSET = "<NOT SET>"
     rows = [
-        # (label, value, required)
-        ("DEEPSEEK_V3_HF_MODEL", os.environ.get("DEEPSEEK_V3_HF_MODEL", UNSET), True),
-        ("TT_DS_PREFILL_TTNN_CACHE", os.environ.get("TT_DS_PREFILL_TTNN_CACHE", DEFAULT_TTNN_CACHE), False),
-        ("TT_IPC_SHM_C2P", os.environ.get("TT_IPC_SHM_C2P", UNSET), False),
-        ("TT_IPC_SHM_P2C", os.environ.get("TT_IPC_SHM_P2C", UNSET), False),
-        ("PREFILL_SP", str(_sp), False),
-        ("PREFILL_TP", str(_tp), False),
-        ("PREFILL_NUM_LAYERS", str(NUM_LAYERS), False),
-        ("PREFILL_MAX_SEQ_LEN", str(MAX_SEQ_LEN), False),
-        ("PREFILL_IS_BALANCED", str(IS_BALANCED), False),
-        ("PREFILL_CAPACITY_FACTOR", str(CAPACITY_FACTOR), False),
-        ("PREFILL_GATE_FALLBACK_MODE", _gate_mode_name, False),
-        ("PREFILL_STANDALONE", os.environ.get("PREFILL_STANDALONE", "0"), False),
-        ("PREFILL_STANDALONE_INPUT", os.environ.get("PREFILL_STANDALONE_INPUT", "<default>"), False),
-        ("PREFILL_STANDALONE_ITERS", os.environ.get("PREFILL_STANDALONE_ITERS", "5"), False),
-        ("PREFILL_ENABLE_MIGRATION", os.environ.get("PREFILL_ENABLE_MIGRATION", "0"), False),
-        ("PREFILL_DEBUG", os.environ.get("PREFILL_DEBUG", "0"), False),
-        ("PREFILL_TRACE_SYNCS", os.environ.get("PREFILL_TRACE_SYNCS", "0"), False),
+        ("DEEPSEEK_V3_HF_MODEL", os.environ.get("DEEPSEEK_V3_HF_MODEL", UNSET)),
+        ("TT_DS_PREFILL_TTNN_CACHE", os.environ.get("TT_DS_PREFILL_TTNN_CACHE", DEFAULT_TTNN_CACHE)),
+        ("TT_IPC_SHM_C2P", os.environ.get("TT_IPC_SHM_C2P", UNSET)),
+        ("TT_IPC_SHM_P2C", os.environ.get("TT_IPC_SHM_P2C", UNSET)),
+        ("PREFILL_SP", str(_sp)),
+        ("PREFILL_TP", str(_tp)),
+        ("PREFILL_NUM_LAYERS", str(NUM_LAYERS)),
+        ("PREFILL_MAX_SEQ_LEN", str(MAX_SEQ_LEN)),
+        ("PREFILL_IS_BALANCED", str(IS_BALANCED)),
+        ("PREFILL_CAPACITY_FACTOR", str(CAPACITY_FACTOR)),
+        ("PREFILL_GATE_FALLBACK_MODE", _gate_mode_name),
+        ("PREFILL_STANDALONE", os.environ.get("PREFILL_STANDALONE", "0")),
+        ("PREFILL_STANDALONE_INPUT", os.environ.get("PREFILL_STANDALONE_INPUT", "<default>")),
+        ("PREFILL_STANDALONE_ITERS", os.environ.get("PREFILL_STANDALONE_ITERS", "1")),
+        ("PREFILL_ENABLE_MIGRATION", os.environ.get("PREFILL_ENABLE_MIGRATION", "0")),
+        ("PREFILL_DEBUG", os.environ.get("PREFILL_DEBUG", "0")),
+        ("PREFILL_TRACE_SYNCS", os.environ.get("PREFILL_TRACE_SYNCS", "0")),
     ]
-
-    missing_required = [label for label, val, req in rows if req and val == UNSET]
 
     sep = "=" * 70
     config_lines = [sep, "prefill_runner configuration", sep]
-    for label, val, req in rows:
-        flag = " [REQUIRED]" if req else ""
-        warn = " *** MISSING ***" if val == UNSET and req else ""
-        config_lines.append(f"  {label:<35} = {val}{flag}{warn}")
+    for label, val in rows:
+        config_lines.append(f"  {label:<35} = {val}")
     config_lines.append(sep)
     logger.info("\n" + "\n".join(config_lines))
-
-    if missing_required:
-        raise RuntimeError(
-            f"Missing required environment variables: {missing_required}. "
-            f"See the module docstring for descriptions."
-        )
 
 
 def main() -> None:

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -127,9 +127,7 @@ def _is_shutdown() -> bool:
 
 
 def _load_hf_config():
-    model_path = os.environ.get("DEEPSEEK_V3_HF_MODEL")
-    if not model_path:
-        raise RuntimeError("DEEPSEEK_V3_HF_MODEL must be set")
+    model_path = os.environ.get("DEEPSEEK_V3_HF_MODEL") or "models/demos/deepseek_v3/reference"
     logger.info(f"Loading HF config from {model_path}")
     return AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 
@@ -228,7 +226,7 @@ def run_standalone_loop(pipeline: TtDeepSeekPrefillPipeline) -> None:
     if len(token_ids) < MAX_SEQ_LEN:
         token_ids = token_ids + [1] * (MAX_SEQ_LEN - len(token_ids))
 
-    num_iterations = int(os.environ.get("PREFILL_STANDALONE_ITERS", "5"))
+    num_iterations = int(os.environ.get("PREFILL_STANDALONE_ITERS", "1"))
     iter_times_ms = []
     first_token = None
     for i in range(num_iterations):

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -27,92 +27,8 @@ NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", 61))
 MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 3200 * _sp))
 IS_BALANCED = os.environ.get("PREFILL_IS_BALANCED", "1") == "1"
 CAPACITY_FACTOR = int(os.environ.get("PREFILL_CAPACITY_FACTOR", 8))
-_gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", "HOST_ALL")
+_gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", "DEVICE_FP32")
 PREFILL_DEBUG = os.environ.get("PREFILL_DEBUG", "0") == "1"
-PREFILL_TRACE_SYNCS = os.environ.get("PREFILL_TRACE_SYNCS", "0") == "1"
-
-
-def _install_sync_tracer() -> None:
-    """Monkey-patch ttnn.synchronize_device + ttnn.to_torch to print where they
-    are called from and how long each call took. First occurrence at each user
-    call site prints a stack snippet; subsequent calls just increment counters
-    that we dump at exit.
-
-    Enabled via PREFILL_TRACE_SYNCS=1. The goal is to expose any 'hidden' sync
-    points inside ttnn ops that we don't see by grepping for synchronize_device
-    in the model python code.
-    """
-    import atexit
-    import time as _time
-    import traceback
-
-    seen: dict = {}  # key -> {"count": int, "total_us": float, "max_us": float}
-
-    def _site_key():
-        # Skip the wrapper frame + this frame; find the first frame that
-        # isn't inside ttnn's own python package.
-        stack = traceback.extract_stack()[:-2]
-        user = [f for f in stack if "/ttnn/ttnn/" not in f.filename]
-        f = user[-1] if user else stack[-1]
-        return (f.filename, f.lineno, f.name)
-
-    def _record(name, key, duration_us):
-        full_key = (name, *key)
-        slot = seen.get(full_key)
-        if slot is None:
-            seen[full_key] = {"count": 1, "total_us": duration_us, "max_us": duration_us}
-            logger.info(f"[sync-trace] FIRST {name} from {key[0]}:{key[1]} in {key[2]}  ({duration_us:.1f} us)")
-        else:
-            slot["count"] += 1
-            slot["total_us"] += duration_us
-            if duration_us > slot["max_us"]:
-                slot["max_us"] = duration_us
-
-    _orig_sync = ttnn.synchronize_device
-
-    def _patched_sync(*args, **kwargs):
-        key = _site_key()
-        t0 = _time.perf_counter()
-        ret = _orig_sync(*args, **kwargs)
-        dt_us = (_time.perf_counter() - t0) * 1e6
-        _record("synchronize_device", key, dt_us)
-        return ret
-
-    ttnn.synchronize_device = _patched_sync
-
-    _orig_to_torch = ttnn.to_torch
-
-    def _patched_to_torch(*args, **kwargs):
-        key = _site_key()
-        t0 = _time.perf_counter()
-        ret = _orig_to_torch(*args, **kwargs)
-        dt_us = (_time.perf_counter() - t0) * 1e6
-        _record("to_torch", key, dt_us)
-        return ret
-
-    ttnn.to_torch = _patched_to_torch
-
-    def _dump_summary():
-        logger.info("=" * 80)
-        logger.info("[sync-trace] summary (per call site)")
-        logger.info("=" * 80)
-        # sort by total_us descending — the expensive ones first
-        rows = sorted(seen.items(), key=lambda kv: -kv[1]["total_us"])
-        for (name, fn, ln, func), s in rows:
-            avg = s["total_us"] / max(1, s["count"])
-            logger.info(
-                f"  {name:<22} {fn}:{ln} in {func}: "
-                f"count={s['count']} total={s['total_us']/1e3:.1f}ms "
-                f"avg={avg:.1f}us max={s['max_us']:.1f}us"
-            )
-        logger.info("=" * 80)
-
-    atexit.register(_dump_summary)
-    logger.info("[sync-trace] installed monkey-patches on ttnn.synchronize_device and ttnn.to_torch")
-
-
-if PREFILL_TRACE_SYNCS:
-    _install_sync_tracer()
 
 _shutdown = False
 
@@ -357,7 +273,6 @@ def _print_config() -> None:
         ("PREFILL_STANDALONE_ITERS", os.environ.get("PREFILL_STANDALONE_ITERS", "1")),
         ("PREFILL_ENABLE_MIGRATION", os.environ.get("PREFILL_ENABLE_MIGRATION", "0")),
         ("PREFILL_DEBUG", os.environ.get("PREFILL_DEBUG", "0")),
-        ("PREFILL_TRACE_SYNCS", os.environ.get("PREFILL_TRACE_SYNCS", "0")),
     ]
 
     sep = "=" * 70


### PR DESCRIPTION
* prefill runner cleanup
* prefill runner argument change
    * DEVICE_FP32 default 
    * PREFILL_STANDALONE_ITERS = 1 default 
    * DEEPSEEK_V3_HF_MODEL no longer required -> now loaded from models/demos/deepseek_v3/reference

after this prefill runner can be run with
PREFILL_STANDALONE=1 python3 models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py  

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-runner-additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-runner-additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/prefill-runner-additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-runner-additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-runner-additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-runner-additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-runner-additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-runner-additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-runner-additions)