### PR TITLE
[Bug fix] Replace flush_l2_cache_line with flush_l2_cache_range for watcher structs

### DIFF
--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -42,7 +42,7 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
         }
         v->tripped = assert_type;
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-        // Flush 64B cache line to L1 so host sees all fields via NOC; fence ensures completion
+        // Flush the cache range covering debug_assert_msg_t to L1 so host sees all fields via NOC; may span multiple cache lines
         flush_l2_cache_range(reinterpret_cast<uintptr_t>(v), sizeof(debug_assert_msg_t));
 #endif
     }

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -43,7 +43,7 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
         v->tripped = assert_type;
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
         // Flush 64B cache line to L1 so host sees all fields via NOC; fence ensures completion
-        flush_l2_cache_line(reinterpret_cast<uintptr_t>(v));
+        flush_l2_cache_range(reinterpret_cast<uintptr_t>(v), sizeof(debug_assert_msg_t));
 #endif
     }
 

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -334,7 +334,7 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
         san->return_code = return_code;
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
         // Flush 64B cache line to L1 so host sees all fields via NOC; fence ensures completion
-        flush_l2_cache_line(reinterpret_cast<uintptr_t>(san));
+        flush_l2_cache_range(reinterpret_cast<uintptr_t>(san), sizeof(debug_sanitize_addr_msg_t));
 #endif
     }
 

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -333,7 +333,7 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
         san->is_target = (which_core == DEBUG_SANITIZE_NOC_TARGET);
         san->return_code = return_code;
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-        // Flush 64B cache line to L1 so host sees all fields via NOC; fence ensures completion
+        // Flush the mailbox metadata range to L1 so host sees all fields via NOC; fence ensures completion
         flush_l2_cache_range(reinterpret_cast<uintptr_t>(san), sizeof(debug_sanitize_addr_msg_t));
 #endif
     }


### PR DESCRIPTION
### Summary
In some cases, a watcher struct would span 2 cache lines, so flush_l2_cache_line would not fully flush the struct to L1. Using flush_l2_cache_range fixes this.

Reviewed all instances of flush_l2_cache_line. No other cases like this currently exist.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/sanitize_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/sanitize_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kstevens/sanitize_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/sanitize_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/sanitize_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/sanitize_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/sanitize_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/sanitize_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/sanitize_flush)