### PR TITLE
[skip ci] Add Blackhole e2e SDPA test selection

### DIFF
--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -20,12 +20,17 @@ on:
         type: string
         default: "all"
         description: "Filter test rows by model-name (untagged rows always run)"
+      test-selection:
+        required: false
+        type: string
+        default: "all"
+        description: "Filter test rows by id, or by the sdpa tag group"
 
 jobs:
   load-test-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.filter-matrix.outputs.matrix || steps.prepare.outputs.matrix }}
+      matrix: ${{ steps.apply-filters.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/blackhole_e2e_tests.yaml
     steps:
@@ -52,16 +57,57 @@ jobs:
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml
-      - name: Filter test matrix by model
-        id: filter-matrix
-        if: inputs.model != 'all'
+      - name: Apply test matrix filters
+        id: apply-filters
         env:
           MATRIX: ${{ steps.prepare.outputs.matrix }}
+          MODEL: ${{ inputs.model }}
+          TEST_SELECTION: ${{ inputs.test-selection }}
         run: |
-          filtered=$(echo "$MATRIX" | jq -c --arg model "${{ inputs.model }}" '[.[] | select(.["model-name"] == $model or (.["model-name"] == null))]')
+          selected="$MATRIX"
+
+          if [[ "$TEST_SELECTION" != "all" ]]; then
+            selection_exists=$(python3 - <<'PY'
+          import os
+          import yaml
+
+          selection = os.environ["TEST_SELECTION"]
+          tests_path = os.environ["TESTS_YAML_PATH"]
+
+          with open(tests_path, "r") as f:
+              tests = yaml.safe_load(f) or []
+
+          if selection == "sdpa":
+              matches = any(selection in (test.get("tags") or []) for test in tests)
+          else:
+              matches = any(test.get("id") == selection for test in tests)
+
+          print("true" if matches else "false")
+          PY
+          )
+            if [[ "$selection_exists" != "true" ]]; then
+              echo "::error::Unknown e2e test-selection '$TEST_SELECTION'. Use 'all', 'sdpa', or an id from $TESTS_YAML_PATH."
+              exit 1
+            fi
+
+            case "$TEST_SELECTION" in
+              sdpa)
+                selected=$(echo "$selected" | jq -c '[.[] | select((.tags // []) | index("sdpa"))]')
+                ;;
+              *)
+                selected=$(echo "$selected" | jq -c --arg id "$TEST_SELECTION" '[.[] | select(.id == $id)]')
+                ;;
+            esac
+          fi
+
+          filtered="$selected"
+          if [[ "$MODEL" != "all" ]]; then
+            filtered=$(echo "$filtered" | jq -c --arg model "$MODEL" '[.[] | select(.["model-name"] == $model or (.["model-name"] == null))]')
+          fi
+
           count=$(echo "$filtered" | jq 'length')
           if [[ "$count" -eq 0 ]]; then
-            echo "::warning::No e2e tests match model '${{ inputs.model }}' for enabled SKU(s) '${{ inputs.enabled-skus }}'; e2e matrix is empty and jobs will be skipped."
+            echo "::warning::No e2e tests match model '$MODEL' and test-selection '$TEST_SELECTION' for enabled SKU(s) '${{ inputs.enabled-skus }}'; e2e matrix is empty and jobs will be skipped."
           fi
           echo "matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$filtered" >> $GITHUB_OUTPUT

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -32,6 +32,16 @@ on:
         options:
           - all
           - deepseek
+      test-selection:
+        description: 'Select e2e tests to run: all tests, all SDPA tests, or one test id'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - sdpa
+          - bh-sdpa-nightly-integration
+          - bh-ring-sdpa-perf
       build-type:
         required: false
         type: choice
@@ -60,6 +70,11 @@ on:
         type: string
         default: 'all'
         description: "Select model to test (filters rows by model-name; untagged rows always run)"
+      test-selection:
+        required: false
+        type: string
+        default: 'all'
+        description: "Select all tests, the sdpa tag group, or one test id from tests/pipeline_reorg/blackhole_e2e_tests.yaml"
       platform:
         required: false
         type: string
@@ -132,3 +147,4 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: ${{ matrix.test-group.sku }}
       model: ${{ inputs.model || 'all' }}
+      test-selection: ${{ inputs.test-selection || 'all' }}

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -10,6 +10,7 @@
 #       timeout: The maximum allowed runtime for this job in minutes on that SKU.
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
+#   tags: (Optional) Labels used by workflow_dispatch test-selection groups.
 #   model-name: (Optional) Model identifier; rows are kept when workflow_dispatch
 #     `model` matches this value or when the row has no `model-name` (always-run).
 
@@ -65,6 +66,7 @@
 
 - id: bh-sdpa-nightly-integration
   name: sdpa nightly tests
+  tags: [sdpa]
   cmd: pytest tests/nightly/blackhole/sdpa/ -svv
   skus:
     bh_deskbox:
@@ -119,6 +121,7 @@
 
 - id: bh-ring-sdpa-perf
   name: ring sdpa perf tests
+  tags: [sdpa]
   # Skip QB1 (bh_llmbox / 4xP150): perf differs slightly from QB2 (2xP300);
   # running on one machine class lets us keep a tighter tolerance (PR #44069).
   cmd: |


### PR DESCRIPTION
## Summary
- Add a `test-selection` input to Blackhole e2e manual/reusable workflows.
- Allow selecting all tests, SDPA-tagged tests, or a specific e2e test id.
- Keep unknown selections as hard errors, but allow valid selections to produce an empty per-SKU matrix so unsupported SKUs skip cleanly.

## Testing
- Commit hooks passed, including workflow YAML checks.
- Pre-squash validation run confirmed the previous red P150 `load-test-matrix` path now passes with the expected empty-matrix warning: https://github.com/tenstorrent/tt-metal/actions/runs/26285704393

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/blackhole-e2e-sdpa-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/blackhole-e2e-sdpa-filter)