### PR TITLE
[Bug fix] Extend page-table alignment to `batch_size > 1` and guard `chunk_start_idx`

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -62,7 +62,7 @@ def _pad_or_create_page_table(table, target_blocks):
     if table is not None:
         num_pad = aligned_blocks - table.shape[1]
         if num_pad > 0:
-            padding = torch.ones(1, num_pad, dtype=torch.int32) * -1
+            padding = torch.ones(table.shape[0], num_pad, dtype=torch.int32) * -1
             return torch.cat([table, padding], dim=-1)
         return table
     return torch.ones(1, aligned_blocks, dtype=torch.int32) * -1
@@ -440,13 +440,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             full_page_table = full_page_table[user_id : user_id + 1, :]
 
         chunk_page_table = None
+        max_blocks_prefill = _get_max_blocks_prefill(kv_cache)
+        # Preserve full per-user page IDs for traced APC slicing.
+        source_page_table = full_page_table if full_page_table is not None else page_table
+        if source_page_table is None:
+            raise ValueError("Traced prefill requires a page_table")
+        page_table = _pad_or_create_page_table(source_page_table, max_blocks_prefill)
         if batch_size == 1:
-            max_blocks_prefill = _get_max_blocks_prefill(kv_cache)
-            # Preserve full per-user page IDs for traced APC slicing.
-            source_page_table = full_page_table if full_page_table is not None else page_table
-            if source_page_table is None:
-                raise ValueError("Traced prefill requires a page_table")
-            page_table = _pad_or_create_page_table(source_page_table, max_blocks_prefill)
             if use_prefix_caching:
                 chunk_start_block = num_cached_tokens // block_size
                 chunk_end_block = num_blocks_in_seq(num_cached_tokens + prefill_seq_len, block_size)

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -437,7 +437,7 @@ class Transformer(LightweightModule):
         else:
             tt_chunk_page_table = None
 
-        if chunk_start_idx is not None:
+        if chunk_start_idx is not None and int(chunk_start_idx) > 0:
             chunk_start_idx_tensor = torch.tensor([chunk_start_idx], dtype=torch.int32)
             tt_chunk_start_idx = ttnn.from_torch(
                 chunk_start_idx_tensor,


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Originally raised by the regression analysis: https://github.com/tenstorrent/tt-metal/actions/runs/26153738685 and mentioned in #44886 (Issue 1)

Currently, some LLama tests with batch-32 options are failing with runtime-error logs like this:
```
RuntimeError: TT_FATAL @ /project/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp:151: p.page_table_stick_size % 32 == 0
info:
page table stick size must be a multiple of 32
```

This PR aligns page table to all batches (previously, considered only `batch_size == 1`) and prevents `chunk_start_idx` tensor creation for value 0, which triggered assertion in SDPA.

### Notes for reviewers

* Llama 8B tests (one alert came from here): https://github.com/tenstorrent/tt-metal/actions/runs/26281833511 - all passed!
* vLLM nightly tests: https://github.com/tenstorrent/tt-metal/actions/runs/26295413319
* E2E tests: https://github.com/tenstorrent/tt-metal/actions/runs/26295395842 (main) vs https://github.com/tenstorrent/tt-metal/actions/runs/26295454261 (PR)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanjaradylov/fix-llama-page-table-stick-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanjaradylov/fix-llama-page-table-stick-size)