### PR TITLE
[Feature] Optional resources for Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -29,6 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <algorithm>
 #include <filesystem>
 #include <optional>
 #include <type_traits>
@@ -39,6 +40,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>  // for CompileProgram (JIT trigger)
+#include <hostdevcommon/tensor_accessor/arg_config.hpp>
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -277,23 +279,37 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
     }
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
+// Metal 2.0 Optional Resource Bindings: a kernel may bind a DFB that does not exist on the
+// ProgramSpec. The framework emits the kernel-side dfb::<accessor> token with the sentinel id
+// (0xFFFF) so the kernel can declare `if constexpr (cta) { DataflowBuffer x(dfb::accessor); }`
+// without paying L1 cost for the unused branch. The wrapper ctor's ASSERT catches misuse at
+// device runtime in debug builds.
+TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBEmitsSentinel) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
-    // Bind to a DFB that doesn't exist
-    BindDFBToKernel(kernel, "nonexistent_dfb", "accessor", KernelSpec::DFBEndpointType::PRODUCER);
+    // Bind to a DFB that doesn't exist on the program (optional binding pattern).
+    BindDFBToKernel(kernel, "nonexistent_dfb", "optional_accessor", KernelSpec::DFBEndpointType::PRODUCER);
 
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Kernel 'kernel' references unknown DFB 'nonexistent_dfb'")));
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Verify the kernel-side accessor handle for the unresolved binding carries the sentinel id.
+    constexpr uint16_t kDFBSentinelId = 0xFFFFu;
+    bool found = false;
+    program.impl().get_kernel_by_spec_name("kernel")->process_dataflow_buffer_local_accessor_handles(
+        [&](const std::string& accessor_name, uint16_t logical_dfb_id) {
+            if (accessor_name == "optional_accessor") {
+                EXPECT_EQ(logical_dfb_id, kDFBSentinelId);
+                found = true;
+            }
+        });
+    EXPECT_TRUE(found);
 }
 
 TEST_F(ProgramSpecTestQuasar, DFBWithNoBindingsFails) {
@@ -905,18 +921,30 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
             ::testing::HasSubstr("Semaphore bindings are not supported for compute kernels.")));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
+// Metal 2.0 Optional Resource Bindings: a kernel may bind a semaphore that does not exist on
+// the ProgramSpec. The framework emits the kernel-side sem::<accessor> token with the sentinel
+// id (0xFFFF); the ckernel::Semaphore ctor ASSERTs on misuse at device runtime.
+TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownSemaphoreEmitsSentinel) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     KernelSpec::SemaphoreBinding binding;
     binding.semaphore_spec_name = "missing_sem";
-    binding.accessor_name = "my_sem";
+    binding.accessor_name = "optional_sem";
     spec.kernels[0].semaphore_bindings = {binding};
 
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("references unknown semaphore 'missing_sem'")));
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    constexpr uint16_t kSemaphoreSentinelId = 0xFFFFu;
+    bool found = false;
+    program.impl()
+        .get_kernel_by_spec_name(spec.kernels[0].unique_id)
+        ->process_semaphore_local_accessor_handles([&](const std::string& accessor_name, uint16_t semaphore_id) {
+            if (accessor_name == "optional_sem") {
+                EXPECT_EQ(semaphore_id, kSemaphoreSentinelId);
+                found = true;
+            }
+        });
+    EXPECT_TRUE(found);
 }
 
 TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
@@ -2792,16 +2820,37 @@ TEST_F(ProgramSpecTestGen1, DuplicateTensorParameterNameFails) {
             ::testing::HasSubstr("Duplicate TensorParameter name 'input_tensor'")));
 }
 
-TEST_F(ProgramSpecTestGen1, KernelReferencesUnknownTensorParameterFails) {
+// Metal 2.0 Optional Resource Bindings: a kernel may bind a TensorParameter that does not
+// exist on the ProgramSpec. The framework emits a two-word zeroed CTA payload (args_config
+// without the Bound bit, aligned_page_size = 0) and marks the TensorBindingHandle as unbound,
+// so no runtime base-address attachment occurs.
+TEST_F(ProgramSpecTestGen1, KernelReferencesUnknownTensorParameterEmitsUnboundPayload) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
-    // Reference a TensorParameter that doesn't exist in the program.
-    BindTensorParameterToKernel(spec.kernels[0], "nonexistent_tensor", "input_ta");
+    // Reference a TensorParameter that doesn't exist in the program (optional binding pattern).
+    BindTensorParameterToKernel(spec.kernels[0], "nonexistent_tensor", "optional_ta");
 
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("references unknown TensorParameter 'nonexistent_tensor'")));
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    auto kernel = program.impl().get_kernel_by_spec_name(spec.kernels[0].unique_id);
+    const auto& binding_handles = kernel->tensor_binding_handles();
+    auto it = std::find_if(binding_handles.begin(), binding_handles.end(), [](const TensorBindingHandle& h) {
+        return h.accessor_name == "optional_ta";
+    });
+    ASSERT_NE(it, binding_handles.end());
+    EXPECT_FALSE(it->bound);
+
+    // Verify the kernel's CTA payload at the binding's offset has the Bound bit unset.
+    // (Two-word unbound payload: args_config = 0, aligned_page_size = 0.)
+    bool checked_cta = false;
+    kernel->process_compile_time_args([&](const std::vector<uint32_t>& values) {
+        ASSERT_LT(it->cta_offset, values.size());
+        const uint8_t args_config_raw = static_cast<uint8_t>(values[it->cta_offset] & 0xFFu);
+        constexpr uint8_t kBoundBit = static_cast<uint8_t>(tensor_accessor::ArgConfig::Bound);
+        EXPECT_EQ(args_config_raw & kBoundBit, 0u) << "Bound bit must be unset for unbound binding";
+        checked_cta = true;
+    });
+    EXPECT_TRUE(checked_cta);
 }
 
 TEST_F(ProgramSpecTestGen1, UnboundTensorParameterFails) {
@@ -2846,6 +2895,45 @@ TEST_F(ProgramSpecTestGen1, InvalidTensorAccessorNameFails) {
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("tensor accessor_name 'has-dash' must be a valid C++ identifier")));
+}
+
+// Metal 2.0 Optional Resource Bindings: a kernel with both a bound and an unbound TensorBinding
+// must keep CTA offsets consistent — the unbound payload (2 zero words) matches non-sharded
+// NumArgsCT, so subsequent bindings' offsets line up. Verifies the Bound bit lands on the
+// resolved binding's payload and is unset on the unresolved one.
+TEST_F(ProgramSpecTestGen1, KernelMixedBoundAndUnboundTensorParametersSucceeds) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    spec.tensor_parameters = {MakeMinimalTensorParameter("real_tensor")};
+    BindTensorParameterToKernel(spec.kernels[0], "real_tensor", "bound_ta");
+    BindTensorParameterToKernel(spec.kernels[0], "missing_tensor", "unbound_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    auto kernel = program.impl().get_kernel_by_spec_name(spec.kernels[0].unique_id);
+    const auto& binding_handles = kernel->tensor_binding_handles();
+
+    auto bound_it = std::find_if(binding_handles.begin(), binding_handles.end(), [](const TensorBindingHandle& h) {
+        return h.accessor_name == "bound_ta";
+    });
+    auto unbound_it = std::find_if(binding_handles.begin(), binding_handles.end(), [](const TensorBindingHandle& h) {
+        return h.accessor_name == "unbound_ta";
+    });
+    ASSERT_NE(bound_it, binding_handles.end());
+    ASSERT_NE(unbound_it, binding_handles.end());
+    EXPECT_TRUE(bound_it->bound);
+    EXPECT_FALSE(unbound_it->bound);
+
+    constexpr uint8_t kBoundBit = static_cast<uint8_t>(tensor_accessor::ArgConfig::Bound);
+    kernel->process_compile_time_args([&](const std::vector<uint32_t>& values) {
+        ASSERT_LT(bound_it->cta_offset, values.size());
+        ASSERT_LT(unbound_it->cta_offset, values.size());
+        EXPECT_NE(values[bound_it->cta_offset] & kBoundBit, 0u);
+        EXPECT_EQ(values[unbound_it->cta_offset] & kBoundBit, 0u);
+    });
+
+    // CTA offsets must be distinct and the unbound binding must occupy exactly 2 words
+    // (args_config + aligned_page_size) so subsequent bindings would be at +2.
+    EXPECT_NE(bound_it->cta_offset, unbound_it->cta_offset);
 }
 
 TEST_F(ProgramSpecTestGen1, AccessorNamesAcrossCategoriesAreSeparateNamespaces) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -40,7 +40,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>  // for CompileProgram (JIT trigger)
-#include <hostdevcommon/tensor_accessor/arg_config.hpp>
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -2821,9 +2820,11 @@ TEST_F(ProgramSpecTestGen1, DuplicateTensorParameterNameFails) {
 }
 
 // Metal 2.0 Optional Resource Bindings: a kernel may bind a TensorParameter that does not
-// exist on the ProgramSpec. The framework emits a two-word zeroed CTA payload (args_config
-// without the Bound bit, aligned_page_size = 0) and marks the TensorBindingHandle as unbound,
-// so no runtime base-address attachment occurs.
+// exist on the ProgramSpec. The framework emits the same two-word zeroed CTA payload that
+// `TensorAccessorArgs(nullptr).append_to()` has always emitted (args_config = 0,
+// aligned_page_size = 0). The kernel-side TensorAccessorArgs<>::is_bound keys on
+// aligned_page_size != 0; the all-zero payload reads as unbound. The TensorBindingHandle is
+// also marked unbound so no runtime base-address attachment occurs.
 TEST_F(ProgramSpecTestGen1, KernelReferencesUnknownTensorParameterEmitsUnboundPayload) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -2840,14 +2841,13 @@ TEST_F(ProgramSpecTestGen1, KernelReferencesUnknownTensorParameterEmitsUnboundPa
     ASSERT_NE(it, binding_handles.end());
     EXPECT_FALSE(it->bound);
 
-    // Verify the kernel's CTA payload at the binding's offset has the Bound bit unset.
-    // (Two-word unbound payload: args_config = 0, aligned_page_size = 0.)
+    // The unbound payload is exactly the legacy `TensorAccessorArgs(nullptr)` shape: two zero
+    // words at the binding's CTA offset.
     bool checked_cta = false;
     kernel->process_compile_time_args([&](const std::vector<uint32_t>& values) {
-        ASSERT_LT(it->cta_offset, values.size());
-        const uint8_t args_config_raw = static_cast<uint8_t>(values[it->cta_offset] & 0xFFu);
-        constexpr uint8_t kBoundBit = static_cast<uint8_t>(tensor_accessor::ArgConfig::Bound);
-        EXPECT_EQ(args_config_raw & kBoundBit, 0u) << "Bound bit must be unset for unbound binding";
+        ASSERT_LT(it->cta_offset + 1u, values.size());
+        EXPECT_EQ(values[it->cta_offset], 0u) << "args_config must be 0 for unbound binding";
+        EXPECT_EQ(values[it->cta_offset + 1], 0u) << "aligned_page_size must be 0 for unbound binding";
         checked_cta = true;
     });
     EXPECT_TRUE(checked_cta);
@@ -2899,8 +2899,9 @@ TEST_F(ProgramSpecTestGen1, InvalidTensorAccessorNameFails) {
 
 // Metal 2.0 Optional Resource Bindings: a kernel with both a bound and an unbound TensorBinding
 // must keep CTA offsets consistent — the unbound payload (2 zero words) matches non-sharded
-// NumArgsCT, so subsequent bindings' offsets line up. Verifies the Bound bit lands on the
-// resolved binding's payload and is unset on the unresolved one.
+// NumArgsCT, so subsequent bindings' offsets line up. Verifies the bound binding gets a real
+// aligned_page_size and the unbound binding gets the all-zero `TensorAccessorArgs(nullptr)`
+// shape that the kernel-side is_bound keys on.
 TEST_F(ProgramSpecTestGen1, KernelMixedBoundAndUnboundTensorParametersSucceeds) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -2923,12 +2924,15 @@ TEST_F(ProgramSpecTestGen1, KernelMixedBoundAndUnboundTensorParametersSucceeds) 
     EXPECT_TRUE(bound_it->bound);
     EXPECT_FALSE(unbound_it->bound);
 
-    constexpr uint8_t kBoundBit = static_cast<uint8_t>(tensor_accessor::ArgConfig::Bound);
+    // Bound binding's aligned_page_size (CTA offset + 1) must be non-zero;
+    // unbound binding must be exactly two zero words. is_bound on the kernel side keys on
+    // aligned_page_size != 0.
     kernel->process_compile_time_args([&](const std::vector<uint32_t>& values) {
-        ASSERT_LT(bound_it->cta_offset, values.size());
-        ASSERT_LT(unbound_it->cta_offset, values.size());
-        EXPECT_NE(values[bound_it->cta_offset] & kBoundBit, 0u);
-        EXPECT_EQ(values[unbound_it->cta_offset] & kBoundBit, 0u);
+        ASSERT_LT(bound_it->cta_offset + 1u, values.size());
+        ASSERT_LT(unbound_it->cta_offset + 1u, values.size());
+        EXPECT_NE(values[bound_it->cta_offset + 1], 0u) << "bound aligned_page_size must be non-zero";
+        EXPECT_EQ(values[unbound_it->cta_offset], 0u) << "unbound args_config must be 0";
+        EXPECT_EQ(values[unbound_it->cta_offset + 1], 0u) << "unbound aligned_page_size must be 0";
     });
 
     // CTA offsets must be distinct and the unbound binding must occupy exactly 2 words

--- a/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
@@ -23,6 +23,11 @@ enum class ArgConfig : uint8_t {
     RuntimeTensorShape = 1 << 4,
     RuntimeShardShape = 1 << 5,
     RuntimeBankCoords = 1 << 6,
+    // Metal 2.0 Optional Resource Bindings: set by the framework when the kernel's TensorBinding
+    // resolves to a TensorParameter on the program. Unset (the zero-initialized payload state)
+    // indicates an unbound accessor — `dfb::name` / `sem::name` use sentinel ids for the same
+    // purpose; TensorAccessorArgs uses this bit because the payload is structurally richer.
+    Bound = 1 << 7,
     Runtime = RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords
 };
 

--- a/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
@@ -23,11 +23,6 @@ enum class ArgConfig : uint8_t {
     RuntimeTensorShape = 1 << 4,
     RuntimeShardShape = 1 << 5,
     RuntimeBankCoords = 1 << 6,
-    // Metal 2.0 Optional Resource Bindings: set by the framework when the kernel's TensorBinding
-    // resolves to a TensorParameter on the program. Unset (the zero-initialized payload state)
-    // indicates an unbound accessor — `dfb::name` / `sem::name` use sentinel ids for the same
-    // purpose; TensorAccessorArgs uses this bit because the payload is structurally richer.
-    Bound = 1 << 7,
     Runtime = RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords
 };
 

--- a/tt_metal/hw/inc/api/compute/experimental/semaphore.h
+++ b/tt_metal/hw/inc/api/compute/experimental/semaphore.h
@@ -35,9 +35,17 @@ namespace ckernel {
  */
 class Semaphore {
 public:
+    // Reserved id value indicating that the host did not bind a SemaphoreSpec for this accessor.
+    // See Metal 2.0 Optional Resource Bindings design: a kernel may declare `sem::<name>` for
+    // conditional use; when the host's ProgramSpec omits the underlying SemaphoreSpec, the
+    // framework emits the accessor with this sentinel id. The ctor traps it via ASSERT.
+    static constexpr uint32_t SENTINEL_ID = 0xFFFFu;
+
     explicit Semaphore(uint32_t semaphore_id) :
         local_l1_addr_(
-            (uintptr_t)(sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)]) + semaphore_id * L1_ALIGNMENT) {}
+            (uintptr_t)(sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)]) + semaphore_id * L1_ALIGNMENT) {
+        ASSERT(semaphore_id != SENTINEL_ID);
+    }
 
     /**
      * @brief Increment the semaphore by the specified value.

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -39,6 +39,13 @@
 // Here my_dfb_name is a constexpr DFBAccessor, auto-included in kernel_bindings_generated.h.
 //
 struct DFBAccessor {
+    // Reserved id value indicating that the host did not bind a DataflowBufferSpec for this accessor.
+    // See Metal 2.0 Optional Resource Bindings design: a kernel may declare `dfb::<name>` for
+    // conditional use (inside `if constexpr` guarded by a CTA); when the host's ProgramSpec omits
+    // the underlying DataflowBufferSpec, the framework emits the accessor with this sentinel id.
+    // The `DataflowBuffer(DFBAccessor)` ctor traps the sentinel via ASSERT.
+    static constexpr uint16_t SENTINEL_ID = 0xFFFFu;
+
     explicit constexpr DFBAccessor(uint16_t id) noexcept : id_(id) {}
 
     // Constexpr behavior for ID extraction:
@@ -74,7 +81,15 @@ public:
     // Preferred constructor for Metal 2.0 / ProgramSpec kernels.
     // Pass the named binding constant from kernel_bindings_generated.h:
     //   DataflowBuffer dfb(my_dfb_name);
-    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(accessor.resolve_id()) {}
+    //
+    // If the host did not bind a DataflowBufferSpec for this accessor (optional binding pattern),
+    // the accessor carries DFBAccessor::SENTINEL_ID. Constructing a DataflowBuffer on it means the
+    // kernel reached the use-site under a configuration where the host expected the resource to be
+    // unused. ASSERT traps this in debug builds; release builds proceed and will hang downstream
+    // on the first sync call (parity with legacy CB misuse).
+    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(accessor.resolve_id()) {
+        ASSERT(accessor.resolve_id() != DFBAccessor::SENTINEL_ID);
+    }
 
     // Low-level constructor: prefer DFBAccessor overload above for new kernel code.
     DataflowBuffer(uint16_t logical_dfb_id);

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -90,11 +90,19 @@ public:
     // The token instance is emitted by host codegen into kernel_bindings_generated.h,
     // based on the information in the user's host code (ProgramSpec).
     // Delegates to the legacy TensorAccessorArgs ctor.
+    //
+    // If the host did not bind a TensorParameter for this accessor (optional binding pattern),
+    // TensorAccessorArgs<CTA_OFFSET>::is_bound is false. The delegated ctor will still complete
+    // (with a zeroed args payload), but ASSERT in the body traps reaching the use-site in debug
+    // builds. The discarded `if constexpr` branch never instantiates this ctor, so the assert
+    // doesn't fire for conditionally-unused bindings.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
             TensorAccessorArgs<CTA_OFFSET>{},
-            static_cast<size_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {}
+            static_cast<size_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
+        ASSERT(TensorAccessorArgs<CTA_OFFSET>::is_bound);
+    }
 
     constexpr const auto& dspec() const {
         if constexpr (DSpec::is_static) {
@@ -369,11 +377,16 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
     // The token instance is emitted by host codegen into kernel_bindings_generated.h,
     // based on the information in the user's host code (ProgramSpec).
     // Delegates to the legacy TensorAccessorArgs ctor.
+    //
+    // See the interleaved-specialization version above for the optional-binding contract:
+    // when TensorAccessorArgs<CTA_OFFSET>::is_bound is false, ASSERT traps reaching the use-site.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
             TensorAccessorArgs<CTA_OFFSET>{},
-            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {}
+            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
+        ASSERT(TensorAccessorArgs<CTA_OFFSET>::is_bound);
+    }
 
     template <typename DSpec_ = DSpec, std::enable_if_t<std::is_same_v<std::decay_t<DSpec_>, DSpec>, int> = 0>
     constexpr explicit TensorAccessor(

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -24,6 +24,11 @@ struct TensorAccessorArgs {
 
     static constexpr bool is_sharded = args_config.test(tensor_accessor::ArgConfig::Sharded);
     static constexpr bool is_dram = args_config.test(tensor_accessor::ArgConfig::IsDram);
+    // Metal 2.0 Optional Resource Bindings: true when the host bound a TensorParameter for this
+    // kernel binding; false when the binding is declared in the KernelSpec but no corresponding
+    // TensorParameter exists on the ProgramSpec. The framework emits a zeroed payload at CTA_OFFSET
+    // for unbound bindings, so is_bound resolves to false at template instantiation time.
+    static constexpr bool is_bound = args_config.test(tensor_accessor::ArgConfig::Bound);
     static constexpr bool rank_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeRank);
     static constexpr bool num_banks_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeNumBanks);
     static constexpr bool tensor_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeTensorShape);

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -24,11 +24,6 @@ struct TensorAccessorArgs {
 
     static constexpr bool is_sharded = args_config.test(tensor_accessor::ArgConfig::Sharded);
     static constexpr bool is_dram = args_config.test(tensor_accessor::ArgConfig::IsDram);
-    // Metal 2.0 Optional Resource Bindings: true when the host bound a TensorParameter for this
-    // kernel binding; false when the binding is declared in the KernelSpec but no corresponding
-    // TensorParameter exists on the ProgramSpec. The framework emits a zeroed payload at CTA_OFFSET
-    // for unbound bindings, so is_bound resolves to false at template instantiation time.
-    static constexpr bool is_bound = args_config.test(tensor_accessor::ArgConfig::Bound);
     static constexpr bool rank_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeRank);
     static constexpr bool num_banks_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeNumBanks);
     static constexpr bool tensor_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeTensorShape);
@@ -47,6 +42,15 @@ struct TensorAccessorArgs {
     // aligned_page_size is always at CTA_OFFSET + 1
     static constexpr uint32_t AlignedPageSizeCTAOffset = CTA_OFFSET + 1;
     static constexpr uint32_t AlignedPageSize = get_compile_time_arg_val(AlignedPageSizeCTAOffset);
+
+    // Metal 2.0 Optional Resource Bindings: derived from the existing payload shape that
+    // TensorAccessorArgs(nullptr).append_to() has always emitted — two zero words at CTA_OFFSET
+    // and CTA_OFFSET + 1 (args_config = None, aligned_page_size = 0). A real Buffer-backed
+    // TensorAccessorArgs has aligned_page_size > 0; the unbound / nullptr case is uniquely the
+    // all-zero payload. Reusing the existing encoding (instead of adding a new bit to args_config)
+    // unifies legacy / descriptor-flow `TensorAccessorArgs(maybe ? buf : nullptr)` callers with
+    // Metal 2.0 unresolved TensorBindings (see also ResolveTensorBindingsForKernel).
+    static constexpr bool is_bound = (AlignedPageSize != 0);
 
     // Calculate offsets for compile-time arguments
     static constexpr uint32_t RankCTAOffset = CTA_OFFSET + 2;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -105,6 +105,11 @@ struct TensorBindingHandle {
     uint32_t cta_offset;                // first word index of this binding's payload in the kernel's compile-time args
     uint32_t addr_crta_offset;  // byte offset of this binding's base-address slot within the kernel's CRTA buffer
                                 // (binding addresses live in their own section appended after user-named CRTAs)
+    // Metal 2.0 Optional Resource Bindings: false when the kernel's TensorBinding referenced a
+    // tensor_parameter_name that does not exist on the ProgramSpec. The handle is still emitted
+    // (the kernel-side `ta::<name>` token must exist for `if constexpr (false)` branches to
+    // compile), but no runtime base-address attachment is performed for unbound handles.
+    bool bound = true;
 };
 
 class Kernel : public JitBuildSettings {

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -445,6 +445,15 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
             combined_crtas.push_back(v_it->second);
         }
         for (const auto& handle : binding_handles) {
+            if (!handle.bound) {
+                // Metal 2.0 Optional Resource Bindings: unbound handle has no associated
+                // TensorArg. Push a zero placeholder so the kernel's CRTA layout stays consistent
+                // with the addr_crta_offsets baked into ta::<name> tokens. The kernel won't read
+                // this slot for a binding it doesn't use (`if constexpr (false)` branch elides
+                // the TensorAccessor ctor); the ctor's ASSERT traps any misuse.
+                combined_crtas.push_back(0u);
+                continue;
+            }
             auto addr_it = ta_binding_addresses.find(handle.tensor_parameter_name);
             TT_FATAL(
                 addr_it != ta_binding_addresses.end(),
@@ -530,6 +539,11 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::Tensor
 
         RuntimeArgsData& crta = kernel->common_runtime_args_data();
         for (const auto& handle : binding_handles) {
+            if (!handle.bound) {
+                // Metal 2.0 Optional Resource Bindings: unbound handle is fixed at zero by
+                // SetProgramRunParameters and stays zero across updates.
+                continue;
+            }
             auto addr_it = ta_binding_addresses.find(handle.tensor_parameter_name);
             TT_FATAL(
                 addr_it != ta_binding_addresses.end(),

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -314,12 +314,16 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 dfb_binding.local_accessor_name);
             seen_this_type = true;
 
-            // Referential integrity: the DFB must exist
-            TT_FATAL(
-                collected.dfb_by_name.contains(dfb_binding.dfb_spec_name),
-                "Kernel '{}' references unknown DFB '{}'",
-                kernel.unique_id,
-                dfb_binding.dfb_spec_name);
+            // Referential integrity: relaxed for Metal 2.0 Optional Resource Bindings.
+            // A DFBBinding may reference a dfb_spec_name that does not exist on the ProgramSpec —
+            // the kernel may use the resource only in a conditional branch (gated by an
+            // if constexpr on a CTA). For such bindings, the framework emits a sentinel-id
+            // DFBAccessor in kernel_bindings_generated.h; the binding does NOT participate in
+            // producer/consumer counting, DFB allocation, or alias-group validation, since
+            // there is no underlying DataflowBufferSpec to attach to.
+            if (!collected.dfb_by_name.contains(dfb_binding.dfb_spec_name)) {
+                continue;
+            }
 
             CollectedSpecData::DFBEndpointInfo& endpoint_info = collected.dfb_endpoints[dfb_binding.dfb_spec_name];
 
@@ -377,11 +381,11 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' semaphore accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
-            TT_FATAL(
-                collected.semaphore_by_name.contains(binding.semaphore_spec_name),
-                "Kernel '{}' references unknown semaphore '{}'",
-                kernel.unique_id,
-                binding.semaphore_spec_name);
+            // Referential integrity: relaxed for Metal 2.0 Optional Resource Bindings.
+            // A SemaphoreBinding may reference a semaphore_spec_name that does not exist on the
+            // ProgramSpec; the framework emits a sentinel-id sem::name token. No semaphore
+            // allocation or per-kernel attachment occurs for unresolved bindings.
+            (void)collected.semaphore_by_name.contains(binding.semaphore_spec_name);
         }
     }
 
@@ -407,11 +411,14 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' tensor accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
-            TT_FATAL(
-                collected.tensor_parameter_by_name.contains(binding.tensor_parameter_name),
-                "Kernel '{}' references unknown TensorParameter '{}'",
-                kernel.unique_id,
-                binding.tensor_parameter_name);
+            // Referential integrity: relaxed for Metal 2.0 Optional Resource Bindings.
+            // A TensorBinding may reference a tensor_parameter_name that does not exist on the
+            // ProgramSpec; the framework emits a zeroed (Bound-unset) CTA payload at the
+            // binding's CTA offset. The binding does NOT participate in TensorParameter usage
+            // counting or runtime tensor-address attachment.
+            if (!collected.tensor_parameter_by_name.contains(binding.tensor_parameter_name)) {
+                continue;
+            }
 
             collected.tensor_parameter_users[binding.tensor_parameter_name].push_back(&kernel);
         }
@@ -746,9 +753,14 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         const auto& compute_config = std::get<ComputeConfiguration>(kernel.config_spec);
 
         // Index the kernel's DFB bindings: which are bound, which are consumed.
+        // Skip optional bindings whose DFBSpec does not exist on the program: they have no
+        // unpack_to_dest_mode semantics (no actual hop runs).
         std::unordered_set<DFBSpecName> bound_dfbs;
         std::unordered_set<DFBSpecName> consumed_dfbs;
         for (const auto& binding : kernel.dfb_bindings) {
+            if (!collected.dfb_by_name.contains(binding.dfb_spec_name)) {
+                continue;
+            }
             bound_dfbs.insert(binding.dfb_spec_name);
             if (binding.endpoint_type == KernelSpec::DFBEndpointType::CONSUMER) {
                 consumed_dfbs.insert(binding.dfb_spec_name);
@@ -812,7 +824,12 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (binding.endpoint_type != KernelSpec::DFBEndpointType::CONSUMER) {
                 continue;
             }
-            const DataflowBufferSpec* dfb_spec = collected.dfb_by_name.at(binding.dfb_spec_name);
+            // Optional binding: no DFBSpec, no fp32-dest check applies.
+            auto dfb_it = collected.dfb_by_name.find(binding.dfb_spec_name);
+            if (dfb_it == collected.dfb_by_name.end()) {
+                continue;
+            }
+            const DataflowBufferSpec* dfb_spec = dfb_it->second;
             if (!dfb_spec->data_format_metadata.has_value()) {
                 continue;  // Deferred to the data_format-required check.
             }
@@ -1715,6 +1732,10 @@ std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
     if (is_dram) {
         args_config.set(tensor_accessor::ArgConfig::IsDram);
     }
+    // Metal 2.0 Optional Resource Bindings: this function only runs for TensorParameters that
+    // exist on the ProgramSpec, so any binding resolved via this path is bound. ResolveTensor-
+    // BindingsForKernel emits a zeroed (Bound-unset) payload when a binding's TP is absent.
+    args_config.set(tensor_accessor::ArgConfig::Bound);
     // No Runtime* flags in the static port.
 
     // aligned_page_size: align the unaligned page size up to the buffer-type alignment.
@@ -1807,19 +1828,29 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
     const KernelSpec& kernel,
     const std::unordered_map<TensorParameterName, std::vector<uint32_t>>& resolved_binding_ctas,
     size_t base_named_crta_count) {
+    // Metal 2.0 Optional Resource Bindings: for a binding whose tensor_parameter_name does not
+    // resolve, emit a 2-word zeroed CTA payload (args_config = None, aligned_page_size = 0).
+    // The kernel-side TensorAccessorArgs<CTA_OFFSET>::is_bound reads `false` (the ArgConfig::Bound
+    // bit is unset), and TensorAccessor's binding-token ctor ASSERTs on use. Two zero words
+    // matches NumArgsCT for non-sharded, so subsequent bindings' CTA offsets remain correct.
+    static const std::vector<uint32_t> kUnboundCtaPayload = {0u, 0u};
+
     TensorBindingsForKernel out;
     out.handles.reserve(kernel.tensor_bindings.size());
 
     uint32_t cta_word_offset = 0;
     size_t crta_word_index = base_named_crta_count;
     for (const auto& binding : kernel.tensor_bindings) {
-        const auto& binding_ctas = resolved_binding_ctas.at(binding.tensor_parameter_name);
+        auto it = resolved_binding_ctas.find(binding.tensor_parameter_name);
+        const bool bound = (it != resolved_binding_ctas.end());
+        const std::vector<uint32_t>& binding_ctas = bound ? it->second : kUnboundCtaPayload;
 
         TensorBindingHandle handle;
         handle.accessor_name = binding.accessor_name;
         handle.tensor_parameter_name = binding.tensor_parameter_name;
         handle.cta_offset = cta_word_offset;
         handle.addr_crta_offset = static_cast<uint32_t>(crta_word_index * sizeof(uint32_t));
+        handle.bound = bound;
 
         out.cta_words.insert(out.cta_words.end(), binding_ctas.begin(), binding_ctas.end());
         cta_word_offset += static_cast<uint32_t>(binding_ctas.size());
@@ -1831,15 +1862,24 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
 }
 
 // Create map of local accessor name -> logical DFB id
+// For Metal 2.0 Optional Resource Bindings: bindings whose dfb_spec_name does not resolve to a
+// DataflowBufferSpec on the ProgramSpec are emitted with DFBAccessor::SENTINEL_ID, so the
+// kernel-side dfb::<name> token always exists and trips DataflowBuffer's ctor ASSERT on misuse.
 tt::tt_metal::DataflowBufferLocalAccessorHandleMap MakeDataflowBufferLocalAccessorHandles(
     const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
+    static constexpr uint16_t kDFBSentinelId = 0xFFFFu;  // matches DFBAccessor::SENTINEL_ID
     tt::tt_metal::DataflowBufferLocalAccessorHandleMap out;
     out.reserve(kernel_spec.dfb_bindings.size());
     for (const auto& dfb_binding : kernel_spec.dfb_bindings) {
-        const uint32_t id = dfb_name_to_id.at(dfb_binding.dfb_spec_name);
+        auto it = dfb_name_to_id.find(dfb_binding.dfb_spec_name);
+        if (it == dfb_name_to_id.end()) {
+            out.emplace(dfb_binding.local_accessor_name, kDFBSentinelId);
+            continue;
+        }
+        const uint32_t id = it->second;
         TT_FATAL(
-            id <= std::numeric_limits<uint16_t>::max(),
-            "Kernel '{}' DFB '{}' logical id {} does not fit uint16_t",
+            id < kDFBSentinelId,
+            "Kernel '{}' DFB '{}' logical id {} collides with sentinel or does not fit uint16_t",
             kernel_spec.unique_id,
             dfb_binding.dfb_spec_name,
             id);
@@ -1849,15 +1889,24 @@ tt::tt_metal::DataflowBufferLocalAccessorHandleMap MakeDataflowBufferLocalAccess
 }
 
 // Create map of local accessor name -> logical Semaphore id
+// For Metal 2.0 Optional Resource Bindings: bindings whose semaphore_spec_name does not resolve
+// are emitted with Semaphore::SENTINEL_ID, so the kernel-side sem::<name> token always exists
+// and trips ckernel::Semaphore's ctor ASSERT on misuse.
 tt::tt_metal::SemaphoreLocalAccessorHandleMap MakeSemaphoreLocalAccessorHandles(
     const KernelSpec& kernel_spec, const SemaphoreNameToIdMap& semaphore_name_to_id) {
+    static constexpr uint16_t kSemaphoreSentinelId = 0xFFFFu;  // matches ckernel::Semaphore::SENTINEL_ID
     tt::tt_metal::SemaphoreLocalAccessorHandleMap out;
     out.reserve(kernel_spec.semaphore_bindings.size());
     for (const auto& semaphore_binding : kernel_spec.semaphore_bindings) {
-        const uint32_t id = semaphore_name_to_id.at(semaphore_binding.semaphore_spec_name);
+        auto it = semaphore_name_to_id.find(semaphore_binding.semaphore_spec_name);
+        if (it == semaphore_name_to_id.end()) {
+            out.emplace(semaphore_binding.accessor_name, kSemaphoreSentinelId);
+            continue;
+        }
+        const uint32_t id = it->second;
         TT_FATAL(
-            id <= std::numeric_limits<uint16_t>::max(),
-            "Kernel '{}' semaphore '{}' id {} does not fit uint16_t",
+            id < kSemaphoreSentinelId,
+            "Kernel '{}' semaphore '{}' id {} collides with sentinel or does not fit uint16_t",
             kernel_spec.unique_id,
             semaphore_binding.semaphore_spec_name,
             id);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1732,11 +1732,12 @@ std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
     if (is_dram) {
         args_config.set(tensor_accessor::ArgConfig::IsDram);
     }
-    // Metal 2.0 Optional Resource Bindings: this function only runs for TensorParameters that
-    // exist on the ProgramSpec, so any binding resolved via this path is bound. ResolveTensor-
-    // BindingsForKernel emits a zeroed (Bound-unset) payload when a binding's TP is absent.
-    args_config.set(tensor_accessor::ArgConfig::Bound);
     // No Runtime* flags in the static port.
+    // Metal 2.0 Optional Resource Bindings: this function only runs for TensorParameters that
+    // exist on the ProgramSpec. The emitted payload's aligned_page_size below is always
+    // non-zero for a real TensorSpec, which is what TensorAccessorArgs<>::is_bound keys on
+    // (matching the existing `TensorAccessorArgs(nullptr)` shape — see is_bound in the
+    // device-side tensor_accessor_args.h).
 
     // aligned_page_size: align the unaligned page size up to the buffer-type alignment.
     const size_t unaligned_page_size = spec.compute_page_size_bytes();


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/enable-optional-resources)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/enable-optional-resources)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/enable-optional-resources)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/enable-optional-resources)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/enable-optional-resources)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/enable-optional-resources)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/enable-optional-resources)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/enable-optional-resources)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/enable-optional-resources)