### PR TITLE
[Bug fix][Quasar] noc_init: cap MAX_BYTES_IN_PACKET at 8KB and init cmd buffers on DM>0

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -112,7 +112,6 @@ void device_setup() {
     // clock gating
     set_deassert_addresses();
     setup_isr_csrs();
-    noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
     // wzeromem
     // invalidate_l1_cache
     // clear_destination_registers
@@ -221,6 +220,7 @@ extern "C" uint32_t _start1() {
         wait_subordinates();
         mailboxes->go_messages[0].signal = RUN_MSG_DONE;
 
+        noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
         trigger_sync_register_init();
 
         DeviceProfilerInit();
@@ -295,7 +295,6 @@ extern "C" uint32_t _start1() {
                 my_relative_x_ = my_logical_x_ - launch_msg_address->kernel_config.sub_device_origin_x;
                 my_relative_y_ = my_logical_y_ - launch_msg_address->kernel_config.sub_device_origin_y;
                 overlay_cmd_buff_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
-                noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
                 // re-initialize the NoCs
                 // uint8_t cmd_buf;
                 // if (noc_mode == DM_DEDICATED_NOC) {

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -110,9 +110,9 @@ void device_setup() {
     // instn_buf
     // pc_buf
     // clock gating
-    // NOC setup
     set_deassert_addresses();
     setup_isr_csrs();
+    noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
     // wzeromem
     // invalidate_l1_cache
     // clear_destination_registers
@@ -210,8 +210,6 @@ extern "C" uint32_t _start1() {
     device_setup();
     if (hartid > 0) {
         signal_subordinate_completion();
-        // Set up overlay command buffers - legacy name
-        noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
     } else {  // This is DM0
         risc_init();
         noc_bank_table_init(MEM_BANK_TO_NOC_SCRATCH);
@@ -296,7 +294,7 @@ extern "C" uint32_t _start1() {
                 // noc_mode = launch_msg_address->kernel_config.brisc_noc_mode;
                 my_relative_x_ = my_logical_x_ - launch_msg_address->kernel_config.sub_device_origin_x;
                 my_relative_y_ = my_logical_y_ - launch_msg_address->kernel_config.sub_device_origin_y;
-                // Set up overlay command buffers - legacy name
+                overlay_cmd_buff_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
                 noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
                 // re-initialize the NoCs
                 // uint8_t cmd_buf;
@@ -416,6 +414,7 @@ extern "C" uint32_t _start1() {
         setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
+        overlay_cmd_buff_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
 
         WAYPOINT("R1");
         while (*((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) != RUN_SYNC_MSG_GO) {

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -210,6 +210,8 @@ extern "C" uint32_t _start1() {
     device_setup();
     if (hartid > 0) {
         signal_subordinate_completion();
+        // Set up overlay command buffers - legacy name
+        noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
     } else {  // This is DM0
         risc_init();
         noc_bank_table_init(MEM_BANK_TO_NOC_SCRATCH);
@@ -294,6 +296,7 @@ extern "C" uint32_t _start1() {
                 // noc_mode = launch_msg_address->kernel_config.brisc_noc_mode;
                 my_relative_x_ = my_logical_x_ - launch_msg_address->kernel_config.sub_device_origin_x;
                 my_relative_y_ = my_logical_y_ - launch_msg_address->kernel_config.sub_device_origin_y;
+                // Set up overlay command buffers - legacy name
                 noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
                 // re-initialize the NoCs
                 // uint8_t cmd_buf;

--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -82,6 +82,7 @@ uint32_t _start() {
 
     if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
 #if defined(NOC_API_V2)
+        overlay_cmd_buff_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
         noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
 #endif
     }

--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -81,10 +81,7 @@ uint32_t _start() {
     }
 
     if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
-#if defined(NOC_API_V2)
         overlay_cmd_buff_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
-        noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
-#endif
     }
 #ifdef ALIGN_LOCAL_CBS_TO_REMOTE_CBS
     ALIGN_LOCAL_CBS_TO_REMOTE_CBS

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v1.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v1.h
@@ -513,6 +513,10 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(
     return (NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED) == noc_nonposted_atomics_acked[noc]);
 }
 
+inline __attribute__((always_inline)) void overlay_cmd_buff_init(uint32_t atomic_ret_val) {
+    // Added for compatability with V2, no local cmd buffers in V1
+}
+
 inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
 #pragma GCC unroll 0
     for (int noc = 0; noc < NUM_NOCS; noc++) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -268,7 +268,7 @@ inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN);
 }
 
-inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
+inline __attribute__((always_inline)) void overlay_cmd_buff_init(uint32_t atomic_ret_val) {
     constexpr uint32_t noc = 0;
     uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc, 0, NOC_NODE_ID);
     uint32_t my_x = noc_id_reg & NOC_NODE_ID_MASK;
@@ -328,6 +328,10 @@ inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_WR_RESP_VC);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MAX_BYTES_IN_PACKET_REG_OFFSET / 8, NOC_V2_MAX_BYTES_IN_PACKET);
+}
+
+inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
+    // TODO: Add ATT configuration here
 }
 
 // set noc local memory state for a single kernel from the global state
@@ -392,7 +396,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read(
         cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, len_bytes);
     __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
 
-    uint32_t num_packets = len_bytes / NOC_MAX_BURST_SIZE + ((len_bytes % NOC_MAX_BURST_SIZE) ? 1 : 0);
+    uint32_t num_packets = len_bytes / NOC_V2_MAX_BYTES_IN_PACKET + ((len_bytes % NOC_V2_MAX_BYTES_IN_PACKET) ? 1 : 0);
     noc_reads_num_issued[noc] += num_packets;
 }
 
@@ -460,7 +464,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
 
     if constexpr (update_counter) {
-        uint32_t num_packets = len_bytes / NOC_MAX_BURST_SIZE + ((len_bytes % NOC_MAX_BURST_SIZE) ? 1 : 0);
+        uint32_t num_packets =
+            len_bytes / NOC_V2_MAX_BYTES_IN_PACKET + ((len_bytes % NOC_V2_MAX_BYTES_IN_PACKET) ? 1 : 0);
         if (posted) {
             noc_posted_writes_num_issued[noc] += num_packets;
         } else {
@@ -514,7 +519,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
 
     if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        uint32_t num_packets = len_bytes / NOC_MAX_BURST_SIZE + ((len_bytes % NOC_MAX_BURST_SIZE) ? 1 : 0);
+        uint32_t num_packets =
+            len_bytes / NOC_V2_MAX_BYTES_IN_PACKET + ((len_bytes % NOC_V2_MAX_BYTES_IN_PACKET) ? 1 : 0);
         noc_nonposted_writes_num_issued[noc] += num_packets;
         noc_nonposted_writes_acked[noc] += num_dests * num_packets;
     }
@@ -853,7 +859,7 @@ inline __attribute__((always_inline)) void noc_issue_transaction() {
  * | len_bytes                       | Size of the transaction in bytes.                  | uint32_t  | 0..1 MB                                                  | False    |
  * | vc                              | Which VC to use for the transaction                | uint32_t  | 0 - 3                                                    | False    |
  * | noc_mode (template parameter)   | NOC mode for the transaction                       | uint8_t   | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
- * | one_packet (template parameter) | Whether transaction size is <= NOC_MAX_BURST_SIZE  | bool      | true or false                                            | False    |
+ * | one_packet (template parameter) | Whether transaction size is <= NOC_V2_MAX_BYTES_IN_PACKET  | bool      | true or false                                            | False    |
  * | use_vc (template parameter)     | Use custom VC, enables vc parameter                | bool      | true or false                                            | False    |
  */
 // clang-format on
@@ -881,7 +887,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_read_set_state(
 /**
  * Initiates an asynchronous read from a specified source node located at NOC
  * coordinates (x,y) at a local address (encoded as a uint64_t using \a
- * get_noc_addr function) for a single packet with size <= NOC_MAX_BURST_SIZE (i.e. maximum packet size).
+ * get_noc_addr function) for a single packet with size <= NOC_V2_MAX_BYTES_IN_PACKET (i.e. maximum packet size).
  * This function must be preceded by a call to \a ncrisc_noc_read_set_state.
  * This function is used to issue the actual read request after the state has been set up.
  *
@@ -896,7 +902,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_read_set_state(
  * | len_bytes                           | Size of transaction in bytes                       | uint32_t  | 0..1 MB                                                  | False    |
  * | noc_mode (template parameter)       | NOC mode for the transaction                       | uint8_t   | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
  * | inc_num_issued (template parameter) | Increment enable for transaction issued counters   | bool      | true or false                                            | False    |
- * | one_packet (template parameter)     | Whether transaction size is <= NOC_MAX_BURST_SIZE  | bool      | true or false                                            | False    |
+ * | one_packet (template parameter)     | Whether transaction size is <= NOC_V2_MAX_BYTES_IN_PACKET  | bool      | true or false                                            | False    |
  */
 // clang-format on
 template <uint8_t noc_mode = DM_DEDICATED_NOC, bool inc_num_issued = true, bool one_packet = false>
@@ -918,7 +924,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_read_with_state(
         if constexpr (one_packet) {
             noc_reads_num_issued[noc] += 1;
         } else {
-            uint32_t num_packets = len_bytes / NOC_MAX_BURST_SIZE + ((len_bytes % NOC_MAX_BURST_SIZE) ? 1 : 0);
+            uint32_t num_packets =
+                len_bytes / NOC_V2_MAX_BYTES_IN_PACKET + ((len_bytes % NOC_V2_MAX_BYTES_IN_PACKET) ? 1 : 0);
             noc_reads_num_issued[noc] += num_packets;
         }
     }
@@ -970,7 +977,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_read_any_len_with_state(
  * | len_bytes                       | Size of the transaction in bytes.                        | uint32_t  | 0..1 MB                          | False    |
  * | vc                              | Which VC to use for the transaction                      | uint32_t  | 0 - 3                            | False    |
  * | posted (template parameter)     | Whether the transaction is posted (i.e. no ack required) | bool      | true or false                    | False    |
- * | one_packet (template parameter) | Whether transaction size is <= NOC_MAX_BURST_SIZE        | bool      | true or false                    | False    |
+ * | one_packet (template parameter) | Whether transaction size is <= NOC_V2_MAX_BYTES_IN_PACKET        | bool      | true or false                    | False    |
  */
 // clang-format on
 template <bool posted = false, bool one_packet = false>
@@ -1015,7 +1022,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
  * | noc_mode (template parameter)       | NOC mode for the transaction                             | uint8_t   | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
  * | posted (template parameter)         | Whether the transaction is posted (i.e. no ack required) | bool      | true or false                                            | False    |
  * | update_counter (template parameter) | Whether to increment write counters                      | bool      | true or false                                            | False    |
- * | one_packet (template parameter)     | Whether transaction size is <= NOC_MAX_BURST_SIZE        | bool      | true or false                                            | False    |
+ * | one_packet (template parameter)     | Whether transaction size is <= NOC_V2_MAX_BYTES_IN_PACKET        | bool      | true or false                                            | False    |
  */
 // clang-format on
 template <uint8_t noc_mode = DM_DEDICATED_NOC, bool posted = false, bool update_counter = true, bool one_packet = false>
@@ -1042,7 +1049,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
                 noc_nonposted_writes_acked[noc] += 1;
             }
         } else {
-            uint32_t num_packets = len_bytes / NOC_MAX_BURST_SIZE + ((len_bytes % NOC_MAX_BURST_SIZE) ? 1 : 0);
+            uint32_t num_packets =
+                len_bytes / NOC_V2_MAX_BYTES_IN_PACKET + ((len_bytes % NOC_V2_MAX_BYTES_IN_PACKET) ? 1 : 0);
             if constexpr (posted) {
                 noc_posted_writes_num_issued[noc] += num_packets;
             } else {
@@ -1427,7 +1435,7 @@ inline __attribute__((always_inline)) void noc_read_init_state(uint32_t noc) {
  * | noc                           | Which NOC to use for the transaction                     | uint32_t         | 0 or 1                                                   | True     |
  * | src_addr                      | Source NOC address (x,y)+local address                   | uint64_t         | Results of \a get_noc_addr calls                         | True     |
  * | dst_addr                      | Destination address in local L1 memory                   | uint32_t         | 0..1 MB                                                  | True     |
- * | size                          | Size of transaction in bytes                             | uint32_t         | 0..NOC_MAX_BURST_SIZE for single packet                  | True     |
+ * | size                          | Size of transaction in bytes                             | uint32_t         | 0..NOC_V2_MAX_BYTES_IN_PACKET for single packet                  | True     |
  * | noc_mode (template parameter) | NOC mode for the transaction                             | uint8_t          | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
  * | cmd_buf (template parameter)  | Which command buffer to use for the transaction          | uint32_t         | 0 - 3                                                    | True     |
  * | flags (template parameter)    | Which NOC registers to update in this call               | enum CQNocFlags  | Combination of CQ_NOC_FLAG_* flags                       | True     |
@@ -1556,7 +1564,7 @@ inline __attribute__((always_inline)) void noc_write_init_state(uint32_t noc, ui
  * | noc                                 | Which NOC to use for the transaction                     | uint32_t        | 0 or 1                                                   | True     |
  * | src_addr                            | Source address in local L1 memory                        | uint32_t        | 0..1 MB                                                  | True     |
  * | dst_addr                            | Destination NOC address (x,y)+local address              | uint64_t        | Results of \a get_noc_addr calls                         | True     |
- * | size                                | Size of transaction in bytes                             | uint32_t        | 0..NOC_MAX_BURST_SIZE for single packet                  | False    |
+ * | size                                | Size of transaction in bytes                             | uint32_t        | 0..NOC_V2_MAX_BYTES_IN_PACKET for single packet                  | False    |
  * | ndests                              | Number of destinations for multicast operations          | uint32_t        | 1 or more                                                | False    |
  * | noc_mode (template parameter)       | NOC mode for the transaction                             | uint8_t         | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
  * | cmd_buf (template parameter)        | Which command buffer to use for the transaction          | uint32_t        | 0 - 3                                                    | True     |

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -54,6 +54,9 @@ constexpr uint32_t NOC_V2_MCAST_RESP_VC = 14;
 // Static transaction ID used for all command buffers
 constexpr uint32_t NOC_V2_TRID_STATIC = 0;
 
+// Per-cmd-buf packetization limit programmed at boot. 8KB; lower than the 64KB HW default to avoid NOC congestion.
+constexpr uint32_t NOC_V2_MAX_BYTES_IN_PACKET = 8 * 1024;
+
 // ============================================================================
 // CMD_BUF_MISC Register Bit Definitions (TT_ROCC_CMD_BUF_MISC_reg_t)
 // ============================================================================
@@ -291,6 +294,10 @@ inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
         OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ACK_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
+    __builtin_riscv_ttrocc_cmdbuf_wr_reg(
+        OVERLAY_WR_CMD_BUF,
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MAX_BYTES_IN_PACKET_REG_OFFSET / 8,
+        NOC_V2_MAX_BYTES_IN_PACKET);
 
     // Read command buffer (CMDBUF_1): remote src → local dest
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
@@ -307,6 +314,10 @@ inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
         OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ACK_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
+    __builtin_riscv_ttrocc_cmdbuf_wr_reg(
+        OVERLAY_RD_CMD_BUF,
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MAX_BYTES_IN_PACKET_REG_OFFSET / 8,
+        NOC_V2_MAX_BYTES_IN_PACKET);
 
     // Atomic command buffer (SCMDBUF): simple buffer for atomics and inline writes
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
@@ -315,6 +326,8 @@ inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_COORD_REG_OFFSET / 8, my_xy);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_WR_RESP_VC);
+    __builtin_riscv_ttrocc_scmdbuf_wr_reg(
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MAX_BYTES_IN_PACKET_REG_OFFSET / 8, NOC_V2_MAX_BYTES_IN_PACKET);
 }
 
 // set noc local memory state for a single kernel from the global state


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Quasar NOC bring-up and per-kernel cmd-buffer init fixes:
- Program `MAX_BYTES_IN_PACKET` to 8KB on `OVERLAY_WR_CMD_BUF`, `OVERLAY_RD_CMD_BUF`, and `SCMDBUF`. The 64KB hardware default was high enough to cause NOC congestion.
- Split V2 `noc_init` into two functions: `noc_init` (now an empty stub reserved for future ATT configuration) and `overlay_cmd_buff_init` (the overlay command buffer setup that used to live inside `noc_init`).
- Add an empty `overlay_cmd_buff_init` stub to V1 so the firmware compiles for both NOC APIs.
- Restructure firmware to match BH BRISC: `noc_init` is called only on DM0 at boot. `overlay_cmd_buff_init` is called per kernel on every DM core (firmware side in `dm.cc`, and kernel side in `dmk.cc`).
- Replace `NOC_MAX_BURST_SIZE` with `NOC_V2_MAX_BYTES_IN_PACKET` in V2's `num_packets` accounting and doc comments so software packet counts match the programmed 8KB packet size.

### Call sites

#### `noc_init`

| Phase | V1 (real impl) | V2 (empty stub) |
|---|---|---|
| Boot — DM0 | Called (real NOC reg setup) | Called (no-op) |
| Boot — DM>0 | Not called | Not called |
| Per-kernel — DM0 (`dm.cc` loop) | Not called | Not called |
| Per-kernel — DM>0 (`dm.cc` loop) | Not called | Not called |
| Per-kernel — kernel (`dmk.cc`) | Not called | Not called |

#### `overlay_cmd_buff_init`

| Phase | V1 (empty stub) | V2 (real impl) |
|---|---|---|
| Boot — DM0 | Not called | Not called |
| Boot — DM>0 | Not called | Not called |
| Per-kernel — DM0 (`dm.cc` loop) | Called (no-op) | Called (cmd buf setup) |
| Per-kernel — DM>0 (`dm.cc` loop) | Called (no-op) | Called (cmd buf setup) |
| Per-kernel — kernel (`dmk.cc`) | Called (no-op) | Called (cmd buf setup) |

Net effect:
- V1: only DM0 gets `noc_init` at boot; everything else is a no-op.
- V2: `overlay_cmd_buff_init` configures the overlay command buffers per kernel on every DM core (both firmware and kernel side). `noc_init` is a placeholder for future ATT config.

### Notes for reviewers
- The 8KB constant lives next to the existing `NOC_V2_*` constants in `noc_nonblocking_api_v2.h` as `NOC_V2_MAX_BYTES_IN_PACKET`.
- Uses `TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MAX_BYTES_IN_PACKET_REG_OFFSET` for all three writes (matches the existing convention: the `_R_` and `_W_` per-cmd-buf offsets are identical, both `0x100`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-noc-init-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-noc-init-fixes)
