### PR TITLE
pdl: re-baseline deeplab_v3_plus_110_cores device perf after pack_untilize MOP opt (#44596)

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -64,7 +64,7 @@ def test_device_perf_pdl_20_cores(
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_110_cores",
-            3_908_667,
+            3_852_250,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,


### PR DESCRIPTION
## Summary

Re-baseline `deeplab_v3_plus_110_cores` device perf target in `test_device_perf_pdl_110_cores` from `3_908_667` ns → `3_852_250` ns (the average of the 8 runs since the step-drop on 2026-05-19).

## Problem

The P150 BH device-perf job started failing intermittently on the **low** side of the tolerance window — i.e. the model is now consistently faster than the expected lower bound:

```
AVG DEVICE KERNEL DURATION [ns] 3848799.0 is outside of expected range (3850036.995, 3967297.0049999994)
```

Example failing run: https://github.com/tenstorrent/tt-metal/actions/runs/26158613695/job/76946017684

## Root cause — not a regression, an unaccounted speed-up

Bisecting the AVG DEVICE KERNEL DURATION across recent main runs shows a clean step-drop:

| Date (UTC) | SHA | Measured ns |
|---|---|---|
| 5/18 20:37 | 8d9fa2968 | 3,903,032 |
| 5/19 03:17 | 8e823c236 | 3,904,036 |
| 5/19 08:14 | c5ebc6351 | 3,903,435 |
| **5/19 11:10** | **580cd8e6e** | **3,848,116** ← **−55 µs** |
| 5/19 15:13 | 097517c7d | 3,850,984 |
| 5/19 17:49 | de85eda0b | 3,854,550 |
| 5/19 20:40 | 3b2e6f322 | 3,854,736 |
| 5/19 23:30 | a8827dfd4 | 3,854,042 |
| 5/20 03:17 | 1bd184219 | 3,855,012 |
| 5/20 08:13 | f7045af65 | 3,851,762 |
| 5/20 11:08 | 15fc9929d | 3,848,799 (failing run) |

The step landed in commit window `c5ebc6351098..580cd8e6e9c5`, which contains:

1. **`215668f3385` — #44596 "[BH] pack_untilize MOP perf: CFGSHIFTMASK + AddrMod-driven row advance"** — explicitly claims −34.6% mean / −57.6% max PACK-isolate cycles on the 832-variant `perf_pack_untilize.py` corpus. DeepLab v3+ uses `pack_untilize` heavily, so a ~1.4% wall-clock kernel-duration improvement is consistent.
2. `580cd8e6e9c` — #44251 LLK packer RMW correctness audit — PR explicitly states *"No runtime behavior change"*.
3. `43d283e028` — #44621 tt-triage CI tooling — no device impact.

#44596 is the responsible commit. Nothing to fix in the model code — the baseline just needs to track the new steady state.

## What's changed

Single value update in `models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py:67`:

- `expected_device_perf_ns_per_iteration` for `deeplab_v3_plus_110_cores`: `3_908_667` → `3_852_250`

Computed from the 8 post-#44596 measurements (n=8, avg=3,852,250, min=3,848,116, max=3,855,012, stdev=2,755, spread=0.18%). With the existing `margin=0.015`, the new window is **[3,794,466, 3,910,034]** — every observed run lands comfortably inside, with headroom on both sides for ordinary device-perf noise.

The 110-core `panoptic_deeplab` baseline above it was not failing and is left unchanged.

## Test plan

- [ ] (Single-card) Device perf regressions — P150 BH device perf job passes `test_device_perf_pdl_110_cores[test_deeplab_v3_plus_110_cores]`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/pdl-rebaseline-44596)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/pdl-rebaseline-44596)