### PR TITLE
RT profiler warning filter

### DIFF
--- a/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
+++ b/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
@@ -7,6 +7,12 @@
 #include <fmt/format.h>
 #include <tt-logger/tt-logger.hpp>
 
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <utility>
+#include <vector>
+
 #if defined(TRACY_ENABLE)
 #include <common/TracyTTDeviceData.hpp>
 #endif
@@ -40,6 +46,29 @@ tracy::TTDeviceMarker make_marker(
 }
 #endif
 
+constexpr size_t kMaxSummaryEntries = 8;
+
+template <typename Key>
+std::string FormatTopCounts(const std::unordered_map<Key, uint64_t>& counts) {
+    if (counts.empty()) {
+        return "none";
+    }
+    std::vector<std::pair<Key, uint64_t>> entries(counts.begin(), counts.end());
+    std::sort(entries.begin(), entries.end(), [](const auto& a, const auto& b) { return a.second > b.second; });
+    std::string result;
+    const size_t limit = std::min(entries.size(), kMaxSummaryEntries);
+    for (size_t i = 0; i < limit; ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        result += fmt::format("{}×{}", entries[i].first, entries[i].second);
+    }
+    if (entries.size() > kMaxSummaryEntries) {
+        result += fmt::format(", ... (+{} more)", entries.size() - kMaxSummaryEntries);
+    }
+    return result;
+}
+
 }  // namespace
 
 RealtimeProfilerTracyHandler::RealtimeProfilerTracyHandler() {
@@ -50,8 +79,10 @@ RealtimeProfilerTracyHandler::RealtimeProfilerTracyHandler() {
 RealtimeProfilerTracyHandler::~RealtimeProfilerTracyHandler() {
     tt::UnregisterProgramRealtimeProfilerCallback(callback_handle_);
 
-#if defined(TRACY_ENABLE)
     std::lock_guard<std::mutex> lock(mutex_);
+    MaybeEmitSkippedZoneSummaryLocked();
+
+#if defined(TRACY_ENABLE)
     for (auto& entry : tracy_contexts_) {
         TracyTTDestroy(entry.second);
     }
@@ -98,16 +129,60 @@ TracyTTCtx RealtimeProfilerTracyHandler::GetContext(uint32_t chip_id) {
     return it != tracy_contexts_.end() ? it->second : nullptr;
 }
 
-void RealtimeProfilerTracyHandler::HandleRecord([[maybe_unused]] const tt::ProgramRealtimeRecord& record) {
-#if defined(TRACY_ENABLE)
-    if (!tracy::GetProfiler().IsConnected()) {
-        return;
-    }
-    TracyTTCtx ctx = GetContext(record.chip_id);
-    if (!ctx) {
+void RealtimeProfilerTracyHandler::RecordSkippedZoneWithEndBeforeStart(
+    const tt::ProgramRealtimeRecord& record, int64_t delta) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto& stats = skipped_end_before_start_stats_;
+    stats.total_skipped++;
+
+    if (!stats.logged_first_detail) {
+        stats.logged_first_detail = true;
+        stats.last_summary_time = std::chrono::steady_clock::now();
+        log_warning(
+            tt::LogMetal,
+            "[Real-time profiler] Skipping zone with end < start: program_id={}, chip_id={}, "
+            "start_timestamp={}, end_timestamp={} (delta={})",
+            record.program_id,
+            record.chip_id,
+            record.start_timestamp,
+            record.end_timestamp,
+            delta);
         return;
     }
 
+    stats.suppressed_since_last_summary++;
+    stats.count_by_program_id[record.program_id]++;
+    stats.count_by_chip_id[record.chip_id]++;
+    const auto now = std::chrono::steady_clock::now();
+    if (now - stats.last_summary_time >= SkippedEndBeforeStartStats::kSummaryInterval) {
+        MaybeEmitSkippedZoneSummaryLocked();
+    }
+}
+
+void RealtimeProfilerTracyHandler::MaybeEmitSkippedZoneSummaryLocked() {
+    auto& stats = skipped_end_before_start_stats_;
+    if (stats.total_skipped == 0) {
+        return;
+    }
+    if (stats.suppressed_since_last_summary == 0) {
+        return;
+    }
+
+    log_warning(
+        tt::LogMetal,
+        "[Real-time profiler] Skipped {} additional zones with end < start ({} total); programs: {}; chips: {}",
+        stats.suppressed_since_last_summary,
+        stats.total_skipped,
+        FormatTopCounts(stats.count_by_program_id),
+        FormatTopCounts(stats.count_by_chip_id));
+
+    stats.suppressed_since_last_summary = 0;
+    stats.count_by_program_id.clear();
+    stats.count_by_chip_id.clear();
+    stats.last_summary_time = std::chrono::steady_clock::now();
+}
+
+void RealtimeProfilerTracyHandler::HandleRecord(const tt::ProgramRealtimeRecord& record) {
     if (record.end_timestamp < record.start_timestamp) {
         auto delta = static_cast<int64_t>(record.end_timestamp) - static_cast<int64_t>(record.start_timestamp);
         constexpr int64_t kStartupRaceThreshold = -100000;
@@ -122,16 +197,17 @@ void RealtimeProfilerTracyHandler::HandleRecord([[maybe_unused]] const tt::Progr
                 record.program_id,
                 delta);
         } else {
-            log_warning(
-                tt::LogMetal,
-                "[Real-time profiler] Skipping zone with end < start: program_id={}, chip_id={}, "
-                "start_timestamp={}, end_timestamp={} (delta={})",
-                record.program_id,
-                record.chip_id,
-                record.start_timestamp,
-                record.end_timestamp,
-                delta);
+            RecordSkippedZoneWithEndBeforeStart(record, delta);
         }
+        return;
+    }
+
+#if defined(TRACY_ENABLE)
+    if (!tracy::GetProfiler().IsConnected()) {
+        return;
+    }
+    TracyTTCtx ctx = GetContext(record.chip_id);
+    if (!ctx) {
         return;
     }
 

--- a/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.hpp
+++ b/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <mutex>
 #include <unordered_map>
@@ -42,8 +43,22 @@ public:
 private:
     TracyTTCtx GetContext(uint32_t chip_id);
 
+    void RecordSkippedZoneWithEndBeforeStart(const tt::ProgramRealtimeRecord& record, int64_t delta);
+    void MaybeEmitSkippedZoneSummaryLocked();
+
+    struct SkippedEndBeforeStartStats {
+        uint64_t total_skipped = 0;
+        uint64_t suppressed_since_last_summary = 0;
+        bool logged_first_detail = false;
+        std::unordered_map<uint64_t, uint64_t> count_by_program_id;
+        std::unordered_map<uint32_t, uint64_t> count_by_chip_id;
+        std::chrono::steady_clock::time_point last_summary_time{};
+        static constexpr std::chrono::seconds kSummaryInterval{30};
+    };
+
     std::mutex mutex_;
     std::unordered_map<uint32_t, TracyTTCtx> tracy_contexts_;
+    SkippedEndBeforeStartStats skipped_end_before_start_stats_;
     tt::ProgramRealtimeProfilerCallbackHandle callback_handle_;
 };
 


### PR DESCRIPTION
### PR Category
Clean up

### Summary
RT profiler warnings could flood stdout on multi-device, big runs. Now they are summarized every 30 sec if they keep happening.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mo/rt_profiler_quiet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mo/rt_profiler_quiet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mo/rt_profiler_quiet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mo/rt_profiler_quiet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mo/rt_profiler_quiet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mo/rt_profiler_quiet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mo/rt_profiler_quiet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mo/rt_profiler_quiet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mo/rt_profiler_quiet)