### PR TITLE
Fix ring joint SDPA scalar reciprocal init

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1075,7 +1075,8 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
     cb_reserve_back(out_cb, num_tiles);
     sub_tiles_init(in0_cb, in1_cb);
     exp_tile_init<false>();
-    // recip_tile_init<false>(); // Can omit this because accurate exp_tile_init performs reduce_tile_init
+    // recip_tile_first_column<false> calls the scalar reciprocal helper directly.
+    MATH((ckernel::sfpu::sfpu_reciprocal_init<false>()));
 
     for (uint32_t i = 0; i < num_tiles; i++) {
         acquire_dst();


### PR DESCRIPTION
## Summary
- Initialize the scalar reciprocal helper explicitly in ring joint SDPA `sigmoid_sub()` before `recip_tile_first_column<false>()`.
- Remove the hidden dependency on `exp_tile_init<false>()` priming reciprocal SFPU state as a side effect.

Fixes #44829.

## Root Cause / Investigation Flow
- #43973 changed the Blackhole BF16 accurate exp implementation. The change was later reverted by #44828 because the P150 ring-joint SDPA CI went red.
- Reapplying that accurate-exp change locally reproduced the failure at:
  `tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_accuracy[wan2_2_1xGLX-q224-k128]`
  with PCC around `0.8166` and RMSE around `0.1437`.
- The failure was shape-sensitive, not isolated to a single parameter: `q224-k128` and `q288-k128` failed, while `q256-k128` and the wider K chunks passed. Error was spread across heads and sequence segments, which pointed away from a shard/tail ordering bug.
- Forcing the non-streaming path and changing QKTV subblock promotion did not move the metric, so the regression was not specific to streaming-v2 scheduling or remainder handling.
- Restoring only the old exact-exp init behavior, specifically the `_init_sfpu_reciprocal_<false>()` side effect, restored the failing shape back to the expected RMSE/PCC.
- The direct dependency is in `sigmoid_sub()`: ring merge computes `sigmoid(cur_lse - prev_lse)` as `1 / (1 + exp(...))`, then calls `recip_tile_first_column<false>()`. That helper calls the scalar SFPU reciprocal helper directly and requires scalar reciprocal constants to be initialized.
- Before #43973, `exp_tile_init<false>()` happened to initialize those scalar reciprocal constants. The new BF16 accurate exp path initializes only the constants it needs for exp, so this accidental reciprocal setup disappeared.
- This PR makes the dependency explicit by calling `ckernel::sfpu::sfpu_reciprocal_init<false>()` in `sigmoid_sub()` before the first-column reciprocal call.

## Testing
- `./build_metal.sh --release`
- `TT_METAL_CACHE=/tmp/tt-metal-cache-isolated-recip-init CI=true scripts/run_safe_pytest.sh 'tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_accuracy[wan2_2_1xGLX-q224-k128]'`
  - Passed on current `origin/main` + this fix: PCC `0.9995651102738401`, RMSE `0.007517`.

Additional local validation on the combined state with the accurate-exp change reapplied:
- `q224-k128`: passed, PCC `0.9995651102738401`, RMSE `0.007517`.
- `q288-k128`: passed.
- `q256-k128`: still passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/ring-joint-sdpa-recip-init)