### PR TITLE
[Cleanup] DeepSeek set trace_region_size=0

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -536,7 +536,9 @@ def run_demo(
     logger.info(f"Opening mesh device with shape {mesh_shape}")
     if enable_trace:
         logger.info("Enabling trace for decode forward pass")
-        # NOTE:
+        # NOTE: A trace_region_size of 0 lets the runtime/device allocate trace buffers dynamically
+        # instead of reserving a fixed region up front. This avoids overcommitting memory, at the
+        # cost of giving us less explicit control over reserved trace capacity.
         trace_region_size = 0
         logger.info(f"Trace region size set to {trace_region_size}")
         mesh_device = ttnn.open_mesh_device(

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -537,19 +537,7 @@ def run_demo(
     if enable_trace:
         logger.info("Enabling trace for decode forward pass")
         # NOTE:
-        # The base trace region size below (~36.3 MiB) was empirically determined from
-        # vLLM decode workloads to be sufficient to keep the trace buffer from
-        # overflowing under typical DeepSeek-V3 demo settings (batch size, sequence
-        # length, and mesh configuration). We add 20% headroom as a conservative
-        # safety margin to accommodate variability across models / prompts without
-        # repeatedly re-tuning this value.
-        #
-        # If you are optimizing memory usage, this can be reduced after verifying
-        # that tracing completes without buffer exhaustion for your target workload.
-        BASE_TRACE_REGION_BYTES = 38_070_272
-        trace_region_size = BASE_TRACE_REGION_BYTES + int(0.20 * BASE_TRACE_REGION_BYTES)
-        if enable_mtp:
-            trace_region_size = max(trace_region_size, 134_217_728)
+        trace_region_size = 0
         logger.info(f"Trace region size set to {trace_region_size}")
         mesh_device = ttnn.open_mesh_device(
             mesh_shape=mesh_shape, trace_region_size=trace_region_size, dispatch_core_config=dispatch_core_config

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py
@@ -359,7 +359,7 @@ def _build_all_gather_embedding_inputs(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py
@@ -393,7 +393,7 @@ def _build_embedding_inputs(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,
@@ -501,7 +501,7 @@ def test_ds_embedding(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
@@ -418,7 +418,7 @@ def _build_lm_head_inputs(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 0,  # Large trace region for vocab projection
+            "trace_region_size": 0,  # Use dynamic trace-region allocation for this workload
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
@@ -418,7 +418,7 @@ def _build_lm_head_inputs(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 23740416,  # Large trace region for vocab projection
+            "trace_region_size": 0,  # Large trace region for vocab projection
         }
     ],
     indirect=True,
@@ -516,7 +516,7 @@ def test_ds_lm_head(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 23740416,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_allgather_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_allgather_deepseek.py
@@ -124,7 +124,7 @@ def run_allgather_deepseek_with_trace(
     "device_params",
     [
         {
-            "trace_region_size": 901200,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
         }

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_alltoall_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_alltoall_deepseek.py
@@ -123,7 +123,7 @@ def run_alltoall_deepseek_with_trace(
     "device_params",
     [
         {
-            "trace_region_size": 550912,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
         }

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_concat_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_concat_deepseek.py
@@ -42,7 +42,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 595968,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py
@@ -26,7 +26,7 @@ DEVICE_PERF_TARGETS_US = {
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": get_fabric_config(), "trace_region_size": 2967552},
+        {"fabric_config": get_fabric_config(), "trace_region_size": 0},
     ],
     indirect=True,
 )

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_flash_mla_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_flash_mla_deepseek.py
@@ -139,7 +139,7 @@ def _reconstruct_logical_cache_from_paged(
     "device_params",
     [
         {
-            "trace_region_size": 0,  # Larger trace region for flash attention
+            "trace_region_size": 0,  # Dynamic allocation mode; no dedicated trace region
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_flash_mla_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_flash_mla_deepseek.py
@@ -139,7 +139,7 @@ def _reconstruct_logical_cache_from_paged(
     "device_params",
     [
         {
-            "trace_region_size": 5500000,  # Larger trace region for flash attention
+            "trace_region_size": 0,  # Larger trace region for flash attention
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_fwd_decode_q_rope_nope_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_fwd_decode_q_rope_nope_deepseek.py
@@ -311,7 +311,7 @@ def run_fwd_decode_q_rope_nope_with_trace(
     "device_params",
     [
         {
-            "trace_region_size": 6052000,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
         }

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_linear_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_linear_deepseek.py
@@ -60,7 +60,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "device_params",
     [
         {
-            "trace_region_size": 704600,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_mesh_partition.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_mesh_partition.py
@@ -42,7 +42,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "device_params",
     [
         {
-            "trace_region_size": 595968,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
         }

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_norm_and_rope_sequence_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_norm_and_rope_sequence_deepseek.py
@@ -311,7 +311,7 @@ def run_norm_and_rope_sequence_with_trace(
     "device_params",
     [
         {
-            "trace_region_size": 5518900,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_pad_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_pad_deepseek.py
@@ -32,7 +32,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 1335296,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_paged_update_cache_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_paged_update_cache_deepseek.py
@@ -260,7 +260,7 @@ def test_paged_update_cache_verify_aliasing_mesh_sharded_update_idxs(mesh_device
     "device_params",
     [
         {
-            "trace_region_size": 2097152,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_permute_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_permute_deepseek.py
@@ -82,7 +82,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 1671168,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_reduce_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_reduce_deepseek.py
@@ -23,7 +23,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "device_params",
     [
         {
-            "trace_region_size": 567296,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
         }

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_reshape_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_reshape_deepseek.py
@@ -39,7 +39,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 1335296,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_rmsnorm_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_rmsnorm_deepseek.py
@@ -34,7 +34,7 @@ def rms_norm_reference(x: torch.Tensor, weight: torch.Tensor, epsilon: float = 1
     "device_params",
     [
         {
-            "trace_region_size": 550912,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_rope_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_rope_deepseek.py
@@ -160,7 +160,7 @@ def create_rope_tensors(device, head_dim, batch_size=32):
     "device_params",
     [
         {
-            "trace_region_size": 550912,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_slice_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_slice_deepseek.py
@@ -31,7 +31,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 550912,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_slice_q_rope_nope.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_slice_q_rope_nope.py
@@ -32,7 +32,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 550912,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_slice_q_rope_nope_mesh.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_slice_q_rope_nope_mesh.py
@@ -33,7 +33,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 6052000,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
         }

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_to_memory_config_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_to_memory_config_deepseek.py
@@ -137,7 +137,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     "device_params",
     [
         {
-            "trace_region_size": 550912,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_wkv_b2_sequence_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_wkv_b2_sequence_deepseek.py
@@ -125,7 +125,7 @@ def run_wkv_b2_sequence_with_trace(
     "device_params",
     [
         {
-            "trace_region_size": 5502496,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_wq_kv_a_sequence_deepseek.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_wq_kv_a_sequence_deepseek.py
@@ -235,7 +235,7 @@ def run_wq_kv_a_sequence_with_trace(
     "device_params",
     [
         {
-            "trace_region_size": 2154500,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
         }

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
@@ -322,7 +322,7 @@ def _build_all_gather_inputs(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
@@ -383,7 +383,7 @@ def _build_ff1_3_inputs(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,
@@ -508,7 +508,7 @@ def test_ds_ff1_3(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
@@ -475,7 +475,7 @@ def _build_ff2_inputs(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,
@@ -595,7 +595,7 @@ def test_ds_ff2(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
@@ -351,7 +351,7 @@ def _build_mul_inputs(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,
@@ -467,7 +467,7 @@ def test_ds_mul(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
@@ -452,7 +452,7 @@ def _build_reduce_scatter_inputs(
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py
@@ -465,7 +465,7 @@ def _build_perf_input_set(
 
 @pytest.mark.parametrize(
     "device_params",
-    [pytest.param({"trace_region_size": 500000}, id="trace_region=500k")],
+    [pytest.param({"trace_region_size": 0}, id="trace_region=500k")],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py
@@ -465,7 +465,7 @@ def _build_perf_input_set(
 
 @pytest.mark.parametrize(
     "device_params",
-    [pytest.param({"trace_region_size": 0}, id="trace_region=500k")],
+    [pytest.param({"trace_region_size": 0}, id="trace_region=0")],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
@@ -47,7 +47,7 @@ def reference_model(hf_config):
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": get_fabric_config(), "trace_region_size": 2967552},
+        {"fabric_config": get_fabric_config(), "trace_region_size": 0},
     ],
     indirect=True,
 )

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -613,7 +613,7 @@ def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 500000,
+            "trace_region_size": 0,
         },
     ],
     ids=["fabric_1D_ring"],

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py
@@ -363,7 +363,7 @@ def _build_distributed_norm_inputs(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py
@@ -373,7 +373,7 @@ def _build_rms_norm_inputs(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,
@@ -467,7 +467,7 @@ def test_ds_rms_norm(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 2967552,
+            "trace_region_size": 0,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
@@ -233,7 +233,7 @@ def run_decode_reduce_scatter_deepseek_impl(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
                 "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-                "trace_region_size": 1531456,
+                "trace_region_size": 0,
             },
             ttnn.Topology.Ring,
         ),

--- a/models/demos/deepseek_v3/tests/test_mtp.py
+++ b/models/demos/deepseek_v3/tests/test_mtp.py
@@ -34,7 +34,7 @@ from models.demos.deepseek_v3.utils.weight_config import _try_load_cached_config
 
 DEFAULT_NUM_STEPS = 128
 GENERATE_REFERENCE = os.getenv("DEEPSEEK_V3_MTP_GENERATE_REFERENCE", "0") == "1"
-TRACE_REGION_SIZE = int(os.getenv("DEEPSEEK_TRACE_REGION_SIZE", "134217728"))
+TRACE_REGION_SIZE = int(os.getenv("DEEPSEEK_TRACE_REGION_SIZE", "0"))
 TIMEOUT_S = int(os.getenv("DEEPSEEK_V3_MTP_TIMEOUT_S", "1200"))
 MAX_E2E_SECONDS = float(os.getenv("DEEPSEEK_V3_MTP_E2E_MAX_S", "0"))
 MIN_TOKENS_PER_SEC = float(os.getenv("DEEPSEEK_V3_MTP_MIN_TPS", "1.0"))

--- a/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_combine_tg.py
+++ b/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_combine_tg.py
@@ -244,7 +244,7 @@ def run_combine_test(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 500000,
+            "trace_region_size": 0,
         },
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_compute_tg.py
+++ b/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_compute_tg.py
@@ -399,7 +399,7 @@ def run_moe_compute_test(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 500000,
+            "trace_region_size": 0,
         },
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_dispatch_tg.py
+++ b/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_dispatch_tg.py
@@ -400,7 +400,7 @@ def run_all_to_all_dispatch_metadata_test(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 500000,
+            "trace_region_size": 0,
         },
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/tg_moe_tests/test_optimized_moe_decode_block_tg.py
+++ b/models/demos/deepseek_v3/tests/tg_moe_tests/test_optimized_moe_decode_block_tg.py
@@ -527,7 +527,7 @@ def verify_output(iteration, mesh_device, mesh_shape, tt_output_tensor, output_r
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 500000,
+            "trace_region_size": 0,
         },
     ],
     ids=["fabric_1D_ring"],

--- a/models/demos/deepseek_v3/tests/unit/test_all_gather.py
+++ b/models/demos/deepseek_v3/tests/unit/test_all_gather.py
@@ -72,7 +72,7 @@ SHAPE_DTYPE_BUFFER_TYPE_SHARD_SPEC = [
 
 @pytest.mark.requires_device(["N300", "T3K", "TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("shape_dtype_buffer_type_shard_spec", SHAPE_DTYPE_BUFFER_TYPE_SHARD_SPEC)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])

--- a/models/demos/deepseek_v3/tests/unit/test_concat.py
+++ b/models/demos/deepseek_v3/tests/unit/test_concat.py
@@ -68,7 +68,7 @@ CLUSTER_AXIS = 1
 
 @pytest.mark.requires_device(["T3K", "TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("shape_list", DEEPSEEK_SHAPE_LISTS)
 @pytest.mark.parametrize("dim", [3, 1])  # slightly overkill

--- a/models/demos/deepseek_v3/tests/unit/test_deepseek_moe_post_combine_tilize.py
+++ b/models/demos/deepseek_v3/tests/unit/test_deepseek_moe_post_combine_tilize.py
@@ -17,7 +17,7 @@ from models.demos.deepseek_v3.utils.config_helpers import get_fabric_config
     [
         {
             "fabric_config": get_fabric_config(),
-            "trace_region_size": 135168,
+            "trace_region_size": 0,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
         }
     ],

--- a/models/demos/deepseek_v3/tests/unit/test_embedding.py
+++ b/models/demos/deepseek_v3/tests/unit/test_embedding.py
@@ -19,7 +19,7 @@ VOCAB_SIZE = 2048
 
 @pytest.mark.requires_device(["N150", "N300", "T3K", "TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("shape_pair", DEEPSEEK_SHAPE_PAIRS)
 @pytest.mark.parametrize("input_dtype", [ttnn.uint32])

--- a/models/demos/deepseek_v3/tests/unit/test_gather.py
+++ b/models/demos/deepseek_v3/tests/unit/test_gather.py
@@ -15,7 +15,7 @@ DEEPSEEK_SHAPES_DTYPES = [[(1, 1, 32, 256), ttnn.bfloat16, (1, 1, 32, 8), ttnn.u
 
 @pytest.mark.requires_device(["N150", "N300", "T3K", "TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("shapes_dtypes", DEEPSEEK_SHAPES_DTYPES)
 @pytest.mark.parametrize("dim", [3])

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -261,7 +261,7 @@ def test_matmul_dram_sharded_single_device(
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,  # TODO: Remove this once we have a fix for issue #40860
-            "trace_region_size": 90112,
+            "trace_region_size": 0,
             "fabric_config": get_fabric_config(),
         }
     ],
@@ -714,7 +714,7 @@ def test_matmul_interleaved_single_device(
 )
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 90112, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 @pytest.mark.requires_device(["T3K", "TG", "DUAL", "QUAD"])
 def test_matmul_interleaved_mesh_device(

--- a/models/demos/deepseek_v3/tests/unit/test_mesh_partition.py
+++ b/models/demos/deepseek_v3/tests/unit/test_mesh_partition.py
@@ -55,7 +55,7 @@ CLUSTER_AXIS = 1
 
 @pytest.mark.requires_device(["N300", "T3K", "TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("dim", [DIM])
 @pytest.mark.parametrize("shape", DEEPSEEK_SHAPES)

--- a/models/demos/deepseek_v3/tests/unit/test_pad.py
+++ b/models/demos/deepseek_v3/tests/unit/test_pad.py
@@ -30,7 +30,7 @@ DEEPSEEK_SHAPE_PADDED_FILL_MEM = [
 
 @pytest.mark.requires_device(["N150", "N300", "T3K", "TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("test_config", DEEPSEEK_SHAPE_PADDED_FILL_MEM)
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])

--- a/models/demos/deepseek_v3/tests/unit/test_permute.py
+++ b/models/demos/deepseek_v3/tests/unit/test_permute.py
@@ -28,7 +28,7 @@ DEEPSEEK_SHAPE_PERM_LAYOUT_MEM = [
 
 @pytest.mark.requires_device(["N150", "N300", "T3K", "TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("test_config", DEEPSEEK_SHAPE_PERM_LAYOUT_MEM)
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])

--- a/models/demos/deepseek_v3/tests/unit/test_reduce.py
+++ b/models/demos/deepseek_v3/tests/unit/test_reduce.py
@@ -72,7 +72,7 @@ def test_reduce_sum_single_device(device, shape):
 )
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_reduce_sum_mesh_device(mesh_device, shape, enable_trace, device_params):
     """

--- a/models/demos/deepseek_v3/tests/unit/test_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/unit/test_reduce_scatter.py
@@ -93,7 +93,7 @@ def _get_tensors(
 @pytest.mark.parametrize(
     "device_params, topology, cluster_axis",
     [
-        ({"fabric_config": get_fabric_config(), "trace_region_size": 1171456}, ttnn.Topology.Linear, 1),
+        ({"fabric_config": get_fabric_config(), "trace_region_size": 0}, ttnn.Topology.Linear, 1),
     ],
     indirect=["device_params"],
     ids=["fabric_linear"],

--- a/models/demos/deepseek_v3/tests/unit/test_repeat.py
+++ b/models/demos/deepseek_v3/tests/unit/test_repeat.py
@@ -27,7 +27,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_repeat(mesh_device, shape, repeat_shape, dtype, mem_config, layout, enable_trace):
     torch_input = random_torch_tensor(dtype, shape)

--- a/models/demos/deepseek_v3/tests/unit/test_reshape.py
+++ b/models/demos/deepseek_v3/tests/unit/test_reshape.py
@@ -31,7 +31,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_reshape(mesh_device, in_shape, out_shape, layout, mem_config, dtype, enable_trace):
     torch_input = random_torch_tensor(dtype, in_shape)

--- a/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
+++ b/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
@@ -129,7 +129,7 @@ def test_rmsnorm_pre_all_gather_single_device(device):
 @pytest.mark.parametrize("mesh_device", [(8, 8)], indirect=True)
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 90112, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_rmsnorm_pre_all_gather_mesh_device(mesh_device, enable_trace, device_params):
     """
@@ -369,7 +369,7 @@ def test_rmsnorm_post_all_gather(device):
 @pytest.mark.requires_device(["TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 90112, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_rmsnorm_distributed_mesh_device(mesh_device, enable_trace, device_params):
     """
@@ -623,7 +623,7 @@ def test_rmsnorm_single_device(device, inp_shape, weight_shape):
 )
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 90112, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 @pytest.mark.requires_device(["T3K", "TG", "DUAL", "QUAD"])
 def test_rmsnorm_mesh_device(mesh_device, inp_shape, weight_shape, enable_trace, device_params):

--- a/models/demos/deepseek_v3/tests/unit/test_scatter.py
+++ b/models/demos/deepseek_v3/tests/unit/test_scatter.py
@@ -25,7 +25,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("index_mem_config", [ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_scatter(
     mesh_device,

--- a/models/demos/deepseek_v3/tests/unit/test_slice.py
+++ b/models/demos/deepseek_v3/tests/unit/test_slice.py
@@ -47,7 +47,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_slice(mesh_device, shape, starts, ends, dtype, mem_config, layout, enable_trace):
     torch_input = random_torch_tensor(dtype, shape)

--- a/models/demos/deepseek_v3/tests/unit/test_tilize.py
+++ b/models/demos/deepseek_v3/tests/unit/test_tilize.py
@@ -26,7 +26,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_tilize(mesh_device, shape, dtype, mem_config, layout, enable_trace):
     torch_input = random_torch_tensor(dtype, shape)
@@ -62,7 +62,7 @@ def test_tilize(mesh_device, shape, dtype, mem_config, layout, enable_trace):
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_tilize_with_val_padding(mesh_device, in_shape, out_shape, pad_val, dtype, mem_config, layout, enable_trace):
     torch_input = random_torch_tensor(dtype, in_shape)

--- a/models/demos/deepseek_v3/tests/unit/test_to_memory_config.py
+++ b/models/demos/deepseek_v3/tests/unit/test_to_memory_config.py
@@ -116,7 +116,7 @@ DEEPSEEK_MEM_CONFIG_SHAPE_DTYPE_MEM_CONFIG = [
 
 @pytest.mark.requires_device(["TG", "DUAL", "QUAD"])
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 90112}], indirect=True
+    "device_params", [{"fabric_config": get_fabric_config(), "trace_region_size": 0}], indirect=True
 )
 @pytest.mark.parametrize("test_config", DEEPSEEK_MEM_CONFIG_SHAPE_DTYPE_MEM_CONFIG)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
@@ -164,7 +164,7 @@ def test_interleaved_to_sharded_deepseek(mesh_device, test_config, layout, enabl
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_sharded_to_interleaved(mesh_device, shape, shard_type, cores, out_mem_config, dtype, layout, enable_trace):
     torch_input = random_torch_tensor(dtype, shape)

--- a/models/demos/deepseek_v3/tests/unit/test_topk.py
+++ b/models/demos/deepseek_v3/tests/unit/test_topk.py
@@ -85,7 +85,7 @@ def test_topk_single_device(shape, k, dtype, device):
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 16000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_topk_mesh_device(mesh_device, shape, k, dtype, enable_trace, device_params):
     """

--- a/models/demos/deepseek_v3/tests/unit/test_transpose.py
+++ b/models/demos/deepseek_v3/tests/unit/test_transpose.py
@@ -68,7 +68,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("mem_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_transpose(mesh_device, shape, transpose_type, pad_val, dtype, layout, mem_config, enable_trace):
     if transpose_type == "HC":

--- a/models/demos/deepseek_v3/tests/unit/test_untilize.py
+++ b/models/demos/deepseek_v3/tests/unit/test_untilize.py
@@ -24,7 +24,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_untilize(mesh_device, shape, dtype, mem_config, layout, enable_trace):
     torch_input = random_torch_tensor(dtype, shape)
@@ -60,7 +60,7 @@ def test_untilize(mesh_device, shape, dtype, mem_config, layout, enable_trace):
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 10000, "fabric_config": get_fabric_config()}], indirect=True
+    "device_params", [{"trace_region_size": 0, "fabric_config": get_fabric_config()}], indirect=True
 )
 def test_untilize_with_unpadding(mesh_device, in_shape, out_shape, dtype, mem_config, layout, enable_trace):
     torch_input = random_torch_tensor(dtype, in_shape)


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Sets trace_region_size=0

### Notes for reviewers
- [X] [Galaxy DeepSeek](https://github.com/tenstorrent/tt-metal/actions/runs/26223129485) - passed
- [X] [Galaxy DeepSeek final op](https://github.com/tenstorrent/tt-metal/actions/runs/26229282319/job/77186365054) - passed
- [X] [Galaxy DeepSeek demo](https://github.com/tenstorrent/tt-metal/actions/runs/26224053142) - passed
- [X] [Galaxy DeepSeek perf](https://github.com/tenstorrent/tt-metal/actions/runs/26224083142) - passed
- [X] [Galaxy DeepSeek dual unit+module](https://github.com/tenstorrent/tt-metal/actions/runs/26225801870/job/77173687726) - passed
- [X] [Galaxy DeepSeek quad unit+module](https://github.com/tenstorrent/tt-metal/actions/runs/26225801870/job/77173688018) - passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtsishkouski/set_trace_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtsishkouski/set_trace_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtsishkouski/set_trace_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtsishkouski/set_trace_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtsishkouski/set_trace_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtsishkouski/set_trace_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtsishkouski/set_trace_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtsishkouski/set_trace_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtsishkouski/set_trace_0)