### PR TITLE
Fix ring joint SDPA sigmoid reciprocal init

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1075,7 +1075,15 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
     cb_reserve_back(out_cb, num_tiles);
     sub_tiles_init(in0_cb, in1_cb);
     exp_tile_init<false>();
-    // recip_tile_init<false>(); // Can omit this because accurate exp_tile_init performs reduce_tile_init
+    // recip_tile_first_column<false>() calls the scalar _sfpu_reciprocal_ path, so initialize exactly
+    // that SFPU state here. Blackhole needs vConstFloatPrgm0 = 2.0 for Newton-Raphson; Wormhole
+    // needs vConstFloatPrgm0/1/2 loaded with reciprocal polynomial coefficients.
+    // This init programs persistent SFPU constants, not per-tile data. It intentionally comes after
+    // exp_tile_init<false>() because the exp call below is the custom exp_tile_first_column<false>(),
+    // whose polynomial implementation loads the constants it consumes into LREGs in the tile body; it
+    // does not depend on vConstFloatPrgm* state from exp_tile_init. Conversely, that exp body also
+    // does not clobber the reciprocal constants, so one reciprocal init before the tile loop is enough.
+    MATH((ckernel::sfpu::sfpu_reciprocal_init<false>()));
 
     for (uint32_t i = 0; i < num_tiles; i++) {
         acquire_dst();


### PR DESCRIPTION
## Summary
- Fixes #44829
- Initialize the scalar reciprocal SFPU state used by the legacy ring-joint SDPA sigmoid path.
- Leave `ring_joint_sdpa_program_factory.cpp` unchanged from `origin/main`; the earlier streaming-selector relaxation was dropped because it appears to cause code size issues.

## Root cause
Some ring-joint SDPA shapes can still hit the legacy compute path. That path uses `sigmoid_sub`, which implements sigmoid as `exp(-x)`, add 1, then scalar reciprocal via `recip_tile_first_column<false>()`.

The reciprocal helper needs reciprocal-specific persistent SFPU program constants initialized before the tile loop. Previously the code relied on an indirect/stale exp-init side effect, which is not a valid contract for the scalar reciprocal path. The issue was exposed while investigating the selector change that moved q224/q288 coverage between streaming and legacy paths, but the fix here is intentionally limited to the latent legacy sigmoid initialization bug.

One `sfpu_reciprocal_init<false>()` before the loop is enough because it programs persistent reciprocal constants, not per-tile data. The first-column exp implementation loads the polynomial state it needs inside the tile body and does not depend on or overwrite those reciprocal program constants.

## Validation
- `./build_metal.sh --release`
- Forced legacy selector check with this reciprocal init: `TT_METAL_CACHE=/tmp/tt-metal-cache-forced-legacy-direct-recip-init-check CI=true scripts/run_safe_pytest.sh 'tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_accuracy[wan2_2_1xGLX-q224-k128]'`
  - PASS, PCC `0.9995651102738401`, RMSE `0.007517`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-recip-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-joint-sdpa-recip-init)