### PR TITLE
[Bug fix] Finalize offsets before writing fast dispatch kernel runtime args

### DIFF
--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -741,6 +741,8 @@ void DispatchTopology::create_cq_program(Device* device) {
 void DispatchTopology::compile_cq_programs() {
     command_queue_compile_group_->compile_all(/*force_slow_dispatch=*/true);
 
+    command_queue_compile_group_->finalize_offsets();
+
     // Write runtime args to device
     command_queue_compile_group_->write_runtime_args(/*force_slow_dispatch=*/true);
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2384,6 +2384,15 @@ void detail::ProgramCompileGroup::compile_all(bool force_slow_dispatch) {
     sync_build_steps(events);
 }
 
+void detail::ProgramCompileGroup::finalize_offsets() {
+    std::lock_guard lock(mutex_);
+    for (auto& [device, program] : program_device_map_) {
+        if (!program->impl().is_finalized()) {
+            program->impl().finalize_offsets(device);
+        }
+    }
+}
+
 void detail::ProgramCompileGroup::write_runtime_args(bool force_slow_dispatch) {
     std::lock_guard lock(mutex_);
     for (auto& [device, program] : program_device_map_) {

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -167,6 +167,9 @@ public:
     // Compiles all programs in the group
     void compile_all(bool force_slow_dispatch);
 
+    // Finalize program offsets for all programs in the group
+    void finalize_offsets();
+
     // Write runtime args for all programs in the group
     void write_runtime_args(bool force_slow_dispatch);
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`DispatchTopology::compile_cq_programs()` called `write_runtime_args()` before `finalize_offsets()` had run. `WriteRuntimeArgsToDevice()` computes write addresses as `kernel_config_base + rta_offset`, which is calculated only by `ProgramImpl::finalize_offsets()`. Without finalization, every FD kernel's runtime args were written to the same L1 address.

Note that user programs are unaffected. All codepaths for user programs call `finalize_offsets()` before writing runtime args to the device. Only the fast dispatch kernel path was missing this call to `finalize_offsets()`.

On WH/BH the bug was masked because the FD kernels run on separate cores, so the writes to the specified L1 address weren't a problem because the FD kernel on each core read from the L1 address of their own core. On Quasar, the FD kernels will be on the same core with non-overlapping L1 regions, so all FD kernels' RTA writes collide at the same L1 address.

The fix calls `finalize_offsets()` between `compile_all()` and `write_runtime_args()`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_dispatch_kernel_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_dispatch_kernel_offsets)