### PR TITLE
Fix finding MPI rank in tt-triage

### DIFF
--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -175,8 +175,13 @@ def run(args, context) -> InspectorData:
             size = MPI.COMM_WORLD.Get_size()
             if size > 1:
                 rank = MPI.COMM_WORLD.Get_rank()
-        except Exception:
+            else:
+                rank_env = os.environ.get("TT_RUN_RANK")
+                if rank_env is not None:
+                    rank = int(rank_env)
+        except Exception as e:
             # If MPI is not available or fails, fall back to rank-less mode without aborting.
+            print(f"Warning: MPI is not available or failed to initialize, running in rank-less mode. Error: {e}")
             pass
 
     # First try to connect to Inspector RPC

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -23,7 +23,7 @@ Owner:
     tt-vjovanovic
 """
 
-from triage import triage_singleton, ScriptConfig, TTTriageError, run_script
+from triage import triage_singleton, ScriptConfig, TTTriageError, log_warning, run_script
 from parse_inspector_logs import get_data as get_logs_data, get_log_directory
 from mpi4py import MPI
 import asyncio
@@ -181,7 +181,7 @@ def run(args, context) -> InspectorData:
                     rank = int(rank_env)
         except Exception as e:
             # If MPI is not available or fails, fall back to rank-less mode without aborting.
-            print(f"Warning: MPI is not available or failed to initialize, running in rank-less mode. Error: {e}")
+            log_warning(f"Warning: MPI is not available or failed to initialize, running in rank-less mode. Error: {e}")
             pass
 
     # First try to connect to Inspector RPC

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -212,9 +212,9 @@ void MetalContext::initialize(
     // Initialize inspector
     if (this->get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
         std::optional<int> rank;
-        const auto& distributed_context = global_distributed_context();
-        if (*(distributed_context.size()) > 1) {
-            rank = *distributed_context.rank();
+        auto world_context = distributed::multihost::DistributedContext::get_world_context();
+        if (*(world_context->size()) > 1) {
+            rank = *world_context->rank();
         }
         inspector_data_ = Inspector::initialize(rank);
         // Set fw_compile_hash for Inspector RPC build environment info

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -1495,6 +1495,7 @@ def get_rank_environment(
             ),
             # Pass the original CWD to subprocesses so they can resolve relative paths correctly
             "TT_RUN_ORIGINAL_CWD": str(ORIGINAL_CWD),
+            "TT_RUN_RANK": str(binding.rank),  # Expose rank as an environment variable for convenience
         }
     )
 


### PR DESCRIPTION
We have a problem when auto timeout detection triggers `tt-triage` in metal runtime it will be spawn as child process. Because of Python and child process limitation we need to expose rank through environment variable. Exposing `TT_RUN_RANK` as an environment variable in `ttrun.py`.

### Notes for reviewers
I forgot to push this change before committing this PR: https://github.com/tenstorrent/tt-metal/pull/41445

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/fix_mpi_tt_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/fix_mpi_tt_triage)