### PR TITLE
MoE: change order of the host execution of the shared expert and dispatch

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_sub_device_load_clear_timing.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_sub_device_load_clear_timing.py
@@ -293,6 +293,7 @@ def _run_case(case, iters):
         "tracy",
         "-r",
         "-p",
+        "--sync-host-device",
         "-m",
         "pytest",
         nodeid,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -496,17 +496,7 @@ class TtMoe(LightweightModule):
             self.mesh_device.load_sub_device_manager(self.sd_manager_id)
 
         # ========================================
-        # Step 1: Shared expert (enabled)
-        # ========================================
-        # Shared expert expects replicated input (full emb_dim)
-        # Convert x to TILE_LAYOUT for shared expert
-        logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
-
-        shared_output = self.shared_expert(x)
-        logger.debug(f"[TtMoe.forward] Shared expert output shape: {shared_output.shape}")
-
-        # ========================================
-        # Step 2: Dispatch (enabled)
+        # Step 1: Dispatch (enabled)
         # ========================================
         # Dispatch expects full emb_dim on each device (x already has this)
         logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
@@ -517,9 +507,18 @@ class TtMoe(LightweightModule):
             tt_expert_offsets,
             self.tt_expert_dispatch_table,
         )
+
+        # ========================================
+        # Step 2: Shared expert (enabled)
+        # ========================================
+        # Shared expert expects replicated input (full emb_dim)
+        # Convert x to TILE_LAYOUT for shared expert
+        shared_output = self.shared_expert(x)
+        logger.debug(f"[TtMoe.forward] Shared expert output shape: {shared_output.shape}")
+
         if self.overlap_shared_expert_with_dispatch:
             self.mesh_device.clear_loaded_sub_device_manager()
-        x = ttnn.deallocate(x)
+        ttnn.deallocate(x)
         scores = ttnn.to_memory_config(scores, ttnn.DRAM_MEMORY_CONFIG)
         indices = ttnn.to_memory_config(indices, ttnn.DRAM_MEMORY_CONFIG)
         logger.debug(f"[TtMoe.forward] Dispatch output: buffer={dispatched_buffer.shape}, metadata={metadata.shape}")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -494,6 +494,7 @@ class TtMoe(LightweightModule):
         signpost("shared_expert_and_dispatch_start")
         if self.overlap_shared_expert_with_dispatch:
             self.mesh_device.load_sub_device_manager(self.sd_manager_id)
+            self.mesh_device.set_sub_device_stall_group([self.shared_sd_id])
 
         # ========================================
         # Step 1: Dispatch (enabled)
@@ -517,13 +518,14 @@ class TtMoe(LightweightModule):
         logger.debug(f"[TtMoe.forward] Shared expert output shape: {shared_output.shape}")
 
         if self.overlap_shared_expert_with_dispatch:
+            self.mesh_device.reset_sub_device_stall_group()
             self.mesh_device.clear_loaded_sub_device_manager()
+        signpost("shared_expert_and_dispatch_end")
+
         ttnn.deallocate(x)
         scores = ttnn.to_memory_config(scores, ttnn.DRAM_MEMORY_CONFIG)
         indices = ttnn.to_memory_config(indices, ttnn.DRAM_MEMORY_CONFIG)
         logger.debug(f"[TtMoe.forward] Dispatch output: buffer={dispatched_buffer.shape}, metadata={metadata.shape}")
-
-        signpost("shared_expert_and_dispatch_end")
 
         # ========================================
         # Step 3: Routed experts (enabled)


### PR DESCRIPTION
## Summary
- Reorder so both ops execute while the sub-device manager is still loaded, then clear:
  1. `load_sub_device_manager`
  2. `dispatch_module(...)` on `dispatch_sd`
  3. `shared_expert(x)` on `shared_sd`
  4. `clear_loaded_sub_device_manager`
- This is the only arrangement that actually achieves the sub-device-level overlap the split was designed for.

The reason for this change is due to the fact that host needs to sequentially "dispatch" ops to their designated CommandQueues. Since the dispatch op takes more time to execute, we want it to be the first thing that the host encounters.

Original order (shared expert --> dispatch):
<img width="2227" height="502" alt="SE_then_dispatch_test_ttnn_moe_1600_linear" src="https://github.com/user-attachments/assets/9d9c17ef-8fb3-4dae-8e05-2bc0f5101191" />

New order (dispatch --> shared expert):
<img width="2327" height="502" alt="dispatch_then_shared_expert_test_ttnn_moe_1600_linear" src="https://github.com/user-attachments/assets/2a5d4d2e-d35a-4d9b-aaca-79e28b2ee4ee" />

TODO: perf gain

## CI Pipelines
[![Galaxy DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch%3Afbajraktari%2Ffix_stalling_group_overlap)
[![T3K e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch%3Afbajraktari%2Ffix_stalling_group_overlap)
[![SP Release DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch%3Afbajraktari%2Ffix_stalling_group_overlap)
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Afbajraktari%2Ffix_stalling_group_overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/fix_stalling_group_overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/fix_stalling_group_overlap)