### PR TITLE
Added token-matching test for Llama 3 70B on Galaxy and made it default

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/conftest.py
+++ b/models/demos/llama3_70b_galaxy/demo/conftest.py
@@ -32,6 +32,13 @@ def pytest_addoption(parser):
         help="Whether to print token output every decode iteration",
     )
     parser.addoption(
+        "--token_accuracy",
+        action="store",
+        default=False,
+        type=bool,
+        help="Whether to compute top1 and top5 exact token matching accuracy",
+    )
+    parser.addoption(
         "--prefill_profile",
         action="store",
         default=False,

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import hashlib
 import requests
 import json
+import math
 import torch
 import pytest
 import os
@@ -96,6 +97,73 @@ def load_inputs(user_input, len_per_batch, instruct):
             in_prompt.append(prompt)
 
     return in_prompt, all_prompts
+
+
+class TokenAccuracy:
+    def __init__(self, model_name):
+        self.gt_pos = -1
+        self.store_predicted_tokens = []
+        reference_data_file = os.path.join("models/tt_transformers/tests/reference_outputs/", model_name) + ".refpt"
+        assert os.path.exists(reference_data_file), f"Reference data file {reference_data_file} does not exist"
+        logger.info(f"Loading reference data from {reference_data_file}")
+        reference_data = torch.load(reference_data_file)
+        reference_tokens = reference_data["reference_tokens"]
+        split_point = reference_tokens.shape[-1] // 2
+        self.input_prompt = reference_tokens[0, :split_point]
+        self.reference_tokens = reference_tokens[0, split_point:]
+        self.top5_tokens = reference_data["top5_tokens"][split_point - 1 :, :]
+        self.maxindex = len(self.reference_tokens) - 1
+
+    def prepare_ref_tokens(self, tokenizer):
+        return tokenizer.decode(self.input_prompt.tolist())
+
+    def collect_predicted_tokens(self, token):
+        token = token.item() if hasattr(token, "item") else token
+        self.store_predicted_tokens.append(int(token))
+        self.gt_pos += 1
+        return self.reference_tokens[min(self.gt_pos, self.maxindex)].unsqueeze(-1).unsqueeze(-1)
+
+    def compute_accuracy(self):
+        count = 0
+        count_t5 = 0
+        matching_sz = min(len(self.reference_tokens), len(self.store_predicted_tokens))
+        assert matching_sz > 0, "No tokens collected for token accuracy"
+        for i in range(matching_sz):
+            if self.top5_tokens[i, 0].item() == self.store_predicted_tokens[i]:
+                count += 1
+            if self.store_predicted_tokens[i] in self.top5_tokens[i, :]:
+                count_t5 += 1
+
+        return count / matching_sz, count_t5 / matching_sz
+
+
+def get_accuracy_thresholds(model_args):
+    """Parse token accuracy thresholds from the common PERF.md Performance table."""
+    perf_file = "models/tt_transformers/PERF.md"
+    with open(perf_file, "r") as f:
+        content = f.read()
+
+    sections = content.split("## ")
+    target_section = next(s for s in sections if s.lower().startswith("performance\n"))
+
+    base_model_name = model_args.base_model_name
+    device_name = model_args.device_name
+    correct_line = (
+        lambda line: "|" in line
+        and base_model_name.lower() in line.split("|")[1].strip().lower()
+        and device_name.lower() in line.split("|")[2].strip().lower()
+        and not "(DP=".lower() in line.lower()
+    )
+    rows = [line.split("|")[1:] for line in target_section.split("\n") if correct_line(line)]
+    if not rows:
+        raise ValueError(f"Could not find accuracy data for {base_model_name} on {device_name} in {perf_file}")
+
+    assert len(rows) == 1, f"Found multiple rows for {base_model_name} on {device_name} in {perf_file}"
+    row = rows[0]
+    top1_acc = float(row[2].strip())
+    top5_acc = float(row[3].strip())
+
+    return top1_acc - 0.5, top5_acc - 0.5
 
 
 def load_demo_targets(filename, galaxy_type):
@@ -192,13 +260,14 @@ def create_tt_model(
 # page_params (dict): Page parameters for paged attention (block_size, max_num_blocks) For smaller context lengths use block_size=32 and max_num_blocks=1024, for larger context use block_size=64 and max_num_blocks=2048
 # sampling_params (dict): Sampling parameters for decoding (temperature, top_p). If temperature is set to 0, argmax (greedy decode) is used.
 # stop_at_eos (bool): Whether to stop decoding when the model generates an EoS token
+# token_accuracy (bool): Whether to run teacher-forced top-1/top-5 token matching against reference outputs
 # is_cur_pos_sharded (bool): Whether to replicate the cur pos tensor on sub core grid as an optimization
 # is_page_table_sharded (bool):  Whether to replicate the page table tensor on sub core grid as an optimization (Currently page table sharding is only supported for BS=32)
 
 
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, prefill_profile, num_layers, print_outputs, is_cur_pos_sharded, is_page_table_sharded, use_prefix_caching, prefix_cached_ratio",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, token_accuracy, prefill_profile, num_layers, print_outputs, is_cur_pos_sharded, is_page_table_sharded, use_prefix_caching, prefix_cached_ratio",
     [
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -213,6 +282,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -242,6 +312,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -268,6 +339,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -289,6 +361,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -310,6 +383,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -331,6 +405,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -352,6 +427,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -373,6 +449,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -394,6 +471,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -415,6 +493,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -436,6 +515,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -457,6 +537,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -478,6 +559,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -499,6 +581,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -520,6 +603,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             True,  # prefill-only profile
             1,  # num layers
             False,  # print_outputs
@@ -541,6 +625,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             True,  # prefill-only profile
             1,  # num layers
             False,  # print_outputs
@@ -562,6 +647,29 @@ def create_tt_model(
             False,  # stop_at_eos
             True,  # apc_test
             True,  # pcc_check
+            False,  # token_accuracy
+            False,  # prefill-only profile
+            80,  # num layers
+            False,  # print_outputs
+            False,  # is_cur_pos_sharded
+            False,  # is_page_table_sharded
+            False,  # use_prefix_caching
+            0.0,  # prefix_cached_ratio
+        ),
+        (  # ci-token-matching - CI Run for teacher-forced top-1/top-5 token accuracy
+            "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            500,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks": 2048},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # apc_test
+            False,  # pcc_check
+            True,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -583,6 +691,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             True,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -604,6 +713,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -625,6 +735,7 @@ def create_tt_model(
             False,  # stop_at_eos
             False,  # apc_test
             True,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
@@ -652,6 +763,7 @@ def create_tt_model(
         "prefill-profile-standard",  # prefill-only profile run
         "prefill-profile-prefix-caching",  # prefill-only, Phase 2 (prefix-cached) only, 50% cache
         "apc-test",  # apc check for 80L + teacher forced for prefill + pcc check on prefill and 1st decode token
+        "ci-token-matching",  # CI performs token accuracy matching with precomputed reference tokens
         "pcc-80L",  # pcc check for 80L + teacher forced
         "batch-1-prefix-caching-perf",  # 1 user, prefix caching (performance)
         "batch-1-prefix-caching-pcc",  # 1 user, prefix caching with PCC (correctness)
@@ -706,6 +818,7 @@ def test_demo_text(
     prefill_profile,
     num_layers,
     pcc_check,
+    token_accuracy,
     pcc_decode_len,
     reset_seeds,
     request,
@@ -759,8 +872,16 @@ def test_demo_text(
     ]:  # If the flag is provided, use it. Take an int instead of bool due to parser limitations
         stop_at_eos = request.config.getoption("--stop_at_eos")
     print_outputs = request.config.getoption("--print_outputs") or print_outputs
+    token_accuracy = request.config.getoption("--token_accuracy") or token_accuracy
+
+    if token_accuracy and pcc_check:
+        raise ValueError("Token accuracy and PCC check are separate demo modes")
+    if token_accuracy and batch_size != 1:
+        raise ValueError("Token accuracy mode only supports batch_size=1")
 
     enable_trace = True  # Use tracing for better perf
+    if token_accuracy:
+        enable_trace = False  # Teacher forcing uses fresh host tokens each iteration.
     prefill_enable_trace = True
     print_to_file = False  # Enable this flag to print the output of all users to a file
     instruct = num_layers == 80 and instruct  # if using instruct weights it must be full model
@@ -873,6 +994,12 @@ def test_demo_text(
     tokenizer = model_args.tokenizer
     generator = Generator(model, model_args, mesh_device, tokenizer=tokenizer)
 
+    token_acc = None
+    acc = None
+    if token_accuracy:
+        token_acc = TokenAccuracy(model_args.model_name)
+        repeat_batch_prompts = [[token_acc.prepare_ref_tokens(tokenizer)]]
+
     num_tokens_generated_decode = []
 
     logger.info("Starting inference...")
@@ -890,7 +1017,7 @@ def test_demo_text(
                 input_prompts,
                 tokenizer,
                 [model_args],
-                instruct,
+                False if token_accuracy else instruct,
                 max_generated_tokens,
             )
 
@@ -1111,6 +1238,8 @@ def test_demo_text(
 
         # Replace the prefill token with reference token if PCC check enabled
         out_tok = prefilled_token if not pcc_check else ref_tokens[max_encoded_prompt_len]
+        if token_accuracy:
+            out_tok = token_acc.collect_predicted_tokens(out_tok[0].item())
 
         if out_tok.shape == torch.Size([]) or (len(out_tok.shape) > 0 and out_tok.shape[0] != 32):
             out_tok = out_tok.repeat(32, 1)
@@ -1131,6 +1260,11 @@ def test_demo_text(
         tt_out_toks = []
 
         while users_decoding:
+            if token_accuracy and iteration > 0:
+                out_tok = token_acc.collect_predicted_tokens(out_tok[0].item())
+                if out_tok.shape == torch.Size([]) or (len(out_tok.shape) > 0 and out_tok.shape[0] != 32):
+                    out_tok = out_tok.repeat(32, 1)
+
             if iteration == 0:  # First iteration also accounts for compile time
                 profiler.start(f"compile_decode", iteration=batch_idx)
             else:
@@ -1146,14 +1280,15 @@ def test_demo_text(
             try:
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
-                tt_out_tok, read_event = generator.decode_forward(
+                decode_async_read = not token_accuracy
+                decode_output = generator.decode_forward(
                     out_tok,
                     current_pos,
                     enable_trace=is_enable_trace,
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
                     read_from_device=True,
-                    async_read=True,
+                    async_read=decode_async_read,
                     sampling_params=device_sampling_params,
                     reset_inputs=iteration == 0,
                     tt_out_logits_saved=tt_out_logits_saved,
@@ -1162,8 +1297,12 @@ def test_demo_text(
                     prompt_tokens=input_tokens_prefill_pt,
                     output_tokens=prefilled_token,
                 )
-                read_events.append(read_event)
-                tt_out_toks.append(tt_out_tok)
+                if decode_async_read:
+                    tt_out_tok, read_event = decode_output
+                    read_events.append(read_event)
+                    tt_out_toks.append(tt_out_tok)
+                else:
+                    tt_out_tok, tt_log_probs = decode_output
                 if apc_test and iteration == 0:
                     tt_out_logits_saved_iter_0 = tt_out_logits_saved
             except Exception as e:
@@ -1181,9 +1320,10 @@ def test_demo_text(
                 and num_layers == 80
             )
 
-            if iteration > 0:
-                ttnn.event_synchronize(read_events.pop(0)[0])
-                tt_out_tok, tt_log_probs = generator.process_decode_output_host(tt_out_toks.pop(0))
+            if iteration > 0 or token_accuracy:
+                if not token_accuracy:
+                    ttnn.event_synchronize(read_events.pop(0)[0])
+                    tt_out_tok, tt_log_probs = generator.process_decode_output_host(tt_out_toks.pop(0))
 
                 if teacher_forcing:
                     out_tok = ref_tokens[max_encoded_prompt_len + iteration + 1]
@@ -1261,29 +1401,32 @@ def test_demo_text(
                         logger.info("[User {}] {}".format(user, text))
 
                 # The e2e decode inference accounts for device execution + host post-processing time
-                profiler.end(f"inference_decode_time_{iteration}", iteration=batch_idx)
-                decode_iteration_time = profiler.get_duration(f"inference_decode_time_{iteration}", iteration=batch_idx)
-                # Always print perf after every iteration
-                tokens_per_second_per_user = 1 / decode_iteration_time
-
-                logger.info(
-                    f"Decode Iteration {iteration}: Time: {1000*decode_iteration_time:.4f}ms, tok/s/user: {tokens_per_second_per_user:.2f}, Throughput: {batch_size*tokens_per_second_per_user:.2f} tok/s"
-                )
-                if apc_test and (demo_targets["token_pos"] - len(input_tokens_prefill_pt)) == iteration:
-                    # Check if the throughput is within the expected range
-                    lower_bound = demo_targets["throughput"] - demo_targets["absolute_margin"]
-                    upper_bound = demo_targets["throughput"] + demo_targets["absolute_margin"]
-                    # TODO: Enable once experimentaly established avg and absolute margin
-                    assert_message = (
-                        f"Current throughput: {tokens_per_second_per_user:.1f} tok/s/user for APC test is not within the expected range: ({lower_bound}, {upper_bound}).\n"
-                        f"Update text_demo_targets.json file with the expected throughput.\n"
-                        f"See the comment on the text_demo.py by the assert for instructions."
+                if iteration > 0:
+                    profiler.end(f"inference_decode_time_{iteration}", iteration=batch_idx)
+                    decode_iteration_time = profiler.get_duration(
+                        f"inference_decode_time_{iteration}", iteration=batch_idx
                     )
-                    assert lower_bound <= tokens_per_second_per_user <= upper_bound, assert_message
-                    # A mismatch of throughput suggests a regression in performance, likely due to changes in one or more ops used by the model, resulting in reduced end-to-end throughput.
-                    # In some cases, small variations in PCC or improved model performance are expected. When this happens, update the target values in models/demos/llama3_70b_galaxy/demo/text_demo_targets.json.
-                    # Once updated, include the modified target file in your PR. The model code owners will then review and approve the changes.
-                    # If no changes to the model are expected from the PR, but targets differ, further investigation is needed to understand the root cause.
+                    # Always print perf after every iteration
+                    tokens_per_second_per_user = 1 / decode_iteration_time
+
+                    logger.info(
+                        f"Decode Iteration {iteration}: Time: {1000*decode_iteration_time:.4f}ms, tok/s/user: {tokens_per_second_per_user:.2f}, Throughput: {batch_size*tokens_per_second_per_user:.2f} tok/s"
+                    )
+                    if apc_test and (demo_targets["token_pos"] - len(input_tokens_prefill_pt)) == iteration:
+                        # Check if the throughput is within the expected range
+                        lower_bound = demo_targets["throughput"] - demo_targets["absolute_margin"]
+                        upper_bound = demo_targets["throughput"] + demo_targets["absolute_margin"]
+                        # TODO: Enable once experimentaly established avg and absolute margin
+                        assert_message = (
+                            f"Current throughput: {tokens_per_second_per_user:.1f} tok/s/user for APC test is not within the expected range: ({lower_bound}, {upper_bound}).\n"
+                            f"Update text_demo_targets.json file with the expected throughput.\n"
+                            f"See the comment on the text_demo.py by the assert for instructions."
+                        )
+                        assert lower_bound <= tokens_per_second_per_user <= upper_bound, assert_message
+                        # A mismatch of throughput suggests a regression in performance, likely due to changes in one or more ops used by the model, resulting in reduced end-to-end throughput.
+                        # In some cases, small variations in PCC or improved model performance are expected. When this happens, update the target values in models/demos/llama3_70b_galaxy/demo/text_demo_targets.json.
+                        # Once updated, include the modified target file in your PR. The model code owners will then review and approve the changes.
+                        # If no changes to the model are expected from the PR, but targets differ, further investigation is needed to understand the root cause.
 
             current_pos += 1
             iteration += 1
@@ -1374,6 +1517,10 @@ def test_demo_text(
                     logger.warning("Expected outputs data is empty or not loaded, cannot compare.")
 
         num_tokens_generated_decode.append(iteration)  # Save the number of tokens generated for each repeat batch
+        if token_accuracy:
+            acc = token_acc.compute_accuracy()
+            logger.info("=== Top1 and Top5 Token Accuracy ===")
+            logger.info(f" Top1 Accuracy: {acc[0] * 100:.2f}%, Top5 Accuracy: {acc[1] * 100:.2f}%")
 
     profiler.end(f"inference_decode", iteration=batch_idx)
 
@@ -1419,6 +1566,22 @@ def test_demo_text(
     if not apc_test and num_layers == 80 and pcc_check and len(top_1_accs) > 0 and len(top_5_accs) > 0:
         measurements["Top 1 Accuracy"] = sum(top_1_accs) / len(top_1_accs)
         measurements["Top 5 Accuracy"] = sum(top_5_accs) / len(top_5_accs)
+
+    if token_accuracy:
+        assert acc is not None, "Token accuracy mode completed without accuracy results"
+        total_top1_acc = math.ceil(acc[0] * 100)
+        total_top5_acc = math.ceil(acc[1] * 100)
+        measurements["Top 1 Accuracy"] = total_top1_acc
+        measurements["Top 5 Accuracy"] = total_top5_acc
+
+        min_top1_acc, min_top5_acc = get_accuracy_thresholds(model_args)
+        assert (
+            total_top1_acc >= min_top1_acc
+        ), f"Top-1 accuracy {total_top1_acc:.1f}% is too low (expected >={min_top1_acc}%)"
+        assert (
+            total_top5_acc >= min_top5_acc
+        ), f"Top-5 accuracy {total_top5_acc:.1f}% is too low (expected >={min_top5_acc}%)"
+        logger.info("Checks of top-1 and top-5 accuracy against PERF.md passed")
 
     # Decode performance for some specific tokens
     tok_1_perf = profiler.get_duration(f"inference_decode_time_{1}")  # Iteration 0 is compile time

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -164,7 +164,7 @@
 - name: Llama 3.3-70B e2e tests (Galaxy)
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG
-    pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "pcc-80L"
+    pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "ci-token-matching"
     pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat2"
   model: llama3.3-70b-galaxy
   skus:

--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -483,7 +483,7 @@
 - name: Galaxy Llama 3.3-70B e2e tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG
-    pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "pcc-80L"
+    pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "ci-token-matching"
     pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat2"
   model-name: llama3.3-70b-galaxy
   skus:


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/45006

### Feature
Accuracy top1/top5 test (ci-token-matching) is added to texr_demo.py test file for Llama 3 70B on Galaxy machines and made default instead of PCC-80L test from before.

Summary:

Added TokenAccuracy support in models/demos/llama3_70b_galaxy/demo/text_demo.py.
Added a new pytest case: ci-token-matching.
The new test uses teacher forcing and computes top-1/top-5 token accuracy from the existing reference .refpt file.
Added PERF.md threshold checking with the same 0.5% slack style as simple_text_demo.py.
Kept pcc-80L in the demo for manual PCC validation.
Added --token_accuracy CLI support in Galaxy demo conftest.py.
Updated Galaxy Llama CI selectors in:
tests/pipeline_reorg/models_e2e_tests.yaml
tests/pipeline_reorg/release_tests.yaml
CI now runs ci-token-matching instead of pcc-80L.
repeat2 remains unchanged.

### Summary
This PR solves flaky issues with PCC tests where both PCC and accuracy is being tested. This also makes it compatible with simple_text_demo.py tests and PERF.md ways of checking the performance of the model.

CI run:
Tier 1 model e2e CI run (fails because of PCC test, but in full log you can see that ci-token-matching is called and everything works as intended): https://github.com/tenstorrent/tt-metal/actions/runs/26288712776

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llama_accuracy_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llama_accuracy_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:llama_accuracy_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llama_accuracy_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llama_accuracy_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llama_accuracy_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llama_accuracy_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llama_accuracy_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llama_accuracy_test)