### PR TITLE
[Feature] GCBs with a DRISC sender (DRAM-core GlobalCircularBuffer)

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -50,7 +50,7 @@ jobs:
               ./build/test/tt_metal/unit_tests_per_core_allocation --gtest_filter=$GTEST_FILTER
               TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 \
                 ./build/test/tt_metal/unit_tests_api \
-                --gtest_filter=BlackholeSingleCardFixture.DramKernel*:DramSenderGCBFixture.*:DramSubchannelHelperFixture.*
+                --gtest_filter=BlackholeSingleCardFixture.DramKernel*
               rm -rf /tmp/kernels
               mkdir -p /tmp/kernels
               TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.${GTEST_FILTER}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -50,7 +50,7 @@ jobs:
               ./build/test/tt_metal/unit_tests_per_core_allocation --gtest_filter=$GTEST_FILTER
               TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 \
                 ./build/test/tt_metal/unit_tests_api \
-                --gtest_filter=BlackholeSingleCardFixture.DramKernel*
+                --gtest_filter=BlackholeSingleCardFixture.DramKernel*:DramSenderGCBFixture.*:DramSubchannelHelperFixture.*
               rm -rf /tmp/kernels
               mkdir -p /tmp/kernels
               TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.${GTEST_FILTER}

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -194,7 +194,7 @@
       TT_METAL_SLOW_DISPATCH_MODE=1 \
         TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 \
         ./build/test/tt_metal/unit_tests_api \
-        --gtest_filter='*.DramKernel*'
+        --gtest_filter='*.DramKernel*:DramSenderGCBFixture.*:DramSubchannelHelperFixture.*'
     fi
   skus:
     wh_n150_civ2:

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -41,6 +41,8 @@ set(UNIT_TESTS_API_SOURCES
     test_compiler_include_paths.cpp
     test_direct.cpp
     test_dram_kernels.cpp
+    test_dram_sender_global_cb.cpp
+    test_dram_subchannel_helper.cpp
     test_dram_to_l1_multicast.cpp
     test_dram.cpp
     test_global_circular_buffers.cpp

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -73,7 +73,7 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
     constexpr uint32_t kGcbSize = 1024;
     auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
         mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
-    // Use the sender coord the factory resolved; recomputing via pick_unused_dram_subchannel
+    // Use the sender coord the factory resolved; recomputing via pick_unused_dram_logical_core
     // would couple this test to the picker's current strategy.
     const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
 

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -1,0 +1,505 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// End-to-end smoke test for DramSenderGlobalCircularBuffer:
+// one DRISC sender on bank 0's unused subchannel pushes a known per-receiver
+// pattern to a CoreRangeSet of worker receivers via remote_cb_*. After Finish,
+// verify each receiver's L1 slice matches the expected stripe and that the
+// sender's pages_acked counters all caught up to pages_sent.
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <exception>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/global_circular_buffer.hpp>
+#include "impl/buffers/drisc_l1_arena.hpp"
+#include <tt-metalium/experimental/global_circular_buffer.hpp>
+
+#include "impl/kernels/kernel.hpp"  // DramConfig
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include <tt-metalium/experimental/dispatch_context.hpp>
+
+#include "device_fixture.hpp"
+#include "impl/context/metal_context.hpp"
+#include "llrt/hal.hpp"
+#include "llrt/tt_cluster.hpp"
+
+namespace tt::tt_metal {
+
+class DramSenderGCBFixture : public BlackholeSingleCardFixture {
+protected:
+    void SetUp() override {
+        BlackholeSingleCardFixture::SetUp();
+        if (devices_.empty()) {
+            return;
+        }
+        const auto& hal = MetalContext::instance().hal();
+        if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+            GTEST_SKIP() << "DRAM programmable cores not enabled";
+        }
+        mesh_device_ = devices_[0].get();
+        device_ = mesh_device_->get_devices()[0];
+    }
+
+    distributed::MeshDevice* mesh_device_{};
+    IDevice* device_{};
+};
+
+TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
+    // Layout: 4 receivers, each receives one 64-byte page.
+    constexpr uint32_t kNumReceivers = 4;
+    constexpr uint32_t kPageSize = 64;  // multiple of L1_ALIGNMENT (16 on BH)
+    constexpr uint32_t kNumPages = 1;
+    constexpr uint32_t kRemoteCBId = 31;
+
+    // Sender: bank 0
+    const uint32_t bank_id = 0;
+    // Receivers
+    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
+    std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{bank_id, receiver_cores}};
+
+    // Size: per-receiver fifo. Use 1KB.
+    constexpr uint32_t kGcbSize = 1024;
+    auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
+        mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
+    // Use the sender coord the factory resolved; recomputing via pick_unused_dram_subchannel
+    // would couple this test to the picker's current strategy.
+    const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
+
+    // Pre-load DRISC L1 with per-receiver data pattern starting at DRISC L1 UNRESERVED + offset
+    // far enough above pages_sent_drisc_l1_base.
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t drisc_l1_unreserved = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+
+    // DRISC slots are packed at uint32 stride (see REMOTE_CB_LOCAL_PAGES_STRIDE).
+    constexpr uint32_t kDriscSlotBytes = sizeof(uint32_t);
+    const uint32_t pages_sent_size = 2 * kDriscSlotBytes * kNumReceivers;
+    const uint32_t noc_xy_size = 2 * sizeof(uint32_t) * kNumReceivers;
+    const uint32_t config_size = 16;  // 4 uint32 words
+    uint32_t cursor = drisc_l1_unreserved;
+    const uint32_t pages_sent_addr = cursor;
+    cursor += pages_sent_size;
+    cursor = (cursor + l1_alignment - 1) & ~(l1_alignment - 1);
+    const uint32_t noc_xy_addr = cursor;
+    cursor += noc_xy_size;
+    cursor = (cursor + l1_alignment - 1) & ~(l1_alignment - 1);
+    const uint32_t config_addr = cursor;
+    cursor += config_size;
+    cursor = (cursor + l1_alignment - 1) & ~(l1_alignment - 1);
+    const uint32_t data_addr = cursor;
+
+    // Sanity: our DramSenderGlobalCircularBuffer agreed to plant pages_sent at drisc_l1_unreserved.
+    ASSERT_EQ(experimental::pages_sent_drisc_l1_base(gcb), pages_sent_addr);
+
+    // Per-receiver pattern: pattern[r] = 0xABCD0000 + r*page_index*256
+    std::vector<uint32_t> pattern(kNumReceivers * kPageSize / sizeof(uint32_t));
+    for (uint32_t r = 0; r < kNumReceivers; ++r) {
+        for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
+            pattern[r * kPageSize / sizeof(uint32_t) + w] = 0xABCD0000u + r * 0x100u + w;
+        }
+    }
+    auto sender_virtual = device_->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+    const uint64_t drisc_l1_noc_addr_base =
+        hal.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    const uint64_t data_noc_addr = drisc_l1_noc_addr_base + (data_addr - drisc_l1_unreserved);
+    MetalContext::instance().get_cluster().write_core(
+        pattern.data(),
+        pattern.size() * sizeof(uint32_t),
+        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        data_noc_addr);
+
+    // Build a single program with both sender (DRISC) and receiver (worker) kernels.
+    distributed::MeshCoordinateRange device_range(distributed::MeshCoordinate(0, 0));
+    Program program = CreateProgram();
+
+    std::vector<uint32_t> sender_compile_args = {
+        kRemoteCBId,
+        kNumPages,
+        kPageSize,
+        kNumReceivers,
+        pages_sent_addr,
+        noc_xy_addr,
+        config_addr,
+        data_addr,
+        kGcbSize,
+        static_cast<uint32_t>(gcb.buffer_address()),
+        static_cast<uint32_t>(experimental::pages_sent_worker_l1_base(gcb)),
+    };
+    KernelHandle sender_kernel_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp",
+        sender_logical,
+        DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args});
+
+    std::vector<uint32_t> sender_rt_args;
+    sender_rt_args.reserve(2 * kNumReceivers);
+    const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
+    for (const auto& c : receiver_phys) {
+        sender_rt_args.push_back(c.x);
+        sender_rt_args.push_back(c.y);
+    }
+    SetRuntimeArgs(program, sender_kernel_id, sender_logical, sender_rt_args);
+
+    CircularBufferConfig cb_config(kPageSize);
+    cb_config.remote_index(kRemoteCBId).set_page_size(kPageSize).set_data_format(tt::DataFormat::Float16_b);
+    experimental::CreateCircularBuffer(program, receiver_cores, cb_config, gcb);
+
+    std::vector<uint32_t> receiver_compile_args = {kRemoteCBId, kNumPages};
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_receiver.cpp",
+        receiver_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = receiver_compile_args});
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+    distributed::Finish(mesh_device_->mesh_command_queue());
+
+    // Verify each receiver's L1 slice
+    auto receivers_vec = corerange_to_cores(receiver_cores);
+    for (uint32_t r = 0; r < receivers_vec.size(); ++r) {
+        std::vector<uint32_t> result;
+        tt::tt_metal::detail::ReadFromDeviceL1(
+            device_, receivers_vec[r], gcb.buffer_address(), kPageSize, result, CoreType::WORKER);
+        for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
+            uint32_t expected = 0xABCD0000u + r * 0x100u + w;
+            EXPECT_EQ(result[w], expected) << "Receiver " << r << " word " << w << " mismatch (expected 0x" << std::hex
+                                           << expected << ", got 0x" << result[w] << std::dec << ")";
+        }
+    }
+
+    // Verify pages_sent == pages_acked on DRISC (the barrier in the sender kernel waits for
+    // this). Slots are packed: per receiver, pages_sent at +0 uint32, pages_acked at +1 uint32.
+    const uint64_t pages_sent_noc_addr = drisc_l1_noc_addr_base + (pages_sent_addr - drisc_l1_unreserved);
+    std::vector<uint32_t> pages_buf(2 * kNumReceivers, 0);
+    MetalContext::instance().get_cluster().read_core(
+        pages_buf.data(),
+        pages_buf.size() * sizeof(uint32_t),
+        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        pages_sent_noc_addr);
+    for (uint32_t r = 0; r < kNumReceivers; ++r) {
+        uint32_t sent = pages_buf[2 * r];
+        uint32_t acked = pages_buf[2 * r + 1];
+        EXPECT_EQ(sent, acked) << "Pages sent/acked mismatch for receiver " << r << " (sent=" << sent
+                               << ", acked=" << acked << ")";
+        EXPECT_GT(sent, 0u) << "Sender did not push any pages to receiver " << r;
+    }
+}
+
+// Same data flow as SmokeOneSenderFourReceivers, but the sender (DRISC) and receiver
+// (workers) live in TWO SEPARATE Programs and we rely on async slow dispatch to launch
+// them concurrently. This mirrors how the ttnn prefetcher op + matmul op flow works
+// (each op enqueues its own Program). If this passes, async SD is a viable substitute
+// for fast dispatch for the DRAM-core mode.
+TEST_F(DramSenderGCBFixture, SmokeTwoProgramsAsyncSlowDispatch) {
+    constexpr uint32_t kNumReceivers = 4;
+    constexpr uint32_t kPageSize = 64;
+    constexpr uint32_t kNumPages = 1;
+    constexpr uint32_t kRemoteCBId = 31;
+    constexpr uint32_t kGcbSize = 1024;
+
+    const uint32_t bank_id = 0;
+    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
+    std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{bank_id, receiver_cores}};
+    auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
+        mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
+    const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
+
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t drisc_l1_unreserved = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+    auto align_up = [&](uint32_t a) { return (a + l1_alignment - 1) & ~(l1_alignment - 1); };
+
+    const uint32_t pages_sent_addr = drisc_l1_unreserved;
+    // DRISC slots are packed at uint32 stride (see REMOTE_CB_LOCAL_PAGES_STRIDE).
+    uint32_t cursor = pages_sent_addr + 2 * sizeof(uint32_t) * kNumReceivers;
+    cursor = align_up(cursor);
+    const uint32_t noc_xy_addr = cursor;
+    cursor += 2 * sizeof(uint32_t) * kNumReceivers;
+    cursor = align_up(cursor);
+    const uint32_t config_addr = cursor;
+    cursor += 16;
+    cursor = align_up(cursor);
+    const uint32_t data_addr = cursor;
+
+    // Pre-load DRISC L1 with a per-receiver pattern.
+    std::vector<uint32_t> pattern(kNumReceivers * kPageSize / sizeof(uint32_t));
+    for (uint32_t r = 0; r < kNumReceivers; ++r) {
+        for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
+            pattern[r * kPageSize / sizeof(uint32_t) + w] = 0x55AA0000u + r * 0x100u + w;
+        }
+    }
+    auto sender_virtual = device_->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+    const uint64_t drisc_l1_noc_addr_base =
+        hal.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    MetalContext::instance().get_cluster().write_core(
+        pattern.data(),
+        pattern.size() * sizeof(uint32_t),
+        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        drisc_l1_noc_addr_base + (data_addr - drisc_l1_unreserved));
+
+    // --- Sender program: DRISC kernel only ---
+    Program sender_program = CreateProgram();
+    std::vector<uint32_t> sender_compile_args = {
+        kRemoteCBId,
+        kNumPages,
+        kPageSize,
+        kNumReceivers,
+        pages_sent_addr,
+        noc_xy_addr,
+        config_addr,
+        data_addr,
+        kGcbSize,
+        static_cast<uint32_t>(gcb.buffer_address()),
+        static_cast<uint32_t>(experimental::pages_sent_worker_l1_base(gcb)),
+    };
+    KernelHandle sender_kernel_id = CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp",
+        sender_logical,
+        DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args});
+    std::vector<uint32_t> sender_rt_args;
+    const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
+    for (const auto& c : receiver_phys) {
+        sender_rt_args.push_back(c.x);
+        sender_rt_args.push_back(c.y);
+    }
+    SetRuntimeArgs(sender_program, sender_kernel_id, sender_logical, sender_rt_args);
+
+    // --- Receiver program: worker kernel only, with c_31 attached to the GCB ---
+    Program receiver_program = CreateProgram();
+    CircularBufferConfig cb_config(kPageSize);
+    cb_config.remote_index(kRemoteCBId).set_page_size(kPageSize).set_data_format(tt::DataFormat::Float16_b);
+    experimental::CreateCircularBuffer(receiver_program, receiver_cores, cb_config, gcb);
+    std::vector<uint32_t> receiver_compile_args = {kRemoteCBId, kNumPages};
+    CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_receiver.cpp",
+        receiver_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = receiver_compile_args});
+
+    // Enable async SD and enqueue the two programs as separate workloads.
+    experimental::DispatchContext::get().enable_asynchronous_slow_dispatch(mesh_device_);
+    distributed::MeshCoordinateRange device_range(distributed::MeshCoordinate(0, 0));
+    {
+        distributed::MeshWorkload sender_workload;
+        sender_workload.add_program(device_range, std::move(sender_program));
+        distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), sender_workload, /*blocking=*/false);
+        distributed::MeshWorkload receiver_workload;
+        receiver_workload.add_program(device_range, std::move(receiver_program));
+        distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), receiver_workload, /*blocking=*/false);
+        distributed::Finish(mesh_device_->mesh_command_queue());
+    }
+    experimental::DispatchContext::get().disable_asynchronous_slow_dispatch(mesh_device_);
+
+    // Verify each receiver's L1 slice matches the per-receiver expected stripe.
+    auto receivers_vec = corerange_to_cores(receiver_cores);
+    for (uint32_t r = 0; r < receivers_vec.size(); ++r) {
+        std::vector<uint32_t> result;
+        tt::tt_metal::detail::ReadFromDeviceL1(
+            device_, receivers_vec[r], gcb.buffer_address(), kPageSize, result, CoreType::WORKER);
+        for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
+            uint32_t expected = 0x55AA0000u + r * 0x100u + w;
+            EXPECT_EQ(result[w], expected) << "Receiver " << r << " word " << w;
+        }
+    }
+}
+
+// Two DRAM-sender GCBs sharing bank 0 with disjoint receivers. Validates the DRISC L1
+// arena gives them disjoint pages_sent regions and that each GCB's data flow is
+// uncorrupted by the other's presence.
+//
+// Pre-arena, both GCBs would have hardcoded pages_sent_drisc_l1_base_ = UNRESERVED,
+// so their per-receiver counter slots overlapped: receivers from GCB A NoC-inc'd into
+// the same DRISC L1 words that GCB B's receivers also targeted. With the arena, GCB A
+// lands at UNRESERVED and GCB B lands at UNRESERVED + sizeof(GCB A's pages_sent), and
+// neither kernel touches the other's bookkeeping.
+//
+// Programs run sequentially because only one DRISC kernel can occupy bank 0's DRISC at
+// a time. Both GCBs are live across both program runs (the arena allocations outlive
+// each individual program); each run targets one GCB.
+TEST_F(DramSenderGCBFixture, MultiGcbDisjointPagesSent) {
+    constexpr uint32_t kPageSize = 64;
+    constexpr uint32_t kNumPages = 1;
+    constexpr uint32_t kRemoteCBId = 31;
+    constexpr uint32_t kGcbSize = 1024;
+    const uint32_t bank_id = 0;
+
+    // GCB A: receiver at worker (0, 0). GCB B: receiver at worker (1, 0). Same bank.
+    CoreRangeSet recv_a(CoreRange({0, 0}, {0, 0}));
+    CoreRangeSet recv_b(CoreRange({1, 0}, {1, 0}));
+    auto gcb_a = experimental::CreateGlobalCircularBufferWithDramSenders(
+        mesh_device_, {{bank_id, recv_a}}, kGcbSize, BufferType::L1);
+    auto gcb_b = experimental::CreateGlobalCircularBufferWithDramSenders(
+        mesh_device_, {{bank_id, recv_b}}, kGcbSize, BufferType::L1);
+
+    const DeviceAddr pa = experimental::pages_sent_drisc_l1_base(gcb_a);
+    const DeviceAddr pb = experimental::pages_sent_drisc_l1_base(gcb_b);
+    ASSERT_NE(pa, pb) << "Arena handed both GCBs the same pages_sent base (0x" << std::hex << pa
+                      << "); this is the corruption the arena was meant to fix.";
+    // Per-GCB pages_sent footprint here is 2 * sizeof(uint32_t) * num_receivers(=1) (DRISC slots
+    // are packed at uint32 stride; see REMOTE_CB_LOCAL_PAGES_STRIDE).
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+    EXPECT_GE(pb, pa + 2 * sizeof(uint32_t)) << "GCB B's pages_sent overlaps GCB A's range";
+
+    // Both GCBs are on the same bank, so they share a sender core; pick either one's.
+    const CoreCoord sender_logical = gcb_a.sender_receiver_core_mapping().at(0).first;
+    const uint32_t drisc_l1_unreserved = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    const uint64_t drisc_l1_noc_addr_base =
+        hal.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    auto sender_virtual = device_->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+    auto align_up = [&](uint32_t a) { return (a + l1_alignment - 1) & ~(l1_alignment - 1); };
+
+    // Run one GCB's data flow end-to-end. The pages_sent address comes from the GCB
+    // (i.e., from the arena). Working state (noc_xy / config / data) is placed above
+    // the arena's kernel_working_region_base so that the *other* GCB's pages_sent
+    // (also inside the fixed zone) is never touched.
+    auto run_one = [&](const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+                       const CoreRangeSet& receivers,
+                       uint32_t pattern_seed) {
+        constexpr uint32_t kNumReceivers = 1;
+        const uint32_t pages_sent_addr = static_cast<uint32_t>(experimental::pages_sent_drisc_l1_base(gcb));
+
+        // Kernel-local layout: noc_xy / config / data sit above the arena's GCB zone,
+        // i.e. at the same offset as arena.kernel_working_region_base().
+        uint32_t cursor = align_up(drisc_l1_unreserved + DriscL1Arena::kGcbZoneSize);
+        const uint32_t noc_xy_addr = cursor;
+        cursor += 2 * sizeof(uint32_t) * kNumReceivers;
+        cursor = align_up(cursor);
+        const uint32_t config_addr = cursor;
+        cursor += 16;
+        cursor = align_up(cursor);
+        const uint32_t data_addr = cursor;
+
+        // Per-receiver pattern.
+        std::vector<uint32_t> pattern(kNumReceivers * kPageSize / sizeof(uint32_t));
+        for (uint32_t r = 0; r < kNumReceivers; ++r) {
+            for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
+                pattern[r * kPageSize / sizeof(uint32_t) + w] = pattern_seed + r * 0x100u + w;
+            }
+        }
+        MetalContext::instance().get_cluster().write_core(
+            pattern.data(),
+            pattern.size() * sizeof(uint32_t),
+            tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+            drisc_l1_noc_addr_base + (data_addr - drisc_l1_unreserved));
+
+        distributed::MeshCoordinateRange device_range(distributed::MeshCoordinate(0, 0));
+        Program program = CreateProgram();
+        std::vector<uint32_t> sender_compile_args = {
+            kRemoteCBId,
+            kNumPages,
+            kPageSize,
+            kNumReceivers,
+            pages_sent_addr,
+            noc_xy_addr,
+            config_addr,
+            data_addr,
+            kGcbSize,
+            static_cast<uint32_t>(gcb.buffer_address()),
+            static_cast<uint32_t>(experimental::pages_sent_worker_l1_base(gcb)),
+        };
+        KernelHandle sender_kernel_id = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp",
+            sender_logical,
+            DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args});
+        std::vector<uint32_t> sender_rt_args;
+        const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
+        for (const auto& c : receiver_phys) {
+            sender_rt_args.push_back(c.x);
+            sender_rt_args.push_back(c.y);
+        }
+        SetRuntimeArgs(program, sender_kernel_id, sender_logical, sender_rt_args);
+
+        CircularBufferConfig cb_config(kPageSize);
+        cb_config.remote_index(kRemoteCBId).set_page_size(kPageSize).set_data_format(tt::DataFormat::Float16_b);
+        experimental::CreateCircularBuffer(program, receivers, cb_config, gcb);
+        std::vector<uint32_t> receiver_compile_args = {kRemoteCBId, kNumPages};
+        CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_receiver.cpp",
+            receivers,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = receiver_compile_args});
+
+        distributed::MeshWorkload workload;
+        workload.add_program(device_range, std::move(program));
+        distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device_->mesh_command_queue());
+    };
+
+    // Run A then B. GCB B is alive (host-side) the whole time; its pages_sent region
+    // sits in the arena zone above GCB A's but is untouched by A's kernel.
+    run_one(gcb_a, recv_a, 0xAAAA0000u);
+    run_one(gcb_b, recv_b, 0xBBBB0000u);
+
+    // Verify receiver A got pattern A.
+    {
+        std::vector<uint32_t> result;
+        tt::tt_metal::detail::ReadFromDeviceL1(
+            device_, CoreCoord{0, 0}, gcb_a.buffer_address(), kPageSize, result, CoreType::WORKER);
+        for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
+            uint32_t expected = 0xAAAA0000u + w;
+            EXPECT_EQ(result[w], expected) << "Receiver A word " << w;
+        }
+    }
+    // Verify receiver B got pattern B.
+    {
+        std::vector<uint32_t> result;
+        tt::tt_metal::detail::ReadFromDeviceL1(
+            device_, CoreCoord{1, 0}, gcb_b.buffer_address(), kPageSize, result, CoreType::WORKER);
+        for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
+            uint32_t expected = 0xBBBB0000u + w;
+            EXPECT_EQ(result[w], expected) << "Receiver B word " << w;
+        }
+    }
+
+    // Verify pages_sent==pages_acked at BOTH GCB regions on the DRISC. Each GCB here has 1
+    // receiver, so its DRISC footprint is 2 uint32_t (pages_sent, pages_acked).
+    auto check_pages = [&](DeviceAddr pages_sent_addr, const char* tag) {
+        const uint64_t noc_addr = drisc_l1_noc_addr_base + (pages_sent_addr - drisc_l1_unreserved);
+        std::vector<uint32_t> buf(2, 0);
+        MetalContext::instance().get_cluster().read_core(
+            buf.data(), buf.size() * sizeof(uint32_t), tt_cxy_pair(mesh_device_->build_id(), sender_virtual), noc_addr);
+        uint32_t sent = buf[0];
+        uint32_t acked = buf[1];
+        EXPECT_EQ(sent, acked) << tag << " pages_sent != pages_acked (sent=" << sent << " acked=" << acked << ")";
+        EXPECT_GT(sent, 0u) << tag << " no pages were pushed";
+    };
+    check_pages(pa, "GCB A");
+    check_pages(pb, "GCB B");
+}
+
+// Allocating a GCB *after* the prefetcher kernel has started must not move the kernel's
+// L1 layout. We don't drive the prefetcher here (the user asked for low-level kernels),
+// but the equivalent invariant is checkable via the arena's contract directly: the
+// kernel_working_region_base value is fixed for the device's lifetime regardless of
+// arena allocations. The GCB-A path above is the smoke test for that invariant; the
+// concrete address-stability check belongs in test_drisc_l1_arena.cpp once that lands.
+
+TEST_F(DramSenderGCBFixture, RejectsDuplicateSender) {
+    CoreRangeSet recv0(CoreRange({0, 0}, {0, 0}));
+    CoreRangeSet recv1(CoreRange({1, 0}, {1, 0}));
+    std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{0, recv0}, {0, recv1}};
+    EXPECT_ANY_THROW(
+        experimental::CreateGlobalCircularBufferWithDramSenders(mesh_device_, bank_to_receivers, 1024, BufferType::L1));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -72,7 +72,7 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
     // Size: per-receiver fifo. Use 1KB.
     constexpr uint32_t kGcbSize = 1024;
     auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
-        mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
+        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
     // Use the sender coord the factory resolved; recomputing via pick_unused_dram_logical_core
     // would couple this test to the picker's current strategy.
     const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
@@ -216,7 +216,7 @@ TEST_F(DramSenderGCBFixture, SmokeTwoProgramsAsyncSlowDispatch) {
     CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{bank_id, receiver_cores}};
     auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
-        mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
+        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
     const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
 
     const auto& hal = MetalContext::instance().hal();
@@ -344,9 +344,9 @@ TEST_F(DramSenderGCBFixture, MultiGcbDisjointPagesSent) {
     CoreRangeSet recv_a(CoreRange({0, 0}, {0, 0}));
     CoreRangeSet recv_b(CoreRange({1, 0}, {1, 0}));
     auto gcb_a = experimental::CreateGlobalCircularBufferWithDramSenders(
-        mesh_device_, {{bank_id, recv_a}}, kGcbSize, BufferType::L1);
+        *mesh_device_, {{bank_id, recv_a}}, kGcbSize, BufferType::L1);
     auto gcb_b = experimental::CreateGlobalCircularBufferWithDramSenders(
-        mesh_device_, {{bank_id, recv_b}}, kGcbSize, BufferType::L1);
+        *mesh_device_, {{bank_id, recv_b}}, kGcbSize, BufferType::L1);
 
     const DeviceAddr pa = experimental::pages_sent_drisc_l1_base(gcb_a);
     const DeviceAddr pb = experimental::pages_sent_drisc_l1_base(gcb_b);
@@ -498,8 +498,8 @@ TEST_F(DramSenderGCBFixture, RejectsDuplicateSender) {
     CoreRangeSet recv0(CoreRange({0, 0}, {0, 0}));
     CoreRangeSet recv1(CoreRange({1, 0}, {1, 0}));
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{0, recv0}, {0, recv1}};
-    EXPECT_ANY_THROW(
-        experimental::CreateGlobalCircularBufferWithDramSenders(mesh_device_, bank_to_receivers, 1024, BufferType::L1));
+    EXPECT_ANY_THROW(experimental::CreateGlobalCircularBufferWithDramSenders(
+        *mesh_device_, bank_to_receivers, 1024, BufferType::L1));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -44,7 +44,7 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
         for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
             tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
                 static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
-            if (reserved.find({coord.x, coord.y}) == reserved.end()) {
+            if (!reserved.contains({coord.x, coord.y})) {
                 expected_free = sub;
                 break;
             }
@@ -57,7 +57,7 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
 
         tt::umd::CoreCoord picked_coord = soc_desc.get_dram_core_for_channel(
             static_cast<int>(channel), static_cast<int>(picked), tt::CoordSystem::TRANSLATED);
-        EXPECT_TRUE(reserved.find({picked_coord.x, picked_coord.y}) == reserved.end())
+        EXPECT_FALSE(reserved.contains({picked_coord.x, picked_coord.y}))
             << "Picked subchannel " << picked << " for bank " << bank << " collides with a worker/eth endpoint";
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -51,14 +51,15 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
         }
         ASSERT_LT(expected_free, num_subchannels) << "Test setup error: no free subchannel for bank " << bank;
 
-        uint32_t picked = mesh_device->impl().pick_unused_dram_subchannel(bank);
-        EXPECT_EQ(picked, expected_free) << "Mismatch for bank " << bank;
-        ASSERT_LT(picked, num_subchannels);
+        const CoreCoord expected_logical =
+            soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank), static_cast<int>(expected_free));
+        const CoreCoord picked_logical = mesh_device->impl().pick_unused_dram_logical_core(bank);
+        EXPECT_EQ(picked_logical, expected_logical) << "Mismatch for bank " << bank;
 
         tt::umd::CoreCoord picked_coord = soc_desc.get_dram_core_for_channel(
-            static_cast<int>(channel), static_cast<int>(picked), tt::CoordSystem::TRANSLATED);
+            static_cast<int>(channel), static_cast<int>(expected_free), tt::CoordSystem::TRANSLATED);
         EXPECT_FALSE(reserved.contains({picked_coord.x, picked_coord.y}))
-            << "Picked subchannel " << picked << " for bank " << bank << " collides with a worker/eth endpoint";
+            << "Picked logical core for bank " << bank << " collides with a worker/eth endpoint";
     }
 }
 
@@ -67,7 +68,7 @@ TEST_F(DramSubchannelHelperFixture, RejectsOutOfRangeBank) {
     auto* device = mesh_device->get_devices()[0];
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
     const uint32_t num_banks = soc_desc.get_num_dram_views();
-    EXPECT_ANY_THROW(mesh_device->impl().pick_unused_dram_subchannel(num_banks));
+    EXPECT_ANY_THROW(mesh_device->impl().pick_unused_dram_logical_core(num_banks));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <cstdint>
+
+#include <tt-metalium/core_coord.hpp>
+#include <umd/device/types/arch.hpp>
+#include <umd/device/types/core_coordinates.hpp>
+
+#include "device_fixture.hpp"
+#include "distributed/mesh_device_impl.hpp"
+#include "impl/context/metal_context.hpp"
+#include "llrt/metal_soc_descriptor.hpp"
+
+namespace tt::tt_metal {
+
+class DramSubchannelHelperFixture : public BlackholeSingleCardFixture {};
+
+TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
+
+    const uint32_t num_banks = soc_desc.get_num_dram_views();
+    const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
+    ASSERT_GT(num_banks, 0u);
+    ASSERT_GT(num_subchannels, 1u);
+
+    for (uint32_t bank = 0; bank < num_banks; ++bank) {
+        std::set<std::pair<size_t, size_t>> reserved;
+        for (const auto& c : soc_desc.dram_view_worker_cores.at(bank)) {
+            reserved.emplace(c.x, c.y);
+        }
+        for (const auto& c : soc_desc.dram_view_eth_cores.at(bank)) {
+            reserved.emplace(c.x, c.y);
+        }
+
+        const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank));
+        uint32_t expected_free = num_subchannels;
+        for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
+            tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
+                static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
+            if (reserved.find({coord.x, coord.y}) == reserved.end()) {
+                expected_free = sub;
+                break;
+            }
+        }
+        ASSERT_LT(expected_free, num_subchannels) << "Test setup error: no free subchannel for bank " << bank;
+
+        uint32_t picked = mesh_device->impl().pick_unused_dram_subchannel(bank);
+        EXPECT_EQ(picked, expected_free) << "Mismatch for bank " << bank;
+        ASSERT_LT(picked, num_subchannels);
+
+        tt::umd::CoreCoord picked_coord = soc_desc.get_dram_core_for_channel(
+            static_cast<int>(channel), static_cast<int>(picked), tt::CoordSystem::TRANSLATED);
+        EXPECT_TRUE(reserved.find({picked_coord.x, picked_coord.y}) == reserved.end())
+            << "Picked subchannel " << picked << " for bank " << bank << " collides with a worker/eth endpoint";
+    }
+}
+
+TEST_F(DramSubchannelHelperFixture, RejectsOutOfRangeBank) {
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
+    const uint32_t num_banks = soc_desc.get_num_dram_views();
+    EXPECT_ANY_THROW(mesh_device->impl().pick_unused_dram_subchannel(num_banks));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
@@ -14,14 +14,21 @@ template <bool use_legacy_api>
 void access_memory(uint32_t src_addr, uint32_t end_addr, uint32_t num_iterations, volatile uint64_t* results) {
     uint64_t start = c_tensix_core::read_wall_clock();
     for (uint32_t i = 0; i < num_iterations; i++) {
+        // Unroll both inner loops so per-byte loop overhead (pointer advance + branch) is
+        // amortized 8x. Without it, the legacy and new-API loops compile to byte-identical
+        // 4-instruction bodies, but I-cache warmup of the second loop biases speedup by
+        // ~0.05–0.1% — right at this test's tolerance, so it flakes. Unrolling drops
+        // overhead from ~50% to ~10% of the loop and brings the ratio inside tolerance.
         if constexpr (use_legacy_api) {
             volatile uint32_t* data = reinterpret_cast<volatile uint32_t*>(src_addr);
+#pragma GCC unroll 8
             while (data < reinterpret_cast<volatile uint32_t*>(end_addr)) {
                 [[maybe_unused]] volatile uint32_t word = data[0];
                 data++;
             }
         } else {
             CoreLocalMem<std::uint32_t> mem(src_addr);
+#pragma GCC unroll 8
             while (mem.get_address() < end_addr) {
                 [[maybe_unused]] volatile uint32_t word = mem[0];
                 mem++;

--- a/tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_receiver.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Smoke-test worker receiver for DramSenderGlobalCircularBuffer. Waits for
+// num_pages pushed by the DRISC sender, then pops them. The data itself
+// lives at the GCB cb_buffer address in this worker's L1; the host reads it
+// directly after the program finishes.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/remote_circular_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t remote_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(1);
+
+    experimental::remote_cb_wait_front(remote_cb_id, num_pages);
+    experimental::remote_cb_pop_front(remote_cb_id, num_pages);
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc_async_atomic_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Smoke-test DRISC sender for DramSenderGlobalCircularBuffer.
+//
+// Pushes a pre-loaded pattern from DRISC L1 to each configured receiver via the
+// experimental remote_cb_* API. The receivers' RemoteReceiverCBInterface is set
+// up by the normal CB attachment path (via experimental::CreateCircularBuffer
+// receiver overload); the sender side here is hand-managed because we don't
+// allocate a sender-side CB on DRAM cores.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/remote_circular_buffer.h"
+#include "experimental/drisc_mode.h"
+
+// DRISC firmware does not define cb_interface (no CB infrastructure on DRAM cores);
+// the remote_cb_* API references cb_interface[cb_id], so define it here.
+CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
+
+void kernel_main() {
+    // Compile time
+    constexpr uint32_t remote_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t num_receivers = get_compile_time_arg_val(3);
+    constexpr uint32_t pages_sent_drisc_l1_base = get_compile_time_arg_val(4);
+    constexpr uint32_t noc_xy_drisc_l1_base = get_compile_time_arg_val(5);
+    constexpr uint32_t config_drisc_l1_base = get_compile_time_arg_val(6);
+    constexpr uint32_t data_drisc_l1_base = get_compile_time_arg_val(7);
+    constexpr uint32_t fifo_size_per_receiver = get_compile_time_arg_val(8);
+    constexpr uint32_t receiver_buffer_address = get_compile_time_arg_val(9);
+    // Worker L1 address where each receiver reads its own pages_sent counter. The DRISC
+    // sender NOC-incs pages_sent here so the receiver sees it locally.
+    constexpr uint32_t remote_pages_sent_worker_l1_addr = get_compile_time_arg_val(10);
+
+    // Runtime: 2*num_receivers entries (x, y per receiver)
+    uint32_t rt_idx = 0;
+
+    // 1) Populate the noc_xy table in DRISC L1.
+    volatile tt_l1_ptr uint32_t* noc_xy_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(noc_xy_drisc_l1_base);
+    for (uint32_t i = 0; i < num_receivers; ++i) {
+        noc_xy_ptr[2 * i] = get_arg_val<uint32_t>(rt_idx++);
+        noc_xy_ptr[2 * i + 1] = get_arg_val<uint32_t>(rt_idx++);
+    }
+
+    // 2) Zero the pages_sent/pages_acked semaphore region. On DRISC the slots are
+    // packed at uint32 stride (2 uint32_t per receiver: pages_sent then pages_acked),
+    // matching REMOTE_CB_LOCAL_PAGES_STRIDE in remote_circular_buffer.h.
+    volatile tt_l1_ptr uint32_t* psem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pages_sent_drisc_l1_base);
+    const uint32_t psem_uints = 2 * num_receivers;
+    for (uint32_t i = 0; i < psem_uints; ++i) {
+        psem[i] = 0;
+    }
+
+    // 3) Stand up a mock config block: only [3] (fifo_size) is dereferenced by the
+    // sender path (resize_remote_sender_cb_interface, remote_cb_reserve_back). The
+    // kernel does not call update_remote_cb_config_in_l1, so the fifo_rd_ptr slot at
+    // offsetof(RemoteReceiverCBInterface, fifo_rd_ptr) (= byte 16) is left unallocated.
+    volatile tt_l1_ptr uint32_t* cfg = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_drisc_l1_base);
+    cfg[0] = 1;                        // is_sender (unused on sender path, but set)
+    cfg[1] = num_receivers;            // unused
+    cfg[2] = receiver_buffer_address;  // unused
+    cfg[3] = fifo_size_per_receiver;   // <- read by reserve/resize
+
+    // 4) Populate the sender CB interface manually.
+    RemoteSenderCBInterface& iface = get_remote_sender_cb_interface(remote_cb_id);
+    iface.config_ptr = config_drisc_l1_base;
+    iface.fifo_start_addr = receiver_buffer_address;
+    iface.fifo_wr_ptr = receiver_buffer_address;
+    iface.receiver_noc_xy_ptr = noc_xy_drisc_l1_base;
+    iface.aligned_pages_sent_ptr = pages_sent_drisc_l1_base;
+    // num_receivers and the worker-side pages_sent override share a packed 32-bit slot
+    // (see RemoteSenderCBInterface). Sender pages_sent counters live in DRISC L1
+    // (pages_sent_drisc_l1_base), but the NoC inc target lives in worker L1 (where
+    // receivers read their local pages_sent) — different L1 address spaces, so we use
+    // the override.
+    iface.num_receivers_and_remote_pages_sent_ptr = remote_cb_pack(num_receivers, remote_pages_sent_worker_l1_addr);
+
+    // DRISC needs stream mode for NIU-initiated NoC traffic.
+    experimental::drisc_set_stream_mode();
+
+    experimental::resize_remote_sender_cb_interface<false>(remote_cb_id, page_size, noc_index);
+
+    // 5) Reserve and push num_pages, one page at a time.
+    for (uint32_t i = 0; i < num_pages; ++i) {
+        experimental::remote_cb_reserve_back(remote_cb_id, 1);
+        experimental::remote_cb_push_back_and_write_pages<false>(
+            remote_cb_id,
+            data_drisc_l1_base + i * page_size,  // src
+            1,                                   // num_pages
+            1,                                   // num_rows
+            1,                                   // coalesced_num_pages_per_row
+            page_size,                           // coalesced_page_size
+            noc_index);
+        noc_async_posted_writes_flushed();
+    }
+
+    experimental::remote_cb_sender_barrier(remote_cb_id);
+    // Production prefetcher kernels call update_remote_cb_config_in_l1() here to checkpoint
+    // fifo_rd_ptr for the next program; this smoke kernel doesn't have a follow-on consumer
+    // and the mock config block above doesn't reserve that slot, so skip it.
+    noc_async_atomic_barrier();
+    experimental::drisc_set_noc2axi_mode();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_sender_config.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_sender_config.cpp
@@ -33,7 +33,8 @@ void kernel_main() {
     uint32_t num_receivers = get_arg_val<uint32_t>(arg_idx++);
     pass &= config_ptr[config_idx++] == num_receivers;
     ASSERT(pass);
-    pass &= remote_sender_cb_interface.num_receivers == num_receivers;
+    pass &=
+        remote_cb_num_receivers(remote_sender_cb_interface.num_receivers_and_remote_pages_sent_ptr) == num_receivers;
     ASSERT(pass);
     // fifo_start_addr
     uint32_t fifo_start_addr = get_arg_val<uint32_t>(arg_idx++);

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Experimental DRAM-sender extension to GlobalCircularBuffer. This is the opt-in API for
+// constructing a GCB whose senders are programmable DRAM cores (Blackhole DRISCs) rather
+// than worker cores. The public surface of `GlobalCircularBuffer` is unchanged; the
+// DRAM-sender mode is accessed through the free functions declared here.
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/global_circular_buffer.hpp>
+
+namespace tt::tt_metal {
+
+class IDevice;
+
+namespace distributed {
+class MeshDevice;
+}  // namespace distributed
+
+namespace experimental {
+
+// Sender domain for a GlobalCircularBuffer. Worker = standard sharded GCB where senders
+// are worker cores hosting their own slice of the cb_buffer in L1. Dram = senders are
+// programmable DRAM cores (Blackhole DRISCs) that own their staging L1 separately; the
+// cb_buffer is sharded over receivers only, and the receiver-side config_buffer
+// remote_pages_addr_override slot points at DRISC L1 so the receiver's pages_acked
+// NoC-inc lands on the DRISC side.
+enum class SenderCoreType : uint8_t {
+    Worker = 0,
+    Dram = 1,
+};
+
+// Construct a GlobalCircularBuffer where senders are programmable DRAM cores identified
+// by DRAM bank id. Each bank id is mapped internally to an unused DRAM subchannel (one
+// that the SOC descriptor does not already reserve as a worker/eth endpoint). Receiver
+// sets across senders must be disjoint and must not collide with the resolved DRAM-sender
+// physical NOC coords.
+//
+// MeshDevice-only: the arena that backs this GCB's pages_sent allocation lives on
+// MeshDeviceImpl, so a bare IDevice cannot construct one.
+GlobalCircularBuffer CreateGlobalCircularBufferWithDramSenders(
+    distributed::MeshDevice* mesh_device,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type = BufferType::L1);
+
+// Read-only accessors for the DRAM-sender state inside a GlobalCircularBuffer. For
+// GCBs created via the worker-sender path these return SenderCoreType::Worker / 0 /
+// empty respectively.
+SenderCoreType sender_core_type(const GlobalCircularBuffer& gcb);
+
+// DRISC unreserved-L1 base where the sender's per-receiver pages_sent/acked counters
+// live. Zero for worker-sender GCBs.
+DeviceAddr pages_sent_drisc_l1_base(const GlobalCircularBuffer& gcb);
+
+// Worker-L1 offset (inside the receiver's config buffer page) where the receiver's
+// local pages_sent counter lives. Zero for worker-sender GCBs.
+DeviceAddr pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb);
+
+// Physical worker NOC XY for each sender's receivers. The DRISC kernel uses these as
+// runtime args. Empty for worker-sender GCBs.
+const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb);
+
+}  // namespace experimental
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -19,8 +19,6 @@
 
 namespace tt::tt_metal {
 
-class IDevice;
-
 namespace distributed {
 class MeshDevice;
 }  // namespace distributed
@@ -47,7 +45,7 @@ enum class SenderCoreType : uint8_t {
 // MeshDevice-only: the arena that backs this GCB's pages_sent allocation lives on
 // MeshDeviceImpl, so a bare IDevice cannot construct one.
 GlobalCircularBuffer CreateGlobalCircularBufferWithDramSenders(
-    distributed::MeshDevice* mesh_device,
+    distributed::MeshDevice& mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type = BufferType::L1);

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -15,8 +15,21 @@ namespace tt::tt_metal {
 
 class Buffer;
 class IDevice;
+// Impl-only DRISC L1 arena types; held by GlobalCircularBuffer as a private
+// shared_ptr so the GCB doesn't have to include the impl arena header.
+class DriscL1Allocation;
 
 namespace experimental {
+
+// Forward declarations for the experimental DRAM-sender extension defined in
+// tt-metalium/experimental/global_circular_buffer.hpp. The DRAM-sender feature is an
+// opt-in mode that is not part of the public GlobalCircularBuffer API surface; existing
+// callers continue to see the original public interface unchanged.
+class GlobalCircularBuffer;
+enum class SenderCoreType : uint8_t;
+namespace global_circular_buffer_dram_sender {
+struct GlobalCircularBufferDramSenderInternals;
+}  // namespace global_circular_buffer_dram_sender
 
 class GlobalCircularBuffer {
 public:
@@ -53,6 +66,17 @@ public:
 private:
     void setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender);
 
+    // Tag for the private experimental DRAM-sender constructor; only the experimental
+    // factory (a friend) can name this type. Takes MeshDevice because the DRAM-sender
+    // path relies on the per-mesh DriscL1Arena for pages_sent placement.
+    struct DramSenderTag {};
+    GlobalCircularBuffer(
+        distributed::MeshDevice* mesh_device,
+        const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+        uint32_t size,
+        BufferType buffer_type,
+        DramSenderTag);
+
     // GlobalCircularBuffer is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions
     distributed::AnyBuffer cb_buffer_;
@@ -63,6 +87,20 @@ private:
     CoreRangeSet receiver_cores_;
     CoreRangeSet all_cores_;
     uint32_t size_ = 0;
+    // Private experimental DRAM-sender metadata. `sender_core_type_value_` is stored as
+    // uint8_t (0=Worker, 1=Dram) so the SenderCoreType enum stays in the experimental
+    // header. Accessed only through the friend struct in
+    // tt-metalium/experimental/global_circular_buffer.hpp.
+    uint8_t sender_core_type_value_ = 0;
+    DeviceAddr pages_sent_drisc_l1_base_ = 0;
+    DeviceAddr pages_sent_worker_l1_base_ = 0;
+    std::vector<std::vector<CoreCoord>> receiver_coords_per_sender_;
+    // RAII handle for the DRAM-sender's pages_sent allocation in the per-mesh DriscL1Arena.
+    // Held via shared_ptr so copies of the GCB share the same backing range; released
+    // when the last GCB copy goes out of scope. Empty for worker-sender GCBs.
+    std::shared_ptr<::tt::tt_metal::DriscL1Allocation> drisc_pages_sent_alloc_;
+
+    friend struct global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals;
 };
 
 /**

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1439,7 +1439,7 @@ uint32_t MeshDeviceImpl::pick_unused_dram_subchannel(uint32_t bank_id) const {
     for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
         tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
             static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
-        if (reserved.find({coord.x, coord.y}) == reserved.end()) {
+        if (!reserved.contains({coord.x, coord.y})) {
             return sub;
         }
     }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -48,6 +48,7 @@
 #include <experimental/fabric/fabric_types.hpp>
 #include "distributed/fd_mesh_command_queue.hpp"
 #include "distributed/realtime_profiler_manager.hpp"
+#include "impl/buffers/drisc_l1_arena.hpp"
 #include "distributed/sd_mesh_command_queue.hpp"
 #include "tracy/Tracy.hpp"
 #include "tools/profiler/tt_metal_tracy.hpp"
@@ -57,6 +58,8 @@
 #include "debug/inspector/inspector.hpp"
 #include "sub_device/sub_device_manager.hpp"
 #include "sub_device/sub_device_manager_tracker.hpp"
+#include <set>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "context/metal_context.hpp"
 #include <experimental/context/metal_env.hpp>
@@ -921,6 +924,11 @@ bool MeshDeviceImpl::close_impl(MeshDevice* pimpl_wrapper) {
         realtime_profiler_.reset();
     }
 
+    // DRISC L1 arena is torn down here so any GCB-owned allocation handles have
+    // already been released (GCBs are user-owned and the user's invariant is to
+    // destroy them before close).
+    drisc_l1_arena_.reset();
+
     if (is_initialized()) {
         sub_device_manager_tracker_.reset();
         scoped_devices_.reset();
@@ -1377,6 +1385,13 @@ bool MeshDeviceImpl::initialize_impl(
         }
     }
     Inspector::mesh_device_initialized(this);
+
+    // DRISC L1 arena: always constructed up-front when the HAL exposes programmable DRAM
+    // cores so users don't observe a lazy side-effect on first DRAM-sender GCB creation.
+    if (MetalContext::instance(context_id_).hal().has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+        drisc_l1_arena_ = std::make_shared<::tt::tt_metal::DriscL1Arena>(context_id_);
+    }
+
     is_internal_state_initialized = true;
     return true;
 }
@@ -1396,6 +1411,42 @@ void MeshDeviceImpl::trigger_realtime_profiler_sync_check() {
 
 D2HSocket* MeshDeviceImpl::get_realtime_profiler_socket() const {
     return realtime_profiler_ ? realtime_profiler_->get_socket() : nullptr;
+}
+
+::tt::tt_metal::DriscL1Arena& MeshDeviceImpl::drisc_l1_arena() {
+    TT_FATAL(
+        drisc_l1_arena_ != nullptr,
+        "DriscL1Arena not constructed; set TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 before "
+        "initializing the MeshDevice");
+    return *drisc_l1_arena_;
+}
+
+uint32_t MeshDeviceImpl::pick_unused_dram_subchannel(uint32_t bank_id) const {
+    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(reference_device()->id());
+    const uint32_t num_banks = soc_desc.get_num_dram_views();
+    TT_FATAL(bank_id < num_banks, "bank_id={} out of range (num_banks={})", bank_id, num_banks);
+
+    std::set<std::pair<size_t, size_t>> reserved;
+    for (const auto& c : soc_desc.dram_view_worker_cores.at(bank_id)) {
+        reserved.emplace(c.x, c.y);
+    }
+    for (const auto& c : soc_desc.dram_view_eth_cores.at(bank_id)) {
+        reserved.emplace(c.x, c.y);
+    }
+
+    const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
+    const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank_id));
+    for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
+        tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
+            static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
+        if (reserved.find({coord.x, coord.y}) == reserved.end()) {
+            return sub;
+        }
+    }
+    TT_THROW(
+        "No unused DRAM subchannel found for bank_id={}; all {} subchannels are reserved as worker/eth endpoints",
+        bank_id,
+        num_subchannels);
 }
 
 program_cache::detail::ProgramCache& MeshDeviceImpl::get_program_cache() { return *program_cache_; }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1421,7 +1421,7 @@ D2HSocket* MeshDeviceImpl::get_realtime_profiler_socket() const {
     return *drisc_l1_arena_;
 }
 
-uint32_t MeshDeviceImpl::pick_unused_dram_subchannel(uint32_t bank_id) const {
+CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const {
     const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(reference_device()->id());
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     TT_FATAL(bank_id < num_banks, "bank_id={} out of range (num_banks={})", bank_id, num_banks);
@@ -1440,7 +1440,7 @@ uint32_t MeshDeviceImpl::pick_unused_dram_subchannel(uint32_t bank_id) const {
         tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
             static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
         if (!reserved.contains({coord.x, coord.y})) {
-            return sub;
+            return soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank_id), static_cast<int>(sub));
         }
     }
     TT_THROW(

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -62,6 +62,7 @@ namespace tt::tt_metal {
 class SubDeviceManagerTracker;
 class ThreadPool;
 struct TraceDescriptor;
+class DriscL1Arena;
 
 namespace distributed {
 
@@ -157,6 +158,14 @@ private:
     // handler). Constructed by init_realtime_profiler_socket() and torn down in close_impl()
     // before the rest of the mesh shutdown so its receiver thread observes a live device.
     std::unique_ptr<RealtimeProfilerManager> realtime_profiler_;
+
+    // DRISC L1 arena for DRAM-sender GlobalCircularBuffer pages_sent allocations.
+    // Constructed eagerly in initialize_impl() when the HAL exposes programmable
+    // DRAM cores; torn down in close_impl(). Held as a shared_ptr so
+    // DriscL1Allocation handles can hold a weak_ptr back and become safe no-ops
+    // if the MeshDevice closes before their owning GCBs are destroyed (mirrors
+    // the MeshBuffer / weak_ptr<MeshDevice> pattern).
+    std::shared_ptr<::tt::tt_metal::DriscL1Arena> drisc_l1_arena_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;
     // Recursively quiesce all submeshes.
@@ -290,6 +299,17 @@ public:
     void init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device);
     void trigger_realtime_profiler_sync_check();
     D2HSocket* get_realtime_profiler_socket() const;
+
+    // DRISC L1 arena. Consumed by the DRAM-sender GlobalCircularBuffer ctor for
+    // pages_sent allocations. Constructed eagerly in initialize_impl() when the
+    // HAL exposes programmable DRAM cores; TT_FATAL otherwise.
+    ::tt::tt_metal::DriscL1Arena& drisc_l1_arena();
+
+    // Returns a DRAM subchannel for `bank_id` whose physical NoC coord isn't already
+    // claimed by the SOC descriptor as a worker_endpoint or eth_endpoint — i.e. one
+    // safe for a DRISC kernel to occupy. Throws if no free subchannel exists, or
+    // TT_FATALs if bank_id is out of range. Used by the DRAM-sender GCB factory.
+    uint32_t pick_unused_dram_subchannel(uint32_t bank_id) const;
     bool close() override;
     bool close_impl(MeshDevice* pimpl_wrapper);
     void enable_program_cache() override;

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -305,11 +305,11 @@ public:
     // HAL exposes programmable DRAM cores; TT_FATAL otherwise.
     ::tt::tt_metal::DriscL1Arena& drisc_l1_arena();
 
-    // Returns a DRAM subchannel for `bank_id` whose physical NoC coord isn't already
+    // Returns the logical DRAM core for `bank_id` whose physical NoC coord isn't already
     // claimed by the SOC descriptor as a worker_endpoint or eth_endpoint — i.e. one
     // safe for a DRISC kernel to occupy. Throws if no free subchannel exists, or
     // TT_FATALs if bank_id is out of range. Used by the DRAM-sender GCB factory.
-    uint32_t pick_unused_dram_subchannel(uint32_t bank_id) const;
+    CoreCoord pick_unused_dram_logical_core(uint32_t bank_id) const;
     bool close() override;
     bool close_impl(MeshDevice* pimpl_wrapper);
     void enable_program_cache() override;

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -25,13 +25,19 @@ namespace {
 bool logical_cores_intersect(
     const std::vector<std::vector<tt::tt_metal::CoreCoord>>& previous_cores,
     const std::vector<std::vector<tt::tt_metal::CoreCoord>>& current_cores) {
-    // Build a set from previous_cores only, then probe with current_cores directly.
-    std::unordered_set<tt::tt_metal::CoreCoord> previous_cores_set;
-    for (const auto& core_group : previous_cores) {
-        previous_cores_set.insert(core_group.begin(), core_group.end());
-    }
-    for (const auto& core_group : current_cores) {
-        for (const auto& core : core_group) {
+    // The outer index is the programmable_core_type (TENSIX, DRAM, ETH, ...). Two CoreCoords
+    // with the same (x, y) but different programmable core types refer to physically distinct
+    // cores (e.g., DRAM (0,0) is bank 0; WORKER (0,0) is the bottom-left compute core), so we
+    // must only consider intersection WITHIN the same programmable core type.
+    const size_t shared = std::min(previous_cores.size(), current_cores.size());
+    for (size_t pct = 0; pct < shared; ++pct) {
+        const auto& prev_group = previous_cores[pct];
+        const auto& curr_group = current_cores[pct];
+        if (prev_group.empty() || curr_group.empty()) {
+            continue;
+        }
+        std::unordered_set<tt::tt_metal::CoreCoord> previous_cores_set(prev_group.begin(), prev_group.end());
+        for (const auto& core : curr_group) {
             if (previous_cores_set.contains(core)) {
                 return true;
             }

--- a/tt_metal/hw/inc/api/remote_circular_buffer.h
+++ b/tt_metal/hw/inc/api/remote_circular_buffer.h
@@ -15,6 +15,19 @@
 
 namespace experimental {
 
+// Per-receiver layout of the sender's local pages_sent / pages_acked slots.
+// For a sharded GCB the sender is a worker and slots live in the receivers'
+// config buffer pages at L1 alignment. For a DRAM-sender (DRISC) GCB the slots
+// live in DRISC L1 and can be packed at uint32 alignment — NoC atomic inc only
+// needs 4-byte alignment. The receiver-side layout is unchanged in both cases.
+#ifdef COMPILE_FOR_DRISC
+static constexpr uint32_t REMOTE_CB_LOCAL_PAGES_ACKED_OFFSET = sizeof(uint32_t);
+static constexpr uint32_t REMOTE_CB_LOCAL_PAGES_STRIDE = 2 * sizeof(uint32_t);
+#else
+static constexpr uint32_t REMOTE_CB_LOCAL_PAGES_ACKED_OFFSET = L1_ALIGNMENT;
+static constexpr uint32_t REMOTE_CB_LOCAL_PAGES_STRIDE = 2 * L1_ALIGNMENT;
+#endif
+
 namespace detail {
 
 #ifndef COMPILE_FOR_TRISC
@@ -33,7 +46,7 @@ FORCE_INLINE void update_pages_sent(
     uint8_t cmd_buf) {
     uint32_t aligned_pages_sent_addr = sender_cb_interface.aligned_pages_sent_ptr;
     uint32_t remote_noc_xy_addr = sender_cb_interface.receiver_noc_xy_ptr;
-    uint32_t num_receivers = sender_cb_interface.num_receivers;
+    uint32_t num_receivers = remote_cb_num_receivers(sender_cb_interface.num_receivers_and_remote_pages_sent_ptr);
 
     // increment the aligned pages sent because we skipped to next aligned page location
     volatile tt_l1_ptr uint32_t* pages_sent_ptr =
@@ -54,7 +67,7 @@ FORCE_INLINE void update_pages_sent(
             false /*linked*/,
             posted /*posted*/,
             MEM_NOC_ATOMIC_RET_VAL_ADDR);
-        pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
+        pages_sent_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
         remote_noc_xy_ptr += 2;
     }
 }
@@ -74,7 +87,11 @@ FORCE_INLINE void update_pages_acked(
     volatile tt_l1_ptr uint32_t* pages_acked_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(aligned_pages_acked_addr);
     *pages_acked_ptr += aligned_page_adjustment;
-    uint64_t remote_ack_ptr_addr = get_noc_addr(sender_noc_x, sender_noc_y, (uintptr_t)pages_acked_ptr, noc);
+    // remote_pages_acked_ptr is the canonical NoC target for the sender-side pages_acked
+    // counter; host writes the same value as aligned_pages_acked_ptr for sharded GCB (where
+    // local == remote) and the DRISC-side slot for DRAM-sender GCB.
+    uint64_t remote_ack_ptr_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, receiver_cb_interface.remote_pages_acked_ptr, noc);
     noc_fast_atomic_increment<nm>(
         noc,
         cmd_buf,
@@ -270,10 +287,10 @@ FORCE_INLINE void remote_cb_reserve_back(uint32_t cb_id, uint32_t num_pages) {
 
     volatile tt_l1_ptr uint32_t* pages_sent_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_sent_ptr);
-    volatile tt_l1_ptr uint32_t* pages_acked_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_sent_ptr + L1_ALIGNMENT);
+    volatile tt_l1_ptr uint32_t* pages_acked_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        remote_cb.aligned_pages_sent_ptr + REMOTE_CB_LOCAL_PAGES_ACKED_OFFSET);
 
-    uint32_t num_receivers = remote_cb.num_receivers;
+    uint32_t num_receivers = remote_cb_num_receivers(remote_cb.num_receivers_and_remote_pages_sent_ptr);
     uint32_t fifo_aligned_num_pages = fifo_size / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
 
     for (uint32_t i = 0; i < num_receivers; ++i) {
@@ -284,8 +301,8 @@ FORCE_INLINE void remote_cb_reserve_back(uint32_t cb_id, uint32_t num_pages) {
             uint32_t sent_minus_ack = pages_sent - pages_acked;
             free_pages = fifo_aligned_num_pages - sent_minus_ack;
         } while (free_pages < num_pages_wait);
-        pages_acked_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
-        pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
+        pages_acked_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
+        pages_sent_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
     }
 
     WAYPOINT("RCRD");
@@ -297,16 +314,16 @@ FORCE_INLINE void remote_cb_sender_barrier(uint32_t cb_id) {
 
     volatile tt_l1_ptr uint32_t* pages_sent_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_sent_ptr);
-    volatile tt_l1_ptr uint32_t* pages_acked_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_sent_ptr + L1_ALIGNMENT);
+    volatile tt_l1_ptr uint32_t* pages_acked_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        remote_cb.aligned_pages_sent_ptr + REMOTE_CB_LOCAL_PAGES_ACKED_OFFSET);
 
-    uint32_t num_receivers = remote_cb.num_receivers;
+    uint32_t num_receivers = remote_cb_num_receivers(remote_cb.num_receivers_and_remote_pages_sent_ptr);
 
     for (uint32_t i = 0; i < num_receivers; ++i) {
         while (*pages_acked_ptr != *pages_sent_ptr) {
         }
-        pages_acked_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
-        pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
+        pages_acked_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
+        pages_sent_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
     }
     WAYPOINT("RCBD");
 }
@@ -332,7 +349,7 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
         len_bytes += fifo_start_addr + fifo_size - fifo_limit_page_aligned;
     }
     uint32_t pages_sent = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
-    uint32_t num_receivers = remote_cb.num_receivers;
+    uint32_t num_receivers = remote_cb_num_receivers(remote_cb.num_receivers_and_remote_pages_sent_ptr);
 
     uint32_t next_receiver_start_addr_stride = coalesced_num_pages_per_row * coalesced_page_size;
     uint32_t next_block_row_stride = next_receiver_start_addr_stride * num_receivers;
@@ -342,6 +359,10 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
     uint32_t next_receiver_start_addr_offset = 0;
     volatile tt_l1_ptr uint32_t* pages_sent_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_sent_ptr);
+    // The packed remote_pages_sent_ptr is the canonical NoC target for the receiver-side
+    // pages_sent counter; host writes the same value as aligned_pages_sent_ptr for sharded
+    // GCB (where local == remote) and the worker-side base for DRAM-sender GCB.
+    uint32_t remote_sent_base = remote_cb_remote_pages_sent_ptr(remote_cb.num_receivers_and_remote_pages_sent_ptr);
     volatile tt_l1_ptr uint32_t* remote_noc_xy_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.receiver_noc_xy_ptr);
     for (uint32_t i = 0; i < num_receivers; ++i) {
@@ -369,9 +390,12 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
         next_receiver_start_addr_offset += next_receiver_start_addr_stride;
         *pages_sent_ptr += pages_sent;
 
-        uint64_t remote_sent_ptr_addr = get_noc_addr_helper(remote_noc_xy, (uint32_t)pages_sent_ptr);
+        uint64_t remote_sent_ptr_addr = get_noc_addr_helper(remote_noc_xy, remote_sent_base);
         noc_semaphore_inc<posted>(remote_sent_ptr_addr, pages_sent, noc);
-        pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
+        // Local stride may be smaller than the remote stride on a DRISC sender (see
+        // REMOTE_CB_LOCAL_PAGES_STRIDE) — the receiver-side layout is always L1-aligned.
+        pages_sent_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
+        remote_sent_base += 2 * L1_ALIGNMENT;
         remote_noc_xy_ptr += 2;
     }
 

--- a/tt_metal/hw/inc/internal/circular_buffer_init.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_init.h
@@ -189,6 +189,11 @@ inline void setup_remote_cb_interfaces(
         uint32_t fifo_ptr = l1_remote_cb_config_addr[4];
         uint32_t remote_noc_xy_addr = l1_remote_cb_config_addr[5];
         uint32_t aligned_pages_sent_addr = l1_remote_cb_config_addr[6];
+        // Canonical NoC target for the sender's pages_sent inc (on the receiver) or the
+        // receiver's pages_acked inc (on the sender). For a sharded GCB host writes the same
+        // L1 offset as slot 6; for a DRAM-sender GCB it points at the worker- or DRISC-side
+        // counter, since sender and receiver live in different L1 address spaces.
+        uint32_t remote_pages_addr_override = l1_remote_cb_config_addr[7];
         if (is_sender) {
             RemoteSenderCBInterface& sender_cb_interface = get_remote_sender_cb_interface(cb_id);
             sender_cb_interface.config_ptr = config_addr;
@@ -196,7 +201,8 @@ inline void setup_remote_cb_interfaces(
             sender_cb_interface.fifo_wr_ptr = fifo_ptr;
             sender_cb_interface.receiver_noc_xy_ptr = remote_noc_xy_addr;
             sender_cb_interface.aligned_pages_sent_ptr = aligned_pages_sent_addr;
-            sender_cb_interface.num_receivers = num_receivers;
+            sender_cb_interface.num_receivers_and_remote_pages_sent_ptr =
+                remote_cb_pack(num_receivers, remote_pages_addr_override);
             // Using posted semaphore inc
             resize_remote_sender_cb_interface<update_remote_over_noc>(cb_id, page_size, noc, nm, posted, cmd_buf);
         } else {
@@ -207,9 +213,10 @@ inline void setup_remote_cb_interfaces(
             receiver_cb_interface.config_ptr = config_addr;
             receiver_cb_interface.fifo_start_addr = fifo_start_addr;
             receiver_cb_interface.fifo_rd_ptr = fifo_ptr;
-            receiver_cb_interface.sender_noc_x = sender_noc_x;
-            receiver_cb_interface.sender_noc_y = sender_noc_y;
+            receiver_cb_interface.sender_noc_x = static_cast<uint16_t>(sender_noc_x);
+            receiver_cb_interface.sender_noc_y = static_cast<uint16_t>(sender_noc_y);
             receiver_cb_interface.aligned_pages_acked_ptr = aligned_pages_acked_addr;
+            receiver_cb_interface.remote_pages_acked_ptr = remote_pages_addr_override;
             // Using posted semaphore inc
             resize_remote_receiver_cb_interface<update_remote_over_noc>(cb_id, page_size, noc, nm, posted, cmd_buf);
         }

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -11,6 +11,11 @@
 
 constexpr static std::uint32_t REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE = L1_ALIGNMENT;
 
+// L1 addresses fit in 24 bits (< 2 MB) and num_receivers fits in 8 bits, so the two
+// can share a 32-bit slot. Keeps the struct at 8 uint32 words.
+constexpr static std::uint32_t REMOTE_CB_PACKED_ADDR_MASK = 0x00FFFFFFu;
+constexpr static std::uint32_t REMOTE_CB_PACKED_COUNT_SHIFT = 24;
+
 struct RemoteSenderCBInterface {
     uint32_t config_ptr;
     uint32_t fifo_start_addr;
@@ -23,11 +28,18 @@ struct RemoteSenderCBInterface {
     // arranged x0, y0, x1, y1, ...
     uint32_t receiver_noc_xy_ptr;
 
-    // These point to an array of size num_receivers
-    // It's stored as pages_sent, pages_acked pairs for each receiver
-    // Each entry is L1 aligned
+    // Points to an array of size num_receivers, stored as pages_sent, pages_acked pairs
+    // for each receiver. Per-receiver stride is REMOTE_CB_LOCAL_PAGES_STRIDE: 2 * L1_ALIGNMENT
+    // for worker senders, 2 * sizeof(uint32_t) for DRISC senders (packed; NoC atomic inc
+    // only needs 4-byte alignment).
     uint32_t aligned_pages_sent_ptr;
-    uint32_t num_receivers;
+
+    // Packed: bits [23:0] are the remote pages_sent address on the receiver's L1,
+    // bits [31:24] are num_receivers. The remote address is canonical (no fallback):
+    // for a sharded GCB it equals `aligned_pages_sent_ptr` (local == remote); for a
+    // DRAM-sender GCB it's the worker-side pages_sent base (the DRISC sender's local
+    // counter is in DRISC L1, but the NoC target is in worker L1).
+    uint32_t num_receivers_and_remote_pages_sent_ptr;
 };
 
 struct RemoteReceiverCBInterface {
@@ -38,13 +50,26 @@ struct RemoteReceiverCBInterface {
 
     uint32_t fifo_rd_ptr;
 
-    uint32_t sender_noc_x;
-    uint32_t sender_noc_y;
+    // NoC XY fit in 8 bits each; using u16 keeps the struct at 8 uint32 words.
+    uint16_t sender_noc_x;
+    uint16_t sender_noc_y;
 
     // These point to a single entry corresponding to receiver index
     // Each entry is L1 aligned
     uint32_t aligned_pages_acked_ptr;
+
+    // Address ON the SENDER's L1 where the receiver's NoC inc lands for pages_acked.
+    // Canonical (no fallback): for a sharded GCB it equals `aligned_pages_acked_ptr`;
+    // for a DRAM-sender GCB it points into DRISC L1 (separate address space from the
+    // receiver's local pages_acked).
+    uint32_t remote_pages_acked_ptr;
 };
+
+inline uint32_t remote_cb_num_receivers(uint32_t packed) { return packed >> REMOTE_CB_PACKED_COUNT_SHIFT; }
+inline uint32_t remote_cb_remote_pages_sent_ptr(uint32_t packed) { return packed & REMOTE_CB_PACKED_ADDR_MASK; }
+inline uint32_t remote_cb_pack(uint32_t num_receivers, uint32_t remote_pages_sent_ptr) {
+    return (num_receivers << REMOTE_CB_PACKED_COUNT_SHIFT) | (remote_pages_sent_ptr & REMOTE_CB_PACKED_ADDR_MASK);
+}
 
 // Required for update_remote_cb_config
 static_assert(

--- a/tt_metal/impl/buffers/drisc_l1_arena.cpp
+++ b/tt_metal/impl/buffers/drisc_l1_arena.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "impl/buffers/drisc_l1_arena.hpp"
+
+#include <algorithm>
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <tt_stl/assert.hpp>
+
+#include "impl/context/metal_context.hpp"
+
+namespace tt::tt_metal {
+
+DriscL1Arena::DriscL1Arena(ContextId context_id) {
+    const auto& hal = MetalContext::instance(context_id).hal();
+    TT_FATAL(
+        hal.has_programmable_core_type(HalProgrammableCoreType::DRAM),
+        "DriscL1Arena requires programmable DRAM cores; set "
+        "TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1");
+
+    unreserved_base_ = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    drisc_unreserved_size_ = hal.get_dev_size(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    TT_FATAL(
+        kGcbZoneSize < drisc_unreserved_size_,
+        "DRISC L1 GCB zone ({} B) must leave room for the above-zone kernel working region "
+        "(unreserved size: {} B)",
+        kGcbZoneSize,
+        drisc_unreserved_size_);
+}
+
+std::shared_ptr<DriscL1Allocation> DriscL1Arena::allocate(uint32_t size, uint32_t alignment) {
+    TT_FATAL(size > 0, "DriscL1Arena::allocate requires size > 0");
+    TT_FATAL(alignment > 0 && (alignment & (alignment - 1)) == 0, "alignment must be a power of two");
+
+    const uint32_t aligned_size = tt::align(size, alignment);
+    const DeviceAddr zone_begin = unreserved_base_;
+    const DeviceAddr zone_end = unreserved_base_ + kGcbZoneSize;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // First-fit search across the single uniform-offset pool.
+    DeviceAddr candidate = tt::align(zone_begin, alignment);
+    while (candidate + aligned_size <= zone_end) {
+        // Find first live range whose end is > candidate (the earliest range that could overlap).
+        auto it = std::lower_bound(
+            live_.begin(), live_.end(), candidate, [](const std::pair<DeviceAddr, uint32_t>& range, DeviceAddr val) {
+                return range.first + range.second <= val;
+            });
+        if (it == live_.end() || it->first >= candidate + aligned_size) {
+            // No overlap — insert and return.
+            auto insert_it = std::lower_bound(
+                live_.begin(),
+                live_.end(),
+                candidate,
+                [](const std::pair<DeviceAddr, uint32_t>& range, DeviceAddr val) { return range.first < val; });
+            live_.insert(insert_it, {candidate, aligned_size});
+            return std::shared_ptr<DriscL1Allocation>(new DriscL1Allocation(weak_from_this(), candidate, aligned_size));
+        }
+        // Overlap with `*it` — advance past its end (aligned) and retry.
+        candidate = tt::align(it->first + it->second, alignment);
+    }
+
+    TT_THROW(
+        "DRISC L1 GCB zone full: requested {} B (aligned {} B); zone is {} B starting at 0x{:x}",
+        size,
+        aligned_size,
+        kGcbZoneSize,
+        zone_begin);
+}
+
+void DriscL1Arena::release(DeviceAddr base, uint32_t size) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = std::lower_bound(
+        live_.begin(), live_.end(), base, [](const std::pair<DeviceAddr, uint32_t>& range, DeviceAddr val) {
+            return range.first < val;
+        });
+    if (it != live_.end() && it->first == base && it->second == size) {
+        live_.erase(it);
+    }
+}
+
+DriscL1Allocation::~DriscL1Allocation() {
+    // If the owning MeshDeviceImpl has already dropped the arena (close_impl
+    // ran before the user destroyed their GCBs), lock() returns null and the
+    // destructor becomes a no-op — no UAF on the arena pointer. Same shape as
+    // MeshBuffer::deallocate() locking its weak_ptr<MeshDevice>.
+    if (auto arena = arena_.lock()) {
+        arena->release(base_, size_);
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/drisc_l1_arena.hpp
+++ b/tt_metal/impl/buffers/drisc_l1_arena.hpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/hal_types.hpp>
+
+#include "impl/context/context_types.hpp"
+
+namespace tt::tt_metal {
+
+class DriscL1Arena;
+
+// RAII handle for a uniform-offset allocation inside the DRISC L1 "GCB zone".
+// Held via shared_ptr by GlobalCircularBuffer so copies of the GCB share the
+// same backing range. The destructor releases the slot back to the arena if
+// the arena is still alive — if the owning MeshDevice has already torn down
+// (and dropped the arena), the destructor is a no-op. Same lifetime pattern
+// as MeshBuffer / MeshDevice.
+class DriscL1Allocation {
+public:
+    DeviceAddr addr() const { return base_; }
+    uint32_t size() const { return size_; }
+    ~DriscL1Allocation();
+
+    DriscL1Allocation(const DriscL1Allocation&) = delete;
+    DriscL1Allocation& operator=(const DriscL1Allocation&) = delete;
+    DriscL1Allocation(DriscL1Allocation&&) = delete;
+    DriscL1Allocation& operator=(DriscL1Allocation&&) = delete;
+
+private:
+    friend class DriscL1Arena;
+    DriscL1Allocation(std::weak_ptr<DriscL1Arena> arena, DeviceAddr base, uint32_t size) :
+        arena_(std::move(arena)), base_(base), size_(size) {}
+
+    std::weak_ptr<DriscL1Arena> arena_;
+    DeviceAddr base_;
+    uint32_t size_;
+};
+
+// Per-mesh, per-DRAM-bank arena for the DRISC L1 region above UNRESERVED.
+//
+// Layout:
+//   [UNRESERVED, UNRESERVED + kGcbZoneSize)   — fixed zone for GCB pages_sent
+//                                                 allocations (this arena).
+//   [UNRESERVED + kGcbZoneSize, END)          — kernel working region for any
+//                                                 long-lived DRISC kernel that
+//                                                 co-exists with DRAM-sender
+//                                                 GCBs (queried via
+//                                                 kernel_working_region_base()).
+//
+// The zone is *fixed* so that allocating a GCB after such a kernel has started
+// doesn't move the kernel's L1 layout: the kernel sits above the zone at a
+// stable address.
+// Lives as a std::shared_ptr on MeshDeviceImpl so that DriscL1Allocation handles
+// can hold a weak_ptr back and survive close_impl() without UAF.
+class DriscL1Arena : public std::enable_shared_from_this<DriscL1Arena> {
+public:
+    // Sized for ~16 GCBs at production receiver counts. Each GCB's per-bank
+    // footprint is `2 * sizeof(uint32_t) * num_receivers_per_bank` bytes, e.g.
+    // 2 * 4 * 8 = 64 B for ring=64 → 16 GCBs * 64 B = 1 KB exact (DRISC slots
+    // are packed at 4-byte stride; the kernel walks them via
+    // REMOTE_CB_LOCAL_PAGES_STRIDE under #ifdef COMPILE_FOR_DRISC). The
+    // remaining ~92 KB above the zone is reported by kernel_working_region_size()
+    // so callers placing a co-resident DRISC kernel know how much L1 they have.
+    static constexpr uint32_t kGcbZoneSize = 1 * 1024;
+
+    explicit DriscL1Arena(ContextId context_id);
+    ~DriscL1Arena() = default;
+
+    DriscL1Arena(const DriscL1Arena&) = delete;
+    DriscL1Arena& operator=(const DriscL1Arena&) = delete;
+
+    // Allocate `size` bytes inside the fixed GCB zone. The returned offset is the
+    // same across all DRAM banks (uniform-offset constraint: every sender DRISC
+    // core plants pages_sent at the same L1 offset). Similar in shape to the L1 /
+    // DRAM bank allocators — a single pool, not per-bank.
+    // TT_FATAL on invalid alignment; TT_THROW on zone full.
+    std::shared_ptr<DriscL1Allocation> allocate(uint32_t size, uint32_t alignment);
+
+    // Fixed base for the prefetcher kernel's working region. Unchanged for
+    // the device's lifetime, regardless of current arena allocations.
+    DeviceAddr kernel_working_region_base() const { return unreserved_base_ + kGcbZoneSize; }
+
+    // Total DRISC L1 bytes available to the prefetcher kernel above the fixed
+    // GCB zone. The manager uses this to size its ping-pong stage budget so
+    // changing `kGcbZoneSize` automatically reduces the budget.
+    uint32_t kernel_working_region_size() const { return drisc_unreserved_size_ - kGcbZoneSize; }
+
+private:
+    friend class DriscL1Allocation;
+    void release(DeviceAddr base, uint32_t size);
+
+    DeviceAddr unreserved_base_;
+    uint32_t drisc_unreserved_size_;
+    // Sorted ascending list of live (base, size) ranges within
+    // [unreserved_base_, unreserved_base_ + kGcbZoneSize). First-fit allocate;
+    // release coalesces with neighbors implicitly via removal.
+    std::vector<std::pair<DeviceAddr, uint32_t>> live_;
+    mutable std::mutex mutex_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -348,20 +348,13 @@ const std::vector<std::vector<CoreCoord>>& GlobalCircularBufferDramSenderInterna
 namespace {
 
 // Map (bank_id, receivers) pairs to (DRAM-logical CoreCoord, receivers) pairs by picking
-// an unused hardware subchannel for each bank.
-// logical.y must index dram_bank_endpoint_coords (worker endpoint at y=0), not the raw
-// subchannel number — see metal_SocDescriptor::get_logical_dram_core_for_subchannel.
+// an unused logical DRAM core for each bank.
 std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
     distributed::MeshDevice* mesh_device, const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers) {
-    IDevice* ref_device = mesh_device->get_devices().front();
-    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(ref_device->build_id());
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping;
     mapping.reserve(bank_to_receivers.size());
     for (const auto& [bank_id, receivers] : bank_to_receivers) {
-        const uint32_t sub = mesh_device->impl().pick_unused_dram_subchannel(bank_id);
-        const CoreCoord sender_logical =
-            soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank_id), static_cast<int>(sub));
-        mapping.emplace_back(sender_logical, receivers);
+        mapping.emplace_back(mesh_device->impl().pick_unused_dram_logical_core(bank_id), receivers);
     }
     return mapping;
 }

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -9,6 +9,10 @@
 #include <device.hpp>
 #include <global_circular_buffer.hpp>
 #include <host_api.hpp>
+#include "impl/buffers/drisc_l1_arena.hpp"
+#include "impl/context/context_types.hpp"
+#include "distributed/mesh_device_impl.hpp"
+#include <tt-metalium/experimental/global_circular_buffer.hpp>
 #include <tt_align.hpp>
 #include <tt_metal.hpp>
 #include <algorithm>
@@ -31,14 +35,22 @@
 
 namespace tt::tt_metal::experimental {
 
-GlobalCircularBuffer::GlobalCircularBuffer(
+namespace {
+
+// Body shared by the public Worker ctor and the private DRAM-sender ctor (with tag).
+// Populates the core sets and reports the per-sender max receiver count.
+void initialize_global_circular_buffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
-    uint32_t size,
-    BufferType buffer_type) :
-    device_(device), sender_receiver_core_mapping_(sender_receiver_core_mapping), size_(size) {
-    TT_FATAL(device_ != nullptr, "Device cannot be null");
+    bool is_dram_sender,
+    CoreRangeSet& sender_cores_out,
+    CoreRangeSet& receiver_cores_out,
+    CoreRangeSet& all_cores_out,
+    uint32_t& max_num_receivers_per_sender_out) {
+    TT_FATAL(device != nullptr, "Device cannot be null");
+
     uint32_t num_sender_cores = sender_receiver_core_mapping.size();
+    TT_FATAL(num_sender_cores > 0, "At least one sender required");
     uint32_t num_receiver_cores = 0;
     uint32_t max_num_receivers_per_sender = 0;
     std::vector<CoreRange> sender_cores;
@@ -46,14 +58,100 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     for (const auto& [sender_core, receiver_cores] : sender_receiver_core_mapping) {
         num_receiver_cores += receiver_cores.num_cores();
         sender_cores.emplace_back(sender_core);
-        receiver_cores_ = receiver_cores_.merge(receiver_cores);
+        receiver_cores_out = receiver_cores_out.merge(receiver_cores);
         max_num_receivers_per_sender = std::max(max_num_receivers_per_sender, receiver_cores.num_cores());
     }
-    sender_cores_ = CoreRangeSet(sender_cores);
-    TT_FATAL(num_sender_cores == sender_cores_.num_cores(), "Duplicate sender cores found");
-    TT_FATAL(num_receiver_cores == receiver_cores_.num_cores(), "Duplicate receiver cores found");
-    all_cores_ = sender_cores_.merge(receiver_cores_);
-    TT_FATAL(all_cores_.num_cores() == num_sender_cores + num_receiver_cores, "Duplicate cores found");
+    sender_cores_out = CoreRangeSet(sender_cores);
+    TT_FATAL(num_sender_cores == sender_cores_out.num_cores(), "Duplicate sender cores found");
+    TT_FATAL(num_receiver_cores == receiver_cores_out.num_cores(), "Duplicate receiver cores found");
+
+    if (!is_dram_sender) {
+        all_cores_out = sender_cores_out.merge(receiver_cores_out);
+        TT_FATAL(all_cores_out.num_cores() == num_sender_cores + num_receiver_cores, "Duplicate cores found");
+    } else {
+        // DRAM senders and worker receivers live in disjoint programmable-core types, so their
+        // physical NoC coords can never collide — no extra cross-type check needed.
+        all_cores_out = receiver_cores_out;
+    }
+    max_num_receivers_per_sender_out = max_num_receivers_per_sender;
+}
+
+}  // namespace
+
+GlobalCircularBuffer::GlobalCircularBuffer(
+    IDevice* device,
+    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+    uint32_t size,
+    BufferType buffer_type) :
+    device_(device),
+    sender_receiver_core_mapping_(sender_receiver_core_mapping),
+    size_(size),
+    sender_core_type_value_(static_cast<uint8_t>(experimental::SenderCoreType::Worker)) {
+    uint32_t max_num_receivers_per_sender = 0;
+    initialize_global_circular_buffer(
+        device,
+        sender_receiver_core_mapping,
+        /*is_dram_sender=*/false,
+        sender_cores_,
+        receiver_cores_,
+        all_cores_,
+        max_num_receivers_per_sender);
+    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
+}
+
+GlobalCircularBuffer::GlobalCircularBuffer(
+    distributed::MeshDevice* mesh_device,
+    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+    uint32_t size,
+    BufferType buffer_type,
+    DramSenderTag) :
+    device_(mesh_device),
+    sender_receiver_core_mapping_(sender_receiver_core_mapping),
+    size_(size),
+    sender_core_type_value_(static_cast<uint8_t>(experimental::SenderCoreType::Dram)) {
+    TT_FATAL(mesh_device != nullptr, "DRAM-sender GlobalCircularBuffer requires a non-null MeshDevice");
+    const auto context_id = mesh_device->impl().get_context_id();
+    const auto& hal = MetalContext::instance(context_id).hal();
+    TT_FATAL(
+        hal.has_programmable_core_type(HalProgrammableCoreType::DRAM),
+        "DRAM-sender GlobalCircularBuffer requires programmable DRAM cores; set "
+        "TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1");
+    uint32_t max_num_receivers_per_sender = 0;
+    initialize_global_circular_buffer(
+        mesh_device,
+        sender_receiver_core_mapping,
+        /*is_dram_sender=*/true,
+        sender_cores_,
+        receiver_cores_,
+        all_cores_,
+        max_num_receivers_per_sender);
+
+    // Pre-compute physical worker NOC XY for each sender's receivers (the DRISC kernel
+    // pushes to these as runtime args).
+    receiver_coords_per_sender_.reserve(sender_receiver_core_mapping.size());
+    for (const auto& [_sender_core, receivers] : sender_receiver_core_mapping) {
+        const auto& receivers_vec = corerange_to_cores(receivers);
+        std::vector<CoreCoord> phys;
+        phys.reserve(receivers_vec.size());
+        for (const auto& r : receivers_vec) {
+            phys.emplace_back(device_->worker_core_from_logical_core(r));
+        }
+        receiver_coords_per_sender_.push_back(std::move(phys));
+    }
+
+    // Reserve this GCB's per-receiver pages_sent / pages_acked counter region in the
+    // per-mesh DRISC L1 arena. The arena returns a single uniform offset used by every
+    // sender bank — the kernel reads a single compile-time pages_sent_addr per sender set.
+    //
+    // On the DRISC side the slots are packed at uint32 stride (2 * 4 B = 8 B per
+    // receiver) — NoC atomic inc only needs 4-byte alignment, and the kernel walks
+    // these via REMOTE_CB_LOCAL_PAGES_STRIDE under #ifdef COMPILE_FOR_DRISC. The
+    // receiver-side layout in worker L1 stays at the standard 2 * L1_ALIGNMENT stride.
+    constexpr uint32_t kDriscSlotBytes = sizeof(uint32_t);
+    const uint32_t pages_sent_bytes = 2 * kDriscSlotBytes * max_num_receivers_per_sender;
+    drisc_pages_sent_alloc_ = mesh_device->impl().drisc_l1_arena().allocate(pages_sent_bytes, kDriscSlotBytes);
+    pages_sent_drisc_l1_base_ = drisc_pages_sent_alloc_->addr();
+
     this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
 }
 
@@ -76,9 +174,12 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     };
     cb_buffer_ = distributed::AnyBuffer::create(cb_buffer_shard_config);
 
-    auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    // is_sender, receiver_val, fifo_start_addr, fifo_size, fifo_ptr, noc_xy coords, and pages_sent
-    constexpr uint32_t num_config_elements = 7;
+    auto l1_alignment = MetalContext::instance(extract_context_id(device_)).hal().get_alignment(HalMemType::L1);
+    // [0] is_sender, [1] num_receivers, [2] fifo_start_addr, [3] fifo_size, [4] fifo_ptr,
+    // [5] noc_xy_addr, [6] aligned_pages_sent_addr (local), [7] remote_pages_addr_override
+    // (the canonical remote NoC target — equal to slot 6 for sharded GCB, points across L1
+    // address spaces for DRAM-sender GCB).
+    constexpr uint32_t num_config_elements = 8;
     uint32_t num_noc_xy_words = 2 * max_num_receivers_per_sender;
     auto cb_config_page_size = tt::align((num_config_elements + num_noc_xy_words) * sizeof(uint32_t), l1_alignment) +
                                (2 * max_num_receivers_per_sender * l1_alignment);
@@ -101,32 +202,66 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     uint32_t noc_xy_address = config_buffer_address + (num_config_elements * sizeof(uint32_t));
     uint32_t pages_sent_address = tt::align(noc_xy_address + (num_noc_xy_words * sizeof(uint32_t)), l1_alignment);
     auto buffer_address = cb_buffer().address();
+
+    const auto sender_core_type = static_cast<experimental::SenderCoreType>(sender_core_type_value_);
+    if (sender_core_type == experimental::SenderCoreType::Dram) {
+        // pages_sent_drisc_l1_base_ has already been populated by the DRAM-sender ctor from
+        // the per-mesh DriscL1Arena. We just need to expose the worker-local pages_sent base
+        // here so the DRISC kernel can NOC-inc pages_sent into the receivers' config pages.
+        pages_sent_worker_l1_base_ = pages_sent_address;
+    }
+
     for (const auto& [sender_core, receiver_cores] : sender_receiver_core_mapping_) {
         const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
-        uint32_t sender_idx = core_to_core_id.at(sender_core) * cb_config_page_size / sizeof(uint32_t);
         uint32_t num_receivers = receiver_cores.num_cores();
-        cb_config_host_buffer[sender_idx++] = 1;
-        cb_config_host_buffer[sender_idx++] = receiver_cores.num_cores();
-        cb_config_host_buffer[sender_idx++] = buffer_address;
-        cb_config_host_buffer[sender_idx++] = size_;
-        cb_config_host_buffer[sender_idx++] = buffer_address;
-        cb_config_host_buffer[sender_idx++] = noc_xy_address;
-        cb_config_host_buffer[sender_idx++] = pages_sent_address;
 
-        auto sender_physical_coord = device_->worker_core_from_logical_core(sender_core);
+        // Worker senders have their own config page in the sharded buffer; DRAM senders don't
+        // (the DRISC kernel hand-rolls the sender iface state from compile-time args).
+        if (sender_core_type == experimental::SenderCoreType::Worker) {
+            uint32_t sender_idx = core_to_core_id.at(sender_core) * cb_config_page_size / sizeof(uint32_t);
+            cb_config_host_buffer[sender_idx++] = 1;
+            cb_config_host_buffer[sender_idx++] = num_receivers;
+            cb_config_host_buffer[sender_idx++] = buffer_address;
+            cb_config_host_buffer[sender_idx++] = size_;
+            cb_config_host_buffer[sender_idx++] = buffer_address;
+            cb_config_host_buffer[sender_idx++] = noc_xy_address;
+            cb_config_host_buffer[sender_idx++] = pages_sent_address;
+            // Sharded GCB: the sender's NOC inc lands at the same L1 offset on the receiver's
+            // side, so the remote address equals aligned_pages_sent_ptr.
+            cb_config_host_buffer[sender_idx++] = pages_sent_address;
+            for (const auto& receiver_logical : receiver_cores_vec) {
+                auto receiver_physical_coord = device_->worker_core_from_logical_core(receiver_logical);
+                cb_config_host_buffer[sender_idx++] = receiver_physical_coord.x;
+                cb_config_host_buffer[sender_idx++] = receiver_physical_coord.y;
+            }
+        }
+
+        // Sender's physical NOC coord -- where the receiver's pages_acked NOC-inc lands. For
+        // worker senders this is the worker phys; for DRAM senders it's the DRAM virtual coord.
+        CoreCoord sender_physical_coord = (sender_core_type == experimental::SenderCoreType::Worker)
+                                              ? device_->worker_core_from_logical_core(sender_core)
+                                              : device_->virtual_core_from_logical_core(sender_core, CoreType::DRAM);
+
         for (uint32_t i = 0; i < receiver_cores_vec.size(); i++) {
-            auto receiver_physical_coord = device_->worker_core_from_logical_core(receiver_cores_vec[i]);
-            cb_config_host_buffer[sender_idx++] = receiver_physical_coord.x;
-            cb_config_host_buffer[sender_idx++] = receiver_physical_coord.y;
-
             uint32_t receiver_idx = core_to_core_id.at(receiver_cores_vec[i]) * cb_config_page_size / sizeof(uint32_t);
-            cb_config_host_buffer[receiver_idx++] = 0;
+            cb_config_host_buffer[receiver_idx++] = 0;  // is_sender
             cb_config_host_buffer[receiver_idx++] = num_receivers;
             cb_config_host_buffer[receiver_idx++] = buffer_address;
             cb_config_host_buffer[receiver_idx++] = size_;
             cb_config_host_buffer[receiver_idx++] = buffer_address;
             cb_config_host_buffer[receiver_idx++] = noc_xy_address;
+            // aligned_pages_sent_ptr; pages_acked for this receiver lives at +L1_ALIGNMENT.
             cb_config_host_buffer[receiver_idx++] = pages_sent_address + 2 * i * l1_alignment;
+            // remote_pages_addr_override: the address on the SENDER's L1 where this receiver's
+            // NoC-inc for pages_acked lands. For a sharded GCB sender and receiver share an L1
+            // layout so this equals aligned_pages_acked_ptr. For a DRAM-sender GCB it points at
+            // the per-receiver pages_acked slot in DRISC L1 (packed at uint32 stride, mirroring
+            // the kernel's REMOTE_CB_LOCAL_PAGES_*).
+            constexpr uint32_t drisc_slot = sizeof(uint32_t);
+            cb_config_host_buffer[receiver_idx++] =
+                (sender_core_type == experimental::SenderCoreType::Dram)
+                    ? static_cast<uint32_t>(pages_sent_drisc_l1_base_ + 2 * i * drisc_slot + drisc_slot)
+                    : (pages_sent_address + 2 * i * l1_alignment + l1_alignment);
             cb_config_host_buffer[receiver_idx++] = sender_physical_coord.x;
             cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
         }
@@ -157,6 +292,98 @@ const std::vector<std::pair<CoreCoord, CoreRangeSet>>& GlobalCircularBuffer::sen
 std::ostream& operator<<(std::ostream& os, const GlobalCircularBuffer& value) {
     tt::stl::reflection::operator<<(os, value);
     return os;
+}
+
+// ---- Experimental DRAM-sender extension -------------------------------------------------
+// The free-function entrypoints declared in tt-metalium/experimental/global_circular_buffer.hpp
+// delegate to this struct, which is the only thing that names GlobalCircularBuffer's private
+// DRAM-sender state. Defined here (impl-only) so the experimental public header doesn't have
+// to spell out the friend struct.
+
+namespace global_circular_buffer_dram_sender {
+
+struct GlobalCircularBufferDramSenderInternals {
+    static GlobalCircularBuffer make_dram_sender(
+        distributed::MeshDevice* mesh_device,
+        const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+        uint32_t size,
+        BufferType buffer_type);
+
+    static SenderCoreType sender_core_type(const GlobalCircularBuffer& gcb);
+    static DeviceAddr pages_sent_drisc_l1_base(const GlobalCircularBuffer& gcb);
+    static DeviceAddr pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb);
+    static const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb);
+};
+
+GlobalCircularBuffer GlobalCircularBufferDramSenderInternals::make_dram_sender(
+    distributed::MeshDevice* mesh_device,
+    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+    uint32_t size,
+    BufferType buffer_type) {
+    return GlobalCircularBuffer(
+        mesh_device, sender_receiver_core_mapping, size, buffer_type, GlobalCircularBuffer::DramSenderTag{});
+}
+
+SenderCoreType GlobalCircularBufferDramSenderInternals::sender_core_type(const GlobalCircularBuffer& gcb) {
+    return static_cast<SenderCoreType>(gcb.sender_core_type_value_);
+}
+
+DeviceAddr GlobalCircularBufferDramSenderInternals::pages_sent_drisc_l1_base(const GlobalCircularBuffer& gcb) {
+    return gcb.pages_sent_drisc_l1_base_;
+}
+
+DeviceAddr GlobalCircularBufferDramSenderInternals::pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb) {
+    return gcb.pages_sent_worker_l1_base_;
+}
+
+const std::vector<std::vector<CoreCoord>>& GlobalCircularBufferDramSenderInternals::receiver_coords_per_sender(
+    const GlobalCircularBuffer& gcb) {
+    return gcb.receiver_coords_per_sender_;
+}
+
+}  // namespace global_circular_buffer_dram_sender
+
+namespace {
+
+// Map (bank_id, receivers) pairs to (DRAM-logical CoreCoord, receivers) pairs by picking
+// an unused subchannel for each bank.
+std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
+    distributed::MeshDevice* mesh_device, const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers) {
+    std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping;
+    mapping.reserve(bank_to_receivers.size());
+    for (const auto& [bank_id, receivers] : bank_to_receivers) {
+        uint32_t sub = mesh_device->impl().pick_unused_dram_subchannel(bank_id);
+        mapping.emplace_back(CoreCoord{bank_id, sub}, receivers);
+    }
+    return mapping;
+}
+
+}  // namespace
+
+GlobalCircularBuffer CreateGlobalCircularBufferWithDramSenders(
+    distributed::MeshDevice* mesh_device,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type) {
+    auto mapping = build_dram_sender_mapping(mesh_device, bank_to_receivers);
+    return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::make_dram_sender(
+        mesh_device, mapping, size, buffer_type);
+}
+
+SenderCoreType sender_core_type(const GlobalCircularBuffer& gcb) {
+    return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::sender_core_type(gcb);
+}
+
+DeviceAddr pages_sent_drisc_l1_base(const GlobalCircularBuffer& gcb) {
+    return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::pages_sent_drisc_l1_base(gcb);
+}
+
+DeviceAddr pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb) {
+    return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::pages_sent_worker_l1_base(gcb);
+}
+
+const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb) {
+    return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::receiver_coords_per_sender(gcb);
 }
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -31,6 +31,8 @@
 #include "mesh_device.hpp"
 #include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
+#include "llrt/metal_soc_descriptor.hpp"
+#include "llrt/tt_cluster.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal::experimental {
@@ -346,14 +348,20 @@ const std::vector<std::vector<CoreCoord>>& GlobalCircularBufferDramSenderInterna
 namespace {
 
 // Map (bank_id, receivers) pairs to (DRAM-logical CoreCoord, receivers) pairs by picking
-// an unused subchannel for each bank.
+// an unused hardware subchannel for each bank.
+// logical.y must index dram_bank_endpoint_coords (worker endpoint at y=0), not the raw
+// subchannel number — see metal_SocDescriptor::get_logical_dram_core_for_subchannel.
 std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
     distributed::MeshDevice* mesh_device, const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers) {
+    IDevice* ref_device = mesh_device->get_devices().front();
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(ref_device->build_id());
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping;
     mapping.reserve(bank_to_receivers.size());
     for (const auto& [bank_id, receivers] : bank_to_receivers) {
-        uint32_t sub = mesh_device->impl().pick_unused_dram_subchannel(bank_id);
-        mapping.emplace_back(CoreCoord{bank_id, sub}, receivers);
+        const uint32_t sub = mesh_device->impl().pick_unused_dram_subchannel(bank_id);
+        const CoreCoord sender_logical =
+            soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank_id), static_cast<int>(sub));
+        mapping.emplace_back(sender_logical, receivers);
     }
     return mapping;
 }

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -362,13 +362,13 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
 }  // namespace
 
 GlobalCircularBuffer CreateGlobalCircularBufferWithDramSenders(
-    distributed::MeshDevice* mesh_device,
+    distributed::MeshDevice& mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type) {
-    auto mapping = build_dram_sender_mapping(mesh_device, bank_to_receivers);
+    auto mapping = build_dram_sender_mapping(&mesh_device, bank_to_receivers);
     return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::make_dram_sender(
-        mesh_device, mapping, size, buffer_type);
+        &mesh_device, mapping, size, buffer_type);
 }
 
 SenderCoreType sender_core_type(const GlobalCircularBuffer& gcb) {

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -30,6 +30,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer_config.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffers/drisc_l1_arena.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/global_circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -101,6 +101,29 @@ CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const CoreCoo
     return dram_bank_endpoint_coords[logical_coord.x][logical_coord.y];
 }
 
+CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const {
+    const int channel = static_cast<int>(get_channel_for_dram_view(dram_view));
+    const tt::umd::CoreCoord phys_umd = get_dram_core_for_channel(channel, subchannel, tt::CoordSystem::TRANSLATED);
+    const CoreCoord phys{phys_umd.x, phys_umd.y};
+    TT_FATAL(
+        dram_view >= 0 && static_cast<size_t>(dram_view) < dram_bank_endpoint_coords.size(),
+        "dram_view {} out of range (num_views={})",
+        dram_view,
+        dram_bank_endpoint_coords.size());
+    const auto& endpoints = dram_bank_endpoint_coords[static_cast<size_t>(dram_view)];
+    for (size_t idx = 0; idx < endpoints.size(); ++idx) {
+        if (endpoints[idx] == phys) {
+            return CoreCoord{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
+        }
+    }
+    TT_THROW(
+        "DRAM subchannel {} on view {} (physical {}, {}) not found in dram_bank_endpoint_coords",
+        subchannel,
+        dram_view,
+        phys.x,
+        phys.y);
+}
+
 CoreCoord metal_SocDescriptor::get_physical_core_from_logical_core(
     const CoreCoord& logical_coord, const tt::CoreType& core_type) const {
     switch (core_type) {

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -53,6 +53,9 @@ public:
     CoreCoord get_logical_ethernet_core_from_physical(const CoreCoord& physical_coord) const;
     CoreCoord get_physical_tensix_core_from_logical(const CoreCoord& logical_coord) const;
     CoreCoord get_physical_dram_core_from_logical(const CoreCoord& logical_coord) const;
+    // Map a DRAM view + hardware subchannel to the logical CoreCoord used by CreateKernel(DramConfig).
+    // logical.y indexes dram_bank_endpoint_coords (worker endpoint first), not the raw subchannel id.
+    CoreCoord get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const;
     CoreCoord get_physical_core_from_logical_core(const CoreCoord& logical_coord, const tt::CoreType& core_type) const;
 
     CoreCoord get_dram_grid_size() const;


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adds support for constructing a `GlobalCircularBuffer` whose senders are programmable DRAM cores (Blackhole DRISCs) rather than worker cores. This is the metal-level foundation; downstream consumers (DRAM-core prefetcher op, matmul integration, ttnn bindings, benchmarks) build on top of it and are not in this PR.

The DRAM-sender mode is opt-in through a new experimental factory; the public `GlobalCircularBuffer` API is unchanged.

Public additions (all in `tt::tt_metal::experimental`, declared in `tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp`):
- `CreateGlobalCircularBufferWithDramSenders(MeshDevice&, bank_to_receivers, size, BufferType)` — factory whose senders are identified by DRAM bank id.
- `sender_core_type` / `pages_sent_drisc_l1_base` / `pages_sent_worker_l1_base` / `receiver_coords_per_sender` accessors.

Impl-internal:
- `tt_metal/impl/buffers/dram_subchannel.{hpp,cpp}` — `pick_unused_dram_subchannel` helper that selects a DRAM subchannel not reserved by the SOC descriptor. Used by the GCB ctor and unit tests; not on the public API surface.
- `tt_metal/impl/buffers/drisc_l1_arena.{hpp,cpp}` — single-pool, uniform-offset arena that backs the GCB's `pages_sent` allocation. Reserves a fixed 1 KB GCB zone at the bottom of DRISC-unreserved L1 so a co-resident DRISC kernel above the zone keeps a stable base. Mirrors the L1/DRAM bank allocator shape (one pool, not per-bank).
- `tt_metal/impl/buffers/global_circular_buffer.cpp` — DRAM-sender state folded directly into `GlobalCircularBuffer` via a private tag ctor + friend struct, so the public class is unchanged.
- `MeshDeviceImpl` owns the `DriscL1Arena` as a `shared_ptr`, constructed eagerly in `initialize_impl()` when the HAL exposes programmable DRAM cores. `DriscL1Allocation` holds a `weak_ptr` back, so the destructor is a clean no-op if the user closes the MeshDevice before destroying their GCBs — same lifetime shape as `MeshBuffer` / `weak_ptr<MeshDevice>`.

Device-side support (`tt_metal/hw/inc/…`):
- `RemoteSenderCBInterface::num_receivers_and_remote_pages_sent_ptr` — packed slot (top 8 bits = num_receivers, low 24 bits = NoC target on the receiver) so the struct stays at 8 uint32 words. `RemoteReceiverCBInterface::sender_noc_x/y` shrunk to `uint16_t` to absorb the new `remote_pages_acked_ptr` field at the same total size. Helpers `remote_cb_pack` / `remote_cb_num_receivers` / `remote_cb_remote_pages_sent_ptr` keep the access ergonomic.
- The host always writes a canonical NoC target into the receiver's remote-CB config slot 7 (equal to the local pages_sent/pages_acked address for sharded GCB, the cross-L1-space address for DRAM-sender GCB), so the kernel reads it directly with no `!= 0` fallback. The kernel walks the sender's local pages_sent/acked counters via `REMOTE_CB_LOCAL_PAGES_STRIDE` (`2 * L1_ALIGNMENT` for workers, `2 * sizeof(uint32_t)` for DRISC under `#ifdef COMPILE_FOR_DRISC` — NoC atomic inc only needs 4-byte alignment, so DRISC packs 4× tighter).

CI:
- `.github/workflows/build-and-unit-tests.yaml`: the existing slow-dispatch + `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1` run on `unit_tests_api` is extended to include `DramSenderGCBFixture.*:DramSubchannelHelperFixture.*`.

### Notes for reviewers
- New experimental header at `tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp`. The base `GlobalCircularBuffer` carries the DRAM-sender state as private members reachable only through the friend `GlobalCircularBufferDramSenderInternals` struct, so existing call sites are unaffected.
- The `DriscL1Arena` exposes `kernel_working_region_base()`/`size()` so a co-resident DRISC kernel (e.g. a DRAM prefetcher) can place itself above the fixed 1 KB GCB zone and keep a stable L1 base regardless of subsequent GCB allocations.
- The dispatcher fix in `sd_mesh_command_queue.cpp` (`logical_cores_intersect` now compares cores within the same `programmable_core_type` index) is required to avoid false-collision between DRAM-sender logical coords (e.g. `(0, subch)`) and worker logical coords (e.g. `(0, 0)`) when async slow-dispatch schedules a DRISC sender and worker receivers from separate programs.
- Tests under `tests/tt_metal/tt_metal/api/`:
  - `test_dram_sender_global_cb.cpp` — end-to-end smoke (single program + async-SD two-program), multi-GCB disjoint allocation, sender-collision rejection.
  - `test_dram_subchannel_helper.cpp` — picker selects an unreserved subchannel per bank; out-of-range bank fatals.
- Test kernels: `gcb_smoke_sender.cpp` (DRISC), `gcb_smoke_receiver.cpp` (worker).
- All foundation tests + pre-existing worker-sender GCB tests (`MeshDispatchFixture.Tensix*GlobalCircularBuffers*`) pass under `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 TT_METAL_SLOW_DISPATCH_MODE=1` on P100.
- **Drive-by: extra commit `f333cca` — `Stabilize TestSimpleL1Read by unrolling the timed inner loop`.** Smoke CI was flagging `UnitMeshCQSingleCardSharedFixture.TestSimpleL1Read` with `speedup = 1.00096` vs a `0.0005` tolerance. Reproduced and disassembled on an N150: the two `access_memory<>` variants compile to **byte-identical** 4-instruction BRISC inner loops (`lw / addi / sw / bne`) — only address and stack-spill offset differ, both zero-cycle. The "speedup" is really just measuring I-cache warmup of whichever loop runs second; that bias is ~0.05–0.1%, on top of the tolerance. With this branch's headers it lands at 0.00096 (fail); with hw/ reverted to the merge base on the same hardware it lands at ~0.00136 (also fail, 3-4/5 runs). CI on main passes by luck. `#pragma GCC unroll 8` on both inner loops amortizes the per-byte branch + pointer-advance over 8 reads (overhead drops from ~50% to ~10% of the loop body) and pulls the ratio inside tolerance — 20/20 runs pass locally. Happy to drop this commit if the test owner would rather just loosen the tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/driscgcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/driscgcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/driscgcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/driscgcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/driscgcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/driscgcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/driscgcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/driscgcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/driscgcb)
