### PR TITLE
#36217: uint8 support for relational ops.

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -9,8 +9,6 @@ import pytest
 import ttnn
 from models.common.utility_functions import is_blackhole
 
-pytestmark = pytest.mark.use_module_device
-
 
 @pytest.mark.parametrize(
     "a_shape, b_shape",
@@ -30,7 +28,7 @@ pytestmark = pytest.mark.use_module_device
 )
 @pytest.mark.parametrize(
     "ttnn_op",
-    [ttnn.ne],
+    [ttnn.ne, ttnn.eq, ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge],
 )
 def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
     if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -2,9 +2,12 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import torch
 import pytest
 import ttnn
+from models.common.utility_functions import is_blackhole
 
 pytestmark = pytest.mark.use_module_device
 
@@ -30,6 +33,8 @@ pytestmark = pytest.mark.use_module_device
     [ttnn.ne],
 )
 def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
+    if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
+        pytest.skip("Skipping on tt-sim in Blackhole/Wormhole B0")
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 255], dtype=torch.int32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -31,9 +31,10 @@ from models.common.utility_functions import is_blackhole
     [ttnn.ne, ttnn.eq, ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge],
 )
 def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
-    # TODO: Remove this when uint8 typcast to uint16 support is added to the BH simulator
+    # TODO: Remove this when typecasting uint8 to uint16 support is added to the BH simulator
+    # issue: https://github.com/tenstorrent/tt-metal/issues/44988
     if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping on tt-sim in Blackhole/Wormhole B0")
+        pytest.skip("Skipping on BH tt-sim: UINT8->UINT16 typecast not supported")
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 255], dtype=torch.int32)
@@ -76,6 +77,8 @@ def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b,
     [ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge, ttnn.ne, ttnn.eq],
 )
 def test_binary_relational_uint8_tensor_scalar(shape, scalar, ttnn_op, device):
+    # TODO: Remove this when typecasting uint8 to uint16 support is added to the BH simulator
+    # issue: https://github.com/tenstorrent/tt-metal/issues/44988
     if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
         pytest.skip("Skipping on BH tt-sim: UINT8->UINT16 typecast not supported")
     num_elements = int(torch.prod(torch.tensor(shape)).item())

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -31,6 +31,7 @@ from models.common.utility_functions import is_blackhole
     [ttnn.ne, ttnn.eq, ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge],
 )
 def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
+    # TODO: Remove this when uint8 typcast to uint16 support is added to the BH simulator
     if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
         pytest.skip("Skipping on tt-sim in Blackhole/Wormhole B0")
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
@@ -46,8 +47,7 @@ def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b,
     torch_input_tensor_b = torch_input_tensor_b[-num_elements:].reshape(b_shape)
 
     golden_function = ttnn.get_golden_function(ttnn_op)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
-
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device).to(torch.uint8)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=ttnn.uint8,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -67,3 +67,31 @@ def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b,
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.uint8)
 
     assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize("shape", [torch.Size([1, 2, 32]), torch.Size([2, 64, 64])])
+@pytest.mark.parametrize("scalar", [0, 1, 128, 255])
+@pytest.mark.parametrize(
+    "ttnn_op",
+    [ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge, ttnn.ne, ttnn.eq],
+)
+def test_binary_relational_uint8_tensor_scalar(shape, scalar, ttnn_op, device):
+    if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
+        pytest.skip("Skipping on BH tt-sim: UINT8->UINT16 typecast not supported")
+    num_elements = int(torch.prod(torch.tensor(shape)).item())
+    torch_input = torch.arange(num_elements, dtype=torch.int32).remainder(256).reshape(shape)
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output = golden_function(torch_input, scalar, device=device).to(torch.uint8)
+
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.uint8,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn_op(input_tensor, float(scalar))
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.uint8)
+
+    assert torch.equal(output_tensor, torch_output)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -21,28 +21,23 @@ from models.common.utility_functions import is_blackhole
     ],
 )
 @pytest.mark.parametrize(
-    "low_a, high_a, low_b, high_b",
-    [
-        (0, 255, 0, 255),
-    ],
-)
-@pytest.mark.parametrize(
     "ttnn_op",
     [ttnn.ne, ttnn.eq, ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge],
 )
-def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
+def test_binary_relational_uint8(a_shape, b_shape, ttnn_op, device):
     # TODO: Remove this when typecasting uint8 to uint16 support is added to the BH simulator
     # issue: https://github.com/tenstorrent/tt-metal/issues/44988
     if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
         pytest.skip("Skipping on BH tt-sim: UINT8->UINT16 typecast not supported")
+    low, high = 0, 255
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
-    torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_tensor_a = torch.linspace(high, low, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 255], dtype=torch.int32)
     torch_input_tensor_a = torch.cat([torch_input_tensor_a, corner_cases])
     torch_input_tensor_a = torch_input_tensor_a[-num_elements:].reshape(a_shape)
 
     num_elements = max(int(torch.prod(torch.tensor(b_shape)).item()), 1)
-    torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    torch_input_tensor_b = torch.linspace(high, low, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 255], dtype=torch.int32)
     torch_input_tensor_b = torch.cat([torch_input_tensor_b, corner_cases])
     torch_input_tensor_b = torch_input_tensor_b[-num_elements:].reshape(b_shape)
@@ -81,6 +76,7 @@ def test_binary_relational_uint8_tensor_scalar(shape, scalar, ttnn_op, device):
     # issue: https://github.com/tenstorrent/tt-metal/issues/44988
     if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
         pytest.skip("Skipping on BH tt-sim: UINT8->UINT16 typecast not supported")
+    # scalar must be in [0, 255] to stay within the UINT8 value range
     num_elements = int(torch.prod(torch.tensor(shape)).item())
     torch_input = torch.arange(num_elements, dtype=torch.int32).remainder(256).reshape(shape)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+
+pytestmark = pytest.mark.use_module_device
+
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    [
+        (torch.Size([1, 2, 32]), torch.Size([1, 2, 32])),
+        (torch.Size([1]), torch.Size([1, 5, 12])),
+        (torch.Size([1, 2, 32, 64, 125]), torch.Size([1, 2, 32, 1, 1])),
+        (torch.Size([]), torch.Size([])),
+        (torch.Size([5]), torch.Size([1])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (0, 255, 0, 255),
+    ],
+)
+@pytest.mark.parametrize(
+    "ttnn_op",
+    [ttnn.ne],
+)
+def test_binary_relational_uint8(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
+    num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
+    torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    corner_cases = torch.tensor([0, 1, 255], dtype=torch.int32)
+    torch_input_tensor_a = torch.cat([torch_input_tensor_a, corner_cases])
+    torch_input_tensor_a = torch_input_tensor_a[-num_elements:].reshape(a_shape)
+
+    num_elements = max(int(torch.prod(torch.tensor(b_shape)).item()), 1)
+    torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    corner_cases = torch.tensor([0, 1, 255], dtype=torch.int32)
+    torch_input_tensor_b = torch.cat([torch_input_tensor_b, corner_cases])
+    torch_input_tensor_b = torch_input_tensor_b[-num_elements:].reshape(b_shape)
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.uint8,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.uint8,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.uint8)
+
+    assert torch.equal(output_tensor, torch_output_tensor)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -933,8 +933,8 @@ Tensor ne(
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::BFLOAT16) : lhs;
-    const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::BFLOAT16) : rhs;
+    const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : lhs;
+    const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : rhs;
     return ttnn::detail::invoke_binary_ng(
         a,
         b,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -41,6 +41,35 @@
             sub_device_id);                                                          \
     }
 
+#define TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                       \
+    Tensor NAME(                                                                                     \
+        const Tensor& lhs,                                                                           \
+        const Tensor& rhs,                                                                           \
+        const std::optional<const DataType>& output_dtype,                                           \
+        const std::optional<MemoryConfig>& memory_config,                                            \
+        const std::optional<Tensor>& output,                                                         \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                 \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                  \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                           \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                             \
+        const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : lhs; \
+        const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : rhs; \
+        return ttnn::detail::invoke_binary_ng(                                                       \
+            a,                                                                                       \
+            b,                                                                                       \
+            operations::binary::BinaryOpType::OP_TYPE,                                               \
+            output_dtype,                                                                            \
+            memory_config,                                                                           \
+            output,                                                                                  \
+            post_activations,                                                                        \
+            lhs_activations,                                                                         \
+            rhs_activations,                                                                         \
+            /*fast_and_approximate_mode*/ false,                                                     \
+            sub_core_grids,                                                                          \
+            sub_device_id);                                                                          \
+    }
+
 #define TTNN_BINARY_OP_TENSOR_FLOAT_IMPL(NAME, OP_TYPE)                              \
     Tensor NAME(                                                                     \
         const Tensor& lhs,                                                           \
@@ -889,7 +918,7 @@ TTNN_BINARY_OP_INPLACE_IMPL(add_, ADD)
 TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(subtract, SUB)
 TTNN_BINARY_OP_TENSOR_FLOAT_IMPL(subtract, SUB)
 TTNN_BINARY_OP_INPLACE_IMPL(subtract_, SUB)
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(eq, EQ)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(eq, EQ)
 Tensor eq(
     const Tensor& lhs,
     float rhs,
@@ -922,33 +951,7 @@ Tensor eq(
     return operations::binary::relational_binary<operations::binary::BinaryOpType::EQ>(
         lhs, rhs, dtype, memory_config, output);
 }
-Tensor ne(
-    const Tensor& lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& output_dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : lhs;
-    const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : rhs;
-    return ttnn::detail::invoke_binary_ng(
-        a,
-        b,
-        operations::binary::BinaryOpType::NE,
-        output_dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        /*fast_and_approximate_mode*/ false,
-        sub_core_grids,
-        sub_device_id);
-}
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(ne, NE)
 Tensor ne(
     const Tensor& lhs,
     float rhs,
@@ -981,7 +984,7 @@ Tensor ne(
     return operations::binary::relational_binary<operations::binary::BinaryOpType::NE>(
         lhs, rhs, dtype, memory_config, output);
 }
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(ge, GE)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(ge, GE)
 Tensor ge(
     const Tensor& lhs,
     float rhs,
@@ -1014,7 +1017,7 @@ Tensor ge(
     return operations::binary::relational_binary<operations::binary::BinaryOpType::GE>(
         lhs, rhs, dtype, memory_config, output);
 }
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(gt, GT)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(gt, GT)
 Tensor gt(
     const Tensor& lhs,
     float rhs,
@@ -1047,7 +1050,7 @@ Tensor gt(
     return operations::binary::relational_binary<operations::binary::BinaryOpType::GT>(
         lhs, rhs, dtype, memory_config, output);
 }
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(le, LE)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(le, LE)
 Tensor le(
     const Tensor& lhs,
     float rhs,
@@ -1080,7 +1083,7 @@ Tensor le(
     return operations::binary::relational_binary<operations::binary::BinaryOpType::LE>(
         lhs, rhs, dtype, memory_config, output);
 }
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(lt, LT)
+TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(lt, LT)
 Tensor lt(
     const Tensor& lhs,
     float rhs,
@@ -1380,6 +1383,7 @@ TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(ne_, NE)
 TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(rsub_, RSUB)
 TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(bias_gelu_, BIAS_GELU)
 #undef TTNN_BINARY_OP_TENSOR_TENSOR_IMPL
+#undef TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL
 #undef TTNN_BINARY_OP_TENSOR_FLOAT_IMPL
 #undef TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL
 #undef TTNN_BINARY_OP_TENSOR_INT32_BITWISE_IMPL

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -70,6 +70,46 @@
             sub_device_id);                                                                          \
     }
 
+#define TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(NAME, OP_TYPE)                                        \
+    Tensor NAME(                                                                                     \
+        const Tensor& lhs,                                                                           \
+        float rhs,                                                                                   \
+        const std::optional<const DataType>& output_dtype,                                           \
+        const std::optional<MemoryConfig>& memory_config,                                            \
+        const std::optional<Tensor>& output,                                                         \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                 \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                  \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                           \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                             \
+        const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : lhs; \
+        return ttnn::detail::invoke_binary_ng(                                                       \
+            a,                                                                                       \
+            rhs,                                                                                     \
+            operations::binary::BinaryOpType::OP_TYPE,                                               \
+            output_dtype,                                                                            \
+            memory_config,                                                                           \
+            output,                                                                                  \
+            post_activations,                                                                        \
+            lhs_activations,                                                                         \
+            rhs_activations,                                                                         \
+            /*fast_and_approximate_mode*/ false,                                                     \
+            sub_core_grids,                                                                          \
+            sub_device_id);                                                                          \
+    }
+
+#define TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                        \
+    Tensor NAME(                                                                                     \
+        float lhs,                                                                                   \
+        const Tensor& rhs,                                                                           \
+        const std::optional<const DataType>& dtype,                                                  \
+        const std::optional<MemoryConfig>& memory_config,                                            \
+        const std::optional<Tensor>& output) {                                                       \
+        const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : rhs; \
+        return operations::binary::relational_binary<operations::binary::BinaryOpType::OP_TYPE>(     \
+            lhs, b, dtype, memory_config, output);                                                   \
+    }
+
 #define TTNN_BINARY_OP_TENSOR_FLOAT_IMPL(NAME, OP_TYPE)                              \
     Tensor NAME(                                                                     \
         const Tensor& lhs,                                                           \
@@ -919,203 +959,23 @@ TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(subtract, SUB)
 TTNN_BINARY_OP_TENSOR_FLOAT_IMPL(subtract, SUB)
 TTNN_BINARY_OP_INPLACE_IMPL(subtract_, SUB)
 TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(eq, EQ)
-Tensor eq(
-    const Tensor& lhs,
-    float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::EQ>(
-        lhs,
-        rhs,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        sub_core_grids,
-        sub_device_id);
-}
-Tensor eq(
-    float lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::EQ>(
-        lhs, rhs, dtype, memory_config, output);
-}
+TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(eq, EQ)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(eq, EQ)
 TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(ne, NE)
-Tensor ne(
-    const Tensor& lhs,
-    float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::NE>(
-        lhs,
-        rhs,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        sub_core_grids,
-        sub_device_id);
-}
-Tensor ne(
-    float lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::NE>(
-        lhs, rhs, dtype, memory_config, output);
-}
+TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(ne, NE)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(ne, NE)
 TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(ge, GE)
-Tensor ge(
-    const Tensor& lhs,
-    float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::GE>(
-        lhs,
-        rhs,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        sub_core_grids,
-        sub_device_id);
-}
-Tensor ge(
-    float lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::GE>(
-        lhs, rhs, dtype, memory_config, output);
-}
+TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(ge, GE)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(ge, GE)
 TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(gt, GT)
-Tensor gt(
-    const Tensor& lhs,
-    float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::GT>(
-        lhs,
-        rhs,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        sub_core_grids,
-        sub_device_id);
-}
-Tensor gt(
-    float lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::GT>(
-        lhs, rhs, dtype, memory_config, output);
-}
+TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(gt, GT)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(gt, GT)
 TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(le, LE)
-Tensor le(
-    const Tensor& lhs,
-    float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::LE>(
-        lhs,
-        rhs,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        sub_core_grids,
-        sub_device_id);
-}
-Tensor le(
-    float lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::LE>(
-        lhs, rhs, dtype, memory_config, output);
-}
+TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(le, LE)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(le, LE)
 TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(lt, LT)
-Tensor lt(
-    const Tensor& lhs,
-    float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::LT>(
-        lhs,
-        rhs,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        sub_core_grids,
-        sub_device_id);
-}
-Tensor lt(
-    float lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
-    return operations::binary::relational_binary<operations::binary::BinaryOpType::LT>(
-        lhs, rhs, dtype, memory_config, output);
-}
+TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(lt, LT)
+TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(lt, LT)
 TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logical_and, LOGICAL_AND)
 TTNN_BINARY_OP_TENSOR_FLOAT_IMPL(logical_and, LOGICAL_AND)
 TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logical_or, LOGICAL_OR)
@@ -1383,6 +1243,8 @@ TTNN_BINARY_OP_INPLACE_RELATIONAL_IMPL(ne_, NE)
 TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(rsub_, RSUB)
 TTNN_BINARY_OP_INPLACE_INVOKE_IMPL(bias_gelu_, BIAS_GELU)
 #undef TTNN_BINARY_OP_TENSOR_TENSOR_IMPL
+#undef TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL
+#undef TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL
 #undef TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL
 #undef TTNN_BINARY_OP_TENSOR_FLOAT_IMPL
 #undef TTNN_BINARY_OP_TENSOR_TENSOR_BITWISE_IMPL

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -922,7 +922,33 @@ Tensor eq(
     return operations::binary::relational_binary<operations::binary::BinaryOpType::EQ>(
         lhs, rhs, dtype, memory_config, output);
 }
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(ne, NE)
+Tensor ne(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::BFLOAT16) : lhs;
+    const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::BFLOAT16) : rhs;
+    return ttnn::detail::invoke_binary_ng(
+        a,
+        b,
+        operations::binary::BinaryOpType::NE,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids,
+        sub_device_id);
+}
 Tensor ne(
     const Tensor& lhs,
     float rhs,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -41,73 +41,81 @@
             sub_device_id);                                                          \
     }
 
-#define TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                       \
-    Tensor NAME(                                                                                     \
-        const Tensor& lhs,                                                                           \
-        const Tensor& rhs,                                                                           \
-        const std::optional<const DataType>& output_dtype,                                           \
-        const std::optional<MemoryConfig>& memory_config,                                            \
-        const std::optional<Tensor>& output,                                                         \
-        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                 \
-        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                  \
-        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                  \
-        const std::optional<CoreRangeSet>& sub_core_grids,                                           \
-        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                             \
-        const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : lhs; \
-        const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : rhs; \
-        return ttnn::detail::invoke_binary_ng(                                                       \
-            a,                                                                                       \
-            b,                                                                                       \
-            operations::binary::BinaryOpType::OP_TYPE,                                               \
-            output_dtype,                                                                            \
-            memory_config,                                                                           \
-            output,                                                                                  \
-            post_activations,                                                                        \
-            lhs_activations,                                                                         \
-            rhs_activations,                                                                         \
-            /*fast_and_approximate_mode*/ false,                                                     \
-            sub_core_grids,                                                                          \
-            sub_device_id);                                                                          \
+#define TTNN_BINARY_OP_TENSOR_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                                \
+    Tensor NAME(                                                                                              \
+        const Tensor& lhs,                                                                                    \
+        const Tensor& rhs,                                                                                    \
+        const std::optional<const DataType>& output_dtype,                                                    \
+        const std::optional<MemoryConfig>& memory_config,                                                     \
+        const std::optional<Tensor>& output,                                                                  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                          \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                           \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                           \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                                    \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                                      \
+        const std::optional<Tensor> lhs_cast =                                                                \
+            lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : std::optional<Tensor>{}; \
+        const Tensor& a = lhs_cast.has_value() ? *lhs_cast : lhs;                                             \
+        const std::optional<Tensor> rhs_cast =                                                                \
+            rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : std::optional<Tensor>{}; \
+        const Tensor& b = rhs_cast.has_value() ? *rhs_cast : rhs;                                             \
+        return ttnn::detail::invoke_binary_ng(                                                                \
+            a,                                                                                                \
+            b,                                                                                                \
+            operations::binary::BinaryOpType::OP_TYPE,                                                        \
+            output_dtype,                                                                                     \
+            memory_config,                                                                                    \
+            output,                                                                                           \
+            post_activations,                                                                                 \
+            lhs_activations,                                                                                  \
+            rhs_activations,                                                                                  \
+            /*fast_and_approximate_mode*/ false,                                                              \
+            sub_core_grids,                                                                                   \
+            sub_device_id);                                                                                   \
     }
 
-#define TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(NAME, OP_TYPE)                                        \
-    Tensor NAME(                                                                                     \
-        const Tensor& lhs,                                                                           \
-        float rhs,                                                                                   \
-        const std::optional<const DataType>& output_dtype,                                           \
-        const std::optional<MemoryConfig>& memory_config,                                            \
-        const std::optional<Tensor>& output,                                                         \
-        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                 \
-        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                  \
-        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                  \
-        const std::optional<CoreRangeSet>& sub_core_grids,                                           \
-        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                             \
-        const auto a = lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : lhs; \
-        return ttnn::detail::invoke_binary_ng(                                                       \
-            a,                                                                                       \
-            rhs,                                                                                     \
-            operations::binary::BinaryOpType::OP_TYPE,                                               \
-            output_dtype,                                                                            \
-            memory_config,                                                                           \
-            output,                                                                                  \
-            post_activations,                                                                        \
-            lhs_activations,                                                                         \
-            rhs_activations,                                                                         \
-            /*fast_and_approximate_mode*/ false,                                                     \
-            sub_core_grids,                                                                          \
-            sub_device_id);                                                                          \
+#define TTNN_BINARY_OP_TENSOR_FLOAT_UINT8_IMPL(NAME, OP_TYPE)                                                 \
+    Tensor NAME(                                                                                              \
+        const Tensor& lhs,                                                                                    \
+        float rhs,                                                                                            \
+        const std::optional<const DataType>& output_dtype,                                                    \
+        const std::optional<MemoryConfig>& memory_config,                                                     \
+        const std::optional<Tensor>& output,                                                                  \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,                          \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,                           \
+        ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,                           \
+        const std::optional<CoreRangeSet>& sub_core_grids,                                                    \
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {                                      \
+        const std::optional<Tensor> lhs_cast =                                                                \
+            lhs.dtype() == DataType::UINT8 ? ttnn::typecast(lhs, DataType::UINT16) : std::optional<Tensor>{}; \
+        const Tensor& a = lhs_cast.has_value() ? *lhs_cast : lhs;                                             \
+        return ttnn::detail::invoke_binary_ng(                                                                \
+            a,                                                                                                \
+            rhs,                                                                                              \
+            operations::binary::BinaryOpType::OP_TYPE,                                                        \
+            output_dtype,                                                                                     \
+            memory_config,                                                                                    \
+            output,                                                                                           \
+            post_activations,                                                                                 \
+            lhs_activations,                                                                                  \
+            rhs_activations,                                                                                  \
+            /*fast_and_approximate_mode*/ false,                                                              \
+            sub_core_grids,                                                                                   \
+            sub_device_id);                                                                                   \
     }
 
-#define TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                        \
-    Tensor NAME(                                                                                     \
-        float lhs,                                                                                   \
-        const Tensor& rhs,                                                                           \
-        const std::optional<const DataType>& dtype,                                                  \
-        const std::optional<MemoryConfig>& memory_config,                                            \
-        const std::optional<Tensor>& output) {                                                       \
-        const auto b = rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : rhs; \
-        return operations::binary::relational_binary<operations::binary::BinaryOpType::OP_TYPE>(     \
-            lhs, b, dtype, memory_config, output);                                                   \
+#define TTNN_BINARY_OP_FLOAT_TENSOR_UINT8_IMPL(NAME, OP_TYPE)                                                 \
+    Tensor NAME(                                                                                              \
+        float lhs,                                                                                            \
+        const Tensor& rhs,                                                                                    \
+        const std::optional<const DataType>& dtype,                                                           \
+        const std::optional<MemoryConfig>& memory_config,                                                     \
+        const std::optional<Tensor>& output) {                                                                \
+        const std::optional<Tensor> rhs_cast =                                                                \
+            rhs.dtype() == DataType::UINT8 ? ttnn::typecast(rhs, DataType::UINT16) : std::optional<Tensor>{}; \
+        const Tensor& b = rhs_cast.has_value() ? *rhs_cast : rhs;                                             \
+        return operations::binary::relational_binary<operations::binary::BinaryOpType::OP_TYPE>(              \
+            lhs, b, dtype, memory_config, output);                                                            \
     }
 
 #define TTNN_BINARY_OP_TENSOR_FLOAT_IMPL(NAME, OP_TYPE)                              \

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -1727,7 +1727,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::ne),
         static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::ne),
         ". ",
-        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16)doc");
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16, UINT8 (cast to UINT16))doc");
 
     detail::bind_binary_operation<"lt">(
         mod,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -1718,7 +1718,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::eq),
         static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::eq),
         ". ",
-        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16)doc");
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT32, UINT16, UINT8 (cast to UINT16))doc");
 
     detail::bind_binary_operation<"ne">(
         mod,
@@ -1736,7 +1736,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::lt),
         static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::lt),
         ". ",
-        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32)doc",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
         "INT32 supported only for tensor-tensor.");
 
     detail::bind_binary_operation<"le">(
@@ -1746,7 +1746,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::le),
         static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::le),
         ". ",
-        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32)doc",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
         "INT32 supported only for tensor-tensor.");
 
     detail::bind_binary_operation<"gt">(
@@ -1756,7 +1756,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::gt),
         static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::gt),
         ". ",
-        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32)doc",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
         "INT32 supported only for tensor-tensor.");
 
     detail::bind_binary_operation<"ge">(
@@ -1766,7 +1766,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::ge),
         static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::ge),
         ". ",
-        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32)doc",
+        R"doc(Float32, BFLOAT16, BFLOAT8_B, INT32, UINT16, UINT8 (cast to UINT16))doc",
         "INT32 supported only for tensor-tensor.");
 
     detail::bind_binary_operation<"logical_and">(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -39,8 +39,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case GT:
         case LT:
         case GE:
-        case LE:
-            return a == b && (a == FLOAT32 || a == BFLOAT16 || a == INT32 || a == UINT16 || a == UINT32 || a == UINT8);
+        case LE: return a == b && (a == FLOAT32 || a == BFLOAT16 || a == INT32 || a == UINT16 || a == UINT32);
         case LCM:
         case GCD: return (a == INT32 && b == INT32);
         case LEFT_SHIFT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -39,7 +39,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case GT:
         case LT:
         case GE:
-        case LE: return a == b && (a == FLOAT32 || a == BFLOAT16 || a == INT32 || a == UINT16 || a == UINT32);
+        case LE:
+            return a == b && (a == FLOAT32 || a == BFLOAT16 || a == INT32 || a == UINT16 || a == UINT32 || a == UINT8);
         case LCM:
         case GCD: return (a == INT32 && b == INT32);
         case LEFT_SHIFT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -763,6 +763,22 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
         use_llk_bcast = false;
     }
 
+    // Integer relational ops (NE/EQ/GT/LT/GE/LE) on UInt16 take the FPU SUB + NEZ
+    // postprocess path with DEST configured for Fp16_b accumulation (fp32_dest_acc_en
+    // is false for UInt16).  Under SCALAR broadcast the B2D datacopy unpacker writes
+    // a single u16 lane into all DEST positions; the resulting Fp16_b-tagged DEST is
+    // then read back by the NEZ postprocess, which interprets the integer bit pattern
+    // through the format-conversion path and corrupts the comparison result (#36217).
+    // Fall back to software broadcast for this combination - non-broadcast u16
+    // relational ops and broadcasted arithmetic u16 ops (no postprocess) are
+    // unaffected.
+    if (use_llk_bcast && a_data_format == tt::DataFormat::UInt16 && b_data_format == tt::DataFormat::UInt16 &&
+        op_config.postprocess.has_value() &&
+        (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+         operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_B)) {
+        use_llk_bcast = false;
+    }
+
     // On Blackhole, the B2D datacopy path (MOVB2D) has a known issue in FP32 dest
     // accumulation mode with non-32-bit source formats (BH Issue #449).  SCALAR and
     // ROW broadcasts use MOVB2D, which produces corrupted results when

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -773,7 +773,12 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     // relational ops and broadcasted arithmetic u16 ops (no postprocess) are
     // unaffected.
     if (use_llk_bcast && a_data_format == tt::DataFormat::UInt16 && b_data_format == tt::DataFormat::UInt16 &&
-        op_config.postprocess.has_value() &&
+        (op_config.postprocess.has_value() ||
+         (std::holds_alternative<OpConfig::SfpuBinaryOp>(op_config.binary_op) &&
+          (std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::LT ||
+           std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::GT ||
+           std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::LE ||
+           std::get<OpConfig::SfpuBinaryOp>(op_config.binary_op) == OpConfig::SfpuBinaryOp::GE))) &&
         (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
          operation_attributes.subtile_broadcast_type == SubtileBroadcastType::SCALAR_B)) {
         use_llk_bcast = false;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -763,12 +763,13 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
         use_llk_bcast = false;
     }
 
-    // Integer relational ops (NE/EQ/GT/LT/GE/LE) on UInt16 take the FPU SUB + NEZ
-    // postprocess path with DEST configured for Fp16_b accumulation (fp32_dest_acc_en
-    // is false for UInt16).  Under SCALAR broadcast the B2D datacopy unpacker writes
-    // a single u16 lane into all DEST positions; the resulting Fp16_b-tagged DEST is
-    // then read back by the NEZ postprocess, which interprets the integer bit pattern
-    // through the format-conversion path and corrupts the comparison result (#36217).
+    // Integer relational ops on UInt16 use either the FPU SUB + {EQZ/NEZ} postprocess
+    // path (EQ/NE) or direct SFPU comparison (LT/GT/LE/GE), both with DEST configured
+    // for Fp16_b accumulation (fp32_dest_acc_en is false for UInt16).  Under SCALAR
+    // broadcast the B2D datacopy unpacker writes a single u16 lane into all DEST
+    // positions; the resulting Fp16_b-tagged DEST is then read back by the postprocess
+    // or SFPU comparison kernel, which interprets the integer bit pattern through the
+    // format-conversion path and corrupts the comparison result (#36217).
     // Fall back to software broadcast for this combination - non-broadcast u16
     // relational ops and broadcasted arithmetic u16 ops (no postprocess) are
     // unaffected.


### PR DESCRIPTION
### Ticket
#36217 

### Problem Description

- uint8 support is not available for relational ops.

### What's changed

- Added uint8 support for relational ops such as [LT, GT, LE, GE, NE, EQ].

<img width="1045" height="746" alt="Screenshot 2026-05-22 at 09 54 27" src="https://github.com/user-attachments/assets/1693411c-ca2a-4533-9223-24e062ef01b4" />

### Note for reviewrs
- [#44988](https://github.com/tenstorrent/tt-metal/issues/44988) A bug exists where typecasting uint8 to uint16 fails on tt-sim (Blackhole architecture) for multi-core tensors with shape [1, 3, 320, 320]. The failure is reproducible 100% of the time by running test_run_eltwise_typecast_op in tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py. So added skip for BH tt-sim.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/uint8_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/uint8_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abdulla/uint8_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/uint8_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/uint8_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/uint8_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/uint8_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/uint8_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/uint8_support)