### PR TITLE
[Bug fix] Fixing eth_fw_api.h warnings

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/eth_fw_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/eth_fw_api.h
@@ -220,7 +220,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while (risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK == MEM_SYSENG_ETH_MSG_CALL);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_CALL);
 
     // This tells link status check to avoid copying results into another location in L1
     *risc1_mailbox_arg0_ptr = 0xFFFFFFFF;
@@ -232,7 +232,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while (risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK == MEM_SYSENG_ETH_MSG_DONE);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_DONE);
 
     volatile eth_live_status_t* link_status =
         (volatile eth_live_status_t*)(MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status));


### PR DESCRIPTION
### Summary
Fixing warnings from sfpi compiler about wrapping '&' usage in brackets in `eth_fw_api.h`.

After the change, I see no warnings reported by sfpi compiler for Quasar compilations.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/eth_fw_api_warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/eth_fw_api_warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kstevens/eth_fw_api_warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/eth_fw_api_warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/eth_fw_api_warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/eth_fw_api_warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/eth_fw_api_warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/eth_fw_api_warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/eth_fw_api_warnings)