### PR TITLE
Feature: Harden bug checker failures and improve PR comment UX

### DIFF
--- a/.github/bug_checker/README.md
+++ b/.github/bug_checker/README.md
@@ -26,40 +26,7 @@ Comment `/bug-check run` on any PR. The workflow at `.github/workflows/bug-check
 | `/bug-check check-rule <id>` | Run only the named rule against the PR |
 | `/bug-check dry-run` | Show which rules match and what diff sections each would analyze (no LLM calls) |
 
-### Local CLI
-
-Install the local dependencies and provide a Claude API key:
-
-```bash
-pip install -r .github/bug_checker/requirements-bug-checker.txt
-export BUG_CHECKER_API_KEY=<your-api-key>  # or ANTHROPIC_API_KEY
-```
-
-`BUG_CHECKER_MODEL` can be set to override the default model (`claude-sonnet-4-6`).
-
-Run the checker against a branch diff or PR, optionally selecting a subcommand:
-
-```bash
-# Analyze the current branch diff against main
-python .github/bug_checker/run_bug_checker.py --branch --verbose
-
-# Analyze against a different base branch
-python .github/bug_checker/run_bug_checker.py --branch origin/release-1.0
-
-# Analyze a PR by number (requires gh CLI auth)
-python .github/bug_checker/run_bug_checker.py --pr 39432 --verbose
-
-# List rules without analyzing a target
-python .github/bug_checker/run_bug_checker.py --subcommand list-rules
-
-# Run one rule against a PR
-python .github/bug_checker/run_bug_checker.py --pr 12345 --subcommand check-rule --rule-id ccl-ring-buffer-mismatch
-
-# Preview matching rules and diff sections without LLM calls
-python .github/bug_checker/run_bug_checker.py --branch --subcommand dry-run
-```
-
-## Adding a New Rule
+## Creating a New Rule
 
 1. **Write the rule markdown** in `.github/bug_checker/rules/your-rule-name.md`. Copy `rules/template-rule.md` and fill in each section:
 
@@ -119,6 +86,39 @@ good_code();
 | `labels` | list of strings | Rule runs if any PR label matches |
 
 A rule is selected if **either** a path or a label matches.
+
+### Local CLI
+
+Install the local dependencies and provide a Claude API key:
+
+```bash
+pip install -r .github/bug_checker/requirements-bug-checker.txt
+export BUG_CHECKER_API_KEY=<your-api-key>  # or ANTHROPIC_API_KEY
+```
+
+`BUG_CHECKER_MODEL` can be set to override the default model (`claude-sonnet-4-6`).
+
+Run the checker against a branch diff or PR, optionally selecting a subcommand:
+
+```bash
+# Analyze the current branch diff against main
+python .github/bug_checker/run_bug_checker.py --branch --verbose
+
+# Analyze against a different base branch
+python .github/bug_checker/run_bug_checker.py --branch origin/release-1.0
+
+# Analyze a PR by number (requires gh CLI auth)
+python .github/bug_checker/run_bug_checker.py --pr 39432 --verbose
+
+# List rules without analyzing a target
+python .github/bug_checker/run_bug_checker.py --subcommand list-rules
+
+# Run one rule against a PR
+python .github/bug_checker/run_bug_checker.py --pr 12345 --subcommand check-rule --rule-id ccl-ring-buffer-mismatch
+
+# Preview matching rules and diff sections without LLM calls
+python .github/bug_checker/run_bug_checker.py --branch --subcommand dry-run
+```
 
 ## Component Reference
 

--- a/.github/bug_checker/README.md
+++ b/.github/bug_checker/README.md
@@ -10,129 +10,11 @@ LLM-powered bug pattern detection for tt-metal PRs. Scans PR diffs against a lib
 4. Each matching rule is sent to Claude along with the PR diff. Claude analyzes the diff against the bug pattern described in the rule's markdown file.
 5. Findings are reported in three formats: CLI stdout, inline PR comments, and SARIF for GitHub Code Scanning.
 
-```mermaid
-flowchart TD
-    CI["CI Path\nfetch_pr_info()"]
-    LOCAL["Local Path\nfetch_branch_diff()"]
-
-    CI --> PRINFO
-    LOCAL --> PRINFO
-
-    PRINFO(["PRInfo dataclass"])
-    PRINFO --> ORCH
-
-    ORCH["Orchestrator\nrun_bug_check()"]
-    ORCH --> RULES
-
-    RULES["Rule Engine\nload_rules() → select_rules()"]
-    RULES --> LLM
-
-    LLM["LLM Analysis\nLLMSession.analyze_rule()"]
-    LLM --> OUT
-
-    OUT["Output Dispatch\nprint_findings() · write_sarif() · post_pr_comment()"]
-    OUT --> EXIT
-
-    EXIT["Exit Code\nexit 1 if blocking, else 0"]
-
-    classDef ci fill:#1a0e00,stroke:#f97316,stroke-width:2px,color:#f97316
-    classDef local fill:#001a1f,stroke:#22d3ee,stroke-width:2px,color:#22d3ee
-    classDef shared fill:#0f0a1f,stroke:#a78bfa,stroke-width:2px,color:#a78bfa
-    classDef llm fill:#1a0815,stroke:#f472b6,stroke-width:2px,color:#f472b6
-    classDef output fill:#001a10,stroke:#34d399,stroke-width:2px,color:#34d399
-    classDef exitcode fill:#111827,stroke:#64748b,stroke-width:2px,color:#94a3b8
-    classDef prinfo fill:#111827,stroke:#94a3b8,stroke-width:2px,color:#e2e8f0
-
-    class CI ci
-    class LOCAL local
-    class PRINFO prinfo
-    class ORCH,RULES shared
-    class LLM llm
-    class OUT output
-    class EXIT exitcode
-```
-
-### Component Reference
-
-#### CI Path — `github_client.py` : `fetch_pr_info()` (41–76)
-
-- Triggered by `--pr`
-- Calls `gh pr view` and `gh pr diff` via the GitHub API
-- Gets the real PR title, labels, SHAs, diff, and changed file list
-
-#### Local Path — `github_client.py` : `fetch_branch_diff()` (79–129)
-
-- Triggered by `--branch`
-- Runs `git merge-base` + `git diff` locally
-- PR number is set to `0`, labels default to `[]` unless `--labels` is passed
-
-#### PRInfo dataclass — `github_client.py` (16–25)
-
-- The shared data structure both input paths produce
-- Fields: `number`, `title`, `base_sha`, `head_sha`, `diff`, `changed_files`, `labels`
-- Everything downstream operates on this single type regardless of input source
-- Diffs exceeding 8000 lines (`MAX_DIFF_LINES`) are truncated with a warning
-
-#### Orchestrator — `orchestrator.py` : `run_bug_check()` (21–89)
-
-- Central coordinator that sequences the entire pipeline:
-  load rules → select matching → per-rule LLM analysis → collect findings → dispatch outputs
-- Fails open — if an LLM call fails, the rule is skipped and the check still passes
-
-#### Rule Engine — `rules.py` + `manifest.yaml` + `rules/*.md`
-
-- `load_rules()` reads `manifest.yaml` and the markdown content of each rule
-- `select_rules()` filters by file-glob and label match against `PRInfo`
-- Current rules:
-  - `ccl-ring-buffer-mismatch` — blocking, paths: `tt_metal/impl/ccl/**`, `ttnn/cpp/ttnn/operations/ccl/**`, labels: `area:ccl`
-  - `reshape-dim-check` — warning, paths: `ttnn/cpp/ttnn/operations/data_movement/**`, labels: `area:ops`
-
-#### LLM Analysis — `llm.py` : `LLMSession.analyze_rule()` (31–194)
-
-- Creates an Anthropic client (`claude-sonnet-4-6`, `max_tokens: 4096`, `temperature: 0`)
-- Per matched rule:
-  1. `_filter_diff_for_rule()` narrows the diff to files matching the rule's path globs; for label-only matches (no path globs matched), the full diff is passed through
-  2. Builds a system prompt requiring structured `` ```finding `` blocks
-  3. Builds a user message with the rule's markdown + filtered diff
-  4. Calls `client.messages.create()`
-  5. Parses the response into `Finding` objects
-
-#### Output Dispatch — `output.py` + `github_client.py`
-
-- **CLI stdout** — `print_findings()` — always runs, colorized with loguru
-- **SARIF file** — `write_sarif()` — if `--sarif`, for GitHub Code Scanning
-- **PR comments** — `post_pr_comment()` — if `--post-comments`, posts inline review comments + a summary comment
-
-#### Exit Code — `__main__.py` (86–87)
-
-- `exit 1` if any finding has `severity == "blocking"`, `exit 0` otherwise
-
-Each rule runs in its own isolated LLM session — no state is shared between rules.
-
 ## Usage
 
 ### GitHub Actions (primary)
 
 Comment `/bug-check run` on any PR. The workflow at `.github/workflows/bug-check.yaml` runs the checker and posts findings as inline comments. Comment `/bug-check` (bare) to see all available subcommands.
-
-### Local CLI
-
-```bash
-# Analyze current branch diff against main
-python .github/bug_checker/run_bug_checker.py --branch --verbose
-
-# Analyze against a different base branch
-python .github/bug_checker/run_bug_checker.py --branch origin/release-1.0
-
-# Analyze a PR by number (requires gh CLI auth)
-python .github/bug_checker/run_bug_checker.py --pr 39432 --verbose
-```
-
-**Requirements**: `pip install -r .github/bug_checker/requirements-bug-checker.txt`
-
-**Environment variables**:
-- `BUG_CHECKER_API_KEY` or `ANTHROPIC_API_KEY` — Claude API key
-- `BUG_CHECKER_MODEL` — Override the default model (default: `claude-sonnet-4-6`)
 
 ## Subcommands
 
@@ -144,11 +26,36 @@ python .github/bug_checker/run_bug_checker.py --pr 39432 --verbose
 | `/bug-check check-rule <id>` | Run only the named rule against the PR |
 | `/bug-check dry-run` | Show which rules match and what diff sections each would analyze (no LLM calls) |
 
-CLI equivalents:
+### Local CLI
+
+Install the local dependencies and provide a Claude API key:
 
 ```bash
+pip install -r .github/bug_checker/requirements-bug-checker.txt
+export BUG_CHECKER_API_KEY=<your-api-key>  # or ANTHROPIC_API_KEY
+```
+
+`BUG_CHECKER_MODEL` can be set to override the default model (`claude-sonnet-4-6`).
+
+Run the checker against a branch diff or PR, optionally selecting a subcommand:
+
+```bash
+# Analyze the current branch diff against main
+python .github/bug_checker/run_bug_checker.py --branch --verbose
+
+# Analyze against a different base branch
+python .github/bug_checker/run_bug_checker.py --branch origin/release-1.0
+
+# Analyze a PR by number (requires gh CLI auth)
+python .github/bug_checker/run_bug_checker.py --pr 39432 --verbose
+
+# List rules without analyzing a target
 python .github/bug_checker/run_bug_checker.py --subcommand list-rules
+
+# Run one rule against a PR
 python .github/bug_checker/run_bug_checker.py --pr 12345 --subcommand check-rule --rule-id ccl-ring-buffer-mismatch
+
+# Preview matching rules and diff sections without LLM calls
 python .github/bug_checker/run_bug_checker.py --branch --subcommand dry-run
 ```
 
@@ -212,6 +119,63 @@ good_code();
 | `labels` | list of strings | Rule runs if any PR label matches |
 
 A rule is selected if **either** a path or a label matches.
+
+## Component Reference
+
+### CI Path — `github_client.py` : `fetch_pr_info()`
+
+- Triggered by `--pr`
+- Calls `gh pr view` and `gh pr diff` via the GitHub API
+- Gets the real PR title, labels, SHAs, diff, and changed file list
+
+### Local Path — `github_client.py` : `fetch_branch_diff()`
+
+- Triggered by `--branch`
+- Runs `git merge-base` + `git diff` locally
+- PR number is set to `0`, labels default to `[]` unless `--labels` is passed
+
+### PRInfo dataclass — `github_client.py`
+
+- The shared data structure both input paths produce
+- Fields: `number`, `title`, `base_sha`, `head_sha`, `diff`, `changed_files`, `labels`
+- Everything downstream operates on this single type regardless of input source
+- Diffs exceeding 8000 lines (`MAX_DIFF_LINES`) are truncated with a warning
+
+### Orchestrator — `orchestrator.py` : `run_bug_check()`
+
+- Central coordinator that sequences the entire pipeline:
+  load rules → select matching → per-rule LLM analysis → collect findings → dispatch outputs
+- Fails closed — if LLM setup or rule analysis fails, the PR gets a failure summary comment and the command exits non-zero
+
+### Rule Engine — `rules.py` + `manifest.yaml` + `rules/*.md`
+
+- `load_rules()` reads `manifest.yaml` and the markdown content of each rule
+- `select_rules()` filters by file-glob and label match against `PRInfo`
+- Current rules:
+  - `ccl-ring-buffer-mismatch` — blocking, paths: `tt_metal/impl/ccl/**`, `ttnn/cpp/ttnn/operations/ccl/**`, labels: `area:ccl`
+  - `reshape-dim-check` — warning, paths: `ttnn/cpp/ttnn/operations/data_movement/**`, labels: `area:ops`
+
+### LLM Analysis — `llm.py` : `LLMSession.analyze_rule()`
+
+- Creates an Anthropic client (`claude-sonnet-4-6`, `max_tokens: 4096`, `temperature: 0`)
+- Per matched rule:
+  1. `_filter_diff_for_rule()` narrows the diff to files matching the rule's path globs; for label-only matches (no path globs matched), the full diff is passed through
+  2. Builds a system prompt requiring structured `` ```finding `` blocks
+  3. Builds a user message with the rule's markdown + filtered diff
+  4. Calls `client.messages.create()`
+  5. Parses the response into `Finding` objects
+
+### Output Dispatch — `output.py` + `github_client.py`
+
+- **CLI stdout** — `print_findings()` — always runs, colorized with loguru
+- **SARIF file** — `write_sarif()` — if `--sarif`, for GitHub Code Scanning
+- **PR comments** — `post_pr_comment()` — if `--post-comments`, posts inline review comments + a summary comment
+
+### Exit Code — `__main__.py`
+
+- `exit 1` if any finding has `severity == "blocking"` or LLM analysis fails, `exit 0` otherwise
+
+Each rule runs in its own isolated LLM session — no state is shared between rules.
 
 ## Data Handling
 

--- a/.github/bug_checker/__main__.py
+++ b/.github/bug_checker/__main__.py
@@ -16,6 +16,7 @@ from bug_checker.github_client import (
 )
 from bug_checker.logger import set_verbose
 from bug_checker.orchestrator import (
+    BugCheckFailed,
     check_rule_command,
     dry_run_command,
     list_rules_command,
@@ -115,21 +116,24 @@ def main() -> int:
         dry_run_command(pr_info=pr_info, post_comments=args.post_comments)
         return 0
 
-    if args.subcommand == "check-rule":
-        findings = check_rule_command(
-            pr_info=pr_info,
-            rule_id=args.rule_id,
-            sarif_path=sarif_path,
-            post_comments=args.post_comments,
-        )
-    else:
-        findings = run_bug_check(
-            pr_info=pr_info,
-            sarif_path=sarif_path,
-            post_comments=args.post_comments,
-        )
+    try:
+        if args.subcommand == "check-rule":
+            findings = check_rule_command(
+                pr_info=pr_info,
+                rule_id=args.rule_id,
+                sarif_path=sarif_path,
+                post_comments=args.post_comments,
+            )
+        else:
+            findings = run_bug_check(
+                pr_info=pr_info,
+                sarif_path=sarif_path,
+                post_comments=args.post_comments,
+            )
+    except BugCheckFailed:
+        return 1
 
-    # Exit code: 1 if any blocking findings, 0 otherwise
+    # Exit code: 1 if any blocking findings or if analysis failed, 0 otherwise
     has_blocking = any(f.severity == "blocking" for f in findings)
     return 1 if has_blocking else 0
 

--- a/.github/bug_checker/github_client.py
+++ b/.github/bug_checker/github_client.py
@@ -52,18 +52,14 @@ def _check_gh() -> None:
     result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(
-            "The 'gh' CLI is not authenticated. "
-            "Run 'gh auth login' to authenticate before using --pr."
+            "The 'gh' CLI is not authenticated. " "Run 'gh auth login' to authenticate before using --pr."
         )
 
 
 def _check_git() -> None:
     result = subprocess.run(["git", "--version"], capture_output=True, text=True)
     if result.returncode != 0:
-        raise RuntimeError(
-            "git is not installed or not on PATH. "
-            "Install git and ensure it is on your PATH."
-        )
+        raise RuntimeError("git is not installed or not on PATH. " "Install git and ensure it is on your PATH.")
 
 
 def _gh(*args: str, input_data: str | None = None) -> str:
@@ -90,7 +86,7 @@ def fetch_pr_info(pr_number: int) -> PRInfo:
         "--repo",
         REPO,
         "--json",
-        "title,baseRefOid,headRefOid,labels,files",
+        "title,labels,files",
     )
     pr_data = json.loads(pr_json)
 
@@ -198,10 +194,7 @@ def _truncate_diff(diff: str, changed_files: list[str]) -> tuple[str, list[str]]
     if len(lines) <= MAX_DIFF_LINES:
         return diff, []
 
-    truncated = (
-        "\n".join(lines[:MAX_DIFF_LINES])
-        + "\n\n# [diff truncated — too large for full analysis]"
-    )
+    truncated = "\n".join(lines[:MAX_DIFF_LINES]) + "\n\n# [diff truncated — too large for full analysis]"
     files_in_truncated = diff_file_paths(truncated)
 
     # The last file with a header in the truncated output may be incomplete —

--- a/.github/bug_checker/github_client.py
+++ b/.github/bug_checker/github_client.py
@@ -86,7 +86,7 @@ def fetch_pr_info(pr_number: int) -> PRInfo:
         "--repo",
         REPO,
         "--json",
-        "title,labels,files",
+        "title,labels,files,commits",
     )
     pr_data = json.loads(pr_json)
 
@@ -94,6 +94,8 @@ def fetch_pr_info(pr_number: int) -> PRInfo:
     diff = _gh("pr", "diff", str(pr_number), "--repo", REPO)
     changed_files = [f["path"] for f in pr_data.get("files", [])]
     labels = [l["name"] for l in pr_data.get("labels", [])]
+    commits = pr_data.get("commits") or []
+    head_sha = commits[-1].get("oid", "") if commits else ""
 
     diff, truncated_files = _truncate_diff(diff, changed_files)
     if truncated_files:
@@ -107,7 +109,7 @@ def fetch_pr_info(pr_number: int) -> PRInfo:
         number=pr_number,
         title=pr_data.get("title", ""),
         base_sha=pr_data.get("baseRefOid", ""),
-        head_sha=pr_data.get("headRefOid", ""),
+        head_sha=head_sha,
         diff=diff,
         changed_files=changed_files,
         labels=labels,

--- a/.github/bug_checker/llm.py
+++ b/.github/bug_checker/llm.py
@@ -11,8 +11,6 @@ try:
 except ImportError:
     anthropic = None  # type: ignore[assignment]
 
-from bug_checker.logger import logger
-
 DEFAULT_MODEL = "claude-sonnet-4-6"
 MAX_TOKENS = 4096
 
@@ -126,10 +124,7 @@ class LLMSession:
             (b for b in response.content if b.type == "tool_use"), None
         )
         if tool_use_block is None:
-            logger.warning(
-                f"Rule {rule_id}: expected tool_use response, got none — skipping"
-            )
-            return []
+            raise RuntimeError(f"Rule {rule_id}: expected tool_use response, got none")
 
         return self._build_findings(tool_use_block.input, rule_id, severity)
 

--- a/.github/bug_checker/llm.py
+++ b/.github/bug_checker/llm.py
@@ -81,16 +81,10 @@ class LLMSession:
             self.model = os.environ.get("BUG_CHECKER_MODEL", DEFAULT_MODEL)
         if self._client is None:
             if anthropic is None:
-                raise ImportError(
-                    "The 'anthropic' package is required. Install it with: pip install anthropic"
-                )
-            api_key = os.environ.get("BUG_CHECKER_API_KEY") or os.environ.get(
-                "ANTHROPIC_API_KEY"
-            )
+                raise ImportError("The 'anthropic' package is required. Install it with: pip install anthropic")
+            api_key = os.environ.get("BUG_CHECKER_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
             if not api_key:
-                raise ValueError(
-                    "Set BUG_CHECKER_API_KEY or ANTHROPIC_API_KEY environment variable"
-                )
+                raise ValueError("Set BUG_CHECKER_API_KEY or ANTHROPIC_API_KEY environment variable")
             self._client = anthropic.Anthropic(api_key=api_key)
 
     def analyze_rule(
@@ -106,9 +100,7 @@ class LLMSession:
         Each call is independent — no state is shared with previous calls.
         """
         system_prompt = self._build_system_prompt()
-        user_message = self._build_user_message(
-            rule_content, rule_id, severity, suggest_fix, diff
-        )
+        user_message = self._build_user_message(rule_content, rule_id, severity, suggest_fix, diff)
 
         response = self._client.messages.create(
             model=self.model,
@@ -120,9 +112,7 @@ class LLMSession:
             tool_choice={"type": "tool", "name": "report_findings"},
         )
 
-        tool_use_block = next(
-            (b for b in response.content if b.type == "tool_use"), None
-        )
+        tool_use_block = next((b for b in response.content if b.type == "tool_use"), None)
         if tool_use_block is None:
             raise RuntimeError(f"Rule {rule_id}: expected tool_use response, got none")
 
@@ -152,19 +142,13 @@ class LLMSession:
         ]
 
         if suggest_fix:
-            parts.append(
-                "\nPlease include a suggested_fix for each finding. Show the corrected code snippet.\n"
-            )
+            parts.append("\nPlease include a suggested_fix for each finding. Show the corrected code snippet.\n")
         else:
-            parts.append(
-                "\nDo NOT include suggested fixes. Leave suggested_fix null.\n"
-            )
+            parts.append("\nDo NOT include suggested fixes. Leave suggested_fix null.\n")
 
         return "\n".join(parts)
 
-    def _build_findings(
-        self, tool_input: dict, rule_id: str, severity: str
-    ) -> list[Finding]:
+    def _build_findings(self, tool_input: dict, rule_id: str, severity: str) -> list[Finding]:
         """Build Finding objects from a validated tool use input dict."""
         findings = []
         for item in tool_input.get("findings", []):

--- a/.github/bug_checker/manifest.yaml
+++ b/.github/bug_checker/manifest.yaml
@@ -13,7 +13,7 @@ rules:
   reshape-dim-check:
     file: reshape-dim-check.md
     severity: warning
-    suggest_fix: false
+    suggest_fix: true
     model: null
     paths:
       - "ttnn/cpp/ttnn/operations/data_movement/**"

--- a/.github/bug_checker/orchestrator.py
+++ b/.github/bug_checker/orchestrator.py
@@ -18,6 +18,10 @@ from .output import (
 from .rules import Rule, load_rules, select_rules
 
 
+class BugCheckFailed(RuntimeError):
+    """Raised when bug checker analysis is incomplete and must fail closed."""
+
+
 def run_bug_check(
     pr_info: PRInfo,
     sarif_path: Optional[Path] = None,
@@ -52,15 +56,24 @@ def run_bug_check(
     )
 
     # Preflight: verify LLM is configured before entering the per-rule loop.
-    # This is intentionally fail-closed for hard config errors (missing API key,
-    # missing anthropic package). Silently skipping every rule on a config error
-    # would give a false "no findings" result. The fail-open policy applies to
-    # per-rule runtime errors only (e.g. transient API failures).
-    LLMSession()
+    # Hard config errors must fail closed; otherwise a broken setup can look like
+    # a clean "no findings" result.
+    try:
+        LLMSession()
+    except Exception as e:
+        failed_rules = [rule.id for rule in matched_rules]
+        logger.exception("Bug Checker failed during LLM setup")
+        print_findings([])
+        if sarif_path:
+            write_sarif([], failed_rules, sarif_path)
+            logger.info(f"SARIF output written to {sarif_path}")
+        if post_comments:
+            _post_findings_as_comments(pr_info, [], failed_rules, [])
+        raise BugCheckFailed("Bug Checker failed during LLM setup") from e
 
     all_findings: list[Finding] = []
     rules_used: list[str] = []
-    skipped_rules: list[str] = []
+    failed_rules: list[str] = []
     truncated_rules: list[str] = []
     truncated_file_set = set(pr_info.truncated_files)
 
@@ -96,13 +109,13 @@ def run_bug_check(
             all_findings.extend(findings)
             logger.info(f"Rule {rule.id}: {len(findings)} finding(s)")
         except Exception:
-            skipped_rules.append(rule.id)
-            logger.exception(f"Rule {rule.id} failed — skipping")
+            failed_rules.append(rule.id)
+            logger.exception(f"Rule {rule.id} failed")
 
-    if skipped_rules:
-        logger.warning(
-            f"{len(skipped_rules)} rule(s) skipped due to errors: "
-            f"{', '.join(skipped_rules)}. Results may be incomplete."
+    if failed_rules:
+        logger.error(
+            f"{len(failed_rules)} rule(s) failed during LLM analysis: "
+            f"{', '.join(failed_rules)}. Failing the check."
         )
     if truncated_rules:
         logger.warning(
@@ -121,7 +134,13 @@ def run_bug_check(
     # Output: PR comments
     if post_comments:
         _post_findings_as_comments(
-            pr_info, all_findings, skipped_rules, truncated_rules
+            pr_info, all_findings, failed_rules, truncated_rules
+        )
+
+    if failed_rules:
+        raise BugCheckFailed(
+            "Bug Checker failed because one or more LLM analyses did not complete: "
+            + ", ".join(failed_rules)
         )
 
     return all_findings
@@ -196,7 +215,17 @@ def check_rule_command(
 
     logger.info(f"Running single rule: {rule.id}")
 
-    LLMSession()  # Preflight check
+    try:
+        LLMSession()  # Preflight check
+    except Exception as e:
+        logger.exception("Bug Checker failed during LLM setup")
+        print_findings([])
+        if sarif_path:
+            write_sarif([], [rule.id], sarif_path)
+            logger.info(f"SARIF output written to {sarif_path}")
+        if post_comments:
+            _post_findings_as_comments(pr_info, [], [rule.id], [])
+        raise BugCheckFailed("Bug Checker failed during LLM setup") from e
 
     filtered_diff = _filter_diff_for_rule(pr_info.diff, pr_info.changed_files, rule)
     if not filtered_diff:
@@ -206,14 +235,24 @@ def check_rule_command(
             post_pr_comment(pr_number=pr_info.number, body=f"## Bug Checker\n{msg}")
         return []
 
-    session = LLMSession(model=rule.model or "")
-    findings = session.analyze_rule(
-        rule_content=rule.content,
-        rule_id=rule.id,
-        severity=rule.severity,
-        suggest_fix=rule.suggest_fix,
-        diff=filtered_diff,
-    )
+    try:
+        session = LLMSession(model=rule.model or "")
+        findings = session.analyze_rule(
+            rule_content=rule.content,
+            rule_id=rule.id,
+            severity=rule.severity,
+            suggest_fix=rule.suggest_fix,
+            diff=filtered_diff,
+        )
+    except Exception as e:
+        logger.exception(f"Rule {rule.id} failed")
+        print_findings([])
+        if sarif_path:
+            write_sarif([], [rule.id], sarif_path)
+            logger.info(f"SARIF output written to {sarif_path}")
+        if post_comments:
+            _post_findings_as_comments(pr_info, [], [rule.id], [])
+        raise BugCheckFailed(f"Bug Checker failed while running rule {rule.id}") from e
 
     print_findings(findings)
     if sarif_path:
@@ -310,7 +349,7 @@ def _format_dry_run(
 def _post_findings_as_comments(
     pr_info: PRInfo,
     findings: list[Finding],
-    skipped_rules: list[str],
+    failed_rules: list[str],
     truncated_rules: list[str],
 ) -> None:
     """Post findings as PR comments (inline where valid, general otherwise) plus a summary."""
@@ -355,7 +394,7 @@ def _post_findings_as_comments(
         summary = format_summary_comment(
             findings,
             comment_failures=failed,
-            skipped_rules=skipped_rules,
+            failed_rules=failed_rules,
             truncated_rules=truncated_rules,
         )
         post_pr_comment(pr_number=pr_info.number, body=summary)

--- a/.github/bug_checker/orchestrator.py
+++ b/.github/bug_checker/orchestrator.py
@@ -50,10 +50,7 @@ def run_bug_check(
             )
         return []
 
-    logger.info(
-        f"Matched {len(matched_rules)} rule(s): "
-        f"{', '.join(r.id for r in matched_rules)}"
-    )
+    logger.info(f"Matched {len(matched_rules)} rule(s): " f"{', '.join(r.id for r in matched_rules)}")
 
     # Preflight: verify LLM is configured before entering the per-rule loop.
     # Hard config errors must fail closed; otherwise a broken setup can look like
@@ -80,13 +77,9 @@ def run_bug_check(
     for rule in matched_rules:
         rules_used.append(rule.id)
         try:
-            filtered_diff = _filter_diff_for_rule(
-                pr_info.diff, pr_info.changed_files, rule
-            )
+            filtered_diff = _filter_diff_for_rule(pr_info.diff, pr_info.changed_files, rule)
             if not filtered_diff:
-                matched_truncated = {
-                    f for f in pr_info.changed_files if rule.matches_pr([f], [])
-                } & truncated_file_set
+                matched_truncated = {f for f in pr_info.changed_files if rule.matches_pr([f], [])} & truncated_file_set
                 if matched_truncated:
                     truncated_rules.append(rule.id)
                     logger.warning(
@@ -94,9 +87,7 @@ def run_bug_check(
                         f"analysis skipped: {', '.join(sorted(matched_truncated))}"
                     )
                 else:
-                    logger.info(
-                        f"Rule {rule.id}: no matching diff sections — skipping LLM call"
-                    )
+                    logger.info(f"Rule {rule.id}: no matching diff sections — skipping LLM call")
                 continue
             session = LLMSession(model=rule.model or "")
             findings = session.analyze_rule(
@@ -114,8 +105,7 @@ def run_bug_check(
 
     if failed_rules:
         logger.error(
-            f"{len(failed_rules)} rule(s) failed during LLM analysis: "
-            f"{', '.join(failed_rules)}. Failing the check."
+            f"{len(failed_rules)} rule(s) failed during LLM analysis: " f"{', '.join(failed_rules)}. Failing the check."
         )
     if truncated_rules:
         logger.warning(
@@ -133,14 +123,11 @@ def run_bug_check(
 
     # Output: PR comments
     if post_comments:
-        _post_findings_as_comments(
-            pr_info, all_findings, failed_rules, truncated_rules
-        )
+        _post_findings_as_comments(pr_info, all_findings, failed_rules, truncated_rules)
 
     if failed_rules:
         raise BugCheckFailed(
-            "Bug Checker failed because one or more LLM analyses did not complete: "
-            + ", ".join(failed_rules)
+            "Bug Checker failed because one or more LLM analyses did not complete: " + ", ".join(failed_rules)
         )
 
     return all_findings
@@ -324,16 +311,12 @@ def _format_dry_run(
 
         lines.append(f"### `{rule.id}` ({rule.severity})")
         lines.append(f"- **Match reason:** {reason}")
-        lines.append(
-            f"- **Diff sections:** {len(diff_files)} file(s), {diff_line_count} line(s)"
-        )
+        lines.append(f"- **Diff sections:** {len(diff_files)} file(s), {diff_line_count} line(s)")
         if diff_files:
             for f in sorted(diff_files):
                 lines.append(f"  - `{f}`")
         else:
-            lines.append(
-                "  - (no diff sections — rule matched by label only or all matched files were truncated)"
-            )
+            lines.append("  - (no diff sections — rule matched by label only or all matched files were truncated)")
         lines.append("")
 
     if unmatched:
@@ -354,9 +337,7 @@ def _post_findings_as_comments(
 ) -> None:
     """Post findings as PR comments (inline where valid, general otherwise) plus a summary."""
     valid_diff_lines = diff_line_numbers(pr_info.diff)
-    rule_paths = {
-        rule.id: f".github/bug_checker/rules/{rule.file}" for rule in load_rules()
-    }
+    rule_paths = {rule.id: f".github/bug_checker/rules/{rule.file}" for rule in load_rules()}
 
     inline_posted = 0
     general_posted = 0
@@ -384,13 +365,9 @@ def _post_findings_as_comments(
                 general_posted += 1
         except Exception as e:
             failed += 1
-            logger.warning(
-                f"Failed to post comment for {finding.rule_id} at {finding.file}:{finding.line}: {e}"
-            )
+            logger.warning(f"Failed to post comment for {finding.rule_id} at {finding.file}:{finding.line}: {e}")
 
-    logger.info(
-        f"Comments: {inline_posted} inline, {general_posted} general, {failed} failed"
-    )
+    logger.info(f"Comments: {inline_posted} inline, {general_posted} general, {failed} failed")
 
     # Post summary comment
     try:

--- a/.github/bug_checker/orchestrator.py
+++ b/.github/bug_checker/orchestrator.py
@@ -12,6 +12,7 @@ from .logger import logger
 from .output import (
     format_pr_comment,
     format_summary_comment,
+    print_failure,
     print_findings,
     write_sarif,
 )
@@ -38,6 +39,7 @@ def run_bug_check(
         List of all findings.
     """
     all_rules = load_rules()
+    rule_paths = _rule_paths(all_rules)
     matched_rules = select_rules(all_rules, pr_info.changed_files, pr_info.labels)
 
     if not matched_rules:
@@ -60,12 +62,12 @@ def run_bug_check(
     except Exception as e:
         failed_rules = [rule.id for rule in matched_rules]
         logger.exception("Bug Checker failed during LLM setup")
-        print_findings([])
+        print_failure("Bug Checker failed during LLM setup", failed_rules)
         if sarif_path:
             write_sarif([], failed_rules, sarif_path)
             logger.info(f"SARIF output written to {sarif_path}")
         if post_comments:
-            _post_findings_as_comments(pr_info, [], failed_rules, [])
+            _post_findings_as_comments(pr_info, [], failed_rules, [], rule_paths)
         raise BugCheckFailed("Bug Checker failed during LLM setup") from e
 
     all_findings: list[Finding] = []
@@ -114,7 +116,12 @@ def run_bug_check(
         )
 
     # Output: CLI
-    print_findings(all_findings)
+    if all_findings:
+        print_findings(all_findings)
+    elif failed_rules:
+        print_failure("Bug Checker failed because one or more LLM analyses did not complete", failed_rules)
+    else:
+        print_findings([])
 
     # Output: SARIF
     if sarif_path:
@@ -123,7 +130,7 @@ def run_bug_check(
 
     # Output: PR comments
     if post_comments:
-        _post_findings_as_comments(pr_info, all_findings, failed_rules, truncated_rules)
+        _post_findings_as_comments(pr_info, all_findings, failed_rules, truncated_rules, rule_paths)
 
     if failed_rules:
         raise BugCheckFailed(
@@ -188,6 +195,7 @@ def check_rule_command(
 ) -> list[Finding]:
     """Run a single named rule against the PR. Error if rule not found."""
     all_rules = load_rules()
+    rule_paths = _rule_paths(all_rules)
     rule = next((r for r in all_rules if r.id == rule_id), None)
     if rule is None:
         available = ", ".join(r.id for r in all_rules)
@@ -206,12 +214,12 @@ def check_rule_command(
         LLMSession()  # Preflight check
     except Exception as e:
         logger.exception("Bug Checker failed during LLM setup")
-        print_findings([])
+        print_failure("Bug Checker failed during LLM setup", [rule.id])
         if sarif_path:
             write_sarif([], [rule.id], sarif_path)
             logger.info(f"SARIF output written to {sarif_path}")
         if post_comments:
-            _post_findings_as_comments(pr_info, [], [rule.id], [])
+            _post_findings_as_comments(pr_info, [], [rule.id], [], rule_paths)
         raise BugCheckFailed("Bug Checker failed during LLM setup") from e
 
     filtered_diff = _filter_diff_for_rule(pr_info.diff, pr_info.changed_files, rule)
@@ -233,19 +241,19 @@ def check_rule_command(
         )
     except Exception as e:
         logger.exception(f"Rule {rule.id} failed")
-        print_findings([])
+        print_failure(f"Bug Checker failed while running rule {rule.id}", [rule.id])
         if sarif_path:
             write_sarif([], [rule.id], sarif_path)
             logger.info(f"SARIF output written to {sarif_path}")
         if post_comments:
-            _post_findings_as_comments(pr_info, [], [rule.id], [])
+            _post_findings_as_comments(pr_info, [], [rule.id], [], rule_paths)
         raise BugCheckFailed(f"Bug Checker failed while running rule {rule.id}") from e
 
     print_findings(findings)
     if sarif_path:
         write_sarif(findings, [rule.id], sarif_path)
     if post_comments:
-        _post_findings_as_comments(pr_info, findings, [], [])
+        _post_findings_as_comments(pr_info, findings, [], [], rule_paths)
 
     return findings
 
@@ -329,15 +337,20 @@ def _format_dry_run(
     return "\n".join(lines)
 
 
+def _rule_paths(rules: list[Rule]) -> dict[str, str]:
+    """Return rule-id to markdown path links for PR comments."""
+    return {rule.id: f".github/bug_checker/rules/{rule.file}" for rule in rules}
+
+
 def _post_findings_as_comments(
     pr_info: PRInfo,
     findings: list[Finding],
     failed_rules: list[str],
     truncated_rules: list[str],
+    rule_paths: dict[str, str],
 ) -> None:
     """Post findings as PR comments (inline where valid, general otherwise) plus a summary."""
     valid_diff_lines = diff_line_numbers(pr_info.diff)
-    rule_paths = {rule.id: f".github/bug_checker/rules/{rule.file}" for rule in load_rules()}
 
     inline_posted = 0
     general_posted = 0

--- a/.github/bug_checker/orchestrator.py
+++ b/.github/bug_checker/orchestrator.py
@@ -354,6 +354,9 @@ def _post_findings_as_comments(
 ) -> None:
     """Post findings as PR comments (inline where valid, general otherwise) plus a summary."""
     valid_diff_lines = diff_line_numbers(pr_info.diff)
+    rule_paths = {
+        rule.id: f".github/bug_checker/rules/{rule.file}" for rule in load_rules()
+    }
 
     inline_posted = 0
     general_posted = 0
@@ -361,7 +364,7 @@ def _post_findings_as_comments(
 
     for finding in findings or []:
         line_in_diff = finding.line in valid_diff_lines.get(finding.file, set())
-        body = format_pr_comment(finding)
+        body = format_pr_comment(finding, rule_path=rule_paths.get(finding.rule_id))
         try:
             if line_in_diff:
                 post_pr_comment(

--- a/.github/bug_checker/output.py
+++ b/.github/bug_checker/output.py
@@ -11,6 +11,7 @@ from .llm import Finding
 from .logger import logger
 
 REPO = os.environ.get("GITHUB_REPOSITORY", "tenstorrent/tt-metal")
+DEFAULT_RULE_REF = "main"
 
 
 # --- SARIF ---
@@ -145,6 +146,16 @@ def print_findings(findings: list[Finding]) -> None:
         )
 
 
+def print_failure(message: str, failed_rules: list[str] | None = None) -> None:
+    """Print a CLI failure message without implying analysis passed."""
+    logger.opt(colors=True).error("<red><bold>[FAILED]</bold></red> {message}", message=message)
+    if failed_rules:
+        logger.opt(colors=True).error(
+            "<red>Failed rule(s):</red> {rules}",
+            rules=", ".join(failed_rules),
+        )
+
+
 # --- PR Comments ---
 
 
@@ -167,7 +178,18 @@ def _format_rule_label(rule_id: str, rule_path: str | None = None) -> str:
         return f"`{rule_id}`"
 
     quoted_path = quote(rule_path, safe="/")
-    return f"[`{rule_id}`](https://github.com/{REPO}/blob/main/{quoted_path})"
+    quoted_ref = quote(_rule_link_ref(), safe="")
+    return f"[`{rule_id}`](https://github.com/{REPO}/blob/{quoted_ref}/{quoted_path})"
+
+
+def _rule_link_ref() -> str:
+    """Return the Git ref used in rule definition links."""
+    return (
+        os.environ.get("BUG_CHECKER_RULE_REF")
+        or os.environ.get("GITHUB_SHA")
+        or os.environ.get("GITHUB_REF_NAME")
+        or DEFAULT_RULE_REF
+    )
 
 
 def format_summary_comment(

--- a/.github/bug_checker/output.py
+++ b/.github/bug_checker/output.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from urllib.parse import quote
 
 from .llm import Finding
 from .logger import logger
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "tenstorrent/tt-metal")
 
 
 # --- SARIF ---
@@ -146,11 +150,14 @@ def print_findings(findings: list[Finding]) -> None:
 # --- PR Comments ---
 
 
-def format_pr_comment(finding: Finding) -> str:
+def format_pr_comment(finding: Finding, rule_path: str | None = None) -> str:
     """Format a single finding as a PR comment body."""
-    severity_emoji = "!!!" if finding.severity == "blocking" else "?"
+    severity_emoji = (
+        ":red_circle:" if finding.severity == "blocking" else ":black_circle:"
+    )
+    rule_label = _format_rule_label(finding.rule_id, rule_path)
     parts = [
-        f"{severity_emoji} **Bug Checker [{finding.severity.upper()}]** `{finding.rule_id}`\n",
+        f"**Bug Checker [{finding.severity.upper()}]** {severity_emoji} {rule_label}\n",
         finding.message,
     ]
     if finding.suggested_fix:
@@ -158,6 +165,15 @@ def format_pr_comment(finding: Finding) -> str:
             f"\n**Suggested fix:**\n```suggestion\n{finding.suggested_fix}\n```"
         )
     return "\n".join(parts)
+
+
+def _format_rule_label(rule_id: str, rule_path: str | None = None) -> str:
+    """Format a rule id, linking to its markdown definition when available."""
+    if not rule_path:
+        return f"`{rule_id}`"
+
+    quoted_path = quote(rule_path, safe="/")
+    return f"[`{rule_id}`](https://github.com/{REPO}/blob/main/{quoted_path})"
 
 
 def format_summary_comment(

--- a/.github/bug_checker/output.py
+++ b/.github/bug_checker/output.py
@@ -163,17 +163,28 @@ def format_pr_comment(finding: Finding) -> str:
 def format_summary_comment(
     findings: list[Finding],
     comment_failures: int = 0,
-    skipped_rules: list[str] | None = None,
+    failed_rules: list[str] | None = None,
     truncated_rules: list[str] | None = None,
+    skipped_rules: list[str] | None = None,
 ) -> str:
     """Format a summary comment for the PR."""
+    if failed_rules is None:
+        failed_rules = skipped_rules
     blocking = [f for f in findings if f.severity == "blocking"]
     warnings = [f for f in findings if f.severity == "warning"]
 
-    lines = ["## Bug Checker Results\n"]
-    if not findings:
+    lines = ["## Bug Checker Failed\n" if failed_rules else "## Bug Checker Results\n"]
+    if failed_rules and not findings:
+        lines.append(
+            "The analysis did not complete, so this run cannot be treated as a pass."
+        )
+    elif not findings:
         lines.append("No issues found.")
     else:
+        if failed_rules:
+            lines.append(
+                "Partial findings were produced before the checker failed. Treat this run as failed.\n"
+            )
         if blocking:
             lines.append(f"**{len(blocking)} blocking issue(s) found.**\n")
         if warnings:
@@ -189,11 +200,11 @@ def format_summary_comment(
             f"truncated before their matched files: {rule_list}. Consider breaking this PR into smaller pieces."
         )
 
-    if skipped_rules:
-        rule_list = ", ".join(f"`{r}`" for r in skipped_rules)
+    if failed_rules:
+        rule_list = ", ".join(f"`{r}`" for r in failed_rules)
         lines.append(
-            f"\n> **Warning:** {len(skipped_rules)} rule(s) were skipped due to errors "
-            f"and may not have been checked: {rule_list}. Results may be incomplete."
+            f"\n> **Failure:** {len(failed_rules)} rule(s) failed during LLM analysis: "
+            f"{rule_list}. The GitHub check exits non-zero so this is not silently accepted."
         )
 
     if comment_failures:

--- a/.github/bug_checker/output.py
+++ b/.github/bug_checker/output.py
@@ -129,9 +129,7 @@ def print_findings(findings: list[Finding]) -> None:
         if f.suggested_fix:
             logger.opt(colors=True).info("<green>  Suggested fix:</green>")
             for fix_line in f.suggested_fix.splitlines():
-                logger.opt(colors=True).info(
-                    "<green>    {fix_line}</green>", fix_line=fix_line
-                )
+                logger.opt(colors=True).info("<green>    {fix_line}</green>", fix_line=fix_line)
 
     if blocking:
         logger.opt(colors=True).info(
@@ -152,18 +150,14 @@ def print_findings(findings: list[Finding]) -> None:
 
 def format_pr_comment(finding: Finding, rule_path: str | None = None) -> str:
     """Format a single finding as a PR comment body."""
-    severity_emoji = (
-        ":red_circle:" if finding.severity == "blocking" else ":black_circle:"
-    )
+    severity_emoji = ":red_circle:" if finding.severity == "blocking" else ":black_circle:"
     rule_label = _format_rule_label(finding.rule_id, rule_path)
     parts = [
         f"**Bug Checker [{finding.severity.upper()}]** {severity_emoji} {rule_label}\n",
         finding.message,
     ]
     if finding.suggested_fix:
-        parts.append(
-            f"\n**Suggested fix:**\n```suggestion\n{finding.suggested_fix}\n```"
-        )
+        parts.append(f"\n**Suggested fix:**\n```suggestion\n{finding.suggested_fix}\n```")
     return "\n".join(parts)
 
 
@@ -191,16 +185,12 @@ def format_summary_comment(
 
     lines = ["## Bug Checker Failed\n" if failed_rules else "## Bug Checker Results\n"]
     if failed_rules and not findings:
-        lines.append(
-            "The analysis did not complete, so this run cannot be treated as a pass."
-        )
+        lines.append("The analysis did not complete, so this run cannot be treated as a pass.")
     elif not findings:
         lines.append("No issues found.")
     else:
         if failed_rules:
-            lines.append(
-                "Partial findings were produced before the checker failed. Treat this run as failed.\n"
-            )
+            lines.append("Partial findings were produced before the checker failed. Treat this run as failed.\n")
         if blocking:
             lines.append(f"**{len(blocking)} blocking issue(s) found.**\n")
         if warnings:
@@ -224,8 +214,6 @@ def format_summary_comment(
         )
 
     if comment_failures:
-        lines.append(
-            f"\n> **Note:** {comment_failures} comment(s) could not be posted due to API errors."
-        )
+        lines.append(f"\n> **Note:** {comment_failures} comment(s) could not be posted due to API errors.")
 
     return "\n".join(lines)

--- a/.github/bug_checker/tests/test_github_client.py
+++ b/.github/bug_checker/tests/test_github_client.py
@@ -17,7 +17,6 @@ from bug_checker.github_client import (
     fetch_pr_info,
 )
 
-
 DIFF_SINGLE_HUNK = """\
 diff --git a/foo/bar.cpp b/foo/bar.cpp
 index abc..def 100644
@@ -160,6 +159,7 @@ def test_fetch_pr_info_uses_gh_fields_supported_by_older_clients(mock_gh):
             "title": "Test PR",
             "labels": [{"name": "area:ops"}],
             "files": [{"path": "ttnn/foo.cpp"}],
+            "commits": [{"oid": "base"}, {"oid": "head"}],
         }
     )
     diff = "diff --git a/ttnn/foo.cpp b/ttnn/foo.cpp\n@@ -1 +1 @@\n+new\n"
@@ -169,7 +169,7 @@ def test_fetch_pr_info_uses_gh_fields_supported_by_older_clients(mock_gh):
 
     assert pr_info.title == "Test PR"
     assert pr_info.base_sha == ""
-    assert pr_info.head_sha == ""
+    assert pr_info.head_sha == "head"
     assert pr_info.changed_files == ["ttnn/foo.cpp"]
     assert pr_info.labels == ["area:ops"]
     assert pr_info.diff == diff
@@ -180,7 +180,7 @@ def test_fetch_pr_info_uses_gh_fields_supported_by_older_clients(mock_gh):
         "--repo",
         "tenstorrent/tt-metal",
         "--json",
-        "title,labels,files",
+        "title,labels,files,commits",
     )
 
 

--- a/.github/bug_checker/tests/test_github_client.py
+++ b/.github/bug_checker/tests/test_github_client.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for diff_line_numbers, diff_file_paths, _truncate_diff, and check_prerequisites."""
+"""Tests for GitHub client helpers."""
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +14,7 @@ from bug_checker.github_client import (
     check_prerequisites,
     diff_file_paths,
     diff_line_numbers,
+    fetch_pr_info,
 )
 
 
@@ -148,6 +150,40 @@ def test_diff_file_paths_empty():
     assert diff_file_paths("") == set()
 
 
+# --- fetch_pr_info ---
+
+
+@patch("bug_checker.github_client._gh")
+def test_fetch_pr_info_uses_gh_fields_supported_by_older_clients(mock_gh):
+    pr_json = json.dumps(
+        {
+            "title": "Test PR",
+            "labels": [{"name": "area:ops"}],
+            "files": [{"path": "ttnn/foo.cpp"}],
+        }
+    )
+    diff = "diff --git a/ttnn/foo.cpp b/ttnn/foo.cpp\n@@ -1 +1 @@\n+new\n"
+    mock_gh.side_effect = [pr_json, diff]
+
+    pr_info = fetch_pr_info(123)
+
+    assert pr_info.title == "Test PR"
+    assert pr_info.base_sha == ""
+    assert pr_info.head_sha == ""
+    assert pr_info.changed_files == ["ttnn/foo.cpp"]
+    assert pr_info.labels == ["area:ops"]
+    assert pr_info.diff == diff
+    mock_gh.assert_any_call(
+        "pr",
+        "view",
+        "123",
+        "--repo",
+        "tenstorrent/tt-metal",
+        "--json",
+        "title,labels,files",
+    )
+
+
 # --- _truncate_diff ---
 
 
@@ -176,9 +212,7 @@ def test_truncate_diff_identifies_cut_files():
 
     # file_a alone exceeds MAX_DIFF_LINES, so file_b's header falls after the cutoff.
     # file_a's header survived but its content is partial, so both are truncated.
-    diff = _make_diff_for_files(
-        ["file_a.cpp", "file_b.cpp"], lines_per_file=MAX_DIFF_LINES
-    )
+    diff = _make_diff_for_files(["file_a.cpp", "file_b.cpp"], lines_per_file=MAX_DIFF_LINES)
     result_diff, truncated = _truncate_diff(diff, ["file_a.cpp", "file_b.cpp"])
     assert "file_b.cpp" in truncated
     assert "file_a.cpp" in truncated

--- a/.github/bug_checker/tests/test_llm.py
+++ b/.github/bug_checker/tests/test_llm.py
@@ -4,6 +4,10 @@
 
 """Tests for LLM tool-use parsing (does not call the API)."""
 
+from types import SimpleNamespace
+
+import pytest
+
 from bug_checker.llm import LLMSession
 
 
@@ -91,3 +95,22 @@ def test_session_has_no_messages_state():
         "LLMSession.messages was re-introduced; each analyze_rule call must be "
         "a fresh single-turn request with no shared history."
     )
+
+
+def test_analyze_rule_raises_when_tool_use_missing():
+    s = _session()
+    s.model = "test-model"
+    s._client = SimpleNamespace(
+        messages=SimpleNamespace(
+            create=lambda **_kwargs: SimpleNamespace(content=[])
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="expected tool_use"):
+        s.analyze_rule(
+            rule_content="# Rule",
+            rule_id="test-rule",
+            severity="warning",
+            suggest_fix=False,
+            diff="",
+        )

--- a/.github/bug_checker/tests/test_llm.py
+++ b/.github/bug_checker/tests/test_llm.py
@@ -71,11 +71,7 @@ def test_build_findings_multiple():
 def test_build_findings_suggested_fix_empty_string_normalized():
     # Empty string suggested_fix should be normalized to None
     s = _session()
-    tool_input = {
-        "findings": [
-            {"file": "a.cpp", "line": 1, "message": "Bug", "suggested_fix": ""}
-        ]
-    }
+    tool_input = {"findings": [{"file": "a.cpp", "line": 1, "message": "Bug", "suggested_fix": ""}]}
     findings = s._build_findings(tool_input, "rule-1", "blocking")
     assert findings[0].suggested_fix is None
 
@@ -100,11 +96,7 @@ def test_session_has_no_messages_state():
 def test_analyze_rule_raises_when_tool_use_missing():
     s = _session()
     s.model = "test-model"
-    s._client = SimpleNamespace(
-        messages=SimpleNamespace(
-            create=lambda **_kwargs: SimpleNamespace(content=[])
-        )
-    )
+    s._client = SimpleNamespace(messages=SimpleNamespace(create=lambda **_kwargs: SimpleNamespace(content=[])))
 
     with pytest.raises(RuntimeError, match="expected tool_use"):
         s.analyze_rule(

--- a/.github/bug_checker/tests/test_orchestrator.py
+++ b/.github/bug_checker/tests/test_orchestrator.py
@@ -112,9 +112,7 @@ def test_empty_diff_returns_empty():
 @patch("bug_checker.orchestrator.LLMSession")
 @patch("bug_checker.orchestrator.select_rules")
 @patch("bug_checker.orchestrator.load_rules")
-def test_run_bug_check_fails_closed_when_llm_rule_errors(
-    mock_load, mock_select, mock_llm_cls, mock_post
-):
+def test_run_bug_check_fails_closed_when_llm_rule_errors(mock_load, mock_select, mock_llm_cls, mock_post):
     rule = _rule(["foo/**"])
     mock_load.return_value = [rule]
     mock_select.return_value = [rule]

--- a/.github/bug_checker/tests/test_orchestrator.py
+++ b/.github/bug_checker/tests/test_orchestrator.py
@@ -4,7 +4,12 @@
 
 """Tests for orchestrator internals — diff filtering."""
 
-from bug_checker.orchestrator import _filter_diff_for_rule
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bug_checker.github_client import PRInfo
+from bug_checker.orchestrator import BugCheckFailed, _filter_diff_for_rule, run_bug_check
 from bug_checker.rules import Rule
 
 
@@ -101,3 +106,38 @@ def test_single_file_diff():
 def test_empty_diff_returns_empty():
     rule = _rule(["foo/**"])
     assert _filter_diff_for_rule("", ["foo/bar.cpp"], rule) == ""
+
+
+@patch("bug_checker.orchestrator.post_pr_comment")
+@patch("bug_checker.orchestrator.LLMSession")
+@patch("bug_checker.orchestrator.select_rules")
+@patch("bug_checker.orchestrator.load_rules")
+def test_run_bug_check_fails_closed_when_llm_rule_errors(
+    mock_load, mock_select, mock_llm_cls, mock_post
+):
+    rule = _rule(["foo/**"])
+    mock_load.return_value = [rule]
+    mock_select.return_value = [rule]
+
+    mock_session = MagicMock()
+    mock_session.analyze_rule.side_effect = RuntimeError("rate limited")
+    mock_llm_cls.side_effect = [MagicMock(), mock_session]
+
+    pr = PRInfo(
+        number=99,
+        title="Test PR",
+        base_sha="aaa",
+        head_sha="bbb",
+        diff=DIFF_TWO_FILES,
+        changed_files=["foo/bar.cpp", "baz/qux.cpp"],
+        labels=[],
+    )
+
+    with pytest.raises(BugCheckFailed):
+        run_bug_check(pr, post_comments=True)
+
+    mock_post.assert_called_once()
+    body = mock_post.call_args[1]["body"]
+    assert "Bug Checker Failed" in body
+    assert "`test-rule`" in body
+    assert "exits non-zero" in body

--- a/.github/bug_checker/tests/test_orchestrator.py
+++ b/.github/bug_checker/tests/test_orchestrator.py
@@ -131,8 +131,14 @@ def test_run_bug_check_fails_closed_when_llm_rule_errors(mock_load, mock_select,
         labels=[],
     )
 
-    with pytest.raises(BugCheckFailed):
-        run_bug_check(pr, post_comments=True)
+    with patch("bug_checker.orchestrator.print_failure") as mock_print_failure:
+        with pytest.raises(BugCheckFailed):
+            run_bug_check(pr, post_comments=True)
+
+    mock_print_failure.assert_called_once_with(
+        "Bug Checker failed because one or more LLM analyses did not complete",
+        ["test-rule"],
+    )
 
     mock_post.assert_called_once()
     body = mock_post.call_args[1]["body"]

--- a/.github/bug_checker/tests/test_output.py
+++ b/.github/bug_checker/tests/test_output.py
@@ -73,6 +73,19 @@ def test_format_pr_comment():
     assert "Something is wrong" in comment
 
 
+def test_format_pr_comment_links_rule_path():
+    finding = _make_finding(rule_id="reshape-dim-check")
+    comment = format_pr_comment(
+        finding,
+        rule_path=".github/bug_checker/rules/reshape-dim-check.md",
+    )
+    expected_link = (
+        "[`reshape-dim-check`](https://github.com/tenstorrent/tt-metal/blob/main/"
+        ".github/bug_checker/rules/reshape-dim-check.md)"
+    )
+    assert expected_link in comment
+
+
 def test_format_pr_comment_with_fix():
     finding = _make_finding(suggested_fix="auto x = correct();")
     comment = format_pr_comment(finding)

--- a/.github/bug_checker/tests/test_output.py
+++ b/.github/bug_checker/tests/test_output.py
@@ -73,7 +73,10 @@ def test_format_pr_comment():
     assert "Something is wrong" in comment
 
 
-def test_format_pr_comment_links_rule_path():
+def test_format_pr_comment_links_rule_path(monkeypatch):
+    monkeypatch.delenv("BUG_CHECKER_RULE_REF", raising=False)
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
     finding = _make_finding(rule_id="reshape-dim-check")
     comment = format_pr_comment(
         finding,
@@ -81,6 +84,20 @@ def test_format_pr_comment_links_rule_path():
     )
     expected_link = (
         "[`reshape-dim-check`](https://github.com/tenstorrent/tt-metal/blob/main/"
+        ".github/bug_checker/rules/reshape-dim-check.md)"
+    )
+    assert expected_link in comment
+
+
+def test_format_pr_comment_links_rule_path_with_configured_ref(monkeypatch):
+    monkeypatch.setenv("BUG_CHECKER_RULE_REF", "release/1.0")
+    finding = _make_finding(rule_id="reshape-dim-check")
+    comment = format_pr_comment(
+        finding,
+        rule_path=".github/bug_checker/rules/reshape-dim-check.md",
+    )
+    expected_link = (
+        "[`reshape-dim-check`](https://github.com/tenstorrent/tt-metal/blob/release%2F1.0/"
         ".github/bug_checker/rules/reshape-dim-check.md)"
     )
     assert expected_link in comment

--- a/.github/bug_checker/tests/test_output.py
+++ b/.github/bug_checker/tests/test_output.py
@@ -96,25 +96,26 @@ def test_format_summary_comment_with_failures():
     assert "2 comment(s) could not be posted" in summary
 
 
-def test_format_summary_comment_with_skipped_rules():
+def test_format_summary_comment_with_failed_rules():
     summary = format_summary_comment(
-        [], skipped_rules=["ccl-ring-buffer-mismatch", "reshape-dim-check"]
+        [], failed_rules=["ccl-ring-buffer-mismatch", "reshape-dim-check"]
     )
-    assert "2 rule(s) were skipped" in summary
+    assert "Bug Checker Failed" in summary
+    assert "2 rule(s) failed" in summary
     assert "`ccl-ring-buffer-mismatch`" in summary
     assert "`reshape-dim-check`" in summary
-    assert "Results may be incomplete" in summary
+    assert "exits non-zero" in summary
 
 
-def test_format_summary_comment_skipped_rules_shown_even_with_no_findings():
-    summary = format_summary_comment([], skipped_rules=["my-rule"])
-    assert "No issues found" in summary
+def test_format_summary_comment_failed_rules_shown_even_with_no_findings():
+    summary = format_summary_comment([], failed_rules=["my-rule"])
+    assert "cannot be treated as a pass" in summary
     assert "my-rule" in summary
 
 
-def test_format_summary_comment_no_skipped_rules_no_note():
+def test_format_summary_comment_no_failed_rules_no_note():
     summary = format_summary_comment([_make_finding()])
-    assert "skipped" not in summary
+    assert "failed during LLM analysis" not in summary
 
 
 def test_format_summary_comment_with_truncated_rules():

--- a/.github/bug_checker/tests/test_output.py
+++ b/.github/bug_checker/tests/test_output.py
@@ -110,9 +110,7 @@ def test_format_summary_comment_with_failures():
 
 
 def test_format_summary_comment_with_failed_rules():
-    summary = format_summary_comment(
-        [], failed_rules=["ccl-ring-buffer-mismatch", "reshape-dim-check"]
-    )
+    summary = format_summary_comment([], failed_rules=["ccl-ring-buffer-mismatch", "reshape-dim-check"])
     assert "Bug Checker Failed" in summary
     assert "2 rule(s) failed" in summary
     assert "`ccl-ring-buffer-mismatch`" in summary

--- a/.github/bug_checker/tests/test_rules.py
+++ b/.github/bug_checker/tests/test_rules.py
@@ -104,8 +104,8 @@ def test_select_rules():
     assert any(r.id == "ccl-ring-buffer-mismatch" for r in selected)
     assert not any(r.id == "reshape-dim-check" for r in selected)
 
+
 def test_select_rules_by_label():
     rules = load_rules()
     selected = select_rules(rules, changed_files=[], pr_labels=["area:ops"])
     assert any(r.id == "reshape-dim-check" for r in selected)
-

--- a/.github/bug_checker/tests/test_rules.py
+++ b/.github/bug_checker/tests/test_rules.py
@@ -104,8 +104,8 @@ def test_select_rules():
     assert any(r.id == "ccl-ring-buffer-mismatch" for r in selected)
     assert not any(r.id == "reshape-dim-check" for r in selected)
 
-
 def test_select_rules_by_label():
     rules = load_rules()
     selected = select_rules(rules, changed_files=[], pr_labels=["area:ops"])
     assert any(r.id == "reshape-dim-check" for r in selected)
+

--- a/.github/workflows/bug-check.yaml
+++ b/.github/workflows/bug-check.yaml
@@ -124,7 +124,7 @@ jobs:
           elif [ "$SUBCOMMAND" = "check-rule" ]; then
             NOTICE="**Bug Checker** — running rule \`$RULE_ID\`…"
           else
-            NOTICE="**Bug Checker** — scanning PR for known bug patterns…"
+            NOTICE="**Bug Checker** — scanning PR for known bug patterns… See the [Bug Checker README](https://github.com/$REPO/blob/main/.github/bug_checker/README.md) for what this tool does."
           fi
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$NOTICE"
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
Improves the PR Bug Checker so incomplete LLM analysis is visible and fails closed instead of looking like a clean pass, while also making reviewer-facing comments easier to understand and link back to the rule definitions that produced them.

Changes:
- Fail closed when LLM setup or per-rule analysis errors: post a `Bug Checker Failed` summary and exit non-zero
- Treat missing Claude tool-use responses as errors instead of returning no findings
- Print explicit `[FAILED]` CLI output on failed analysis paths instead of misleading `No findings.` messages
- Link finding rule IDs to their markdown definitions in PR comments
- Make rule links use `BUG_CHECKER_RULE_REF`, `GITHUB_SHA`, or `GITHUB_REF_NAME`, falling back to `main`
- Avoid reloading rule files while posting comments by passing a precomputed rule path map
- Preserve inline PR comments on older `gh` versions by reading PR head SHA from the compatible `commits` field instead of unsupported `baseRefOid` / `headRefOid`
- Point the `/bug-check run` running notice at the Bug Checker README
- Enable suggested fixes for the `reshape-dim-check` rule
- Reorganize the Bug Checker README so rule authoring comes before local CLI usage

### Notes for reviewers
- The main behavior change is fail-closed LLM handling; skipped or failed rules should no longer leave the check green with incomplete coverage.
- PR comment formatting now uses GitHub emoji shortcodes and links rule IDs to `.github/bug_checker/rules/*.md` at the ref used for the run.
- Diff truncation behavior is unchanged; truncated rules still only produce warnings.
- `issue_comment` workflows run from the default branch workflow definition, so live `/bug-check run` comments on this PR do not reflect workflow-file changes until they land on `main`. The branch implementation was verified locally instead.

### Test plan
- [x] Added/updated unit tests for fail-closed orchestration, missing tool-use handling, linked PR comment formatting, configurable rule-link refs, and `gh` compatibility
- [x] Ran full bug checker unit suite: `PYTHONPATH=.github python -m pytest .github/bug_checker/tests/ -v` (`78 passed`)
- [x] Ran `black --check` on touched bug checker files
- [x] Ran local branch-mode bug checker with simulated `area:ops` label and real `BUG_CHECKER_API_KEY`; `reshape-dim-check` ran and returned `0 finding(s)`
- [x] Simulated LLM authentication failure with a bad key; command exited `1` and printed explicit `[FAILED]` output
- [x] Ran local PR-mode smoke test: `run_bug_checker.py --pr 44845 --sarif /tmp/bug-checker-pr-44845.sarif --verbose`
- [x] Posted `/bug-check run` on this PR and confirmed the workflow runs from `main`; this validates the workflow dispatch behavior but not the changed running notice until after merge

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stevendae/pr-bug-checker-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stevendae/pr-bug-checker-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stevendae/pr-bug-checker-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stevendae/pr-bug-checker-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stevendae/pr-bug-checker-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stevendae/pr-bug-checker-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stevendae/pr-bug-checker-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stevendae/pr-bug-checker-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stevendae/pr-bug-checker-update)