### PR TITLE
[Bug fix]composite_reduce_scatter: typecast BFLOAT8_B → BFLOAT16 around split/pad/concat

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_minimal_reduce_scatter_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_minimal_reduce_scatter_async_bh.py
@@ -255,6 +255,11 @@ def run_reduce_scatter_impl(
         (4, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         (4, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
         (4, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        # BFLOAT8_B + TILE input that IS tile-aligned but whose per-device output along the scatter
+        # dim is sub-tile (64 / 4 = 16 < TILE_WIDTH=32). Exercises the BFLOAT8_B guard in
+        # composite_reduce_scatter when the input-side alignment check is insufficient and only the
+        # dispatch-side (per-device output) check fires.
+        (4, [1, 1, 32, 64], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -268,6 +273,7 @@ def run_reduce_scatter_impl(
         "composite_rs_test_one",
         "composite_rs_test_two",
         "composite_rs_test_three",
+        "composite_rs_test_four",
     ],
 )
 @pytest.mark.parametrize(
@@ -365,6 +371,11 @@ def test_reduce_scatter_async_4dev_ring(
         (4, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
         (4, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
         # (4, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True), #Issue 27619
+        # BFLOAT8_B + TILE input that IS tile-aligned but whose per-device output along the scatter
+        # dim is sub-tile (64 / 4 = 16 < TILE_WIDTH=32). Exercises the BFLOAT8_B guard in
+        # composite_reduce_scatter when the input-side alignment check is insufficient and only the
+        # dispatch-side (per-device output) check fires.
+        (4, [1, 1, 32, 64], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -378,6 +389,7 @@ def test_reduce_scatter_async_4dev_ring(
         "composite_rs_test_one",
         "composite_rs_test_two",
         # "composite_rs_test_three",
+        "composite_rs_test_four",
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -88,6 +88,28 @@ ttnn::Tensor composite_reduce_scatter(
         "config to the input sharded memory config will break the op as the input and output shapes are different.");
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
 
+    // BFLOAT8_B + TILE_LAYOUT + non-tile-aligned input is unsafe through the composite split→pad→concat
+    // sequence below. Intermediate ops (split, pad, view) can produce per-chunk tensors with inconsistent
+    // dtypes, causing ttnn::concat to fail its "All Tensors should have same dtypes." validation. Mirror the
+    // guard already used in composite_all_to_all (below in this file): typecast BFLOAT8_B → BFLOAT16 at the
+    // top, execute the composite path in BFLOAT16, then typecast back at the end. The dtype-cast is cheap
+    // relative to the multi-device collective and only triggers for the BFLOAT8_B + non-tile-aligned case.
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_height = tile_shape[0];
+    uint32_t tile_width = tile_shape[1];
+    const auto& input_logical_shape = input_tensor.logical_shape();
+    bool is_tiled_and_not_tile_aligned =
+        input_tensor.layout() == ttnn::Layout::TILE &&
+        (input_logical_shape[-2] % tile_height != 0 || input_logical_shape[-1] % tile_width != 0);
+    const ttnn::DataType original_input_dtype = input_tensor.dtype();
+    const bool convert_to_bfloat16_for_composite =
+        is_tiled_and_not_tile_aligned && original_input_dtype == ttnn::DataType::BFLOAT8_B;
+    if (convert_to_bfloat16_for_composite) {
+        ttnn::Tensor bfloat16_input = ttnn::typecast(input_tensor, ttnn::DataType::BFLOAT16);
+        input_tensor.deallocate();
+        input_tensor = bfloat16_input;
+    }
+
     /*
      * - If sharded to interleaved, convert to the final interleaved memory config, and use that final
      *   interleaved memory config for all ops within the composite.
@@ -174,6 +196,14 @@ ttnn::Tensor composite_reduce_scatter(
     if (output_memory_config.is_sharded()) {
         rs_output_tensor = ttnn::to_memory_config(rs_output_tensor, output_memory_config);
     }
+
+    // Restore the original dtype if we typecast BFLOAT8_B → BFLOAT16 at the top of the composite path.
+    if (convert_to_bfloat16_for_composite) {
+        ttnn::Tensor bfloat8_output = ttnn::typecast(rs_output_tensor, original_input_dtype);
+        rs_output_tensor.deallocate();
+        rs_output_tensor = bfloat8_output;
+    }
+
     return rs_output_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -88,26 +88,18 @@ ttnn::Tensor composite_reduce_scatter(
         "config to the input sharded memory config will break the op as the input and output shapes are different.");
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
 
-    // BFLOAT8_B + TILE_LAYOUT + non-tile-aligned input is unsafe through the composite split→pad→concat
-    // sequence below. Intermediate ops (split, pad, view) can produce per-chunk tensors with inconsistent
-    // dtypes, causing ttnn::concat to fail its "All Tensors should have same dtypes." validation. Mirror the
-    // guard already used in composite_all_to_all (below in this file): typecast BFLOAT8_B → BFLOAT16 at the
-    // top, execute the composite path in BFLOAT16, then typecast back at the end. The dtype-cast is cheap
-    // relative to the multi-device collective and only triggers for the BFLOAT8_B + non-tile-aligned case.
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    uint32_t tile_height = tile_shape[0];
-    uint32_t tile_width = tile_shape[1];
-    const auto& input_logical_shape = input_tensor.logical_shape();
-    bool is_tiled_and_not_tile_aligned =
-        input_tensor.layout() == ttnn::Layout::TILE &&
-        (input_logical_shape[-2] % tile_height != 0 || input_logical_shape[-1] % tile_width != 0);
+    // BFLOAT8_B + TILE inputs are unsafe through the composite split→pad→concat below: intermediate ops
+    // can leave per-chunk tensors with inconsistent dtypes, tripping ttnn::concat's dtype-equality check.
+    // Mirror composite_all_to_all: typecast BF8 → BF16 at the top, run in BF16, typecast back at the end.
+    // Guard on layout+dtype only — use_composite_reduce_scatter dispatches on per-device output, so every
+    // BF8 + TILE input reaching here is unsafe. Temporarily doubles tensor footprint for the composite path.
     const ttnn::DataType original_input_dtype = input_tensor.dtype();
     const bool convert_to_bfloat16_for_composite =
-        is_tiled_and_not_tile_aligned && original_input_dtype == ttnn::DataType::BFLOAT8_B;
+        input_tensor.layout() == ttnn::Layout::TILE && original_input_dtype == ttnn::DataType::BFLOAT8_B;
     if (convert_to_bfloat16_for_composite) {
-        ttnn::Tensor bfloat16_input = ttnn::typecast(input_tensor, ttnn::DataType::BFLOAT16);
-        input_tensor.deallocate();
-        input_tensor = bfloat16_input;
+        // No explicit deallocate: input_tensor is pass-by-value, so deallocate(false) is a no-op
+        // (refcount > 1); the assignment releases the local handle.
+        input_tensor = ttnn::typecast(input_tensor, ttnn::DataType::BFLOAT16);
     }
 
     /*
@@ -192,16 +184,18 @@ ttnn::Tensor composite_reduce_scatter(
             ttnn::slice(padded_native_rs_output_tensor, sbegins, sends, ssteps, native_rs_output_memory_config);
     }
 
-    // if the output is sharded, do the conversion
-    if (output_memory_config.is_sharded()) {
-        rs_output_tensor = ttnn::to_memory_config(rs_output_tensor, output_memory_config);
-    }
-
-    // Restore the original dtype if we typecast BFLOAT8_B → BFLOAT16 at the top of the composite path.
+    // Restore the original dtype before any (optional) sharded reshard: typecast on an interleaved
+    // BFLOAT16 tensor is cheaper than typecast on a sharded one, and the sharded-typecast path is less
+    // battle-tested.
     if (convert_to_bfloat16_for_composite) {
         ttnn::Tensor bfloat8_output = ttnn::typecast(rs_output_tensor, original_input_dtype);
         rs_output_tensor.deallocate();
         rs_output_tensor = bfloat8_output;
+    }
+
+    // if the output is sharded, do the conversion
+    if (output_memory_config.is_sharded()) {
+        rs_output_tensor = ttnn::to_memory_config(rs_output_tensor, output_memory_config);
     }
 
     return rs_output_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -88,20 +88,6 @@ ttnn::Tensor composite_reduce_scatter(
         "config to the input sharded memory config will break the op as the input and output shapes are different.");
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
 
-    // BFLOAT8_B + TILE inputs are unsafe through the composite split→pad→concat below: intermediate ops
-    // can leave per-chunk tensors with inconsistent dtypes, tripping ttnn::concat's dtype-equality check.
-    // Mirror composite_all_to_all: typecast BF8 → BF16 at the top, run in BF16, typecast back at the end.
-    // Guard on layout+dtype only — use_composite_reduce_scatter dispatches on per-device output, so every
-    // BF8 + TILE input reaching here is unsafe. Temporarily doubles tensor footprint for the composite path.
-    const ttnn::DataType original_input_dtype = input_tensor.dtype();
-    const bool convert_to_bfloat16_for_composite =
-        input_tensor.layout() == ttnn::Layout::TILE && original_input_dtype == ttnn::DataType::BFLOAT8_B;
-    if (convert_to_bfloat16_for_composite) {
-        // No explicit deallocate: input_tensor is pass-by-value, so deallocate(false) is a no-op
-        // (refcount > 1); the assignment releases the local handle.
-        input_tensor = ttnn::typecast(input_tensor, ttnn::DataType::BFLOAT16);
-    }
-
     /*
      * - If sharded to interleaved, convert to the final interleaved memory config, and use that final
      *   interleaved memory config for all ops within the composite.
@@ -123,6 +109,20 @@ ttnn::Tensor composite_reduce_scatter(
         native_rs_output_memory_config = output_memory_config;
     } else {
         native_rs_output_memory_config = input_tensor.memory_config();
+    }
+
+    // BFLOAT8_B + TILE inputs are unsafe through the composite split→pad→concat below: intermediate ops
+    // can leave per-chunk tensors with inconsistent dtypes, tripping ttnn::concat's dtype-equality check.
+    // Mirror composite_all_to_all: typecast BF8 → BF16 here, run in BF16, typecast back at the end.
+    // Placed AFTER the sharded→interleaved conversion above so the typecast always runs on an interleaved
+    // tensor (sharded-typecast is more expensive and less battle-tested). Guard on layout+dtype only —
+    // use_composite_reduce_scatter dispatches on per-device output, so every BF8 + TILE input reaching
+    // here is unsafe. Temporarily doubles tensor footprint for the composite path.
+    const ttnn::DataType original_input_dtype = input_tensor.dtype();
+    const bool convert_to_bfloat16_for_composite =
+        input_tensor.layout() == ttnn::Layout::TILE && original_input_dtype == ttnn::DataType::BFLOAT8_B;
+    if (convert_to_bfloat16_for_composite) {
+        input_tensor = ttnn::typecast(input_tensor, ttnn::DataType::BFLOAT16);
     }
 
     // split the input tensor so we can insert internal padding


### PR DESCRIPTION
### Ticket

Fixes the deterministic CI failure on `composite_rs_test_two` (BFLOAT8_B variant)
in `blackhole-e2e-tests / ccl nightly tests [bh_quietbox_2]`:

- Failing job: https://github.com/tenstorrent/tt-metal/actions/runs/26216301452/job/77140570826
- Failing tests (8 parametrizations, all `-composite_rs_test_two-1link`):
  - `test_reduce_scatter_async_4dev_ring[...-Ring-{barrier,no_barrier}_{with,without}_persistent_buffers-{check,perf}-...]`
  - `test_reduce_scatter_async_line[...-Linear-{barrier,no_barrier}_{with,without}_persistent_buffers-{check,perf}-...]`
- Common error: `RuntimeError: TT_FATAL @ ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp:86: in_ref.dtype() == first_input.dtype() info: All Tensors should have same dtypes.`


### Problem

The composite reduce-scatter path (`composite_common::composite_reduce_scatter`) runs `split → pad → concat` on every input whose per-device output along the scatter dim is sub-tile. With `BFLOAT8_B + TILE_LAYOUT` inputs, the intermediate `split`/`pad`/`view` calls can produce per-chunk tensors with inconsistent dtypes, which trips `ttnn::concat`'s `All Tensors should have same dtypes.` validation (`concat_device_operation.cpp:86`).

Before #42770, this latent bug was silently masked: `ttnn::fill_implicit_tile_padding` had a BFLOAT8_B → BFLOAT16 dtype-leak on its `rank > 3` path, so every BF8 chunk passing through `ttnn::pad` was implicitly upcast to BFLOAT16, all chunks ended up the same (wrong) dtype, and the downstream `concat` happened to succeed.

#42770 correctness-fixed that leak — BFLOAT8_B inputs now correctly return BFLOAT8_B on every code path. That fix unmasked this latent bug in `composite_reduce_scatter`.

(Same pattern as the three other unmasks already addressed downstream of #42770: `test_reduction_h_interleaved`, `test_layernorm_mix_precision`, `test_softmax_mix_precision`. The previous three surfaced as PCC/precision regressions; this one surfaces as an outright TT_FATAL because `ttnn::concat` validates dtype equality strictly.)

### What's changing

`composite_reduce_scatter` now mirrors the `convert_to_bfloat16_for_composite` guard already used by `composite_all_to_all` in the same file (`composite_common.cpp:455–528`):

- At the **top** of the composite path: if the input is `BFLOAT8_B + TILE_LAYOUT`, typecast to BFLOAT16.
- Execute the existing `split → pad → concat → native RS → unpad` sequence in BFLOAT16 unchanged.
- At the **bottom**: typecast back to the original dtype, *before* the optional sharded `to_memory_config` reshard (so we reshard the half-size BFLOAT8_B tensor rather than the full-size BFLOAT16 one, and we avoid the less-tested
sharded-typecast path).

The guard predicate is intentionally `BFLOAT8_B + TILE_LAYOUT` only (not also `non-tile-aligned`): `composite_reduce_scatter` is only dispatched by `use_composite_reduce_scatter` when the per-device output along the scatter dim is sub-tile, so by construction every BFLOAT8_B input that reaches this function will exercise the unsafe path — even when the *input* itself is tile-aligned (e.g. `[1,1,32,64]` BFLOAT8_B with 4 devices on dim 3 → per-device output dim = 16). An input-side alignment check would have missed that case.

Blast radius:
- BFLOAT16 / FLOAT32 paths: unchanged.
- BFLOAT8_B + ROW_MAJOR paths: unchanged.
- BFLOAT8_B + TILE paths that *don't* reach `composite_reduce_scatter` (i.e. the
per-device output is already tile-aligned): unchanged.

### Why this and not a fix deeper in `pad`/`split`/`concat`?

1. **Pattern parity.** The same guard already exists in `composite_all_to_all` in the same file. The reason it wasn't in `composite_reduce_scatter` is purely  historical — `composite_reduce_scatter` happened to "work" for BF8 only
 because of the upstream dtype-leak. The right long-term shape is for both  composite paths to share this guard.
2. **Scope.** A fix inside `ttnn::pad` / `ttnn::split` / `ttnn::concat` to  uniformly handle BF8 + non-tile-aligned inputs is a much larger change with  wider blast radius. The pad/concat ops in general aren't BF8-native at sub-tile granularity; the composite path is the right place to enforce that.
3. **Cost.** The added typecasts only run on a small, well-defined input class (BF8 + TILE + composite-RS path), and they're cheap (time-wise) relative to the multi-device collective they wrap. See "Memory cost" below for the one  non-trivial trade-off.

### Memory cost

The BFLOAT8_B → BFLOAT16 typecast temporarily doubles the tensor footprint for the duration of the composite path. For inputs near device-memory ceilings on BFLOAT8_B + composite-RS, this is the first place to look if you start seeing OOMs post-merge. Time cost remains negligible relative to the multi-device collective.

### CI Check with PR

- Main branch failing CI : [blackhole-e2e-tests (QuietBox 2 (2xP300), bh_quietbox_2) / ccl nightly tests [bh_quietbox_2]](https://github.com/tenstorrent/tt-metal/actions/runs/26216301452/job/77140570826#logs)
- Proposed branch passing CI : [blackhole-e2e-tests (QuietBox 2 (2xP300), bh_quietbox_2) / ccl nightly tests [bh_quietbox_2]](https://github.com/tenstorrent/tt-metal/actions/runs/26232925744/job/77205200938#logs)

### Related PRs

- #42770 — `ttnn.reshape`: apply pad_value for tiled tensors (root unmask).

### Pipeline Checklist

- [x] Sanity tests - Passed
- [x] (Runtime) Sanity Tests - Passed
- [x] BHPC - Passed
- [x] Nightly tt-metal L2 tests - Passed as in main
- [x] Single card - Passed as in main
- [x] T3K - Passed as in main
- [x] Galaxy - Passed
- [x] All Model Tests - Passed as in main

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/reshape_dtype_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/reshape_dtype_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/reshape_dtype_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/reshape_dtype_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/reshape_dtype_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/reshape_dtype_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/reshape_dtype_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/reshape_dtype_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/reshape_dtype_fix)