### PR TITLE
[Bugfix] Fix legality checks for aliased DFBs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3015,11 +3015,11 @@ TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
 }
 
 // ============================================================================
-// DFB alias validation — negative tests
+// DFB alias validation
 // ============================================================================
 
-// Helper: build a minimal 1-producer / 1-consumer ProgramSpec with a single
-// DFB, reusing the Quasar fixture's node coordinate.
+// Helper: build a minimal 1-producer / 1-consumer ProgramSpec where both DFBs are
+// bound to the same producer/consumer kernels in a single WorkUnit on a single node.
 namespace {
 ProgramSpec MakeAliasProgramSpec(
     const NodeCoord& node,
@@ -3059,8 +3059,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnMismatchedTotalSize) {
             ::testing::HasSubstr("different total sizes")));
 }
 
-TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnNonMutualDeclaration) {
-    // DFB_A lists DFB_B but DFB_B does not list DFB_A → TT_FATAL
+TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnAsymmetricDeclaration) {
+    // DFB_A lists DFB_B but DFB_B does not list DFB_A — clique violation → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
     dfb_a.alias_with = {"dfb_b"};
@@ -3071,29 +3071,33 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnNonMutualDeclaration) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("alias_with must be mutual")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("do not declare the same alias group")));
 }
 
-TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentKernelBindings) {
-    // DFB_A and DFB_B have the same total size but are bound to different kernels → TT_FATAL
+TEST_F(ProgramSpecTestQuasar, AliasDFBMatmulStyleSucceeds) {
+    // This is the nasty case from the matmul op....
+    // Two DFBs share L1 but are bound to different kernels.
+    //  - DFB_A is bound to {producer_kernel, consumer_kernel};
+    //  - DFB_B is bound to {producer_kernel, other_kernel}.
+    //
+    // This looks unspeakably evil and I'd like to forbid it. But, it does work.
+    // All kernels run on the same node set, so they all have the same L1.
+    // And (presumably) the DFB is used in a temporally disjoint way.
+    // So, nothing stops them from re-using the DFB memory.
+
     const NodeCoord node{0, 0};
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
-    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
     dfb_a.alias_with = {"dfb_b"};
     dfb_b.alias_with = {"dfb_a"};
 
-    // Bind dfb_a to producer_kernel / consumer_kernel as usual
     KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
     KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
-    // A third kernel that will be the only consumer of dfb_b
     KernelSpec other = MakeMinimalDMKernel("other_kernel");
 
     BindDFBToKernel(producer, "dfb_a", "out_a", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb_a", "in_a", KernelSpec::DFBEndpointType::CONSUMER);
-
-    // dfb_b bound to producer_kernel but consumed by a *different* kernel
     BindDFBToKernel(producer, "dfb_b", "out_b", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(other, "dfb_b", "in_b", KernelSpec::DFBEndpointType::CONSUMER);
 
@@ -3103,10 +3107,74 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentKernelBindings) {
     spec.work_units = {
         MakeMinimalWorkUnit("wu", node, {"producer_kernel", "consumer_kernel", "other_kernel"})};
 
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentNodeCoverage) {
+    // Two DFBs aliased, but bound to kernels running on disjoint nodes. The shared L1
+    // region only makes sense if both members cover the same cores; otherwise the
+    // secondary's address propagation would alias into L1 the primary never reserved.
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
+
+    auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
+    dfb_a.alias_with = {"dfb_b"};
+    dfb_b.alias_with = {"dfb_a"};
+
+    KernelSpec producer_a = MakeMinimalDMKernel("producer_a");
+    KernelSpec consumer_a = MakeMinimalDMKernel("consumer_a");
+    KernelSpec producer_b = MakeMinimalDMKernel("producer_b");
+    KernelSpec consumer_b = MakeMinimalDMKernel("consumer_b");
+    BindDFBToKernel(producer_a, "dfb_a", "out_a", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer_a, "dfb_a", "in_a", KernelSpec::DFBEndpointType::CONSUMER);
+    BindDFBToKernel(producer_b, "dfb_b", "out_b", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer_b, "dfb_b", "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+
+    ProgramSpec spec;
+    spec.kernels = {producer_a, consumer_a, producer_b, consumer_b};
+    spec.dataflow_buffers = {dfb_a, dfb_b};
+    spec.work_units = {
+        MakeMinimalWorkUnit("wu_a", node_a, {"producer_a", "consumer_a"}),
+        MakeMinimalWorkUnit("wu_b", node_b, {"producer_b", "consumer_b"}),
+    };
+
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("different producer/consumer kernels")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("cover different sets of nodes")));
+}
+
+TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
+    // DFB_A borrows from a TensorParameter, DFB_B does not. Within an alias group, either
+    // no member borrows or all members borrow from the same TensorParameter.
+    const NodeCoord node{0, 0};
+
+    auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/16, /*num_entries=*/2);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/16, /*num_entries=*/2);
+    dfb_a.alias_with = {"dfb_b"};
+    dfb_b.alias_with = {"dfb_a"};
+    dfb_a.borrowed_from = "borrowed_tensor";
+    // dfb_b.borrowed_from intentionally left unset
+
+    KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
+    KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
+    BindDFBToKernel(producer, "dfb_a", "out_a", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb_a", "in_a", KernelSpec::DFBEndpointType::CONSUMER);
+    BindDFBToKernel(producer, "dfb_b", "out_b", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb_b", "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+
+    auto tensor_param = MakeMinimalTensorParameter("borrowed_tensor", tt::tt_metal::BufferType::L1);
+    BindTensorParameterToKernel(producer, "borrowed_tensor", "borrowed_t");
+
+    ProgramSpec spec;
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb_a, dfb_b};
+    spec.tensor_parameters = {tensor_param};
+    spec.work_units = {MakeMinimalWorkUnit("wu", node, {"producer_kernel", "consumer_kernel"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("inconsistent borrowed_from")));
 }
 
 }  // namespace

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -96,9 +96,13 @@ struct DataflowBufferSpec {
 
     // Alias two or more DFBs
     // Aliased DFBs are logically distinct, but physically share the same backing memory.
-    // All aliased DFBs must have the same total size (num_entries * entry_size), must be bound to the same kernels,
-    // and must mutually declare each other as aliases.
-    // (Aliased DFBs offer NO guarantees against data clobbering; the kernel author must ensure safety.)
+    // Aliased DFBs offer NO guarantees against data clobbering; kernel logic must ensure safety.
+    //
+    // Rules for aliased DFBs:
+    //   - Every DFB in the alias group must list every other member as an alias
+    //   - Aliased DFBs must have the same total size (num_entries * entry_size).
+    //   - All members must target the same node set
+    //     (derived from their bound kernels' WorkUnitSpecs).
     using DFBIdentifiers = std::vector<DFBSpecName>;
     DFBIdentifiers alias_with;  // empty vector means no aliasing
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1114,71 +1114,83 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
     // Validate DFB alias groups.
     // Rules:
-    //  1. Mutual declaration: if A lists B, B must list A.
+    //  1. Transitivity: every DFB in an alias group must list every other member in its
+    //     alias_with field. This strict requirement is redundant by design. This is a
+    //     "dangerous" feature that a kernel author should use deliberately.
     //  2. Same total size: entry_size * num_entries must match within a group.
-    //  3. Same kernel bindings: each DFB in the group must be bound to the same
-    //     set of producer and consumer KernelSpec unique_ids.
+    //  3. Same node coverage: each DFB in the group must cover the same set of nodes
+    //  4. Consistent borrowed_from: either no member borrows, or all members borrow from
+    //     the same TensorParameter. (Aliased borrows from the same memory object is a
+    //     weird-but-valid scenario.)
     {
-        // Build a name -> spec lookup for convenience.
-        std::unordered_map<DFBSpecName, const DataflowBufferSpec*> dfb_spec_by_name;
-        for (const auto& dfb : spec.dataflow_buffers) {
-            dfb_spec_by_name[dfb.unique_id] = &dfb;
-        }
-
-        auto kernel_ids_for_dfb = [&](const DFBSpecName& name) {
-            std::pair<std::vector<std::string>, std::vector<std::string>> result;
-            for (const auto& rec : collected.dfb_endpoints.at(name).producers) {
-                result.first.push_back(rec.kernel->unique_id);
-            }
-            for (const auto& rec : collected.dfb_endpoints.at(name).consumers) {
-                result.second.push_back(rec.kernel->unique_id);
-            }
-            std::sort(result.first.begin(), result.first.end());
-            std::sort(result.second.begin(), result.second.end());
-            return result;
+        // The "extended group" of a DFB is its alias_with plus the DFB itself. Two DFBs
+        // are in the same alias group iff their extended groups are equal.
+        auto extended_group = [](const DataflowBufferSpec& d) {
+            std::set<DFBSpecName> s(d.alias_with.begin(), d.alias_with.end());
+            s.insert(d.unique_id);
+            return s;
         };
+
+        // Pre-pass: every name in every alias_with must refer to a real DFB and must not
+        // be self-referential.
+        for (const auto& dfb : spec.dataflow_buffers) {
+            for (const auto& alias_name : dfb.alias_with) {
+                TT_FATAL(
+                    collected.dfb_by_name.contains(alias_name),
+                    "DFB '{}' lists unknown alias '{}' in alias_with",
+                    dfb.unique_id,
+                    alias_name);
+                TT_FATAL(alias_name != dfb.unique_id, "DFB '{}' lists itself in alias_with", dfb.unique_id);
+            }
+        }
 
         for (const auto& dfb : spec.dataflow_buffers) {
             if (dfb.alias_with.empty()) {
                 continue;
             }
             const size_t total_size_a = dfb.entry_size * dfb.num_entries;
-            const auto bindings_a = kernel_ids_for_dfb(dfb.unique_id);
+            const auto group_a = extended_group(dfb);
+            const auto& nodes_a = collected.dfb_node_set.at(dfb.unique_id);
 
             for (const auto& alias_name : dfb.alias_with) {
-                TT_FATAL(
-                    dfb_spec_by_name.contains(alias_name),
-                    "DFB '{}' lists unknown alias '{}' in alias_with",
-                    dfb.unique_id,
-                    alias_name);
+                const DataflowBufferSpec* alias_spec = collected.dfb_by_name.at(alias_name);
 
-                const DataflowBufferSpec* alias_spec = dfb_spec_by_name.at(alias_name);
+                // Rule 1: full clique declaration.
+                const auto group_b = extended_group(*alias_spec);
+                if (group_a != group_b) {
+                    TT_THROW(
+                        "DFBs '{}' and '{}' do not declare the same alias group. Every DFB in an "
+                        "alias group must list every other member in its alias_with field.",
+                        dfb.unique_id,
+                        alias_name);
+                }
 
-                // Rule 1: mutual declaration
-                const bool mutual = std::find(
-                    alias_spec->alias_with.begin(),
-                    alias_spec->alias_with.end(),
-                    dfb.unique_id) != alias_spec->alias_with.end();
-                TT_FATAL(
-                    mutual,
-                    "DFB '{}' lists '{}' as an alias, but '{}' does not list '{}' — alias_with must be mutual",
-                    dfb.unique_id, alias_name, alias_name, dfb.unique_id);
-
-                // Rule 2: same total size
-                const uint32_t total_size_b = alias_spec->entry_size * alias_spec->num_entries;
+                // Rule 2: same total size.
+                const size_t total_size_b = alias_spec->entry_size * alias_spec->num_entries;
                 TT_FATAL(
                     total_size_a == total_size_b,
                     "Aliased DFBs '{}' and '{}' have different total sizes ({} vs {} bytes). "
                     "Aliased DFBs must have the same total size (entry_size * num_entries).",
                     dfb.unique_id, alias_name, total_size_a, total_size_b);
 
-                // Rule 3: same kernel bindings
-                const auto bindings_b = kernel_ids_for_dfb(alias_name);
+                // Rule 3: same node coverage.
+                const auto& nodes_b = collected.dfb_node_set.at(alias_name);
                 TT_FATAL(
-                    bindings_a == bindings_b,
-                    "Aliased DFBs '{}' and '{}' are bound to different producer/consumer kernels. "
-                    "Aliased DFBs must be bound to the same kernel specs.",
-                    dfb.unique_id, alias_name);
+                    nodes_a == nodes_b,
+                    "Aliased DFBs '{}' and '{}' cover different sets of nodes. Aliased DFBs must "
+                    "cover the same node coverage (their bound kernels' WorkUnitSpec membership "
+                    "must yield identical target_nodes unions) — the shared L1 region must be "
+                    "reserved at the same cores for all members.",
+                    dfb.unique_id,
+                    alias_name);
+
+                // Rule 4: consistent borrowed_from.
+                TT_FATAL(
+                    dfb.borrowed_from == alias_spec->borrowed_from,
+                    "Aliased DFBs '{}' and '{}' have inconsistent borrowed_from. Either no member "
+                    "of an alias group borrows, or all members borrow from the same TensorParameter.",
+                    dfb.unique_id,
+                    alias_name);
             }
         }
     }
@@ -2291,7 +2303,9 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     // Wire alias groups: for each DFB that has alias_with entries, make the first
     // encountered DFB in the group the primary and call set_dfb_alias for each secondary.
     // handled_as_secondary prevents a DFB from being treated as a primary when it was
-    // already registered as a secondary by an earlier DFB in the group (mutual declaration).
+    // already registered as a secondary by an earlier DFB in the group. Soundness relies
+    // on the strict-clique invariant enforced by ValidateProgramSpec: every group member
+    // lists every other member, so the primary's alias_with covers the whole group.
     {
         std::unordered_set<DFBSpecName> handled_as_secondary;
         for (const auto& dfb_spec : spec.dataflow_buffers) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1148,7 +1148,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (dfb.alias_with.empty()) {
                 continue;
             }
-            const size_t total_size_a = dfb.entry_size * dfb.num_entries;
+            const size_t total_size_a = static_cast<size_t>(dfb.entry_size) * static_cast<size_t>(dfb.num_entries);
             const auto group_a = extended_group(dfb);
             const auto& nodes_a = collected.dfb_node_set.at(dfb.unique_id);
 
@@ -1166,7 +1166,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 }
 
                 // Rule 2: same total size.
-                const size_t total_size_b = alias_spec->entry_size * alias_spec->num_entries;
+                const size_t total_size_b =
+                    static_cast<size_t>(alias_spec->entry_size) * static_cast<size_t>(alias_spec->num_entries);
                 TT_FATAL(
                     total_size_a == total_size_b,
                     "Aliased DFBs '{}' and '{}' have different total sizes ({} vs {} bytes). "


### PR DESCRIPTION
### PR Category
Bugfix

### Summary
Fix some minor bugs in aliased DFB validation (https://github.com/tenstorrent/tt-metal/pull/44806)

- Relax the "same kernel bindings" rule in favor of "same node set". (Matmul kernels need this.)
- Strictly require that DFB aliasing is transitive (if I alias you, you _must_ alias me)
- Add legality checks for simultaneous DFB borrowed mem + aliasing. (Weird but technically allowed, as long as all the aliasees binds the same borrowed mem.)

Add some unit tests.

### Notes for reviewers
N/A

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-aliased-dbfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/fix-aliased-dbfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-aliased-dbfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-aliased-dbfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/fix-aliased-dbfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-aliased-dbfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-aliased-dbfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-aliased-dbfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-aliased-dbfs)