### PR TITLE
[Bug fix]: Teardown RT profiler on FD to SD transition

### DIFF
--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -281,4 +281,26 @@ TEST_F(DispatchContextFixture, AsyncSdStatePreservedAcrossFdTransition) {
     EXPECT_TRUE(experimental::DispatchContext::get().is_asynchronous_slow_dispatch_enabled(mesh_device_.get()));
 }
 
+// Verify that we can SD LaunchProgram after FD init/teardown
+TEST_F(DispatchContextFixture, SDLaunchProgramAfterFD) {
+    const auto& rt_options = MetalContext::instance().rtoptions();
+    if (rt_options.get_fast_dispatch()) {
+        GTEST_SKIP() << "This test requires starting in Slow Dispatch mode.";
+    }
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (!cluster.is_ubb_galaxy() && cluster.arch() != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Service-core APIs require BH or UBB Galaxy.";
+    }
+
+    auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape(1, 1)));
+    IDevice* device = mesh_device_->get_device(MeshCoordinate(0, 0));
+
+    experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get());
+    Finish(mesh_device_->mesh_command_queue());
+    experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get());
+
+    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(1, CoreCoord(1, 1), 0);
+    EXPECT_NO_THROW(tt::tt_metal::detail::LaunchProgram(device, *programs[0], true, true));
+}
+
 }  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/tt_metal/test_kernels/misc/service_counter.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/service_counter.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "internal/firmware_common.h"
+
+void kernel_main() {
+    uint32_t stop_addr = get_arg_val<uint32_t>(0);
+    uint32_t counter_addr = get_arg_val<uint32_t>(1);
+    uint32_t service_done_addr = get_arg_val<uint32_t>(2);
+
+    volatile tt_l1_ptr uint32_t* stop = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stop_addr);
+    volatile tt_l1_ptr uint32_t* counter = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_addr);
+    volatile tt_l1_ptr uint32_t* service_done = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(service_done_addr);
+
+    // GET_MAILBOX_ADDRESS_DEV(go_messages[0]) yields a go_msg_t* — the go message
+    // for this BRISC core. Used to detect and acknowledge FD dispatch go signals.
+    volatile tt_l1_ptr go_msg_t* go_msg = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+
+    // Consume the initial SD launch go signal without notifying:
+    // there is no FD dispatcher at SD launch time.
+    go_msg->signal = RUN_MSG_DONE;
+
+    //     while (*stop == 0) {
+    //         (*counter)++;
+
+    //         // When the FD dispatcher multicasts a go signal to this core (as part of any
+    //         // EnqueueMeshWorkload), acknowledge it immediately via notify_dispatch_core_done.
+    //         // Without this the dispatcher waits forever for a DONE from this core.
+    //         if (go_msg->signal == RUN_MSG_GO) {
+    // #if defined(COMPILE_FOR_BRISC)
+    //             uint64_t dispatch_addr = calculate_dispatch_addr(go_msg);
+    //             notify_dispatch_core_done(dispatch_addr, noc_index);
+    // #endif
+    //             go_msg->signal = RUN_MSG_DONE;
+    //         }
+    //     }
+
+    // Signal host that the kernel has exited. We use a dedicated L1 word rather than
+    // go_msg->signal because that is co-opted above for FD dispatch signaling.
+    *service_done = 1;
+}

--- a/tt_metal/api/tt-metalium/experimental/service_core_claims.hpp
+++ b/tt_metal/api/tt-metalium/experimental/service_core_claims.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stddef.h>
+#include <unordered_set>
+#include <vector>
+
+#include <tt-metalium/core_coord.hpp>
+#include <umd/device/types/cluster_descriptor_types.hpp>
+
+namespace tt::tt_metal {
+class IDevice;
+using DeviceAddr = uint64_t;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::experimental::service {
+
+// These functions are NOT thread-safe. Expected usage is sequential calls from
+// the main thread during application setup/teardown.
+//
+// Arch/mode gate: claim() and allocate_l1() TT_FATAL unless the cluster is BH or
+// UBB Galaxy AND a manual FD session is currently active (i.e. initialize_fast_dispatch
+// has been called and terminate_fast_dispatch has not yet been called).
+
+// --- Reservation ---
+
+// Reserve one or more free FD-column cores for service use.
+// TT_FATALs if any core in the list is already claimed. Use is_claimed() to check first.
+// After claim(), the pool filter registered with dispatch_core_manager ensures
+// subsequent initialize_fast_dispatch() calls never allocate these cores to FD.
+void claim(IDevice* device, const std::vector<CoreCoord>& cores);
+
+// Release one or more claimed cores. Silent no-op for any core that is not currently
+// claimed (safe to call in teardown/destructor paths regardless of prior state).
+void release(IDevice* device, const std::vector<CoreCoord>& cores);
+
+bool is_claimed(IDevice* device, CoreCoord core);
+
+std::unordered_set<CoreCoord> claimed_cores(ChipId device_id);
+
+// Called from Device::close() to drop all claims for a device.
+void on_device_close(ChipId device_id);
+
+// --- Per-core L1 allocator ---
+// Valid only for currently-claimed cores. TT_FATALs otherwise.
+// Alignment is fixed at claim() time to HalMemType::DRAM alignment so NoC rd/wr
+// to allocations are valid (mirrors BankManager's lockstep L1 path).
+// TT_FATALs on OOM.
+
+DeviceAddr allocate_l1(IDevice* device, CoreCoord core, size_t size);
+void deallocate_l1(IDevice* device, CoreCoord core, DeviceAddr addr);
+size_t bytes_available(IDevice* device, CoreCoord core);
+
+}  // namespace tt::tt_metal::experimental::service

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -125,6 +125,9 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();
 
+    // Kill the RT profiler for each device as we transit out of FD into SD
+    mesh_device_impl.destroy_realtime_profiler_socket();
+
     // Restore stashed SD queues to preserve pre-FD state (e.g. asynchronous_slow_dispatch_enabled_)
     TT_FATAL(
         stashed_sd_queues_ && !stashed_sd_queues_->queues.empty(),

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -916,10 +916,7 @@ bool MeshDeviceImpl::close_impl(MeshDevice* pimpl_wrapper) {
 
     // Tear down RT profiler after the CQ has shut down (so dispatch_s has already issued
     // the final TERMINATE) but before the rest of the device teardown.
-    if (realtime_profiler_) {
-        realtime_profiler_->shutdown();
-        realtime_profiler_.reset();
-    }
+    destroy_realtime_profiler_socket();
 
     if (is_initialized()) {
         sub_device_manager_tracker_.reset();
@@ -1386,6 +1383,18 @@ void MeshDeviceImpl::init_realtime_profiler_socket(const std::shared_ptr<MeshDev
         return;
     }
     realtime_profiler_ = std::make_unique<RealtimeProfilerManager>(mesh_device);
+}
+
+void MeshDeviceImpl::destroy_realtime_profiler_socket() {
+    if (!realtime_profiler_) {
+        return;
+    }
+    auto& device_manager = MetalContext::instance(get_context_id()).device_manager();
+    for (const auto& device : get_devices()) {
+        device_manager->clear_rt_profiler_device_init_complete(device->id());
+    }
+    realtime_profiler_->shutdown();
+    realtime_profiler_.reset();
 }
 
 void MeshDeviceImpl::trigger_realtime_profiler_sync_check() {

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -288,6 +288,7 @@ public:
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false);
     void init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device);
+    void destroy_realtime_profiler_socket();
     void trigger_realtime_profiler_sync_check();
     D2HSocket* get_realtime_profiler_socket() const;
     bool close() override;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`terminate_fast_dispatch()` was not tearing down the RT profiler, leaving `rt_profiler_device_init_complete` set on each device after the FD session ended. Any subsequent `LaunchProgram()` call would hit the assert in `tt_metal.cpp`. Fix: add `destroy_realtime_profiler_socket()` to `terminate_fast_dispatch()`. The new method clears the per-device init flags before calling shutdown() + reset().

### Notes for reviewers
- Test `SDLaunchProgramAfterFD`: initializes FD, tears it down, then calls `LaunchProgram(force_slow_dispatch=true)` - this specific assert path that was broken. The other tests don't this path. This path/pattern might be used to launch services soon.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/profiler_clean_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/profiler_clean_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/profiler_clean_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/profiler_clean_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/profiler_clean_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/profiler_clean_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/profiler_clean_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/profiler_clean_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/profiler_clean_up)