### PR TITLE
[tt-train] Wire up or disable vocab parallel cross entropy loss across all trainers

### DIFF
--- a/tt-train/sources/examples/grpo/utils/llama_completer.py
+++ b/tt-train/sources/examples/grpo/utils/llama_completer.py
@@ -196,6 +196,8 @@ class LlamaGRPOCompleter(GRPOCompleter):
         tt_model = LlamaCompositeKV(llama_cfg)
 
         if dev_config.enable_ddp:
+            # NOTE: TP is intentionally disabled here. The cross_entropy_loss call below
+            # assumes full-vocab logits;
             autograd_ctx.initialize_parallelism_context(
                 ttml.autograd.DistributedConfig(enable_ddp=True, enable_tp=False)
             )

--- a/tt-train/sources/examples/lora_llama/train_lora_llama.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama.py
@@ -379,7 +379,14 @@ def main():
 
         optimizer.zero_grad()
         logits = model(tt_x, None)
-        loss = ttml.ops.loss.cross_entropy_loss(logits, tt_y, ttml.ops.ReduceType.MEAN)
+        # When TP is enabled the LoRA-wrapped Llama LM head returns vocab-sharded
+        # logits ([B,1,S,padded_V/tp_size] per device).
+        if use_tp:
+            loss = ttml.ops.distributed.vocab_parallel_cross_entropy_loss(
+                logits, tt_y, cluster_axis=mesh.axis_index("tp")
+            )
+        else:
+            loss = ttml.ops.loss.cross_entropy_loss(logits, tt_y, ttml.ops.ReduceType.MEAN)
 
         if use_ddp:
             loss_val = float(get_loss_over_devices(loss))

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -799,7 +799,8 @@ int main(int argc, char **argv) {
             float loss_float = 0.0F;
             if (needs_to_call_loss) {
                 auto loss = use_vocab_parallel_loss
-                                ? ttml::ops::distributed::vocab_parallel_cross_entropy_loss(output, target, 1U)
+                                ? ttml::ops::distributed::vocab_parallel_cross_entropy_loss(
+                                      output, target, ttml::autograd::ctx().get_parallelism_context().get_tp_axis())
                                 : ttml::ops::cross_entropy_loss(output, target);
                 loss = gradient_accumulator_helper.scale(loss);
                 loss_float = get_loss_value(loss);

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -779,9 +779,9 @@ int main(int argc, char **argv) {
     };
 
     const bool needs_to_call_loss = pipeline_needs_to_call_loss(multihost_config);
-    // pipeline_parallel_llama still hardcodes gather_output=true at the LM head, so its
-    // last-stage logits are full-vocab
-    const bool use_vocab_parallel_loss = device_config.enable_tp && !is_pipeline_parallel_enabled(multihost_config);
+    // All TP-enabled LM heads (TP-only and PP+TP) emit vocab-sharded logits, so the loss
+    // path is uniformly vocab_parallel_cross_entropy_loss whenever TP is on.
+    const bool use_vocab_parallel_loss = device_config.enable_tp;
 
     // Training loop
     for (uint32_t epoch = 0; epoch < num_epochs; ++epoch) {

--- a/tt-train/sources/examples/nano_gpt/train_nanogpt.py
+++ b/tt-train/sources/examples/nano_gpt/train_nanogpt.py
@@ -474,19 +474,29 @@ def train_step(
     # When mask is None, SDPA kernel uses native causal masking (AttentionMaskType::Causal)
     logits = model(input_tokens, mask)
 
-    # Compute loss
-    loss = ttml.ops.loss.cross_entropy_loss(logits, target_tokens, reduce=ttml.ops.ReduceType.MEAN)
+    # Compute loss.  When TP is enabled the LM head returns vocab-sharded
+    # logits ([B,1,S,V/tp_size] per device), so route through
+    # vocab_parallel_cross_entropy_loss.
+    mesh = ttml.mesh()
+    if mesh.has_axis("tp") and mesh.axis_size("tp") > 1:
+        loss = ttml.ops.distributed.vocab_parallel_cross_entropy_loss(
+            logits, target_tokens, cluster_axis=mesh.axis_index("tp")
+        )
+    else:
+        loss = ttml.ops.loss.cross_entropy_loss(logits, target_tokens, reduce=ttml.ops.ReduceType.MEAN)
 
     # Scale loss for gradient accumulation
     loss = gradient_accumulator.scale(loss)
 
-    # Under DDP each rank produced loss on its own microbatch, so the
-    # printed/accumulated value must be the mean across the "dp" axis.
-    # get_loss_over_devices internally builds a concat_mesh_to_tensor
-    # composer and takes the mean, mirroring how the C++ trainer logs
-    # per-rank loss when DDP is on.
-    mesh = ttml.mesh()
-    if mesh.has_axis("dp") and mesh.axis_size("dp") > 1:
+    # Any multi-device mesh — DDP, TP, or DP+TP — produces a loss tensor
+    # with one host buffer per device (per-rank values under DDP; TP-reduced
+    # replicas under TP). Tensor.item() asserts buffers.size()==1, so we
+    # must compose across the mesh before reading to host.
+    # get_loss_over_devices builds a concat_mesh_to_tensor composer and
+    # takes the mean, mirroring the C++ trainer's IdentityComposer-then-
+    # average path in main.cpp::get_loss_value (works for replicas too,
+    # since mean of N identical values equals any one).
+    if mesh.num_devices() > 1:
         loss_float = float(get_loss_over_devices(loss))
     else:
         loss_float = get_loss_value(loss)

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/trainer.py
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/trainer.py
@@ -68,6 +68,7 @@ def worker(
     use_ddp: bool = False,
     use_tp: bool = False,
     num_workers: int = None,
+    use_vocab_parallel_loss: bool = False,
 ):
     """Execute worker training loop.
 
@@ -83,13 +84,16 @@ def worker(
         use_ddp: Whether to use distributed data parallel
         use_tp: Whether to use tensor parallel
         num_workers: Number of worker ranks (if None, assumes 3-tier with world_size - 2)
+        use_vocab_parallel_loss: Whether the model emits vocab-sharded logits and
+            therefore expects ``ttml.ops.distributed.vocab_parallel_cross_entropy_loss``.
+            Should be sourced from ``TransformerModelFactory.use_vocab_parallel_loss``.
 
     Returns:
         Tuple of (train_losses, val_losses) lists
     """
     # Setup loss function and causal mask
-    loss_fn = ttml.ops.loss.cross_entropy_loss
     reduce = ttml.ops.ReduceType.MEAN
+    tp_cluster_axis = ttml.mesh().axis_index("tp") if use_vocab_parallel_loss else None
 
     causal_mask = build_causal_mask(cfg.seq_len)
     tt_mask = ttml.autograd.Tensor.from_numpy(
@@ -145,7 +149,12 @@ def worker(
 
             # Forward and backward pass
             logits = model(tt_x, tt_mask)
-            loss = loss_fn(logits, tt_y, reduce)
+            if use_vocab_parallel_loss:
+                loss = ttml.ops.distributed.vocab_parallel_cross_entropy_loss(
+                    logits, tt_y, cluster_axis=tp_cluster_axis
+                )
+            else:
+                loss = ttml.ops.loss.cross_entropy_loss(logits, tt_y, reduce)
 
             # Scale loss by accumulation steps for proper gradient averaging
             if cfg.gradient_accumulation_steps > 1:

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/trainer.py
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/trainer.py
@@ -68,7 +68,6 @@ def worker(
     use_ddp: bool = False,
     use_tp: bool = False,
     num_workers: int = None,
-    use_vocab_parallel_loss: bool = False,
 ):
     """Execute worker training loop.
 
@@ -84,16 +83,13 @@ def worker(
         use_ddp: Whether to use distributed data parallel
         use_tp: Whether to use tensor parallel
         num_workers: Number of worker ranks (if None, assumes 3-tier with world_size - 2)
-        use_vocab_parallel_loss: Whether the model emits vocab-sharded logits and
-            therefore expects ``ttml.ops.distributed.vocab_parallel_cross_entropy_loss``.
-            Should be sourced from ``TransformerModelFactory.use_vocab_parallel_loss``.
 
     Returns:
         Tuple of (train_losses, val_losses) lists
     """
     # Setup loss function and causal mask
     reduce = ttml.ops.ReduceType.MEAN
-    tp_cluster_axis = ttml.mesh().axis_index("tp") if use_vocab_parallel_loss else None
+    tp_cluster_axis = ttml.mesh().axis_index("tp") if use_tp else None
 
     causal_mask = build_causal_mask(cfg.seq_len)
     tt_mask = ttml.autograd.Tensor.from_numpy(
@@ -149,7 +145,7 @@ def worker(
 
             # Forward and backward pass
             logits = model(tt_x, tt_mask)
-            if use_vocab_parallel_loss:
+            if use_tp:
                 loss = ttml.ops.distributed.vocab_parallel_cross_entropy_loss(
                     logits, tt_y, cluster_axis=tp_cluster_axis
                 )

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/trainer.py
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/trainer.py
@@ -19,9 +19,7 @@ from ttml.common.data import get_batch, build_causal_mask
 from ttml.common.utils import no_grad, PerformanceMeter
 
 
-def get_batch_ttml(
-    ids: np.ndarray, seq_len: int, batch_size: int, use_ddp: bool = False
-):
+def get_batch_ttml(ids: np.ndarray, seq_len: int, batch_size: int, use_ddp: bool = False):
     """Prepare a batch of data for TTML training.
 
     Args:
@@ -45,18 +43,14 @@ def get_batch_ttml(
             ttnn.DataType.UINT32,
             mapper,
         )
-        tt_y = ttml.autograd.Tensor.from_numpy(
-            y_u32, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32, mapper
-        )
+        tt_y = ttml.autograd.Tensor.from_numpy(y_u32, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32, mapper)
     else:
         tt_x = ttml.autograd.Tensor.from_numpy(
             x_u32.reshape(batch_size, 1, 1, seq_len),
             ttnn.Layout.ROW_MAJOR,
             ttnn.DataType.UINT32,
         )
-        tt_y = ttml.autograd.Tensor.from_numpy(
-            y_u32, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32
-        )
+        tt_y = ttml.autograd.Tensor.from_numpy(y_u32, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32)
     return tt_x, tt_y
 
 
@@ -92,9 +86,7 @@ def worker(
     tp_cluster_axis = ttml.mesh().axis_index("tp") if use_tp else None
 
     causal_mask = build_causal_mask(cfg.seq_len)
-    tt_mask = ttml.autograd.Tensor.from_numpy(
-        causal_mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16
-    )
+    tt_mask = ttml.autograd.Tensor.from_numpy(causal_mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16)
 
     # Setup distributed context
     autograd_ctx = ttml.autograd.AutoContext.get_instance()
@@ -221,14 +213,10 @@ def aggregator(model, cfg, use_ddp: bool = False):
 
     # Create sub-contexts for communication
     workers_and_aggregator_ranks = list(range(num_workers + 1))
-    workers_and_aggregator_ctx = distributed_ctx.create_sub_context(
-        workers_and_aggregator_ranks
-    )
+    workers_and_aggregator_ctx = distributed_ctx.create_sub_context(workers_and_aggregator_ranks)
 
     aggregator_and_optimizer_ranks = [rank, rank + 1]
-    aggregator_and_optimizer_ctx = distributed_ctx.create_sub_context(
-        aggregator_and_optimizer_ranks
-    )
+    aggregator_and_optimizer_ctx = distributed_ctx.create_sub_context(aggregator_and_optimizer_ranks)
 
     # In sub-context: aggregator is local rank 0, optimizer is local rank 1
     optimizer_local_rank = 1
@@ -236,9 +224,7 @@ def aggregator(model, cfg, use_ddp: bool = False):
     # Receive and broadcast initial weights from optimizer to workers
     print(f"[Aggregator {rank}] Waiting for initial weights from optimizer {rank + 1}")
     for name, tensor_ptr in sorted_parameters.items():
-        socket_manager.recv(
-            tensor_ptr, aggregator_and_optimizer_ctx, optimizer_local_rank
-        )
+        socket_manager.recv(tensor_ptr, aggregator_and_optimizer_ctx, optimizer_local_rank)
 
         # Broadcast to all workers
         for worker_id in range(num_workers):
@@ -267,15 +253,11 @@ def aggregator(model, cfg, use_ddp: bool = False):
                 tensor_ptr = ttml.ops.distributed.all_reduce(tensor_ptr)
 
             # Send averaged gradient to optimizer (local rank 1 in sub-context)
-            socket_manager.send(
-                tensor_ptr, aggregator_and_optimizer_ctx, optimizer_local_rank
-            )
+            socket_manager.send(tensor_ptr, aggregator_and_optimizer_ctx, optimizer_local_rank)
 
         # Receive updated weights from optimizer and broadcast to all workers
         for name, tensor_ptr in sorted_parameters.items():
-            socket_manager.recv(
-                tensor_ptr, aggregator_and_optimizer_ctx, optimizer_local_rank
-            )
+            socket_manager.recv(tensor_ptr, aggregator_and_optimizer_ctx, optimizer_local_rank)
 
             # Broadcast to all workers
             for worker_id in range(num_workers):
@@ -312,21 +294,15 @@ def optimizer(model, cfg, optimizer_instance):
     # Create sub-context for aggregator-optimizer communication
     aggregator_global_rank = rank - 1
     aggregator_and_optimizer_ranks = [aggregator_global_rank, rank]
-    aggregator_and_optimizer_ctx = distributed_ctx.create_sub_context(
-        aggregator_and_optimizer_ranks
-    )
+    aggregator_and_optimizer_ctx = distributed_ctx.create_sub_context(aggregator_and_optimizer_ranks)
 
     # In sub-context: aggregator is local rank 0, optimizer is local rank 1
     aggregator_local_rank = 0
 
     # Send initial weights to aggregator
-    print(
-        f"[Optimizer {rank}] Sending initial weights to aggregator {aggregator_global_rank}"
-    )
+    print(f"[Optimizer {rank}] Sending initial weights to aggregator {aggregator_global_rank}")
     for name, tensor_ptr in sorted_parameters.items():
-        socket_manager.send(
-            tensor_ptr, aggregator_and_optimizer_ctx, aggregator_local_rank
-        )
+        socket_manager.send(tensor_ptr, aggregator_and_optimizer_ctx, aggregator_local_rank)
 
     print(f"[Optimizer {rank}] Starting training loop for {cfg.steps} steps")
 
@@ -346,9 +322,7 @@ def optimizer(model, cfg, optimizer_instance):
 
         # Send updated weights back to aggregator (local rank 0 in sub-context)
         for name, tensor_ptr in sorted_parameters.items():
-            socket_manager.send(
-                tensor_ptr, aggregator_and_optimizer_ctx, aggregator_local_rank
-            )
+            socket_manager.send(tensor_ptr, aggregator_and_optimizer_ctx, aggregator_local_rank)
 
     print(f"[Optimizer {rank}] Completed {cfg.steps} steps")
 
@@ -391,9 +365,7 @@ def aggregator_optimizer(model, cfg, optimizer_instance, use_ddp: bool = False):
     all_ctx = distributed_ctx.create_sub_context(all_ranks)
 
     # Send initial weights to all workers
-    print(
-        f"[AggregatorOptimizer {rank}] Sending initial weights to {num_workers} workers"
-    )
+    print(f"[AggregatorOptimizer {rank}] Sending initial weights to {num_workers} workers")
     for worker_id in range(num_workers):
         for name, tensor_ptr in sorted_parameters.items():
             socket_manager.send(tensor_ptr, all_ctx, worker_id)

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py
@@ -150,9 +150,7 @@ def main(config: str, worker_type: str):
     elif worker_type == "aggregator_optimizer":
         # Combined aggregator and optimizer for 2-tier architecture
         optimizer_instance = create_optimizer(model, yaml_config)
-        aggregator_optimizer(
-            model, training_cfg, optimizer_instance, device_config.enable_ddp
-        )
+        aggregator_optimizer(model, training_cfg, optimizer_instance, device_config.enable_ddp)
 
     # Cleanup
     distributed_ctx.barrier()

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py
@@ -138,6 +138,7 @@ def main(config: str, worker_type: str):
             device_config.enable_ddp,
             device_config.enable_tp,
             num_workers,
+            use_vocab_parallel_loss=model_factory.use_vocab_parallel_loss,
         )
         print(f"[Worker {rank}] Completed with {len(train_losses)} loss values")
     elif worker_type == "aggregator":

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py
@@ -138,7 +138,6 @@ def main(config: str, worker_type: str):
             device_config.enable_ddp,
             device_config.enable_tp,
             num_workers,
-            use_vocab_parallel_loss=model_factory.use_vocab_parallel_loss,
         )
         print(f"[Worker {rank}] Completed with {len(train_losses)} loss values")
     elif worker_type == "aggregator":

--- a/tt-train/sources/ttml/models/distributed/pipeline_parallel_llama.cpp
+++ b/tt-train/sources/ttml/models/distributed/pipeline_parallel_llama.cpp
@@ -139,8 +139,12 @@ PipelineParallelLlama::PipelineParallelLlama(
     if (is_last_rank()) {
         ln_fc = std::make_shared<ttml::modules::RMSNormLayer>(embedding_dim);
         if (is_tensor_parallel) {
+            fmt::print(
+                "WARNING: Building pipeline-parallel + tensor-parallel LM head with "
+                "gather_output=false. PP+TP end-to-end correctness has not been validated; "
+                "please sanity-check loss values before relying on this path.\n");
             fc = std::make_shared<ttml::modules::distributed::ColumnParallelLinear>(
-                embedding_dim, vocab_size, /* has_bias */ false, /* gather_output */ true);
+                embedding_dim, vocab_size, /* has_bias */ false, /* gather_output */ false);
         } else {
             fc = std::make_shared<ttml::modules::LinearLayer>(embedding_dim, vocab_size, /* bias */ false);
         }

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -152,7 +152,8 @@ void py_module(nb::module_& m) {
             &ttml::ops::distributed::vocab_parallel_cross_entropy_loss,
             nb::arg("logits"),
             nb::arg("targets"),
-            nb::arg("cluster_axis") = nb::none());
+            nb::arg("cluster_axis") = nb::none(),
+            nb::arg("reduce") = ReduceType::MEAN);
     }
 
     {

--- a/tt-train/sources/ttml/ops/distributed/losses.cpp
+++ b/tt-train/sources/ttml/ops/distributed/losses.cpp
@@ -41,7 +41,16 @@ ttnn::Tensor fused_subtract_exp_fp32(const ttnn::Tensor& a, const ttnn::Tensor& 
 }  // namespace
 
 autograd::TensorPtr vocab_parallel_cross_entropy_loss(
-    const autograd::TensorPtr& logits, const autograd::TensorPtr& targets, std::optional<uint32_t> cluster_axis) {
+    const autograd::TensorPtr& logits,
+    const autograd::TensorPtr& targets,
+    std::optional<uint32_t> cluster_axis,
+    ReduceType reduce) {
+    if (reduce != ReduceType::NONE && reduce != ReduceType::MEAN) {
+        throw std::logic_error(fmt::format(
+            "vocab_parallel_cross_entropy_loss: only NONE and MEAN reductions are supported. Got: {}",
+            enchantum::to_string(reduce)));
+    }
+
     const auto logits_shape = logits->get_value().logical_shape();
     const auto targets_shape = targets->get_value().logical_shape();
 
@@ -80,6 +89,10 @@ autograd::TensorPtr vocab_parallel_cross_entropy_loss(
     const uint32_t S = logits_shape[2];
     const uint32_t local_V = logits_shape[3];
     const uint32_t N = B * S;
+    // For MEAN we fold 1/N into (softmax−onehot) so the upstream scalar grad
+    // multiplies through unchanged.  For NONE the upstream grad is the
+    // per-position [B,1,S,1] tensor itself, so no extra factor is needed.
+    const float inv_N = (reduce == ReduceType::MEAN) ? (1.0F / static_cast<float>(N)) : 1.0F;
 
     // Step 1: local max [B,1,S,1] per device (BF16 — no precision loss)
     auto local_max = ttnn::max(logits->get_value(), 3, /* keepdim */ true);
@@ -114,30 +127,48 @@ autograd::TensorPtr vocab_parallel_cross_entropy_loss(
     // All-reduce to collect contributions from all TP shards  [B,1,S,1]
     auto target_logit = ttnn_fixed::distributed::all_reduce(gather_output, cluster_axis);
 
-    // Step 5: per-position loss = log_normalizer − target_logit  →  mean over B*S
-    // log_normalizer is FP32, target_logit is BF16 — output_dtype keeps subtraction in FP32.
+    // Step 5: per-position loss = log_normalizer − target_logit  [B,1,S,1].
+    // Always subtract in FP32. For MEAN we keep the FP32 tensor
+    // for the precise sum reductions; for NONE we typecast to BF16 to match
+    // the output dtype of the non-sharded ttml::ops::cross_entropy_loss.
     auto per_pos = ttnn::subtract(log_normalizer, target_logit, ttnn::DataType::FLOAT32);
-    auto s0 = ttnn::sum(per_pos, 0, /* keepdim */ true, std::nullopt, core::ComputeKernelConfig::precise());
-    auto s2 = ttnn::sum(s0, 2, /* keepdim */ true, std::nullopt, core::ComputeKernelConfig::precise());
-    // Transition back to BF16 to match the non-sharded cross_entropy_loss output type.
-    auto loss_val = ttnn::multiply(s2, 1.0F / static_cast<float>(N), ttnn::DataType::BFLOAT16);
+    ttnn::Tensor loss_val;
+    if (reduce == ReduceType::MEAN) {
+        auto s0 = ttnn::sum(per_pos, 0, /* keepdim */ true, std::nullopt, core::ComputeKernelConfig::precise());
+        auto s2 = ttnn::sum(s0, 2, /* keepdim */ true, std::nullopt, core::ComputeKernelConfig::precise());
+        loss_val = ttnn::multiply(s2, inv_N, ttnn::DataType::BFLOAT16);
+    } else {
+        loss_val = ttnn::typecast(per_pos, ttnn::DataType::BFLOAT16);
+    }
 
     auto out = autograd::create_tensor(loss_val);
 
     // ---------------------------------------------------------------
     // Backward  (purely local — no inter-device communication)
     //
-    // dCE/dx_k = (softmax_k / N − onehot_k / N) * grad_output
+    // dCE/dx_k = (softmax_k − onehot_k) * scale * grad_output
+    //   scale = 1/N  for MEAN  → grad_output is scalar [1,1,1,1]
+    //   scale = 1.0  for NONE  → grad_output is per-position [B,1,S,1]
     //
-    // Note we scale by 1/N first, cast to BF16, then scatter-subtract 1/N at the
-    // target position; the ordering matches the reference cross_entropy_bw kernel,
-    // whose writer does the onehot subtraction directly on the already-scaled BF16 tile.
+    // The same ttml_subtract_at_target kernel handles both: the `subtract_value`
+    // it scatters at target positions matches the scale already applied to
+    // softmax_k, so the resulting tile encodes (softmax_k − onehot_k) * scale
+    // before the upstream-grad broadcast multiply.  The trailing
+    // ttnn::multiply broadcasts the scalar grad over [B,1,S,V/tp] for MEAN
+    // and broadcasts the per-position grad over the local vocab dim for NONE
+    // — the same broadcast pattern used by the forward-pass max/exp path.
     // ---------------------------------------------------------------
-    autograd::GradFunction grad_fn = [logits, out, global_max, global_sum, targets_raw, local_V, cluster_axis, N]() {
+    autograd::GradFunction grad_fn = [logits,
+                                      out,
+                                      global_max,
+                                      global_sum,
+                                      targets_raw,
+                                      local_V,
+                                      cluster_axis,
+                                      inv_N]() {
         if (!out->is_grad_initialized()) {
             return;
         }
-        const float inv_N = 1.0F / static_cast<float>(N);
 
         auto local_exp = fused_subtract_exp_fp32(logits->get_value(), global_max);
 

--- a/tt-train/sources/ttml/ops/distributed/losses.hpp
+++ b/tt-train/sources/ttml/ops/distributed/losses.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "autograd/tensor.hpp"
+#include "ops/losses.hpp"
 
 namespace ttml::ops::distributed {
 
@@ -22,19 +23,29 @@ namespace ttml::ops::distributed {
 //   2. Shifted exp + local sum           → all-reduce  → global sum
 //   3. log_normalizer = global_max + log(global_sum)
 //   4. On-device one-hot via arange + eq → target logit → all-reduce
-//   5. loss = mean(log_normalizer − target_logit)
+//   5. per-position loss = log_normalizer − target_logit  [B,1,S,1]
+//   6. ReduceType::MEAN: collapse to scalar via mean over B*S.
+//      ReduceType::NONE: return the per-position [B,1,S,1] tensor as-is, so
+//      callers can apply per-token weighting (e.g. SFT loss masks) before
+//      taking their own reduction.
 //
 // Backward: purely local, no inter-device communication.
-//   dL/dx_k = (softmax_k − onehot_k) / N * grad_output
+//   dL/dx_k = (softmax_k − onehot_k) * scale * grad_output
+//   scale = 1/N for MEAN, 1.0 for NONE.  The trailing multiply broadcasts
+//   the upstream gradient: scalar [1,1,1,1] for MEAN, per-position
+//   [B,1,S,1] for NONE — both expand against scaled_softmax [B,1,S,V/tp].
 //
 // logits  : [B, 1, S, local_V] bfloat16, sharded along vocab (last) dim across TP.
 // targets : [B, 1, S, 1] or [B, S] uint32, integer target indices in [0, full_V),
 //           replicated across TP devices within each DP group.
 // cluster_axis : mesh axis that logits are sharded across (TP axis).
 //                nullopt for a 1-D mesh where all devices are TP.
+// reduce  : ReduceType::MEAN (default) or ReduceType::NONE.  ReduceType::SUM
+//           is rejected to match the ttml::ops::cross_entropy_loss contract.
 autograd::TensorPtr vocab_parallel_cross_entropy_loss(
     const autograd::TensorPtr& logits,
     const autograd::TensorPtr& targets,
-    std::optional<uint32_t> cluster_axis = std::nullopt);
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    ReduceType reduce = ReduceType::MEAN);
 
 }  // namespace ttml::ops::distributed

--- a/tt-train/sources/ttml/ttml/common/model_factory.py
+++ b/tt-train/sources/ttml/ttml/common/model_factory.py
@@ -168,3 +168,18 @@ class TransformerModelFactory:
             return self._create_llama()
         else:
             raise ValueError(f"Model type {self.model_type} not supported")
+
+    @property
+    def use_vocab_parallel_loss(self) -> bool:
+        """Whether the model the factory builds expects vocab-parallel CE.
+
+        Mirrors the C++ trainer in nano_gpt/main.cpp: the TP-only paths build
+        ``models.distributed.{llama,gpt2}`` whose LM heads are
+        ``ColumnParallelLinear(gather_output=False)``, so they emit vocab-sharded
+        logits ([B,1,S,padded_V/tp_size] per device) and must be paired with
+        ``ttml.ops.distributed.vocab_parallel_cross_entropy_loss``.  The
+        pipeline-parallel Llama path still hardcodes ``gather_output=true`` at
+        the LM head, so the last stage gets full-vocab logits and plain
+        ``cross_entropy_loss`` is the right call there.
+        """
+        return self.device_config.enable_tp and self.multihost_config.pipeline_parallel_config is None

--- a/tt-train/sources/ttml/ttml/common/model_factory.py
+++ b/tt-train/sources/ttml/ttml/common/model_factory.py
@@ -168,18 +168,3 @@ class TransformerModelFactory:
             return self._create_llama()
         else:
             raise ValueError(f"Model type {self.model_type} not supported")
-
-    @property
-    def use_vocab_parallel_loss(self) -> bool:
-        """Whether the model the factory builds expects vocab-parallel CE.
-
-        Mirrors the C++ trainer in nano_gpt/main.cpp: the TP-only paths build
-        ``models.distributed.{llama,gpt2}`` whose LM heads are
-        ``ColumnParallelLinear(gather_output=False)``, so they emit vocab-sharded
-        logits ([B,1,S,padded_V/tp_size] per device) and must be paired with
-        ``ttml.ops.distributed.vocab_parallel_cross_entropy_loss``.  The
-        pipeline-parallel Llama path still hardcodes ``gather_output=true`` at
-        the LM head, so the last stage gets full-vocab logits and plain
-        ``cross_entropy_loss`` is the right call there.
-        """
-        return self.device_config.enable_tp and self.multihost_config.pipeline_parallel_config is None

--- a/tt-train/sources/ttml/ttml/models/llama/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/llama/__init__.py
@@ -41,9 +41,13 @@ class LlamaConfig:
     size must evenly divide ``num_attention_heads``, ``num_key_value_heads``,
     and ``intermediate_size`` — this is validated in ``__post_init__``.  The
     vocab does *not* need to be TP-divisible: the embedding and LM-head
-    weights are padded internally to ``lcm(32, tp_size)`` and the padded logit
-    columns are sliced away before returning.  The effective pre-slice width
-    is exposed as ``Llama.padded_vocab_size``.
+    weights are padded internally to ``lcm(32, tp_size)``, exposed as
+    ``Llama.padded_vocab_size``.  In TP mode the LM head keeps its output
+    vocab-sharded ([B,1,S,padded_V/tp_size] per device) so the trailing
+    padded columns can be handled by the downstream loss; pair the model
+    with :func:`ttml.ops.distributed.vocab_parallel_cross_entropy_loss`.
+    In non-TP mode the LM head is fully replicated and the padded columns
+    are sliced off before returning.
     """
 
     hidden_size: int = 384
@@ -132,19 +136,22 @@ class Llama(AbstractModuleBase):
         if config.use_tp:
             # Pad the vocab so the LM head's sharded output rows are
             # tile-aligned: ColumnParallelLinear shards dim 2 across TP, so
-            # each shard needs to be divisible by 32.  Forward slices the
-            # padded logit columns away before returning, so
-            # ``config.vocab_size`` is free to be arbitrary.
+            # each shard needs to be divisible by 32.  The trailing padded
+            # columns are kept on-device and handled by the downstream
+            # vocab_parallel_cross_entropy_loss, so ``config.vocab_size`` is
+            # free to be arbitrary.
             tp_size = ttml.mesh().axis_size("tp")
             align = lcm(32, tp_size)
             self.padded_vocab_size = ((config.vocab_size + align - 1) // align) * align
-            # gather_output=True: the LM head must produce full-vocab logits
-            # on every device so the loss can be computed without further CCL.
+            # gather_output=False: keep the LM head output vocab-sharded
+            # ([B,1,S,padded_V/tp_size] per device) so callers can route through
+            # ttml.ops.distributed.vocab_parallel_cross_entropy_loss without an
+            # all-gather of the full vocab dimension.
             self.fc = ColumnParallelLinear(
                 config.hidden_size,
                 self.padded_vocab_size,
                 has_bias=False,
-                gather_output=True,
+                gather_output=False,
                 axis_name="tp",
             )
         else:
@@ -246,7 +253,11 @@ class Llama(AbstractModuleBase):
 
         out = self.ln_fc(out)
         logits = self.fc(out)
-        if self.padded_vocab_size != self.config.vocab_size:
+        # In TP mode the LM head output stays vocab-sharded; the trailing
+        # padded columns are handled by vocab_parallel_cross_entropy_loss.
+        # The non-TP path returns full-vocab logits, so we still need to drop
+        # the tile-alignment padding before handing them off to the caller.
+        if not self.config.use_tp and self.padded_vocab_size != self.config.vocab_size:
             logits = SliceLastDim.apply(logits, self.config.vocab_size)
         return logits
 

--- a/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
@@ -177,7 +177,7 @@ class SFTTrainer:
         self._optimizer = self._build_optimizer(optimizer)
         self._lr_schedule = lr_schedule if lr_schedule is not None else self._build_lr_schedule()
         self._attention_mask = attention_mask
-        self._loss_fn = ttml.ops.loss.cross_entropy_loss
+        self._loss_fn = self._build_loss_fn()
         self._callbacks = callbacks or []
         self._compute_loss_override = compute_loss_func
         self._loss_composer = self._build_loss_composer(loss_composer)
@@ -387,6 +387,42 @@ class SFTTrainer:
             return loss_composer
         device = ttml.autograd.AutoContext.get_instance().get_device()
         return ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
+
+    def _build_loss_fn(self):
+        """Pick the cross-entropy variant matching the LM head's logit sharding.
+
+        When the active mesh has a TP axis with size > 1 the conventional
+        SFTTrainer model shape (Llama with ``use_tp=True`` or
+        ``models.distributed.{llama,gpt2}``) emits vocab-sharded logits via
+        ``ColumnParallelLinear(gather_output=False)``.  Plain
+        ``cross_entropy_loss`` would compute its softmax denominator over each
+        TP shard instead of the full vocab — wrong by construction — so we
+        route through ``vocab_parallel_cross_entropy_loss`` with
+        ``cluster_axis`` bound to the TP axis.
+
+        The wrapper preserves the ``(logits, labels, reduce)`` signature of
+        ``cross_entropy_loss`` so the masked-CE flow in ``_compute_loss``
+        (``ReduceType.NONE`` per-token loss → ``* loss_mask`` → ``mean``) is
+        unchanged: the per-token shape ``[B, 1, T, 1]`` matches between the
+        two ops, and the upstream-grad broadcast in vocab-parallel CE handles
+        the ``loss_mask`` weighting in backward.
+
+        Pipeline-parallel models whose last stage gathers logits to the full
+        vocab fall outside this auto-detect rule (mesh has TP axis but the
+        loss should stay full-vocab CE); for those, pass ``compute_loss_func``
+        when constructing the trainer.
+        """
+        mesh = ttml.mesh()
+        if mesh.has_axis("tp") and mesh.axis_size("tp") > 1:
+            tp_cluster_axis = mesh.axis_index("tp")
+
+            def vocab_parallel_loss(logits, labels, reduce):
+                return ttml.ops.distributed.vocab_parallel_cross_entropy_loss(
+                    logits, labels, cluster_axis=tp_cluster_axis, reduce=reduce
+                )
+
+            return vocab_parallel_loss
+        return ttml.ops.loss.cross_entropy_loss
 
     @staticmethod
     def _enable_gradient_checkpointing(model: Any) -> None:

--- a/tt-train/tests/ops/distributed/vocab_parallel_cross_entropy_loss_test.cpp
+++ b/tt-train/tests/ops/distributed/vocab_parallel_cross_entropy_loss_test.cpp
@@ -80,6 +80,65 @@ xt::xarray<float> cross_entropy_grad_reference(
     return grad;
 }
 
+// Reference forward (per-position, no reduction): [B, 1, S, 1] of
+// log_normalizer − target_logit, the value vocab_parallel_cross_entropy_loss
+// returns under ReduceType::NONE.
+xt::xarray<float> cross_entropy_loss_reference_per_position(
+    const xt::xarray<float>& logits, const xt::xarray<uint32_t>& targets) {
+    const uint32_t B = static_cast<uint32_t>(logits.shape(0));
+    const uint32_t S = static_cast<uint32_t>(logits.shape(2));
+    const uint32_t V = static_cast<uint32_t>(logits.shape(3));
+
+    xt::xarray<float> per_pos = xt::zeros<float>({B, 1U, S, 1U});
+    for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t s = 0; s < S; ++s) {
+            float row_max = -std::numeric_limits<float>::infinity();
+            for (uint32_t v = 0; v < V; ++v) {
+                row_max = std::max(row_max, logits(b, 0U, s, v));
+            }
+            float exp_sum = 0.0F;
+            for (uint32_t v = 0; v < V; ++v) {
+                exp_sum += std::exp(logits(b, 0U, s, v) - row_max);
+            }
+            float log_norm = row_max + std::log(exp_sum);
+            float target_logit = logits(b, 0U, s, targets(b, s));
+            per_pos(b, 0U, s, 0U) = log_norm - target_logit;
+        }
+    }
+    return per_pos;
+}
+
+// Reference backward for ReduceType::NONE:
+//   dL/dx_k = (softmax_k − onehot_k) * grad_per_pos[b,0,s,0]
+// (no 1/N factor; the per-position upstream grad carries any weighting).
+xt::xarray<float> cross_entropy_grad_reference_per_position(
+    const xt::xarray<float>& logits, const xt::xarray<uint32_t>& targets, const xt::xarray<float>& grad_per_pos) {
+    const uint32_t B = static_cast<uint32_t>(logits.shape(0));
+    const uint32_t S = static_cast<uint32_t>(logits.shape(2));
+    const uint32_t V = static_cast<uint32_t>(logits.shape(3));
+
+    xt::xarray<float> grad = xt::zeros<float>(logits.shape());
+    for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t s = 0; s < S; ++s) {
+            float row_max = -std::numeric_limits<float>::infinity();
+            for (uint32_t v = 0; v < V; ++v) {
+                row_max = std::max(row_max, logits(b, 0U, s, v));
+            }
+            float exp_sum = 0.0F;
+            for (uint32_t v = 0; v < V; ++v) {
+                exp_sum += std::exp(logits(b, 0U, s, v) - row_max);
+            }
+            const float g = grad_per_pos(b, 0U, s, 0U);
+            for (uint32_t v = 0; v < V; ++v) {
+                float sm = std::exp(logits(b, 0U, s, v) - row_max) / exp_sum;
+                float oh = (v == targets(b, s)) ? 1.0F : 0.0F;
+                grad(b, 0U, s, v) = (sm - oh) * g;
+            }
+        }
+    }
+    return grad;
+}
+
 }  // namespace
 
 class ShardedCrossEntropyLossTest : public ::testing::Test {
@@ -537,4 +596,182 @@ TEST_F(ShardedCrossEntropyLossTest, MatchesNonShardedImplementationExplicitClust
 
     EXPECT_TRUE(xt::allclose(sharded_grad_xt[0], ref_shard0, 3e-2F, 1e-2F));
     EXPECT_TRUE(xt::allclose(sharded_grad_xt[1], ref_shard1, 3e-2F, 1e-2F));
+}
+
+// ReduceType::NONE forward: the op should return [B,1,S,1] with the same
+// per-position log_normalizer − target_logit value the SFT trainer's masked
+// cross-entropy path consumes when it calls cross_entropy_loss(NONE).
+TEST_F(ShardedCrossEntropyLossTest, ForwardNoneReductionMatchesPerPosition) {
+    SKIP_FOR_WATCHER();
+
+    using namespace ttml;
+
+    auto* device = &autograd::ctx().get_device();
+    const uint32_t B = 2U, S = 32U;
+    const uint32_t local_V = 128U;
+    const uint32_t full_V = local_V * 2U;
+
+    std::mt19937 gen(11);
+    xt::xarray<float> logits_xt = xt::empty<float>({B, 1U, S, full_V});
+    std::uniform_real_distribution<float> dist(-3.0F, 3.0F);
+    for (auto& v : logits_xt) {
+        v = dist(gen);
+    }
+
+    xt::xarray<uint32_t> targets_xt = xt::zeros<uint32_t>({B, S});
+    std::uniform_int_distribution<uint32_t> idx_dist(0U, full_V - 1U);
+    for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t s = 0; s < S; ++s) {
+            targets_xt(b, s) = idx_dist(gen);
+        }
+    }
+
+    auto shard_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto logits_dev =
+        core::from_xtensor<float, ttnn::DataType::BFLOAT16>(logits_xt, device, ttnn::Layout::TILE, shard_mapper.get());
+
+    auto replicate_mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto targets_dev = core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(
+        targets_xt, device, ttnn::Layout::ROW_MAJOR, replicate_mapper.get());
+
+    auto logits_ptr = autograd::create_tensor(logits_dev, true);
+    auto targets_ptr = autograd::create_tensor(targets_dev, false);
+
+    auto loss = ops::distributed::vocab_parallel_cross_entropy_loss(
+        logits_ptr, targets_ptr, /*cluster_axis=*/std::nullopt, ops::ReduceType::NONE);
+
+    // Per-position output is replicated across TP devices.  Each shard's local
+    // copy should equal the full reference per-position tensor.
+    auto loss_xt = core::to_xtensor<float>(loss->get_value(), core::IdentityComposer{});
+    auto expected = cross_entropy_loss_reference_per_position(logits_xt, targets_xt);
+
+    EXPECT_TRUE(xt::allclose(loss_xt[0], expected, 3e-2F, 5e-2F));
+    EXPECT_TRUE(xt::allclose(loss_xt[1], expected, 3e-2F, 5e-2F));
+}
+
+// ReduceType::NONE backward: with a non-uniform per-position upstream grad,
+// the resulting logits gradient should match (softmax − onehot) * grad
+// elementwise — i.e. no implicit 1/N, and the per-position weighting
+// broadcasts across the local vocab shard.
+TEST_F(ShardedCrossEntropyLossTest, BackwardNoneReductionAppliesPerPositionGrad) {
+    SKIP_FOR_WATCHER();
+
+    using namespace ttml;
+
+    auto* device = &autograd::ctx().get_device();
+    const uint32_t B = 2U, S = 32U;
+    const uint32_t local_V = 128U;
+    const uint32_t full_V = local_V * 2U;
+
+    std::mt19937 gen(13);
+    xt::xarray<float> logits_xt = xt::empty<float>({B, 1U, S, full_V});
+    std::uniform_real_distribution<float> dist(-3.0F, 3.0F);
+    for (auto& v : logits_xt) {
+        v = dist(gen);
+    }
+
+    xt::xarray<uint32_t> targets_xt = xt::zeros<uint32_t>({B, S});
+    std::uniform_int_distribution<uint32_t> idx_dist(0U, full_V - 1U);
+    for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t s = 0; s < S; ++s) {
+            targets_xt(b, s) = idx_dist(gen);
+        }
+    }
+
+    // Non-uniform per-position upstream grad — exercises the [B,1,S,1] →
+    // [B,1,S,V/tp] broadcast in the backward multiply.  Mimics the result of
+    // `loss * batch.loss_mask` in SFTTrainer: most positions weighted 1.0,
+    // a few zeroed out (prompt/padding), then re-normalised.
+    xt::xarray<float> grad_per_pos = xt::ones<float>({B, 1U, S, 1U});
+    for (uint32_t b = 0; b < B; ++b) {
+        grad_per_pos(b, 0U, 0U, 0U) = 0.0F;
+        grad_per_pos(b, 0U, 1U, 0U) = 0.0F;
+    }
+    grad_per_pos *= static_cast<float>(B * S) / static_cast<float>(xt::sum(grad_per_pos)());
+
+    auto shard_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto logits_dev =
+        core::from_xtensor<float, ttnn::DataType::BFLOAT16>(logits_xt, device, ttnn::Layout::TILE, shard_mapper.get());
+
+    auto replicate_mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto targets_dev = core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(
+        targets_xt, device, ttnn::Layout::ROW_MAJOR, replicate_mapper.get());
+
+    auto logits_ptr = autograd::create_tensor(logits_dev, true);
+    auto targets_ptr = autograd::create_tensor(targets_dev, false);
+
+    auto loss = ops::distributed::vocab_parallel_cross_entropy_loss(
+        logits_ptr, targets_ptr, /*cluster_axis=*/std::nullopt, ops::ReduceType::NONE);
+
+    auto grad_dev = core::from_xtensor<float, ttnn::DataType::BFLOAT16>(
+        grad_per_pos, device, ttnn::Layout::TILE, replicate_mapper.get());
+    loss->set_grad(grad_dev);
+    loss->backward();
+
+    ASSERT_TRUE(core::is_tensor_initialized(logits_ptr->get_grad()));
+
+    auto grad_xtensors = core::to_xtensor<float>(logits_ptr->get_grad(), core::IdentityComposer{});
+    auto expected_grad = cross_entropy_grad_reference_per_position(logits_xt, targets_xt, grad_per_pos);
+
+    auto expected_shard0 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(0, local_V));
+    auto expected_shard1 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(local_V, full_V));
+
+    EXPECT_TRUE(xt::allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F));
+    EXPECT_TRUE(xt::allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F));
+}
+
+// Equivalence sanity-check between the two reductions: explicitly summing the
+// NONE-mode per-position output and dividing by N must match the MEAN-mode
+// scalar to within bf16 noise.  Catches accidental rescaling drift in either
+// branch.
+TEST_F(ShardedCrossEntropyLossTest, NoneReductionSummedMatchesMean) {
+    SKIP_FOR_WATCHER();
+
+    using namespace ttml;
+
+    auto* device = &autograd::ctx().get_device();
+    const uint32_t B = 2U, S = 32U;
+    const uint32_t local_V = 128U;
+    const uint32_t full_V = local_V * 2U;
+
+    std::mt19937 gen(17);
+    xt::xarray<float> logits_xt = xt::empty<float>({B, 1U, S, full_V});
+    std::uniform_real_distribution<float> dist(-3.0F, 3.0F);
+    for (auto& v : logits_xt) {
+        v = dist(gen);
+    }
+
+    xt::xarray<uint32_t> targets_xt = xt::zeros<uint32_t>({B, S});
+    std::uniform_int_distribution<uint32_t> idx_dist(0U, full_V - 1U);
+    for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t s = 0; s < S; ++s) {
+            targets_xt(b, s) = idx_dist(gen);
+        }
+    }
+
+    auto shard_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto replicate_mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+
+    auto make_logits = [&]() {
+        auto dev = core::from_xtensor<float, ttnn::DataType::BFLOAT16>(
+            logits_xt, device, ttnn::Layout::TILE, shard_mapper.get());
+        return autograd::create_tensor(dev, true);
+    };
+    auto make_targets = [&]() {
+        auto dev = core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(
+            targets_xt, device, ttnn::Layout::ROW_MAJOR, replicate_mapper.get());
+        return autograd::create_tensor(dev, false);
+    };
+
+    auto mean_loss = ops::distributed::vocab_parallel_cross_entropy_loss(
+        make_logits(), make_targets(), /*cluster_axis=*/std::nullopt, ops::ReduceType::MEAN);
+    auto none_loss = ops::distributed::vocab_parallel_cross_entropy_loss(
+        make_logits(), make_targets(), /*cluster_axis=*/std::nullopt, ops::ReduceType::NONE);
+
+    auto mean_xt = core::to_xtensor<float>(mean_loss->get_value(), core::IdentityComposer{});
+    auto none_xt = core::to_xtensor<float>(none_loss->get_value(), core::IdentityComposer{});
+
+    const float mean_val = mean_xt[0](0, 0, 0, 0);
+    const float none_summed = static_cast<float>(xt::sum(none_xt[0])()) / static_cast<float>(B * S);
+    EXPECT_NEAR(mean_val, none_summed, 5e-2F);
 }

--- a/tt-train/tests/python/test_vocab_parallel_loss.py
+++ b/tt-train/tests/python/test_vocab_parallel_loss.py
@@ -107,6 +107,24 @@ def pytorch_reference(logits_np, targets_np):
     return loss.item(), logits_t.grad.numpy()
 
 
+def pytorch_reference_per_position(logits_np, targets_np, grad_per_pos_np):
+    """Compute PyTorch reference for ReduceType.NONE.
+
+    Returns (per_position_loss [B,1,S,1], logits_grad [B,1,S,V]) where
+    per_position_loss is F.cross_entropy(reduction="none") reshaped to
+    [B,1,S,1] and logits_grad is the gradient propagated back through that
+    NONE-reduction with the supplied [B,1,S,1] upstream gradient.
+    """
+    logits_t = torch.from_numpy(logits_np).float().requires_grad_(True)
+    targets_t = torch.from_numpy(targets_np.astype(np.int64))
+    grad_t = torch.from_numpy(grad_per_pos_np).float()
+
+    B, _, S, V = logits_t.shape
+    per_pos = F.cross_entropy(logits_t.reshape(B * S, V), targets_t.reshape(-1), reduction="none").reshape(B, 1, S, 1)
+    per_pos.backward(grad_t)
+    return per_pos.detach().numpy(), logits_t.grad.numpy()
+
+
 # ---------------------------------------------------------------------------
 # Main test runner
 # ---------------------------------------------------------------------------
@@ -272,6 +290,105 @@ def run_test(ctx, device, mesh_shape, batch_size=2, seq_len=32, vocab_size=64):
             else:
                 failed += 1
             print(f"  C++ dist CE backward: {tag}  max_diff={max_diff:.6f}  " f"mean_diff={mean_diff:.6f}")
+
+    # ==================================================================
+    # 4. C++ vocab_parallel_cross_entropy_loss with ReduceType.NONE
+    # ==================================================================
+    if tp_size > 1:
+        # Per-position output is replicated across the TP axis (every TP rank
+        # holds the same [B/dp, 1, S, 1] tensor).  The grad_composer above
+        # concats along TP-axis dim 3, producing tp_size identical columns;
+        # take any one of them to recover the natural [dp*B, 1, S, 1] tensor.
+        np.random.seed(43)
+        grad_per_pos_global = np.random.randn(global_batch, 1, seq_len, 1).astype(np.float32)
+        ref_per_pos, ref_grad_none = pytorch_reference_per_position(logits_np, targets_np, grad_per_pos_global)
+
+        print("\n--- C++ vocab_parallel_cross_entropy_loss: NONE forward ---")
+
+        def test_cpp_ce_none_forward():
+            ctx.set_gradient_mode(ttml.autograd.GradMode.DISABLED)
+            logits = ttml.autograd.Tensor.from_numpy(
+                logits_np,
+                ttnn.Layout.TILE,
+                ttnn.DataType.BFLOAT16,
+                logits_mapper,
+            )
+            tgt = make_cpp_targets_tensor()
+            loss = ttml.ops.distributed.vocab_parallel_cross_entropy_loss(
+                logits, tgt, cluster_axis=1, reduce=ttml.ops.ReduceType.NONE
+            )
+            full = ttnn.to_torch(loss.get_value(), mesh_composer=grad_composer).float().numpy()
+            # Drop the TP-replication along dim 3 — every column is identical.
+            per_pos = full[..., 0:1]
+            ctx.reset_graph()
+            return float(np.abs(per_pos - ref_per_pos).max())
+
+        max_diff, err = try_op(test_cpp_ce_none_forward)
+        total += 1
+        if err is not None:
+            failed += 1
+            print(f"  C++ dist CE NONE forward: FAIL (crashed: {err})")
+        else:
+            ok = max_diff < 0.1
+            tag = "PASS" if ok else "FAIL"
+            if ok:
+                passed += 1
+            else:
+                failed += 1
+            print(f"  C++ dist CE NONE forward: {tag}  max_diff={max_diff:.6f}")
+
+        print("\n--- C++ vocab_parallel_cross_entropy_loss: NONE backward ---")
+
+        def test_cpp_ce_none_backward():
+            ctx.set_gradient_mode(ttml.autograd.GradMode.ENABLED)
+            logits = ttml.autograd.Tensor.from_numpy(
+                logits_np,
+                ttnn.Layout.TILE,
+                ttnn.DataType.BFLOAT16,
+                logits_mapper,
+            )
+            logits.set_requires_grad(True)
+            tgt = make_cpp_targets_tensor()
+            loss = ttml.ops.distributed.vocab_parallel_cross_entropy_loss(
+                logits, tgt, cluster_axis=1, reduce=ttml.ops.ReduceType.NONE
+            )
+            # Upstream grad: replicated across both DP and TP — all devices
+            # contribute the same per-position weighting.
+            grad_t = ttml.autograd.Tensor.from_numpy(
+                grad_per_pos_global,
+                ttnn.Layout.TILE,
+                ttnn.DataType.BFLOAT16,
+            )
+            loss.set_grad(grad_t.get_value())
+            loss.backward(False)
+
+            grad_full = reconstruct_full_grad_from_mesh(logits.get_grad())
+            # PyTorch reference uses NONE so there is no implicit 1/N; the
+            # dp_size compensation in reconstruct_full_grad_from_mesh assumes
+            # the C++ op divides by per-DP B*S (true for MEAN, NOT true for
+            # NONE), so undo it here.
+            if dp_size > 1:
+                grad_full = grad_full * dp_size
+
+            max_diff = float(np.abs(grad_full - ref_grad_none).max())
+            mean_diff = float(np.abs(grad_full - ref_grad_none).mean())
+            ctx.reset_graph()
+            return max_diff, mean_diff
+
+        val, err = try_op(test_cpp_ce_none_backward)
+        total += 1
+        if err is not None:
+            failed += 1
+            print(f"  C++ dist CE NONE backward: FAIL (crashed: {err})")
+        else:
+            max_diff, mean_diff = val
+            ok = max_diff < 0.05
+            tag = "PASS" if ok else "FAIL"
+            if ok:
+                passed += 1
+            else:
+                failed += 1
+            print(f"  C++ dist CE NONE backward: {tag}  max_diff={max_diff:.6f}  mean_diff={mean_diff:.6f}")
 
     # ==================================================================
     # Summary


### PR DESCRIPTION
## Motivation
[#42579](https://github.com/tenstorrent/tt-metal/pull/42579) (`[tt-train] Vocab parallel cross entropy loss`) introduced a vocab-parallel CE op, but none of the Python trainers were actually using it — under TP they still computed loss on the full vocab logits, which is expensive and defeats the point of the op. This PR plumbs the op through the trainers (nano_gpt, lora_llama, SFTTrainer, multihost pipeline/hierarchical) so TP runs pick it up automatically, and adds the `ReduceType::NONE` mode the multihost trainers need.

## Summary
- Wires Python training paths (nano_gpt, lora_llama, multihost pipeline/hierarchical, SFTTrainer) through vocab-parallel cross-entropy when tensor parallelism is active, so loss is computed without materializing the full vocab logits.
- Extends `vocab_parallel_cross_entropy_loss` with a `ReduceType::NONE` mode and exposes it via nanobind; SFTTrainer auto-selects it under TP.
- Adds a C++ test (`vocab_parallel_cross_entropy_loss_test.cpp`) and Python test (`test_vocab_parallel_loss.py`) covering the new loss paths.
- Misc: fixes `tp_axis` in nano_gpt, small clarifying comment in the GRPO Llama completer.

## Notes for reviewers
- Follow the commits

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bklockiewicz/voc-par-ce-pyth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bklockiewicz/voc-par-ce-pyth)