### PR TITLE
Propagate kernel compilation warnings

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <iterator>
 #include <mutex>
 #include <string>
@@ -66,6 +67,9 @@ void report_result(const string& target_name, string_view op, const string& cmd,
             TT_THROW("{} build failed. Log: {}", target_name, log_contents);
         }
         if (!log_contents.empty()) {
+            // Don't mix warnings from parallel compilations.
+            static std::mutex mutex;
+            std::lock_guard lock(mutex);
             std::cerr << "Building " << target_name << ", " << op << " step:\n" << cmd << "\n" << log_contents;
         }
     } else if (!result) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -54,13 +54,21 @@ namespace tt::tt_metal {
 
 namespace {
 
-void build_failure(const string& target_name, const string& op, const string& cmd, const string& log_file) {
-    log_error(tt::LogBuildKernels, "{} {} failure -- cmd: {}", target_name, op, cmd);
+void report_result(const string& target_name, string_view op, const string& cmd, const string& log_file, bool result) {
+    if (!result) {
+        log_error(tt::LogBuildKernels, "{} {} failure -- cmd: {}", target_name, op, cmd);
+    }
+
     std::ifstream file{log_file};
     if (file.is_open()) {
-        std::string log_contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-        TT_THROW("{} build failed. Log: {}", target_name, log_contents);
-    } else {
+        std::string log_contents{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+        if (!result) {
+            TT_THROW("{} build failed. Log: {}", target_name, log_contents);
+        }
+        if (!log_contents.empty()) {
+            std::cerr << "Building " << target_name << ", " << op << " step:\n" << cmd << "\n" << log_contents;
+        }
+    } else if (!result) {
         TT_THROW("Failed to open {} failure log file {}", op, log_file);
     }
 }
@@ -552,9 +560,9 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     // needs to be renamed after link step to avoid LTO reading inconsistent object files.
     jit_build::utils::FileRenamer log_file(obj_path + ".log");
     fs::remove(log_file.path());
-    if (!tt::jit_build::utils::run_command(cmd, log_file.path(), env_.get_rtoptions().get_dump_build_commands())) {
-        build_failure(this->target_name_, "compile", cmd, log_file.path());
-    }
+    bool result =
+        tt::jit_build::utils::run_command(cmd, log_file.path(), env_.get_rtoptions().get_dump_build_commands());
+    report_result(this->target_name_, "compile", cmd, log_file.path(), result);
     jit_build::write_dependency_hashes(out_dir, obj_temp_path, obj_temp_path + ".dephash");
     fs::remove(temp_d_path);  // .d file not needed after hash is written
 }
@@ -636,9 +644,9 @@ void JitBuildState::link(const string& out_dir, const JitBuildSettings* settings
     }
     jit_build::utils::FileRenamer log_file(elf_name + ".log");
     fs::remove(log_file.path());
-    if (!tt::jit_build::utils::run_command(cmd, log_file.path(), env_.get_rtoptions().get_dump_build_commands())) {
-        build_failure(this->target_name_, "link", cmd, log_file.path());
-    }
+    bool result =
+        tt::jit_build::utils::run_command(cmd, log_file.path(), env_.get_rtoptions().get_dump_build_commands());
+    report_result(this->target_name_, "link", cmd, log_file.path(), result);
     jit_build::utils::FileRenamer dephash_file(elf_name + ".dephash");
     std::ofstream hash_file(dephash_file.path());
     jit_build::write_dependency_hashes({{elf_name, std::move(link_deps)}}, out_dir, elf_name, hash_file);


### PR DESCRIPTION
### PR Category
Feature

### Summary
Kernel (& firmware) compilation warnings are not presented to the user -- they're swallowed into the log file, which is only shown if there's a compilation failure.

This means the user has no clue about questionable uses of C++, and more importantly these days, that they're using deprecated features. The failure more for the deprecated Fns being deleted after 30 days will be unpleasant.

look at   https://github.com/tenstorrent/tt-metal/actions/runs/26167771338/job/76979456238 for instance, here's a snippet with this patch running:
```
Building brisc, compile step:
cd /github/home/.cache/tt-metal-cache/13758058153021483361/kernels/cq_dispatch/3212468454053991394/brisc/ && ccache /opt/tenstorrent/sfpi/compiler/bin/riscv-tt-elf-g++ -O2 -std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -flto=auto -ffast-math -fno-exceptions -g -MMD -fno-use-cxa-atexit -Wall -Werror -Wno-error=deprecated-declarations -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -Wno-unused-function -mcpu=tt-bh -fno-tree-loop-distribute-patterns -I. -I.. -I/opt/venv/lib/python3.10/site-packages/ttnn/ -I/opt/venv/lib/python3.10/site-packages/ttnn/ttnn -I/opt/venv/lib/python3.10/site-packages/ttnn/ttnn/cpp -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/inc -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/tt-llk/common -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hostdevcommon/api -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/api/ -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/ckernels/blackhole/metal/common -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/ckernels/blackhole/metal/llk_io -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/inc/internal/tt-1xx -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/inc/internal/tt-1xx/blackhole -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/inc/internal/tt-1xx/blackhole/blackhole_defines -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/tt-llk/tt_llk_blackhole/common/inc -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/tt-llk/tt_llk_blackhole/llk_lib -I/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/firmware/src/tt-1xx -I/work/tt_metal/impl/dispatch/kernels -c -o /github/home/.cache/tt-metal-cache/13758058153021483361/kernels/cq_dispatch/3212468454053991394/brisc/brisck.9349903262246218411.o /opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/firmware/src/tt-1xx/brisck.cc -MF /github/home/.cache/tt-metal-cache/13758058153021483361/kernels/cq_dispatch/3212468454053991394/brisc/brisck.9349903262246218411.d -DIS_NOT_POW2_NUM_L1_BANKS=1 -DLOG_BASE_2_OF_NUM_DRAM_BANKS=3 -DNUM_DRAM_BANKS=8 -DNUM_L1_BANKS=110 -DPCIE_NOC_X=19 -DPCIE_NOC_Y=24 -DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 -DPROCESSOR_INDEX=0 -DCOMPILE_FOR_BRISC -DARCH_BLACKHOLE -DDISPATCH_MESSAGE_ADDR=4290184248 -DKERNEL_BUILD -DCOMMAND_QUEUE_BASE_ADDR='0' -DCOMPLETION_QUEUE_BASE_ADDR='805302272' -DCOMPLETION_QUEUE_SIZE='268431360' -DDEV_COMPLETION_Q_RD_PTR='111136' -DDEV_COMPLETION_Q_WR_PTR='111120' -DDEV_DISPATCH_PROGRESS_PTR='111456' -DDISPATCH_CB_BASE='114688' -DDISPATCH_CB_BLOCKS='4' -DDISPATCH_CB_LOG_PAGE_SIZE='12' -DDISPATCH_CB_PAGES='128' -DDISPATCH_D_SHUTDOWN_SEM_ID='2' -DDISPATCH_KERNEL='1' -DDISPATCH_S_SYNC_SEM_BASE_ADDR='111184' -DDISTRIBUTED_DISPATCHER='0' -DDOWNSTREAM_CB_BASE='0' -DDOWNSTREAM_CB_SEM_ID='0' -DDOWNSTREAM_CB_SIZE='0' -DDOWNSTREAM_NOC_X='1' -DDOWNSTREAM_NOC_Y='2' -DDOWNSTREAM_SUBORDINATE_NOC_X='14' -DDOWNSTREAM_SUBORDINATE_NOC_Y='3' -DEW_DIM='0' -DFABRIC_HEADER_RB_BASE='111312' -DFABRIC_HEADER_RB_ENTRIES='1' -DFABRIC_MUX_BUFFER_INDEX_ADDRESS='0' -DFABRIC_MUX_CHANNEL_BASE_ADDRESS='0' -DFABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES='0' -DFABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS='0' -DFABRIC_MUX_CONNECTION_INFO_ADDRESS='0' -DFABRIC_MUX_FLOW_CONTROL_ADDRESS='0' -DFABRIC_MUX_NUM_BUFFERS_PER_CHANNEL='0' -DFABRIC_MUX_STATUS_ADDRESS='0' -DFABRIC_MUX_TERMINATION_SIGNAL_ADDRESS='0' -DFABRIC_MUX_X='0' -DFABRIC_MUX_Y='0' -DFABRIC_WORKER_BUFFER_INDEX_SEM='0' -DFABRIC_WORKER_FLOW_CONTROL_SEM='0' -DFABRIC_WORKER_TEARDOWN_SEM='0' -DFD_CORE_TYPE='0' -DFIRST_STREAM_USED='48' -DFORCE_DPRINT_OFF='1' -DHOST_COMPLETION_Q_WR_PTR='128' -DIS_CQ_DRAM_BACKED='0' -DIS_D_VARIANT='1' -DIS_H_VARIANT='1' -DMAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES='64' -DMAX_NUM_WORKER_SEMS='8' -DMCAST_GO_SIGNAL_ADDR='1008' -DMY_DISPATCH_CB_SEM_ID='0' -DMY_DOWNSTREAM_CB_SEM_ID='0' -DMY_FABRIC_SYNC_STATUS_ADDR='111440' -DMY_NOC_X='14' -DMY_NOC_Y='3' -DNUM_HOPS='0' -DNUM_PHYSICAL_UNICAST_CORES='0' -DNUM_VIRTUAL_UNICAST_CORES='0' -DNUM_WORKER_CORES_TO_MCAST='110' -DOFFSETOF_MY_DEV_ID='0' -DOFFSETOF_ROUTER_DIRECTION='2' -DOFFSETOF_TO_DEV_ID='1' -DPACKED_WRITE_MAX_UNICAST_SUB_CMDS='110' -DPREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR='0' -DPREFETCH_H_MAX_CREDITS='0' -DPREFETCH_H_NOC_XY='0' -DREALTIME_PROFILER_MSG_ADDR='111472' -DSPLIT_PREFETCH='0' -DTO_MESH_ID='0' -DUNICAST_GO_SIGNAL_ADDR='1168' -DUPSTREAM_DISPATCH_CB_SEM_ID='0' -DUPSTREAM_NOC_INDEX='1' -DUPSTREAM_NOC_X='14' -DUPSTREAM_NOC_Y='2' -DUPSTREAM_SYNC_SEM='1' -DVIRTUALIZE_UNICAST_CORES='0' -DWORKER_CREDITS_STREAM_ID='0' -DWORKER_MCAST_GRID='529101' -DNOC_INDEX='0' -DNOC_MODE='0' 
In file included from ../kernel_includes.hpp:1,
                 from /opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/hw/firmware/src/tt-1xx/brisck.cc:21:
/work/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp: In function 'void relay_to_next_cb(uint32_t, uint64_t)':
/work/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp:423:18: warning: variable 'not_end_of_cmd' set but not used [-Wunused-but-set-variable]
  423 |             bool not_end_of_cmd;
      |                  ^~~~~~~~~~~~~~
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/warn-44714)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/warn-44714)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/warn-44714)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/warn-44714)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/warn-44714)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/warn-44714)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/warn-44714)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/warn-44714)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/warn-44714)