### PR TITLE
Revert "track TtSmiReset attempts with Pydantic model

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -153,7 +153,7 @@ jobs:
           echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
           echo "attempt-number=$attempt_number" >> "$GITHUB_OUTPUT"
 
-          echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/tenstorrent/tt-metal/actions/runs/${run_id}/attempts/${attempt_number}"
+          echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/tenstorrent/tt-metal/actions/runs/$run_id/attempts/$attempt_number"
       - name: Get API rate limit status
         env:
           GH_TOKEN: ${{ github.token }}

--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from pprint import pprint
 from loguru import logger
 
 from infra.data_collection.github.utils import (
@@ -19,7 +20,6 @@ from infra.data_collection.github.workflows import (
 )
 from infra.data_collection import pydantic_models
 from infra.data_collection.pydantic_models import Step
-from infra.data_collection.pydantic_models import TtSmiReset
 
 
 def get_cicd_json_filename(pipeline):
@@ -45,8 +45,6 @@ def create_cicd_json_for_data_analysis(
 
     github_pipeline_id = raw_pipeline["github_pipeline_id"]
     github_pipeline_start_ts = raw_pipeline["pipeline_start_ts"]
-    workflow_attempt = github_pipeline_json["run_attempt"]
-    raw_pipeline["workflow_attempt"] = workflow_attempt
 
     github_job_id_to_annotations = get_github_job_id_to_annotations(workflow_outputs_dir, github_pipeline_id)
 
@@ -61,16 +59,12 @@ def create_cicd_json_for_data_analysis(
         workflow_outputs_dir, github_pipeline_id, github_job_ids
     )
 
-    github_job_id_to_smi_versions, github_job_id_to_smi_resets = get_github_job_ids_to_tt_smi_versions(
-        workflow_outputs_dir,
-        github_pipeline_id,
-        workflow_attempt,
-    )
+    github_job_id_to_smi_versions = get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, github_pipeline_id)
+
     jobs = []
-    tt_smi_resets = []
 
     for raw_job in raw_jobs:
-        github_job_id = int(raw_job["github_job_id"])
+        github_job_id = raw_job["github_job_id"]
 
         logger.info(f"Processing raw GitHub job {github_job_id}")
 
@@ -97,18 +91,7 @@ def create_cicd_json_for_data_analysis(
 
         # Remove 'steps' from raw_job to avoid double-passing of 'steps'
         raw_job = dict(raw_job)
-        raw_job["workflow_attempt"] = workflow_attempt
         raw_job.pop("steps", None)
-        raw_job.pop("tt_smi_reset", None)
-
-        reset_data = github_job_id_to_smi_resets.get((workflow_attempt, github_job_id))
-
-        if reset_data:
-            for tt_smi_reset_attempt in reset_data:
-                tt_smi_reset_attempt = dict(tt_smi_reset_attempt)
-                tt_smi_reset_attempt["github_job_id"] = github_job_id
-                tt_smi_reset_attempt["workflow_attempt"] = workflow_attempt
-                tt_smi_resets.append(TtSmiReset(**tt_smi_reset_attempt))
 
         job = pydantic_models.Job(
             **raw_job,
@@ -118,24 +101,9 @@ def create_cicd_json_for_data_analysis(
         )
         jobs.append(job)
 
-    # Collect SMI reset data for all earlier workflow attempts.
-    # raw_jobs only contains jobs from the latest attempt (workflow_jobs.json is overwritten
-    # per attempt during log download). Log files for all attempts are downloaded, so
-    # github_job_id_to_smi_resets contains keys for every attempt. We iterate over those
-    # earlier-attempt keys here so their reset data is captured in the pipeline record.
-    for (attempt_num, job_id), reset_entries in github_job_id_to_smi_resets.items():
-        if attempt_num == workflow_attempt:
-            continue  # Already handled in the job loop above
-        for tt_smi_reset_attempt in reset_entries:
-            tt_smi_reset_attempt = dict(tt_smi_reset_attempt)
-            tt_smi_reset_attempt["github_job_id"] = job_id
-            tt_smi_reset_attempt["workflow_attempt"] = attempt_num
-            tt_smi_resets.append(TtSmiReset(**tt_smi_reset_attempt))
-
     pipeline = pydantic_models.Pipeline(
         **raw_pipeline,
         jobs=jobs,
-        tt_smi_resets=tt_smi_resets,
     )
 
     return pipeline

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -144,9 +144,7 @@ main() {
 
     set_up_dirs "$workflow_run_id"
     download_artifacts "$repo" "$workflow_run_id"
-    for attempt in $(seq 1 $attempt_number); do
-    download_logs_for_all_jobs "$repo" "$workflow_run_id" "$attempt"
-    done
+    download_logs_for_all_jobs "$repo" "$workflow_run_id" "$attempt_number"
 }
 
 main "$@"

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -67,7 +67,6 @@ def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline
     github_pipeline_link = github_pipeline_json["html_url"]
 
     pipeline_status = github_pipeline_json["conclusion"]
-    workflow_attempt = github_pipeline_json["run_attempt"]
 
     return {
         "github_pipeline_id": github_pipeline_id,
@@ -85,7 +84,6 @@ def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline
         "orchestrator": orchestrator,
         "github_pipeline_link": github_pipeline_link,
         "pipeline_status": pipeline_status,
-        "workflow_attempt": workflow_attempt,
     }
 
 
@@ -348,7 +346,6 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         "failure_signature": failure_signature,
         "failure_description": failure_description,
         "job_label": ",".join(labels),
-        "workflow_attempt": github_job.get("run_attempt"),
         "steps": github_job.get("steps", []),
     }
 

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -15,7 +15,6 @@ from infra.data_collection import junit_xml_utils, pydantic_models
 
 
 smi_pattern = re.compile(r'.*"tt_smi":\s*"([a-zA-Z0-9\-\.]+)"')
-tt_smi_reset_pattern = re.compile(r'"tt_smi_reset":\s*(\[.*\])')
 # Define a regex pattern to match timestamps in ISO 8601 format (e.g., 2025-03-26T19:18:31.7521333Z)
 timestamp_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z")
 
@@ -29,171 +28,28 @@ def search_for_tt_smi_version_in_log_file_(log_file):
     return None
 
 
-def search_for_tt_smi_reset_in_log_file_(log_file):
-    ts_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\s*")
-    # Strip GitHub Actions annotation prefixes like ##[error], ##[warning]
-    gh_annotation_pattern = re.compile(r"^##\[[a-z]+\]", re.IGNORECASE)
-
-    def strip_ansi(text):
-        return re.sub(r"\x1B[@-_][0-?]*[ -/]*[@-~]", "", text)
-
-    def parse_ts(line):
-        try:
-            line = line.strip()
-            if not ts_pattern.match(line):
-                return None
-            ts_str = line.split(" ")[0].rstrip("Z")
-            if "." in ts_str:
-                base, frac = ts_str.split(".")
-                ts_str = f"{base}.{frac[:6]}"
-            return datetime.fromisoformat(ts_str)
-        except Exception:
-            return None
-
-    def clean_line(line):
-        """Strip ISO timestamp prefix and GitHub annotation prefix, return clean content."""
-        s = line.strip()
-        m = ts_pattern.match(s)
-        if m:
-            s = s[m.end() :]
-        # Strip ##[error] / ##[warning] / ##[group] etc.
-        s = gh_annotation_pattern.sub("", s).strip()
-        return s
-
-    with open(log_file, "r") as f:
-        log = strip_ansi(f.read())
-
-    lines = log.splitlines()
-
-    # Check if there is any tt-smi reset activity in this log at all
-    has_reset = any(
-        "tt-smi reset" in line.lower() or ("tt_metal_infra" in line.lower() and ".sh" in line.lower()) for line in lines
-    )
-
-    if not has_reset:
-        return [
-            {
-                "tt_smi_reset_attempt": 1,
-                "final_status": "UNKNOWN",
-                "total_reset_time_sec": None,
-                "error_summary": "No tt-smi reset found",
-            }
-        ]
-
-    # Find where the reset section starts
-    reset_start_idx = None
-    for i, line in enumerate(lines):
-        lower = line.lower()
-        if (
-            ("tt_metal_infra" in lower and ".sh" in lower)
-            or "starting tt-smi reset" in lower
-            or "tt-smi reset" in lower
-        ):
-            reset_start_idx = i
-            break
-
-    # If no explicit start found, scan from beginning (e.g. WH simple case)
-    if reset_start_idx is None:
-        reset_start_idx = 0
-
-    block_lines = lines[reset_start_idx:]
-    block_start_ts = parse_ts(lines[reset_start_idx])
-    block_end_ts = None
-    # Count internal tt-smi retry attempts via "===== START of output =====" occurrences
-    num_smi_attempts = 0
-    final_status = "UNKNOWN"
-    seen_errors = set()
-    error_lines = []
-
-    reset_done = False
-
-    for line in block_lines:
-        lower = line.strip().lower()
-        ts = parse_ts(line)
-        # Only update end timestamp while reset is still in progress
-        if ts and not reset_done:
-            block_end_ts = ts
-        if "===== start of output =====" in lower:
-            num_smi_attempts += 1
-        if "tt-smi reset was successful" in lower:
-            final_status = "SUCCESS"
-            if ts:
-                block_end_ts = ts
-            reset_done = True
-        if "error:" in lower:
-            # Always collect all conclusive failure lines (there can be multiple)
-            content = clean_line(line)
-            if content and content not in seen_errors:
-                seen_errors.add(content)
-                error_lines.append(content)
-            if not reset_done:
-                final_status = "FAILURE"
-                if ts:
-                    block_end_ts = ts
-                reset_done = True
-
-    if num_smi_attempts == 0:
-        num_smi_attempts = 1
-
-    duration = None
-    if block_start_ts and block_end_ts:
-        duration = (block_end_ts - block_start_ts).total_seconds()
-
-    if final_status == "SUCCESS":
-        error_summary = "tt-smi reset was successful"
-    elif error_lines:
-        error_summary = " | ".join(error_lines)
-    else:
-        error_summary = None
-
-    return [
-        {
-            "tt_smi_reset_attempt": num_smi_attempts,
-            "final_status": final_status,
-            "total_reset_time_sec": duration,
-            "error_summary": error_summary,
-        }
-    ]
-
-
-def get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, workflow_run_id: int, workflow_attempt: int):
+def get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, workflow_run_id: int):
+    """
+    Read the job output log for the tt-smi version. The tt-smi version is printed in the
+    Set up runner step, where we call tt-smi-metal -s to dump the smi output.
+    The tt-smi version stored in the "host_sw_vers" dict is only available in
+    higher versions of tt-smi (3.0.4+). For older versions we will not be able to extract
+    the smi version directly from the smi output log dump.
+    See: https://github.com/tenstorrent/tt-metal/issues/19095
+    """
     logs_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
 
-    assert logs_dir.exists(), f"Logs dir does not exist: {logs_dir}"
-    assert logs_dir.is_dir(), f"Logs path is not a dir: {logs_dir}"
-
-    log_files = list(logs_dir.glob("*.log"))
-    assert log_files, f"No log files found in {logs_dir}"
+    log_files = logs_dir.glob("*.log")
 
     github_job_ids_to_tt_smi_versions = {}
-    github_job_ids_to_tt_smi_resets = {}
-
     for log_file in log_files:
-        filename = log_file.stem
-
-        assert filename.isdigit(), f"Unexpected filename format: {filename}"
-
-        github_job_id = int(filename)
-        assert github_job_id > 0
-
-        workflow_attempt_from_file = workflow_attempt
-
         tt_smi_version = search_for_tt_smi_version_in_log_file_(log_file)
         if tt_smi_version:
+            github_job_id = log_file.name.replace(".log", "")
+            assert github_job_id.isnumeric(), f"{github_job_id}"
+            github_job_id = int(github_job_id)
             github_job_ids_to_tt_smi_versions[github_job_id] = tt_smi_version
-
-        tt_smi_reset = search_for_tt_smi_reset_in_log_file_(log_file)
-        for reset in tt_smi_reset:
-            reset["workflow_attempt"] = workflow_attempt_from_file
-        assert tt_smi_reset is not None, f"Parser returned None for {log_file}"
-
-        key = (workflow_attempt_from_file, github_job_id)
-
-        assert key not in github_job_ids_to_tt_smi_resets, f"Duplicate reset key detected: {key}"
-
-        github_job_ids_to_tt_smi_resets[key] = tt_smi_reset
-
-    return github_job_ids_to_tt_smi_versions, github_job_ids_to_tt_smi_resets
+    return github_job_ids_to_tt_smi_versions
 
 
 def parse_github_log_timestamp(line):
@@ -220,14 +76,7 @@ def is_job_hanging_from_job_log(error_snippet, workflow_outputs_dir, workflow_ru
     ** Threshold may be reduced in the future
     """
     log_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
-    assert str(workflow_job_id).isdigit()
-    matching_logs = list(log_dir.glob(f"{workflow_job_id}.log"))
-
-    if not matching_logs:
-        logger.warning(f"Unable to find github job log file for job: {workflow_job_id}")
-        return False
-
-    log_file = matching_logs[0]
+    log_file = log_dir.joinpath(str(workflow_job_id) + ".log")
     max_time_delta_seconds = 300
 
     if not log_file.exists():
@@ -329,9 +178,9 @@ def get_github_job_ids_to_workflow_run_uuids_(workflow_outputs_dir, workflow_run
         artifact_uuid_name = search_for_uuid_in_log_file_(log_file)
         if artifact_uuid_name:
             uuid = artifact_uuid_name.replace("test_reports_", "")
-            filename = log_file.stem
-            assert filename.isdigit(), f"Unexpected filename format: {filename}"
-            github_job_id = int(filename)
+            github_job_id = log_file.name.replace(".log", "")
+            assert github_job_id.isnumeric(), f"{github_job_id}"
+            github_job_id = int(github_job_id)
             github_job_ids_to_workflow_run_uuids[github_job_id] = uuid
     return github_job_ids_to_workflow_run_uuids
 
@@ -390,9 +239,9 @@ def get_github_job_id_to_annotations(workflow_outputs_dir, workflow_run_id: int)
             annot_json_info = json.load(f)
         if annot_json_info:
             # Map job id to annotation info (list of dict)
-            filename = annot_json_file.name.replace("_annotations.json", "")
-            assert filename.isdigit(), f"Unexpected filename format: {filename}"
-            github_job_id = int(filename)
+            github_job_id = annot_json_file.name.replace("_annotations.json", "")
+            assert github_job_id.isnumeric(), f"{github_job_id}"
+            github_job_id = int(github_job_id)
             github_job_ids_to_annotation_jsons[github_job_id] = annot_json_info
     return github_job_ids_to_annotation_jsons
 

--- a/infra/data_collection/pydantic_models.py
+++ b/infra/data_collection/pydantic_models.py
@@ -61,15 +61,6 @@ class JobStatus(str, Enum):
     action_required = "action_required"
 
 
-class TtSmiReset(BaseModel):
-    github_job_id: int
-    workflow_attempt: Optional[int] = None
-    tt_smi_reset_attempt: int
-    final_status: Optional[str] = None
-    total_reset_time_sec: Optional[float] = None
-    error_summary: Optional[str] = None
-
-
 class Job(BaseModel):
     """
     Contains information about the execution of CI/CD jobs, each one associated with a
@@ -86,10 +77,6 @@ class Job(BaseModel):
     github_job_link: Optional[str] = Field(
         None,
         description="Link to the Github Actions CI job, for pipelines orchestrated and " "executed by Github.",
-    )
-    workflow_attempt: Optional[int] = Field(
-        None,
-        description="GitHub workflow rerun attempt number.",
     )
     name: str = Field(description="Name of the job.")
     job_submission_ts: datetime = Field(description="Timestamp with timezone when the job was submitted.")
@@ -167,10 +154,6 @@ class Pipeline(BaseModel):
         None,
         description="Link to the Github Actions CI pipeline, for pipelines " "orchestrated and executed by Github.",
     )
-    workflow_attempt: Optional[int] = Field(
-        None,
-        description="GitHub workflow rerun attempt number.",
-    )
     pipeline_submission_ts: datetime = Field(
         description="Timestamp with timezone when the pipeline was submitted for " "execution.",
     )
@@ -193,7 +176,6 @@ class Pipeline(BaseModel):
     git_author: str = Field(description="Author of the Git commit.")
     orchestrator: Optional[str] = Field(None, description="CI/CD pipeline orchestration platform.")
     jobs: List[Job] = []
-    tt_smi_resets: List[TtSmiReset] = []
 
     # Model validator to check the unique combination constraint
     @model_validator(mode="before")


### PR DESCRIPTION
This reverts commit bd5e8354258.

Reason:
workflow_attempt was added into nested pipeline payloads and breaks airflow wrangling with:

TypeError: 'workflow_attempt' is an invalid keyword argument for Pipeline

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:revert-tt-smi-pydantic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:revert-tt-smi-pydantic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:revert-tt-smi-pydantic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:revert-tt-smi-pydantic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:revert-tt-smi-pydantic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:revert-tt-smi-pydantic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:revert-tt-smi-pydantic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=revert-tt-smi-pydantic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:revert-tt-smi-pydantic)