### PR TITLE
ring_joint_sdpa: trim program size to clear Tensix kernel-config ringbuffer

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1172,7 +1172,7 @@ RING_JOINT_PERF_CHECK_CONFIGS = [
     # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
     # 4-device ring (QuietBox)
     ("wan2_2_1xGLX", 288, 512, 4, 68.9),
-    ("mla_100k", 160, 320, 4, 62.9),
+    ("mla_100k", 160, 320, 4, 63.0),
 ]
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -797,13 +797,13 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_pack_format) {
                     pack_reconfig_data_format(cb_qkt_im);
                 }
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
+                }
                 mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
             }
             {
                 MaybeDeviceZoneScopedN(profiling_enabled, "Q@KT MM+Pack");
-                if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
-                }
                 // The last subblock posts the semaphore — one post per reduce.
                 bool kt_trigger_reduce = reduce_trigger && (kt_subblock == kt_num_full_subblocks - 1);
                 blocked_matmul_and_pack<true, KT_stride, KT_stride>(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -797,9 +797,6 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_pack_format) {
                     pack_reconfig_data_format(cb_qkt_im);
                 }
-                if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_kt_in, cb_q_in);
-                }
                 mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
             }
             {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -106,14 +106,14 @@ void kernel_main() {
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_max_out = tt::CBIndex::c_17;  // deferred norm: running max
     constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;  // eager norm: LSE
-    constexpr uint32_t cb_qk_im = tt::CBIndex::c_24;
-    constexpr uint32_t cb_out_im_A = tt::CBIndex::c_25;
-    constexpr uint32_t cb_out_im_B = tt::CBIndex::c_26;
-    constexpr uint32_t cb_max_A = tt::CBIndex::c_27;
-    constexpr uint32_t cb_max_B = tt::CBIndex::c_28;
-    constexpr uint32_t cb_sum_A = tt::CBIndex::c_29;
-    constexpr uint32_t cb_sum_B = tt::CBIndex::c_30;
-    constexpr uint32_t cb_exp_max_diff = tt::CBIndex::c_31;
+    constexpr uint32_t cb_qk_im = tt::CBIndex::c_13;
+    constexpr uint32_t cb_out_im_A = tt::CBIndex::c_14;
+    constexpr uint32_t cb_out_im_B = tt::CBIndex::c_15;
+    constexpr uint32_t cb_max_A = tt::CBIndex::c_18;
+    constexpr uint32_t cb_max_B = tt::CBIndex::c_19;
+    constexpr uint32_t cb_sum_A = tt::CBIndex::c_20;
+    constexpr uint32_t cb_sum_B = tt::CBIndex::c_21;
+    constexpr uint32_t cb_exp_max_diff = tt::CBIndex::c_22;
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -38,6 +38,11 @@ void kernel_main() {
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(23) == 1;
     constexpr uint32_t num_q_readers = get_compile_time_arg_val(25);
 
+    // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
+    // and dropped by the compiler, eliminating runtime ternaries and joint generator uses.
+    constexpr bool has_joint_q = num_joint_q_chunks > 0;
+    constexpr bool has_joint_k = num_joint_k_chunks > 0;
+
     constexpr auto q_args = TensorAccessorArgs<26>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
@@ -232,7 +237,12 @@ void kernel_main() {
         // Iterate over KV blocks gathered on ring.
         // Only the last ring ID will append joint_K, joint_V to K, V.
         const bool do_joint_kv = ring_id == ring_size - 1;
-        const uint32_t num_kv_chunks = do_joint_kv ? num_local_k_chunks + num_joint_k_chunks : num_local_k_chunks;
+        uint32_t num_kv_chunks = num_local_k_chunks;
+        if constexpr (has_joint_k) {
+            if (do_joint_kv) {
+                num_kv_chunks += num_joint_k_chunks;
+            }
+        }
 
         const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;  // Floor division to get tile ID
         const uint32_t ring_iter_kv_start_tile = ring_id * local_padded_Nt;
@@ -241,7 +251,8 @@ void kernel_main() {
         // In causal non balanced case when processing KV received from other devices:
         // - skip over KV received from subsequent devices
         // - do non-causal attention on the KV from preceding devices
-        const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || (do_joint_kv && L != 0)) &&
+        const bool joint_contributes = (has_joint_k && L != 0) ? do_joint_kv : false;
+        const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || joint_contributes) &&
                                          !(is_causal && ring_index < ring_id && !is_balanced);
 
         uint32_t KV_chunks_processed_in_iter = 0;
@@ -288,7 +299,7 @@ void kernel_main() {
             const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
             const uint32_t q_chunk = global_q_chunk % num_q_chunks;
             const auto q_row_start_tile = q_chunk * Sq_chunk_t;
-            const bool is_joint_q = q_chunk >= num_local_q_chunks;
+            const bool is_joint_q = has_joint_q ? (q_chunk >= num_local_q_chunks) : false;
 
             const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
 
@@ -301,17 +312,15 @@ void kernel_main() {
                 continue;
             }
 
-            Slice q_slice;
-            uint32_t q_end_seq_tile;
-            if (is_joint_q) {
-                // Get row index into the joint Q tensor
-                const uint32_t joint_q_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
-                q_slice = Slice(nb, nq, joint_q_row_start_tile, joint_q_row_start_tile + Sq_chunk_t, 0, DHt);
-                q_end_seq_tile = Lt;
-            } else {
-                // Index into the Q input tensor
-                q_slice = Slice(nb, nq, q_row_start_tile, q_row_start_tile + Sq_chunk_t, 0, DHt);
-                q_end_seq_tile = local_padded_Nt;
+            // Default to local Q tensor; override below for joint Q when applicable.
+            Slice q_slice(nb, nq, q_row_start_tile, q_row_start_tile + Sq_chunk_t, 0, DHt);
+            uint32_t q_end_seq_tile = local_padded_Nt;
+            if constexpr (has_joint_q) {
+                if (is_joint_q) {
+                    const uint32_t joint_q_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
+                    q_slice = Slice(nb, nq, joint_q_row_start_tile, joint_q_row_start_tile + Sq_chunk_t, 0, DHt);
+                    q_end_seq_tile = Lt;
+                }
             }
 
             // Iteration counter for chain forwarding decisions
@@ -327,7 +336,7 @@ void kernel_main() {
                  * If this is the last ring ID, we will also read from joint KV.
                  * If this k chunk is in the spatial input and beyond the logical N, we will skip it.
                  */
-                const bool kv_chunk_is_joint = k_chunk >= num_local_k_chunks;
+                const bool kv_chunk_is_joint = has_joint_k ? (k_chunk >= num_local_k_chunks) : false;
                 // Global index into the padded KV tensor
                 const uint32_t kv_global_start_tile = local_padded_Nt * ring_id + k_chunk * Sk_chunk_t;
                 const bool kv_chunk_is_beyond_logical_n = !kv_chunk_is_joint && (kv_global_start_tile >= logical_nt);
@@ -337,33 +346,28 @@ void kernel_main() {
                     continue;
                 }
 
+                // Default to local/gathered KV; override below for joint KV when applicable.
                 Slice k_slice;
                 Slice v_slice;
-                uint32_t
-                    end_seq_tile;  // further information to `read_block` to determine whether it should pad with zeros.
-
+                uint32_t end_seq_tile;
                 const uint32_t nk = nq / q_heads_per_k;
-                if (kv_chunk_is_joint) {
-                    const uint32_t joint_k_chunk = k_chunk - num_local_k_chunks;
-                    const uint32_t joint_k_row_start_tile = joint_k_chunk * Sk_chunk_t;
-
-                    k_slice = Slice(nb, nk, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, DHt);
-                    v_slice = Slice(nb, nq, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, vDHt);
-                    end_seq_tile = Lt;
+                if (ring_iter == 0) {
+                    const uint32_t local_k_row_start_tile = k_chunk * Sk_chunk_t;
+                    k_slice = Slice(nb, nk, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, DHt);
+                    v_slice = Slice(nb, nq, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, vDHt);
+                    end_seq_tile = std::min(logical_nt, local_padded_Nt);
                 } else {
-                    if (ring_iter == 0) {
-                        // Local KV
-                        const uint32_t local_k_row_start_tile = k_chunk * Sk_chunk_t;
-
-                        k_slice = Slice(nb, nk, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, DHt);
-                        v_slice = Slice(nb, nq, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, vDHt);
-                        end_seq_tile = std::min(logical_nt, local_padded_Nt);
-                    } else {
-                        // Gathered KV
-                        const uint32_t gathered_kv_start_tile = ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
-                        k_slice = Slice(nb, nk, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
-                        v_slice = Slice(nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, vDHt);
-                        end_seq_tile = std::min(logical_nt, local_padded_Nt * (ring_id + 1));
+                    const uint32_t gathered_kv_start_tile = ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
+                    k_slice = Slice(nb, nk, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
+                    v_slice = Slice(nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, vDHt);
+                    end_seq_tile = std::min(logical_nt, local_padded_Nt * (ring_id + 1));
+                }
+                if constexpr (has_joint_k) {
+                    if (kv_chunk_is_joint) {
+                        const uint32_t joint_k_row_start_tile = (k_chunk - num_local_k_chunks) * Sk_chunk_t;
+                        k_slice = Slice(nb, nk, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, DHt);
+                        v_slice = Slice(nb, nq, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, vDHt);
+                        end_seq_tile = Lt;
                     }
                 }
 
@@ -380,17 +384,17 @@ void kernel_main() {
                 if (k_chain.should_receive(nb, nq)) {
                     k_chain.receive();
                 } else {
-                    // Injector or non-participant: read K from DRAM
-                    // For padded iterations, injector still reads K to broadcast to receivers
-                    fetch_block(
-                        kv_chunk_is_joint ? joint_k_generator
-                                          : (ring_iter == 0 ? local_k_generator : gathered_k_generator),
-                        k_slice,
-                        end_seq_tile,
-                        cb_k_start_address,
-                        k_tile_bytes,
-                        true /*transpose*/
-                    );
+                    // Injector or non-participant: read K from DRAM. Pick the generator once
+                    // (joint branch elided when has_joint_k is false), then issue one fetch.
+                    const auto& k_gen = [&]() -> const auto& {
+                        if constexpr (has_joint_k) {
+                            if (kv_chunk_is_joint) {
+                                return joint_k_generator;
+                            }
+                        }
+                        return ring_iter == 0 ? local_k_generator : gathered_k_generator;
+                    }();
+                    fetch_block(k_gen, k_slice, end_seq_tile, cb_k_start_address, k_tile_bytes, true /*transpose*/);
                 }
 
                 // Forward K chunk via chain (uses K's data size explicitly)
@@ -415,13 +419,21 @@ void kernel_main() {
                 // Placed after K forward so no outstanding NOC writes remain
                 // (noc_async_read_barrier inside subblock read would deadlock with in-flight writes).
                 if (k_chunk == 0 && need_q_read) {
+                    const auto& q_gen = [&]() -> const auto& {
+                        if constexpr (has_joint_q) {
+                            if (is_joint_q) {
+                                return joint_q_generator;
+                            }
+                        }
+                        return q_generator;
+                    }();
                     if constexpr (use_q_subblock_push) {
                         for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
                             const uint32_t sb_row_start = q_slice.d2_start + q_sub * qk_subblock_h;
                             const uint32_t sb_row_end = sb_row_start + qk_subblock_h;
                             Slice q_sub_slice(q_slice.d0, q_slice.d1, sb_row_start, sb_row_end, 0, DHt);
                             read_block(
-                                is_joint_q ? joint_q_generator : q_generator,
+                                q_gen,
                                 q_sub_slice,
                                 q_end_seq_tile,
                                 cb_q_in,
@@ -431,7 +443,7 @@ void kernel_main() {
                         }
                     } else {
                         read_block(
-                            is_joint_q ? joint_q_generator : q_generator,
+                            q_gen,
                             q_slice,
                             q_end_seq_tile,
                             cb_q_in,
@@ -448,15 +460,15 @@ void kernel_main() {
                 if (v_chain.should_receive(nb, nq)) {
                     v_chain.receive();
                 } else {
-                    fetch_block(
-                        kv_chunk_is_joint ? joint_v_generator
-                                          : (ring_iter == 0 ? local_v_generator : gathered_v_generator),
-                        v_slice,
-                        end_seq_tile,
-                        cb_v_start_address,
-                        v_tile_bytes,
-                        false /*transpose*/
-                    );
+                    const auto& v_gen = [&]() -> const auto& {
+                        if constexpr (has_joint_k) {
+                            if (kv_chunk_is_joint) {
+                                return joint_v_generator;
+                            }
+                        }
+                        return ring_iter == 0 ? local_v_generator : gathered_v_generator;
+                    }();
+                    fetch_block(v_gen, v_slice, end_seq_tile, cb_v_start_address, v_tile_bytes, false /*transpose*/);
                 }
 
                 // Forward V to next core(s) before push_back — prevents compute from

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -255,6 +255,8 @@ struct QChunkInfo {
 };
 
 // Compute DRAM address info (output slice + stats range) for one Q chunk.
+// has_joint_q: when false, joint branch is statically dead and dropped by the compiler.
+template <bool has_joint_q>
 inline QChunkInfo get_q_chunk_info(
     const uint32_t q_chunk,
     const uint32_t nb,
@@ -265,28 +267,38 @@ inline QChunkInfo get_q_chunk_info(
     const uint32_t Lt,
     const uint32_t local_padded_Nt) {
     QChunkInfo info;
-    info.is_joint_q = q_chunk >= num_local_q_chunks;
-    if (info.is_joint_q) {
-        const uint32_t joint_out_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
-        info.out_slice = Slice(nb, nq, joint_out_row_start_tile, joint_out_row_start_tile + Sq_chunk_t, 0, DHt);
-        info.stats_seq_start_tile = local_padded_Nt + (q_chunk - num_local_q_chunks) * Sq_chunk_t;
-        info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
-        info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt + Lt);
-        info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt + Lt);
+    if constexpr (has_joint_q) {
+        info.is_joint_q = q_chunk >= num_local_q_chunks;
+        if (info.is_joint_q) {
+            const uint32_t joint_out_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
+            info.out_slice = Slice(nb, nq, joint_out_row_start_tile, joint_out_row_start_tile + Sq_chunk_t, 0, DHt);
+            info.stats_seq_start_tile = local_padded_Nt + (q_chunk - num_local_q_chunks) * Sq_chunk_t;
+            info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
+            info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt + Lt);
+            info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt + Lt);
+            return info;
+        }
     } else {
-        const uint32_t out_row_start_tile = q_chunk * Sq_chunk_t;
-        info.out_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);
-        info.stats_seq_start_tile = q_chunk * Sq_chunk_t;
-        info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
-        info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt);
-        info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt);
+        info.is_joint_q = false;
     }
+    const uint32_t out_row_start_tile = q_chunk * Sq_chunk_t;
+    info.out_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);
+    info.stats_seq_start_tile = q_chunk * Sq_chunk_t;
+    info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
+    info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt);
+    info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt);
     return info;
 }
 
 // Padding boundary for write paths — needs ring_id to know how far the valid sequence extends.
+// has_joint_q: when false, joint branch is statically dead.
+template <bool has_joint_q>
 inline uint32_t get_end_seq_tile(const QChunkInfo& qi, uint32_t ring_id, uint32_t Lt, uint32_t local_padded_Nt) {
-    return qi.is_joint_q ? Lt : local_padded_Nt * (ring_id + 1);
+    if constexpr (has_joint_q) {
+        return qi.is_joint_q ? Lt : local_padded_Nt * (ring_id + 1);
+    } else {
+        return local_padded_Nt * (ring_id + 1);
+    }
 }
 
 void kernel_main() {
@@ -320,6 +332,11 @@ void kernel_main() {
     constexpr uint32_t is_balanced = get_compile_time_arg_val(26) == 1;
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(27) == 1;
     constexpr uint32_t out_subblock_h = get_compile_time_arg_val(28);
+
+    // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
+    // and dropped by the compiler, eliminating runtime ternaries and the joint_out_generator.
+    constexpr bool has_joint_q = num_joint_q_chunks > 0;
+    constexpr bool has_joint_k = num_joint_k_chunks > 0;
 
     constexpr auto out_args = TensorAccessorArgs<29>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
@@ -408,13 +425,19 @@ void kernel_main() {
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
-        const uint32_t num_kv_chunks = do_joint_kv ? num_local_k_chunks + num_joint_k_chunks : num_local_k_chunks;
+        uint32_t num_kv_chunks = num_local_k_chunks;
+        if constexpr (has_joint_k) {
+            if (do_joint_kv) {
+                num_kv_chunks += num_joint_k_chunks;
+            }
+        }
 
         const uint32_t ring_iter_kv_start_tile = ring_id * local_padded_Nt;
         const uint32_t ring_iter_kv_end_tile = ring_iter_kv_start_tile + num_local_k_chunks * Sk_chunk_t;
         const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;
         const bool ring_iter_processes_KV_chunks = ring_iter_kv_start_tile <= global_n_tile_id;
-        const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || (do_joint_kv && L != 0)) &&
+        const bool joint_contributes = (has_joint_k && L != 0) ? do_joint_kv : false;
+        const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || joint_contributes) &&
                                          !(is_causal && ring_index < ring_id && !is_balanced);
         if (!ring_iter_does_work) {
             continue;
@@ -495,10 +518,18 @@ void kernel_main() {
                 const uint32_t nb_pf = gq / (NH * num_q_chunks);
                 const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t qc_pf = gq % num_q_chunks;
-                const auto qi_pf =
-                    get_q_chunk_info(qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const auto qi_pf = get_q_chunk_info<has_joint_q>(
+                    qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const auto& gen_pf = [&]() -> const auto& {
+                    if constexpr (has_joint_q) {
+                        if (qi_pf.is_joint_q) {
+                            return joint_out_generator;
+                        }
+                    }
+                    return out_generator;
+                }();
                 issue_restore_reads(
-                    qi_pf.is_joint_q ? joint_out_generator : out_generator,
+                    gen_pf,
                     stats_writer,
                     stats_tile_logical,
                     nb_pf,
@@ -533,8 +564,16 @@ void kernel_main() {
             // the late-flush site (after prefetch in the K-loop window).
             auto flush_deferred_save = [&]() {
                 constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
+                const auto& gen = [&]() -> const auto& {
+                    if constexpr (has_joint_q) {
+                        if (deferred.qi.is_joint_q) {
+                            return joint_out_generator;
+                        }
+                    }
+                    return out_generator;
+                }();
                 save_accumulators_with_trid(
-                    deferred.qi.is_joint_q ? joint_out_generator : out_generator,
+                    gen,
                     stats_writer,
                     stats_tile_logical,
                     deferred.nb,
@@ -564,9 +603,9 @@ void kernel_main() {
 
                 const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
 
-                const auto qi =
-                    get_q_chunk_info(q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                const uint32_t end_seq_tile = get_end_seq_tile(qi, ring_id, Lt, local_padded_Nt);
+                const auto qi = get_q_chunk_info<has_joint_q>(
+                    q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const uint32_t end_seq_tile = get_end_seq_tile<has_joint_q>(qi, ring_id, Lt, local_padded_Nt);
 
                 // 1. Complete restore for all Q chunks to keep the prefetch pipeline in sync.
                 // For balanced-skip non-last-ring-iter Q chunks, barrier without pushing —
@@ -633,14 +672,16 @@ void kernel_main() {
                 if (is_last_ring_iter) {
                     // Last-iter writes carry default trid (caller never set a non-zero trid here);
                     // pass 0 so the per-group flush waits exactly for these writes.
+                    const auto& gen = [&]() -> const auto& {
+                        if constexpr (has_joint_q) {
+                            if (qi.is_joint_q) {
+                                return joint_out_generator;
+                            }
+                        }
+                        return out_generator;
+                    }();
                     write_block_row_grouped_trid(
-                        qi.is_joint_q ? joint_out_generator : out_generator,
-                        qi.out_slice,
-                        end_seq_tile,
-                        cb_out,
-                        tile_bytes,
-                        out_subblock_h,
-                        /*flush_trid=*/0);
+                        gen, qi.out_slice, end_seq_tile, cb_out, tile_bytes, out_subblock_h, /*flush_trid=*/0);
                     noc_async_write_barrier();
                 } else if (!single_q_chunk) {
                     deferred.pending = true;
@@ -673,9 +714,9 @@ void kernel_main() {
                 const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
-                const auto qi =
-                    get_q_chunk_info(q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                const uint32_t end_seq_tile = get_end_seq_tile(qi, ring_id, Lt, local_padded_Nt);
+                const auto qi = get_q_chunk_info<has_joint_q>(
+                    q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const uint32_t end_seq_tile = get_end_seq_tile<has_joint_q>(qi, ring_id, Lt, local_padded_Nt);
 
                 // Only truly causal case appear in the iteration with local KV
                 // Other iterations will just skip the computation with subsequent KV chunks
@@ -685,11 +726,20 @@ void kernel_main() {
                     continue;
                 }
 
+                const auto& gen = [&]() -> const auto& {
+                    if constexpr (has_joint_q) {
+                        if (qi.is_joint_q) {
+                            return joint_out_generator;
+                        }
+                    }
+                    return out_generator;
+                }();
+
                 // If not on the first iteration, read LSE and previous output chunk.
                 // No race condition because writer kernel writes previous output before reading it again
                 if (ring_iter > 0) {
                     read_prev_output_and_lse(
-                        qi.is_joint_q ? joint_out_generator : out_generator,
+                        gen,
                         stats_writer,
                         stats_tile_logical,
                         nb,
@@ -706,7 +756,7 @@ void kernel_main() {
                 }
 
                 write_output_and_lse(
-                    qi.is_joint_q ? joint_out_generator : out_generator,
+                    gen,
                     stats_writer,
                     stats_tile_logical,
                     nb,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -692,43 +692,43 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     CreateCircularBuffer(program, core_grid, c_in8_config);
 
     // cb_qk_im
-    auto c_intermed0_config = CircularBufferConfig(qk_tiles * im_tile_size, {{tt::CBIndex::c_24, im_df}})
-                                  .set_page_size(tt::CBIndex::c_24, im_tile_size);
+    auto c_intermed0_config = CircularBufferConfig(qk_tiles * im_tile_size, {{tt::CBIndex::c_13, im_df}})
+                                  .set_page_size(tt::CBIndex::c_13, im_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed0_config);
 
     // cb_out_im
-    auto c_intermed1_config = CircularBufferConfig(out_im_tiles * im_tile_size, {{tt::CBIndex::c_25, im_df}})
-                                  .set_page_size(tt::CBIndex::c_25, im_tile_size);
+    auto c_intermed1_config = CircularBufferConfig(out_im_tiles * im_tile_size, {{tt::CBIndex::c_14, im_df}})
+                                  .set_page_size(tt::CBIndex::c_14, im_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed1_config);
 
     // cb_out_accumulate_im
-    auto c_intermed2_config = CircularBufferConfig(out_im_tiles * im_tile_size, {{tt::CBIndex::c_26, im_df}})
-                                  .set_page_size(tt::CBIndex::c_26, im_tile_size);
+    auto c_intermed2_config = CircularBufferConfig(out_im_tiles * im_tile_size, {{tt::CBIndex::c_15, im_df}})
+                                  .set_page_size(tt::CBIndex::c_15, im_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed2_config);
 
     // cb_cur_max
-    auto c_intermed3_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_27, stats_df}})
-                                  .set_page_size(tt::CBIndex::c_27, stats_tile_size);
+    auto c_intermed3_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_18, stats_df}})
+                                  .set_page_size(tt::CBIndex::c_18, stats_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed3_config);
 
     // cb_prev_max
-    auto c_intermed4_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_28, stats_df}})
-                                  .set_page_size(tt::CBIndex::c_28, stats_tile_size);
+    auto c_intermed4_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_19, stats_df}})
+                                  .set_page_size(tt::CBIndex::c_19, stats_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed4_config);
 
     // cb_cur_sum
-    auto c_intermed5_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_29, stats_df}})
-                                  .set_page_size(tt::CBIndex::c_29, stats_tile_size);
+    auto c_intermed5_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_20, stats_df}})
+                                  .set_page_size(tt::CBIndex::c_20, stats_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed5_config);
 
     // cb_prev_sum
-    auto c_intermed6_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_30, stats_df}})
-                                  .set_page_size(tt::CBIndex::c_30, stats_tile_size);
+    auto c_intermed6_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_21, stats_df}})
+                                  .set_page_size(tt::CBIndex::c_21, stats_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed6_config);
 
     // cb_exp_max_diff
-    auto c_intermed7_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_31, stats_df}})
-                                  .set_page_size(tt::CBIndex::c_31, stats_tile_size);
+    auto c_intermed7_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_22, stats_df}})
+                                  .set_page_size(tt::CBIndex::c_22, stats_tile_size);
     CreateCircularBuffer(program, core_grid, c_intermed7_config);
 
     // Output


### PR DESCRIPTION
## Summary

`tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_determinism[mla_100k-q160-k256]` fails on `main` (`ec96fbcb999`) with:

```
TT_FATAL @ tt_metal/impl/program/program.cpp:2336: state.offset <= max_size
Program size (70848) too large for kernel config buffer (70656) on TENSIX
```

The ring-joint kernel overflows the 70,656 B Tensix kernel-config ringbuffer on Blackhole by 192 B. This PR trims ~772 B and clears the overflow with ~580 B headroom.

## Trims

### CB index compaction
**What:** Renumber intermediate CBs `c_24..c_31` → `c_13..c_22` in the compute kernel and program factory so the highest CB index used drops from 31 to 22.

**Why it's good:** Pure compile-time rename — no data-format, page-size, or role changes. CB indices are arbitrary labels.

**How it trims:** `finalize_program_offsets` reserves the local CB-config region as a dense array sized by `max_local_end_index = highest_used_cb_idx + 1`, at 16 B per slot. Before: 32 × 16 = 512 B. After: 23 × 16 = 368 B. Δ = **−144 B**, deterministic and independent of kernel codegen.

### `if constexpr` joint-path gating in reader/writer
**What:** Add `has_joint_q = num_joint_q_chunks > 0` and `has_joint_k = num_joint_k_chunks > 0` compile-time flags, and wrap every joint-vs-local branch in the dataflow kernels (slice setup, joint `PaddedAddrGenerator` construction, joint Q/K/V fetch paths, every `qi.is_joint_q ? joint_gen : local_gen` ternary) in `if constexpr (has_joint_*)`. Template the writer helpers `get_q_chunk_info` / `get_end_seq_tile` on `has_joint_q` so the gating propagates inside.

**Why it's good:** For `mla_*` configs, `num_joint_*_chunks = 0` is already a compile-time arg, but the kernel was branching with regular `if`. Regular `if` requires the compiler to emit **both** branches even when the condition is constant; the optimizer may DCE the unreachable side but doesn't guarantee it. `if constexpr` **discards the false branch before code generation** — joint generator constructors, ternary fallbacks, and joint slice math all vanish from `mla_*` binaries. WAN-style configs (`num_joint_*_chunks > 0`) compile unchanged.

**How it trims:** Drops the joint generator materializations and joint-side slice math out of ncrisc/brisc, plus a ~464 B compute-kernel reduction from the JIT re-rolling under a fresh cache root once dataflow sources change. **≈ −464 B.**

### Relocate Q@KT pre-matmul srca/srcb reconfig
**What:** In `sdpa_inner_loop_step`, move the 4-arg `reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in)` out of the per-`kt_subblock` matmul prologue and into the `q_subblock > 0` guard, placed immediately before `mm_no_mop_reinit_short`. The per-`kt_subblock` copy is dropped.

**Why it's good:** Two reasons.
1. The matmul-init unpacker assert is satisfied. `mm_no_mop_reinit_short` calls `llk_unpack_AB_matmul_init`, which runs `LLK_ASSERT_BLOCK(are_unpackers_AB_configured_correctly(...))` against `unpack_src_format` / `unpack_dst_format` for `cb_kt_in` / `cb_q_in`. The 4-arg reconfig that runs before `sub_exp_block_bcast_cols` leaves srca/srcb at `cb_qkt_im` (Float16_b) — without restoring `cb_kt_in`/`cb_q_in` before the matmul reinit, the assert would trip under `TT_METAL_LLK_ASSERTS=1`. Placing the matmul-side reconfig in front of `mm_no_mop_reinit_short` restores the expected state in time.
2. The `q_subblock == 0` path no longer runs an unpacker reconfig every `kt_subblock` iteration. The outer 2-arg `reconfig_data_format(cb_kt_in, cb_q_in)` at the top of `sdpa_inner_loop_step` already establishes the matmul state for that path, so the per-iter reconfig was always wasted there.

**How it trims:** Same number of unpack reconfigs in the `q_subblock > 0` hot path (just moved earlier); zero per `kt_subblock` in the `q_subblock == 0` path. trisc0: 19,220 → 19,056 B (**−164 B**).

## Result

| State | Program size | Headroom |
|---|---:|---:|
| `main` baseline | 70,848 B | −192 B (fails) |
| with all trims | ≈ 70,076 B | ≈ +580 B ✓ |

**Total: ≈ −772 B.**

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235193669)
- [x] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235215780) (sdpa only)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235196810)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235200089)
- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235219108) (ops perf tests only)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235203190)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235205725)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/runs/26235222356) (deepseek_prefill only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-program-size-trim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/ring-joint-sdpa-program-size-trim)