### PR TITLE
Hoist BH DEST remap setup for conv3d hot loops

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_fast_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_fast_tilize_api.h
@@ -16,6 +16,11 @@ inline void llk_math_fast_tilize_init(const std::uint32_t operand) {
     _llk_math_fast_tilize_init_<DST_ACCUM_MODE>(unpack_dst_format[operand_id]);
 }
 
+inline void llk_math_fast_tilize_init_skip_remap(const std::uint32_t operand) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    _llk_math_fast_tilize_init_<DST_ACCUM_MODE, false>(unpack_dst_format[operand_id]);
+}
+
 template <bool is_fp32_dest_acc_en>
 inline void llk_math_fast_tilize_uninit(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_fast_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_fast_tilize_api.h
@@ -12,6 +12,7 @@
  *************************************************************************/
 
 inline void llk_math_fast_tilize_init(const std::uint32_t operand) {
+    // Default fast-tilize init configures DEST remap; use the skip-remap variant only when the caller hoists it.
     const std::uint32_t operand_id = get_operand_id(operand);
     _llk_math_fast_tilize_init_<DST_ACCUM_MODE>(unpack_dst_format[operand_id]);
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -81,6 +81,8 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
     }
 }
 
+inline void llk_math_reconfig_remap(const bool /*remap_enable*/) {}
+
 /**
  * @brief Sets the dest dvalid for FPU/SFPU
  *

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -29,6 +29,8 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
 
 inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_acc_(enable); }
 
+inline void llk_math_reconfig_remap(const bool /*remap_enable*/) {}
+
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
     _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();

--- a/tt_metal/hw/inc/api/compute/common.h
+++ b/tt_metal/hw/inc/api/compute/common.h
@@ -32,12 +32,6 @@ extern uint32_t crta_count;
 #endif
 #endif
 
-ALWI void configure_dest_remap() {
-#ifdef ARCH_BLACKHOLE
-    MATH((llk_math_reconfig_remap(true)));
-#endif
-}
-
 // clang-format off
 /**
  * Returns the address in L1 for a given runtime argument index for unique (per core) runtime arguments set via

--- a/tt_metal/hw/inc/api/compute/common.h
+++ b/tt_metal/hw/inc/api/compute/common.h
@@ -32,6 +32,12 @@ extern uint32_t crta_count;
 #endif
 #endif
 
+ALWI void configure_dest_remap() {
+#ifdef ARCH_BLACKHOLE
+    MATH((llk_math_reconfig_remap(true)));
+#endif
+}
+
 // clang-format off
 /**
  * Returns the address in L1 for a given runtime argument index for unique (per core) runtime arguments set via

--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -44,16 +44,20 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Param Type | Name           | Description                                      | Type      | Valid Range               | Required              |
- * |------------|----------------|--------------------------------------------------|-----------|---------------------------|-----------------------|
- * | Template   | block_ct_dim   | Width of a single block in tiles                 | uint32_t  | 1 to max (see note)       | False (default = 8)   |
- * | Template   | full_ct_dim    | Width of a full input in tiles                   | uint32_t  | Divisible by block_ct_dim | False                 |
- * | Template   | narrow_row     |  Whether the provided input is narrow            | bool      | true/false                | False                 |
- * | Template   | row_num_datums | Number of datums per row                         | uint32_t  | >= 1                      | False                 |
- * | Template   | dense          | Packs two 2 face tiles in a single 4 face region | bool      | true/false                | False (default false) |
- * | Function   | ocb            | Output circular buffer identifier                | uint32_t  | 0 to 31                   | True                  |
- * | Function   | face_r_dim     | Face height in rows                              | uint32_t  | 1, 8 or 16                | False (default = 16)  |
- * | Function   | num_faces      | Number of faces                                  | uint32_t  | 1, 2 or 4                 | False (default = 4)   |
+ * | Param Type | Name            | Description                                      | Type     | Valid Range               | Required               |
+ * |------------|-----------------|--------------------------------------------------|----------|---------------------------|------------------------|
+ * | Template   | block_ct_dim    | Width of a single block in tiles                 | uint32_t | 1 to max (see note)       | False (default = 8)    |
+ * | Template   | full_ct_dim     | Width of a full input in tiles                   | uint32_t | Divisible by block_ct_dim | False                  |
+ * | Template   | narrow_row      | Whether the provided input is narrow             | bool     | true/false                | False                  |
+ * | Template   | row_num_datums  | Number of datums per row                         | uint32_t | >= 1                      | False                  |
+ * | Template   | dense           | Packs two 2 face tiles in a single 4 face region | bool     | true/false                | False (default false)  |
+ * | Template   | configure_remap  | Configure BH DEST remap before pack untilize      | bool     | true/false                | False (default = true) |
+ * | Function   | ocb             | Output circular buffer identifier                 | uint32_t | 0 to 31                   | True                   |
+ * | Function   | face_r_dim      | Face height in rows                              | uint32_t | 1, 8 or 16                | False (default = 16)   |
+ * | Function   | num_faces       | Number of faces                                  | uint32_t | 1, 2 or 4                 | False (default = 4)    |
+ *
+ * `configure_remap = false` is valid only when the caller has already configured BH DEST remap and no intervening
+ * operation requires a different DEST remap state.
  */
 // clang-format on
 template <
@@ -113,12 +117,16 @@ ALWI void pack_untilize_dest_init_skip_remap(
  *
  * Return value: None
  *
- * | Param Type | Name         | Description                                | Type      | Valid Range               | Required                |
- * |------------|--------------|--------------------------------------------|-----------|---------------------------|-------------------------|
- * | Template   | block_ct_dim | Width of a single block in tiles           | uint32_t  | 1 to max (see note)       | False (default = 8)     |
- * | Template   | full_ct_dim  | Width of a full input in tiles             | uint32_t  | Divisible by block_ct_dim | False                   |
- * | Function   | icb          | Input circular buffer identifier           | uint32_t  | 0 to 31                   | True                    |
- * | Function   | ocb          | Output circular buffer identifier          | uint32_t  | 0 to 31                   | True                    |
+ * | Param Type | Name            | Description                        | Type     | Valid Range               | Required               |
+ * |------------|-----------------|------------------------------------|----------|---------------------------|------------------------|
+ * | Template   | block_ct_dim    | Width of a single block in tiles   | uint32_t | 1 to max (see note)       | False (default = 8)    |
+ * | Template   | full_ct_dim     | Width of a full input in tiles     | uint32_t | Divisible by block_ct_dim | False                  |
+ * | Template   | configure_remap  | Configure BH DEST remap during init | bool     | true/false                | False (default = true) |
+ * | Function   | icb             | Input circular buffer identifier    | uint32_t | 0 to 31                   | True                   |
+ * | Function   | ocb             | Output circular buffer identifier   | uint32_t | 0 to 31                   | True                   |
+ *
+ * `configure_remap = false` is valid only when the caller has already configured BH DEST remap and no intervening
+ * operation requires a different DEST remap state.
  */
 // clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim, bool configure_remap = true>

--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -19,6 +19,48 @@
 
 namespace ckernel {
 
+namespace detail {
+
+template <
+    uint32_t block_ct_dim,
+    uint32_t full_ct_dim,
+    bool narrow_row,
+    std::uint32_t row_num_datums,
+    bool dense,
+    bool configure_remap>
+ALWI void pack_untilize_dest_init_impl(
+    uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4, uint32_t call_line = __builtin_LINE()) {
+#ifndef ARCH_QUASAR
+    state_configure<Operand::PACK>(ocb, call_line);
+    if constexpr (configure_remap) {
+        MATH((llk_math_reconfig_remap(true)));
+    }
+    PACK((llk_pack_reconfig_data_format_disaggregated<DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
+    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, false, narrow_row, row_num_datums, dense>(
+        ocb, face_r_dim, num_faces)));
+    PACK((llk_init_packer_dest_offset_registers<PackMode::Untilize, false>()));
+#else
+    LLK_ASSERT(narrow_row == false, "narrow_row not supported on Quasar");
+    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
+#endif
+}
+
+template <uint32_t block_ct_dim, uint32_t full_ct_dim, bool configure_remap>
+ALWI void pack_untilize_init_impl(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+#ifndef ARCH_QUASAR
+    state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+        false, false, icb)));  // init must be after configure
+    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+#else
+    UNPACK((llk_unpack_A_init</*TRANSPOSE_EN=*/false, DST_ACCUM_MODE>(icb)));
+    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE>(icb)));
+#endif
+    pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, false, TILE_C_DIM, false, configure_remap>(ocb);
+}
+
+}  // namespace detail
+
 // clang-format off
 /**
  * Performs the necessary hardware and software initialization for the pack untilize operation. This initialization
@@ -51,13 +93,12 @@ namespace ckernel {
  * | Template   | narrow_row      | Whether the provided input is narrow             | bool     | true/false                | False                  |
  * | Template   | row_num_datums  | Number of datums per row                         | uint32_t | >= 1                      | False                  |
  * | Template   | dense           | Packs two 2 face tiles in a single 4 face region | bool     | true/false                | False (default false)  |
- * | Template   | configure_remap  | Configure BH DEST remap before pack untilize      | bool     | true/false                | False (default = true) |
  * | Function   | ocb             | Output circular buffer identifier                 | uint32_t | 0 to 31                   | True                   |
  * | Function   | face_r_dim      | Face height in rows                              | uint32_t | 1, 8 or 16                | False (default = 16)   |
  * | Function   | num_faces       | Number of faces                                  | uint32_t | 1, 2 or 4                 | False (default = 4)    |
  *
- * `configure_remap = false` is valid only when the caller has already configured BH DEST remap and no intervening
- * operation requires a different DEST remap state.
+ * This default init configures BH DEST remap. Use `pack_untilize_dest_init_skip_remap` only when the caller has
+ * already configured BH DEST remap and no intervening operation requires a different DEST remap state.
  */
 // clang-format on
 template <
@@ -65,25 +106,11 @@ template <
     uint32_t full_ct_dim = block_ct_dim,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    bool dense = false,
-    bool configure_remap = true>
+    bool dense = false>
 ALWI void pack_untilize_dest_init(
     uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4, uint32_t call_line = __builtin_LINE()) {
-#ifndef ARCH_QUASAR
-    state_configure<Operand::PACK>(ocb, call_line);
-#ifdef ARCH_BLACKHOLE
-    if constexpr (configure_remap) {
-        configure_dest_remap();
-    }
-#endif  // TODO NC: A workaround for tt-metal#17132. Should be addressed more systematically in tt-llk#989
-    PACK((llk_pack_reconfig_data_format_disaggregated<DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
-    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, false, narrow_row, row_num_datums, dense>(
-        ocb, face_r_dim, num_faces)));
-    PACK((llk_init_packer_dest_offset_registers<PackMode::Untilize, false>()));
-#else
-    LLK_ASSERT(narrow_row == false, "narrow_row not supported on Quasar");
-    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
-#endif
+    detail::pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, true>(
+        ocb, face_r_dim, num_faces, call_line);
 }
 
 template <
@@ -94,7 +121,7 @@ template <
     bool dense = false>
 ALWI void pack_untilize_dest_init_skip_remap(
     uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4, uint32_t call_line = __builtin_LINE()) {
-    pack_untilize_dest_init<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, false>(
+    detail::pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, false>(
         ocb, face_r_dim, num_faces, call_line);
 }
 
@@ -121,26 +148,21 @@ ALWI void pack_untilize_dest_init_skip_remap(
  * |------------|-----------------|------------------------------------|----------|---------------------------|------------------------|
  * | Template   | block_ct_dim    | Width of a single block in tiles   | uint32_t | 1 to max (see note)       | False (default = 8)    |
  * | Template   | full_ct_dim     | Width of a full input in tiles     | uint32_t | Divisible by block_ct_dim | False                  |
- * | Template   | configure_remap  | Configure BH DEST remap during init | bool     | true/false                | False (default = true) |
  * | Function   | icb             | Input circular buffer identifier    | uint32_t | 0 to 31                   | True                   |
  * | Function   | ocb             | Output circular buffer identifier   | uint32_t | 0 to 31                   | True                   |
  *
- * `configure_remap = false` is valid only when the caller has already configured BH DEST remap and no intervening
- * operation requires a different DEST remap state.
+ * This default init configures BH DEST remap. Use `pack_untilize_init_skip_remap` only when the caller has already
+ * configured BH DEST remap and no intervening operation requires a different DEST remap state.
  */
 // clang-format on
-template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim, bool configure_remap = true>
+template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
 ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-#ifndef ARCH_QUASAR
-    state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        false, false, icb)));  // init must be after configure
-    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
-#else
-    UNPACK((llk_unpack_A_init</*TRANSPOSE_EN=*/false, DST_ACCUM_MODE>(icb)));
-    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE>(icb)));
-#endif
-    pack_untilize_dest_init<block_ct_dim, full_ct_dim, false, TILE_C_DIM, false, configure_remap>(ocb);
+    detail::pack_untilize_init_impl<block_ct_dim, full_ct_dim, true>(icb, ocb, call_line);
+}
+
+template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
+ALWI void pack_untilize_init_skip_remap(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+    detail::pack_untilize_init_impl<block_ct_dim, full_ct_dim, false>(icb, ocb, call_line);
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -61,14 +61,16 @@ template <
     uint32_t full_ct_dim = block_ct_dim,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    bool dense = false>
+    bool dense = false,
+    bool configure_remap = true>
 ALWI void pack_untilize_dest_init(
     uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4, uint32_t call_line = __builtin_LINE()) {
 #ifndef ARCH_QUASAR
     state_configure<Operand::PACK>(ocb, call_line);
 #ifdef ARCH_BLACKHOLE
-    // Needed for setting swizzle_32b:
-    MATH((llk_math_reconfig_remap(true)));
+    if constexpr (configure_remap) {
+        configure_dest_remap();
+    }
 #endif  // TODO NC: A workaround for tt-metal#17132. Should be addressed more systematically in tt-llk#989
     PACK((llk_pack_reconfig_data_format_disaggregated<DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
     PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, false, narrow_row, row_num_datums, dense>(
@@ -78,6 +80,18 @@ ALWI void pack_untilize_dest_init(
     LLK_ASSERT(narrow_row == false, "narrow_row not supported on Quasar");
     PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
 #endif
+}
+
+template <
+    uint32_t block_ct_dim = 8,
+    uint32_t full_ct_dim = block_ct_dim,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    bool dense = false>
+ALWI void pack_untilize_dest_init_skip_remap(
+    uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4, uint32_t call_line = __builtin_LINE()) {
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, false>(
+        ocb, face_r_dim, num_faces, call_line);
 }
 
 // clang-format off
@@ -107,7 +121,7 @@ ALWI void pack_untilize_dest_init(
  * | Function   | ocb          | Output circular buffer identifier          | uint32_t  | 0 to 31                   | True                    |
  */
 // clang-format on
-template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
+template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim, bool configure_remap = true>
 ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
 #ifndef ARCH_QUASAR
     state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
@@ -118,7 +132,7 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __
     UNPACK((llk_unpack_A_init</*TRANSPOSE_EN=*/false, DST_ACCUM_MODE>(icb)));
     MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE>(icb)));
 #endif
-    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(ocb);
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim, false, TILE_C_DIM, false, configure_remap>(ocb);
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -271,9 +271,10 @@ ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb
 #endif
 }
 
-template <bool configure_remap = true>
-ALWI void fast_tilize_init_with_remap_mode(
-    uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+namespace detail {
+
+template <bool configure_remap>
+ALWI void fast_tilize_init_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
 #ifdef ARCH_BLACKHOLE
     if (full_dim == 1) {
         tilize_init(icb, full_dim, ocb, call_line);
@@ -300,32 +301,38 @@ ALWI void fast_tilize_init_with_remap_mode(
 #endif
 }
 
+}  // namespace detail
+
 ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    fast_tilize_init_with_remap_mode<true>(icb, full_dim, ocb, call_line);
+    detail::fast_tilize_init_impl<true>(icb, full_dim, ocb, call_line);
 }
 
 ALWI void fast_tilize_init_skip_remap(
     uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    fast_tilize_init_with_remap_mode<false>(icb, full_dim, ocb, call_line);
+    detail::fast_tilize_init_impl<false>(icb, full_dim, ocb, call_line);
 }
 
-template <bool configure_remap = true>
-ALWI void fast_tilize_init_with_dt_remap_mode(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
+namespace detail {
+
+template <bool configure_remap>
+ALWI void fast_tilize_init_with_dt_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     // Reconfig both SrcA and SrcB to match WH: some activation-reuse call sites
     // leave SrcB in a prior matmul-weights config that's incompatible with the
     // fast-tilize path, producing garbage output.
     UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(icb, icb)));
     MATH((llk_math_reconfig_data_format<true, true>(icb, icb)));
 
-    fast_tilize_init_with_remap_mode<configure_remap>(icb, full_dim, ocb);
+    fast_tilize_init_impl<configure_remap>(icb, full_dim, ocb);
 }
 
+}  // namespace detail
+
 ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
-    fast_tilize_init_with_dt_remap_mode<true>(icb, full_dim, ocb);
+    detail::fast_tilize_init_with_dt_impl<true>(icb, full_dim, ocb);
 }
 
 ALWI void fast_tilize_init_with_dt_skip_remap(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
-    fast_tilize_init_with_dt_remap_mode<false>(icb, full_dim, ocb);
+    detail::fast_tilize_init_with_dt_impl<false>(icb, full_dim, ocb);
 }
 
 ALWI void fast_tilize_uninit(uint32_t icb, uint32_t ocb, uint32_t full_dim) {

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -271,7 +271,9 @@ ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb
 #endif
 }
 
-ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+template <bool configure_remap = true>
+ALWI void fast_tilize_init_with_remap_mode(
+    uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
 #ifdef ARCH_BLACKHOLE
     if (full_dim == 1) {
         tilize_init(icb, full_dim, ocb, call_line);
@@ -285,7 +287,11 @@ ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32
     // first_chunk = decompose_row(full_dim)[0]: avoids first reinit_xdim in block loop.
     uint32_t first_chunk = (full_dim > 5) ? 4 : (full_dim == 5) ? 2 : full_dim;
     UNPACK((llk_unpack_fast_tilize_init(icb, full_dim, first_chunk)));
-    MATH((llk_math_fast_tilize_init(icb)));
+    if constexpr (configure_remap) {
+        MATH((llk_math_fast_tilize_init(icb)));
+    } else {
+        MATH((llk_math_fast_tilize_init_skip_remap(icb)));
+    }
     PACK((llk_pack_fast_tilize_init(icb, ocb, first_chunk)));
 #else
     UNPACK((llk_unpack_fast_tilize_init(icb, full_dim)));
@@ -294,14 +300,32 @@ ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32
 #endif
 }
 
-ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
+ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+    fast_tilize_init_with_remap_mode<true>(icb, full_dim, ocb, call_line);
+}
+
+ALWI void fast_tilize_init_skip_remap(
+    uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+    fast_tilize_init_with_remap_mode<false>(icb, full_dim, ocb, call_line);
+}
+
+template <bool configure_remap = true>
+ALWI void fast_tilize_init_with_dt_remap_mode(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     // Reconfig both SrcA and SrcB to match WH: some activation-reuse call sites
     // leave SrcB in a prior matmul-weights config that's incompatible with the
     // fast-tilize path, producing garbage output.
     UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(icb, icb)));
     MATH((llk_math_reconfig_data_format<true, true>(icb, icb)));
 
-    fast_tilize_init(icb, full_dim, ocb);
+    fast_tilize_init_with_remap_mode<configure_remap>(icb, full_dim, ocb);
+}
+
+ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
+    fast_tilize_init_with_dt_remap_mode<true>(icb, full_dim, ocb);
+}
+
+ALWI void fast_tilize_init_with_dt_skip_remap(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
+    fast_tilize_init_with_dt_remap_mode<false>(icb, full_dim, ocb);
 }
 
 ALWI void fast_tilize_uninit(uint32_t icb, uint32_t ocb, uint32_t full_dim) {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_fast_tilize.h
@@ -24,15 +24,16 @@
 // Pack then reads 4 tiles from the DEST half using DST_ACCESS_STRIDED_MODE.
 // ============================================================================
 
-template <bool is_fp32_dest_acc_en = false>
+template <bool is_fp32_dest_acc_en = false, bool configure_remap = true>
 inline void _llk_math_fast_tilize_init_([[maybe_unused]] const std::uint32_t unpack_dst_format)
 {
-    // DEST remap (remap_addrs + swizzle_32b) is enabled here to mirror
-    // pack_untilize_dest_init's BH workaround (see tt-metal#17132 / tt-llk#989).
-    // Kernels that call fast_tilize_init from inside a loop pay the tensix_sync
-    // cost per iteration; systematic hoist is tracked in the same issues.
-    // No uninit - leaving the bits set is benign for subsequent ops.
-    _llk_math_reconfig_remap_(true);
+    if constexpr (configure_remap)
+    {
+        // DEST remap (remap_addrs + swizzle_32b) is enabled here to mirror
+        // pack_untilize_dest_init's BH workaround (see tt-metal#17132 / tt-llk#989).
+        // No uninit - leaving the bits set is benign for subsequent ops.
+        _llk_math_reconfig_remap_(true);
+    }
 
     // Compat fp32-dest: MOVA2D does not correctly handle 32-bit DEST rows (BH HW quirk,
     // same as WH). Temporarily clear Fp32_enabled so MOVA2D treats DEST as 16-bit.

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
@@ -82,10 +82,13 @@ enum class RemapMode : uint8_t {
  *   output_cb        — Output circular buffer index (0–31, tiled output, must differ from input_cb).
  *   init_uninit_mode — Init/uninit lifecycle control (default: InitAndUninit).
  *   wait_mode        — How to synchronize on input data (default: WaitBlock).
- *   reconfig_mode    — Register datatype reconfiguration (default: UnpackAndPackReconfigure).
+ *   reconfig_mode     — Register datatype reconfiguration (default: UnpackAndPackReconfigure).
  *   fp32_mode        — Float32 precision control (default: Fast).
  *                       Fast: uses fast_tilize when possible (lossy for fp32 — truncates to tf32 precision).
  *                       Lossless: forces standard tilize path, preserving exact fp32 values.
+ *   remap_mode       — BH DEST remap setup control (default: Configure).
+ *                       Configure: helper configures remap when the selected tilize path needs it.
+ *                       AssumeConfigured: caller already enabled BH DEST remap and no intervening code changes it.
  *
  * ── Block Geometry ─────────────────────────────────────────────────────────
  *

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
@@ -53,6 +53,13 @@ enum class Fp32Mode : uint8_t {
     Lossless  // Forces standard tilize path for fp32 data (exact, no truncation)
 };
 
+// Controls whether BH fast tilize configures DEST remap during init.
+// Use AssumeConfigured only when the caller configured remap once before entering a hot loop.
+enum class RemapMode : uint8_t {
+    Configure,        // Default: init configures remap when the selected tilize path needs it
+    AssumeConfigured  // Caller already configured remap for this kernel
+};
+
 }  // namespace tilize_config
 
 /**
@@ -149,7 +156,8 @@ template <
     tilize_config::WaitMode wait_mode = tilize_config::WaitMode::WaitBlock,
     tilize_config::ReconfigureRegisterDatatypeMode reconfig_mode =
         tilize_config::ReconfigureRegisterDatatypeMode::UnpackAndPackReconfigure,
-    tilize_config::Fp32Mode fp32_mode = tilize_config::Fp32Mode::Fast>
+    tilize_config::Fp32Mode fp32_mode = tilize_config::Fp32Mode::Fast,
+    tilize_config::RemapMode remap_mode = tilize_config::RemapMode::Configure>
 ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages = std::nullopt);
 
 }  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -83,11 +83,8 @@ constexpr bool can_use_fast_tilize() {
     // That truncation is acceptable for bf16/bfp output but destroys precision
     // for fp32 output, producing garbage results in downstream fp32 consumers
     // (see attn_matmul_fp32 regression).
-    return block_width_tiles < 256 &&
-           has_32x32_tiles<output_cb>() &&
-           !get_dst_full_sync_enabled() &&
-           has_supported_fast_tilize_format<input_cb>() &&
-           !is_fp32_output_format<output_cb>();
+    return block_width_tiles < 256 && has_32x32_tiles<output_cb>() && !get_dst_full_sync_enabled() &&
+           has_supported_fast_tilize_format<input_cb>() && !is_fp32_output_format<output_cb>();
 }
 
 // =============================================================================
@@ -101,20 +98,14 @@ template <
     tilize_config::InitUninitMode init_uninit_mode,
     tilize_config::WaitMode wait_mode,
     tilize_config::ReconfigureRegisterDatatypeMode reconfig_mode,
-    tilize_config::Fp32Mode fp32_mode>
-ALWI void tilize(
-    uint32_t num_blocks,
-    std::optional<uint32_t> total_input_pages) {
-
+    tilize_config::Fp32Mode fp32_mode,
+    tilize_config::RemapMode remap_mode>
+ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages) {
     // Compile-time validation
-    static_assert(block_width_tiles > 0,
-        "block_width_tiles must be greater than 0");
-    static_assert(input_cb != output_cb,
-        "Tilize cannot be done in-place: input_cb and output_cb must be different");
-    static_assert(input_cb < 32,
-        "Invalid input_cb: must be less than 32");
-    static_assert(output_cb < 32,
-        "Invalid output_cb: must be less than 32");
+    static_assert(block_width_tiles > 0, "block_width_tiles must be greater than 0");
+    static_assert(input_cb != output_cb, "Tilize cannot be done in-place: input_cb and output_cb must be different");
+    static_assert(input_cb < 32, "Invalid input_cb: must be less than 32");
+    static_assert(output_cb < 32, "Invalid output_cb: must be less than 32");
 
     // Runtime parameter validation
     ASSERT(num_blocks > 0);
@@ -122,10 +113,9 @@ ALWI void tilize(
     // Determine if we're using fast tilize mode (automatic detection based on tile size, sync mode, and data format).
     // Fp32Mode::Lossless disables fast tilize only for fp32 inputs to preserve exact values
     // (fast tilize truncates fp32 → tf32). Has no effect on non-fp32 formats.
-    constexpr bool lossless_fp32_override = (fp32_mode == tilize_config::Fp32Mode::Lossless) &&
-                                            is_fp32_input_format<input_cb>();
-    constexpr bool use_fast = can_use_fast_tilize<block_width_tiles, input_cb, output_cb>() &&
-                              !lossless_fp32_override;
+    constexpr bool lossless_fp32_override =
+        (fp32_mode == tilize_config::Fp32Mode::Lossless) && is_fp32_input_format<input_cb>();
+    constexpr bool use_fast = can_use_fast_tilize<block_width_tiles, input_cb, output_cb>() && !lossless_fp32_override;
 
     // Determine if we're doing data type reconfiguration
     constexpr bool use_unpack_reconfig =
@@ -139,7 +129,7 @@ ALWI void tilize(
     const bool asymmetric_cb_pages = total_input_pages.has_value();
     if (asymmetric_cb_pages) {
         ASSERT(*total_input_pages > (num_blocks - 1) * 32);  // at least one row in the last block
-        ASSERT(*total_input_pages <= num_blocks * 32);        // rows fit within num_blocks tile-rows
+        ASSERT(*total_input_pages <= num_blocks * 32);       // rows fit within num_blocks tile-rows
     }
 
     // Tilize input must not be a block float format (Bfp8/4/2 and _b variants).
@@ -170,9 +160,15 @@ ALWI void tilize(
     if constexpr (
         init_uninit_mode == tilize_config::InitUninitMode::InitAndUninit ||
         init_uninit_mode == tilize_config::InitUninitMode::InitOnly) {
-
         if constexpr (use_fast) {
-            fast_tilize_init(input_cb, block_width_tiles, output_cb);
+#ifdef ARCH_BLACKHOLE
+            if constexpr (remap_mode == tilize_config::RemapMode::AssumeConfigured) {
+                fast_tilize_init_skip_remap(input_cb, block_width_tiles, output_cb);
+            } else
+#endif
+            {
+                fast_tilize_init(input_cb, block_width_tiles, output_cb);
+            }
         } else {
             tilize_init(input_cb, block_width_tiles, output_cb);
         }
@@ -231,7 +227,6 @@ ALWI void tilize(
     if constexpr (
         init_uninit_mode == tilize_config::InitUninitMode::InitAndUninit ||
         init_uninit_mode == tilize_config::InitUninitMode::UninitOnly) {
-
         if constexpr (use_fast) {
             fast_tilize_uninit(input_cb, output_cb, block_width_tiles);
         } else {

--- a/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp
@@ -90,7 +90,10 @@ ALWI void untilize_uninit();
  *   output_cb         — Output circular buffer index (0–31, row-major output, must differ from input_cb).
  *   init_uninit_mode  — Init/uninit lifecycle control (default: InitAndUninit).
  *   wait_mode         — How to synchronize on input data (default: WaitBlock).
- *   reconfig_mode     — Register datatype reconfiguration (default: UnpackAndPackReconfigure).
+ *   reconfig_mode      — Register datatype reconfiguration (default: UnpackAndPackReconfigure).
+ *   remap_mode        — BH DEST remap setup control (default: Configure).
+ *                        Configure: helper configures remap during pack untilize init.
+ *                        AssumeConfigured: caller already enabled BH DEST remap and no intervening code changes it.
  *
  * ── Block Geometry ─────────────────────────────────────────────────────────
  *

--- a/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp
@@ -43,6 +43,13 @@ enum class WaitMode : uint8_t {
     NoWait        // Caller manages synchronization externally
 };
 
+// Controls whether BH untilize configures DEST remap during init.
+// Use AssumeConfigured only when the caller configured remap once before entering a hot loop.
+enum class RemapMode : uint8_t {
+    Configure,        // Default: init configures remap
+    AssumeConfigured  // Caller already configured remap for this kernel
+};
+
 }  // namespace untilize_config
 
 // Standalone init/uninit wrappers for manual lifecycle control.
@@ -53,7 +60,11 @@ enum class WaitMode : uint8_t {
 // untilize() reconfig_mode — use NoReconfigure or PackReconfigure only.
 // If you need unpacker reconfiguration, call unpacker and packer reconfiguration manually
 // before untilize_init(), or use the unified untilize() which handles it automatically.
-template <uint32_t block_width_tiles, uint32_t input_cb, uint32_t output_cb>
+template <
+    uint32_t block_width_tiles,
+    uint32_t input_cb,
+    uint32_t output_cb,
+    untilize_config::RemapMode remap_mode = untilize_config::RemapMode::Configure>
 ALWI void untilize_init();
 
 template <uint32_t block_width_tiles, uint32_t input_cb, uint32_t output_cb>
@@ -136,7 +147,8 @@ template <
     untilize_config::InitUninitMode init_uninit_mode = untilize_config::InitUninitMode::InitAndUninit,
     untilize_config::WaitMode wait_mode = untilize_config::WaitMode::WaitBlock,
     untilize_config::ReconfigureRegisterDatatypeMode reconfig_mode =
-        untilize_config::ReconfigureRegisterDatatypeMode::UnpackAndPackReconfigure>
+        untilize_config::ReconfigureRegisterDatatypeMode::UnpackAndPackReconfigure,
+    untilize_config::RemapMode remap_mode = untilize_config::RemapMode::Configure>
 ALWI void untilize(uint32_t num_blocks);
 
 }  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
@@ -43,17 +43,19 @@ constexpr uint32_t compute_num_blocks(uint32_t total_width, uint32_t max_block_w
 // Standalone Init/Uninit Wrapper Functions Implementations
 // =============================================================================
 
-template <uint32_t block_width_tiles, uint32_t input_cb, uint32_t output_cb>
+template <uint32_t block_width_tiles, uint32_t input_cb, uint32_t output_cb, untilize_config::RemapMode remap_mode>
 ALWI void untilize_init() {
     constexpr uint32_t dest_limit = DEST_AUTO_LIMIT;
     constexpr bool use_block_based_pack = (block_width_tiles > dest_limit);
     constexpr uint32_t num_sub_blocks = use_block_based_pack ? compute_num_blocks(block_width_tiles, dest_limit) : 1;
-    constexpr uint32_t sub_block_width = use_block_based_pack ? (block_width_tiles / num_sub_blocks) : block_width_tiles;
+    constexpr uint32_t sub_block_width =
+        use_block_based_pack ? (block_width_tiles / num_sub_blocks) : block_width_tiles;
+    constexpr bool configure_remap = (remap_mode == untilize_config::RemapMode::Configure);
 
     if constexpr (use_block_based_pack) {
-        pack_untilize_init<sub_block_width, block_width_tiles>(input_cb, output_cb);
+        pack_untilize_init<sub_block_width, block_width_tiles, configure_remap>(input_cb, output_cb);
     } else {
-        pack_untilize_init<block_width_tiles, block_width_tiles>(input_cb, output_cb);
+        pack_untilize_init<block_width_tiles, block_width_tiles, configure_remap>(input_cb, output_cb);
     }
 }
 
@@ -72,18 +74,14 @@ template <
     uint32_t output_cb,
     untilize_config::InitUninitMode init_uninit_mode,
     untilize_config::WaitMode wait_mode,
-    untilize_config::ReconfigureRegisterDatatypeMode reconfig_mode>
+    untilize_config::ReconfigureRegisterDatatypeMode reconfig_mode,
+    untilize_config::RemapMode remap_mode>
 ALWI void untilize(uint32_t num_blocks) {
-
     // Compile-time validation
-    static_assert(input_cb != output_cb,
-        "Untilize cannot be done in-place: input_cb and output_cb must be different");
-    static_assert(block_width_tiles > 0,
-        "block_width_tiles must be greater than 0");
-    static_assert(input_cb < 32,
-        "Invalid input_cb: must be less than 32");
-    static_assert(output_cb < 32,
-        "Invalid output_cb: must be less than 32");
+    static_assert(input_cb != output_cb, "Untilize cannot be done in-place: input_cb and output_cb must be different");
+    static_assert(block_width_tiles > 0, "block_width_tiles must be greater than 0");
+    static_assert(input_cb < 32, "Invalid input_cb: must be less than 32");
+    static_assert(output_cb < 32, "Invalid output_cb: must be less than 32");
 
     // Runtime parameter validation
     ASSERT(num_blocks > 0);
@@ -116,10 +114,10 @@ ALWI void untilize(uint32_t num_blocks) {
     constexpr bool use_block_based_pack = (block_width_tiles > dest_limit);
 
     // Compute block parameters for block-based pack path
-    constexpr uint32_t num_sub_blocks = use_block_based_pack ?
-        compute_num_blocks(block_width_tiles, dest_limit) : 1;
-    constexpr uint32_t sub_block_width = use_block_based_pack ?
-        (block_width_tiles / num_sub_blocks) : block_width_tiles;
+    constexpr uint32_t num_sub_blocks = use_block_based_pack ? compute_num_blocks(block_width_tiles, dest_limit) : 1;
+    constexpr uint32_t sub_block_width =
+        use_block_based_pack ? (block_width_tiles / num_sub_blocks) : block_width_tiles;
+    constexpr bool configure_remap = (remap_mode == untilize_config::RemapMode::Configure);
 
     // Validate CB capacity.
     // Guarded because get_local_cb_interface() references cb_interface, which is
@@ -138,11 +136,10 @@ ALWI void untilize(uint32_t num_blocks) {
     if constexpr (
         init_uninit_mode == untilize_config::InitUninitMode::InitAndUninit ||
         init_uninit_mode == untilize_config::InitUninitMode::InitOnly) {
-
         if constexpr (use_block_based_pack) {
-            pack_untilize_init<sub_block_width, block_width_tiles>(input_cb, output_cb);
+            pack_untilize_init<sub_block_width, block_width_tiles, configure_remap>(input_cb, output_cb);
         } else {
-            pack_untilize_init<block_width_tiles, block_width_tiles>(input_cb, output_cb);
+            pack_untilize_init<block_width_tiles, block_width_tiles, configure_remap>(input_cb, output_cb);
         }
     }
 
@@ -206,7 +203,6 @@ ALWI void untilize(uint32_t num_blocks) {
     if constexpr (
         init_uninit_mode == untilize_config::InitUninitMode::InitAndUninit ||
         init_uninit_mode == untilize_config::InitUninitMode::UninitOnly) {
-
         pack_untilize_uninit(output_cb);
     }
 }

--- a/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
@@ -53,9 +53,17 @@ ALWI void untilize_init() {
     constexpr bool configure_remap = (remap_mode == untilize_config::RemapMode::Configure);
 
     if constexpr (use_block_based_pack) {
-        pack_untilize_init<sub_block_width, block_width_tiles, configure_remap>(input_cb, output_cb);
+        if constexpr (configure_remap) {
+            pack_untilize_init<sub_block_width, block_width_tiles>(input_cb, output_cb);
+        } else {
+            pack_untilize_init_skip_remap<sub_block_width, block_width_tiles>(input_cb, output_cb);
+        }
     } else {
-        pack_untilize_init<block_width_tiles, block_width_tiles, configure_remap>(input_cb, output_cb);
+        if constexpr (configure_remap) {
+            pack_untilize_init<block_width_tiles, block_width_tiles>(input_cb, output_cb);
+        } else {
+            pack_untilize_init_skip_remap<block_width_tiles, block_width_tiles>(input_cb, output_cb);
+        }
     }
 }
 
@@ -137,9 +145,17 @@ ALWI void untilize(uint32_t num_blocks) {
         init_uninit_mode == untilize_config::InitUninitMode::InitAndUninit ||
         init_uninit_mode == untilize_config::InitUninitMode::InitOnly) {
         if constexpr (use_block_based_pack) {
-            pack_untilize_init<sub_block_width, block_width_tiles, configure_remap>(input_cb, output_cb);
+            if constexpr (configure_remap) {
+                pack_untilize_init<sub_block_width, block_width_tiles>(input_cb, output_cb);
+            } else {
+                pack_untilize_init_skip_remap<sub_block_width, block_width_tiles>(input_cb, output_cb);
+            }
         } else {
-            pack_untilize_init<block_width_tiles, block_width_tiles, configure_remap>(input_cb, output_cb);
+            if constexpr (configure_remap) {
+                pack_untilize_init<block_width_tiles, block_width_tiles>(input_cb, output_cb);
+            } else {
+                pack_untilize_init_skip_remap<block_width_tiles, block_width_tiles>(input_cb, output_cb);
+            }
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -146,7 +146,8 @@ void untilize_block() {
         out_cb,
         compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
-        untilize_reconfig_mode>(rows);
+        untilize_reconfig_mode,
+        compute_kernel_lib::untilize_config::RemapMode::AssumeConfigured>(rows);
 }
 
 template <
@@ -243,6 +244,7 @@ void kernel_main() {
     constexpr uint32_t subblock_tiles = subblock_h * matmul_N_t;
 
     mm_init(cb_vol2col_tiled, cb_weight_tiled, cb_matmul_interm_tiled);
+    configure_dest_remap();
 
     // Load range parameters
     uint32_t argidx = 0;
@@ -299,7 +301,10 @@ void kernel_main() {
                                             compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
                                             compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
                                             compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::
-                                                NoReconfigure>(1, patches_this_row);
+                                                NoReconfigure,
+                                            compute_kernel_lib::tilize_config::Fp32Mode::Fast,
+                                            compute_kernel_lib::tilize_config::RemapMode::AssumeConfigured>(
+                                            1, patches_this_row);
                                         patches_left -= patches_this_row;
                                     }
 
@@ -354,7 +359,9 @@ void kernel_main() {
                                             cb_matmul_result_rm,
                                             compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
                                             compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
-                                            untilize_reconfig_mode_sb>(subblock_h);
+                                            untilize_reconfig_mode_sb,
+                                            compute_kernel_lib::untilize_config::RemapMode::AssumeConfigured>(
+                                            subblock_h);
                                     }
                                 }
                             }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -244,7 +244,7 @@ void kernel_main() {
     constexpr uint32_t subblock_tiles = subblock_h * matmul_N_t;
 
     mm_init(cb_vol2col_tiled, cb_weight_tiled, cb_matmul_interm_tiled);
-    configure_dest_remap();
+    MATH((llk_math_reconfig_remap(true)));
 
     // Load range parameters
     uint32_t argidx = 0;


### PR DESCRIPTION
## Summary

Hoist Blackhole DEST remap setup out of the conv3d tilize/matmul/untilize hot loop. Fast tilize and pack/untilize both need DEST remap enabled, but `_llk_math_reconfig_remap_(true)` is not performance-idempotent: it performs `tensix_sync()` and waits for `MATH_PACK` to drain before rewriting the same remap state.

Before this change, conv3d could pay two conservative packer-drain boundaries per repeated unit:

- fast-tilize init -> `_llk_math_reconfig_remap_(true)`
- pack/untilize init -> `configure_dest_remap()` -> `_llk_math_reconfig_remap_(true)`

Both calls set the same true state, so they were not protecting a real mode transition. They serialized math/pack traffic and partially defeated the intended half-sync DEST overlap.

This change adds:

- `configure_dest_remap()` as a common compute helper
- explicit `RemapMode::AssumeConfigured` paths in tilize/untilize helpers
- skip-remap fast-tilize and pack-untilize init variants
- conv3d opt-in that configures DEST remap once after matmul setup and uses `AssumeConfigured` in repeated tilize/untilize calls

The default helper behavior stays conservative: standalone users still configure remap unless they explicitly opt into `AssumeConfigured`. Other kernels are intentionally not opted in in this PR without targeted perf evidence.

## Motivation

The main motivator is speeding up `ttnn.conv3d` workloads used by video generation.

## Performance

Wan VAE conv3d perf sweep, corrected pre-hoist vs post-hoist over 96 HiFi2/fp32-dest cases:

- Total: `423.497 ms -> 285.779 ms` (`-32.52%`)
- Weighted FPU utilization: `15.85% -> 23.49%`
- Largest recovered cases:
  - `h2w4_480p_t7_up1_spatial`: `-56.07%`
  - `h4w8_720p_t16_up1_spatial`: `-55.88%`
  - `h4w8_720p_t15_up1_tconv`: `-54.74%`

## Limitations

`AssumeConfigured` is only valid when the caller has already enabled BH DEST remap and no intervening code requires a different remap state. Standalone helper users should keep the default `Configure` mode.

## Testing

- Not rerun after latest rebase/amend.
- `git diff --check` was clean before the final rebase/amend.
- `clang-format -i` was run on the changed code files before the final rebase/amend.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/hoist-bh-remap-tilize-untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/hoist-bh-remap-tilize-untilize)