### PR TITLE
DS Prefill: fix BH e2e model filter + CI skip precedence

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -183,7 +183,7 @@ models:
     bh_p300: 30
     bh_deskbox: 60
     bh_quietbox_2: 85
-    bh_llmbox: 40
+    bh_llmbox: 45
     bh_galaxy_perf: 78
   unit:
     wh_llmbox: 175

--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
         default: "all"
-        description: "Filter test rows by model-name (untagged rows always run)"
+        description: "Filter test rows by model-name (strict: only rows whose model-name matches will run; use 'all' to run every row)"
       test-selection:
         required: false
         type: string
@@ -101,9 +101,10 @@ jobs:
           fi
 
           filtered="$selected"
-          if [[ "$MODEL" != "all" ]]; then
-            filtered=$(echo "$filtered" | jq -c --arg model "$MODEL" '[.[] | select(.["model-name"] == $model or (.["model-name"] == null))]')
+          if [[ "$MODEL" != "all" && -n "$MODEL" ]]; then
+            filtered=$(echo "$filtered" | jq -c --arg model "$MODEL" '[.[] | select(.["model-name"] == $model)]')
           fi
+
 
           count=$(echo "$filtered" | jq 'length')
           if [[ "$count" -eq 0 ]]; then

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -31,7 +31,7 @@ on:
         type: choice
         options:
           - all
-          - deepseek
+          - deepseek_prefill
       test-selection:
         description: 'Select e2e tests to run: all tests, all SDPA tests, or one test id'
         required: false

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -25,7 +25,7 @@ on:
           - "Ubuntu 24.04"
         description: "Platform to build and test"
       model:
-        description: 'Select model to test (filters rows by model-name in tests/pipeline_reorg/blackhole_e2e_tests.yaml; untagged rows always run)'
+        description: 'Select model to test (filters rows strictly by model-name in tests/pipeline_reorg/blackhole_e2e_tests.yaml; use "all" to run every row including untagged)'
         required: false
         default: 'all'
         type: choice

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -107,7 +107,7 @@ def test_prefill_block(
     is_ci_env,
     is_ci_v2_env,
 ):
-    if is_ci_env or is_ci_v2_env and pcc_validation == False:
+    if (is_ci_env or is_ci_v2_env) and pcc_validation == False:
         pytest.skip("Skip non-PCC test in CI to save time")
     if (is_ci_env or is_ci_v2_env) and not is_balanced:
         pytest.skip("Skip non_balanced variant in CI — runnable locally for non_balanced-mode validation")

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -257,7 +257,6 @@ def test_prefill_block(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         weight_cache_path=cache_dir,
-        capacity_factor=32,
         is_balanced=is_balanced,
     )
     if gate_fallback_mode is not None:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -295,6 +295,6 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py -vvv --tb=short
   skus:
     bh_llmbox:
-      timeout: 30
+      timeout: 45
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -253,7 +253,7 @@
 # --- deepseek_prefill ---
 - id: bh-lb-deepseek-prefill
   name: bh_lb_DeepSeek_PREFILL
-  model-name: deepseek
+  model-name: deepseek_prefill
   cmd: |
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64" --timeout 1800 || exit_code=$?
@@ -287,7 +287,7 @@
 
 - id: bh-qb-deepseek-prefill
   name: bh_qb_DeepSeek_PREFILL
-  model-name: deepseek
+  model-name: deepseek_prefill
   cmd: |
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64" --timeout 1800
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check' -vvv --tb=short

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -271,7 +271,7 @@
 
 - id: bh-lb-deepseek-prefill-perf
   name: bh_lb_DeepSeek_PREFILL_PERF
-  model-name: deepseek
+  model-name: deepseek_prefill
   cmd: |
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -m models_device_performance_bare_metal -vvv --tb=short --timeout=900 || exit_code=$?


### PR DESCRIPTION
### Tickets
Fixes [#44651](https://github.com/tenstorrent/tt-metal/issues/44651)
Fixes [#44652](https://github.com/tenstorrent/tt-metal/issues/44652)

### Problem description
Two BH e2e DeepSeek prefill bugs from the reorg ([#44022](https://github.com/tenstorrent/tt-metal/pull/44022)):

1. **Filter bug ([#44652](https://github.com/tenstorrent/tt-metal/issues/44652)).**
   On the BH e2e pipeline, picking `model=deepseek_prefill` was running 17 of 18
   rows instead of just the 2 prefill rows — the jq filter passed any row with
   `model-name == null`. The same bug was fixed in March (82221d1ca25) and
   reintroduced by the BH e2e reorg in May. The reorg also renamed the BH
   prefill row tags from `deepseek_prefill` to `deepseek` (a perf row added
   later inherited the same tag by copy-paste).

2. **Skip-condition precedence ([#44651](https://github.com/tenstorrent/tt-metal/issues/44651)).**
   `test_prefill_block.py` was skipping all CI runs (including PCC and MoE layer
   tests on LB; not running on galaxy) because
   `is_ci_env or is_ci_v2_env and pcc_validation == False` short-circuited on
   `is_ci_env` alone.

### What's changed
- `blackhole-e2e-tests-impl.yaml`: strict model filter — `select(.["model-name"] == $model)`. Re-applies 82221d1ca25. Preserves main's `test-selection` input by routing both filters through the existing `apply-filters` step; empty-string `model` falls through to all-rows.
- `blackhole-e2e-tests.yaml`: dropdown updated `deepseek` → `deepseek_prefill`; descriptions reflect strict behavior.
- `blackhole_e2e_tests.yaml`: BH PCC + perf rows tagged `model-name: deepseek_prefill` (restoring pre-reorg state; matches `demo_sp_release_tests.yaml`). `bh-qb-deepseek-prefill` per-row timeout bumped **30 → 45 min** (was hitting the cap on every scheduled main run); matching `models.e2e.bh_llmbox` budget in `.github/time_budget.yaml` bumped 40 → 45.
- `test_prefill_block.py`: parenthesized — `(is_ci_env or is_ci_v2_env) and pcc_validation == False`. Also removed stray `capacity_factor=32` kwarg (introduced by #43168) that raised `TypeError: TtPrefillBlock.__init__() got an unexpected keyword argument 'capacity_factor'` on every PCC test execution; only surfaced once the operator-precedence fix let the PCC variant actually run in CI.

### CI status
Failures on the dispatched pipelines are either pre-existing main regressions (BH e2e segfaults/aborts; Galaxy 8x4 `test_prefill_block_loop` device hang) or numerical issues (KVPE PE PCC on `test_prefill_block.py`) unmasked by the operator-precedence fix in this PR. To clean up tests at a later date.

### Checklist
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ianastasijevic%2Ffix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/runs/26649052763)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ianastasijevic%2Ffix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/runs/26649054390)
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=ianastasijevic%2Ffix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/runs/26649055924)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ianastasijevic/fix-ds-prefill-bh-e2e-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/fix-ds-prefill-bh-e2e-filtering)
