### PR TITLE
[Performance] Update Swin-S device perf target

### DIFF
--- a/models/experimental/swin_s/tests/perf/test_perf.py
+++ b/models/experimental/swin_s/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "Swin_s", 13.1106),
+        (1, "Swin_s", 13.8606),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### PR Category
Performance

### Summary
Update the Swin-S device perf target from `13.1106` to `13.8606` AVG DEVICE KERNEL SAMPLES/S.

The regression-analysis workflow identified this as a deterministic faster-than-expected failure in `device-perf / N300 WH B0 Set 2 device perf` for `test_perf_device_bare_metal_swin_s`:

https://github.com/tenstorrent/tt-metal/actions/runs/26282942242

CI measured `13.8606`, while the previous `13.1106` target had a 3% upper bound of `13.5039`, so the improved run failed the suspiciously-fast perf guard.

The first failing commit was `7439b73b72d45d8de437c925790c62bf2eac6b62`, which changed the Python default for `ttnn::pad use_multicore` from `false` to `true` while fixing stale pad-value buffers on program-cache hits. Swin-S uses `ttnn::pad` through weight preparation, so it now takes the multi-core pad implementation and has a higher stable throughput baseline.

### Notes for reviewers
A narrowed single-card device perf run was triggered for `requested-models=["swin-s"]` and `architecture=["wormhole_b0"]`:

https://github.com/tenstorrent/tt-metal/actions/runs/26283835734

This PR only updates the target baseline; no model code or perf-check logic changes.