### PR TITLE
ci(blackhole-e2e): Consolidate per-SKU AI run summaries into one

### DIFF
--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -112,6 +112,18 @@ jobs:
           echo "matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$filtered" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      - name: Write test matrix to file
+        env:
+          # Same as load-test-matrix outputs.matrix above.
+          MATRIX: ${{ steps.apply-filters.outputs.matrix }}
+        run: |
+          echo "$MATRIX" > test_matrix_${{ inputs.enabled-skus }}.json
+      - name: Upload test matrix
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: test_matrix_${{ inputs.enabled-skus }}
+          path: test_matrix_${{ inputs.enabled-skus }}.json
+          retention-days: 1
 
   blackhole-e2e-tests:
     needs: load-test-matrix
@@ -235,57 +247,3 @@ jobs:
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
-
-  ai-run-summary:
-    name: "AI Run Summary"
-    needs: [load-test-matrix, blackhole-e2e-tests]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - id: extract-matrix
-        env:
-          MATRIX: ${{ needs.load-test-matrix.outputs.matrix }}
-        run: |
-          # load-test-matrix exposes the flat array of leg dicts directly
-          # (unlike the legacy {"test-group":[...]} wrapper used in
-          # blackhole-multi-card-unit-tests-impl.yaml). Validate-parse via
-          # jq and default to [] when the upstream output is empty.
-          if [ -z "$MATRIX" ]; then
-            EXPECTED="[]"
-          else
-            EXPECTED=$(echo "$MATRIX" | jq -c '. // []')
-          fi
-          {
-            echo "matrix<<EOF"
-            echo "$EXPECTED"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - id: ai-run-summary
-        continue-on-error: true
-        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
-        with:
-          config: |
-            {
-              "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE",
-              "input_dir": "ai_job_summaries",
-              "output_dir": "ai_run_summaries"
-            }
-          api-key: ${{ secrets.TT_CHAT_API_KEY }}
-          api-url: ${{ secrets.TT_CHAT_URL }}
-          expected-jobs: ${{ steps.extract-matrix.outputs.matrix }}
-          run-result: ${{ needs.blackhole-e2e-tests.result }}
-      - name: Show report
-        if: always() && steps.ai-run-summary.outputs.report-file != ''
-        continue-on-error: true
-        shell: bash
-        env:
-          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
-        run: |
-          if [ -f "$REPORT_FILE" ]; then
-            cat "$REPORT_FILE"
-            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::warning::Report file not found: $REPORT_FILE"
-          fi

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -148,3 +148,65 @@ jobs:
       enabled-skus: ${{ matrix.test-group.sku }}
       model: ${{ inputs.model || 'all' }}
       test-selection: ${{ inputs.test-selection || 'all' }}
+
+  ai-run-summary:
+    name: "AI Run Summary"
+    # Single run-level summary across all SKU invocations of the impl.
+    # Each impl invocation uploads its already-computed leg matrix as
+    # test_matrix_<sku>; here we download + merge them to form
+    # expected-jobs, so the matrix script runs only once per SKU (in
+    # the impl) and there's no logic duplication across workflows.
+    needs: blackhole-e2e-tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download per-SKU matrices
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: test_matrix_*
+          path: matrices
+          merge-multiple: true
+        continue-on-error: true
+      - name: Merge matrices into expected-jobs union
+        id: merge
+        run: |
+          # Files land flat (merge-multiple) as test_matrix_<sku>.json.
+          # Default to [] when no artifacts arrived (e.g., every impl
+          # leg failed before upload).
+          if compgen -G "matrices/test_matrix_*.json" > /dev/null; then
+            merged=$(jq -cs 'add // []' matrices/test_matrix_*.json)
+          else
+            merged='[]'
+          fi
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          echo "$merged" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ steps.merge.outputs.matrix }}
+          run-result: ${{ needs.blackhole-e2e-tests.result }}
+      - name: Show report
+        if: always() && steps.ai-run-summary.outputs.report-file != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -156,7 +156,7 @@ jobs:
     # test_matrix_<sku>; here we download + merge them to form
     # expected-jobs, so the matrix script runs only once per SKU (in
     # the impl) and there's no logic duplication across workflows.
-    needs: blackhole-e2e-tests
+    needs: [build-artifact, generate-card-matrix, blackhole-e2e-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -182,6 +182,21 @@ jobs:
           echo "matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$merged" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      - name: Aggregate upstream run result
+        id: run-result
+        env:
+          # Most-severe-wins so build/matrix failures aren't masked when
+          # blackhole-e2e-tests gets skipped because of an upstream fail.
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          RESULT=$(jq -rn --argjson n "$NEEDS" '
+            [$n[].result] as $r |
+            if   any($r[]; . == "failure")   then "failure"
+            elif any($r[]; . == "cancelled") then "cancelled"
+            elif any($r[]; . == "success")   then "success"
+            else                                  "skipped"
+            end')
+          echo "run-result=$RESULT" >> "$GITHUB_OUTPUT"
       - id: ai-run-summary
         continue-on-error: true
         uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
@@ -196,7 +211,7 @@ jobs:
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}
           expected-jobs: ${{ steps.merge.outputs.matrix }}
-          run-result: ${{ needs.blackhole-e2e-tests.result }}
+          run-result: ${{ steps.run-result.outputs.run-result }}
       - name: Show report
         if: always() && steps.ai-run-summary.outputs.report-file != ''
         continue-on-error: true


### PR DESCRIPTION
Since test impl is invoked several times, moving the ai-run-summary to the parent.
It's the only way to show the consolidated run summary for all jobs.

https://github.com/tenstorrent/tt-metal/actions/runs/26218330148/attempts/1#summary-77165897824

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/blackhole-single-ai-run-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/blackhole-single-ai-run-summary)