### PR TITLE
[Bug Fix] DRAM Matmul - Fix Compute Reading Un-pushed Data

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -493,6 +493,10 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
             {"cb_in1_intermediate", tt::CBIndex::c_9},
             {"cb_in0_transposed", tt::CBIndex::c_10},
             {"bias_ntiles", per_core_N},
+            // This factory does not pad per_core_N_compute beyond per_core_N_in1_sender, so the
+            // last subblock is always fully valid. Pass out_subblock_w so the compute kernel takes
+            // its original full-width path (last_subblock_padded == false).
+            {"last_subblock_w_valid", out_subblock_w},
         };
         if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
             using ttnn::operations::matmul::utilities::get_activation_params;

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -162,6 +162,15 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         per_core_N_compute = out_subblock_w * num_subblock_w_per_core_N;
     }
 
+    // Number of in1 columns in the last subblock that are actually backed by reader-pushed tiles.
+    // When the subblock-width optimization above pads per_core_N_compute beyond per_core_N_in1_sender,
+    // the last subblock has out_subblock_w lanes total but only this many lanes correspond to in1
+    // tiles the reader pushed into cb_in1; the rest are padded columns that the output writer drops.
+    // The compute kernel uses this to narrow the matmul_block call for the last subblock so it never
+    // reads cb_in1 tile indices that were not produced for the current block.
+    // When no padding occurs (per_core_N_compute == per_core_N_in1_sender) this equals out_subblock_w.
+    uint32_t last_subblock_w_valid = out_subblock_w - (per_core_N_compute - per_core_N_in1_sender);
+
     uint32_t num_blocks = K / in0_block_w;
     bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
 
@@ -458,6 +467,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             {"cb_in1_intermediate", tt::CBIndex::c_9},
             {"cb_in0_transposed", tt::CBIndex::c_10},
             {"bias_ntiles", per_core_N_compute},
+            {"last_subblock_w_valid", last_subblock_w_valid},
         };
         if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
             using ttnn::operations::matmul::utilities::get_activation_params;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -500,7 +500,10 @@ void kernel_main() {
                             uint32_t bias_tile_idx = in1_index_subblock_offset;
                             for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
                                 const uint32_t safe_bias_tile_idx =
-                                    (is_last_in1_subblock_padded && k >= last_subblock_w_valid) ? 0u : bias_tile_idx;
+                                    (is_last_in1_subblock_padded && k >= last_subblock_w_valid)
+                                        ? 0u              // Padded output columns with tile 0 of cb_bias added are
+                                        : bias_tile_idx;  // dropped by the writer.
+
                                 if constexpr (row_broadcast_bias) {
                                     add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, safe_bias_tile_idx, i);
                                 } else {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -210,6 +210,19 @@ void kernel_main() {
 #endif
     CircularBuffer mm_out_cb(mm_out_cb_id);
 
+    // Number of valid in1 columns in the last in1 subblock. For the DRAM-sharded variant the
+    // planner may pad per_core_N_compute beyond per_core_N_in1_sender so that out_subblock_w can be
+    // larger; the reader only pushes per_core_N_in1_sender tiles per block into cb_in1. To avoid
+    // reading those non-existent (padded) cb_in1 tiles, the compute kernel narrows the matmul_block
+    // call on the last in1 subblock to last_subblock_w_valid lanes. When no padding occurs this
+    // equals out_subblock_w and the original full-width path is preserved.
+#ifdef MATMUL_DRAM_SHARDED
+    constexpr uint32_t last_subblock_w_valid = get_named_compile_time_arg_val("last_subblock_w_valid");
+#else
+    constexpr uint32_t last_subblock_w_valid = out_subblock_w;
+#endif
+    constexpr bool last_subblock_padded = last_subblock_w_valid < out_subblock_w;
+
 #ifdef SFPU_ACTIVATION
     constexpr KernelActivation activation_type =
         static_cast<KernelActivation>(get_named_compile_time_arg_val("activation_type"));
@@ -297,6 +310,16 @@ void kernel_main() {
                     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                         int in1_index_subblock_offset = 0;
                         for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                            // When last_subblock_padded is true the last in1 subblock has
+                            // (out_subblock_w - last_subblock_w_valid) padded lanes whose cb_in1 tiles were
+                            // never pushed by the reader. Narrow matmul_block so the unpacker only touches
+                            // tiles that exist; the padded dst lanes are left at whatever the previous
+                            // operation wrote there and the output writer (BRISC) drops those columns.
+                            const bool is_last_in1_subblock_padded =
+                                last_subblock_padded && (in1_subblock == in1_num_subblocks - 1);
+                            const uint32_t effective_subblock_w =
+                                is_last_in1_subblock_padded ? last_subblock_w_valid : out_subblock_w;
+
                             tile_regs_acquire();
                             if (enable_reload) {
                                 reload_from_cb_to_dst(
@@ -329,7 +352,7 @@ void kernel_main() {
                                     in1_index,
                                     dst_index,
                                     in1_transpose_tile,
-                                    out_subblock_w,
+                                    effective_subblock_w,
                                     out_subblock_h,
                                     in0_block_w);
                                 in0_index++;               // stride right by 1
@@ -464,16 +487,24 @@ void kernel_main() {
                 for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                     int in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                        // See matmul stage: the last in1 subblock has padded lanes whose bias tile was
+                        // never pushed by the reader. Redirect those out-of-range bias_tile_idx reads to
+                        // tile 0 of cb_bias to keep them in-bounds; the resulting padded output columns
+                        // are dropped by the writer.
+                        const bool is_last_in1_subblock_padded =
+                            last_subblock_padded && (in1_subblock == in1_num_subblocks - 1);
                         // Redundant wait since we know data was just pushed
                         mm_partials_cb.wait_front(out_subblock_num_tiles);
                         tile_regs_acquire();
                         for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
                             uint32_t bias_tile_idx = in1_index_subblock_offset;
                             for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
+                                const uint32_t safe_bias_tile_idx =
+                                    (is_last_in1_subblock_padded && k >= last_subblock_w_valid) ? 0u : bias_tile_idx;
                                 if constexpr (row_broadcast_bias) {
-                                    add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, bias_tile_idx, i);
+                                    add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, safe_bias_tile_idx, i);
                                 } else {
-                                    add_tiles(mm_partials_cb_id, bias_cb_id, i, bias_tile_idx, i);
+                                    add_tiles(mm_partials_cb_id, bias_cb_id, i, safe_bias_tile_idx, i);
                                 }
                                 bias_tile_idx++;
                             }


### PR DESCRIPTION
### Summary
The DRAM-sharded matmul would pad compute along the N dimension to the nearest tile, which meant it could be reading more data from the in1 CB than what the reader kernel actually put out. The output writer kernel would then drop those extra columns from the output so PCC often stayed green, and the in1 CB was large enough that these extra reads hadn't been an issue, but the path was incorrect and fragile.

This change computes now also checks if the last subblock is valid and passes is to the compute kernel. On the last in1 subblock only, matmul_block uses the proper width so the unpacker only touches real tiles. When there is no padding, last_subblock_w_valid == out_subblock_w and behaviour is unchanged. This functionality is exercised in existing test [tt-metal/models/demos/deepseek_v3/tests/unit/test_matmul.py](https://github.com/tenstorrent/tt-metal/blob/149588004ebb42a7e6ca8ea9dc3b95c78cb61332/models/demos/deepseek_v3/tests/unit/test_matmul.py#L229-L245), which continues to pass with this change.

Fixes #43998

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/43998/DRAM_MM_CB_Count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/43998/DRAM_MM_CB_Count)
- Single card perf [passes](https://github.com/tenstorrent/tt-metal/actions/runs/26189142176)
- Single card model [passes](https://github.com/tenstorrent/tt-metal/actions/runs/26186863019)
- Model Perf [passes](https://github.com/tenstorrent/tt-metal/actions/runs/26228492196)