### PR TITLE
[Bug fix] Pool 2D compute: replace thread-unsafe pack HW configure with lightweight reconfig

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -227,7 +227,7 @@ void kernel_main() {
 
                     constexpr uint32_t PACKER_FACE_R_DIM_STICK = 1;  // face_r_dim = 1 => one-row faces (stick packing)
                     if constexpr (is_output_block_format) {
-                        PACK((llk_pack_untilize_hw_configure_disaggregated<DST_ACCUM_MODE, ckernel::PackMode::Default>(
+                        PACK((llk_pack_reconfig_data_format_disaggregated<DST_ACCUM_MODE>(
                             pre_tilize_cb_id, PACKER_FACE_R_DIM_STICK, num_faces_in_output_tile)));
                     }
                     PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(


### PR DESCRIPTION
## Summary

- The mid-loop call to `llk_pack_untilize_hw_configure_disaggregated` in `compute_pool_2d.cpp` runs the broader pack HW configure path, which is **not thread-safe** and is unsafe to call while compute threads may already be active.
- Replace it with `llk_pack_reconfig_data_format_disaggregated`, which only re-derives the pack data format / face geometry for the new CB.
- This mirrors the pattern adopted in #44417 for `pack_untilize_dest_init` (extending the disaggregated reconfig wrappers in `llk_pack_common_api.h` so callers can supply explicit untilize geometry).

The downstream `llk_pack_untilize_init` call on the next line still handles untilize-specific init, so behavior is preserved.

## Test plan

- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/26169730660)
- [x] [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/26169675630) 
- [x] [Single card Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/26169608669)