### PR TITLE
[Bug fix]: Teardown RT profiler on FD to SD transition

### DIFF
--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -281,4 +281,26 @@ TEST_F(DispatchContextFixture, AsyncSdStatePreservedAcrossFdTransition) {
     EXPECT_TRUE(experimental::DispatchContext::get().is_asynchronous_slow_dispatch_enabled(mesh_device_.get()));
 }
 
+// Verify that we can SD LaunchProgram after FD init/teardown
+TEST_F(DispatchContextFixture, SDLaunchProgramAfterFD) {
+    const auto& rt_options = MetalContext::instance().rtoptions();
+    if (rt_options.get_fast_dispatch()) {
+        GTEST_SKIP() << "This test requires starting in Slow Dispatch mode.";
+    }
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (!cluster.is_ubb_galaxy() && cluster.arch() != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Service-core APIs require BH or UBB Galaxy.";
+    }
+
+    auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape(1, 1)));
+    IDevice* device = mesh_device_->get_device(MeshCoordinate(0, 0));
+
+    experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get());
+    Finish(mesh_device_->mesh_command_queue());
+    experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get());
+
+    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(1, CoreCoord(1, 1), 0);
+    EXPECT_NO_THROW(tt::tt_metal::detail::LaunchProgram(device, *programs[0], true, true));
+}
+
 }  // namespace tt::tt_metal::distributed::test

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -125,6 +125,9 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();
 
+    // Kill the RT profiler for each device as we transit out of FD into SD
+    mesh_device_impl.destroy_realtime_profiler_socket();
+
     // Restore stashed SD queues to preserve pre-FD state (e.g. asynchronous_slow_dispatch_enabled_)
     TT_FATAL(
         stashed_sd_queues_ && !stashed_sd_queues_->queues.empty(),

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -916,10 +916,7 @@ bool MeshDeviceImpl::close_impl(MeshDevice* pimpl_wrapper) {
 
     // Tear down RT profiler after the CQ has shut down (so dispatch_s has already issued
     // the final TERMINATE) but before the rest of the device teardown.
-    if (realtime_profiler_) {
-        realtime_profiler_->shutdown();
-        realtime_profiler_.reset();
-    }
+    destroy_realtime_profiler_socket();
 
     if (is_initialized()) {
         sub_device_manager_tracker_.reset();
@@ -1386,6 +1383,18 @@ void MeshDeviceImpl::init_realtime_profiler_socket(const std::shared_ptr<MeshDev
         return;
     }
     realtime_profiler_ = std::make_unique<RealtimeProfilerManager>(mesh_device);
+}
+
+void MeshDeviceImpl::destroy_realtime_profiler_socket() {
+    if (!realtime_profiler_) {
+        return;
+    }
+    auto& device_manager = MetalContext::instance(get_context_id()).device_manager();
+    for (const auto& device : get_devices()) {
+        device_manager->clear_rt_profiler_device_init_complete(device->id());
+    }
+    realtime_profiler_->shutdown();
+    realtime_profiler_.reset();
 }
 
 void MeshDeviceImpl::trigger_realtime_profiler_sync_check() {

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -288,6 +288,7 @@ public:
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false);
     void init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device);
+    void destroy_realtime_profiler_socket();
     void trigger_realtime_profiler_sync_check();
     D2HSocket* get_realtime_profiler_socket() const;
     bool close() override;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`terminate_fast_dispatch()` was not tearing down the RT profiler, leaving `rt_profiler_device_init_complete` set on each device after the FD session ended. Any subsequent `LaunchProgram()` call would hit the assert in `tt_metal.cpp`. Fix: add `destroy_realtime_profiler_socket()` to `terminate_fast_dispatch()`. The new method clears the per-device init flags before calling shutdown() + reset().

### Notes for reviewers
Test `SDLaunchProgramAfterFD`: initializes FD, tears it down, then calls `LaunchProgram(force_slow_dispatch=true)` - this specific assert path that was broken. The other tests don't this path. This path/pattern might be used to launch services soon.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/profiler_teardown_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/profiler_teardown_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/profiler_teardown_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/profiler_teardown_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/profiler_teardown_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/profiler_teardown_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/profiler_teardown_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/profiler_teardown_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/profiler_teardown_fix)