### PR TITLE
Fix conv3d streaming output partial block race

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -498,6 +498,70 @@ def test_conv3d_sweep_blocks(
 
 
 @pytest.mark.parametrize(
+    "input_shape, out_channels, kernel_size, stride, groups, padding, padding_mode, blocking",
+    [
+        [(1, 96, 3, 16, 16), 3, (3, 3, 3), (1, 1, 1), 1, (1, 1, 1), "zeros", (96, 32, 2, 8, 8)],
+    ],
+    ids=["c_out_3_t_leftover"],
+)
+def test_conv3d_streaming_output_t_leftover(
+    device, input_shape, out_channels, kernel_size, stride, groups, padding, padding_mode, blocking
+):
+    """Regression test for issue #44792: streaming output with a partial T block."""
+    C_in_block, C_out_block, T_out_block, H_out_block, W_out_block = blocking
+
+    tt_input, conv3d_module, gt_output, kernel_config, output_dims = setup_conv3d_test(
+        input_shape, out_channels, kernel_size, stride, groups, padding, padding_mode, device
+    )
+    N, D_out, H_out, W_out = output_dims
+
+    w = conv3d_module.weight.data
+    tt_weight = ttnn.from_torch(w, dtype=ttnn.DataType.BFLOAT16, pad_value=0)
+    tt_bias = ttnn.from_torch(
+        conv3d_module.bias.data.reshape(1, -1),
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        pad_value=0,
+    )
+
+    config = create_conv3d_config(
+        T_out_block=T_out_block,
+        H_out_block=H_out_block,
+        W_out_block=W_out_block,
+        C_out_block=C_out_block,
+        C_in_block=C_in_block,
+        # Keep sequential spatial blocks on one core so the partial T block is followed by another CB read.
+        compute_with_storage_grid_size=(1, 1),
+    )
+
+    tt_output = ttnn.experimental.conv3d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        device=device,
+        bias_tensor=tt_bias,
+        dtype=ttnn.bfloat16,
+        output_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        padding_mode=padding_mode,
+        groups=groups,
+        config=config,
+        compute_kernel_config=kernel_config,
+    )
+
+    tt_output = reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device)
+
+    assert tt_output.shape == gt_output.shape
+    pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
+    max_abs_diff = (tt_output - gt_output).abs().max().item()
+    logger.info(f"Conv3d streaming T-leftover: {pcc_message}, max_abs_diff={max_abs_diff:.4f}")
+    assert pcc_passed, pcc_message
+    assert max_abs_diff < 0.1, f"Expected aligned output, got max_abs_diff={max_abs_diff}"
+
+
+@pytest.mark.parametrize(
     "input_shape, out_channels, kernel_size, stride, groups, padding, padding_mode",
     [
         # C_in=4, kernel=3x3x3 → patch_size=3*3*3*32=864 (C_in padded to 32)

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -363,6 +363,9 @@ void kernel_main() {
                                         }
                                     }
                                 }
+                                if constexpr (enable_streaming_output) {
+                                    cb_out.wait_front(output_tiles);
+                                }
                                 noc.async_write_barrier();
                                 cb_out.pop_front(output_tiles);
                             }


### PR DESCRIPTION
### Problem
`conv3d` streaming output can acknowledge/pop a full padded output block before all padded tiles for a partial block have actually been produced. This can corrupt the next block when spatial blocks are processed sequentially on one core.

Related: #44792

### Fix
Add a final cumulative `cb_out.wait_front(output_tiles)` in the streaming-output writer path before the async write barrier and `cb_out.pop_front(output_tiles)`. This preserves the existing row-by-row waits for writes while ensuring the full padded block is available before the circular buffer is popped.

### Test
- Added nightly regression: `tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py::test_conv3d_streaming_output_t_leftover`
- Local targeted regression passed: `PCC=0.9999904694559231`, `max_abs_diff=0.0141`
- `python -m py_compile tests/ttnn/unit_tests/operations/conv/test_conv3d.py tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py`
- `python -m black --check tests/ttnn/unit_tests/operations/conv/test_conv3d.py tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py`
- `git diff --check`
- CI Nightly L2 conv-only dispatched: https://github.com/tenstorrent/tt-metal/actions/runs/26253325371

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-conv3d-streaming-output-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-conv3d-streaming-output-race)