### PR TITLE
ring_joint_sdpa: chunked prefill

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1609,7 +1609,6 @@ def _generate_chunked_configs():
 CHUNKED_CONFIGS, CHUNKED_CONFIG_IDS = _generate_chunked_configs()
 
 
-@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Long-running accuracy test - skip on CI")
 @pytest.mark.timeout(1200)
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
 @pytest.mark.parametrize(

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -247,7 +247,6 @@ from tests.nightly.sdpa_perf_utils import (
     post_process_ops_log,
     compute_sdpa_flops,
     compute_math_utilization as compute_ring_joint_utilization,
-    compute_math_util_from_flops,
     create_balanced_chunk_order,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -815,7 +815,7 @@ def run_ring_joint_sdpa_chunked(
     SUT: n_chunks calls; each call passes a short Q chunk at absolute positions
     [i*c, (i+1)*c) against a K/V cache holding the first (i+1)*c rows.
     """
-    torch.manual_seed(1234)
+    torch.manual_seed(CHUNKED_PREFILL_SEED)
 
     sp_size = mesh_config.sp_size
     if sp_size < 2:

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -247,6 +247,7 @@ from tests.nightly.sdpa_perf_utils import (
     post_process_ops_log,
     compute_sdpa_flops,
     compute_math_utilization as compute_ring_joint_utilization,
+    compute_math_util_from_flops,
     create_balanced_chunk_order,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
@@ -791,6 +792,345 @@ def run_ring_joint_sdpa(
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
 
+# ============================================================================
+# CHUNKED-PREFILL VALIDATION
+# ============================================================================
+CHUNKED_PREFILL_TOTAL_SEQ = 25 * 1024
+CHUNKED_PREFILL_CHUNK_SIZE = 5 * 1024
+CHUNKED_PREFILL_PCC_THRESHOLD = 0.99
+CHUNKED_PREFILL_SEED = 1234
+
+
+def run_ring_joint_sdpa_chunked(
+    mesh_config,
+    model: ModelConfig,
+    chunk_size: int = CHUNKED_PREFILL_CHUNK_SIZE,
+    total_seq: int = CHUNKED_PREFILL_TOTAL_SEQ,
+    pcc_threshold: float = CHUNKED_PREFILL_PCC_THRESHOLD,
+    q_chunk_size: int = None,
+    k_chunk_size: int = None,
+):
+    """
+    Validate ring joint SDPA chunked-prefill against a full-sequence torch oracle.
+
+    SUT: n_chunks calls; each call passes a short Q chunk at absolute positions
+    [i*c, (i+1)*c) against a K/V cache holding the first (i+1)*c rows.
+    """
+    torch.manual_seed(1234)
+
+    sp_size = mesh_config.sp_size
+    if sp_size < 2:
+        pytest.skip(f"Ring joint chunked prefill requires at least 2 devices in ring, got SP={sp_size}")
+
+    assert total_seq % sp_size == 0, f"total_seq {total_seq} must divide sp_size {sp_size}"
+    assert chunk_size % sp_size == 0, f"chunk_size {chunk_size} must divide sp_size {sp_size}"
+    assert total_seq % chunk_size == 0, f"total_seq {total_seq} must be a multiple of chunk_size {chunk_size}"
+
+    n_chunks = total_seq // chunk_size
+
+    if q_chunk_size is None:
+        q_chunk_size = model.q_chunk_sizes[0]
+    if k_chunk_size is None:
+        k_chunk_size = model.k_chunk_sizes[0]
+    nhq, nhk, nhv = model.nhq, model.nhk, model.nhv
+    d_q, d_k, d_v = model.d_q, model.d_k, model.d_v
+    q_dtype, kv_dtype = model.q_dtype, model.kv_dtype
+    is_balanced = False
+
+    b = BATCH_SIZE
+
+    use_ring = sp_size > 2
+    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
+    topology = Topology.Ring if use_ring else Topology.Linear
+
+    ttnn.set_fabric_config(
+        fabric_config,
+        ttnn.FabricReliabilityMode.STRICT_INIT,
+        None,
+        ttnn.FabricTensixConfig.DISABLED,
+        ttnn.FabricUDMMode.DISABLED,
+        ttnn.FabricManagerMode.DEFAULT,
+    )
+
+    sp_axis = 1
+    tp_axis = 0
+    joint_seq_len = 0
+    num_links = 2
+
+    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+
+    try:
+        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
+        ccl_column = mesh_config.ccl_column
+        full_compute_grid = mesh_device.compute_with_storage_grid_size()
+
+        ccl_sub_device_crs = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+        )
+        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+        worker_sub_device_id = ttnn.SubDeviceId(0)
+        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+        mesh_device.load_sub_device_manager(sub_device_manager)
+        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+
+        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
+
+        joint_Q = torch.zeros((b, nhq, joint_seq_len, d_q), dtype=torch.bfloat16)
+        joint_K = torch.zeros((b, nhk, joint_seq_len, d_k), dtype=torch.bfloat16)
+        joint_V = torch.zeros((b, nhv, joint_seq_len, d_v), dtype=torch.bfloat16)
+
+        torch.manual_seed(CHUNKED_PREFILL_SEED)
+        Q_full = fa_rand(b, nhq, total_seq, d_q)
+        K_full = fa_rand(b, nhk, total_seq, d_k)
+        V_full = fa_rand(b, nhv, total_seq, d_v)
+        ref_full, _ = torch_joint_sdpa_reference(Q_full, K_full, V_full, joint_Q, joint_K, joint_V, is_causal=True)
+
+        sdpa_input_shard_dims = [None, None]
+        sdpa_input_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            sdpa_input_shard_dims[tp_axis] = 1
+
+        sdpa_k_shard_dims = [None, None]
+        sdpa_k_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1 and nhk != 1:
+            sdpa_k_shard_dims[tp_axis] = 1
+
+        sdpa_joint_shard_dims = [None, None]
+        if mesh_config.tp_size > 1:
+            sdpa_joint_shard_dims[tp_axis] = 1
+
+        sdpa_joint_k_shard_dims = [None, None]
+        if mesh_config.tp_size > 1 and nhk != 1:
+            sdpa_joint_k_shard_dims[tp_axis] = 1
+
+        persistent_k_shard_dims = [None, None]
+        if mesh_config.tp_size > 1 and nhk != 1:
+            persistent_k_shard_dims[tp_axis] = 1
+
+        kv_persistent_shard_dims = [None, None]
+        if mesh_config.tp_size > 1:
+            kv_persistent_shard_dims[tp_axis] = 1
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=sdpa_compute_grid,
+            q_chunk_size=q_chunk_size,
+            k_chunk_size=k_chunk_size,
+            exp_approx_mode=False,
+        )
+
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+        main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
+        main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
+
+        def upload_q(q_host):
+            return ttnn.from_torch(
+                q_host,
+                dtype=q_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+                ),
+            )
+
+        def upload_k(k_host):
+            return ttnn.from_torch(
+                k_host,
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_k_shard_dims
+                ),
+            )
+
+        def upload_v(v_host):
+            return ttnn.from_torch(
+                v_host,
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+                ),
+            )
+
+        tt_joint_Q = ttnn.from_torch(
+            joint_Q,
+            dtype=q_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
+            ),
+        )
+        tt_joint_K = ttnn.from_torch(
+            joint_K,
+            dtype=kv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_k_shard_dims
+            ),
+        )
+        tt_joint_V = ttnn.from_torch(
+            joint_V,
+            dtype=kv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
+            ),
+        )
+
+        def call_sdpa(tt_Q, tt_K, tt_V, logical_n, is_causal, p_buf_k, p_buf_v):
+            tt_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+                tt_Q,
+                tt_K,
+                tt_V,
+                tt_joint_Q,
+                tt_joint_K,
+                tt_joint_V,
+                persistent_output_buffer_k=p_buf_k,
+                persistent_output_buffer_v=p_buf_v,
+                joint_strategy="rear",
+                logical_n=logical_n,
+                is_causal=is_causal,
+                is_balanced=is_balanced,
+                program_config=program_config,
+                compute_kernel_config=compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=ccl_semaphore_handles,
+                num_links=num_links,
+                cluster_axis=sp_axis,
+                mesh_device=mesh_device,
+                topology=topology,
+                subdevice_id=worker_sub_device_id,
+                ccl_core_grid_offset=(ccl_column, 0),
+                use_column_major_ccl=True,
+            )
+            return tt_out
+
+        def to_host(tt_out, expected_q_len):
+            out = ttnn.to_torch(
+                tt_out,
+                mesh_composer=ttnn.create_mesh_composer(
+                    mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim)
+                ),
+            )
+            return out[:, :, :expected_q_len, :]
+
+        logger.info(
+            f"Chunked prefill: model={model.name}, total_seq={total_seq}, "
+            f"sp_size={sp_size}, per-device Q seq_len={total_seq // sp_size}, "
+            f"q_chunk={q_chunk_size}, k_chunk={k_chunk_size}"
+        )
+
+        # Balanced K/V layout: device d's local slab c holds global rows
+        # [c*chunk_size + d*slab_rows, c*chunk_size + (d+1)*slab_rows). Cache grows one
+        # chunk per call → program cache forks one entry per chunk.
+        slab_rows = chunk_size // sp_size
+        assert chunk_size % sp_size == 0, f"chunk_size {chunk_size} not divisible by sp_size {sp_size}"
+        assert slab_rows % 32 == 0, f"slab_rows {slab_rows} not tile-aligned (TILE_HEIGHT=32)"
+
+        def to_balanced_growing(src_full, last_uploaded_chunk):
+            """Permute src_full into balanced per-device layout for the populated prefix
+            [0..last_uploaded_chunk]; returns length (last_uploaded_chunk + 1) * chunk_size.
+            """
+            n_populated = last_uploaded_chunk + 1
+            K_local_curr = n_populated * slab_rows
+            populated_len = n_populated * chunk_size
+            b_, nh_, _, d_ = src_full.shape
+            perm = torch.zeros(b_, nh_, populated_len, d_, dtype=src_full.dtype, device=src_full.device)
+            for dev in range(sp_size):
+                for c in range(n_populated):
+                    local_start = dev * K_local_curr + c * slab_rows
+                    global_start = c * chunk_size + dev * slab_rows
+                    perm[:, :, local_start : local_start + slab_rows, :] = src_full[
+                        :, :, global_start : global_start + slab_rows, :
+                    ]
+            return perm
+
+        # SUT: per-chunk calls with growing K/V cache + growing logical_n.
+        per_chunk_results = []
+        for i in range(n_chunks):
+            s, e = i * chunk_size, (i + 1) * chunk_size
+
+            K_balanced = to_balanced_growing(K_full, i)
+            V_balanced = to_balanced_growing(V_full, i)
+            Q_chunk = Q_full[:, :, s:e, :].contiguous()
+
+            tt_Q = upload_q(Q_chunk)
+            tt_K = upload_k(K_balanced)
+            tt_V = upload_v(V_balanced)
+
+            # AllGather output buffer sized to post-gather K/V: N_global == (i+1) * chunk_size.
+            persistent_output_buffer_k = ttnn.from_torch(
+                torch.zeros(b, nhk, e, d_k),
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_k_shard_dims
+                ),
+            )
+            persistent_output_buffer_v = ttnn.from_torch(
+                torch.zeros(b, nhv, e, d_v),
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_persistent_shard_dims
+                ),
+            )
+
+            try:
+                tt_out = call_sdpa(
+                    tt_Q,
+                    tt_K,
+                    tt_V,
+                    e,
+                    is_causal=True,
+                    p_buf_k=persistent_output_buffer_k,
+                    p_buf_v=persistent_output_buffer_v,
+                )
+            except Exception as exc:
+                pytest.fail(
+                    f"Chunked prefill SDPA call raised on chunk {i} "
+                    f"(Q rows [{s}, {e}), logical_n={e}): {type(exc).__name__}: {exc}"
+                )
+
+            out_i = to_host(tt_out, chunk_size)
+            expected_i = ref_full[:, :, s:e, :]
+
+            passed, pcc = comp_pcc(expected_i, out_i, pcc_threshold)
+            rmse = torch.sqrt(((expected_i - out_i) ** 2).mean()).item()
+            logger.info(
+                f"Chunk {i:2d} [{s:6d}, {e:6d}) logical_n={e}: PCC={pcc} RMSE={rmse:.6f} "
+                f"-> {'PASS' if passed else 'FAIL'}"
+            )
+            per_chunk_results.append((i, e, passed, pcc, rmse))
+
+        failures = [(i, e, pcc, rmse) for i, e, passed, pcc, rmse in per_chunk_results if not passed]
+        if failures:
+            details = "; ".join(
+                f"chunk {i} (logical_n={e}): PCC={pcc}, RMSE={rmse:.6f}" for i, e, pcc, rmse in failures
+            )
+            pytest.fail(f"Chunked prefill PCC failures (threshold={pcc_threshold}): {details}")
+
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
 # Generate test parameters dynamically based on detected hardware for different models (WAN, MLA, VideGen...)
 TEST_CONFIGS, TEST_CONFIG_IDS = generate_test_configs(MESH_CONFIG, MODEL_CONFIGS)
 TEST_CONFIG_MODELS = list(MODEL_CONFIGS.keys())
@@ -1248,4 +1588,46 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
     assert lower <= utilization <= upper, (
         f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
         f"(expected {expected_util:.2f}%, margin +/- {RING_JOINT_PERF_MARGIN*100:.1f}%)"
+    )
+
+
+# === TEST 6: CHUNKED-PREFILL ACCURACY ===
+CHUNKED_PREFILL_MODELS = [m for m in ("mla_100k",) if m in MODEL_CONFIGS]
+
+
+def _generate_chunked_configs():
+    configs = []
+    ids = []
+    for model_name in CHUNKED_PREFILL_MODELS:
+        model = MODEL_CONFIGS[model_name]
+        for q, k in product(model.q_chunk_sizes, model.k_chunk_sizes):
+            configs.append((model_name, q, k))
+            ids.append(f"{model_name}-q{q}-k{k}")
+    return configs, ids
+
+
+CHUNKED_CONFIGS, CHUNKED_CONFIG_IDS = _generate_chunked_configs()
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Long-running accuracy test - skip on CI")
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
+@pytest.mark.parametrize(
+    "model_name,q_chunk_size,k_chunk_size",
+    CHUNKED_CONFIGS,
+    ids=CHUNKED_CONFIG_IDS,
+)
+def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, q_chunk_size, k_chunk_size, chunk_size):
+    """Validate ring joint SDPA chunked prefill against a full-sequence oracle."""
+    mesh_config = MESH_CONFIG
+
+    if model_name not in MODEL_CONFIGS:
+        pytest.skip(f"Model {model_name} not available for current mesh config")
+
+    run_ring_joint_sdpa_chunked(
+        mesh_config,
+        MODEL_CONFIGS[model_name],
+        chunk_size=chunk_size,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
     )

--- a/tests/nightly/sdpa_perf_utils.py
+++ b/tests/nightly/sdpa_perf_utils.py
@@ -231,13 +231,9 @@ def compute_math_utilization(
         is_causal: Whether causal masking is used.
         arch: Architecture name ("blackhole" or "wormhole_b0").
     """
-    mm_flops = compute_sdpa_flops(local_seqlen, total_seqlen, d_q, d_v, num_heads_per_device, is_causal)
-    return compute_math_util_from_flops(mm_flops, duration_ns, core_count, arch=arch)
-
-
-def compute_math_util_from_flops(mm_flops, duration_ns, core_count, arch="blackhole"):
-    """Math utilization (0-100) from a precomputed FLOP count."""
     constants = ARCH_CONSTANTS[arch]
+    mm_flops = compute_sdpa_flops(local_seqlen, total_seqlen, d_q, d_v, num_heads_per_device, is_causal)
+
     cycles = duration_ns * constants["clock_ghz"]
     theoretical_flops = core_count * cycles * constants["mm_flops_per_cycle_per_core"]
     return (mm_flops / theoretical_flops) * 100 if theoretical_flops > 0 else 0

--- a/tests/nightly/sdpa_perf_utils.py
+++ b/tests/nightly/sdpa_perf_utils.py
@@ -231,9 +231,13 @@ def compute_math_utilization(
         is_causal: Whether causal masking is used.
         arch: Architecture name ("blackhole" or "wormhole_b0").
     """
-    constants = ARCH_CONSTANTS[arch]
     mm_flops = compute_sdpa_flops(local_seqlen, total_seqlen, d_q, d_v, num_heads_per_device, is_causal)
+    return compute_math_util_from_flops(mm_flops, duration_ns, core_count, arch=arch)
 
+
+def compute_math_util_from_flops(mm_flops, duration_ns, core_count, arch="blackhole"):
+    """Math utilization (0-100) from a precomputed FLOP count."""
+    constants = ARCH_CONSTANTS[arch]
     cycles = duration_ns * constants["clock_ghz"]
     theoretical_flops = core_count * cycles * constants["mm_flops_per_cycle_per_core"]
     return (mm_flops / theoretical_flops) * 100 if theoretical_flops > 0 else 0

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1956,9 +1956,13 @@ void sdpa_inner_loop(
                     uint32_t lw_straddle_jump = 0;
                     if constexpr (sdpa_type == RING && chunked_enabled) {
                         k_start_tile_for_mask = kv_global_start_tile;
-                        // When Sk_chunk_t ∤ chunked_q_local_padded_Nt a K-chunk can straddle two
-                        // per-chunk slabs; global K coord jumps by chunk_size_t - q_local_padded_Nt
-                        // at the slab boundary. Stamp evaluates per-col when straddle_col > 0.
+                        // Chunked-prefill straddle: a K-chunk can begin in one per-chunk K
+                        // region and end in the next when k_chunk_size does not divide
+                        // q_local_padded_Nt. Global K is non-contiguous across the K-chunk in
+                        // that case (jumps by chunk_size_t - q_local_padded_Nt between regions),
+                        // so we signal the column boundary (straddle_col) and the jump
+                        // (straddle_jump) to the diag stamp — see same comment block in
+                        // compute_streaming.hpp:sdpa_inner_loop_step for the full picture.
                         if (chunked_q_local_padded_Nt > 0) {
                             const uint32_t local_start = k_chunk * Sk_chunk_t;
                             const uint32_t slab_end_local =

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -24,6 +24,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/reduce_custom.h"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp"
 #include "cpp/ttnn/kernel_lib/dest_helpers.hpp"
 
 ALWI void sdpa_reduce_copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0) {
@@ -1412,34 +1413,59 @@ void apply_causal_mask_lightweight(
     uint32_t q_start_tile,
     uint32_t k_start_tile,
     uint32_t num_rows,
-    uint32_t num_cols) {
+    uint32_t num_cols,
+    uint32_t straddle_col = 0,
+    uint32_t straddle_jump = 0) {
     copy_tile_to_dst_init_short(mask_cb);
     PACK((llk_pack_reconfig_l1_acc(1)));
 
     for (uint32_t row = 0; row < num_rows; row++) {
-        int32_t diag_col = static_cast<int32_t>(q_start_tile + row) - static_cast<int32_t>(k_start_tile);
         uint32_t row_offset = row * num_cols;
+        const int32_t q_pos = static_cast<int32_t>(q_start_tile + row);
 
-        if (diag_col < 0) {
-            // Entire row above diagonal -> stamp all neginf
-            stamp_tile_range_l1_acc<dst_batch>(mask_cb, neginf_idx, out_cb, row_offset, num_cols);
-        } else if (static_cast<uint32_t>(diag_col) < num_cols) {
-            // Stamp the diagonal tile
-            tile_regs_acquire();
-            copy_tile(mask_cb, diag_idx, 0);
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile<true>(0, out_cb, row_offset + static_cast<uint32_t>(diag_col));
-            tile_regs_release();
+        if (straddle_col == 0) {
+            // Fast path: K coords contiguous across cols.
+            int32_t diag_col = q_pos - static_cast<int32_t>(k_start_tile);
+            if (diag_col < 0) {
+                // Entire row above diagonal -> stamp all neginf
+                stamp_tile_range_l1_acc<dst_batch>(mask_cb, neginf_idx, out_cb, row_offset, num_cols);
+            } else if (static_cast<uint32_t>(diag_col) < num_cols) {
+                // Stamp the diagonal tile
+                tile_regs_acquire();
+                copy_tile(mask_cb, diag_idx, 0);
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile<true>(0, out_cb, row_offset + static_cast<uint32_t>(diag_col));
+                tile_regs_release();
 
-            // Stamp neginf tiles to the right of diagonal
-            uint32_t neginf_start = static_cast<uint32_t>(diag_col) + 1;
-            if (neginf_start < num_cols) {
-                stamp_tile_range_l1_acc<dst_batch>(
-                    mask_cb, neginf_idx, out_cb, row_offset + neginf_start, num_cols - neginf_start);
+                // Stamp neginf tiles to the right of diagonal
+                uint32_t neginf_start = static_cast<uint32_t>(diag_col) + 1;
+                if (neginf_start < num_cols) {
+                    stamp_tile_range_l1_acc<dst_batch>(
+                        mask_cb, neginf_idx, out_cb, row_offset + neginf_start, num_cols - neginf_start);
+                }
+            }
+            // else: diag_col >= num_cols -> entire row below diagonal, no mask needed
+        } else {
+            // Chunked-prefill straddle: K coord jumps by straddle_jump at col >= straddle_col
+            // (the K-chunk crosses a slab boundary). Evaluate per-col.
+            for (uint32_t col = 0; col < num_cols; col++) {
+                int32_t k_pos = static_cast<int32_t>(k_start_tile) + static_cast<int32_t>(col);
+                if (col >= straddle_col) {
+                    k_pos += static_cast<int32_t>(straddle_jump);
+                }
+                if (k_pos > q_pos) {
+                    stamp_tile_range_l1_acc<dst_batch>(mask_cb, neginf_idx, out_cb, row_offset + col, 1);
+                } else if (k_pos == q_pos) {
+                    tile_regs_acquire();
+                    copy_tile(mask_cb, diag_idx, 0);
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    pack_tile<true>(0, out_cb, row_offset + col);
+                    tile_regs_release();
+                }
             }
         }
-        // else: diag_col >= num_cols -> entire row below diagonal, no mask needed
     }
 
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -1527,9 +1553,11 @@ struct LightweightMaskContext {
         uint32_t global_n_mask_chunk_id,
         uint32_t local_n_mask_chunk_id,
         uint32_t joint_n_mask_chunk_id,
-        uint32_t q_start_tile = 0) const {
+        uint32_t q_start_tile,
+        uint32_t k_start_tile,
+        uint32_t straddle_col = 0,
+        uint32_t straddle_jump = 0) const {
         if (is_causal) {
-            uint32_t k_start_tile = k_chunk * Sk_chunk_t;
             apply_causal_mask_lightweight<dst_size>(
                 cb_mask_in,
                 neginf_tile_idx,
@@ -1538,7 +1566,9 @@ struct LightweightMaskContext {
                 q_start_tile,
                 k_start_tile,
                 Sq_chunk_t,
-                Sk_chunk_t);
+                Sk_chunk_t,
+                straddle_col,
+                straddle_jump);
         }
 
         // Apply padding stamp (also when is_causal — the causal stamp doesn't handle K padding).
@@ -1675,7 +1705,10 @@ template <
     bool is_chunked,
     uint32_t scale_fp32,
     uint32_t sliding_window_size,
-    bool lightweight_mask_enabled = false>
+    bool lightweight_mask_enabled = false,
+    bool chunked_enabled = false,
+    uint32_t chunked_q_local_padded_Nt = 0,
+    uint32_t chunked_chunk_size_t = 0>
 void sdpa_inner_loop(
     const uint32_t Skt,
     const uint32_t qk_in0_block_w,
@@ -1735,7 +1768,8 @@ void sdpa_inner_loop(
     const bool is_causal = false,
     const bool is_balanced = false,
     const bool use_zigzag_balancing = false,
-    const bool is_last_ring_iter = true) {
+    const bool is_last_ring_iter = true,
+    const ChunkedContext& chunked = {}) {
     constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
     uint32_t KV_chunks_processed_in_iter = 0;
     const uint32_t q_per_core = iter_q_end - iter_q_start;
@@ -1766,7 +1800,11 @@ void sdpa_inner_loop(
         } else if (sdpa_type == RING) {
             uint32_t q_chunk = remap_q_index(q_iter, q_num_chunks, use_zigzag_balancing) % q_num_chunks;
 
-            if (is_causal) {
+            if constexpr (chunked_enabled) {
+                // Absolute Q tile row. Diag stamp masks K past Q's range; logical_n skip handles K past the cache.
+                q_start_tile =
+                    chunked.q_start_idx_t + chunked.ring_index * chunked_q_local_padded_Nt + q_chunk * Sq_chunk_t;
+            } else if (is_causal) {
                 q_start_tile = q_chunk * Sq_chunk_t;
                 causal_k_limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
             }
@@ -1794,10 +1832,17 @@ void sdpa_inner_loop(
         uint32_t processed_k_chunks = 0;
 
         for (uint32_t k_chunk = iter_k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
+            uint32_t kv_global_start_tile = 0;  // RING only: abs K-tile index of this k_chunk's start
             if constexpr (sdpa_type == RING) {
                 const bool kv_chunk_is_joint = k_chunk >= num_local_k_chunks;
-                // Global index into the padded KV tensor
-                const uint32_t kv_global_start_tile = local_padded_Nt * ring_id + k_chunk * Sk_chunk_t;
+                // Global index into the padded KV tensor. Chunked: non-monotonic local→abs map.
+                if constexpr (chunked_enabled) {
+                    kv_global_start_tile =
+                        kv_global_tile_for_local<true, 0, chunked_chunk_size_t, chunked_q_local_padded_Nt>(
+                            ring_id, k_chunk * Sk_chunk_t);
+                } else {
+                    kv_global_start_tile = local_padded_Nt * ring_id + k_chunk * Sk_chunk_t;
+                }
                 if (!kv_chunk_is_joint && (kv_global_start_tile >= logical_nt)) {
                     // This is a KV chunk on spatial input beyond the logical N, and not joint KV. Skip it.
                     continue;
@@ -1806,7 +1851,9 @@ void sdpa_inner_loop(
 
             KV_chunks_processed_in_iter++;
 
-            if (sdpa_type == RING && k_chunk >= causal_k_limit && is_causal) {
+            // Chunked-prefill: never take this skip (local-frame causal_k_limit doesn't apply —
+            // the diag stamp uses absolute coords every k_chunk instead).
+            if (sdpa_type == RING && !chunked_enabled && k_chunk >= causal_k_limit && is_causal) {
                 cb_wait_front(cb_k_in, k_chunk_tiles);
                 cb_wait_front(cb_v_in, v_chunk_tiles);
                 cb_pop_front(cb_k_in, k_chunk_tiles);
@@ -1854,8 +1901,27 @@ void sdpa_inner_loop(
             if (sdpa_type == RING && !is_causal) {
                 apply_mask = needs_padding_mask;
             } else if (is_causal || sliding_window_size > 0) {
-                const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
-                const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
+                // Chunked-prefill (RING): use abs K so the causal-overlap test matches the diag stamp's frame.
+                uint32_t k_low_idx;
+                uint32_t k_high_idx;
+                if constexpr (sdpa_type == RING && chunked_enabled) {
+                    k_low_idx = kv_global_start_tile;
+                    k_high_idx = k_low_idx + Sk_chunk_t;
+                    // Straddle: chunk crosses a per-chunk slab boundary in the local cache. The
+                    // tail tiles land in the next slab, so the actual high global K is shifted by
+                    // chunk_size_t - q_local_padded_Nt.
+                    if (chunked_q_local_padded_Nt > 0) {
+                        const uint32_t local_start = k_chunk * Sk_chunk_t;
+                        const uint32_t slab_end_local =
+                            (local_start / chunked_q_local_padded_Nt + 1) * chunked_q_local_padded_Nt;
+                        if (local_start + Sk_chunk_t > slab_end_local) {
+                            k_high_idx += (chunked_chunk_size_t - chunked_q_local_padded_Nt);
+                        }
+                    }
+                } else {
+                    k_low_idx = k_chunk * Sk_chunk_t;
+                    k_high_idx = k_low_idx + Sk_chunk_t;
+                }
                 // Apply mask if causal overlap, sliding window, or this K chunk has padding
                 apply_mask = (q_start_tile < k_high_idx) || (sliding_window_size > 0) || needs_padding_mask;
             } else if constexpr (use_provided_mask) {
@@ -1884,6 +1950,27 @@ void sdpa_inner_loop(
                     cb_wait_front(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
                     cb_pop_front(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
                     cb_reserve_back(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
+                    // Chunked-prefill: feed abs K (matches abs q_start_tile so diag stamp lines up).
+                    uint32_t k_start_tile_for_mask;
+                    uint32_t lw_straddle_col = 0;
+                    uint32_t lw_straddle_jump = 0;
+                    if constexpr (sdpa_type == RING && chunked_enabled) {
+                        k_start_tile_for_mask = kv_global_start_tile;
+                        // When Sk_chunk_t ∤ chunked_q_local_padded_Nt a K-chunk can straddle two
+                        // per-chunk slabs; global K coord jumps by chunk_size_t - q_local_padded_Nt
+                        // at the slab boundary. Stamp evaluates per-col when straddle_col > 0.
+                        if (chunked_q_local_padded_Nt > 0) {
+                            const uint32_t local_start = k_chunk * Sk_chunk_t;
+                            const uint32_t slab_end_local =
+                                (local_start / chunked_q_local_padded_Nt + 1) * chunked_q_local_padded_Nt;
+                            if (local_start + Sk_chunk_t > slab_end_local) {
+                                lw_straddle_col = slab_end_local - local_start;
+                                lw_straddle_jump = chunked_chunk_size_t - chunked_q_local_padded_Nt;
+                            }
+                        }
+                    } else {
+                        k_start_tile_for_mask = k_chunk * Sk_chunk_t;
+                    }
                     lw_mask.template apply<dst_size>(
                         cb_mask_in,
                         cb_qk_im,
@@ -1897,7 +1984,10 @@ void sdpa_inner_loop(
                         global_n_mask_chunk_id,
                         local_n_mask_chunk_id,
                         joint_n_mask_chunk_id,
-                        q_start_tile);
+                        q_start_tile,
+                        k_start_tile_for_mask,
+                        lw_straddle_col,
+                        lw_straddle_jump);
                     cb_push_back(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
                 } else {
                     add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
@@ -2412,7 +2502,10 @@ template <
     uint32_t DHt,
     uint32_t vDHt,
     uint32_t scale_fp32,
-    bool lightweight_mask_enabled = false>
+    bool lightweight_mask_enabled = false,
+    bool chunked_enabled = false,
+    uint32_t chunked_q_local_padded_Nt = 0,
+    uint32_t chunked_chunk_size_t = 0>
 void sdpa_ring(
     const uint32_t qk_in0_block_w,
     const uint32_t qk_subblock_w,
@@ -2467,7 +2560,8 @@ void sdpa_ring(
     const bool is_causal_ring_iter,
     const bool skip_first_half_q,
     const bool is_last_ring_iter,
-    const bool use_zigzag_balancing = false) {
+    const bool use_zigzag_balancing = false,
+    const ChunkedContext& chunked = {}) {
     sdpa_inner_loop<
         RING,
         cb_qk_im,
@@ -2486,7 +2580,10 @@ void sdpa_ring(
         false,  // is_chunked (not used)
         scale_fp32,
         0,  // sliding_window_size (not used)
-        lightweight_mask_enabled>(
+        lightweight_mask_enabled,
+        chunked_enabled,
+        chunked_q_local_padded_Nt,
+        chunked_chunk_size_t>(
         0,  // Skt (not used)
         qk_in0_block_w,
         qk_subblock_w,
@@ -2545,7 +2642,8 @@ void sdpa_ring(
         is_causal_ring_iter,
         skip_first_half_q,
         use_zigzag_balancing,
-        is_last_ring_iter);
+        is_last_ring_iter,
+        chunked);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -24,7 +24,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/reduce_custom.h"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp"
-#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp"
 #include "cpp/ttnn/kernel_lib/dest_helpers.hpp"
 
 ALWI void sdpa_reduce_copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1819,10 +1819,20 @@ void sdpa_ring_v2(
                                       ring_id, k_chunk * Sk_chunk_t)
                                 : (k_chunk * Sk_chunk_t);
 
-            // Chunked-prefill: when Sk_chunk_t ∤ q_local_padded_Nt a K-chunk can straddle two
-            // per-chunk slabs in the local cache. step_k_start_tile is the global K coord of
-            // the chunk's first tile (in slab j); cols past straddle_col jump to slab j+1, an
-            // increment of chunk_size_t - q_local_padded_Nt. Stamp evaluates per-col then.
+            // Chunked-prefill straddle. Background: each device's K cache holds the per-chunk
+            // K region for every chunk back-to-back, q_local_padded_Nt tiles per region. When
+            // k_chunk_size does not divide q_local_padded_Nt, a single K-chunk can begin in
+            // one region (chunk j) and end in the next (chunk j+1). Because adjacent regions
+            // map to *non-adjacent* global K positions (jumping by chunk_size_t between them),
+            // the global K coord is no longer contiguous across the K-chunk's columns. We
+            // signal this to the diag stamp via:
+            //   - straddle_col: column index at which the jump happens (= tiles remaining in
+            //     region j from this K-chunk's start)
+            //   - straddle_jump: the global-K increment at that boundary
+            //     (= chunk_size_t - q_local_padded_Nt, i.e. the gap between region j's end and
+            //     region j+1's start in global K).
+            // When straddle_col > 0 the stamp evaluates the diagonal per column instead of
+            // per row, applying the jump for columns >= straddle_col.
             uint32_t step_straddle_col = 0;
             uint32_t step_straddle_jump = 0;
             if constexpr (chunked_enabled) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -11,7 +11,7 @@
 #include <type_traits>
 
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sdpa_streaming_qktv.hpp"
-#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp"
 
 #if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
 #include "api/compute/experimental/matmul_custom.h"

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sdpa_streaming_qktv.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp"
 
 #if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
 #include "api/compute/experimental/matmul_custom.h"
@@ -624,7 +625,9 @@ static SDPA_NOINLINE void apply_lightweight_mask_streaming(
     uint32_t causal_diag_idx,
     uint32_t q_start_tile,
     uint32_t k_start_tile,
-    uint32_t active_Sk) {
+    uint32_t active_Sk,
+    uint32_t straddle_col = 0,
+    uint32_t straddle_jump = 0) {
     // Caller-owned contract (see function comment): pack state for mask_cb is initialized
     // before entry via copy_tile_to_dst_init_short + llk_pack_reconfig_l1_acc(1).
     uint32_t boundary_col = num_cols - num_padded - (has_partial ? 1 : 0);
@@ -634,16 +637,34 @@ static SDPA_NOINLINE void apply_lightweight_mask_streaming(
         // Causal mask: per-row diagonal + trailing neginf
         if constexpr (is_causal_sdpa) {
             if (apply_causal) {
-                int32_t diag_col =
-                    static_cast<int32_t>(q_start_tile + q_subblock * sbh + row) - static_cast<int32_t>(k_start_tile);
-                if (diag_col < 0) {
-                    for (uint32_t col = 0; col < active_Sk; col++) {
-                        l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
+                const int32_t q_pos = static_cast<int32_t>(q_start_tile + q_subblock * sbh + row);
+                if (straddle_col == 0) {
+                    // Fast path: K coords contiguous across cols.
+                    int32_t diag_col = q_pos - static_cast<int32_t>(k_start_tile);
+                    if (diag_col < 0) {
+                        for (uint32_t col = 0; col < active_Sk; col++) {
+                            l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
+                        }
+                    } else if (static_cast<uint32_t>(diag_col) < active_Sk) {
+                        l1_acc_single_tile(
+                            mask_cb, causal_diag_idx, out_cb, row_offset + static_cast<uint32_t>(diag_col));
+                        for (uint32_t col = static_cast<uint32_t>(diag_col) + 1; col < active_Sk; col++) {
+                            l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
+                        }
                     }
-                } else if (static_cast<uint32_t>(diag_col) < active_Sk) {
-                    l1_acc_single_tile(mask_cb, causal_diag_idx, out_cb, row_offset + static_cast<uint32_t>(diag_col));
-                    for (uint32_t col = static_cast<uint32_t>(diag_col) + 1; col < active_Sk; col++) {
-                        l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
+                } else {
+                    // Chunked-prefill straddle: K coord jumps by straddle_jump at col >= straddle_col
+                    // (the K-chunk crosses a slab boundary). Evaluate per-col.
+                    for (uint32_t col = 0; col < active_Sk; col++) {
+                        int32_t k_pos = static_cast<int32_t>(k_start_tile) + static_cast<int32_t>(col);
+                        if (col >= straddle_col) {
+                            k_pos += static_cast<int32_t>(straddle_jump);
+                        }
+                        if (k_pos > q_pos) {
+                            l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
+                        } else if (k_pos == q_pos) {
+                            l1_acc_single_tile(mask_cb, causal_diag_idx, out_cb, row_offset + col);
+                        }
                     }
                 }
             }
@@ -723,7 +744,9 @@ static void sdpa_inner_loop_step(
     const uint32_t causal_q_start_tile = 0,
     const uint32_t causal_k_start_tile = 0,
     const uint32_t neginf_idx = 0,
-    const uint32_t causal_diag_idx = 0) {
+    const uint32_t causal_diag_idx = 0,
+    const uint32_t causal_straddle_col = 0,
+    const uint32_t causal_straddle_jump = 0) {
     // Callers guarantee active_Sk is evenly divisible by actual_sbw (via largest_factor_le).
     const uint32_t kt_num_full_subblocks = active_Sk / actual_sbw;
     constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
@@ -850,7 +873,9 @@ static void sdpa_inner_loop_step(
                     causal_diag_idx,
                     causal_q_start_tile,
                     causal_k_start_tile,
-                    active_Sk);
+                    active_Sk,
+                    causal_straddle_col,
+                    causal_straddle_jump);
                 PACK((llk_pack_reconfig_l1_acc(0)));
             }
         }
@@ -1462,6 +1487,11 @@ void sdpa_standard_v2(
  * @tparam cb_normalized_out CB for normalized output rows (written by normalize_row_streaming)
  * @tparam cb_sum_out       CB for saving row-sum to DRAM (multi Q-chunk, c_10)
  * @tparam cb_sum_in        CB for restoring row-sum from DRAM (multi Q-chunk, c_11)
+ * @tparam local_padded_Nt   Per-device KV padded sequence length in tiles (N_local / TILE_H)
+ * @tparam q_local_padded_Nt Per-device Q padded sequence length in tiles. Under chunked-prefill it
+ *                           also doubles as the per-chunk K-region stride on this device (one
+ *                           chunk's Q lives in one such region); equals local_padded_Nt otherwise.
+ * @tparam chunk_size_t      Per-chunk Q/K extent in tiles (chunked-only)
  *
  * @param global_q_start     First global Q chunk index for this core
  * @param global_q_end       One-past-last global Q chunk index for this core
@@ -1469,12 +1499,15 @@ void sdpa_standard_v2(
  * @param ring_iter          Current ring iteration (0..ring_size-1)
  * @param ring_id            Device ID within the ring that owns this iter's KV shard
  * @param num_local_k_chunks Number of K chunks from the local (non-joint) sequence
- * @param local_padded_Nt    Per-device padded sequence length in tiles (N_local / TILE_H)
  * @param logical_nt         Actual (unpadded) global sequence length in tiles
  * @param acc_state          Persistent accumulator state (prev/cur CB halves for ping-pong)
  * @param is_last_ring_iter  True on the final ring iteration — triggers normalization
  * @param q_per_core         Number of Q chunks per core (1 = L1-only, >1 = DRAM round-trip)
  * @param lw_mask            Lightweight mask context for partial-tile padding
+ * @param chunked            Chunked-prefill runtime state (q_start_idx_t, ring_index); ignored when
+ * chunked_enabled=false
+ * @param is_first_active_iter Set on the first ring iter that does work (decoupled from ring_iter==0 for skipped-chain
+ * bounds)
  */
 template <
     uint32_t Sq_chunk_t,
@@ -1508,7 +1541,11 @@ template <
     uint32_t cb_signal = 0,
     bool lightweight_mask_enabled = false,
     bool is_causal_sdpa = false,
-    bool is_balanced_sdpa = false>
+    bool is_balanced_sdpa = false,
+    bool chunked_enabled = false,
+    uint32_t local_padded_Nt = 0,
+    uint32_t q_local_padded_Nt = 0,
+    uint32_t chunk_size_t = 0>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1517,7 +1554,6 @@ void sdpa_ring_v2(
     const uint32_t ring_iter,
     const uint32_t ring_id,
     const uint32_t num_local_k_chunks,
-    const uint32_t local_padded_Nt,
     const uint32_t logical_nt,
     const bool ring_iter_needs_global_n_mask,
     const bool ring_iter_needs_joint_n_mask,
@@ -1530,10 +1566,13 @@ void sdpa_ring_v2(
     const uint32_t q_per_core = 1,
     const LightweightMaskContext& lw_mask = {},
     const bool skip_first_half_q = false,
-    const bool use_zigzag_balancing = false) {
+    const bool use_zigzag_balancing = false,
+    const ChunkedContext& chunked = {},
+    const bool is_first_active_iter = true) {
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool uniform_format = uniform_dataformat;
-    const bool is_causal_iter = is_causal_sdpa && (ring_iter == 0);
+    // is_causal: diagonal stamp only on iter 0 (K is local-frame). Chunked: every iter (absolute coords).
+    const bool is_causal_iter = (is_causal_sdpa && (ring_iter == 0)) || chunked_enabled;
 
     // reduce_trigger enables early reduce start via semaphore signaling from packer to unpacker.
     // All conditions are compile-time except the active_Sk == Sk_chunk_t guard (padded chunks).
@@ -1598,7 +1637,13 @@ void sdpa_ring_v2(
 
     // Skip KV chunks beyond the logical sequence length (padding tiles).
     auto try_skip_oob_kv = [&](uint32_t k_chunk, bool kv_chunk_is_joint) -> bool {
-        return !kv_chunk_is_joint && (local_padded_Nt * ring_id + k_chunk * Sk_chunk_t >= logical_nt);
+        if (kv_chunk_is_joint) {
+            return false;
+        }
+        const uint32_t global_start =
+            kv_global_tile_for_local<chunked_enabled, local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
+                ring_id, k_chunk * Sk_chunk_t);
+        return global_start >= logical_nt;
     };
 
     // Causal skip: K chunks fully above the diagonal — drain K/V from CBs and skip.
@@ -1632,6 +1677,9 @@ void sdpa_ring_v2(
                 q_start_tile = q_chunk * Sq_chunk_t;
                 causal_k_limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
             }
+        } else if constexpr (chunked_enabled) {
+            // Absolute Q tile row. Diag stamp masks K past Q's range; logical_n skip handles K past the cache.
+            q_start_tile = chunked.q_start_idx_t + chunked.ring_index * q_local_padded_Nt + q_chunk * Sq_chunk_t;
         }
 
         if (try_balanced_skip(q_chunk)) {
@@ -1661,14 +1709,13 @@ void sdpa_ring_v2(
         // or restore from DRAM (multi Q-chunk).
         AccumulatorHalf q_prev = acc_state.prev, q_cur = acc_state.cur;
 
-        // First ring iteration starts fresh; subsequent ones have prior accumulated state.
-        const bool is_first_kv_for_this_q = (ring_iter == 0);
+        const bool is_first_kv_for_this_q = is_first_active_iter;
 
         // Multi Q-chunk restore: K0 reads prev accumulators directly from staging buffers
         // (cb_prev_out, cb_max_in, cb_sum_in) — no copy_block needed.
         // After K0's swap, reset q_cur to original accumulator CBs for normal ping-pong.
         const AccumulatorHalf original_prev = q_prev;
-        const bool restore_from_staging = (q_per_core > 1 && ring_iter > 0);
+        const bool restore_from_staging = (q_per_core > 1 && !is_first_active_iter);
         if (restore_from_staging) {
             q_prev = {cb_sum_in, cb_max_in, cb_prev_out};
         }
@@ -1766,6 +1813,29 @@ void sdpa_ring_v2(
                 q_cur.sum = cb_sum_out;
             }
 
+            // K start tile fed to diag stamp must share Q's coord frame (local for is_causal, global for chunked).
+            const uint32_t step_k_start_tile =
+                chunked_enabled ? kv_global_tile_for_local<true, local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
+                                      ring_id, k_chunk * Sk_chunk_t)
+                                : (k_chunk * Sk_chunk_t);
+
+            // Chunked-prefill: when Sk_chunk_t ∤ q_local_padded_Nt a K-chunk can straddle two
+            // per-chunk slabs in the local cache. step_k_start_tile is the global K coord of
+            // the chunk's first tile (in slab j); cols past straddle_col jump to slab j+1, an
+            // increment of chunk_size_t - q_local_padded_Nt. Stamp evaluates per-col then.
+            uint32_t step_straddle_col = 0;
+            uint32_t step_straddle_jump = 0;
+            if constexpr (chunked_enabled) {
+                if (q_local_padded_Nt > 0) {
+                    const uint32_t local_start = k_chunk * Sk_chunk_t;
+                    const uint32_t slab_end_local = (local_start / q_local_padded_Nt + 1) * q_local_padded_Nt;
+                    if (local_start + Sk_chunk_t > slab_end_local) {
+                        step_straddle_col = slab_end_local - local_start;
+                        step_straddle_jump = chunk_size_t - q_local_padded_Nt;
+                    }
+                }
+            }
+
             sdpa_inner_loop_step<
                 false,  // profiling_enabled
                 Sq_chunk_t,
@@ -1780,7 +1850,7 @@ void sdpa_ring_v2(
                 qktv_subblock_w,
                 false,  // use_padded_mask — ring uses ring mask instead
                 true,   // ring_mode
-                is_causal_sdpa,
+                is_causal_sdpa || chunked_enabled,
                 uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
@@ -1805,9 +1875,11 @@ void sdpa_ring_v2(
                 step_save_max_cb,
                 is_causal_iter,
                 q_start_tile,
-                k_chunk * Sk_chunk_t,
+                step_k_start_tile,
                 lw_mask.neginf_tile_idx,
-                lw_mask.causal_diag_tile_idx);
+                lw_mask.causal_diag_tile_idx,
+                step_straddle_col,
+                step_straddle_jump);
 
             // Post-iteration cleanup: pop previous values and swap aliases
             // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -234,7 +234,11 @@ void kernel_main() {
                 acc_state,
                 is_last_ring_iter,
                 q_per_core,
-                lw_mask);
+                lw_mask,
+                /*skip_first_half_q=*/false,
+                /*use_zigzag_balancing=*/false,
+                ChunkedContext{},
+                /*is_first_active_iter=*/(ring_iter == 0));
         } else {
             sdpa_ring<
                 cb_qk_im,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -212,7 +212,11 @@ void kernel_main() {
                 cb_sum_out,
                 cb_sum_in,
                 cb_signal,
-                needs_lightweight_mask>(
+                needs_lightweight_mask,
+                false,  // is_causal_sdpa
+                false,  // is_balanced_sdpa
+                false,  // chunked_enabled
+                local_padded_Nt>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,
@@ -220,7 +224,6 @@ void kernel_main() {
                 ring_iter,
                 ring_id,
                 num_local_k_chunks,
-                local_padded_Nt,
                 logical_nt,
                 ring_iter_needs_global_n_mask,
                 ring_iter_needs_joint_n_mask,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -154,7 +154,7 @@ void kernel_main() {
     uint32_t ring_index = fused_op_indexer.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
     // The first active iter starts with fresh accumulators; restoring would read stale staging.
-    uint32_t active_iter_idx = 0;
+    bool seen_active_iter = false;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -163,6 +163,8 @@ void kernel_main() {
         // First, find out if this ring iter processes any KV chunks.
         const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;
         const uint32_t ring_iter_kv_end_tile = ring_iter_kv_start_tile + num_local_k_chunks * Sk_chunk_t;
+        // Last tile id holding any real K data; partial trailing tile is included here and gets
+        // its padding cells masked downstream (see same line in ring_joint_reader.cpp).
         const uint32_t global_n_tile_id = logical_nt - 1;
         const bool ring_iter_processes_KV_chunks =
             chunked_enabled ? true : (ring_iter_kv_start_tile <= global_n_tile_id);
@@ -172,8 +174,8 @@ void kernel_main() {
         if (!ring_iter_does_work) {
             continue;
         }
-        const bool is_first_active_iter = (active_iter_idx == 0);
-        active_iter_idx++;
+        const bool is_first_active_iter = !seen_active_iter;
+        seen_active_iter = true;
 
         // Tile-aligned form. Chunked: real region ends on a per-chunk-region boundary
         // (k-chunk-aligned via q_local_padded_Nt % Sk_chunk_t TT_FATAL), so the per-k_chunk-

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -21,11 +21,12 @@ void kernel_main() {
     constexpr uint32_t vDHt = get_compile_time_arg_val(4);
     constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(6);
-    constexpr uint32_t local_padded_N = get_compile_time_arg_val(7);
-    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(8);
+    constexpr uint32_t q_local_padded_Nt [[maybe_unused]] = get_compile_time_arg_val(7);
+    constexpr uint32_t kv_local_padded_Nt = get_compile_time_arg_val(8);
     constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
+    // Slots 10/11: CT layout hints for the constexpr mask-CB sizing; runtime logical_nt is read below.
+    constexpr uint32_t logical_n_layout_hint = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt_layout_hint = get_compile_time_arg_val(11);
     constexpr uint32_t Lt = get_compile_time_arg_val(12);
     constexpr uint32_t L = get_compile_time_arg_val(13);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
@@ -55,28 +56,42 @@ void kernel_main() {
     constexpr bool is_causal = get_compile_time_arg_val(37) == 1;
     constexpr bool is_balanced = get_compile_time_arg_val(38) == 1;
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(39) == 1;
+    constexpr bool chunked_enabled = get_compile_time_arg_val(40) == 1;
+    constexpr uint32_t chunk_size_t = get_compile_time_arg_val(41);
+    // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
+    // path. kernel_is_causal is masked off by the program factory when chunked is on, so only
+    // one of the two paths drives the stamp per program — but they share the CB slot layout.
+    constexpr bool diag_tile_enabled = is_causal || chunked_enabled;
 
     // Lightweight mask: all mask tiles live in cb_mask_in.
     // Layout: [neginf(0)] [causal_diag?(1)] [global_n_partial?] [joint_l_partial?]
-    // Needed when any K/joint dimension has padding, or when causal masking is active.
-    constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
-    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool local_n_has_padding = kv_local_padded_Nt % Sk_chunk_t != 0;
+    constexpr bool global_n_has_padding = logical_n_layout_hint % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || is_causal;
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
 
     constexpr uint32_t neginf_tile_idx = 0;
-    constexpr uint32_t causal_diag_tile_idx = is_causal ? 1 : 0;
-    constexpr uint32_t base_partial_offset = 1 + (is_causal ? 1 : 0);
+    constexpr uint32_t causal_diag_tile_idx = diag_tile_enabled ? 1 : 0;
+    constexpr uint32_t base_partial_offset = 1 + (diag_tile_enabled ? 1 : 0);
     constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? base_partial_offset : 0;
     constexpr uint32_t joint_l_partial_tile_idx =
         (joint_l_partial_col > 0) ? (base_partial_offset + (global_n_partial_col > 0 ? 1 : 0)) : 0;
     constexpr uint32_t total_mask_tiles =
-        1 + (is_causal ? 1 : 0) + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
+        1 + (diag_tile_enabled ? 1 : 0) + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
+    // Chunked: q_start_idx_t + logical_nt pushed as RT (vary per chunk). Non-chunked: CT hints.
+    uint32_t q_start_idx_t = 0;
+    uint32_t logical_nt;
+    if constexpr (chunked_enabled) {
+        q_start_idx_t = get_arg_val<uint32_t>(argidx++);
+        logical_nt = get_arg_val<uint32_t>(argidx++);
+    } else {
+        logical_nt = logical_nt_layout_hint;
+    }
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     RingSDPAOpIndexer fused_op_indexer = RingSDPAOpIndexer(argidx);
@@ -128,10 +143,10 @@ void kernel_main() {
 
     // Precompute padded tile counts that are constant across ring iterations
     constexpr uint32_t local_n_padded_tiles =
-        (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
+        (kv_local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (kv_local_padded_Nt % Sk_chunk_t)) : 0;
     constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
 
-    using Straddle = KCausalStraddleInfo<local_padded_Nt, Sk_chunk_t>;
+    using Straddle = KCausalStraddleInfo<kv_local_padded_Nt, Sk_chunk_t>;
     constexpr bool has_straddle = Straddle::has_straddle;
     constexpr uint32_t straddle_chunk_id = Straddle::straddle_chunk_id;
     constexpr uint32_t straddle_num_padded_tiles = Straddle::straddle_num_padded_tiles;
@@ -142,47 +157,56 @@ void kernel_main() {
     };
 
     const uint32_t last_active_ring_iter = find_last_active_ring_iter(
-        fused_op_indexer.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L, is_causal, is_balanced);
+        fused_op_indexer.seq, kv_local_padded_Nt, logical_nt - 1, L, is_causal, is_balanced, chunked_enabled);
 
     uint32_t ring_index = fused_op_indexer.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
+    // The first active iter starts with fresh accumulators; restoring would read stale staging.
+    uint32_t active_iter_idx = 0;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
         const uint32_t num_kv_chunks = do_joint_kv ? num_local_k_chunks + num_joint_k_chunks : num_local_k_chunks;
 
         // First, find out if this ring iter processes any KV chunks.
-        const uint32_t ring_iter_kv_start_tile = ring_id * local_padded_Nt;
+        const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;
         const uint32_t ring_iter_kv_end_tile = ring_iter_kv_start_tile + num_local_k_chunks * Sk_chunk_t;
-        const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;
-        const bool ring_iter_processes_KV_chunks = ring_iter_kv_start_tile <= global_n_tile_id;
+        const uint32_t global_n_tile_id = logical_nt - 1;
+        const bool ring_iter_processes_KV_chunks =
+            chunked_enabled ? true : (ring_iter_kv_start_tile <= global_n_tile_id);
         const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || (do_joint_kv && L != 0)) &&
                                          !(is_causal && ring_index < ring_id && !is_balanced);
 
         if (!ring_iter_does_work) {
             continue;
         }
+        const bool is_first_active_iter = (active_iter_idx == 0);
+        active_iter_idx++;
 
-        const int32_t global_n_within_ring_iter = logical_n - ring_id * local_padded_N;
-        // Note the > and <=. This means there is real length of logical_n within this ring iter.
+        // Tile-aligned form. Chunked: real region ends on a per-chunk-region boundary
+        // (k-chunk-aligned via q_local_padded_Nt % Sk_chunk_t TT_FATAL), so the per-k_chunk-
+        // start skip handles it.
+        const int32_t global_nt_within_ring_iter =
+            static_cast<int32_t>(logical_nt) - static_cast<int32_t>(ring_id * kv_local_padded_Nt);
         const bool global_n_is_within_ring_iter =
-            global_n_within_ring_iter > 0 && global_n_within_ring_iter <= (int32_t)local_padded_N;
-        const bool global_n_needs_masking = global_n_within_ring_iter % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+            !chunked_enabled &&
+            (global_nt_within_ring_iter > 0 && global_nt_within_ring_iter <= (int32_t)kv_local_padded_Nt);
+        const bool global_n_needs_masking = (global_nt_within_ring_iter % (int32_t)Sk_chunk_t) != 0;
         const bool ring_iter_needs_global_n_mask = global_n_is_within_ring_iter && global_n_needs_masking;
-        const uint32_t global_n_mask_chunk_id = global_n_within_ring_iter / (Sk_chunk_t * tt::constants::TILE_HEIGHT);
+        const uint32_t global_n_mask_chunk_id = global_nt_within_ring_iter / Sk_chunk_t;
 
         // LOCAL N MASK
-        const bool local_n_needs_masking = local_padded_Nt % Sk_chunk_t != 0;
-        const uint32_t local_n_mask_chunk_id = local_padded_Nt / Sk_chunk_t;
+        const bool local_n_needs_masking = kv_local_padded_Nt % Sk_chunk_t != 0;
+        const uint32_t local_n_mask_chunk_id = kv_local_padded_Nt / Sk_chunk_t;
 
         // JOINT L MASK
         const bool joint_n_needs_masking = L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
         const bool ring_iter_needs_joint_n_mask = joint_n_needs_masking && do_joint_kv;
         const uint32_t joint_n_mask_chunk_id = L / (Sk_chunk_t * tt::constants::TILE_HEIGHT);
 
-        // Build lightweight mask context for this ring iteration
+        // is_causal: diagonal only on iter 0 (K is local-frame). Chunked: every iter (absolute coords).
         LightweightMaskContext lw_mask;
-        lw_mask.is_causal = (ring_iter == 0 ? is_causal : false);
+        lw_mask.is_causal = chunked_enabled || (is_causal && ring_iter == 0);
         lw_mask.neginf_tile_idx = neginf_tile_idx;
         lw_mask.causal_diag_tile_idx = causal_diag_tile_idx;
         lw_mask.local_n_padded_tiles = local_n_padded_tiles;
@@ -197,9 +221,8 @@ void kernel_main() {
         lw_mask.straddle_num_padded_tiles = ring_iter_needs_straddle_mask ? straddle_num_padded_tiles : 0;
         lw_mask.straddle_mask_chunk_id = straddle_chunk_id;
         if (ring_iter_needs_global_n_mask) {
-            const uint32_t unpadded_in_chunk = global_n_within_ring_iter % (Sk_chunk_t * tt::constants::TILE_HEIGHT);
-            const uint32_t valid_tiles =
-                (unpadded_in_chunk + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT;
+            // Tile-aligned: valid_tiles == global_nt_within_ring_iter % Sk_chunk_t
+            const uint32_t valid_tiles = global_nt_within_ring_iter % Sk_chunk_t;
             lw_mask.global_n_padded_tiles = Sk_chunk_t - valid_tiles;
         }
 
@@ -254,7 +277,11 @@ void kernel_main() {
                 cb_signal,
                 needs_lightweight_mask,
                 is_causal,
-                is_balanced>(
+                is_balanced,
+                chunked_enabled,
+                kv_local_padded_Nt,
+                q_local_padded_Nt,
+                chunk_size_t>(
                 global_q_start,
                 global_q_end,
                 iter_num_kv_chunks,
@@ -262,7 +289,6 @@ void kernel_main() {
                 ring_iter,
                 ring_id,
                 num_local_k_chunks,
-                local_padded_Nt,
                 logical_nt,
                 ring_iter_needs_global_n_mask,
                 ring_iter_needs_joint_n_mask,
@@ -275,7 +301,9 @@ void kernel_main() {
                 q_per_core,
                 lw_mask,
                 skip_first_half_q,
-                use_zigzag_balancing);
+                use_zigzag_balancing,
+                ChunkedContext{q_start_idx_t, ring_index},
+                is_first_active_iter);
         } else {
             sdpa_ring<
                 cb_qk_im,
@@ -287,7 +315,10 @@ void kernel_main() {
                 DHt,
                 vDHt,
                 scale_fp32,
-                needs_lightweight_mask>(
+                needs_lightweight_mask,
+                chunked_enabled,
+                q_local_padded_Nt,
+                chunk_size_t>(
                 qk_in0_block_w,
                 qk_subblock_w,
                 qk_subblock_h,
@@ -313,7 +344,7 @@ void kernel_main() {
                 ring_iter,
                 ring_id,
                 num_local_k_chunks,
-                local_padded_Nt,
+                kv_local_padded_Nt,
                 logical_nt,
                 ring_iter_needs_global_n_mask,
                 ring_iter_needs_joint_n_mask,
@@ -341,7 +372,8 @@ void kernel_main() {
                 lw_mask.is_causal,
                 skip_first_half_q,
                 is_last_ring_iter,
-                use_zigzag_balancing);
+                use_zigzag_balancing,
+                ChunkedContext{q_start_idx_t, ring_index});
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -24,9 +24,8 @@ void kernel_main() {
     constexpr uint32_t q_local_padded_Nt [[maybe_unused]] = get_compile_time_arg_val(7);
     constexpr uint32_t kv_local_padded_Nt = get_compile_time_arg_val(8);
     constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
-    // Slots 10/11: CT layout hints for the constexpr mask-CB sizing; runtime logical_nt is read below.
-    constexpr uint32_t logical_n_layout_hint = get_compile_time_arg_val(10);
-    constexpr uint32_t logical_nt_layout_hint = get_compile_time_arg_val(11);
+    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
     constexpr uint32_t Lt = get_compile_time_arg_val(12);
     constexpr uint32_t L = get_compile_time_arg_val(13);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
@@ -66,7 +65,7 @@ void kernel_main() {
     // Lightweight mask: all mask tiles live in cb_mask_in.
     // Layout: [neginf(0)] [causal_diag?(1)] [global_n_partial?] [joint_l_partial?]
     constexpr bool local_n_has_padding = kv_local_padded_Nt % Sk_chunk_t != 0;
-    constexpr bool global_n_has_padding = logical_n_layout_hint % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask =
         (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
@@ -80,18 +79,11 @@ void kernel_main() {
     constexpr uint32_t total_mask_tiles =
         1 + (diag_tile_enabled ? 1 : 0) + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
+    constexpr uint32_t q_start_idx_t = chunked_enabled ? (kv_local_padded_Nt - q_local_padded_Nt) * ring_size : 0;
+
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    // Chunked: q_start_idx_t + logical_nt pushed as RT (vary per chunk). Non-chunked: CT hints.
-    uint32_t q_start_idx_t = 0;
-    uint32_t logical_nt;
-    if constexpr (chunked_enabled) {
-        q_start_idx_t = get_arg_val<uint32_t>(argidx++);
-        logical_nt = get_arg_val<uint32_t>(argidx++);
-    } else {
-        logical_nt = logical_nt_layout_hint;
-    }
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     RingSDPAOpIndexer fused_op_indexer = RingSDPAOpIndexer(argidx);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Chunked-prefill helpers consumed by the compute kernels (compute_common.hpp,
+// compute_streaming.hpp). Kept separate from ring_utils.hpp so the compute
+// headers don't pull in RingIdSequencer / find_last_active_ring_iter — the
+// experimental sibling kernel (exp_ring_joint_sdpa) defines its own copies of
+// those in exp_ring_utils.hpp, and including ring_utils.hpp from the compute
+// headers would collide with that copy.
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * Per-call chunked-prefill runtime state for sdpa_ring_v2. The compile-time per-chunk
+ * geometry (q_local_padded_Nt / chunk_size_t) lives in template params; this struct
+ * carries the per-chunk runtime offsets.
+ */
+struct ChunkedContext {
+    uint32_t q_start_idx_t = 0;  // absolute Q-tile offset of this chunk's Q slab
+    uint32_t ring_index = 0;     // logical ring rotation index for absolute-Q-tile compute
+};
+
+/**
+ * Map a device-local K tile index to its global attention K position. Used by the
+ * logical_n skip predicate and the diagonal-stamp mask coords. Under chunked-prefill
+ * the local cache packs the per-chunk K region for each chunk back-to-back; each
+ * region is q_local_padded_Nt tiles (= Q's per-device extent, since one chunk's Q
+ * is one such region), so the mapping is non-monotonic.
+ */
+template <
+    bool chunked_enabled,
+    uint32_t kv_local_padded_Nt = 0,
+    uint32_t chunk_size_t = 0,
+    uint32_t q_local_padded_Nt = 0>
+inline uint32_t kv_global_tile_for_local(uint32_t ring_id, uint32_t local_tile_idx) {
+    if constexpr (chunked_enabled) {
+        return (local_tile_idx / q_local_padded_Nt) * chunk_size_t + ring_id * q_local_padded_Nt +
+               (local_tile_idx % q_local_padded_Nt);
+    } else {
+        return ring_id * kv_local_padded_Nt + local_tile_idx;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -248,7 +248,9 @@ void kernel_main() {
             }
         }
 
-        // Last real (non-padding) tile id; logical_nt-1 == (logical_n-1)/TILE_H for tile-aligned logical_n.
+        // Last tile id holding any real (non-padding) K data (logical_nt is ceil(logical_n / TILE_H)).
+        // When logical_n is not tile-aligned, this tile is partially real — its padding cells are
+        // stamped to -inf by the lightweight mask later, so we still include it as active here.
         // Chunked-prefill: balanced layout puts one slab of real K per chunk on every device → every iter is active.
         const uint32_t global_n_tile_id = logical_nt - 1;
         const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -23,9 +23,8 @@ void kernel_main() {
     constexpr uint32_t kv_local_padded_Nt = get_compile_time_arg_val(8);
     constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
     // Slot 10: reader-unused (writer/compute consume it for constexpr mask-CB sizing).
-    // Slot 11: non-chunked logical_nt fallback — reader uses an RT logical_nt only when chunked.
-    constexpr uint32_t logical_n_layout_hint [[maybe_unused]] = get_compile_time_arg_val(10);
-    constexpr uint32_t logical_nt_layout_hint = get_compile_time_arg_val(11);
+    constexpr uint32_t logical_n [[maybe_unused]] = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
     constexpr uint32_t Lt = get_compile_time_arg_val(12);
     constexpr uint32_t L = get_compile_time_arg_val(13);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
@@ -68,13 +67,6 @@ void kernel_main() {
     const uint32_t joint_v_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    // Chunked: RT (varies per chunk, not in program-cache key). Non-chunked: CT hint keeps the skip math constexpr.
-    uint32_t logical_nt;
-    if constexpr (chunked_enabled) {
-        logical_nt = get_arg_val<uint32_t>(argidx++);
-    } else {
-        logical_nt = logical_nt_layout_hint;
-    }
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     // Head chain runtime args (always present)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -19,11 +19,13 @@ void kernel_main() {
     constexpr uint32_t vDHt = get_compile_time_arg_val(4);
     constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(6);
-    constexpr uint32_t local_padded_N = get_compile_time_arg_val(7);
-    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(8);
+    constexpr uint32_t q_local_padded_Nt = get_compile_time_arg_val(7);
+    constexpr uint32_t kv_local_padded_Nt = get_compile_time_arg_val(8);
     constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
+    // Slot 10: reader-unused (writer/compute consume it for constexpr mask-CB sizing).
+    // Slot 11: non-chunked logical_nt fallback — reader uses an RT logical_nt only when chunked.
+    constexpr uint32_t logical_n_layout_hint [[maybe_unused]] = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt_layout_hint = get_compile_time_arg_val(11);
     constexpr uint32_t Lt = get_compile_time_arg_val(12);
     constexpr uint32_t L = get_compile_time_arg_val(13);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
@@ -36,14 +38,17 @@ void kernel_main() {
     constexpr uint32_t is_causal = get_compile_time_arg_val(21);
     constexpr uint32_t is_balanced = get_compile_time_arg_val(22);
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(23) == 1;
+    // Reader's slot-24 carries chunked_enabled; writer/compute use slot-24/33 for use_streaming_compute.
+    constexpr bool chunked_enabled = get_compile_time_arg_val(24) == 1;
     constexpr uint32_t num_q_readers = get_compile_time_arg_val(25);
+    constexpr uint32_t chunk_size_t = get_compile_time_arg_val(26);
 
     // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
     // and dropped by the compiler, eliminating runtime ternaries and joint generator uses.
     constexpr bool has_joint_q = num_joint_q_chunks > 0;
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
 
-    constexpr auto q_args = TensorAccessorArgs<26>();
+    constexpr auto q_args = TensorAccessorArgs<27>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -63,6 +68,13 @@ void kernel_main() {
     const uint32_t joint_v_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
+    // Chunked: RT (varies per chunk, not in program-cache key). Non-chunked: CT hint keeps the skip math constexpr.
+    uint32_t logical_nt;
+    if constexpr (chunked_enabled) {
+        logical_nt = get_arg_val<uint32_t>(argidx++);
+    } else {
+        logical_nt = logical_nt_layout_hint;
+    }
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     // Head chain runtime args (always present)
@@ -204,9 +216,9 @@ void kernel_main() {
     const auto joint_k_reader = TensorAccessor(joint_k_args, joint_k_addr);
     const auto joint_v_reader = TensorAccessor(joint_v_args, joint_v_addr);
 
-    const auto input_q_tile_logical = TensorTileShape(B, NH, local_padded_Nt, DHt);
-    const auto input_k_tile_logical = TensorTileShape(B, NHK, local_padded_Nt, DHt);
-    const auto input_v_tile_logical = TensorTileShape(B, NH, local_padded_Nt, vDHt);
+    const auto input_q_tile_logical = TensorTileShape(B, NH, q_local_padded_Nt, DHt);
+    const auto input_k_tile_logical = TensorTileShape(B, NHK, kv_local_padded_Nt, DHt);
+    const auto input_v_tile_logical = TensorTileShape(B, NH, kv_local_padded_Nt, vDHt);
     const auto gathered_k_input_tile_logical = TensorTileShape(B, NHK, padded_Nt, DHt);
     const auto gathered_v_input_tile_logical = TensorTileShape(B, NH, padded_Nt, vDHt);
     const auto joint_input_tile_logical = TensorTileShape(B, NH, Lt, DHt);
@@ -244,9 +256,12 @@ void kernel_main() {
             }
         }
 
-        const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;  // Floor division to get tile ID
-        const uint32_t ring_iter_kv_start_tile = ring_id * local_padded_Nt;
-        const bool ring_iter_processes_KV_chunks = ring_iter_kv_start_tile <= global_n_tile_id;
+        // Last real (non-padding) tile id; logical_nt-1 == (logical_n-1)/TILE_H for tile-aligned logical_n.
+        // Chunked-prefill: balanced layout puts one slab of real K per chunk on every device → every iter is active.
+        const uint32_t global_n_tile_id = logical_nt - 1;
+        const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;
+        const bool ring_iter_processes_KV_chunks =
+            chunked_enabled ? true : (ring_iter_kv_start_tile <= global_n_tile_id);
 
         // In causal non balanced case when processing KV received from other devices:
         // - skip over KV received from subsequent devices
@@ -275,7 +290,7 @@ void kernel_main() {
             iter_num_kv_chunks /= 2;
             // Mirror compute's K-loop extension: include the straddle chunk so K/V tiles
             // for it get loaded. Compute -inf-masks its late-half columns via lw_mask.
-            using Straddle = KCausalStraddleInfo<local_padded_Nt, Sk_chunk_t>;
+            using Straddle = KCausalStraddleInfo<kv_local_padded_Nt, Sk_chunk_t>;
             if constexpr (Straddle::has_straddle) {
                 iter_num_kv_chunks = Straddle::straddle_chunk_id + 1;
             }
@@ -314,7 +329,7 @@ void kernel_main() {
 
             // Default to local Q tensor; override below for joint Q when applicable.
             Slice q_slice(nb, nq, q_row_start_tile, q_row_start_tile + Sq_chunk_t, 0, DHt);
-            uint32_t q_end_seq_tile = local_padded_Nt;
+            uint32_t q_end_seq_tile = q_local_padded_Nt;
             if constexpr (has_joint_q) {
                 if (is_joint_q) {
                     const uint32_t joint_q_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
@@ -337,8 +352,9 @@ void kernel_main() {
                  * If this k chunk is in the spatial input and beyond the logical N, we will skip it.
                  */
                 const bool kv_chunk_is_joint = has_joint_k ? (k_chunk >= num_local_k_chunks) : false;
-                // Global index into the padded KV tensor
-                const uint32_t kv_global_start_tile = local_padded_Nt * ring_id + k_chunk * Sk_chunk_t;
+                const uint32_t kv_global_start_tile =
+                    kv_global_tile_for_local<chunked_enabled, kv_local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
+                        ring_id, k_chunk * Sk_chunk_t);
                 const bool kv_chunk_is_beyond_logical_n = !kv_chunk_is_joint && (kv_global_start_tile >= logical_nt);
 
                 if (kv_chunk_is_beyond_logical_n) {
@@ -355,12 +371,15 @@ void kernel_main() {
                     const uint32_t local_k_row_start_tile = k_chunk * Sk_chunk_t;
                     k_slice = Slice(nb, nk, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, DHt);
                     v_slice = Slice(nb, nq, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, vDHt);
-                    end_seq_tile = std::min(logical_nt, local_padded_Nt);
+                    // Chunked: gathered-K coord ≠ global-K coord, so skip the logical_nt clamp
+                    // (host pre-zeros padding slabs, so reading the full slice is safe).
+                    end_seq_tile = chunked_enabled ? kv_local_padded_Nt : std::min(logical_nt, kv_local_padded_Nt);
                 } else {
                     const uint32_t gathered_kv_start_tile = ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
                     k_slice = Slice(nb, nk, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
                     v_slice = Slice(nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, vDHt);
-                    end_seq_tile = std::min(logical_nt, local_padded_Nt * (ring_id + 1));
+                    end_seq_tile = chunked_enabled ? kv_local_padded_Nt * (ring_id + 1)
+                                                   : std::min(logical_nt, kv_local_padded_Nt * (ring_id + 1));
                 }
                 if constexpr (has_joint_k) {
                     if (kv_chunk_is_joint) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -312,9 +312,8 @@ void kernel_main() {
     constexpr uint32_t q_local_padded_Nt = get_compile_time_arg_val(7);
     constexpr uint32_t kv_local_padded_Nt = get_compile_time_arg_val(8);
     constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
-    // Slots 10/11: CT layout hints for the constexpr mask-CB sizing; runtime logical_nt is read below.
-    constexpr uint32_t logical_n_layout_hint = get_compile_time_arg_val(10);
-    constexpr uint32_t logical_nt_layout_hint = get_compile_time_arg_val(11);
+    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
     constexpr uint32_t Lt = get_compile_time_arg_val(12);
     constexpr uint32_t L = get_compile_time_arg_val(13);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
@@ -355,13 +354,6 @@ void kernel_main() {
     const uint32_t stats_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    // Chunked: RT (varies per chunk). Non-chunked: CT hint keeps the skip math constexpr.
-    uint32_t logical_nt;
-    if constexpr (chunked_enabled) {
-        logical_nt = get_arg_val<uint32_t>(argidx++);
-    } else {
-        logical_nt = logical_nt_layout_hint;
-    }
 
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         false, /* wait_for_op_signal */
@@ -412,7 +404,7 @@ void kernel_main() {
     // Lightweight mask: generate all mask tiles once into single CB before the ring loop.
     // Needed when any K/joint dimension has padding, or when causal/chunked masking is active.
     constexpr bool local_n_has_padding = kv_local_padded_Nt % Sk_chunk_t != 0;
-    constexpr bool global_n_has_padding = logical_n_layout_hint % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask =
         (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -265,17 +265,17 @@ inline QChunkInfo get_q_chunk_info(
     const uint32_t Sq_chunk_t,
     const uint32_t DHt,
     const uint32_t Lt,
-    const uint32_t local_padded_Nt) {
+    const uint32_t q_local_padded_Nt) {
     QChunkInfo info;
     if constexpr (has_joint_q) {
         info.is_joint_q = q_chunk >= num_local_q_chunks;
         if (info.is_joint_q) {
             const uint32_t joint_out_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
             info.out_slice = Slice(nb, nq, joint_out_row_start_tile, joint_out_row_start_tile + Sq_chunk_t, 0, DHt);
-            info.stats_seq_start_tile = local_padded_Nt + (q_chunk - num_local_q_chunks) * Sq_chunk_t;
+            info.stats_seq_start_tile = q_local_padded_Nt + (q_chunk - num_local_q_chunks) * Sq_chunk_t;
             info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
-            info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt + Lt);
-            info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt + Lt);
+            info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, q_local_padded_Nt + Lt);
+            info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, q_local_padded_Nt + Lt);
             return info;
         }
     } else {
@@ -285,19 +285,19 @@ inline QChunkInfo get_q_chunk_info(
     info.out_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);
     info.stats_seq_start_tile = q_chunk * Sq_chunk_t;
     info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
-    info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt);
-    info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt);
+    info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, q_local_padded_Nt);
+    info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, q_local_padded_Nt);
     return info;
 }
 
 // Padding boundary for write paths — needs ring_id to know how far the valid sequence extends.
 // has_joint_q: when false, joint branch is statically dead.
 template <bool has_joint_q>
-inline uint32_t get_end_seq_tile(const QChunkInfo& qi, uint32_t ring_id, uint32_t Lt, uint32_t local_padded_Nt) {
+inline uint32_t get_end_seq_tile(const QChunkInfo& qi, uint32_t ring_id, uint32_t Lt, uint32_t q_local_padded_Nt) {
     if constexpr (has_joint_q) {
-        return qi.is_joint_q ? Lt : local_padded_Nt * (ring_id + 1);
+        return qi.is_joint_q ? Lt : q_local_padded_Nt * (ring_id + 1);
     } else {
-        return local_padded_Nt * (ring_id + 1);
+        return q_local_padded_Nt * (ring_id + 1);
     }
 }
 
@@ -309,11 +309,12 @@ void kernel_main() {
     constexpr uint32_t vDHt = get_compile_time_arg_val(4);
     constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(6);
-    constexpr uint32_t local_padded_N = get_compile_time_arg_val(7);
-    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(8);
+    constexpr uint32_t q_local_padded_Nt = get_compile_time_arg_val(7);
+    constexpr uint32_t kv_local_padded_Nt = get_compile_time_arg_val(8);
     constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
+    // Slots 10/11: CT layout hints for the constexpr mask-CB sizing; runtime logical_nt is read below.
+    constexpr uint32_t logical_n_layout_hint = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt_layout_hint = get_compile_time_arg_val(11);
     constexpr uint32_t Lt = get_compile_time_arg_val(12);
     constexpr uint32_t L = get_compile_time_arg_val(13);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
@@ -332,13 +333,19 @@ void kernel_main() {
     constexpr uint32_t is_balanced = get_compile_time_arg_val(26) == 1;
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(27) == 1;
     constexpr uint32_t out_subblock_h = get_compile_time_arg_val(28);
+    constexpr bool chunked_enabled = get_compile_time_arg_val(29) == 1;
+    constexpr uint32_t chunk_size_t = get_compile_time_arg_val(30);
+    // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
+    // path. The program factory masks kernel_is_causal off when chunked is on, so only one of
+    // the two paths drives the stamp per program — but they share the CB slot layout.
+    constexpr bool diag_tile_enabled = (is_causal == 1) || chunked_enabled;
 
     // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
     // and dropped by the compiler, eliminating runtime ternaries and the joint_out_generator.
     constexpr bool has_joint_q = num_joint_q_chunks > 0;
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
 
-    constexpr auto out_args = TensorAccessorArgs<29>();
+    constexpr auto out_args = TensorAccessorArgs<31>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
 
@@ -348,6 +355,13 @@ void kernel_main() {
     const uint32_t stats_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
+    // Chunked: RT (varies per chunk). Non-chunked: CT hint keeps the skip math constexpr.
+    uint32_t logical_nt;
+    if constexpr (chunked_enabled) {
+        logical_nt = get_arg_val<uint32_t>(argidx++);
+    } else {
+        logical_nt = logical_nt_layout_hint;
+    }
 
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         false, /* wait_for_op_signal */
@@ -377,11 +391,11 @@ void kernel_main() {
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr);
     const auto stats_writer = TensorAccessor(stats_args, stats_addr);
 
-    const auto output_tile_logical = TensorTileShape(B, NH, local_padded_Nt, vDHt);
+    const auto output_tile_logical = TensorTileShape(B, NH, q_local_padded_Nt, vDHt);
     const auto joint_tile_logical = TensorTileShape(B, NH, Lt, vDHt);
     // stats tensor is 2× the sequence length: first half stores max (used by both eager and
     // deferred-norm paths), second half stores sum (deferred-norm only).
-    const auto stats_tile_logical = TensorTileShape(B, NH, (local_padded_Nt + Lt) * 2, 1);
+    const auto stats_tile_logical = TensorTileShape(B, NH, (q_local_padded_Nt + Lt) * 2, 1);
 
     const auto out_generator = PaddedAddrGenerator(out_writer, output_tile_logical);
     const auto joint_out_generator = PaddedAddrGenerator(joint_out_writer, joint_tile_logical);
@@ -396,18 +410,18 @@ void kernel_main() {
         /*compute_uses_reduce_tile=*/true>();
 
     // Lightweight mask: generate all mask tiles once into single CB before the ring loop.
-    // Needed when any K/joint dimension has padding, or when causal masking is active.
-    constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
-    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    // Needed when any K/joint dimension has padding, or when causal/chunked masking is active.
+    constexpr bool local_n_has_padding = kv_local_padded_Nt % Sk_chunk_t != 0;
+    constexpr bool global_n_has_padding = logical_n_layout_hint % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || is_causal;
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
     if constexpr (needs_lightweight_mask) {
-        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in, is_causal>();
+        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in, diag_tile_enabled>();
     }
 
     const uint32_t last_active_ring_iter = find_last_active_ring_iter(
-        fused_op_receiver.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L, is_causal, is_balanced);
+        fused_op_receiver.seq, kv_local_padded_Nt, logical_nt - 1, L, is_causal, is_balanced, chunked_enabled);
 
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
@@ -422,6 +436,8 @@ void kernel_main() {
         QChunkInfo qi = {};
     } deferred = {};
 
+    // Track non-skipped iters so the first active iter starts with fresh accumulators (matches compute).
+    uint32_t active_iter_idx = 0;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -432,22 +448,26 @@ void kernel_main() {
             }
         }
 
-        const uint32_t ring_iter_kv_start_tile = ring_id * local_padded_Nt;
+        const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;
         const uint32_t ring_iter_kv_end_tile = ring_iter_kv_start_tile + num_local_k_chunks * Sk_chunk_t;
-        const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;
-        const bool ring_iter_processes_KV_chunks = ring_iter_kv_start_tile <= global_n_tile_id;
+        const uint32_t global_n_tile_id = logical_nt - 1;
+        const bool ring_iter_processes_KV_chunks =
+            chunked_enabled ? true : (ring_iter_kv_start_tile <= global_n_tile_id);
         const bool joint_contributes = (has_joint_k && L != 0) ? do_joint_kv : false;
         const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || joint_contributes) &&
                                          !(is_causal && ring_index < ring_id && !is_balanced);
         if (!ring_iter_does_work) {
             continue;
         }
+        const bool is_first_active_iter = (active_iter_idx == 0);
+        active_iter_idx++;
 
         // When total_valid_kv == 1, compute's sole K chunk triggers save_to_staging on K0,
         // reserving staging CBs immediately. The deferred flush must happen before any
         // prefetch that blocks on cb_prev_out, or the writer and compute deadlock.
         const uint32_t total_valid_kv =
-            count_valid_kv_chunks(num_kv_chunks, num_local_k_chunks, ring_iter_kv_start_tile, Sk_chunk_t, logical_nt);
+            count_valid_kv_chunks<chunked_enabled, kv_local_padded_Nt, Sk_chunk_t, chunk_size_t, q_local_padded_Nt>(
+                num_kv_chunks, num_local_k_chunks, ring_id, logical_nt);
         const bool single_valid_kv_chunk = (total_valid_kv <= 1);
 
         /**
@@ -467,17 +487,19 @@ void kernel_main() {
             - If joint length L does not divide by K chunk size, the last chunk needs a mask
         */
 
-        // GLOBAL N MASK
-        // Find out if logical_n falls within this ring iter's KV range
-        const int32_t global_n_within_ring_iter = logical_n - ring_id * local_padded_N;
-        // Note the > and <=. This means there is real length of logical_n within this ring iter.
+        // GLOBAL N MASK — tile-aligned form. Chunked uses the per-k_chunk-start skip
+        // (q_local_padded_Nt % Sk_chunk_t == 0 TT_FATAL guarantees the real region ends at a
+        // chunk boundary).
+        const int32_t global_nt_within_ring_iter =
+            static_cast<int32_t>(logical_nt) - static_cast<int32_t>(ring_id * kv_local_padded_Nt);
         const bool global_n_is_within_ring_iter =
-            global_n_within_ring_iter > 0 && global_n_within_ring_iter <= (int32_t)local_padded_N;
-        const bool global_n_needs_masking = global_n_within_ring_iter % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+            !chunked_enabled &&
+            (global_nt_within_ring_iter > 0 && global_nt_within_ring_iter <= (int32_t)kv_local_padded_Nt);
+        const bool global_n_needs_masking = (global_nt_within_ring_iter % (int32_t)Sk_chunk_t) != 0;
         const bool ring_iter_needs_global_n_mask = global_n_is_within_ring_iter && global_n_needs_masking;
 
         // LOCAL N MASK
-        const bool local_n_needs_masking = local_padded_Nt % Sk_chunk_t != 0;
+        const bool local_n_needs_masking = kv_local_padded_Nt % Sk_chunk_t != 0;
         // If global N is in the ring iter, it supersedes the local N mask.
         const bool ring_iter_needs_local_n_mask = local_n_needs_masking && !global_n_is_within_ring_iter;
 
@@ -493,7 +515,7 @@ void kernel_main() {
             // Multi Q-chunk: raw accumulators round-trip through DRAM between ring iterations.
             const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
             const bool single_q_chunk = (global_q_end - global_q_start == 1);
-            constexpr uint32_t sum_offset = local_padded_Nt + Lt;
+            constexpr uint32_t sum_offset = q_local_padded_Nt + Lt;
             constexpr uint32_t out_num_tiles = Sq_chunk_t * vDHt;
 
             const uint32_t q_per_core = global_q_end - global_q_start;
@@ -519,7 +541,7 @@ void kernel_main() {
                 const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t qc_pf = gq % num_q_chunks;
                 const auto qi_pf = get_q_chunk_info<has_joint_q>(
-                    qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                    qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, q_local_padded_Nt);
                 const auto& gen_pf = [&]() -> const auto& {
                     if constexpr (has_joint_q) {
                         if (qi_pf.is_joint_q) {
@@ -604,13 +626,14 @@ void kernel_main() {
                 const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
 
                 const auto qi = get_q_chunk_info<has_joint_q>(
-                    q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                const uint32_t end_seq_tile = get_end_seq_tile<has_joint_q>(qi, ring_id, Lt, local_padded_Nt);
+                    q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, q_local_padded_Nt);
+                const uint32_t end_seq_tile = get_end_seq_tile<has_joint_q>(qi, ring_id, Lt, q_local_padded_Nt);
 
                 // 1. Complete restore for all Q chunks to keep the prefetch pipeline in sync.
                 // For balanced-skip non-last-ring-iter Q chunks, barrier without pushing —
                 // compute skips these Q chunks entirely and doesn't need staging data.
-                if (!single_q_chunk && ring_iter > 0) {
+                // First active iter has no prior save (matches compute's is_first_kv_for_this_q).
+                if (!single_q_chunk && !is_first_active_iter) {
                     if (balanced_skip_q && !is_last_ring_iter) {
                         noc_async_read_barrier();
                     } else {
@@ -638,7 +661,7 @@ void kernel_main() {
                 // normalize finishes, creating a cycle with cb_out. Deferred prefetch below
                 // runs after write_out to break the cycle.
                 const bool defer_prefetch = balanced_skip_q && is_last_ring_iter;
-                if (!single_q_chunk && ring_iter > 0 && !defer_prefetch) {
+                if (!single_q_chunk && !is_first_active_iter && !defer_prefetch) {
                     prefetch_intra_ring(q_index + 1);
                 }
                 // Cross-ring: Q[N-1] -> Q[0] of next ring iter.
@@ -715,8 +738,8 @@ void kernel_main() {
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
                 const auto qi = get_q_chunk_info<has_joint_q>(
-                    q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                const uint32_t end_seq_tile = get_end_seq_tile<has_joint_q>(qi, ring_id, Lt, local_padded_Nt);
+                    q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, q_local_padded_Nt);
+                const uint32_t end_seq_tile = get_end_seq_tile<has_joint_q>(qi, ring_id, Lt, q_local_padded_Nt);
 
                 // Only truly causal case appear in the iteration with local KV
                 // Other iterations will just skip the computation with subsequent KV chunks

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -429,7 +429,7 @@ void kernel_main() {
     } deferred = {};
 
     // Track non-skipped iters so the first active iter starts with fresh accumulators (matches compute).
-    uint32_t active_iter_idx = 0;
+    bool seen_active_iter = false;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -442,6 +442,8 @@ void kernel_main() {
 
         const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;
         const uint32_t ring_iter_kv_end_tile = ring_iter_kv_start_tile + num_local_k_chunks * Sk_chunk_t;
+        // Last tile id holding any real K data; partial trailing tile is included here and gets
+        // its padding cells masked downstream (see same line in ring_joint_reader.cpp).
         const uint32_t global_n_tile_id = logical_nt - 1;
         const bool ring_iter_processes_KV_chunks =
             chunked_enabled ? true : (ring_iter_kv_start_tile <= global_n_tile_id);
@@ -451,8 +453,8 @@ void kernel_main() {
         if (!ring_iter_does_work) {
             continue;
         }
-        const bool is_first_active_iter = (active_iter_idx == 0);
-        active_iter_idx++;
+        const bool is_first_active_iter = !seen_active_iter;
+        seen_active_iter = true;
 
         // When total_valid_kv == 1, compute's sole K chunk triggers save_to_staging on K0,
         // reserving staging CBs immediately. The deferred flush must happen before any
@@ -479,9 +481,10 @@ void kernel_main() {
             - If joint length L does not divide by K chunk size, the last chunk needs a mask
         */
 
-        // GLOBAL N MASK — tile-aligned form. Chunked uses the per-k_chunk-start skip
-        // (q_local_padded_Nt % Sk_chunk_t == 0 TT_FATAL guarantees the real region ends at a
-        // chunk boundary).
+        // GLOBAL N MASK — tile-aligned form. In chunked-prefill mode this whole mask path is
+        // disabled: global_n_is_within_ring_iter is gated on !chunked_enabled below, so the
+        // skip-by-per-k-chunk-start logic in compute handles the trailing real-region boundary
+        // instead.
         const int32_t global_nt_within_ring_iter =
             static_cast<int32_t>(logical_nt) - static_cast<int32_t>(ring_id * kv_local_padded_Nt);
         const bool global_n_is_within_ring_iter =

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
@@ -91,15 +91,49 @@ struct RingIdSequencer {
 };
 
 /**
+ * Per-call chunked-prefill runtime state for sdpa_ring_v2. The compile-time per-chunk
+ * geometry (q_local_padded_Nt / chunk_size_t) lives in template params; this struct
+ * carries the per-chunk runtime offsets.
+ */
+struct ChunkedContext {
+    uint32_t q_start_idx_t = 0;  // absolute Q-tile offset of this chunk's Q slab
+    uint32_t ring_index = 0;     // logical ring rotation index for absolute-Q-tile compute
+};
+
+/**
+ * Map a device-local K tile index to its global attention K position. Used by the
+ * logical_n skip predicate and the diagonal-stamp mask coords. Under chunked-prefill
+ * the local cache packs the per-chunk K region for each chunk back-to-back; each
+ * region is q_local_padded_Nt tiles (= Q's per-device extent, since one chunk's Q
+ * is one such region), so the mapping is non-monotonic.
+ */
+template <
+    bool chunked_enabled,
+    uint32_t kv_local_padded_Nt = 0,
+    uint32_t chunk_size_t = 0,
+    uint32_t q_local_padded_Nt = 0>
+inline uint32_t kv_global_tile_for_local(uint32_t ring_id, uint32_t local_tile_idx) {
+    if constexpr (chunked_enabled) {
+        return (local_tile_idx / q_local_padded_Nt) * chunk_size_t + ring_id * q_local_padded_Nt +
+               (local_tile_idx % q_local_padded_Nt);
+    } else {
+        return ring_id * kv_local_padded_Nt + local_tile_idx;
+    }
+}
+
+/**
  * Find the last ring iteration that performs actual KV computation.
  * Creates a copy of the sequencer and iterates it with no synchronization.
  *
- * @param seq               Sequencer state (copied — original is not modified)
- * @param local_padded_Nt   Per-device padded sequence length in tiles
- * @param global_n_tile_id  Logical (unpadded) sequence length in tiles (logical_n / TILE_HEIGHT)
- * @param L                 Joint sequence length in elements (0 if no joint attention)
- * @param is_causal         Whether causal masking is enabled
- * @param is_balanced       Whether balanced (zigzag) causal distribution is enabled
+ * @param seq                       Sequencer state (copied — original is not modified)
+ * @param local_padded_Nt           Per-device padded sequence length in tiles
+ * @param global_n_tile_id          Logical (unpadded) sequence length in tiles (logical_n / TILE_HEIGHT)
+ * @param L                         Joint sequence length in elements (0 if no joint attention)
+ * @param is_causal                 Whether causal masking is enabled
+ * @param is_balanced               Whether balanced (zigzag) causal distribution is enabled
+ * @param chunked_enabled   Whether balanced chunked-prefill layout is active. When
+ *                                  true, every iter holds one slab of real data per chunk
+ *                                  → every iter does work.
  */
 inline uint32_t find_last_active_ring_iter(
     RingIdSequencer seq,
@@ -107,7 +141,12 @@ inline uint32_t find_last_active_ring_iter(
     uint32_t global_n_tile_id,
     uint32_t L,
     bool is_causal = false,
-    bool is_balanced = false) {
+    bool is_balanced = false,
+    bool chunked_enabled = false) {
+    if (chunked_enabled) {
+        return seq.ring_size - 1;
+    }
+
     uint32_t last_active = 0;
     auto no_sync = [](uint32_t, uint32_t) {};
 
@@ -126,26 +165,27 @@ inline uint32_t find_last_active_ring_iter(
 }
 
 /**
- * Count valid (non-skipped) K chunks for a ring iteration.
- * Same skip logic as compute: local K chunks whose global start tile >= logical_nt are skipped.
- *
- * @param num_kv_chunks      Total K chunks this ring iter (local + joint if applicable)
- * @param num_local_k_chunks Number of local (non-joint) K chunks
- * @param ring_iter_kv_start_tile  First tile index of this ring iter's KV range
- * @param Sk_chunk_t         K chunk size in tiles
- * @param logical_nt         Logical sequence length in tiles (logical_n / TILE_HEIGHT)
+ * Count valid (non-skipped) K chunks for a ring iteration. Local K chunks whose global
+ * start tile >= logical_nt are skipped (matches compute).
  */
-inline uint32_t count_valid_kv_chunks(
-    uint32_t num_kv_chunks,
-    uint32_t num_local_k_chunks,
-    uint32_t ring_iter_kv_start_tile,
+template <
+    bool chunked_enabled,
+    uint32_t kv_local_padded_Nt,
     uint32_t Sk_chunk_t,
-    uint32_t logical_nt) {
+    uint32_t chunk_size_t = 0,
+    uint32_t q_local_padded_Nt = 0>
+inline uint32_t count_valid_kv_chunks(
+    uint32_t num_kv_chunks, uint32_t num_local_k_chunks, uint32_t ring_id, uint32_t logical_nt) {
     uint32_t count = 0;
     for (uint32_t k = 0; k < num_kv_chunks; ++k) {
         const bool is_joint = k >= num_local_k_chunks;
-        if (!is_joint && (ring_iter_kv_start_tile + k * Sk_chunk_t >= logical_nt)) {
-            continue;
+        if (!is_joint) {
+            const uint32_t kv_global_start_tile =
+                kv_global_tile_for_local<chunked_enabled, kv_local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
+                    ring_id, k * Sk_chunk_t);
+            if (kv_global_start_tile >= logical_nt) {
+                continue;
+            }
         }
         count++;
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
@@ -125,20 +125,23 @@ inline uint32_t kv_global_tile_for_local(uint32_t ring_id, uint32_t local_tile_i
  * Find the last ring iteration that performs actual KV computation.
  * Creates a copy of the sequencer and iterates it with no synchronization.
  *
- * @param seq                       Sequencer state (copied — original is not modified)
- * @param local_padded_Nt           Per-device padded sequence length in tiles
- * @param global_n_tile_id          Logical (unpadded) sequence length in tiles (logical_n / TILE_HEIGHT)
- * @param L                         Joint sequence length in elements (0 if no joint attention)
- * @param is_causal                 Whether causal masking is enabled
- * @param is_balanced               Whether balanced (zigzag) causal distribution is enabled
- * @param chunked_enabled   Whether balanced chunked-prefill layout is active. When
- *                                  true, every iter holds one slab of real data per chunk
- *                                  → every iter does work.
+ * @param seq                 Sequencer state (copied — original is not modified)
+ * @param local_padded_Nt     Per-device padded sequence length in tiles
+ * @param last_n_tile_id      Last valid global K tile index (i.e., logical_nt - 1). The
+ *                            "does_work" predicate compares ring start to this with `<=`,
+ *                            so it represents an inclusive upper bound, not a count.
+ *                            Caller must ensure logical_nt > 0.
+ * @param L                   Joint sequence length in elements (0 if no joint attention)
+ * @param is_causal           Whether causal masking is enabled
+ * @param is_balanced         Whether balanced (zigzag) causal distribution is enabled
+ * @param chunked_enabled     Whether balanced chunked-prefill layout is active. When
+ *                            true, every iter holds one slab of real data per chunk
+ *                            → every iter does work.
  */
 inline uint32_t find_last_active_ring_iter(
     RingIdSequencer seq,
     uint32_t local_padded_Nt,
-    uint32_t global_n_tile_id,
+    uint32_t last_n_tile_id,
     uint32_t L,
     bool is_causal = false,
     bool is_balanced = false,
@@ -154,7 +157,7 @@ inline uint32_t find_last_active_ring_iter(
         uint32_t ring_id = seq.get_next_ring_id(no_sync);
         bool does_joint = (ring_id == seq.ring_size - 1);
         uint32_t kv_start = ring_id * local_padded_Nt;
-        bool does_work = ((kv_start <= global_n_tile_id) || (does_joint && L != 0)) &&
+        bool does_work = ((kv_start <= last_n_tile_id) || (does_joint && L != 0)) &&
                          !(is_causal && seq.ring_index < ring_id && !is_balanced);
         if (does_work) {
             last_active = t;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
@@ -10,6 +10,8 @@
 
 #include <cstdint>
 
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp"
+
 /**
  * Direction-alternating ring_id sequencer.
  * Computes which device's KV shard to process at each ring iteration.
@@ -89,37 +91,6 @@ struct RingIdSequencer {
         return sender_ring_id;
     }
 };
-
-/**
- * Per-call chunked-prefill runtime state for sdpa_ring_v2. The compile-time per-chunk
- * geometry (q_local_padded_Nt / chunk_size_t) lives in template params; this struct
- * carries the per-chunk runtime offsets.
- */
-struct ChunkedContext {
-    uint32_t q_start_idx_t = 0;  // absolute Q-tile offset of this chunk's Q slab
-    uint32_t ring_index = 0;     // logical ring rotation index for absolute-Q-tile compute
-};
-
-/**
- * Map a device-local K tile index to its global attention K position. Used by the
- * logical_n skip predicate and the diagonal-stamp mask coords. Under chunked-prefill
- * the local cache packs the per-chunk K region for each chunk back-to-back; each
- * region is q_local_padded_Nt tiles (= Q's per-device extent, since one chunk's Q
- * is one such region), so the mapping is non-monotonic.
- */
-template <
-    bool chunked_enabled,
-    uint32_t kv_local_padded_Nt = 0,
-    uint32_t chunk_size_t = 0,
-    uint32_t q_local_padded_Nt = 0>
-inline uint32_t kv_global_tile_for_local(uint32_t ring_id, uint32_t local_tile_idx) {
-    if constexpr (chunked_enabled) {
-        return (local_tile_idx / q_local_padded_Nt) * chunk_size_t + ring_id * q_local_padded_Nt +
-               (local_tile_idx % q_local_padded_Nt);
-    } else {
-        return ring_id * kv_local_padded_Nt + local_tile_idx;
-    }
-}
 
 /**
  * Find the last ring iteration that performs actual KV computation.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -117,6 +117,17 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(!(L != 0 && args.is_causal), "Causality is enabled only for ring attention");
 
     TT_FATAL(
+        args.logical_n > 0,
+        "Logical sequence length must be > 0; kernels derive last-valid-tile = logical_nt - 1 and would underflow.");
+
+    TT_FATAL(
+        N_local_q <= N_local_kv,
+        "Per-device Q seq length must be <= per-device K/V seq length. Equal: full-prefill path. Less: "
+        "chunked-prefill path. Greater is undefined. Got N_local_q={}, N_local_kv={}",
+        N_local_q,
+        N_local_kv);
+
+    TT_FATAL(
         !chunked_enabled || args.is_causal,
         "Chunked-prefill (N_local_q < N_local_kv) is mathematically causal; callers must pass is_causal=True. "
         "Got N_local_q={}, N_local_kv={}, is_causal={}",

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -63,9 +63,20 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     // Validate joint strategy is 'rear'
     TT_FATAL(args.joint_strategy == "rear", "Joint strategy must be 'rear'. Got: {}", args.joint_strategy);
 
-    // Validate all tensors have the same dtype
+    // Get shapes
+    const auto& q_shape = input_tensor_q.logical_shape();
+    const auto& k_shape = gathered_input_tensor_k.logical_shape();
+    const auto& v_shape = gathered_input_tensor_v.logical_shape();
+    const auto& joint_q_shape = joint_tensor_q.logical_shape();
+    const auto& joint_k_shape = joint_tensor_k.logical_shape();
+    const auto& joint_v_shape = joint_tensor_v.logical_shape();
+
+    // Chunked-prefill: Q is shorter than the per-device K shard (latest slab against a
+    // growing K cache). Chunk 0 has equal shapes and uses the regular is_causal=True path.
+    const bool chunked_enabled = tensor_args.is_chunked();
+
     const auto dtype = input_tensor_q.dtype();
-    if (!args.is_causal) {
+    if (!args.is_causal && !chunked_enabled) {
         for (const auto& tensor : sdpa_input_tensors) {
             TT_FATAL(
                 tensor.dtype() == dtype,
@@ -74,14 +85,6 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
                 tensor.dtype());
         }
     }
-
-    // Get shapes
-    const auto& q_shape = input_tensor_q.logical_shape();
-    const auto& k_shape = gathered_input_tensor_k.logical_shape();
-    const auto& v_shape = gathered_input_tensor_v.logical_shape();
-    const auto& joint_q_shape = joint_tensor_q.logical_shape();
-    const auto& joint_k_shape = joint_tensor_k.logical_shape();
-    const auto& joint_v_shape = joint_tensor_v.logical_shape();
 
     // Validate storage types and buffers
     for (const auto& tensor : sdpa_input_tensors) {
@@ -102,7 +105,8 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto NQH = q_shape[1];
     const auto NKH = k_shape[1];
     const auto NVH = v_shape[1];
-    const auto N_local = q_shape[2];
+    const auto N_local_q = q_shape[2];
+    const auto N_local_kv = tensor_args.input_k.logical_shape()[2];
     const auto N_global = k_shape[2];
     const auto L = joint_q_shape[2];
     const auto DH = q_shape[3];
@@ -113,7 +117,15 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(!(L != 0 && args.is_causal), "Causality is enabled only for ring attention");
 
     TT_FATAL(
-        !(args.is_balanced && (N_local / 2) % q_chunk_size != 0),
+        !chunked_enabled || args.is_causal,
+        "Chunked-prefill (N_local_q < N_local_kv) is mathematically causal; callers must pass is_causal=True. "
+        "Got N_local_q={}, N_local_kv={}, is_causal={}",
+        N_local_q,
+        N_local_kv,
+        args.is_causal);
+
+    TT_FATAL(
+        !(args.is_balanced && (N_local_q / 2) % q_chunk_size != 0),
         "q_chunk_size must divide half of local q seq_len in balanced case");
 
     TT_FATAL(
@@ -126,8 +138,8 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         joint_k_shape[0],
         joint_v_shape[0]);
 
-    // Validate head dimensions match
-    if (!args.is_causal) {
+    // Chunked-prefill targets MLA (K head dim == Q != V) — use is_causal's relaxed K-only check.
+    if (!args.is_causal && !chunked_enabled) {
         TT_FATAL(
             k_shape[3] == DH && v_shape[3] == DH && joint_q_shape[3] == DH && joint_k_shape[3] == DH &&
                 joint_v_shape[3] == DH,
@@ -153,14 +165,6 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         N_global);
 
     TT_FATAL(
-        N_global == N_local * args.ring_size,
-        "Global sequence length must be equal to local sequence length times ring size. Got global sequence length: "
-        "{}, local sequence length: {}, ring size: {}",
-        N_global,
-        N_local,
-        args.ring_size);
-
-    TT_FATAL(
         args.logical_n <= N_global,
         "Logical sequence length must be less than or equal to global sequence length. Got logical sequence length: "
         "{}, global sequence length: {}",
@@ -168,26 +172,17 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         N_global);
 
     TT_FATAL(
-        (N_global - args.logical_n) < N_local,
-        "Delta between global (padded) and logical (unpadded) sequence length must be less than local (per device) "
-        "sequence length. Got delta: {}, local sequence length: {} "
-        "This implies at least one device will have only padded tokens and no real tokens to process. Either "
-        "reduce the ring size or reduce padding by reducing the chunk size.",
-        N_global - args.logical_n,
-        N_local);
-
-    TT_FATAL(
         joint_k_shape[2] == L && joint_v_shape[2] == L,
         "Joint sequence length must match. Got joint_K: {}, joint_V: {}",
         joint_k_shape[2],
         joint_v_shape[2]);
 
-    // Check shapes based on ring
     TT_FATAL(
-        q_shape[2] * args.ring_size == k_shape[2],
-        "Q sequence length times ring size must be equal to K sequence length. Got Q: {}, K: {}, ring_size: {}",
-        q_shape[2],
-        k_shape[2],
+        N_global == N_local_kv * args.ring_size,
+        "Gathered K seq length must equal per-device K shard times ring size. Got N_global: {}, N_local_kv: {}, "
+        "ring_size: {}",
+        N_global,
+        N_local_kv,
         args.ring_size);
     TT_FATAL(
         k_shape[2] == v_shape[2],
@@ -212,9 +207,14 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         tt::constants::TILE_WIDTH);
 
     TT_FATAL(
-        N_local % tt::constants::TILE_HEIGHT == 0,
-        "Local sequence length must be divisible by TILE_HEIGHT. Got N_local: {}, TILE_HEIGHT: {}",
-        N_local,
+        N_local_q % tt::constants::TILE_HEIGHT == 0,
+        "Per-device Q seq length must be divisible by TILE_HEIGHT. Got N_local_q: {}, TILE_HEIGHT: {}",
+        N_local_q,
+        tt::constants::TILE_HEIGHT);
+    TT_FATAL(
+        N_local_kv % tt::constants::TILE_HEIGHT == 0,
+        "Per-device K/V seq length must be divisible by TILE_HEIGHT. Got N_local_kv: {}, TILE_HEIGHT: {}",
+        N_local_kv,
         tt::constants::TILE_HEIGHT);
 
     // Validate padding: Only the sequence dimension may be padded

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -71,12 +71,12 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto& joint_k_shape = joint_tensor_k.logical_shape();
     const auto& joint_v_shape = joint_tensor_v.logical_shape();
 
-    // Chunked-prefill: Q is shorter than the per-device K shard (latest slab against a
-    // growing K cache). Chunk 0 has equal shapes and uses the regular is_causal=True path.
-    const bool chunked_enabled = tensor_args.is_chunked();
+    // Chunked-prefill (`tensor_args.is_chunked()`): Q is shorter than the per-device K shard
+    // (latest slab against a growing K cache). Chunk 0 has equal shapes and uses the regular
+    // is_causal=True path.
 
     const auto dtype = input_tensor_q.dtype();
-    if (!args.is_causal && !chunked_enabled) {
+    if (!args.is_causal && !tensor_args.is_chunked()) {
         for (const auto& tensor : sdpa_input_tensors) {
             TT_FATAL(
                 tensor.dtype() == dtype,
@@ -128,7 +128,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         N_local_kv);
 
     TT_FATAL(
-        !chunked_enabled || args.is_causal,
+        !tensor_args.is_chunked() || args.is_causal,
         "Chunked-prefill (N_local_q < N_local_kv) is mathematically causal; callers must pass is_causal=True. "
         "Got N_local_q={}, N_local_kv={}, is_causal={}",
         N_local_q,
@@ -150,7 +150,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         joint_v_shape[0]);
 
     // Chunked-prefill targets MLA (K head dim == Q != V) — use is_causal's relaxed K-only check.
-    if (!args.is_causal && !chunked_enabled) {
+    if (!args.is_causal && !tensor_args.is_chunked()) {
         TT_FATAL(
             k_shape[3] == DH && v_shape[3] == DH && joint_q_shape[3] == DH && joint_k_shape[3] == DH &&
                 joint_v_shape[3] == DH,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -91,6 +91,10 @@ struct RingJointSDPAInputs {
     Tensor joint_v;
     Tensor gathered_k;
     Tensor gathered_v;
+
+    // Chunked-prefill is signalled implicitly by Q being shorter than the per-device K shard:
+    // Q is the latest slab, K is the populated prefix from chunk 0 through the current chunk.
+    bool is_chunked() const { return input_q.logical_shape()[2] < input_k.logical_shape()[2]; }
 };
 
 // Index constants for RingJointSDPAResult vector

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -207,7 +207,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const bool chunked_enabled = tensor_args.is_chunked();
     const uint32_t ring_size_u = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
     const uint32_t chunk_size_t = chunked_enabled ? q_local_padded_Nt * ring_size_u : 0u;
-    const uint32_t q_start_idx_t = chunked_enabled ? (kv_local_padded_Nt - q_local_padded_Nt) * ring_size_u : 0u;
     const bool diag_tile_needed = args.is_causal || chunked_enabled;
     // Kernel-level is_causal flag carries the legacy local-frame causal-stamp semantics. Chunked
     // prefill is mathematically causal (args.is_causal=True) but uses absolute-coords stamps every
@@ -1430,10 +1429,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             global_q_start,
             global_q_end,
         };
-        // RT logical_nt only for chunked-prefill — for non-chunked builds it lives in the CT layout hint.
-        if (chunked_enabled) {
-            reader_args.push_back(logical_nt);
-        }
         // Append chain runtime args for store-and-forward
         const auto& head_chain = head_chain_configs.at(i);
         const auto& batch_chain = batch_chain_configs.at(i);
@@ -1477,21 +1472,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             global_q_start,
             global_q_end,
         };
-        if (chunked_enabled) {
-            writer_args.push_back(logical_nt);
-        }
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(writer_args);
         SetRuntimeArgs(program, writer_kernels_id, core, writer_args);
 
-        // q_start_idx_t and RT logical_nt only pushed when chunked — non-chunked builds use CT layout hints.
         std::vector<uint32_t> compute_args = {
             global_q_start,
             global_q_end,
         };
-        if (chunked_enabled) {
-            compute_args.push_back(q_start_idx_t);
-            compute_args.push_back(logical_nt);
-        }
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(compute_args);
         SetRuntimeArgs(program, compute_kernels_id, core, compute_args);
     }
@@ -1579,25 +1566,13 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
 
         auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernels_id);
         auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernels_id);
-        auto& compute_args_by_core = GetRuntimeArgs(program, shared_vars.compute_kernels_id);
-
-        // Refresh chunked-prefill RT slots on cached-program reuse. Slot positions mirror the gated push in create_at.
-        const bool chunked_enabled = tensor_args.is_chunked();
-        const uint32_t q_local_padded_Nt_rt = tensor_args.input_q.logical_shape()[2] / tt::constants::TILE_HEIGHT;
-        const uint32_t kv_local_padded_Nt_rt = tensor_args.input_k.logical_shape()[2] / tt::constants::TILE_HEIGHT;
-        const uint32_t ring_size_u = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
-        const uint32_t logical_nt_rt = tt::div_up(static_cast<uint32_t>(args.logical_n), tt::constants::TILE_HEIGHT);
-        const uint32_t q_start_idx_t_rt =
-            chunked_enabled ? (kv_local_padded_Nt_rt - q_local_padded_Nt_rt) * ring_size_u : 0u;
 
         for (uint32_t i = 0; i < shared_vars.num_cores; ++i) {
             CoreCoord core = {i % shared_vars.grid_size.x, i / shared_vars.grid_size.x};
 
             auto& reader_args = reader_args_by_core[core.x][core.y];
             auto& writer_args = writer_args_by_core[core.x][core.y];
-            auto& compute_args = compute_args_by_core[core.x][core.y];
 
-            // Update reader args
             reader_args[0] = q_addr;
             reader_args[1] = k_addr;
             reader_args[2] = v_addr;
@@ -1607,17 +1582,9 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
             reader_args[6] = joint_k_addr;
             reader_args[7] = joint_v_addr;
 
-            // Update writer args
             writer_args[0] = out_addr;
             writer_args[1] = joint_out_addr;
             writer_args[2] = stats_addr;
-
-            if (chunked_enabled) {
-                reader_args[10] = logical_nt_rt;
-                writer_args[5] = logical_nt_rt;
-                compute_args[2] = q_start_idx_t_rt;
-                compute_args[3] = logical_nt_rt;
-            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -175,7 +175,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     log_debug(tt::LogOp, "v_shape (gathered): {}", v_shape);
 
     // q_local_padded_N (Q rows per device) can be shorter than kv_local_padded_N for chunked prefill.
-    const uint32_t B = q_shape[0], NH = q_shape[1], NHK = k_shape[1], DH = q_shape[3];
+    const uint32_t B = q_shape[0];
+    const uint32_t NH = q_shape[1];
+    const uint32_t NHK = k_shape[1];
+    const uint32_t DH = q_shape[3];
     const uint32_t q_local_padded_N = q_shape[2];
     const uint32_t kv_local_padded_N = tensor_args.input_k.logical_shape()[2];
     const uint32_t padded_N = k_shape[2];
@@ -204,14 +207,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // Chunked-prefill balanced layout: each device holds one per-chunk K region per chunk.
     // The region is q_local_padded_Nt tiles (Q is exactly one such region per call). The
     // diagonal-tile CB slot is shared with is_causal — needed whenever either is on.
-    const bool chunked_enabled = tensor_args.is_chunked();
-    const uint32_t ring_size_u = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
-    const uint32_t chunk_size_t = chunked_enabled ? q_local_padded_Nt * ring_size_u : 0u;
-    const bool diag_tile_needed = args.is_causal || chunked_enabled;
+    const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
+    const uint32_t chunk_size_t = q_local_padded_Nt * ring_size;
+    const bool diag_tile_needed = args.is_causal || tensor_args.is_chunked();
     // Kernel-level is_causal flag carries the legacy local-frame causal-stamp semantics. Chunked
     // prefill is mathematically causal (args.is_causal=True) but uses absolute-coords stamps every
     // ring iter, so the chunked path supersedes the legacy path — mask the flag off here.
-    const bool kernel_is_causal = args.is_causal && !chunked_enabled;
+    const bool kernel_is_causal = args.is_causal && !tensor_args.is_chunked();
 
     // Lightweight mask: needed when any K/joint dimension has padding, or when causal/chunked
     // masking is active.
@@ -473,7 +475,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
         // Reader slot 24: chunked_enabled (writer/compute use slot 24/33 for use_streaming_compute).
-        static_cast<uint32_t>(chunked_enabled),
+        static_cast<uint32_t>(tensor_args.is_chunked()),
         num_active_cores,
         chunk_size_t,
     };
@@ -563,7 +565,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
         (std::uint32_t)out_out_subblock_h,
-        static_cast<uint32_t>(chunked_enabled),
+        static_cast<uint32_t>(tensor_args.is_chunked()),
         chunk_size_t,
     };
 
@@ -623,7 +625,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         kernel_is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
-        static_cast<uint32_t>(chunked_enabled),
+        static_cast<uint32_t>(tensor_args.is_chunked()),
         chunk_size_t};
 
     std::map<std::string, std::string> defines;
@@ -1475,6 +1477,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(writer_args);
         SetRuntimeArgs(program, writer_kernels_id, core, writer_args);
 
+        // Compute args
         std::vector<uint32_t> compute_args = {
             global_q_start,
             global_q_end,
@@ -1573,6 +1576,7 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
             auto& reader_args = reader_args_by_core[core.x][core.y];
             auto& writer_args = writer_args_by_core[core.x][core.y];
 
+            // Update reader args
             reader_args[0] = q_addr;
             reader_args[1] = k_addr;
             reader_args[2] = v_addr;
@@ -1582,6 +1586,7 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
             reader_args[6] = joint_k_addr;
             reader_args[7] = joint_v_addr;
 
+            // Update writer args
             writer_args[0] = out_addr;
             writer_args[1] = joint_out_addr;
             writer_args[2] = stats_addr;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -53,35 +53,36 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     Naming:
         - padded_N: the global, padded sequence length
-        - local_padded_N: the local shard of the padded sequence length. local_padded_N = padded_N / ring_size
+        - kv_local_padded_N: local shard of padded sequence length for K/V (== padded_N / ring_size)
+        - q_local_padded_N: local Q seq length. For chunked prefill < kv_local_padded_N; otherwise equal.
         - logical_n: the logical global sequence length. logical_n <= padded_N.
         - L: the logical joint sequence length
 
-    input_tensor_q: B x NH x local_padded_N x DH
-    input_tensor_k: B x NH x local_padded_N x DH
-    input_tensor_v: B x NH x local_padded_N x DH
+    input_tensor_q: B x NH  x q_local_padded_N  x DH
+    input_tensor_k: B x NHK x kv_local_padded_N x DH
+    input_tensor_v: B x NH  x kv_local_padded_N x DH
 
-    gathered_input_tensor_k: B x NH x padded_N x DH
-    gathered_input_tensor_v: B x NH x padded_N x DH
+    gathered_input_tensor_k: B x NHK x padded_N x DH
+    gathered_input_tensor_v: B x NH  x padded_N x DH
 
     joint_tensor_q: B x NH x L x DH
     joint_tensor_k: B x NH x L x DH
     joint_tensor_v: B x NH x L x DH
 
-    output_tensor: B x NH x local_padded_N x DH
+    output_tensor: B x NH x q_local_padded_N x DH
     joint_output_tensor: B x NH x L x DH
 
 
     The algorithm is roughly described below.
     - for each ring iteration:
         - read a Q chunk from input_tensor_q
-        - for each KV chunk in local_padded_N:
+        - for each KV chunk in kv_local_padded_N:
             - on the first ring iteration, read from local input_tensor_k and input_tensor_v
             - otherwise, read from gathered_input_tensor_k and gathered_input_tensor_v
             - on the last ring iteration, also read from joint_tensor_k and joint_tensor_v
             - if the KV chunk is from the non-joint input and contains the global token index (logical_n - 1), generate
     a mask
-            - else if the KV chunk is from non-joint input and contains the local token index (local_padded_N - 1),
+            - else if the KV chunk is from non-joint input and contains the local token index (kv_local_padded_N - 1),
     generate an attention mask
             - else if the KV chunk is from the joint input and contains the local token index (L - 1), generate a mask
             - compute attention
@@ -173,12 +174,16 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     log_debug(tt::LogOp, "k_shape (gathered): {}", k_shape);
     log_debug(tt::LogOp, "v_shape (gathered): {}", v_shape);
 
-    const uint32_t B = q_shape[0], NH = q_shape[1], NHK = k_shape[1], local_padded_N = q_shape[2], DH = q_shape[3];
+    // q_local_padded_N (Q rows per device) can be shorter than kv_local_padded_N for chunked prefill.
+    const uint32_t B = q_shape[0], NH = q_shape[1], NHK = k_shape[1], DH = q_shape[3];
+    const uint32_t q_local_padded_N = q_shape[2];
+    const uint32_t kv_local_padded_N = tensor_args.input_k.logical_shape()[2];
     const uint32_t padded_N = k_shape[2];
     const uint32_t L = joint_q_shape[2];
     const uint32_t vDH = v_shape[3];
 
-    const uint32_t local_padded_Nt = local_padded_N / tt::constants::TILE_HEIGHT;
+    const uint32_t q_local_padded_Nt = q_local_padded_N / tt::constants::TILE_HEIGHT;
+    const uint32_t kv_local_padded_Nt = kv_local_padded_N / tt::constants::TILE_HEIGHT;
     const uint32_t padded_Nt = padded_N / tt::constants::TILE_HEIGHT;
     // Find unpadded sequence lengths in tiles
     const uint32_t Lt = tt::div_up(L, tt::constants::TILE_HEIGHT);
@@ -196,25 +201,39 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const uint32_t Sq_chunk_t = q_chunk_size / tt::constants::TILE_HEIGHT;
     const uint32_t Sk_chunk_t = k_chunk_size / tt::constants::TILE_HEIGHT;
 
-    // Lightweight mask: needed when any K/joint dimension has padding, or when causal masking is active.
-    const bool local_n_has_padding = (local_padded_Nt % Sk_chunk_t) != 0;
+    // Chunked-prefill balanced layout: each device holds one per-chunk K region per chunk.
+    // The region is q_local_padded_Nt tiles (Q is exactly one such region per call). The
+    // diagonal-tile CB slot is shared with is_causal — needed whenever either is on.
+    const bool chunked_enabled = tensor_args.is_chunked();
+    const uint32_t ring_size_u = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
+    const uint32_t chunk_size_t = chunked_enabled ? q_local_padded_Nt * ring_size_u : 0u;
+    const uint32_t q_start_idx_t = chunked_enabled ? (kv_local_padded_Nt - q_local_padded_Nt) * ring_size_u : 0u;
+    const bool diag_tile_needed = args.is_causal || chunked_enabled;
+    // Kernel-level is_causal flag carries the legacy local-frame causal-stamp semantics. Chunked
+    // prefill is mathematically causal (args.is_causal=True) but uses absolute-coords stamps every
+    // ring iter, so the chunked path supersedes the legacy path — mask the flag off here.
+    const bool kernel_is_causal = args.is_causal && !chunked_enabled;
+
+    // Lightweight mask: needed when any K/joint dimension has padding, or when causal/chunked
+    // masking is active.
+    const bool local_n_has_padding = (kv_local_padded_Nt % Sk_chunk_t) != 0;
     const bool global_n_has_padding = (args.logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool joint_has_padding = L > 0 && (L % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || args.is_causal;
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_needed;
 
     // Partial tile support when padding boundary falls inside a tile.
     const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
     const uint32_t joint_l_partial_col = L % tt::constants::TILE_HEIGHT;
     const uint32_t partial_mask_tiles = (global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
-    const uint32_t causal_diag_tiles = args.is_causal ? 1 : 0;
+    const uint32_t causal_diag_tiles = diag_tile_needed ? 1 : 0;
     // Single CB holds: 1 neginf tile + optional causal diagonal + up to 2 partial mask tiles
     const uint32_t total_lightweight_mask_tiles = 1 + causal_diag_tiles + partial_mask_tiles;
 
-    const uint32_t num_local_q_chunks = tt::div_up(local_padded_N, q_chunk_size);
+    const uint32_t num_local_q_chunks = tt::div_up(q_local_padded_N, q_chunk_size);
     const uint32_t num_joint_q_chunks = tt::div_up(L, q_chunk_size);
     const uint32_t num_q_chunks = num_local_q_chunks + num_joint_q_chunks;
-    const uint32_t num_local_k_chunks = tt::div_up(local_padded_N, k_chunk_size);
+    const uint32_t num_local_k_chunks = tt::div_up(kv_local_padded_N, k_chunk_size);
     const uint32_t num_joint_k_chunks = tt::div_up(L, k_chunk_size);
 
     log_debug(tt::LogOp, "B: {}", B);
@@ -225,14 +244,16 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     log_debug(tt::LogOp, "vDH: {}", vDH);
 
     // Log padded dimensions
-    log_debug(tt::LogOp, "local_padded_N: {}", local_padded_N);
+    log_debug(tt::LogOp, "q_local_padded_N: {}", q_local_padded_N);
+    log_debug(tt::LogOp, "kv_local_padded_N: {}", kv_local_padded_N);
     log_debug(tt::LogOp, "padded_N: {}", padded_N);
     log_debug(tt::LogOp, "L: {}", L);
 
     // Log tile dimensions
     log_debug(tt::LogOp, "DHt: {}", DHt);
     log_debug(tt::LogOp, "vDHt: {}", vDHt);
-    log_debug(tt::LogOp, "local_padded_Nt: {}", local_padded_Nt);
+    log_debug(tt::LogOp, "q_local_padded_Nt: {}", q_local_padded_Nt);
+    log_debug(tt::LogOp, "kv_local_padded_Nt: {}", kv_local_padded_Nt);
     log_debug(tt::LogOp, "padded_Nt: {}", padded_Nt);
     log_debug(tt::LogOp, "Lt: {}", Lt);
 
@@ -417,7 +438,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     // Enable per-head zigzag for load balancing in balanced causal mode
     // Requires even num_q_chunks for symmetric light/heavy work distribution
-    const bool enable_zigzag_balancing = args.is_balanced && args.is_causal && (num_q_chunks % 2 == 0);
+    // Chunked prefill rides its own absolute-coords path, not the legacy local-frame causal stamp,
+    // so the zigzag asymmetry doesn't apply — gate on kernel_is_causal, not args.is_causal.
+    const bool enable_zigzag_balancing = args.is_balanced && kernel_is_causal && (num_q_chunks % 2 == 0);
 
     // Cores actually issuing Q reads. When the flat q-chunk distribution is smaller
     // than the grid the trailing cores get zero work; zigzag distributes pairs, so
@@ -433,8 +456,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         vDHt,
         Sq_chunk_t,
         Sk_chunk_t,
-        local_padded_N,
-        local_padded_Nt,
+        q_local_padded_Nt,
+        kv_local_padded_Nt,
         padded_Nt,
         static_cast<uint32_t>(args.logical_n),
         logical_nt,
@@ -447,11 +470,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         num_q_chunks,
         args.all_gather_operation_attributes.ring_size,
         qk_out_subblock_h,
-        args.is_causal,
+        kernel_is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
-        static_cast<uint32_t>(use_streaming_compute),
-        num_active_cores,  // num_q_readers for get_barrier_read_threshold
+        // Reader slot 24: chunked_enabled (writer/compute use slot 24/33 for use_streaming_compute).
+        static_cast<uint32_t>(chunked_enabled),
+        num_active_cores,
+        chunk_size_t,
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
@@ -517,8 +542,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         vDHt,
         Sq_chunk_t,
         Sk_chunk_t,
-        local_padded_N,
-        local_padded_Nt,
+        q_local_padded_Nt,
+        kv_local_padded_Nt,
         padded_Nt,
         args.logical_n,
         logical_nt,
@@ -535,10 +560,12 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         global_n_partial_col,
         joint_l_partial_col,
         (std::uint32_t)use_streaming_compute,
-        args.is_causal,
+        kernel_is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
         (std::uint32_t)out_out_subblock_h,
+        static_cast<uint32_t>(chunked_enabled),
+        chunk_size_t,
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -564,8 +591,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         vDHt,
         Sq_chunk_t,
         Sk_chunk_t,
-        local_padded_N,
-        local_padded_Nt,
+        q_local_padded_Nt,
+        kv_local_padded_Nt,
         padded_Nt,
         args.logical_n,
         logical_nt,
@@ -594,9 +621,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         global_n_partial_col,
         joint_l_partial_col,
         (std::uint32_t)uniform_dataformat,
-        args.is_causal,
+        kernel_is_causal,
         args.is_balanced,
-        static_cast<uint32_t>(enable_zigzag_balancing)};
+        static_cast<uint32_t>(enable_zigzag_balancing),
+        static_cast<uint32_t>(chunked_enabled),
+        chunk_size_t};
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -1401,6 +1430,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             global_q_start,
             global_q_end,
         };
+        // RT logical_nt only for chunked-prefill — for non-chunked builds it lives in the CT layout hint.
+        if (chunked_enabled) {
+            reader_args.push_back(logical_nt);
+        }
         // Append chain runtime args for store-and-forward
         const auto& head_chain = head_chain_configs.at(i);
         const auto& batch_chain = batch_chain_configs.at(i);
@@ -1444,14 +1477,21 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             global_q_start,
             global_q_end,
         };
+        if (chunked_enabled) {
+            writer_args.push_back(logical_nt);
+        }
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(writer_args);
         SetRuntimeArgs(program, writer_kernels_id, core, writer_args);
 
-        // Compute args
+        // q_start_idx_t and RT logical_nt only pushed when chunked — non-chunked builds use CT layout hints.
         std::vector<uint32_t> compute_args = {
             global_q_start,
             global_q_end,
         };
+        if (chunked_enabled) {
+            compute_args.push_back(q_start_idx_t);
+            compute_args.push_back(logical_nt);
+        }
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(compute_args);
         SetRuntimeArgs(program, compute_kernels_id, core, compute_args);
     }
@@ -1539,12 +1579,23 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
 
         auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernels_id);
         auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernels_id);
+        auto& compute_args_by_core = GetRuntimeArgs(program, shared_vars.compute_kernels_id);
+
+        // Refresh chunked-prefill RT slots on cached-program reuse. Slot positions mirror the gated push in create_at.
+        const bool chunked_enabled = tensor_args.is_chunked();
+        const uint32_t q_local_padded_Nt_rt = tensor_args.input_q.logical_shape()[2] / tt::constants::TILE_HEIGHT;
+        const uint32_t kv_local_padded_Nt_rt = tensor_args.input_k.logical_shape()[2] / tt::constants::TILE_HEIGHT;
+        const uint32_t ring_size_u = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
+        const uint32_t logical_nt_rt = tt::div_up(static_cast<uint32_t>(args.logical_n), tt::constants::TILE_HEIGHT);
+        const uint32_t q_start_idx_t_rt =
+            chunked_enabled ? (kv_local_padded_Nt_rt - q_local_padded_Nt_rt) * ring_size_u : 0u;
 
         for (uint32_t i = 0; i < shared_vars.num_cores; ++i) {
             CoreCoord core = {i % shared_vars.grid_size.x, i / shared_vars.grid_size.x};
 
             auto& reader_args = reader_args_by_core[core.x][core.y];
             auto& writer_args = writer_args_by_core[core.x][core.y];
+            auto& compute_args = compute_args_by_core[core.x][core.y];
 
             // Update reader args
             reader_args[0] = q_addr;
@@ -1560,6 +1611,13 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
             writer_args[0] = out_addr;
             writer_args[1] = joint_out_addr;
             writer_args[2] = stats_addr;
+
+            if (chunked_enabled) {
+                reader_args[10] = logical_nt_rt;
+                writer_args[5] = logical_nt_rt;
+                compute_args[2] = q_start_idx_t_rt;
+                compute_args[3] = logical_nt_rt;
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -209,7 +209,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // diagonal-tile CB slot is shared with is_causal — needed whenever either is on.
     const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
     const uint32_t chunk_size_t = q_local_padded_Nt * ring_size;
-    const bool diag_tile_needed = args.is_causal || tensor_args.is_chunked();
+    const bool diag_tile_enabled = args.is_causal || tensor_args.is_chunked();
     // Kernel-level is_causal flag carries the legacy local-frame causal-stamp semantics. Chunked
     // prefill is mathematically causal (args.is_causal=True) but uses absolute-coords stamps every
     // ring iter, so the chunked path supersedes the legacy path — mask the flag off here.
@@ -221,13 +221,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const bool global_n_has_padding = (args.logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool joint_has_padding = L > 0 && (L % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_needed;
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
 
     // Partial tile support when padding boundary falls inside a tile.
     const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
     const uint32_t joint_l_partial_col = L % tt::constants::TILE_HEIGHT;
     const uint32_t partial_mask_tiles = (global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
-    const uint32_t causal_diag_tiles = diag_tile_needed ? 1 : 0;
+    const uint32_t causal_diag_tiles = diag_tile_enabled ? 1 : 0;
     // Single CB holds: 1 neginf tile + optional causal diagonal + up to 2 partial mask tiles
     const uint32_t total_lightweight_mask_tiles = 1 + causal_diag_tiles + partial_mask_tiles;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -422,6 +422,12 @@ void bind_sdpa(nb::module_& mod) {
             is_causal (bool): Whether to use causal attention masking. Defaults to False.
             is_balanced (bool): Whether to use balanced attention computation. Defaults to False.
 
+        Chunked-prefill mode is entered implicitly when input_tensor_q's per-device seq
+        length is less than input_tensor_k's (Q is the latest slab; K is the populated
+        prefix from chunk 0 through the current chunk). The op derives chunk_size and
+        the absolute Q-row offset from the shapes plus sp_size — no extra args needed.
+        Chunked prefill is mathematically causal; callers must pass is_causal=True.
+
         Returns:
             (ttnn.Tensor, ttnn.Tensor, ttnn.Tensor):
               - The attention output for the original Q/K/V shape [b x nh x N/num_devices x dh].


### PR DESCRIPTION
## What is chunked SDPA

Chunked prefill for `ring_joint_scaled_dot_product_attention`: instead of running the full prefill sequence in a single SDPA call, the caller processes the sequence in fixed-size chunks. Each call passes a short Q slab (the latest chunk) against a K/V cache that grows by one chunk per step. Per-chunk outputs match a single full-sequence call on the same Q/K/V.

This is the standard prefill-time chunked-attention pattern (used for very long contexts where one-shot prefill is impractical) adapted to the ring/joint SDPA path.

## How to use the API

The public op signature is unchanged. Chunked mode is inferred from input shapes — when Q's per-device seq length is strictly less than K's per-device seq length, the op recognises it as chunked and derives both `chunk_size` and the absolute Q offset from shapes + `ring_size`:

```
chunk_size  = N_local_q * ring_size
q_start_idx = (N_local_kv - N_local_q) * ring_size
```

Caller pattern (per chunk `i = 0..n_chunks-1`):

```python
Q_chunk = Q_full[..., i*chunk_size : (i+1)*chunk_size, :]   # this chunk's Q only
K_cache = K_full[..., : (i+1)*chunk_size, :]                # K grown by one chunk
V_cache = V_full[..., : (i+1)*chunk_size, :]

tt_out = ttnn.transformer.ring_joint_scaled_dot_product_attention(
    tt_Q, tt_K, tt_V, ..., is_causal=True, ...
)
```

`is_causal=True` is passed on every chunk. Chunk 0 (`N_local_q == N_local_kv`) is handled by the existing causal path; chunks 1..n-1 trigger the chunked-prefill path implicitly via the shape check. Each device's K/V slab holds the global K positions matching its Q slice — cache updates are local appends, no cross-device shuffles per chunk.

## Scope

**Goal of this PR is correctness, not performance.** Perf characterisation, tuning, and perf-table sweep tests will land in a follow-up PR.

## Tests

`tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_chunked_accuracy`:

- mla_100k, total_seq = 25K, chunk_size = 5120, n_chunks = 5
- Parametrized over all `(q_chunk_size, k_chunk_size)` combos in the model config (q160 × {k160, k256, k320})
- Per-chunk PCC vs a single full-sequence torch reference, threshold 0.99

Local run on sp=4 BH QuietBox — 3/3 configs pass, per-chunk PCC ~0.9997 (chunk 0) → ~0.9992 (chunk 4), well above threshold.

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26286165273)
- [x] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26287880364) (sdpa only)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26286169199)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26291086431)
- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26286172856) (ops perf tests only)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26286174616)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26286176468)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/runs/26286178147) (deepseek_prefill only)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/ring_joint_sdpa_chunked_prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/ring_joint_sdpa_chunked_prefill)
