### PR TITLE
ds_prefill [Feature]: ttnn.kv_cache.fill_cache_for_user_ update_idx exposed

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -11,7 +11,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 from models.common.utility_functions import skip_for_blackhole
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("head_dim", [64])
 @pytest.mark.parametrize("max_seq_len", [4096])
 @pytest.mark.parametrize("num_users", [8, 16, 32, 64])
@@ -19,6 +18,7 @@ from models.common.utility_functions import skip_for_blackhole
 @pytest.mark.parametrize("in_sharded", [True, False])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 class TestUpdateCache:
+    @skip_for_blackhole("Mismatching on BH, see #12349")
     @pytest.mark.parametrize("seq_len", [32, 512, 2048, 4096])
     def test_fill_cache(self, seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, device):
         cache_dtype = input_dtype
@@ -59,6 +59,50 @@ class TestUpdateCache:
         logger.info(output)
         assert eq
 
+    @pytest.mark.parametrize("slab_seq_len", [32, 128])
+    def test_fill_cache_with_update_idx(
+        self, slab_seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, device
+    ):
+        cache_dtype = input_dtype
+        input_shape = [1, num_heads, slab_seq_len, head_dim]
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+        cache = torch.zeros(cache_shape).bfloat16().float()
+        cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+        for i in range(num_users):
+            for slab_idx in range(2):
+                update_idx = slab_idx * slab_seq_len
+                x = torch.randn(input_shape).bfloat16().float()
+                xt = ttnn.Tensor(x, input_dtype).to(ttnn.TILE_LAYOUT)
+                if in_sharded:
+                    compute_grid_size = device.compute_with_storage_grid_size()
+                    num_cores = min(slab_seq_len // 32 * num_heads, 32)
+                    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+                    input_shard_spec = ttnn.ShardSpec(
+                        shard_grid,
+                        [
+                            xt.volume() // xt.padded_shape[-1] // num_cores,
+                            xt.padded_shape[-1],
+                        ],
+                        ttnn.ShardOrientation.ROW_MAJOR,
+                    )
+                    input_mem_config = ttnn.MemoryConfig(
+                        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+                    )
+                    xt = xt.to(device, input_mem_config)
+                else:
+                    xt = xt.to(device)
+                cachett = ttnn.fill_cache(cachett, xt, i, update_idx=update_idx)
+                cache[i : i + 1, :, update_idx : update_idx + slab_seq_len, :] = x
+
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16 and cache_dtype == input_dtype:
+            eq, output = comp_equal(cache, tt_got_back)
+        else:
+            eq, output = comp_pcc(cache, tt_got_back)
+        logger.info(output)
+        assert eq
+
+    @skip_for_blackhole("Mismatching on BH, see #12349")
     @pytest.mark.parametrize("cache_idx", [0, 1, 127, 1057])
     @pytest.mark.parametrize("cache_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
     @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -93,8 +93,14 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
             args.batch_idx,
             cache_tensor.padded_shape()[0]);
         TT_FATAL(
-            input_tensor.padded_shape()[-2] <= cache_tensor.padded_shape()[-2],
-            "Input tensor height ({}) must be <= cache tensor height ({})",
+            args.update_idx % TILE_HEIGHT == 0,
+            "Fill update_idx ({}) must be a multiple of TILE_HEIGHT ({})",
+            args.update_idx,
+            TILE_HEIGHT);
+        TT_FATAL(
+            args.update_idx + input_tensor.padded_shape()[-2] <= cache_tensor.padded_shape()[-2],
+            "Fill update_idx ({}) + input tensor height ({}) must be <= cache tensor height ({})",
+            args.update_idx,
             input_tensor.padded_shape()[-2],
             cache_tensor.padded_shape()[-2]);
     } else if (args.op_type == UpdateCacheOpType::UPDATE) {

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -98,7 +98,8 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
             args.update_idx,
             TILE_HEIGHT);
         TT_FATAL(
-            args.update_idx + input_tensor.padded_shape()[-2] <= cache_tensor.padded_shape()[-2],
+            args.update_idx <= cache_tensor.padded_shape()[-2] &&
+                input_tensor.padded_shape()[-2] <= cache_tensor.padded_shape()[-2] - args.update_idx,
             "Fill update_idx ({}) + input tensor height ({}) must be <= cache tensor height ({})",
             args.update_idx,
             input_tensor.padded_shape()[-2],

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.cpp
@@ -23,8 +23,8 @@ ttnn::Tensor update_cache_for_token_(
 }
 
 ttnn::Tensor fill_cache_for_user_(
-    const ttnn::Tensor& cache, const ttnn::Tensor& input, const uint32_t batch_index) {
-    ttnn::prim::update_cache(cache, input, batch_index, 0, 0, ttnn::prim::UpdateCacheOpType::FILL);
+    const ttnn::Tensor& cache, const ttnn::Tensor& input, const uint32_t batch_index, const uint32_t update_idx) {
+    ttnn::prim::update_cache(cache, input, batch_index, update_idx, 0, ttnn::prim::UpdateCacheOpType::FILL);
     return cache;
 }
 
@@ -41,8 +41,11 @@ ttnn::Tensor update_cache(
 }
 
 ttnn::Tensor fill_cache(
-    const ttnn::Tensor& cache_tensor, const ttnn::Tensor& input_tensor, const uint32_t batch_idx) {
-    ttnn::prim::update_cache(cache_tensor, input_tensor, batch_idx, 0, 0, ttnn::prim::UpdateCacheOpType::FILL);
+    const ttnn::Tensor& cache_tensor,
+    const ttnn::Tensor& input_tensor,
+    const uint32_t batch_idx,
+    const uint32_t update_idx) {
+    ttnn::prim::update_cache(cache_tensor, input_tensor, batch_idx, update_idx, 0, ttnn::prim::UpdateCacheOpType::FILL);
     return cache_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.hpp
@@ -9,7 +9,8 @@
 
 namespace ttnn {
 
-ttnn::Tensor fill_cache_for_user_(const ttnn::Tensor& cache, const ttnn::Tensor& input, uint32_t batch_index);
+ttnn::Tensor fill_cache_for_user_(
+    const ttnn::Tensor& cache, const ttnn::Tensor& input, uint32_t batch_index, uint32_t update_idx = 0);
 
 ttnn::Tensor update_cache_for_token_(
     const ttnn::Tensor& cache,
@@ -25,7 +26,8 @@ ttnn::Tensor update_cache(
     uint32_t batch_offset = 0,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
-ttnn::Tensor fill_cache(const ttnn::Tensor& cache_tensor, const ttnn::Tensor& input_tensor, uint32_t batch_idx);
+ttnn::Tensor fill_cache(
+    const ttnn::Tensor& cache_tensor, const ttnn::Tensor& input_tensor, uint32_t batch_idx, uint32_t update_idx = 0);
 
 ttnn::Tensor zero_cache_range(const ttnn::Tensor& cache, uint32_t start_token, uint32_t end_token);
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_nanobind.cpp
@@ -23,13 +23,17 @@ namespace {
 
 void bind_fill_cache_for_user_(nb::module_& mod) {
     const auto* doc = R"doc(
-        Populates the :attr:`cache` tensor in-place with values sourced from :attr:`input` at :attr:`batch_index`.
+        Populates the :attr:`cache` tensor in-place with values sourced from :attr:`input` at :attr:`batch_index`,
+        optionally offset along the sequence dimension by :attr:`update_idx` (tile-aligned).
 
 
         Args:
             cache (ttnn.Tensor): the cache tensor to be written to.
             input_tensor (ttnn.Tensor): the input tensor to be written to the cache.
             batch_index (int): the index into the cache tensor.
+
+        Keyword Args:
+            update_idx (int): seq-dim offset within the user slot, must be a multiple of TILE_HEIGHT. Default = 0.
 
 
         Returns:
@@ -39,7 +43,14 @@ void bind_fill_cache_for_user_(nb::module_& mod) {
         )doc";
 
     ttnn::bind_function<"fill_cache_for_user_", "ttnn.kv_cache.">(
-        mod, doc, &ttnn::fill_cache_for_user_, nb::arg("cache"), nb::arg("input"), nb::arg("batch_index"));
+        mod,
+        doc,
+        &ttnn::fill_cache_for_user_,
+        nb::arg("cache"),
+        nb::arg("input"),
+        nb::arg("batch_index"),
+        nb::kw_only(),
+        nb::arg("update_idx") = 0);
 }
 
 void bind_update_cache_for_token_(nb::module_& mod) {
@@ -105,12 +116,16 @@ void bind_update_cache(nb::module_& mod) {
 
 void bind_fill_cache(nb::module_& mod) {
     const auto* doc = R"doc(
-        Fills the cache tensor in place with the values from input at the specified batch_idx.
+        Fills the cache tensor in place with the values from input at the specified batch_idx,
+        optionally offset along the sequence dimension by update_idx (tile-aligned).
 
         Args:
             * :attr:`cache_tensor` (ttnn.Tensor): The cache tensor to be written to.
             * :attr:`input_tensor` (ttnn.Tensor): The token tensor to be written to the cache.
             * :attr:`batch_idx` (int): The index into the cache tensor.
+
+        Keyword Args:
+            * :attr:`update_idx` (int): seq-dim offset within the user slot, must be a multiple of TILE_HEIGHT. Default = 0.
 
         Example:
             >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
@@ -120,7 +135,14 @@ void bind_fill_cache(nb::module_& mod) {
     )doc";
 
     ttnn::bind_function<"fill_cache">(
-        mod, doc, &ttnn::fill_cache, nb::arg("cache_tensor"), nb::arg("input_tensor"), nb::arg("batch_idx"));
+        mod,
+        doc,
+        &ttnn::fill_cache,
+        nb::arg("cache_tensor"),
+        nb::arg("input_tensor"),
+        nb::arg("batch_idx"),
+        nb::kw_only(),
+        nb::arg("update_idx") = 0);
 }
 
 void bind_zero_cache_range(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_nanobind.cpp
@@ -29,7 +29,7 @@ void bind_fill_cache_for_user_(nb::module_& mod) {
 
         Args:
             cache (ttnn.Tensor): the cache tensor to be written to.
-            input_tensor (ttnn.Tensor): the input tensor to be written to the cache.
+            input (ttnn.Tensor): the input tensor to be written to the cache.
             batch_index (int): the index into the cache tensor.
 
         Keyword Args:
@@ -128,9 +128,9 @@ void bind_fill_cache(nb::module_& mod) {
             * :attr:`update_idx` (int): seq-dim offset within the user slot, must be a multiple of TILE_HEIGHT. Default = 0.
 
         Example:
-            >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-            >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-            >>> output = ttnn.update_cache(tensor1, tensor2, batch_idx)
+            >>> cache_tensor = ttnn.from_torch(torch.zeros((4, 1, 128, 64), dtype=torch.bfloat16), device=device)
+            >>> input_tensor = ttnn.from_torch(torch.randn((1, 1, 32, 64), dtype=torch.bfloat16), device=device)
+            >>> output = ttnn.fill_cache(cache_tensor, input_tensor, batch_idx=0, update_idx=32)
 
     )doc";
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
This PR resolves #44825. `update_idx` is exposed in the binding of `ttnn.kv_cache.fill_cache_for_user_`.

This parameter is already present in the function `update_cache` called by the above op. It was just hardcoded to 0. This is needed to enable multi-user chunked update of kv cache for the upcoming ds chunked prefill. The old behavior is maintained by keeping the argument optional with a default value of 0.

### Notes for reviewers
Small change that maintains the expected behavior should not have an impact on any of the existing models

### CI runs

- [(Blackhole) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/26100060980)
- [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/26100084682)
- [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/26100128206)
- [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/26100152826)
- [(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/runs/26100221403)

All failures in the above were investigated and look unrelated to the change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/fill_cache_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/fill_cache_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/fill_cache_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/fill_cache_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/fill_cache_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/fill_cache_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/fill_cache_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/fill_cache_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/fill_cache_op)