### PR TITLE
descriptor framework: re-apply CB total_size + page_size on cache hit

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -540,5 +540,82 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CommonScalarMatching
     EXPECT_NO_THROW(resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()}));
 }
 
+// ============================================================================
+// SECTION 3: apply_descriptor_runtime_args — slow-path CB re-application
+// ============================================================================
+//
+// Contract-1 factories use apply_descriptor_runtime_args on cache hit when
+// there are no Buffer* bindings (factory hands the freshly-re-run descriptor
+// back to the framework; rt args, common rt args, dynamic CB addresses, and —
+// since this PR — CB total_size / per-format page_size are patched into the
+// cached program in place).
+//
+// The 4 size-mutation ops (attn_matmul, group_attn_matmul, slice_rm,
+// generic_op) deliberately keep CB total_size out of the program hash and
+// rely on cheap UpdateCircularBufferTotalSize on cache hit.  Without this
+// patching the cached program would keep the first-build size forever.
+
+namespace {
+
+ProgramDescriptor MakeOneCbDescriptor(uint32_t total_size, uint32_t page_size) {
+    ProgramDescriptor desc;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = total_size,
+        .core_ranges = CoreRangeSet{CoreRange{CoreCoord{0, 0}}},
+        .format_descriptors = {CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = page_size,
+        }},
+    });
+    desc.kernels = {MakeBlankReaderKernel({0, 0})};
+    return desc;
+}
+
+}  // namespace
+
+// total_size in a fresh descriptor is applied to the cached program's CB.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_PatchesCbTotalSize) {
+    ProgramDescriptor desc = MakeOneCbDescriptor(/*total_size=*/1024, /*page_size=*/64);
+    Program program{desc};
+
+    auto cbs = program.circular_buffers();
+    ASSERT_EQ(cbs.size(), 1u);
+    EXPECT_EQ(cbs[0]->size(), 1024u);
+
+    // Mutate total_size as a factory would on rebuild — kernel hash unchanged
+    // because total_size is not hashed (see hash_cb_descriptor).
+    desc.cbs[0].total_size = 2048;
+    apply_descriptor_runtime_args(program, desc);
+
+    EXPECT_EQ(program.circular_buffers()[0]->size(), 2048u);
+}
+
+// page_size in a fresh descriptor is applied to the cached program's CB.
+// (Today page_size IS hashed, but the framework still re-applies it for
+// future opt-out scenarios — see comment in apply_descriptor_runtime_args.)
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_PatchesCbPageSize) {
+    ProgramDescriptor desc = MakeOneCbDescriptor(/*total_size=*/1024, /*page_size=*/64);
+    Program program{desc};
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(0), 64u);
+
+    desc.cbs[0].format_descriptors[0].page_size = 128;
+    apply_descriptor_runtime_args(program, desc);
+
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(0), 128u);
+}
+
+// When the descriptor's sizes match the cached program's, no Update* call is
+// issued (early-out keeps the cache-hit fast path lean for the common case).
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_NoMutation_NoSideEffect) {
+    ProgramDescriptor desc = MakeOneCbDescriptor(/*total_size=*/1024, /*page_size=*/64);
+    Program program{desc};
+
+    apply_descriptor_runtime_args(program, desc);  // identical sizes
+
+    EXPECT_EQ(program.circular_buffers()[0]->size(), 1024u);
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(0), 64u);
+}
+
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -617,5 +617,61 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_NoMutatio
     EXPECT_EQ(program.circular_buffers()[0]->page_size(0), 64u);
 }
 
+// Regression: when total_size and page_size BOTH change such that the new
+// total_size is not divisible by the OLD page_size (or vice versa), the
+// patcher must not trip the divisibility invariant mid-update.  Comparing
+// against CircularBuffer::page_size() (which validates total_size % page_size)
+// after UpdateCircularBufferTotalSize would throw.  We compare against the
+// cached config's raw page_sizes() array instead.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_IncompatibleIntermediate_DoesNotThrow) {
+    // Cached: total_size=1024, page_size=64 (1024 % 64 == 0).
+    ProgramDescriptor desc = MakeOneCbDescriptor(/*total_size=*/1024, /*page_size=*/64);
+    Program program{desc};
+
+    // New: total_size=192, page_size=96.  192 % 64 != 0 (incompatible with the
+    // OLD cached page_size between the two Update calls); 192 % 96 == 0
+    // (consistent once both updates land).
+    desc.cbs[0].total_size = 192;
+    desc.cbs[0].format_descriptors[0].page_size = 96;
+    EXPECT_NO_THROW(apply_descriptor_runtime_args(program, desc));
+
+    EXPECT_EQ(program.circular_buffers()[0]->size(), 192u);
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(0), 96u);
+}
+
+// remote_format_descriptors (GlobalCircularBuffer-backed CBs) must also be
+// walked when patching page_size.  Today page_size is hashed so values match,
+// but this guards the path for future opt-outs and matches the legacy
+// GenericMeshProgramFactory behavior.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_RemoteFormatDescriptors_AlsoPatched) {
+    ProgramDescriptor desc;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1024,
+        .core_ranges = CoreRangeSet{CoreRange{CoreCoord{0, 0}}},
+        .format_descriptors = {CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = 64,
+        }},
+        .remote_format_descriptors = {CBFormatDescriptor{
+            .buffer_index = 1,
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = 64,
+        }},
+    });
+    desc.kernels = {MakeBlankReaderKernel({0, 0})};
+    Program program{desc};
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(0), 64u);
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(1), 64u);
+
+    // Mutating only the remote descriptor's page_size should still produce a
+    // patch call (no throw, value updated).
+    desc.cbs[0].remote_format_descriptors[0].page_size = 128;
+    EXPECT_NO_THROW(apply_descriptor_runtime_args(program, desc));
+
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(0), 64u);
+    EXPECT_EQ(program.circular_buffers()[0]->page_size(1), 128u);
+}
+
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -673,5 +673,44 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_RemoteFor
     EXPECT_EQ(program.circular_buffers()[0]->page_size(1), 128u);
 }
 
+// Regression: when a sharded CB rebinds its buffer AND grows total_size beyond
+// the OLD buffer's bank size, the patcher must use the combined
+// UpdateDynamicCircularBufferAddressAndTotalSize so max_size_ is refreshed
+// atomically with total_size_.  Two separate Update* calls would trip the
+// "total_size <= max_size_" assertion inside set_total_size against the stale
+// max_size from the smaller previous buffer.  Surfaced by
+// test_group_attn_matmul_with_program_cache when shape changes shrink/grow
+// the sharded src0 CB across cache hits.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyDescriptorRuntimeArgs_ShardedRebind_LargerTotalSize_DoesNotThrow) {
+    // Cached: total_size=2048 (1 tile), backed by a 2048-byte L1 buffer.
+    auto small_buf = MakeL1Buffer(device(), /*size=*/2048);
+    ProgramDescriptor desc;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2048,
+        .core_ranges = CoreRangeSet{CoreRange{CoreCoord{0, 0}}},
+        .format_descriptors = {CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = 2048,
+        }},
+        .buffer = small_buf.get(),
+    });
+    desc.kernels = {MakeBlankReaderKernel({0, 0})};
+    Program program{desc};
+    EXPECT_EQ(program.circular_buffers()[0]->size(), 2048u);
+
+    // New: total_size=4096 backed by a larger 4096-byte buffer.  If the patcher
+    // calls UpdateDynamicCircularBufferAddress (rebinds to large_buf, but does
+    // not refresh max_size_) and then UpdateCircularBufferTotalSize(4096), the
+    // latter trips the cached max_size_ (still 2048 from small_buf).  The
+    // combined Update*AndTotalSize path resets max_size_ from large_buf.
+    auto large_buf = MakeL1Buffer(device(), /*size=*/4096);
+    desc.cbs[0].buffer = large_buf.get();
+    desc.cbs[0].total_size = 4096;
+    EXPECT_NO_THROW(apply_descriptor_runtime_args(program, desc));
+
+    EXPECT_EQ(program.circular_buffers()[0]->size(), 4096u);
+}
+
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -190,9 +190,31 @@ void apply_descriptor_runtime_args(Program& program, const ProgramDescriptor& de
 
     auto program_cbs = program.circular_buffers();
     for (uint32_t ci = 0; ci < static_cast<uint32_t>(desc.cbs.size()); ++ci) {
-        if (desc.cbs[ci].buffer) {
-            UpdateDynamicCircularBufferAddress(
-                program, program_cbs[ci]->id(), *desc.cbs[ci].buffer, desc.cbs[ci].address_offset);
+        const auto& cb_desc = desc.cbs[ci];
+        const auto& cb = *program_cbs[ci];
+        const auto cb_handle = cb.id();
+
+        if (cb_desc.buffer) {
+            UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer, cb_desc.address_offset);
+        }
+
+        // Re-apply CB total_size / per-format page_size on cache-hit slow-path rebuild.
+        // CBDescriptor::total_size is not in the program hash (see hash_cb_descriptor), so
+        // factories that compute total_size from runtime-varying op attributes (e.g.
+        // attn_matmul, group_attn_matmul, slice_rm, generic_op) must have their fresh size
+        // applied here — otherwise the cached program keeps the first-build size and the
+        // kernel reads from / writes to mismatched memory.
+        if (cb.size() != cb_desc.total_size) {
+            UpdateCircularBufferTotalSize(program, cb_handle, cb_desc.total_size);
+        }
+        for (const auto& format_desc : cb_desc.format_descriptors) {
+            // CBFormatDescriptor::page_size IS in the program hash, so by construction it
+            // matches across cache hits today.  Update is a no-op when values match; the
+            // call is here so factories that opt out of hashing page_size in the future
+            // stay correct without a second framework change.
+            if (cb.page_size(format_desc.buffer_index) != format_desc.page_size) {
+                UpdateCircularBufferPageSize(program, cb_handle, format_desc.buffer_index, format_desc.page_size);
+            }
         }
     }
 }

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -191,8 +191,19 @@ void apply_descriptor_runtime_args(Program& program, const ProgramDescriptor& de
     auto program_cbs = program.circular_buffers();
     for (uint32_t ci = 0; ci < static_cast<uint32_t>(desc.cbs.size()); ++ci) {
         const auto& cb_desc = desc.cbs[ci];
-        const auto& cb = *program_cbs[ci];
-        const auto cb_handle = cb.id();
+        const auto cb_handle = program_cbs[ci]->id();
+
+        // Snapshot the cached config BEFORE any Update* call so comparisons stay
+        // consistent across the patch sequence.  In particular: comparing against
+        // `CircularBuffer::page_size()` after `UpdateCircularBufferTotalSize` can
+        // throw — that accessor re-checks total_size % page_size and a fresh
+        // total_size may be incompatible with the still-stale page_size before
+        // the page_size update lands.  The raw `page_sizes()` array doesn't
+        // validate, so we use that as our reference (same pattern the legacy
+        // GenericMeshProgramFactory::override_program_runtime_arguments uses).
+        const auto& cached_cb_config = GetCircularBufferConfig(program, cb_handle);
+        const uint32_t cached_total_size = cached_cb_config.total_size();
+        const auto cached_page_sizes = cached_cb_config.page_sizes();  // copy, not ref
 
         if (cb_desc.buffer) {
             UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer, cb_desc.address_offset);
@@ -204,18 +215,24 @@ void apply_descriptor_runtime_args(Program& program, const ProgramDescriptor& de
         // attn_matmul, group_attn_matmul, slice_rm, generic_op) must have their fresh size
         // applied here — otherwise the cached program keeps the first-build size and the
         // kernel reads from / writes to mismatched memory.
-        if (cb.size() != cb_desc.total_size) {
+        if (cached_total_size != cb_desc.total_size) {
             UpdateCircularBufferTotalSize(program, cb_handle, cb_desc.total_size);
         }
-        for (const auto& format_desc : cb_desc.format_descriptors) {
-            // CBFormatDescriptor::page_size IS in the program hash, so by construction it
-            // matches across cache hits today.  Update is a no-op when values match; the
-            // call is here so factories that opt out of hashing page_size in the future
-            // stay correct without a second framework change.
-            if (cb.page_size(format_desc.buffer_index) != format_desc.page_size) {
-                UpdateCircularBufferPageSize(program, cb_handle, format_desc.buffer_index, format_desc.page_size);
+        // CBFormatDescriptor::page_size IS in the program hash today, so by construction
+        // values match across cache hits; Update is a no-op when they match.  The call
+        // is here so factories that opt out of hashing page_size in the future stay
+        // correct without a second framework change.  remote_format_descriptors covers
+        // the GlobalCircularBuffer path.
+        const auto patch_page_sizes = [&](const CBDescriptor::FormatDescriptors& fmt_list) {
+            for (const auto& fmt : fmt_list) {
+                const auto& cached = cached_page_sizes[fmt.buffer_index];
+                if (!cached.has_value() || *cached != fmt.page_size) {
+                    UpdateCircularBufferPageSize(program, cb_handle, fmt.buffer_index, fmt.page_size);
+                }
             }
-        }
+        };
+        patch_page_sizes(cb_desc.format_descriptors);
+        patch_page_sizes(cb_desc.remote_format_descriptors);
     }
 }
 

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -205,17 +205,28 @@ void apply_descriptor_runtime_args(Program& program, const ProgramDescriptor& de
         const uint32_t cached_total_size = cached_cb_config.total_size();
         const auto cached_page_sizes = cached_cb_config.page_sizes();  // copy, not ref
 
-        if (cb_desc.buffer) {
-            UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer, cb_desc.address_offset);
-        }
-
         // Re-apply CB total_size / per-format page_size on cache-hit slow-path rebuild.
         // CBDescriptor::total_size is not in the program hash (see hash_cb_descriptor), so
         // factories that compute total_size from runtime-varying op attributes (e.g.
         // attn_matmul, group_attn_matmul, slice_rm, generic_op) must have their fresh size
         // applied here — otherwise the cached program keeps the first-build size and the
         // kernel reads from / writes to mismatched memory.
-        if (cached_total_size != cb_desc.total_size) {
+        //
+        // For sharded CBs (.buffer != nullptr) where total_size ALSO changes, use the
+        // combined UpdateDynamicCircularBufferAddressAndTotalSize.  Separate Address +
+        // TotalSize calls would trip the `total_size <= max_size_` assertion because
+        // max_size_ is bound to the OLD buffer's bank size between the two updates.
+        const bool total_size_changed = cached_total_size != cb_desc.total_size;
+        if (cb_desc.buffer && total_size_changed) {
+            UpdateDynamicCircularBufferAddressAndTotalSize(program, cb_handle, *cb_desc.buffer, cb_desc.total_size);
+            if (cb_desc.address_offset != 0) {
+                // The combined call sets address (without offset) and total_size.  Apply
+                // address_offset separately if requested (uncommon — generic_op pattern).
+                UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer, cb_desc.address_offset);
+            }
+        } else if (cb_desc.buffer) {
+            UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer, cb_desc.address_offset);
+        } else if (total_size_changed) {
             UpdateCircularBufferTotalSize(program, cb_handle, cb_desc.total_size);
         }
         // CBFormatDescriptor::page_size IS in the program hash today, so by construction


### PR DESCRIPTION
## Summary
- Extends `apply_descriptor_runtime_args` so the cache-hit slow-path rebuild also patches `CBDescriptor::total_size` and per-format `page_size` into the cached program (matches the legacy `UpdateCircularBufferTotalSize` / `UpdateCircularBufferPageSize` behavior).
- Unblocks migrating the four ops that today keep CB size out of the program hash and update it cheaply on cache hit: `attn_matmul`, `group_attn_matmul`, `slice_program_factory_rm`, and `generic_op`.

## Why
[#42193](https://github.com/tenstorrent/tt-metal/issues/42193) tracks the descriptor migration. The four ops above (under #42339, #42340, #42235, #42391) deliberately leave CB sizes out of the program hash so a single cached program absorbs decode-time shape variation via cheap `Update*` calls. Without this patch, any ProgramDescriptor migration of those ops would silently keep the first-build CB size forever — correctness bug + perf regression (River's attempt #44029 hit exactly this and was closed).

`CBDescriptor::total_size` is already excluded from `hash_cb_descriptor`, so the hash stays stable across size variations. This change makes the slow-path rebuild actually use the fresh `total_size` value. `CBFormatDescriptor::page_size` IS still hashed today; the new Update call is a cheap no-op when values match and prepares the framework for future opt-out flags.

## What's changed
- `tt_metal/impl/program/program_descriptors.cpp`: extend `apply_descriptor_runtime_args` to walk `desc.cbs[*]` and call `UpdateCircularBufferTotalSize` / `UpdateCircularBufferPageSize` when the cached CB differs from the fresh descriptor.
- `tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp`: 3 device-bound tests covering total-size patch, page-size patch, and the no-mutation early-out.

## Test plan
- [x] Local: all 3 new tests pass (`unit_tests_api --gtest_filter='*ApplyDescriptorRuntimeArgs*'` → 3 OK on wormhole_b0)
- [ ] Sanity tests
- [ ] Runtime sanity tests
- [ ] Blackhole post-commit tests

## Follow-ups
- Migrate `attn_matmul` (#42339) and `group_attn_matmul` (#42340) — mine
- Coordinate with @azaytsev-epam on `generic_op` migration (#42391, currently open as #43419 which drops the optimization silently — needs this fix to merge first)
- `slice_program_factory_rm` (#42235) — mine + @mouliraj-mcw

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/descriptor-dynamic-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/descriptor-dynamic-cb-size)