### PR TITLE
[Bug fix] Write `MCAST_DESTS` register in `noc_write_with_state` and `noc_wwrite_with_state` functions on Quasar

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -1586,6 +1586,8 @@ inline __attribute__((always_inline)) void noc_write_with_state(
         __builtin_riscv_ttrocc_cmdbuf_wr_reg(
             cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, size);
     }
+    __builtin_riscv_ttrocc_cmdbuf_wr_reg(
+        cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MCAST_DESTS_REG_OFFSET / 8, ndests);
     if constexpr (send) {
         __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
     }
@@ -1629,6 +1631,8 @@ inline __attribute__((always_inline)) void noc_wwrite_with_state(
         __builtin_riscv_ttrocc_cmdbuf_wr_reg(
             cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, size);
     }
+    __builtin_riscv_ttrocc_cmdbuf_wr_reg(
+        cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MCAST_DESTS_REG_OFFSET / 8, ndests);
     if constexpr (send) {
         __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
     }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The `noc_write_with_state` and `noc_wwrite_with_state` functions in the Quasar NOC nonblocking API V2 were not writing the `MCAST_DESTS` register into the command buffer. This meant the multicast destination count (`ndests`) was never committed to hardware when these functions were called.

The fix adds the missing `__builtin_riscv_ttrocc_cmdbuf_wr_reg` call for `TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MCAST_DESTS_REG_OFFSET` in both `noc_write_with_state` and `noc_wwrite_with_state`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_mcast_dests_reg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_mcast_dests_reg)