### PR TITLE
ci(scaleout): use mesh-graph-descriptor for SP1/SP4 multihost tests

### DIFF
--- a/tests/pipeline_reorg/demo_sp_multihost_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_multihost_tests.yaml
@@ -74,17 +74,15 @@
 
 - name: "Stress Test (DeepSeek V3 B1 Supercluster 4 aka Superpod 1)"
   cmd: |
-    echo "============= SP1 superpod: using branch ttrun.py and rank files ============="
-    TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
-    SCALEOUT_CONFIG_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_b1/scaleout_configs/rev_c"
-    cp "${SCALEOUT_CONFIG_DIR}/rev_c_rank_binding_single_pod.yaml" .
-    cp "${SCALEOUT_CONFIG_DIR}/rev_c_rank_file_single_pod" .
+    TTRUN_PY=/ci/tt-metal/ttnn/ttnn/distributed/ttrun.py
 
-    PIPELINE_HOSTS=$(awk '{printf "%s:4,", $1}' /ci/ttrun/hostfile | sed 's/,$//')
+    # todo)) add proper stress test that can run for 2 hours -- repeat batches?
+    PIPELINE_HOSTS=$(awk '{printf "%s,", $1}' /ci/ttrun/hostfile | sed 's/,$//')
     TT_METAL_ALLOCATOR_MODE_HYBRID=1 TT_METAL_SLOW_DISPATCH_MODE=1 python3 "${TTRUN_PY}" \
       --tcp-interface ens5f0np0 \
-      --mpi-args "--host $PIPELINE_HOSTS --map-by rankfile:file=rev_c_rank_file_single_pod --bind-to hwt:overload-allowed --tag-output --wdir ${TT_METAL_HOME}" \
-      --rank-binding rev_c_rank_binding_single_pod.yaml \
+      --hosts $PIPELINE_HOSTS \
+      --mpi-args "--oversubscribe --tag-output --wdir /home/user/tt-metal" \
+      --mesh-graph-descriptor models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_single_pod_mesh_graph_descriptor.textproto \
       python3 -m models.demos.deepseek_v3_b1.demo.cli \
         --max-new-tokens 128000 \
         --repeat-generations 2 \
@@ -106,18 +104,15 @@
 
 - name: "Teacher Forcing Test (DeepSeek V3 B1 Supercluster 16 aka Superpod 4)"
   cmd: |
-    echo "============= SP4 superpod: using branch ttrun.py and rank files ============="
-    TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
-    SCALEOUT_CONFIG_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_b1/scaleout_configs/rev_c"
-    cp "${SCALEOUT_CONFIG_DIR}/rev_c_rank_binding_superpod.yaml" .
-    cp "${SCALEOUT_CONFIG_DIR}/rev_c_rank_file_superpod" .
+    TTRUN_PY=/ci/tt-metal/ttnn/ttnn/distributed/ttrun.py
 
     echo "============= SP4 superpod: setting PIPELINE_HOSTS ============="
-    PIPELINE_HOSTS=$(awk '{printf "%s:4,", $1}' /ci/ttrun/hostfile | sed 's/,$//')
+    PIPELINE_HOSTS=$(awk '{printf "%s,", $1}' /ci/ttrun/hostfile | sed 's/,$//')
     TT_METAL_ALLOCATOR_MODE_HYBRID=1 TT_METAL_SLOW_DISPATCH_MODE=1 python3 "${TTRUN_PY}" \
       --tcp-interface ens5f0np0 \
-      --mpi-args "--host $PIPELINE_HOSTS --map-by rankfile:file=rev_c_rank_file_superpod --bind-to hwt:overload-allowed --tag-output --wdir ${TT_METAL_HOME}" \
-      --rank-binding rev_c_rank_binding_superpod.yaml \
+      --hosts $PIPELINE_HOSTS \
+      --mpi-args "--oversubscribe --tag-output --wdir /home/user/tt-metal" \
+      --mesh-graph-descriptor models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_mesh_graph_descriptor_superpod.textproto \
       python3 -m models.demos.deepseek_v3_b1.demo.teacher_forced \
         --weights real \
         --cache-path /mnt/models/deepseek-ai/cache-2026-03-22 \


### PR DESCRIPTION
### PR Category
CI / Test Infrastructure

### Summary
Applies Ridvan's review comments from #44608 — switches SP1 and SP4 multihost test launch from rank-binding files to the auto-mapper (`--mesh-graph-descriptor`).

**Rebased onto main** after #44608 merged (2026-05-27). The following changes from #44608 are already on main and are not re-applied here: `sku_config.yaml`, `time_budget.yaml`, `demo-sp-multihost-impl.yaml`, `blitz_pipeline_config_single_pod_ci.yaml`, and rev_c rank files.

Key changes in this PR (delta over main):

- **`.github/workflows/demo-sp-release.yaml`**: Comment out prefill/decode/wan22 jobs; enable single-galaxy job (`spsg`); SP1 and SP4 already enabled on main from #44608.
- **`tests/pipeline_reorg/demo_sp_multihost_tests.yaml`**: SP1 and SP4 commands now use `--mesh-graph-descriptor` + `--hosts` instead of `--rank-binding` + `--mpi-args --host $HOST:4,...`. Single-galaxy (spsg) test enabled with mpirun Host I/O loopback.
- **`docs/automapper-runbook.md`**: New step-by-step guide for running SP1/SP4 with `--mesh-graph-descriptor`.

### Notes for reviewers
The rev_c rank binding/file assets are no longer needed by CI — the mesh graph descriptor files (`blitz_decode_single_pod_mesh_graph_descriptor.textproto`, `blitz_decode_mesh_graph_descriptor_superpod.textproto`) already exist in `scaleout_configs/` on main.

Based on review: https://github.com/tenstorrent/tt-metal/pull/44608#pullrequestreview-4330900603

### Test plan
- [ ] SP1 run on bh_sp1 hardware with `--mesh-graph-descriptor blitz_decode_single_pod_mesh_graph_descriptor.textproto`
- [ ] SP4 run on bh_sp4 hardware with `--mesh-graph-descriptor blitz_decode_mesh_graph_descriptor_superpod.textproto`
- [ ] Single galaxy host I/O loopback on bh_spsg

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/sp-mesh-graph-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/sp-mesh-graph-descriptor)