### PR TITLE
[skip ci] Fix upstream bh galaxy and multicard MLperf weights paths

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -293,7 +293,7 @@ jobs:
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
             --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \
-            -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH \
+            -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH -e HF_HUB_OFFLINE=1 \
             ${{ needs.get-image-tags.outputs.bh-glx-image-tag }}
   test-bh-multicard-image:
     needs:
@@ -336,7 +336,7 @@ jobs:
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
             --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \
-            -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH ${{ matrix.bh-config.image-name }}
+            -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH -e HF_HUB_OFFLINE=1 ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -292,7 +292,7 @@ jobs:
           TT_CACHE_PATH: /mnt/MLPerf/huggingface/tt_cache/meta-llama--Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
-            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \
+            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:ro \
             -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH -e HF_HUB_OFFLINE=1 \
             ${{ needs.get-image-tags.outputs.bh-glx-image-tag }}
   test-bh-multicard-image:
@@ -335,7 +335,7 @@ jobs:
             || '/mnt/MLPerf/huggingface/tt_cache' }}/meta-llama--Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
-            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \
+            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:ro \
             -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH -e HF_HUB_OFFLINE=1 ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
@@ -368,7 +368,7 @@ jobs:
           TT_CACHE_PATH: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
         run: |
           docker run --network none --device /dev/tenstorrent \
-            -v $HF_MODEL:$HF_MODEL:rw -e HF_MODEL -e TT_CACHE_PATH \
+            -v $HF_MODEL:$HF_MODEL:ro -e HF_MODEL -e TT_CACHE_PATH \
             ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -285,14 +285,15 @@ jobs:
         timeout-minutes: 10
         run: docker pull ${{ needs.get-image-tags.outputs.bh-glx-image-tag }}
       - name: Run image
-        timeout-minutes: 65
+        timeout-minutes: 75
         env:
-          HF_MODEL: /mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct
-          TT_CACHE_PATH: /mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct
+          HF_HOME: /mnt/MLPerf/huggingface
+          HF_MODEL: meta-llama/Llama-3.1-8B-Instruct
+          TT_CACHE_PATH: /mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
-            --device /dev/tenstorrent -v $HF_MODEL:$HF_MODEL:ro \
-            -e HF_MODEL -e TT_CACHE_PATH \
+            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:ro \
+            -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH \
             ${{ needs.get-image-tags.outputs.bh-glx-image-tag }}
   test-bh-multicard-image:
     needs:
@@ -323,18 +324,19 @@ jobs:
         timeout-minutes: 30
         env:
           # For different environments, BH VLAN vs. cloud
-          HF_MODEL: >-
+          HF_HOME: >-
             ${{ matrix.bh-config.extra-tag == 'pipeline-perf'
             && '/localdev/blackhole_demos/huggingface_data'
-            || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
+            || '/mnt/MLPerf/huggingface' }}
+          HF_MODEL: meta-llama/Llama-3.1-8B-Instruct
           TT_CACHE_PATH: >-
             ${{ matrix.bh-config.extra-tag == 'pipeline-perf'
-            && '/localdev/blackhole_demos/huggingface_data'
-            || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
+            && '/localdev/blackhole_demos/huggingface_data/tt_cache'
+            || '/mnt/MLPerf/huggingface/tt_cache' }}/meta-llama/Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
-            --device /dev/tenstorrent -v $HF_MODEL:$HF_MODEL:ro \
-            -e HF_MODEL -e TT_CACHE_PATH ${{ matrix.bh-config.image-name }}
+            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:ro \
+            -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -292,7 +292,7 @@ jobs:
           TT_CACHE_PATH: /mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
-            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:ro \
+            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \
             -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH \
             ${{ needs.get-image-tags.outputs.bh-glx-image-tag }}
   test-bh-multicard-image:
@@ -335,7 +335,7 @@ jobs:
             || '/mnt/MLPerf/huggingface/tt_cache' }}/meta-llama/Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
-            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:ro \
+            --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \
             -e HF_HOME -e HF_MODEL -e TT_CACHE_PATH ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
@@ -368,7 +368,7 @@ jobs:
           TT_CACHE_PATH: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
         run: |
           docker run --network none --device /dev/tenstorrent \
-            -v $HF_MODEL:$HF_MODEL:ro -e HF_MODEL -e TT_CACHE_PATH \
+            -v $HF_MODEL:$HF_MODEL:rw -e HF_MODEL -e TT_CACHE_PATH \
             ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -289,7 +289,7 @@ jobs:
         env:
           HF_HOME: /mnt/MLPerf/huggingface
           HF_MODEL: meta-llama/Llama-3.1-8B-Instruct
-          TT_CACHE_PATH: /mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
+          TT_CACHE_PATH: /mnt/MLPerf/huggingface/tt_cache/meta-llama--Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
             --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \
@@ -332,7 +332,7 @@ jobs:
           TT_CACHE_PATH: >-
             ${{ matrix.bh-config.extra-tag == 'pipeline-perf'
             && '/localdev/blackhole_demos/huggingface_data/tt_cache'
-            || '/mnt/MLPerf/huggingface/tt_cache' }}/meta-llama/Llama-3.1-8B-Instruct
+            || '/mnt/MLPerf/huggingface/tt_cache' }}/meta-llama--Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
             --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:rw \

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -47,6 +47,11 @@ verify_llama_dir_() {
     if [ -z "${LLAMA_DIR:-}" ]; then
       echo "LLAMA_DIR environment variable not set. Checking for HF_MODEL and TT_CACHE_PATH..."
 
+      if [ -n "${HF_HOME:-}" ] && [ -d "$HF_HOME" ] && [ "$(ls -A "$HF_HOME")" ]; then
+        echo "[upstream-tests] HF_HOME is set to $HF_HOME and exists, continuing"
+        return 0
+      fi
+
       # Check if both HF_MODEL and TT_CACHE_PATH are set
       if [ -z "${HF_MODEL:-}" ] || [ -z "${TT_CACHE_PATH:-}" ]; then
         echo "Error: HF_MODEL and TT_CACHE_PATH environment variables not detected. Please set these environment variables to tell the tests where to find the downloaded Llama weights." >&2


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix / cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
https://tenstorrent.atlassian.net/browse/MINFRA-583
Blackhole llama3.1-8b weights were moved to hf hub cache format. Upstream test jobs need to be updated to look for weights and caches in the new directories. Documentation page also updated to reflect changes.

CI (wh-6u failure is unrelated): https://github.com/tenstorrent/tt-metal/actions/runs/26234968497

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/fix-upstream-mlperf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/fix-upstream-mlperf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/fix-upstream-mlperf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/fix-upstream-mlperf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/fix-upstream-mlperf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/fix-upstream-mlperf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/fix-upstream-mlperf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/fix-upstream-mlperf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/fix-upstream-mlperf)