### PR TITLE
Move transformer operations to device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
@@ -6,6 +6,10 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 /**
  * ChainConfig: Runtime args for store-and-forward chain configuration.
@@ -76,11 +80,10 @@ struct ChainConfig {
  * - mcast_enabled: selects multicast vs unicast forwarding at compile time
  * - is_head_level: true = head chain (matches batch AND head), false = batch chain (matches batch only)
  *
- * @param signal_target_x/y: Where receivers send "ready" signal
- *   - Unicast mode: previous core's sender semaphore
- *   - Mcast mode: injector's sender semaphore
- * @param next_core_x/y: Where to forward data in unicast mode
- * @param mcast_start_x/y, mcast_end_x/y: Multicast rectangle bounds (injector only)
+ * Constructor stores semaphore IDs and target coords.
+ *
+ * For non-participating cores the semaphores are not used; the valid semaphore is only
+ * initialized when is_participant=true.
  */
 template <bool mcast_enabled, bool is_head_level>
 class ChainLink {
@@ -99,9 +102,9 @@ public:
         bool is_participant,
         bool is_injector,
         bool is_sink,
-        uint32_t sender_sem_addr,
-        uint32_t receiver_sem_addr,
-        uint32_t valid_sem_addr,
+        uint32_t sender_sem_id,
+        uint32_t receiver_sem_id,
+        uint32_t valid_sem_id,
         uint32_t signal_target_x,
         uint32_t signal_target_y,
         uint32_t next_core_x,
@@ -123,34 +126,24 @@ public:
         chain_batch(chain_batch),
         chain_head(chain_head),
         next_core_q_chunks(next_core_q_chunks),
-        sender_sem_ptr_(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr)),
-        receiver_sem_ptr_(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr)),
-        valid_sem_addr_(valid_sem_addr),
-        sender_sem_noc_addr_(get_noc_addr(signal_target_x, signal_target_y, sender_sem_addr)),
-        receiver_sem_noc_addr_(0),
-        mcast_base_noc_addr_(0),
-        mcast_sem_noc_addr_(0),
-        sender_wait_count_(1),
+        sender_sem_id_(sender_sem_id),
+        receiver_sem_id_(receiver_sem_id),
+        valid_sem_id_(valid_sem_id),
+        signal_target_x_(signal_target_x),
+        signal_target_y_(signal_target_y),
+        next_core_x_(next_core_x),
+        next_core_y_(next_core_y),
+        mcast_start_x_(mcast_start_x),
+        mcast_start_y_(mcast_start_y),
+        mcast_end_x_(mcast_end_x),
+        mcast_end_y_(mcast_end_y),
+        sender_wait_count_((mcast_enabled && is_injector) ? mcast_sender_wait : 1),
         mcast_num_dests_(mcast_num_dests),
         chunk_tiles_(chunk_tiles),
-        tile_bytes_(tile_bytes),
-        next_core_x_(next_core_x),
-        next_core_y_(next_core_y) {
-        // Initialize valid semaphore (skip if address is 0 to avoid corrupting memory)
-        if (valid_sem_addr != 0) {
-            volatile tt_l1_ptr uint32_t* valid_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_sem_addr);
-            *valid_sem_ptr = VALID;
-        }
-
-        if constexpr (mcast_enabled) {
-            if (is_injector) {
-                mcast_base_noc_addr_ =
-                    get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, 0);
-                mcast_sem_noc_addr_ = mcast_base_noc_addr_ | receiver_sem_addr;
-                sender_wait_count_ = mcast_sender_wait;
-            }
-        } else {
-            receiver_sem_noc_addr_ = get_noc_addr(next_core_x, next_core_y, receiver_sem_addr);
+        tile_bytes_(tile_bytes) {
+        // Initialize valid semaphore (only meaningful for participants; non-participants leave it alone)
+        if (is_participant) {
+            Semaphore<>(valid_sem_id_).set(VALID);
         }
     }
 
@@ -206,10 +199,11 @@ public:
      * Receive data from upstream link (called by non-injector participants).
      * Protocol: signal sender that we're ready, then wait for data.
      */
-    void receive() const {
-        noc_semaphore_set(receiver_sem_ptr_, INVALID);
-        noc_semaphore_inc(sender_sem_noc_addr_, 1);
-        noc_semaphore_wait(receiver_sem_ptr_, VALID);
+    void receive(Noc noc) const {
+        Semaphore<> receiver_sem(receiver_sem_id_);
+        receiver_sem.set(INVALID);
+        Semaphore<>(sender_sem_id_).up(noc, signal_target_x_, signal_target_y_, 1);
+        receiver_sem.wait(VALID);
     }
 
     /**
@@ -217,49 +211,78 @@ public:
      * In mcast mode: wait for all receivers, then broadcast.
      * In unicast mode: wait for next receiver, then point-to-point transfer.
      */
-    void forward(uint32_t cb_addr) const { forward(cb_addr, chunk_tiles_, tile_bytes_); }
+    void forward(Noc noc, uint32_t cb_addr) const { forward(noc, cb_addr, chunk_tiles_, tile_bytes_); }
 
     /**
      * Forward data to downstream link(s) with explicit size.
      * Use this when the data size differs from the default (e.g., K using head chain).
      */
-    void forward(uint32_t cb_addr, uint32_t num_tiles, uint32_t tile_bytes) const {
+    void forward(Noc noc, uint32_t cb_addr, uint32_t num_tiles, uint32_t tile_bytes) const {
+        Semaphore<> sender_sem(sender_sem_id_);
         if constexpr (mcast_enabled) {
-            noc_semaphore_wait(sender_sem_ptr_, sender_wait_count_);
-            noc_semaphore_set(sender_sem_ptr_, 0);
-            uint64_t mcast_addr = mcast_base_noc_addr_ | cb_addr;
-            noc_async_write_multicast(cb_addr, mcast_addr, num_tiles * tile_bytes, mcast_num_dests_, true);
-            noc_semaphore_set_multicast(valid_sem_addr_, mcast_sem_noc_addr_, mcast_num_dests_);
-            noc_async_writes_flushed();
+            sender_sem.wait(sender_wait_count_);
+            sender_sem.set(0);
+            noc.async_write_multicast(
+                CoreLocalMem<uint32_t>(cb_addr),
+                MulticastEndpoint{},
+                num_tiles * tile_bytes,
+                mcast_num_dests_,
+                {},
+                {.noc_x_start = mcast_start_x_,
+                 .noc_y_start = mcast_start_y_,
+                 .noc_x_end = mcast_end_x_,
+                 .noc_y_end = mcast_end_y_,
+                 .addr = cb_addr},
+                /*linked=*/true);
+            // Must be back-to-back after the linked data write — any flush/barrier between them
+            // deadlocks the linked transaction.
+            Semaphore<>(valid_sem_id_)
+                .relay_multicast(
+                    noc,
+                    Semaphore<>(receiver_sem_id_),
+                    mcast_start_x_,
+                    mcast_start_y_,
+                    mcast_end_x_,
+                    mcast_end_y_,
+                    mcast_num_dests_,
+                    /*linked=*/false);
+            noc.async_writes_flushed();
         } else {
-            noc_semaphore_wait(sender_sem_ptr_, 1);
-            noc_semaphore_set(sender_sem_ptr_, 0);
-            uint64_t unicast_addr = get_noc_addr(next_core_x_, next_core_y_, cb_addr);
-            noc_async_write(cb_addr, unicast_addr, num_tiles * tile_bytes);
-            noc_async_writes_flushed();
-            noc_semaphore_set_remote(valid_sem_addr_, receiver_sem_noc_addr_);
+            sender_sem.wait(1);
+            sender_sem.set(0);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(cb_addr),
+                UnicastEndpoint{},
+                num_tiles * tile_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = next_core_x_, .noc_y = next_core_y_, .addr = cb_addr});
+            noc.async_writes_flushed();
+            Semaphore<>(valid_sem_id_)
+                .relay_unicast(noc, Semaphore<>(receiver_sem_id_), next_core_x_, next_core_y_);
         }
     }
 
 private:
-    // Semaphore pointers (derived from addresses in constructor)
-    volatile tt_l1_ptr uint32_t* sender_sem_ptr_;
-    volatile tt_l1_ptr uint32_t* receiver_sem_ptr_;
+    // Semaphore IDs (resolved to L1 addresses on use via Semaphore<>).
+    uint32_t sender_sem_id_;
+    uint32_t receiver_sem_id_;
+    uint32_t valid_sem_id_;
 
-    // Semaphore L1 address (needed for mcast set_multicast)
-    uint32_t valid_sem_addr_;
+    // Remote coordinates, NoC arithmetic happens per-call
+    uint32_t signal_target_x_;  // Upstream sender semaphore target
+    uint32_t signal_target_y_;
+    uint32_t next_core_x_;  // Downstream unicast target
+    uint32_t next_core_y_;
 
-    // NOC addresses (computed in constructor)
-    uint64_t sender_sem_noc_addr_;
-    uint64_t receiver_sem_noc_addr_;
-    uint64_t mcast_base_noc_addr_;
-    uint64_t mcast_sem_noc_addr_;
+    // Multicast rectangle
+    uint32_t mcast_start_x_;
+    uint32_t mcast_start_y_;
+    uint32_t mcast_end_x_;
+    uint32_t mcast_end_y_;
 
     // Configuration
     uint32_t sender_wait_count_;
     uint32_t mcast_num_dests_;
     uint32_t chunk_tiles_;
     uint32_t tile_bytes_;
-    uint32_t next_core_x_;
-    uint32_t next_core_y_;
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -7,7 +7,11 @@
 #include <cstdint>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include <tt-metalium/constants.hpp>
 #include "api/debug/assert.h"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp"
@@ -66,18 +70,24 @@ uint32_t virtual_seq_tile_id_to_physical_tile_id(
 
 template <typename PageTableArgs>
 volatile tt_l1_ptr uint32_t* read_page_table_for_batch(
+    Noc noc,
     uint32_t cb_id,
     uint32_t batch_idx,
     const PageTableArgs& page_table_args,
     uint32_t page_table_addr,
     uint32_t page_table_stick_size) {
-    uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id);
+    CircularBuffer cb(cb_id);
+    uint32_t page_table_cb_wr_ptr = cb.get_write_ptr();
     // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
     // program cache hits.
     const auto page_table_reader = TensorAccessor(page_table_args, page_table_addr, page_table_stick_size);
-    uint64_t page_table_noc_addr = page_table_reader.get_noc_addr(batch_idx);
-    noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-    noc_async_read_barrier();
+    noc.async_read(
+        page_table_reader,
+        CoreLocalMem<uint32_t>(page_table_cb_wr_ptr),
+        page_table_stick_size,
+        {.page_id = batch_idx},
+        {});
+    noc.async_read_barrier();
     return reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
 }
 
@@ -142,23 +152,24 @@ uint32_t read_chunk_with_padding(
       This handles the case where the dst CB is larger than the src CB, with some padding on the
       rows or cols of the DST CB.
     */
+    Noc noc;
     const uint32_t num_tiles = dst_rows * dst_cols;
-    cb_reserve_back(cb_id, num_tiles);
-    const uint32_t base_write_ptr = get_write_ptr(cb_id);
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(num_tiles);
+    const uint32_t base_write_ptr = cb.get_write_ptr();
     uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
     uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
 
-    Noc noc;
     uint32_t barrier_count = 0;
     for (uint32_t row = 0; row < src_rows; ++row) {
         uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
-            noc_async_read_page(start_tile_id, reader, write_ptr);
+            noc.async_read(reader, CoreLocalMem<uint32_t>(write_ptr), tile_bytes, {.page_id = start_tile_id}, {});
             start_tile_id += 1;
             write_ptr += inner_ptr_stride;
 
             if (++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
                 barrier_count = 0;
             }
         }
@@ -177,11 +188,11 @@ uint32_t read_chunk_with_padding(
     }
     // NOC reads and async_write_zeros use the same completion path on WH/BH but different
     // paths on Quasar (NOC channels vs iDMA). Issue both — second is a no-op on WH/BH.
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     noc.write_zeros_l1_barrier();
 
     if constexpr (push_num_tiles) {
-        cb_push_back(cb_id, num_tiles);
+        cb.push_back(num_tiles);
         return 0;
     } else {
         return num_tiles;
@@ -202,11 +213,12 @@ FORCE_INLINE void read_q_subblock(
     const uint32_t src_cols,
     const uint32_t dst_cols,
     const uint32_t barrier_threshold) {
-    const uint32_t sb_tiles = subblock_h * dst_cols;
-    cb_reserve_back(cb_id, sb_tiles);
-    const uint32_t base_write_ptr = get_write_ptr(cb_id);
-
     Noc noc;
+    const uint32_t sb_tiles = subblock_h * dst_cols;
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(sb_tiles);
+    const uint32_t base_write_ptr = cb.get_write_ptr();
+
     uint32_t barrier_count = 0;
     for (uint32_t row = sb_start_row; row < sb_start_row + subblock_h; ++row) {
         const uint32_t local_row = row - sb_start_row;
@@ -214,10 +226,10 @@ FORCE_INLINE void read_q_subblock(
 
         if (row < src_rows) {
             for (uint32_t col = 0; col < src_cols; ++col) {
-                noc_async_read_page(start_tile_id++, reader, write_ptr);
+                noc.async_read(reader, CoreLocalMem<uint32_t>(write_ptr), tile_bytes, {.page_id = start_tile_id++}, {});
                 write_ptr += tile_bytes;
                 if (++barrier_count == barrier_threshold) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                     barrier_count = 0;
                 }
             }
@@ -235,9 +247,9 @@ FORCE_INLINE void read_q_subblock(
 
     // NOC reads and async_write_zeros use the same completion path on WH/BH but different
     // paths on Quasar (NOC channels vs iDMA). Issue both — second is a no-op on WH/BH.
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     noc.write_zeros_l1_barrier();
-    cb_push_back(cb_id, sb_tiles);
+    cb.push_back(sb_tiles);
 }
 
 template <uint32_t num_heads, uint32_t block_size_t, uint32_t Wt, typename ReaderType>
@@ -255,9 +267,11 @@ void read_paged_chunk_with_padding(
     const volatile tt_l1_ptr uint32_t* const page_table_ptr,
     const bool transpose = false,
     const uint32_t skip_src_cols = 0) {
+    Noc noc;
     const uint32_t num_tiles = dst_rows * dst_cols;
-    cb_reserve_back(cb_id, num_tiles);
-    const uint32_t base_write_ptr = get_write_ptr(cb_id);
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(num_tiles);
+    const uint32_t base_write_ptr = cb.get_write_ptr();
 
     // Stride calculation based on transpose flag
     uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
@@ -271,12 +285,12 @@ void read_paged_chunk_with_padding(
             virtual_row_num, cur_head, page_table_ptr);
 
         for (uint32_t col = 0; col < src_cols; ++col) {
-            noc_async_read_page(physical_tile_id, reader, write_ptr);
+            noc.async_read(reader, CoreLocalMem<uint32_t>(write_ptr), tile_bytes, {.page_id = physical_tile_id}, {});
             physical_tile_id += 1;
             write_ptr += inner_ptr_stride;
 
             if (++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
                 barrier_count = 0;
             }
         }
@@ -284,7 +298,6 @@ void read_paged_chunk_with_padding(
     }
 
     // Zero out the padding
-    Noc noc;
     for (uint32_t row = 0; row < dst_rows; ++row) {
         for (uint32_t col = 0; col < dst_cols; ++col) {
             if (row < src_rows && col < src_cols) {
@@ -296,15 +309,22 @@ void read_paged_chunk_with_padding(
     }
     // NOC reads and async_write_zeros use the same completion path on WH/BH but different
     // paths on Quasar (NOC channels vs iDMA). Issue both — second is a no-op on WH/BH.
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     noc.write_zeros_l1_barrier();
-    cb_push_back(cb_id, num_tiles);
+    cb.push_back(num_tiles);
 }
 
 template <uint32_t tile_bytes>
-void copy_tile(uint64_t noc_read_addr_base, uint32_t q_write_ptr_base, uint32_t src_tile_id, uint32_t dst_tile_id) {
-    noc_async_read(
-        noc_read_addr_base + src_tile_id * tile_bytes, q_write_ptr_base + dst_tile_id * tile_bytes, tile_bytes);
+void copy_tile(
+    Noc noc, uint32_t src_l1_addr_base, uint32_t dst_l1_addr_base, uint32_t src_tile_id, uint32_t dst_tile_id) {
+    const uint8_t noc_id = noc.get_noc_id();
+    UnicastEndpoint src;
+    noc.async_read(
+        src,
+        CoreLocalMem<uint32_t>(dst_l1_addr_base + dst_tile_id * tile_bytes),
+        tile_bytes,
+        {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = src_l1_addr_base + src_tile_id * tile_bytes},
+        {});
 }
 
 // Generic fill with -inf that works for all supported mask formats (bfp4, bfp8, bfloat16)
@@ -315,7 +335,8 @@ void fill_neginf_tile(uint32_t cb_id, uint32_t tile_id) {
     constexpr uint32_t bfp8_size = num_exponents + tt::constants::TILE_HW;
     constexpr uint32_t bf16_size = tt::constants::TILE_HW * 2;
 
-    uint32_t write_addr = get_write_ptr(cb_id) + tile_id * tile_bytes;
+    CircularBuffer cb(cb_id);
+    uint32_t write_addr = cb.get_write_ptr() + tile_id * tile_bytes;
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
     constexpr uint32_t total_words = tile_bytes / sizeof(uint32_t);
 
@@ -349,17 +370,18 @@ void fill_neginf_tile(uint32_t cb_id, uint32_t tile_id) {
  * Within each uint32 word: low 16 bits = even column, high 16 bits = odd column.
  */
 template <uint32_t tile_bytes>
-void fill_vertical_tile_bf16(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_col_in_tile) {
+void fill_vertical_tile_bf16(Noc noc, uint32_t cb_id, uint32_t tile_id, uint32_t unpad_col_in_tile) {
     // Start with all zeros (valid)
-    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+    fill_tile_zeros<tile_bytes>(noc, cb_id, tile_id);
 
     constexpr uint32_t NEGINF_PAIR = 0xFF80FF80;
     constexpr uint32_t bf16_per_uint32 = 2;
     constexpr uint32_t uint32_per_face_row = tt::constants::FACE_WIDTH / bf16_per_uint32;  // 8
     constexpr uint32_t uint32_per_face = tt::constants::FACE_HW / bf16_per_uint32;         // 128
 
+    CircularBuffer cb(cb_id);
     volatile tt_l1_ptr uint32_t* ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
 
     // Face offsets in uint32 words
     constexpr uint32_t face_offsets[4] = {
@@ -416,17 +438,18 @@ void fill_vertical_tile_bf16(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_co
  * Face 3 (rows 16-31, cols 16-31): same diagonal pattern as face 0 (shifted by 16 in both dims)
  */
 template <uint32_t tile_bytes>
-void fill_causal_diagonal_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
+void fill_causal_diagonal_tile_bf16(Noc noc, uint32_t cb_id, uint32_t tile_id) {
     // Start with all zeros
-    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+    fill_tile_zeros<tile_bytes>(noc, cb_id, tile_id);
 
     constexpr uint32_t NEGINF_PAIR = 0xFF80FF80;
     constexpr uint32_t bf16_per_uint32 = 2;
     constexpr uint32_t uint32_per_face_row = tt::constants::FACE_WIDTH / bf16_per_uint32;  // 8
     constexpr uint32_t uint32_per_face = tt::constants::FACE_HW / bf16_per_uint32;         // 128
 
+    CircularBuffer cb(cb_id);
     volatile tt_l1_ptr uint32_t* ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
 
     // Face offsets in uint32 words
     constexpr uint32_t face_offsets[4] = {
@@ -479,8 +502,8 @@ void fill_causal_diagonal_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
  *   - trailing edge (leading_edge=false): col c is -inf if c > boundary_col
  */
 template <uint32_t tile_bytes, int32_t diagonal_offset = 0, bool leading_edge = true>
-void fill_diagonal_edge_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
-    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+void fill_diagonal_edge_tile_bf16(Noc noc, uint32_t cb_id, uint32_t tile_id) {
+    fill_tile_zeros<tile_bytes>(noc, cb_id, tile_id);
 
     constexpr uint32_t neginf_bf16 = 0xFF80;
     constexpr uint32_t bf16_per_uint32 = 2;
@@ -547,7 +570,7 @@ void fill_diagonal_edge_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
  * ceil-based loop bounds in SlidingWindowLoopGeometry. See sliding_window_geometry.hpp.
  */
 template <uint32_t sliding_window_size, bool is_causal_lw, uint32_t cb_mask_in, uint32_t tile_bytes>
-void fill_sliding_window_edge_tiles(uint32_t start_tile_idx) {
+void fill_sliding_window_edge_tiles(Noc noc, uint32_t start_tile_idx) {
     constexpr uint32_t half_window = sliding_window_size / 2;
     constexpr uint32_t leading_remainder =
         is_causal_lw ? (sliding_window_size % tt::constants::TILE_HEIGHT) : (half_window % tt::constants::TILE_HEIGHT);
@@ -563,15 +586,15 @@ void fill_sliding_window_edge_tiles(uint32_t start_tile_idx) {
 
     // Tile 0: trailing/right edge. Causal uses the normal causal diagonal.
     fill_diagonal_edge_tile_bf16<tile_bytes, trailing_primary_offset, /*leading_edge=*/false>(
-        cb_mask_in, start_tile_idx);
+        noc, cb_mask_in, start_tile_idx);
     // Tile 1/2: left edge when it straddles two K tiles; tile 1 is unused for aligned windows.
     fill_diagonal_edge_tile_bf16<tile_bytes, leading_prev_offset, /*leading_edge=*/true>(
-        cb_mask_in, start_tile_idx + 1);
+        noc, cb_mask_in, start_tile_idx + 1);
     fill_diagonal_edge_tile_bf16<tile_bytes, leading_current_offset, /*leading_edge=*/true>(
-        cb_mask_in, start_tile_idx + 2);
+        noc, cb_mask_in, start_tile_idx + 2);
     // Tile 3: non-causal right edge when it straddles into the next K tile; unused for causal/aligned windows.
     fill_diagonal_edge_tile_bf16<tile_bytes, trailing_next_offset, /*leading_edge=*/false>(
-        cb_mask_in, start_tile_idx + 3);
+        noc, cb_mask_in, start_tile_idx + 3);
 }
 
 /**
@@ -592,7 +615,7 @@ template <
     uint32_t cb_mask_in,
     bool is_causal_lw = false,
     uint32_t sliding_window_size = 0>
-void generate_lightweight_mask_tiles() {
+void generate_lightweight_mask_tiles(Noc noc) {
     constexpr uint32_t partial_mask_tiles = (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
     constexpr bool has_sliding_window = sliding_window_size > 0;
     constexpr uint32_t sliding_diag_tiles = has_sliding_window ? kSlidingWindowEdgeTiles : 0;
@@ -600,7 +623,8 @@ void generate_lightweight_mask_tiles() {
     constexpr uint32_t total_mask_tiles = 1 + sliding_diag_tiles + causal_diag_tiles + partial_mask_tiles;
     constexpr uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
 
-    cb_reserve_back(cb_mask_in, total_mask_tiles);
+    CircularBuffer cb(cb_mask_in);
+    cb.reserve_back(total_mask_tiles);
 
     // Tile 0: neginf tile
     fill_neginf_tile<mask_tile_size_bytes>(cb_mask_in, 0);
@@ -608,34 +632,39 @@ void generate_lightweight_mask_tiles() {
     uint32_t tile_idx = 1;
 
     if constexpr (has_sliding_window) {
-        fill_sliding_window_edge_tiles<sliding_window_size, is_causal_lw, cb_mask_in, mask_tile_size_bytes>(tile_idx);
+        fill_sliding_window_edge_tiles<sliding_window_size, is_causal_lw, cb_mask_in, mask_tile_size_bytes>(
+            noc, tile_idx);
         tile_idx += kSlidingWindowEdgeTiles;
     } else if constexpr (is_causal_lw) {
-        fill_causal_diagonal_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++);
+        fill_causal_diagonal_tile_bf16<mask_tile_size_bytes>(noc, cb_mask_in, tile_idx++);
     }
 
     // Subsequent tiles: partial mask tiles for boundary conditions
     if constexpr (partial_mask_tiles > 0) {
         if constexpr (global_n_partial_col > 0) {
-            fill_vertical_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++, global_n_partial_col);
+            fill_vertical_tile_bf16<mask_tile_size_bytes>(noc, cb_mask_in, tile_idx++, global_n_partial_col);
         }
         if constexpr (joint_l_partial_col > 0) {
-            fill_vertical_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++, joint_l_partial_col);
+            fill_vertical_tile_bf16<mask_tile_size_bytes>(noc, cb_mask_in, tile_idx++, joint_l_partial_col);
         }
     }
 
-    cb_push_back(cb_mask_in, total_mask_tiles);
+    cb.push_back(total_mask_tiles);
 }
 
 template <uint32_t tile_bytes>
 inline void fill_custom_diagonal_tile_bfp4(
-    uint32_t cb_id, uint32_t tile_id, int32_t leading_diagonal_offset, int32_t trailing_diagonal_offset) {
+    Noc noc,
+    uint32_t cb_id,
+    uint32_t tile_id,
+    int32_t leading_diagonal_offset,
+    int32_t trailing_diagonal_offset) {
     // Assert that we're not in a case where the entire tile should be fully masked or fully allowed
     // Those cases should be handled before calling this function
     ASSERT(leading_diagonal_offset >= -32 && trailing_diagonal_offset >= -32);
 
     // Clear the tile first
-    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+    fill_tile_zeros<tile_bytes>(noc, cb_id, tile_id);
 
     /**
      * In bfp4_b, -inf is represented as 0xF exp and 0xC mantissa.
@@ -665,8 +694,9 @@ inline void fill_custom_diagonal_tile_bfp4(
     constexpr uint32_t uint32_datums_per_face = (tt::constants::FACE_HW) / bf4_mant_per_uint32;
     constexpr uint32_t uint32_exp_per_face = tt::constants::FACE_HEIGHT / bf4_exp_per_uint32;
 
+    CircularBuffer cb(cb_id);
     volatile tt_l1_ptr uint32_t* uint32_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
 
     // Fill all exponents with NEG_INF_EXP
     for (uint32_t i = 0; i < uint32_exp_per_face * 4; i++) {
@@ -758,14 +788,14 @@ inline void fill_custom_diagonal_tile_bfp4(
 }
 
 template <uint32_t tile_bytes>
-void fill_vertical_tile_bfp4(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_col_in_tile) {
+void fill_vertical_tile_bfp4(Noc noc, uint32_t cb_id, uint32_t tile_id, uint32_t unpad_col_in_tile) {
     /*
     This tile should be set such that tile[:, unpad_col_in_tile:] = -inf
     For block float 4 format where 8 mantissas are packed per uint32
     */
 
     // Prefill with zeros (fast)
-    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+    fill_tile_zeros<tile_bytes>(noc, cb_id, tile_id);
 
     constexpr uint32_t NEG_INF_EXP = 0xFFFFFFFF;
     constexpr uint32_t NEG_INF_MANT = 0xCCCCCCCC;  // All mantissas set to 0xC
@@ -776,8 +806,9 @@ void fill_vertical_tile_bfp4(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_co
     constexpr uint32_t uint32_datums_per_face = (tt::constants::FACE_HW) / bf4_mant_per_uint32;
     constexpr uint32_t uint32_exp_per_face = tt::constants::FACE_HEIGHT / bf4_exp_per_uint32;
 
+    CircularBuffer cb(cb_id);
     volatile tt_l1_ptr uint32_t* uint32_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
 
     // Calculate face offsets in uint32 words
     constexpr uint32_t exp_section_size = uint32_exp_per_face * 4;
@@ -855,6 +886,7 @@ enum class MaskType { FULLY_ALLOWED, FULLY_MASKED, PARTIAL_MASK };
 
 template <uint32_t cb_mask_in>
 void generate_causal_sliding_window_mask(
+    Noc noc,
     uint32_t Sq_chunk_t,
     uint32_t Sk_chunk_t,
     uint32_t q_chunk,
@@ -862,10 +894,10 @@ void generate_causal_sliding_window_mask(
     bool is_causal = true,
     uint32_t sliding_window_size = 0) {
     uint32_t mask_size_tiles = Sq_chunk_t * Sk_chunk_t;
-    cb_reserve_back(cb_mask_in, mask_size_tiles);
+    CircularBuffer cb(cb_mask_in);
+    cb.reserve_back(mask_size_tiles);
 
-    uint32_t write_ptr_base = get_write_ptr(cb_mask_in);
-    uint64_t noc_write_addr_base = get_noc_addr(write_ptr_base);
+    uint32_t write_ptr_base = cb.get_write_ptr();
     constexpr uint32_t tile_bytes = get_tile_size(cb_mask_in);
 
     int zero_tile_idx = -1;
@@ -964,10 +996,10 @@ void generate_causal_sliding_window_mask(
             switch (mask_type) {
                 case MaskType::FULLY_ALLOWED:
                     if (zero_tile_idx == -1) {
-                        fill_tile_zeros<tile_bytes>(cb_mask_in, in_mask_tile_id);
+                        fill_tile_zeros<tile_bytes>(noc, cb_mask_in, in_mask_tile_id);
                         zero_tile_idx = in_mask_tile_id;
                     } else {
-                        copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, zero_tile_idx, in_mask_tile_id);
+                        copy_tile<tile_bytes>(noc, write_ptr_base, write_ptr_base, zero_tile_idx, in_mask_tile_id);
                     }
                     break;
                 case MaskType::FULLY_MASKED:
@@ -975,26 +1007,26 @@ void generate_causal_sliding_window_mask(
                         fill_neginf_tile<tile_bytes>(cb_mask_in, in_mask_tile_id);
                         inf_tile_idx = in_mask_tile_id;
                     } else {
-                        copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, inf_tile_idx, in_mask_tile_id);
+                        copy_tile<tile_bytes>(noc, write_ptr_base, write_ptr_base, inf_tile_idx, in_mask_tile_id);
                     }
                     break;
                 case MaskType::PARTIAL_MASK:
                     fill_custom_diagonal_tile_bfp4<tile_bytes>(
-                        cb_mask_in, in_mask_tile_id, leading_diagonal_offset, trailing_diagonal_offset);
+                        noc, cb_mask_in, in_mask_tile_id, leading_diagonal_offset, trailing_diagonal_offset);
             }
         }
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_mask_in, mask_size_tiles);
+    noc.async_read_barrier();
+    cb.push_back(mask_size_tiles);
 }
 
 template <uint32_t cb_mask_in>
-void generate_noncausal_padded_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, uint32_t unpadded_Sk) {
+void generate_noncausal_padded_mask(Noc noc, uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, uint32_t unpadded_Sk) {
     uint32_t mask_size_tiles = Sq_chunk_t * Sk_chunk_t;
-    cb_reserve_back(cb_mask_in, mask_size_tiles);
+    CircularBuffer cb(cb_mask_in);
+    cb.reserve_back(mask_size_tiles);
 
-    uint32_t write_ptr_base = get_write_ptr(cb_mask_in);
-    uint64_t noc_write_addr_base = get_noc_addr(write_ptr_base);
+    uint32_t write_ptr_base = cb.get_write_ptr();
     constexpr uint32_t tile_bytes = get_tile_size(cb_mask_in);
 
     int zero_tile_idx = -1;
@@ -1015,36 +1047,36 @@ void generate_noncausal_padded_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, ui
 
             if (do_zero) {
                 if (zero_tile_idx == -1) {
-                    fill_tile_zeros<tile_bytes>(cb_mask_in, in_mask_tile_id);
+                    fill_tile_zeros<tile_bytes>(noc, cb_mask_in, in_mask_tile_id);
                     zero_tile_idx = in_mask_tile_id;
                 } else {
-                    copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, zero_tile_idx, in_mask_tile_id);
+                    copy_tile<tile_bytes>(noc, write_ptr_base, write_ptr_base, zero_tile_idx, in_mask_tile_id);
                 }
             } else if (do_inf) {
                 if (inf_tile_idx == -1) {
                     fill_neginf_tile<tile_bytes>(cb_mask_in, in_mask_tile_id);
                     inf_tile_idx = in_mask_tile_id;
                 } else {
-                    copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, inf_tile_idx, in_mask_tile_id);
+                    copy_tile<tile_bytes>(noc, write_ptr_base, write_ptr_base, inf_tile_idx, in_mask_tile_id);
                 }
             } else {
                 if (vertical_tile_idx == -1) {
-                    fill_vertical_tile_bfp4<tile_bytes>(cb_mask_in, in_mask_tile_id, unpad_col_in_tile);
+                    fill_vertical_tile_bfp4<tile_bytes>(noc, cb_mask_in, in_mask_tile_id, unpad_col_in_tile);
                     vertical_tile_idx = in_mask_tile_id;
                 } else {
-                    copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, vertical_tile_idx, in_mask_tile_id);
+                    copy_tile<tile_bytes>(noc, write_ptr_base, write_ptr_base, vertical_tile_idx, in_mask_tile_id);
                 }
             }
         }
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_mask_in, mask_size_tiles);
+    noc.async_read_barrier();
+    cb.push_back(mask_size_tiles);
 }
 
-// Issue noc_async_read_page for a (num_rows × cols) tile block. tile_id starts at base_tile_id,
+// Issue noc.async_read for a (num_rows x cols) tile block. tile_id starts at base_tile_id,
 // advances by ++ per col and by row_stride per row (i.e., tile_id += row_stride - cols after each
 // inner col loop). dst starts at dst_addr + dst_row_origin * outer_stride, advances by
-// inner_stride per col and outer_stride per row. No barrier — caller must noc_async_read_barrier().
+// inner_stride per col and outer_stride per row. No barrier - caller must noc.async_read_barrier().
 // barrier_threshold > 0 fires a partial barrier every barrier_threshold tiles.
 template <typename ReaderType>
 inline void issue_block_reads(
@@ -1060,14 +1092,21 @@ inline void issue_block_reads(
     uint32_t barrier_threshold,
     uint32_t& barrier_count) {
     uint32_t tile_id = base_tile_id;
+    uint32_t tile_bytes;
+    if constexpr (has_get_aligned_page_size_v<ReaderType>) {
+        tile_bytes = reader.get_aligned_page_size();
+    } else {
+        tile_bytes = reader.page_size;
+    }
+    Noc noc;
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;
         for (uint32_t col = 0; col < cols; ++col) {
-            noc_async_read_page(tile_id, reader, dst);
+            noc.async_read(reader, CoreLocalMem<uint32_t>(dst), tile_bytes, {.page_id = tile_id}, {});
             ++tile_id;
             dst += inner_stride;
             if (barrier_threshold > 0 && ++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
                 barrier_count = 0;
             }
         }
@@ -1089,13 +1128,13 @@ inline void zero_fill_block(
     uint32_t dst_addr,
     uint32_t outer_stride,
     uint32_t inner_stride) {
+    Noc noc;
     uint32_t page_size;
     if constexpr (has_get_aligned_page_size_v<ReaderType>) {
         page_size = reader.get_aligned_page_size();
     } else {
         page_size = reader.page_size;
     }
-    Noc noc;
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;
         for (uint32_t col = 0; col < cols; ++col) {
@@ -1105,10 +1144,12 @@ inline void zero_fill_block(
     }
 }
 
-// Issue noc_async_write_page for a (num_rows × cols) tile block. Same tile_id/src arithmetic
-// as issue_block_reads (with src instead of dst). No barrier — caller must noc_async_write_barrier().
+// Issue noc.async_write for a (num_rows x cols) tile block. Same tile_id/src arithmetic
+// as issue_block_reads (with src instead of dst). No barrier - caller must noc.async_write_barrier().
+// trid=0 is the default tag for untagged writes; nonzero tags writes for per-TRID barriers/flushes.
 template <typename WriterType>
 inline void issue_block_writes(
+    Noc noc,
     const WriterType& writer,
     uint32_t base_tile_id,
     uint32_t row_stride,
@@ -1117,12 +1158,20 @@ inline void issue_block_writes(
     uint32_t src_row_origin,
     uint32_t src_addr,
     uint32_t outer_stride,
-    uint32_t inner_stride) {
+    uint32_t inner_stride,
+    uint32_t trid = 0) {
     uint32_t tile_id = base_tile_id;
+    uint32_t tile_bytes;
+    if constexpr (has_get_aligned_page_size_v<WriterType>) {
+        tile_bytes = writer.get_aligned_page_size();
+    } else {
+        tile_bytes = writer.page_size;
+    }
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t src = src_addr + (src_row_origin + r) * outer_stride;
         for (uint32_t col = 0; col < cols; ++col) {
-            noc_async_write_page(tile_id, writer, src);
+            noc.async_write<NocOptions::TXN_ID>(
+                CoreLocalMem<uint32_t>(src), writer, tile_bytes, {}, {.page_id = tile_id}, {.trid = trid});
             ++tile_id;
             src += inner_stride;
         }
@@ -1258,11 +1307,13 @@ struct CatAddrGenerator {
     // noc_async_write_barrier(). Same segment split as issue_reads; gap and tail produce no
     // writes (those rows aren't mapped to either tensor). end_seq_tile unused (see issue_reads).
     void issue_writes(
+        Noc noc,
         const Slice& slice,
         uint32_t /*end_seq_tile*/,
         uint32_t src_addr,
         uint32_t outer_stride,
-        uint32_t inner_stride) const {
+        uint32_t inner_stride,
+        uint32_t trid = 0) const {
         const uint32_t d2_start = slice.d2_start;
         const uint32_t d2_end = slice.d2_end;
         const uint32_t cols = slice.get_d3_size();
@@ -1274,6 +1325,7 @@ struct CatAddrGenerator {
         const uint32_t s0_end = std::min(d2_end, first_end);
         if (d2_start < s0_end) {
             issue_block_writes(
+                noc,
                 first_reader,
                 first_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
                 first_shape.strides[2],
@@ -1282,7 +1334,8 @@ struct CatAddrGenerator {
                 /*src_row_origin=*/0,
                 src_addr,
                 outer_stride,
-                inner_stride);
+                inner_stride,
+                trid);
         }
         // Gap rows: no writes.
         // Segment 2: second tensor.
@@ -1290,6 +1343,7 @@ struct CatAddrGenerator {
         const uint32_t s2_end = std::min(d2_end, second_end);
         if (s2_start < s2_end) {
             issue_block_writes(
+                noc,
                 second_reader,
                 second_shape.id_of(slice.d0, slice.d1, s2_start - first_seq_padded, slice.d3_start),
                 second_shape.strides[2],
@@ -1298,7 +1352,8 @@ struct CatAddrGenerator {
                 s2_start - d2_start,
                 src_addr,
                 outer_stride,
-                inner_stride);
+                inner_stride,
+                trid);
         }
         // Tail rows: no writes.
     }
@@ -1357,13 +1412,15 @@ struct PaddedAddrGenerator {
     }
 
     // Issue async NoC writes for a slice from L1. No barrier — caller must
-    // noc_async_write_barrier(). Out-of-bound rows produce no writes.
+    // noc.async_write_barrier(). Out-of-bound rows produce no writes.
     void issue_writes(
+        Noc noc,
         const Slice& slice,
         uint32_t end_seq_tile,
         uint32_t src_addr,
         uint32_t outer_stride,
-        uint32_t inner_stride) const {
+        uint32_t inner_stride,
+        uint32_t trid = 0) const {
         const uint32_t d2_start = slice.d2_start;
         const uint32_t rows = slice.get_d2_size();
         const uint32_t cols = slice.get_d3_size();
@@ -1373,6 +1430,7 @@ struct PaddedAddrGenerator {
 
         // Valid segment only; out-of-bound rows produce no writes.
         issue_block_writes(
+            noc,
             reader,
             tensor_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
             tensor_shape.stride2(),
@@ -1381,12 +1439,19 @@ struct PaddedAddrGenerator {
             /*src_row_origin=*/0,
             src_addr,
             outer_stride,
-            inner_stride);
+            inner_stride,
+            trid);
     }
 
     void issue_writes_no_padding(
-        const Slice& slice, uint32_t src_addr, uint32_t outer_stride, uint32_t inner_stride) const {
+        Noc noc,
+        const Slice& slice,
+        uint32_t src_addr,
+        uint32_t outer_stride,
+        uint32_t inner_stride,
+        uint32_t trid = 0) const {
         issue_block_writes(
+            noc,
             reader,
             tensor_shape.id_of(slice.d0, slice.d1, slice.d2_start, slice.d3_start),
             tensor_shape.stride2(),
@@ -1395,7 +1460,8 @@ struct PaddedAddrGenerator {
             /*src_row_origin=*/0,
             src_addr,
             outer_stride,
-            inner_stride);
+            inner_stride,
+            trid);
     }
 };
 
@@ -1422,6 +1488,7 @@ __attribute__((noinline)) void fetch_block(
     const uint32_t tile_bytes,
     const bool transpose,
     const uint32_t barrier_threshold = 0) {
+    Noc noc;
     const uint32_t src_rows = src_slice.get_d2_size();
     const uint32_t src_cols = src_slice.get_d3_size();
     const uint32_t outer_ptr_stride = transpose ? tile_bytes : src_cols * tile_bytes;
@@ -1429,11 +1496,10 @@ __attribute__((noinline)) void fetch_block(
 
     cat_addr_generator.issue_reads(
         src_slice, end_seq_tile, dst_cb_id, dst_addr, outer_ptr_stride, inner_ptr_stride, barrier_threshold);
-    // issue_reads internally emits noc_async_read (NOC) AND zero_fill_block → async_write_zeros
+    // issue_reads internally emits noc.async_read (NOC) AND zero_fill_block → async_write_zeros
     // (iDMA on Quasar). NOC reads and async_write_zeros use the same completion path on WH/BH
     // but different paths on Quasar. Issue both — second is a no-op on WH/BH.
-    Noc noc;
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     noc.write_zeros_l1_barrier();
 }
 
@@ -1447,17 +1513,18 @@ void read_block(
     const bool transpose,
     const uint32_t barrier_threshold = 0) {
     const uint32_t num_tiles = src_slice.get_d2_size() * src_slice.get_d3_size();
-    cb_reserve_back(cb_id, num_tiles);
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(num_tiles);
     fetch_block(
         cat_addr_generator,
         src_slice,
         end_seq_tile,
         cb_id,
-        get_write_ptr(cb_id),
+        cb.get_write_ptr(),
         tile_bytes,
         transpose,
         barrier_threshold);
-    cb_push_back(cb_id, num_tiles);
+    cb.push_back(num_tiles);
 }
 
 // Pop a (rows × cols) tile block out of a CB and write it via NoC. Symmetric to read_block:
@@ -1466,6 +1533,7 @@ void read_block(
 // dispatch). Out-of-bound rows are skipped (no zero-fill on writes).
 template <typename CatAddrGeneratorType>
 void write_block(
+    Noc noc,
     const CatAddrGeneratorType& cat_addr_generator,
     const Slice& dst_slice,
     const uint32_t end_seq_tile,
@@ -1474,18 +1542,20 @@ void write_block(
     const uint32_t dst_rows = dst_slice.get_d2_size();
     const uint32_t dst_cols = dst_slice.get_d3_size();
     const uint32_t num_tiles = dst_rows * dst_cols;
-    const uint32_t base_read_ptr = get_read_ptr(cb_id);
+    CircularBuffer cb(cb_id);
     const uint32_t outer_ptr_stride = dst_cols * tile_bytes;
     const uint32_t inner_ptr_stride = tile_bytes;
 
-    cb_wait_front(cb_id, num_tiles);
-    cat_addr_generator.issue_writes(dst_slice, end_seq_tile, base_read_ptr, outer_ptr_stride, inner_ptr_stride);
-    noc_async_write_barrier();
-    cb_pop_front(cb_id, num_tiles);
+    cb.wait_front(num_tiles);
+    cat_addr_generator.issue_writes(
+        noc, dst_slice, end_seq_tile, cb.get_read_ptr(), outer_ptr_stride, inner_ptr_stride);
+    noc.async_write_barrier();
+    cb.pop_front(num_tiles);
 }
 
 template <typename TensorAccessorType>
 void write_block(
+    Noc noc,
     const TensorAccessorType& out_writer,
     const uint32_t cb_out,
     const uint32_t out_chunk_tiles,
@@ -1497,23 +1567,24 @@ void write_block(
     uint32_t barrier_count = 0;
     uint32_t tile_id = out_tile_id;
 
-    cb_wait_front(cb_out, out_chunk_tiles);
+    CircularBuffer cb(cb_out);
+    cb.wait_front(out_chunk_tiles);
 
-    uint32_t l1_read_addr = get_read_ptr(cb_out);
+    uint32_t l1_read_addr = cb.get_read_ptr();
     for (uint32_t row = 0; row < rows; ++row) {
         for (uint32_t col = 0; col < cols; ++col) {
-            noc_async_write_page(tile_id, out_writer, l1_read_addr);
+            noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), out_writer, tile_bytes, {}, {.page_id = tile_id});
             ++tile_id;
             l1_read_addr += tile_bytes;
 
             if (++barrier_count == barrier_threshold) {
-                noc_async_writes_flushed();
+                noc.async_writes_flushed();
                 barrier_count = 0;
             }
         }
     }
-    noc_async_write_barrier();
-    cb_pop_front(cb_out, out_chunk_tiles);
+    noc.async_write_barrier();
+    cb.pop_front(out_chunk_tiles);
 }
 
 // Single-chip linear-tile-id drain. Iterates total_rows in groups of sbh rows (last group is
@@ -1524,6 +1595,7 @@ void write_block(
 // sets a non-zero trid → drain flushes trid 0 (the default trid all writes here carry).
 template <typename TensorAccessorType>
 void write_block_row_grouped(
+    Noc noc,
     const TensorAccessorType& out_writer,
     const uint32_t cb_out,
     const uint32_t total_rows,
@@ -1541,19 +1613,25 @@ void write_block_row_grouped(
     const uint32_t remainder_rows = total_rows - num_full_groups * sbh;
     const uint32_t num_groups = num_full_groups + (remainder_rows ? 1 : 0);
 
+    CircularBuffer cb(cb_out);
     for (uint32_t rg = 0; rg < num_groups; ++rg) {
         const uint32_t rows_this_group = (rg < num_full_groups) ? sbh : remainder_rows;
         const uint32_t tiles_this_group = rows_this_group * cols;
-        cb_wait_front(cb_out, tiles_this_group);
-        uint32_t l1_read_addr = get_read_ptr(cb_out);
+        cb.wait_front(tiles_this_group);
+        uint32_t l1_read_addr = cb.get_read_ptr();
         for (uint32_t r = 0; r < rows_this_group; ++r) {
             const uint32_t row = rg * sbh + r;
             if (row < write_rows) {
                 for (uint32_t col = 0; col < cols; ++col) {
-                    noc_async_write_page(tile_id, out_writer, l1_read_addr + col * tile_bytes);
+                    noc.async_write(
+                        CoreLocalMem<uint32_t>(l1_read_addr + col * tile_bytes),
+                        out_writer,
+                        tile_bytes,
+                        {},
+                        {.page_id = tile_id});
                     ++tile_id;
                     if (++barrier_count == barrier_threshold) {
-                        noc_async_write_flushed_with_trid(default_trid);
+                        noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = default_trid});
                         barrier_count = 0;
                     }
                 }
@@ -1561,20 +1639,21 @@ void write_block_row_grouped(
             l1_read_addr += cols * tile_bytes;
         }
         // Flush THIS drain's writes (default trid) before pop so compute can safely reuse the L1 slot.
-        noc_async_write_flushed_with_trid(default_trid);
-        cb_pop_front(cb_out, tiles_this_group);
+        noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = default_trid});
+        cb.pop_front(tiles_this_group);
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }
 
-// Multi-chip row-grouped drain of cb_out to DRAM via cat_addr_generator.issue_writes; writes
-// overlap with compute's next row-group push. Padding past end_seq_tile is silently skipped
-// (out-of-bound rows produce no writes). flush_trid is the TRID the caller stamped writes
-// with via noc_async_write_set_trid (0 = default); per-group flush uses
-// noc_async_write_flushed_with_trid(flush_trid) so it waits exactly for THIS drain's writes
-// to be source-L1-acked. Caller handles any final DRAM-arrival NoC barrier.
+// Multi-chip row-grouped drain of cb_out to DRAM;
+// writes overlap with compute's next row-group push. Padding past end_seq_tile is silently skipped
+// (out-of-bound rows produce no writes). flush_trid is the TRID stamped on each individual
+// write via noc.async_write<NocOptions::TXN_ID>(..., {.trid=flush_trid});
+// per-group flush uses noc.async_writes_flushed<TXN_ID>(flush_trid) so it waits exactly for
+// THIS drain's writes to be source-L1-acked. Caller handles any final DRAM-arrival NoC barrier.
 template <bool all_rows_valid = false, typename CatAddrGeneratorType>
 void write_block_row_grouped_trid(
+    Noc noc,
     const CatAddrGeneratorType& cat_addr_generator,
     const Slice& dst_slice,
     const uint32_t end_seq_tile,
@@ -1590,10 +1669,11 @@ void write_block_row_grouped_trid(
     const uint32_t remainder_rows = total_rows - num_full_groups * sbh;
     const uint32_t num_groups = num_full_groups + (remainder_rows ? 1 : 0);
 
+    CircularBuffer cb(cb_out);
     for (uint32_t rg = 0; rg < num_groups; ++rg) {
         const uint32_t rows_this_group = (rg < num_full_groups) ? sbh : remainder_rows;
         const uint32_t tiles_this_group = rows_this_group * cols;
-        cb_wait_front(cb_out, tiles_this_group);
+        cb.wait_front(tiles_this_group);
         const Slice group_slice(
             dst_slice.d0,
             dst_slice.d1,
@@ -1602,12 +1682,14 @@ void write_block_row_grouped_trid(
             dst_slice.d3_start,
             dst_slice.d3_end);
         if constexpr (all_rows_valid) {
-            cat_addr_generator.issue_writes_no_padding(group_slice, get_read_ptr(cb_out), outer_stride, tile_bytes);
+            cat_addr_generator.issue_writes_no_padding(
+                noc, group_slice, cb.get_read_ptr(), outer_stride, tile_bytes, flush_trid);
         } else {
-            cat_addr_generator.issue_writes(group_slice, end_seq_tile, get_read_ptr(cb_out), outer_stride, tile_bytes);
+            cat_addr_generator.issue_writes(
+                noc, group_slice, end_seq_tile, cb.get_read_ptr(), outer_stride, tile_bytes, flush_trid);
         }
-        noc_async_write_flushed_with_trid(flush_trid);
-        cb_pop_front(cb_out, tiles_this_group);
+        noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = flush_trid});
+        cb.pop_front(tiles_this_group);
     }
 }
 
@@ -1633,7 +1715,8 @@ void fill_attention_sink_tiles(uint32_t cb_id, uint32_t num_tiles, uint32_t sour
     // This ensures stale L1 values don't affect the max computation
     constexpr uint16_t neg_inf_bf16 = 0xFF80;
 
-    uint32_t write_ptr = get_write_ptr(cb_id);
+    CircularBuffer cb(cb_id);
+    uint32_t write_ptr = cb.get_write_ptr();
 
     // Tile is 32x32 in row-major order within faces
     // For bfloat16, each element is 2 bytes (uint16_t)
@@ -1676,6 +1759,7 @@ void fill_attention_sink_tiles(uint32_t cb_id, uint32_t num_tiles, uint32_t sour
 
 template <bool is_chunked, uint32_t sliding_window_size, bool padded_or_joint_masks, uint32_t cb_mask_in>
 void generate_mask(
+    Noc noc,
     const uint32_t Sq_chunk_t,
     const uint32_t Sk_chunk_t,
     const uint32_t q_chunk,
@@ -1707,15 +1791,15 @@ void generate_mask(
                 // If no sliding window, only generate mask along diagonal
                 // Otherwise, generate mask for all chunks
                 generate_causal_sliding_window_mask<cb_mask_in>(
-                    Sq_chunk_t, Sk_chunk_t, offset_q_chunk, k_chunk, is_causal, sliding_window_size);
+                    noc, Sq_chunk_t, Sk_chunk_t, offset_q_chunk, k_chunk, is_causal, sliding_window_size);
             }
         }
     } else if constexpr (padded_or_joint_masks) {
         if (generate_mask_0) {
-            generate_noncausal_padded_mask<cb_mask_in>(Sq_chunk_t, Sk_chunk_t, unpadded_Sk_mask_0);
+            generate_noncausal_padded_mask<cb_mask_in>(noc, Sq_chunk_t, Sk_chunk_t, unpadded_Sk_mask_0);
         }
         if (generate_mask_1) {
-            generate_noncausal_padded_mask<cb_mask_in>(Sq_chunk_t, Sk_chunk_t, unpadded_Sk_mask_1);
+            generate_noncausal_padded_mask<cb_mask_in>(noc, Sq_chunk_t, Sk_chunk_t, unpadded_Sk_mask_1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_reader.cpp
@@ -4,10 +4,16 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "dataflow_common.hpp"
 #include "exp_fused_op_indexer.hpp"
 void kernel_main() {
-    noc_async_write_barrier();
+    Noc noc;
+    noc.async_write_barrier();
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
     constexpr uint32_t DHt = get_compile_time_arg_val(2);
@@ -66,7 +72,8 @@ void kernel_main() {
 
     const uint32_t is_mux_writer = get_arg_val<uint32_t>(argidx++);
 
-    // Per-link semaphore addresses for chunk-level sync
+    // Per-link semaphore addresses for chunk-level sync.
+    // Kept as raw L1 pointers (not Semaphore<>) because they're passed as L1 addresses via RT args.
     const uint32_t num_links = get_arg_val<uint32_t>(argidx++);
     volatile tt_l1_ptr uint32_t* per_link_sem_ptrs[2] = {nullptr, nullptr};
     for (uint32_t lnk = 0; lnk < num_links; ++lnk) {
@@ -78,47 +85,21 @@ void kernel_main() {
 
     // After fused-op receiver consumed its runtime args, remaining RT args are S&F chain metadata
 
-    // Compile-time semaphore ids and mcast flag are appended after all TensorAccessorArgs()
-    uint32_t sender_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset()));
-    uint32_t receiver_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 1));
-    uint32_t valid_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 2));
+    // Compile-time semaphore ids and mcast flag are appended after all TensorAccessorArgs().
+    // Semaphore<> wrapper resolves IDs to L1 addrs internally.
+    const uint32_t sender_semaphore_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset());
+    const uint32_t receiver_semaphore_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 1);
+    const uint32_t valid_semaphore_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 2);
     constexpr bool mcast_enabled = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 3) == 1;
 
-    // VALID sem used to write L1-L1 valid semaphore
-    volatile tt_l1_ptr uint32_t* valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_semaphore_addr);
-    *(valid_semaphore_addr_ptr) = VALID;
+    // Receiver flips this to INVALID before each wait; initialize so the first iteration sees it as VALID.
+    Semaphore<>(valid_semaphore_id).set(VALID);
 
-    volatile tt_l1_ptr uint32_t* receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);
-
-    volatile tt_l1_ptr uint32_t* sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore_addr);
-
-    uint64_t receiver_semaphore_noc_addr = 0;
-    uint64_t mcast_base_noc_addr = 0;
-    uint64_t mcast_sem_noc_addr = 0;
     uint32_t sender_wait_count = 1;
-
-    const uint64_t sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
-
     if constexpr (mcast_enabled) {
         if (is_injector) {
-            // prev_physical = mcast_start (first receiver), next_physical = mcast_end (last receiver)
-            mcast_base_noc_addr = get_noc_multicast_addr(
-                prev_physical_x,
-                prev_physical_y,
-                next_physical_x,
-                next_physical_y,
-                0);  // addr=0; will OR in actual L1 addr at use site
-            mcast_sem_noc_addr = mcast_base_noc_addr | receiver_semaphore_addr;
             sender_wait_count = mcast_sender_wait;
         }
-    } else {
-        receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
     }
 
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
@@ -273,15 +254,18 @@ void kernel_main() {
                 }
 
                 // K: get data into CB buffer
-                cb_reserve_back(cb_k_in, k_chunk_tiles);
+                CircularBuffer cb_k(cb_k_in);
+                CircularBuffer cb_k_writer(cb_k_writer_in);
+                cb_k.reserve_back(k_chunk_tiles);
                 if (is_mux_writer) {
-                    cb_reserve_back(cb_k_writer_in, k_chunk_tiles);
+                    cb_k_writer.reserve_back(k_chunk_tiles);
                 }
-                uint32_t cb_k_start_address = get_write_ptr(cb_k_in);
+                uint32_t cb_k_start_address = cb_k.get_write_ptr();
                 if (should_receive) {
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                    Semaphore<> receiver_sem(receiver_semaphore_id);
+                    receiver_sem.set(INVALID);
+                    Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                    receiver_sem.wait(VALID);
                 } else {
                     fetch_block(
                         kv_chunk_is_joint ? joint_k_generator
@@ -298,39 +282,60 @@ void kernel_main() {
                 // Forward K to next core(s) before push_back — prevents compute from
                 // popping the buffer while the mcast is still reading from it.
                 if (should_forward) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                    Semaphore<> sender_sem(sender_semaphore_id);
+                    sender_sem.wait(sender_wait_count);
+                    sender_sem.set(0);
                     if constexpr (mcast_enabled) {
-                        uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
-                        noc_async_write_multicast(
-                            cb_k_start_address,
-                            k_mcast_addr,
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(cb_k_start_address),
+                            MulticastEndpoint{},
                             k_chunk_tiles * k_tile_bytes,
                             mcast_num_dests,
+                            {},
+                            {.noc_x_start = prev_physical_x,
+                             .noc_y_start = prev_physical_y,
+                             .noc_x_end = next_physical_x,
+                             .noc_y_end = next_physical_y,
+                             .addr = cb_k_start_address},
                             true /* linked: semaphore mcast follows */);
-                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                        // Must be back-to-back after the linked data write — any flush between them
+                        // deadlocks the linked transaction.
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_multicast(
+                                noc,
+                                Semaphore<>(receiver_semaphore_id),
+                                prev_physical_x,
+                                prev_physical_y,
+                                next_physical_x,
+                                next_physical_y,
+                                mcast_num_dests,
+                                /*linked=*/false);
                     } else {
-                        uint64_t k_unicast_data_addr =
-                            get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                        noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
+                        noc.async_write(
+                            CoreLocalMem<uint32_t>(cb_k_start_address),
+                            UnicastEndpoint{},
+                            k_chunk_tiles * k_tile_bytes,
+                            {},
+                            {.noc_x = next_physical_x, .noc_y = next_physical_y, .addr = cb_k_start_address});
                     }
-                    noc_async_writes_flushed();
+                    noc.async_writes_flushed();
                     if constexpr (!mcast_enabled) {
-                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_unicast(noc, Semaphore<>(receiver_semaphore_id), next_physical_x, next_physical_y);
                     }
                 }
 
                 // Make K available to compute
-                cb_push_back(cb_k_in, k_chunk_tiles);
+                cb_k.push_back(k_chunk_tiles);
                 if (is_mux_writer) {
-                    cb_push_back(cb_k_writer_in, k_chunk_tiles);
-                    ASSERT(get_write_ptr(cb_k_in) == get_write_ptr(cb_k_writer_in));
+                    cb_k_writer.push_back(k_chunk_tiles);
+                    ASSERT(cb_k.get_write_ptr() == cb_k_writer.get_write_ptr());
                 }
 
                 // Download Q on the first K iteration — after K is downloaded and forwarded.
                 // Push Q one subblock at a time so compute can start QK matmul incrementally.
                 // Placed after K forward so no outstanding NOC writes remain
-                // (noc_async_read_barrier inside subblock read would deadlock with in-flight writes).
+                // (noc.async_read_barrier inside subblock read would deadlock with in-flight writes).
                 if (k_chunk == 0 && need_q_read) {
                     if constexpr (use_q_subblock_push) {
                         const auto& q_gen = is_joint_q ? joint_q_generator : q_generator;
@@ -356,15 +361,18 @@ void kernel_main() {
                 }
 
                 // V: get data into CB buffer
-                cb_reserve_back(cb_v_in, v_chunk_tiles);
+                CircularBuffer cb_v(cb_v_in);
+                CircularBuffer cb_v_writer(cb_v_writer_in);
+                cb_v.reserve_back(v_chunk_tiles);
                 if (is_mux_writer) {
-                    cb_reserve_back(cb_v_writer_in, v_chunk_tiles);
+                    cb_v_writer.reserve_back(v_chunk_tiles);
                 }
-                uint32_t cb_v_start_address = get_write_ptr(cb_v_in);
+                uint32_t cb_v_start_address = cb_v.get_write_ptr();
                 if (should_receive) {
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                    Semaphore<> receiver_sem(receiver_semaphore_id);
+                    receiver_sem.set(INVALID);
+                    Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                    receiver_sem.wait(VALID);
                 } else {
                     fetch_block(
                         kv_chunk_is_joint ? joint_v_generator
@@ -381,47 +389,71 @@ void kernel_main() {
                 // Forward V to next core(s) before push_back — prevents compute from
                 // popping the buffer while the mcast is still reading from it.
                 if (should_forward) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                    Semaphore<> sender_sem(sender_semaphore_id);
+                    sender_sem.wait(sender_wait_count);
+                    sender_sem.set(0);
                     if constexpr (mcast_enabled) {
-                        uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
-                        noc_async_write_multicast(
-                            cb_v_start_address,
-                            v_mcast_addr,
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(cb_v_start_address),
+                            MulticastEndpoint{},
                             v_chunk_tiles * v_tile_bytes,
                             mcast_num_dests,
+                            {},
+                            {.noc_x_start = prev_physical_x,
+                             .noc_y_start = prev_physical_y,
+                             .noc_x_end = next_physical_x,
+                             .noc_y_end = next_physical_y,
+                             .addr = cb_v_start_address},
                             true /* linked: semaphore mcast follows */);
-                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                        // Companion semaphore mcast — see K path above for rationale.
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_multicast(
+                                noc,
+                                Semaphore<>(receiver_semaphore_id),
+                                prev_physical_x,
+                                prev_physical_y,
+                                next_physical_x,
+                                next_physical_y,
+                                mcast_num_dests,
+                                /*linked=*/false);
                     } else {
-                        uint64_t v_unicast_data_addr =
-                            get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
-                        noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
+                        noc.async_write(
+                            CoreLocalMem<uint32_t>(cb_v_start_address),
+                            UnicastEndpoint{},
+                            v_chunk_tiles * v_tile_bytes,
+                            {},
+                            {.noc_x = next_physical_x, .noc_y = next_physical_y, .addr = cb_v_start_address});
                     }
-                    noc_async_writes_flushed();
+                    noc.async_writes_flushed();
                     if constexpr (!mcast_enabled) {
-                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_unicast(noc, Semaphore<>(receiver_semaphore_id), next_physical_x, next_physical_y);
                     }
                 }
 
                 // Make V available to compute
-                cb_push_back(cb_v_in, v_chunk_tiles);
+                cb_v.push_back(v_chunk_tiles);
                 if (is_mux_writer) {
-                    cb_push_back(cb_v_writer_in, v_chunk_tiles);
-                    ASSERT(get_write_ptr(cb_v_in) == get_write_ptr(cb_v_writer_in));
+                    cb_v_writer.push_back(v_chunk_tiles);
+                    ASSERT(cb_v.get_write_ptr() == cb_v_writer.get_write_ptr());
                 }
             }
         }
 
         if (KV_chunks_processed_in_iter % 2 == 0) {
-            cb_reserve_back(cb_k_in, k_chunk_tiles);
-            cb_reserve_back(cb_v_in, k_chunk_tiles);
-            cb_push_back(cb_k_in, k_chunk_tiles);
-            cb_push_back(cb_v_in, k_chunk_tiles);
+            CircularBuffer cb_k(cb_k_in);
+            CircularBuffer cb_v(cb_v_in);
+            cb_k.reserve_back(k_chunk_tiles);
+            cb_v.reserve_back(k_chunk_tiles);
+            cb_k.push_back(k_chunk_tiles);
+            cb_v.push_back(k_chunk_tiles);
             if (is_mux_writer) {
-                cb_reserve_back(cb_k_writer_in, k_chunk_tiles);
-                cb_reserve_back(cb_v_writer_in, v_chunk_tiles);
-                cb_push_back(cb_k_writer_in, k_chunk_tiles);
-                cb_push_back(cb_v_writer_in, v_chunk_tiles);
+                CircularBuffer cb_k_writer(cb_k_writer_in);
+                CircularBuffer cb_v_writer(cb_v_writer_in);
+                cb_k_writer.reserve_back(k_chunk_tiles);
+                cb_v_writer.reserve_back(v_chunk_tiles);
+                cb_k_writer.push_back(k_chunk_tiles);
+                cb_v_writer.push_back(v_chunk_tiles);
             }
         }
     }
@@ -433,6 +465,6 @@ void kernel_main() {
             noc_semaphore_set(per_link_sem_ptrs[lnk], 0);
         }
     }
-    noc_async_writes_flushed();
-    noc_async_write_barrier();
+    noc.async_writes_flushed();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
@@ -63,6 +65,8 @@ inline QChunkInfo get_q_chunk_info(
 }
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
     constexpr uint32_t DHt = get_compile_time_arg_val(2);
@@ -237,6 +241,9 @@ void kernel_main() {
     constexpr uint32_t cb_k_writer_in = tt::CBIndex::c_14;
     constexpr uint32_t cb_v_writer_in = tt::CBIndex::c_15;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
+
+    CircularBuffer cb_k_w(cb_k_writer_in);
+    CircularBuffer cb_v_w(cb_v_writer_in);
     const auto out_writer = TensorAccessor(out_args, out_addr);
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr);
 
@@ -266,7 +273,7 @@ void kernel_main() {
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
     if constexpr (needs_lightweight_mask) {
-        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in>();
+        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in>(noc);
     }
 
     const uint32_t last_active_ring_iter =
@@ -328,10 +335,10 @@ void kernel_main() {
                         const uint32_t bh_offset = (nb * NH + nq) * ag_output_Wt * ag_output_Ht;
 
                         // Wait for reader to fill K, forward this writer's row slice over fabric
-                        cb_wait_front(cb_k_writer_in, k_chunk_tiles);
+                        cb_k_w.wait_front(k_chunk_tiles);
                         if (!is_last_ring_iter) {
                         if (!kv_chunk_is_joint) {
-                            const uint32_t base_k_read_ptr = get_read_ptr(cb_k_writer_in);
+                            const uint32_t base_k_read_ptr = cb_k_w.get_read_ptr();
                             for (uint32_t col = 0; col < DHt; ++col) {
                                 for (uint32_t row = my_row_start; row < my_row_end; row += ag_packet_size_in_pages) {
                                     uint32_t tiles_in_batch = 0;
@@ -360,11 +367,11 @@ void kernel_main() {
                                             &mux_conn, pkt_scatter_hdr, src_l1_addr,
                                             NocUnicastScatterCommandHeader(k_noc_addrs, k_cs, tiles_in_batch),
                                             ag_page_size * tiles_in_batch);
-                                        noc_async_writes_flushed();
+                                        noc.async_writes_flushed();
                                     } else {
                                         // Partial batch: fall back to per-tile unicast writes to avoid
                                         // variable chunk_count scatter writes which cause non-determinism.
-                                        // noc_async_writes_flushed() after each send ensures the previous
+                                        // noc.async_writes_flushed() after each send ensures the previous
                                         // header NOC write completes before pkt_unicast_hdr is modified
                                         // for the next tile (they share the same L1 header).
                                         for (uint32_t i = 0; i < tiles_in_batch; i++) {
@@ -374,20 +381,20 @@ void kernel_main() {
                                                 pkt_unicast_hdr,
                                                 src_l1_addr + i * ag_page_size,
                                                 NocUnicastCommandHeader{k_noc_addrs[i]});
-                                            noc_async_writes_flushed();
+                                            noc.async_writes_flushed();
                                         }
                                     }
                                 }
                             }
                         }
                         }
-                        cb_pop_front(cb_k_writer_in, k_chunk_tiles);
+                        cb_k_w.pop_front(k_chunk_tiles);
 
                         // Wait for reader to fill V, forward this writer's row slice over fabric
-                        cb_wait_front(cb_v_writer_in, v_chunk_tiles);
+                        cb_v_w.wait_front(v_chunk_tiles);
                         if (!is_last_ring_iter) {
                         if (!kv_chunk_is_joint) {
-                            const uint32_t base_v_read_ptr = get_read_ptr(cb_v_writer_in);
+                            const uint32_t base_v_read_ptr = cb_v_w.get_read_ptr();
                             for (uint32_t row = my_row_start; row < my_row_end; ++row) {
                                 if (kv_slice.d2_start + row >= end_seq_tile) break;
                                 for (uint32_t col = 0; col < DHt; col += ag_packet_size_in_pages) {
@@ -416,11 +423,11 @@ void kernel_main() {
                                             &mux_conn, pkt_scatter_hdr, src_l1_addr,
                                             NocUnicastScatterCommandHeader(v_noc_addrs, v_cs, tiles_in_batch),
                                             ag_page_size * tiles_in_batch);
-                                        noc_async_writes_flushed();
+                                        noc.async_writes_flushed();
                                     } else {
                                         // Partial batch: fall back to per-tile unicast writes to avoid
                                         // variable chunk_count scatter writes which cause non-determinism.
-                                        // noc_async_writes_flushed() after each send ensures the previous
+                                        // noc.async_writes_flushed() after each send ensures the previous
                                         // header NOC write completes before pkt_unicast_hdr is modified
                                         // for the next tile (they share the same L1 header).
                                         for (uint32_t i = 0; i < tiles_in_batch; i++) {
@@ -430,26 +437,26 @@ void kernel_main() {
                                                 pkt_unicast_hdr,
                                                 src_l1_addr + i * ag_page_size,
                                                 NocUnicastCommandHeader{v_noc_addrs[i]});
-                                            noc_async_writes_flushed();
+                                            noc.async_writes_flushed();
                                         }
                                     }
                                 }
                             }
                         }
                         }
-                        cb_pop_front(cb_v_writer_in, v_chunk_tiles);
+                        cb_v_w.pop_front(v_chunk_tiles);
 
                         if (!is_last_ring_iter) {
                             fabric_unicast_noc_unicast_atomic_inc_with_state(&mux_conn, pkt_hdr_sem_inc);
-                            noc_async_writes_flushed();
+                            noc.async_writes_flushed();
                         }
                     }
 
                     if (KV_chunks_processed_in_iter % 2 == 0) {
-                        cb_wait_front(cb_k_writer_in, k_chunk_tiles);
-                        cb_wait_front(cb_v_writer_in, v_chunk_tiles);
-                        cb_pop_front(cb_k_writer_in, k_chunk_tiles);
-                        cb_pop_front(cb_v_writer_in, v_chunk_tiles);
+                        cb_k_w.wait_front(k_chunk_tiles);
+                        cb_v_w.wait_front(v_chunk_tiles);
+                        cb_k_w.pop_front(k_chunk_tiles);
+                        cb_v_w.pop_front(v_chunk_tiles);
                     }
                 }
 #endif
@@ -458,6 +465,7 @@ void kernel_main() {
                 if (is_last_ring_iter) {
                     // Default trid here → pass 0 so per-group flush waits exactly for these writes.
                     write_block_row_grouped_trid(
+                        noc,
                         qi.is_joint_q ? joint_out_generator : out_generator,
                         qi.out_slice,
                         qi.end_seq_tile,
@@ -465,7 +473,7 @@ void kernel_main() {
                         tile_bytes,
                         out_subblock_h,
                         /*flush_trid=*/0);
-                    noc_async_write_barrier();
+                    noc.async_write_barrier();
                 }
             }
         }
@@ -473,7 +481,7 @@ void kernel_main() {
 
 #ifdef USE_MUX
     if (mux_connection_valid) {
-        noc_async_atomic_barrier();
+        noc.async_atomic_barrier();
         tt::tt_fabric::fabric_client_disconnect(mux_conn);
         if (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_sem_addr);
@@ -483,9 +491,9 @@ void kernel_main() {
             uint64_t dest_addr =
                 get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_sem_addr);
             noc_semaphore_inc(dest_addr, 1);
-            noc_async_atomic_barrier();
+            noc.async_atomic_barrier();
         }
     }
 #endif
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/assert.h"
 #include "ring_utils.hpp"
 #include <array>
@@ -12,7 +13,7 @@
 struct RingSDPAOpReceiver {
     RingIdSequencer seq;
     bool wait_for_op_signal = false;
-    std::array<volatile tt_l1_ptr uint32_t*, 2> signal_op_semaphore_addr_ptrs = {};
+    std::array<uint32_t, 2> signal_op_semaphore_ids = {0, 0};
     bool initialized = false;
 
     RingSDPAOpReceiver() {}
@@ -25,11 +26,9 @@ struct RingSDPAOpReceiver {
 
         if (this->wait_for_op_signal) {
             // First semaphore is AllGather's BWD semaphore. It belongs to direction 1.
-            signal_op_semaphore_addr_ptrs[1] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
+            signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
             // Second is AllGather's FWD semaphore. It belongs to direction 0.
-            signal_op_semaphore_addr_ptrs[0] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
+            signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
         }
 
         seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);
@@ -40,7 +39,7 @@ struct RingSDPAOpReceiver {
         ASSERT(initialized);
         return seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
             if (this->wait_for_op_signal) {
-                noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[dir], val);
+                Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_reader.cpp
@@ -4,9 +4,12 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "dataflow_common.hpp"
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
     constexpr uint32_t DHt = get_compile_time_arg_val(2);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
     constexpr uint32_t DHt = get_compile_time_arg_val(2);
@@ -69,6 +72,7 @@ void kernel_main() {
         for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
             for (uint32_t q_chunk = local_q_start; q_chunk < local_q_end; ++q_chunk) {
                 generate_mask<false, 0, use_joint_mask, cb_mask_in>(
+                    noc,
                     Sq_chunk_t,
                     Sk_chunk_t,
                     q_chunk,
@@ -82,7 +86,7 @@ void kernel_main() {
                 const uint32_t out_row_start_tile = q_chunk * Sq_chunk_t;
                 const auto dst_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);
                 const auto out_row_end_tile = out_row_start_tile + Sq_chunk_t;
-                write_block(cat_out_generator, dst_slice, out_row_end_tile, cb_out, tile_bytes);
+                write_block(noc, cat_out_generator, dst_slice, out_row_end_tile, cb_out, tile_bytes);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -4,6 +4,12 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "dataflow_common.hpp"
 
 // Fetch a KV chunk into L1 for forwarding. No CB lifecycle — caller manages
@@ -19,6 +25,7 @@ FORCE_INLINE void read_chunk_for_forwarding(
     const uint32_t dst_rows,
     const uint32_t dst_cols,
     const uint32_t skip_src_cols = 0) {
+    Noc noc;
     const uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
     const uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
 
@@ -26,12 +33,11 @@ FORCE_INLINE void read_chunk_for_forwarding(
     for (uint32_t row = 0; row < src_rows; ++row) {
         uint32_t write_ptr = dst_addr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
-            noc_async_read_page(tile_id++, reader, write_ptr);
+            noc.async_read(reader, CoreLocalMem<uint32_t>(write_ptr), tile_bytes, {.page_id = tile_id++}, {});
             write_ptr += inner_ptr_stride;
         }
         tile_id += skip_src_cols;
     }
-    Noc noc;
     for (uint32_t row = 0; row < dst_rows; ++row) {
         for (uint32_t col = 0; col < dst_cols; ++col) {
             if (row < src_rows && col < src_cols) {
@@ -43,11 +49,13 @@ FORCE_INLINE void read_chunk_for_forwarding(
     }
     // NOC reads and async_write_zeros use the same completion path on WH/BH but different
     // paths on Quasar (NOC channels vs iDMA). Issue both — second is a no-op on WH/BH.
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     noc.write_zeros_l1_barrier();
 }
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NQH = get_compile_time_arg_val(1);
     constexpr uint32_t NKH = get_compile_time_arg_val(2);
@@ -132,17 +140,8 @@ void kernel_main() {
     uint32_t next_core_q_chunks = 0;
     uint32_t mcast_num_dests = 0;
     uint32_t mcast_sender_wait = 0;
-    uint64_t mcast_base_noc_addr = 0;
 
-    // Initialize semaphore addresses and NOC addresses for chain forwarding
-    volatile tt_l1_ptr uint32_t* sender_semaphore_addr_ptr = nullptr;
-    volatile tt_l1_ptr uint32_t* receiver_semaphore_addr_ptr = nullptr;
-    volatile tt_l1_ptr uint32_t* valid_semaphore_addr_ptr = nullptr;
-    uint64_t sender_semaphore_noc_addr = 0;
-    uint64_t receiver_semaphore_noc_addr = 0;
-    uint32_t valid_semaphore_addr = 0;
-    uint32_t receiver_semaphore_l1_addr = 0;
-    uint64_t mcast_sem_noc_addr = 0;
+    // Initialize NOC/semaphore state for chain forwarding
     uint32_t sender_wait_count = 1;
 
     if constexpr (!is_causal) {
@@ -161,34 +160,12 @@ void kernel_main() {
         mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
 
         if (is_chain_participant) {
-            const uint32_t sender_semaphore_addr = get_semaphore(sender_semaphore_id);
-            const uint32_t receiver_semaphore_addr = get_semaphore(receiver_semaphore_id);
-            valid_semaphore_addr = get_semaphore(valid_semaphore_id);
-            receiver_semaphore_l1_addr = receiver_semaphore_addr;
-
-            sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore_addr);
-            receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);
-            valid_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_semaphore_addr);
-
-            *valid_semaphore_addr_ptr = VALID;
+            Semaphore<>(valid_semaphore_id).set(VALID);
 
             if constexpr (mcast_enabled) {
-                // All chains use mcast (all-or-nothing compile-time decision)
-                sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
                 if (is_injector) {
-                    // prev_physical = mcast_start (first receiver), next_physical = mcast_end (last receiver)
-                    mcast_base_noc_addr = get_noc_multicast_addr(
-                        prev_physical_x,
-                        prev_physical_y,
-                        next_physical_x,
-                        next_physical_y,
-                        0);  // addr=0; will OR in actual L1 addr at use site
-                    mcast_sem_noc_addr = mcast_base_noc_addr | receiver_semaphore_l1_addr;
                     sender_wait_count = mcast_sender_wait;
                 }
-            } else {
-                sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
-                receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
             }
         }
     }
@@ -251,21 +228,31 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* page_table_ptr;
 
+    CircularBuffer cb_k(cb_k_in);
+    CircularBuffer cb_v(cb_v_in);
+    CircularBuffer cb_mask(cb_mask_in);
+    CircularBuffer cb_attn_sink(cb_attention_sink);
+    CircularBuffer cb_page_table(cb_id_page_table);
+
     uint32_t chunked_q_chunk_offset = 0;
     if constexpr (is_chunked) {
         if (chunk_start_idx_addr != 0) {
-            cb_reserve_back(cb_id_chunk_start_idx_compute, 1);
-            uint32_t chunk_start_write_ptr = get_write_ptr(cb_id_chunk_start_idx_compute);
-            noc_async_read(chunk_start_idx_reader.get_noc_addr(0), chunk_start_write_ptr, 4);
-            noc_async_read_barrier();
+            CircularBuffer cb_chunk_compute(cb_id_chunk_start_idx_compute);
+            cb_chunk_compute.reserve_back(1);
+            uint32_t chunk_start_write_ptr = cb_chunk_compute.get_write_ptr();
+            noc.async_read(
+                chunk_start_idx_reader, CoreLocalMem<uint32_t>(chunk_start_write_ptr), 4, {.page_id = 0}, {});
+            noc.async_read_barrier();
             uint32_t chunk_start_idx = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(chunk_start_write_ptr);
-            cb_push_back(cb_id_chunk_start_idx_compute, 1);
+            cb_chunk_compute.push_back(1);
 
-            cb_reserve_back(cb_id_chunk_start_idx_writer, 1);
-            uint32_t chunk_start_write_ptr_2 = get_write_ptr(cb_id_chunk_start_idx_writer);
-            noc_async_read(chunk_start_idx_reader.get_noc_addr(0), chunk_start_write_ptr_2, 4);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_chunk_start_idx_writer, 1);
+            CircularBuffer cb_chunk_writer(cb_id_chunk_start_idx_writer);
+            cb_chunk_writer.reserve_back(1);
+            uint32_t chunk_start_write_ptr_2 = cb_chunk_writer.get_write_ptr();
+            noc.async_read(
+                chunk_start_idx_reader, CoreLocalMem<uint32_t>(chunk_start_write_ptr_2), 4, {.page_id = 0}, {});
+            noc.async_read_barrier();
+            cb_chunk_writer.push_back(1);
 
             const uint32_t q_chunk_size = Sq_chunk_t * tt::constants::TILE_HEIGHT;
             chunked_q_chunk_offset_phase_1_local = chunk_start_idx / q_chunk_size;
@@ -315,12 +302,12 @@ void kernel_main() {
                 }
                 if constexpr (is_chunked) {
                     if (prev_nb != static_cast<uint32_t>(-1)) {
-                        cb_pop_front(cb_id_page_table, 1);
+                        cb_page_table.pop_front(1);
                     }
-                    cb_reserve_back(cb_id_page_table, 1);
+                    cb_page_table.reserve_back(1);
                     page_table_ptr = read_page_table_for_batch(
-                        cb_id_page_table, decoded.nb, page_table_args, page_table_addr, page_table_stick_size);
-                    cb_push_back(cb_id_page_table, 1);
+                        noc, cb_id_page_table, decoded.nb, page_table_args, page_table_addr, page_table_stick_size);
+                    cb_page_table.push_back(1);
                 }
             }
             if (decoded.nb != prev_nb || decoded.nq != prev_nq) {
@@ -329,14 +316,19 @@ void kernel_main() {
                 prev_nq = decoded.nq;
             }
             if constexpr (use_attention_sink) {
-                cb_reserve_back(cb_attention_sink, Sq_chunk_t);
-                uint32_t attention_sink_write_ptr = get_write_ptr(cb_attention_sink);
+                cb_attn_sink.reserve_back(Sq_chunk_t);
+                uint32_t attention_sink_write_ptr = cb_attn_sink.get_write_ptr();
                 const uint32_t sink_tile_id = attention_sink_tile_shape.id_of(0, decoded.nq, 0, 0);
-                noc_async_read_page(sink_tile_id, attention_sink_reader, attention_sink_write_ptr);
-                noc_async_read_barrier();
+                noc.async_read(
+                    attention_sink_reader,
+                    CoreLocalMem<uint32_t>(attention_sink_write_ptr),
+                    attention_sink_tile_bytes,
+                    {.page_id = sink_tile_id},
+                    {});
+                noc.async_read_barrier();
                 fill_attention_sink_tiles<attention_sink_tile_bytes>(
                     cb_attention_sink, Sq_chunk_t, attention_sink_write_ptr);
-                cb_push_back(cb_attention_sink, Sq_chunk_t);
+                cb_attn_sink.push_back(Sq_chunk_t);
             }
 
             const uint32_t nb = decoded.nb;
@@ -414,12 +406,13 @@ void kernel_main() {
 
                 if (should_receive) {
                     // Receive forwarded K chunk from previous core
-                    cb_reserve_back(cb_k_in, k_chunk_tiles);
-                    cb_k_start_address = get_write_ptr(cb_k_in);
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                    cb_push_back(cb_k_in, k_chunk_tiles);
+                    cb_k.reserve_back(k_chunk_tiles);
+                    cb_k_start_address = cb_k.get_write_ptr();
+                    Semaphore<> receiver_sem(receiver_semaphore_id);
+                    receiver_sem.set(INVALID);
+                    Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                    receiver_sem.wait(VALID);
+                    cb_k.push_back(k_chunk_tiles);
                 } else {
                     // Read K chunk from DRAM
                     if constexpr (is_chunked) {
@@ -441,8 +434,8 @@ void kernel_main() {
                         );
                     } else {
                         if (should_forward) {
-                            cb_reserve_back(cb_k_in, k_chunk_tiles);
-                            cb_k_start_address = get_write_ptr(cb_k_in);
+                            cb_k.reserve_back(k_chunk_tiles);
+                            cb_k_start_address = cb_k.get_write_ptr();
                             read_chunk_for_forwarding<k_tile_bytes, true>(
                                 k_reader,
                                 cb_k_in,
@@ -474,32 +467,54 @@ void kernel_main() {
                 // any noc_async_read_barrier() between them deadlocks (the read barrier
                 // blocks while a linked write awaits its companion).
                 if (should_forward) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                    Semaphore<> sender_sem(sender_semaphore_id);
+                    sender_sem.wait(sender_wait_count);
+                    sender_sem.set(0);
                     if constexpr (mcast_enabled) {
-                        uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
-                        noc_async_write_multicast(
-                            cb_k_start_address,
-                            k_mcast_addr,
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(cb_k_start_address),
+                            MulticastEndpoint{},
                             k_chunk_tiles * k_tile_bytes,
                             mcast_num_dests,
+                            {},
+                            {.noc_x_start = prev_physical_x,
+                             .noc_y_start = prev_physical_y,
+                             .noc_x_end = next_physical_x,
+                             .noc_y_end = next_physical_y,
+                             .addr = cb_k_start_address},
                             true /* linked: semaphore mcast follows */);
-                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                        noc_async_writes_flushed();
+                        // Companion semaphore mcast: write the local valid_semaphore value into the
+                        // remote receiver_semaphore slot (different L1 offset). Must be issued
+                        // back-to-back after the linked data write — any noc.async_*_barrier()
+                        // between them deadlocks the linked transaction.
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_multicast(
+                                noc,
+                                Semaphore<>(receiver_semaphore_id),
+                                prev_physical_x,
+                                prev_physical_y,
+                                next_physical_x,
+                                next_physical_y,
+                                mcast_num_dests,
+                                /*linked=*/false);
+                        noc.async_writes_flushed();
                         if (!should_receive) {
-                            cb_push_back(cb_k_in, k_chunk_tiles);
+                            cb_k.push_back(k_chunk_tiles);
                         }
                     } else {
-                        uint64_t k_unicast_data_addr =
-                            get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                        noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
+                        noc.async_write(
+                            CoreLocalMem<uint32_t>(cb_k_start_address),
+                            UnicastEndpoint{},
+                            k_chunk_tiles * k_tile_bytes,
+                            {},
+                            {.noc_x = next_physical_x, .noc_y = next_physical_y, .addr = cb_k_start_address});
                     }
                 }
 
                 // Mask read — safe after linked write pair is complete
                 if constexpr (use_provided_mask) {
-                    cb_reserve_back(cb_mask_in, mask_chunk_tiles);
-                    uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
+                    cb_mask.reserve_back(mask_chunk_tiles);
+                    uint32_t mask_write_ptr = cb_mask.get_write_ptr();
                     uint32_t barrier_count = 0;
 
                     uint32_t mask_row_start = mask_batch_offset + q_chunk * Sq_chunk_t * valid_Skt;
@@ -515,14 +530,19 @@ void kernel_main() {
                             const uint32_t global_k_tile = k_chunk * Sk_chunk_t + col;
                             const bool k_valid = !use_padded_mask || (global_k_tile < valid_Skt);
                             if (q_valid && k_valid) {
-                                noc_async_read_page(mask_row_start + global_k_tile, mask_reader, mask_write_ptr);
+                                noc.async_read(
+                                    mask_reader,
+                                    CoreLocalMem<uint32_t>(mask_write_ptr),
+                                    mask_tile_bytes,
+                                    {.page_id = mask_row_start + global_k_tile},
+                                    {});
                             } else {
                                 fill_neginf_tile<mask_tile_bytes>(cb_mask_in, tile_idx);
                             }
                             mask_write_ptr += mask_tile_bytes;
                             tile_idx++;
                             if (++barrier_count == barrier_threshold) {
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
                                 barrier_count = 0;
                             }
                         }
@@ -530,19 +550,20 @@ void kernel_main() {
                             mask_row_start += valid_Skt;
                         }
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_mask_in, mask_chunk_tiles);
+                    noc.async_read_barrier();
+                    cb_mask.push_back(mask_chunk_tiles);
                 }
 
                 // Complete K forward: flush write and signal receiver(s)
                 // (mcast path already completed above — companion sent with linked write)
                 if (should_forward) {
                     if constexpr (!mcast_enabled) {
-                        noc_async_writes_flushed();
+                        noc.async_writes_flushed();
                         if (!should_receive) {
-                            cb_push_back(cb_k_in, k_chunk_tiles);
+                            cb_k.push_back(k_chunk_tiles);
                         }
-                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_unicast(noc, Semaphore<>(receiver_semaphore_id), next_physical_x, next_physical_y);
                     }
                 }
 
@@ -575,12 +596,13 @@ void kernel_main() {
 
                 if (should_receive) {
                     // Receive forwarded V chunk from previous core
-                    cb_reserve_back(cb_v_in, v_chunk_tiles);
-                    cb_v_start_address = get_write_ptr(cb_v_in);
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                    cb_push_back(cb_v_in, v_chunk_tiles);
+                    cb_v.reserve_back(v_chunk_tiles);
+                    cb_v_start_address = cb_v.get_write_ptr();
+                    Semaphore<> receiver_sem(receiver_semaphore_id);
+                    receiver_sem.set(INVALID);
+                    Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                    receiver_sem.wait(VALID);
+                    cb_v.push_back(v_chunk_tiles);
                 } else {
                     // Read V chunk from DRAM
                     if constexpr (is_chunked) {
@@ -603,8 +625,8 @@ void kernel_main() {
                             skip_src_cols);
                     } else {
                         if (should_forward) {
-                            cb_reserve_back(cb_v_in, v_chunk_tiles);
-                            cb_v_start_address = get_write_ptr(cb_v_in);
+                            cb_v.reserve_back(v_chunk_tiles);
+                            cb_v_start_address = cb_v.get_write_ptr();
                             read_chunk_for_forwarding<v_tile_bytes, false>(
                                 v_reader,
                                 cb_v_in,
@@ -634,35 +656,55 @@ void kernel_main() {
                 // Forward V chunk to next core(s) before push_back — prevents compute from
                 // popping the buffer while the mcast is still reading from it.
                 if (should_forward) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                    Semaphore<> sender_sem(sender_semaphore_id);
+                    sender_sem.wait(sender_wait_count);
+                    sender_sem.set(0);
                     if constexpr (mcast_enabled) {
-                        uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
-                        noc_async_write_multicast(
-                            cb_v_start_address,
-                            v_mcast_addr,
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(cb_v_start_address),
+                            MulticastEndpoint{},
                             v_chunk_tiles * v_tile_bytes,
                             mcast_num_dests,
+                            {},
+                            {.noc_x_start = prev_physical_x,
+                             .noc_y_start = prev_physical_y,
+                             .noc_x_end = next_physical_x,
+                             .noc_y_end = next_physical_y,
+                             .addr = cb_v_start_address},
                             true /* linked: semaphore mcast follows */);
-                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                        // Companion semaphore mcast — see K path above for rationale.
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_multicast(
+                                noc,
+                                Semaphore<>(receiver_semaphore_id),
+                                prev_physical_x,
+                                prev_physical_y,
+                                next_physical_x,
+                                next_physical_y,
+                                mcast_num_dests,
+                                /*linked=*/false);
                     } else {
-                        uint64_t v_unicast_data_addr =
-                            get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
-                        noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
+                        noc.async_write(
+                            CoreLocalMem<uint32_t>(cb_v_start_address),
+                            UnicastEndpoint{},
+                            v_chunk_tiles * v_tile_bytes,
+                            {},
+                            {.noc_x = next_physical_x, .noc_y = next_physical_y, .addr = cb_v_start_address});
                     }
-                    noc_async_writes_flushed();
+                    noc.async_writes_flushed();
                     if constexpr (!mcast_enabled) {
-                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                        Semaphore<>(valid_semaphore_id)
+                            .relay_unicast(noc, Semaphore<>(receiver_semaphore_id), next_physical_x, next_physical_y);
                     }
                     if (!should_receive) {
-                        cb_push_back(cb_v_in, v_chunk_tiles);
+                        cb_v.push_back(v_chunk_tiles);
                     }
                 }
             }  // close k_chunk
         }  // close global_q_iter
         if constexpr (is_chunked) {
             if (prev_nb != static_cast<uint32_t>(-1)) {
-                cb_pop_front(cb_id_page_table, 1);
+                cb_page_table.pop_front(1);
             }
         }
     }  // close phase

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "dataflow_common.hpp"
 #include "chunked_prefill_utils.hpp"
 #include "chain_link.hpp"
@@ -127,20 +131,31 @@ struct VSourceGenerators {
 };
 
 template <uint32_t cb_v_in, uint32_t v_cb_entry_tiles, uint32_t Sk_chunk_t, uint32_t vDHt, uint32_t k_tile_bytes>
-inline void materialize_v_prefix_from_k(uint32_t kt_base_addr, uint32_t rows_to_materialize) {
-    cb_reserve_back(cb_v_in, v_cb_entry_tiles);
-    uint32_t v_write_ptr = get_write_ptr(cb_v_in);
-    noc_async_read_one_packet_set_state(get_noc_addr(kt_base_addr), k_tile_bytes);
+inline void materialize_v_prefix_from_k(Noc noc, uint32_t kt_base_addr, uint32_t rows_to_materialize) {
+    CircularBuffer cb_v(cb_v_in);
+    cb_v.reserve_back(v_cb_entry_tiles);
+    uint32_t v_write_ptr = cb_v.get_write_ptr();
+    const uint8_t noc_id = noc.get_noc_id();
+    const uint32_t my_noc_x = my_x[noc_id];
+    const uint32_t my_noc_y = my_y[noc_id];
+    UnicastEndpoint kt_src;
+    noc.set_async_read_state<NocOptions::DEFAULT, k_tile_bytes>(
+        kt_src, k_tile_bytes, {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = kt_base_addr});
     for (uint32_t sk = 0; sk < rows_to_materialize; ++sk) {
         uint32_t kt_read_ptr = kt_base_addr + sk * k_tile_bytes;
         for (uint32_t vd = 0; vd < vDHt; ++vd) {
-            noc_async_read_one_packet_with_state<true>(kt_read_ptr, v_write_ptr);
+            noc.async_read_with_state<NocOptions::DEFAULT, k_tile_bytes>(
+                kt_src,
+                CoreLocalMem<uint32_t>(v_write_ptr),
+                k_tile_bytes,
+                {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = kt_read_ptr},
+                {});
             v_write_ptr += k_tile_bytes;
             kt_read_ptr += Sk_chunk_t * k_tile_bytes;
         }
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_v_in, v_cb_entry_tiles);
+    noc.async_read_barrier();
+    cb_v.push_back(v_cb_entry_tiles);
 }
 
 void kernel_main() {
@@ -240,18 +255,18 @@ void kernel_main() {
         true, /* wait_for_op_signal */
         argidx);
 
-    // Compile-time semaphore ids and chain flags are appended after all TensorAccessorArgs()
-    // Head chain semaphores (head-level chain, always built)
-    uint32_t head_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset));
-    uint32_t head_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 1));
-    uint32_t head_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 2));
+    // Compile-time semaphore ids and chain flags are appended after all TensorAccessorArgs().
+    // ChainLink takes semaphore IDs directly (the new Semaphore<> wrapper resolves them to L1 addrs).
+    uint32_t head_sender_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset);
+    uint32_t head_receiver_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 1);
+    uint32_t head_valid_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 2);
     constexpr bool head_mcast_enabled = get_compile_time_arg_val(post_tensor_args_offset + 3) == 1;
 
-    // Batch chain semaphores (only present when k_uses_batch_chain / NHK == 1)
-    // Initialize to 0; will be overwritten if k_uses_batch_chain
-    uint32_t batch_sender_semaphore_addr = 0;
-    uint32_t batch_receiver_semaphore_addr = 0;
-    uint32_t batch_valid_semaphore_addr = 0;
+    // Batch chain semaphores (only present when k_uses_batch_chain / NHK == 1).
+    // Initialize to 0; will be overwritten if k_uses_batch_chain. Non-participants never use them.
+    uint32_t batch_sender_semaphore_id = 0;
+    uint32_t batch_receiver_semaphore_id = 0;
+    uint32_t batch_valid_semaphore_id = 0;
 
     // batch_mcast_enabled: read from compile-time args if present, else false (for template instantiation)
     constexpr bool batch_mcast_enabled = []() {
@@ -262,9 +277,9 @@ void kernel_main() {
     }();
 
     if constexpr (k_uses_batch_chain) {
-        batch_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 4));
-        batch_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 5));
-        batch_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 6));
+        batch_sender_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 4);
+        batch_receiver_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 5);
+        batch_valid_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + 6);
     }
 
     constexpr uint32_t head_chain_arg_count = 4;
@@ -282,14 +297,16 @@ void kernel_main() {
     constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
     constexpr uint32_t v_cb_entry_tiles = v_shares_k_buffer ? k_chunk_tiles : v_chunk_tiles;
 
+    Noc noc;
+
     // Head chain (head-level): matches (batch, head), used by V and optionally K
     ChainLink<head_mcast_enabled, true> head_chain(
         head_cfg.participates,
         head_cfg.is_injector,
         head_cfg.is_sink,
-        head_sender_semaphore_addr,
-        head_receiver_semaphore_addr,
-        head_valid_semaphore_addr,
+        head_sender_semaphore_id,
+        head_receiver_semaphore_id,
+        head_valid_semaphore_id,
         head_cfg.signal_target_x<head_mcast_enabled>(),
         head_cfg.signal_target_y<head_mcast_enabled>(),
         head_cfg.next_physical_x,
@@ -311,9 +328,9 @@ void kernel_main() {
         batch_cfg.participates,
         batch_cfg.is_injector,
         batch_cfg.is_sink,
-        batch_sender_semaphore_addr,
-        batch_receiver_semaphore_addr,
-        batch_valid_semaphore_addr,
+        batch_sender_semaphore_id,
+        batch_receiver_semaphore_id,
+        batch_valid_semaphore_id,
         batch_cfg.signal_target_x<batch_mcast_enabled>(),
         batch_cfg.signal_target_y<batch_mcast_enabled>(),
         batch_cfg.next_physical_x,
@@ -526,23 +543,30 @@ void kernel_main() {
                 }
 
                 // K: either read locally (injector or not participant) or receive from chain
+                CircularBuffer cb_k(cb_k_in);
                 if constexpr (k_uses_batch_chain && batch_mcast_enabled) {
                     // Ensures that compute has completed with the previous K chunk before we overwrite the buffer with
                     // the next K chunk for mcast.
                     const uint32_t reserve_tiles = is_padded_iter ? 2 * k_chunk_tiles : k_chunk_tiles;
-                    cb_reserve_back(cb_k_in, reserve_tiles);
+                    cb_k.reserve_back(reserve_tiles);
                 } else {
-                    cb_reserve_back(cb_k_in, k_chunk_tiles);
+                    cb_k.reserve_back(k_chunk_tiles);
                 }
-                uint32_t cb_k_start_address = get_write_ptr(cb_k_in);
+                uint32_t cb_k_start_address = cb_k.get_write_ptr();
                 if (k_chain.should_receive(nb, nq)) {
-                    k_chain.receive();
+                    k_chain.receive(noc);
                 } else {
                     // Injector or non-participant: read K from DRAM. Dispatch directly so
                     // local and gathered tensors may use different accessor types.
                     const auto fetch_k = [&](const auto& k_gen) {
                         fetch_block(
-                            k_gen, k_slice, end_seq_tile, cb_k_in, cb_k_start_address, k_tile_bytes, true /*transpose*/);
+                            k_gen,
+                            k_slice,
+                            end_seq_tile,
+                            cb_k_in,
+                            cb_k_start_address,
+                            k_tile_bytes,
+                            true /*transpose*/);
                     };
                     fetch_k_from_source<has_joint_k, joint_tensor_args_offset>(
                         kv_chunk_is_joint,
@@ -556,12 +580,12 @@ void kernel_main() {
 
                 // Forward K chunk via chain (uses K's data size explicitly)
                 if (k_chain.should_forward(nb, nq, q_iter_local)) {
-                    k_chain.forward(cb_k_start_address, k_chunk_tiles, k_tile_bytes);
+                    k_chain.forward(noc, cb_k_start_address, k_chunk_tiles, k_tile_bytes);
                 }
 
                 // Skip Q and compute-visible pushes for padded K-mcast iterations.
-                // Note: cb_push_back is intentionally skipped — without it, the write pointer
-                // doesn't advance, so cb_reserve_back returns the same address each iteration.
+                // Note: push_back is intentionally skipped — without it, the write pointer
+                // doesn't advance, so reserve_back returns the same address each iteration.
                 // This lets the buffer act as a reusable staging area for the mcast.
                 if (is_padded_iter) {
                     // Padded iterations participate in the chain handshake but do not generate
@@ -570,7 +594,7 @@ void kernel_main() {
                 }
 
                 // Make K available to compute.
-                cb_push_back(cb_k_in, k_chunk_tiles);
+                cb_k.push_back(k_chunk_tiles);
                 KV_chunks_processed_in_iter++;
 
                 // Download Q on the first K iteration — after K is downloaded and forwarded.
@@ -637,24 +661,32 @@ void kernel_main() {
                     if (skip_v_materialization) {
                         // Preserve the logical V FIFO entry for phase alignment. No fill is needed
                         // because compute skips the fully masked K chunk.
-                        cb_reserve_back(cb_v_in, v_cb_entry_tiles);
-                        cb_push_back(cb_v_in, v_cb_entry_tiles);
+                        CircularBuffer cb_v_skip(cb_v_in);
+                        cb_v_skip.reserve_back(v_cb_entry_tiles);
+                        cb_v_skip.push_back(v_cb_entry_tiles);
                     } else {
                         materialize_v_prefix_from_k<cb_v_in, v_cb_entry_tiles, Sk_chunk_t, vDHt, k_tile_bytes>(
-                            cb_k_start_address, v_rows_to_materialize);
+                            noc, cb_k_start_address, v_rows_to_materialize);
                     }
                 } else if constexpr (!v_shares_k_buffer) {
                     // V: either read locally (injector or not participant) or receive from chain.
                     const uint32_t nv = nq / q_heads_per_v;
                     const Slice v_slice(k_slice.d0, nv, k_slice.d2_start, k_slice.d2_end, 0, vDHt);
-                    cb_reserve_back(cb_v_in, v_cb_entry_tiles);
-                    uint32_t cb_v_start_address = get_write_ptr(cb_v_in);
+                    CircularBuffer cb_v(cb_v_in);
+                    cb_v.reserve_back(v_cb_entry_tiles);
+                    uint32_t cb_v_start_address = cb_v.get_write_ptr();
                     if (v_chain.should_receive(nb, nv)) {
-                        v_chain.receive();
+                        v_chain.receive(noc);
                     } else {
                         const auto fetch_v = [&](const auto& v_gen) {
                             fetch_block(
-                                v_gen, v_slice, end_seq_tile, cb_v_in, cb_v_start_address, v_tile_bytes, false /*transpose*/);
+                                v_gen,
+                                v_slice,
+                                end_seq_tile,
+                                cb_v_in,
+                                cb_v_start_address,
+                                v_tile_bytes,
+                                false /*transpose*/);
                         };
                         fetch_v_from_source<has_joint_k, joint_tensor_args_offset>(
                             kv_chunk_is_joint,
@@ -669,11 +701,11 @@ void kernel_main() {
                     // Forward V to next core(s) before push_back — prevents compute from
                     // popping the buffer while the mcast is still reading from it.
                     if (v_chain.should_forward(nb, nv, q_iter_local)) {
-                        v_chain.forward(cb_v_start_address);
+                        v_chain.forward(noc, cb_v_start_address);
                     }
 
                     // Make V available to compute.
-                    cb_push_back(cb_v_in, v_cb_entry_tiles);
+                    cb_v.push_back(v_cb_entry_tiles);
                 }
             }
         }
@@ -681,11 +713,13 @@ void kernel_main() {
              dummy_chunk <
              dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(KV_chunks_processed_in_iter);
              ++dummy_chunk) {
-            cb_reserve_back(cb_k_in, k_chunk_tiles);
-            cb_push_back(cb_k_in, k_chunk_tiles);
+            CircularBuffer cb_k_dummy(cb_k_in);
+            cb_k_dummy.reserve_back(k_chunk_tiles);
+            cb_k_dummy.push_back(k_chunk_tiles);
             if constexpr (!kt_inplace_v) {
-                cb_reserve_back(cb_v_in, v_cb_entry_tiles);
-                cb_push_back(cb_v_in, v_cb_entry_tiles);
+                CircularBuffer cb_v_dummy(cb_v_in);
+                cb_v_dummy.reserve_back(v_cb_entry_tiles);
+                cb_v_dummy.push_back(v_cb_entry_tiles);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -5,6 +5,8 @@
 #include <type_traits>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
@@ -30,6 +32,7 @@
 // @param stats_tile_bytes    Stats tile size in bytes
 template <typename CatAddrGeneratorType, typename TensorAccessorType, typename StatsShapeType>
 void read_prev_output_and_lse(
+    Noc noc,
     const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
     const StatsShapeType& stats_tile_logical,
@@ -48,18 +51,25 @@ void read_prev_output_and_lse(
     read_block(cat_out_generator, out_slice, end_seq_tile, cb_prev_out, tile_bytes, false);
 
     // Read previous LSE for this Q chunk
-    cb_reserve_back(cb_lse_in, Sq_chunk_t);
-    uint32_t lse_addr = get_write_ptr(cb_lse_in);
+    CircularBuffer cb_lse(cb_lse_in);
+    cb_lse.reserve_back(Sq_chunk_t);
+    uint32_t lse_addr = cb_lse.get_write_ptr();
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_read_page(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
+        noc.async_read(
+            stats_writer,
+            CoreLocalMem<uint32_t>(lse_addr),
+            stats_tile_bytes,
+            {.page_id = stats_tile_logical.id_of(nb, nq, i, 0)},
+            {});
         lse_addr += stats_tile_bytes;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_lse_in, Sq_chunk_t);
+    noc.async_read_barrier();
+    cb_lse.push_back(Sq_chunk_t);
 }
 
 template <typename TensorAccessorType, typename StatsShapeType>
 static __attribute__((noinline, noclone)) void issue_stats_column_reads(
+    Noc noc,
     const TensorAccessorType& stats_writer,
     const StatsShapeType& stats_tile_logical,
     const uint32_t nb,
@@ -69,12 +79,13 @@ static __attribute__((noinline, noclone)) void issue_stats_column_reads(
     const uint32_t cb_id,
     const uint32_t reserve_tiles,
     const uint32_t stats_tile_bytes) {
-    cb_reserve_back(cb_id, reserve_tiles);
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(reserve_tiles);
     uint32_t tile_id = stats_tile_logical.id_of(nb, nq, row_start, 0);
     const uint32_t row_stride = stats_tile_logical.stride2();
-    uint32_t addr = get_write_ptr(cb_id);
+    uint32_t addr = cb.get_write_ptr();
     for (uint32_t r = 0; r < num_rows; ++r) {
-        noc_async_read_page(tile_id, stats_writer, addr);
+        noc.async_read(stats_writer, CoreLocalMem<uint32_t>(addr), stats_tile_bytes, {.page_id = tile_id}, {});
         tile_id += row_stride;
         addr += stats_tile_bytes;
     }
@@ -82,6 +93,7 @@ static __attribute__((noinline, noclone)) void issue_stats_column_reads(
 
 template <typename TensorAccessorType, typename StatsShapeType>
 static __attribute__((noinline, noclone)) void issue_stats_column_writes(
+    Noc noc,
     const TensorAccessorType& stats_writer,
     const StatsShapeType& stats_tile_logical,
     const uint32_t nb,
@@ -89,12 +101,15 @@ static __attribute__((noinline, noclone)) void issue_stats_column_writes(
     const uint32_t row_start,
     const uint32_t num_rows,
     const uint32_t cb_id,
-    const uint32_t stats_tile_bytes) {
+    const uint32_t stats_tile_bytes,
+    const uint32_t trid = 0) {
+    CircularBuffer cb(cb_id);
     uint32_t tile_id = stats_tile_logical.id_of(nb, nq, row_start, 0);
     const uint32_t row_stride = stats_tile_logical.stride2();
-    uint32_t addr = get_read_ptr(cb_id);
+    uint32_t addr = cb.get_read_ptr();
     for (uint32_t r = 0; r < num_rows; ++r) {
-        noc_async_write_page(tile_id, stats_writer, addr);
+        noc.async_write<NocOptions::TXN_ID>(
+            CoreLocalMem<uint32_t>(addr), stats_writer, stats_tile_bytes, {}, {.page_id = tile_id}, {.trid = trid});
         tile_id += row_stride;
         addr += stats_tile_bytes;
     }
@@ -106,6 +121,7 @@ static __attribute__((noinline, noclone)) void issue_stats_column_writes(
 // while Q[q]'s K-loop runs, hiding DRAM read latency behind compute.
 template <typename CatAddrGeneratorType, typename TensorAccessorType, typename StatsShapeType>
 void issue_restore_reads(
+    Noc noc,
     const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
     const StatsShapeType& stats_tile_logical,
@@ -127,7 +143,8 @@ void issue_restore_reads(
     const uint32_t out_rows = out_slice.get_d2_size();
     const uint32_t out_cols = out_slice.get_d3_size();
     const uint32_t out_num_tiles = out_rows * out_cols;
-    cb_reserve_back(cb_prev_out, out_num_tiles);
+    CircularBuffer cb_prev(cb_prev_out);
+    cb_prev.reserve_back(out_num_tiles);
     uint32_t out_barrier_count = 0;
     issue_block_reads(
         cat_out_generator.reader,
@@ -136,7 +153,7 @@ void issue_restore_reads(
         out_rows,
         out_cols,
         /*dst_row_origin=*/0,
-        get_write_ptr(cb_prev_out),
+        cb_prev.get_write_ptr(),
         /*outer_stride=*/out_cols * tile_bytes,
         /*inner_stride=*/tile_bytes,
         /*barrier_threshold=*/0,
@@ -147,6 +164,7 @@ void issue_restore_reads(
     const uint32_t stats_rows = stats_seq_end_tile - stats_seq_start_tile;
 
     issue_stats_column_reads(
+        noc,
         stats_writer,
         stats_tile_logical,
         nb,
@@ -157,6 +175,7 @@ void issue_restore_reads(
         Sq_chunk_t,
         stats_tile_bytes);
     issue_stats_column_reads(
+        noc,
         stats_writer,
         stats_tile_logical,
         nb,
@@ -171,15 +190,16 @@ void issue_restore_reads(
 
 // Complete a previously issued restore — single barrier for all 3 CBs, then push.
 void complete_restore(
+    Noc noc,
     const uint32_t cb_prev_out,
     const uint32_t out_num_tiles,
     const uint32_t cb_max_in,
     const uint32_t cb_sum_in,
     const uint32_t Sq_chunk_t) {
-    noc_async_read_barrier();
-    cb_push_back(cb_prev_out, out_num_tiles);
-    cb_push_back(cb_max_in, Sq_chunk_t);
-    cb_push_back(cb_sum_in, Sq_chunk_t);
+    noc.async_read_barrier();
+    CircularBuffer(cb_prev_out).push_back(out_num_tiles);
+    CircularBuffer(cb_max_in).push_back(Sq_chunk_t);
+    CircularBuffer(cb_sum_in).push_back(Sq_chunk_t);
 }
 
 // Three transaction IDs for fine-grained write barrier tracking.
@@ -201,6 +221,7 @@ template <
     typename TensorAccessorType,
     typename StatsShapeType>
 void save_accumulators_with_trid(
+    Noc noc,
     const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
     const StatsShapeType& stats_tile_logical,
@@ -219,19 +240,34 @@ void save_accumulators_with_trid(
     const uint32_t stats_tile_bytes,
     const uint32_t sbh,
     const uint32_t save_trid) {
-    noc_async_write_set_trid(save_trid);
+    // Each write is tagged per-call with save_trid (no sticky-set state needed). The matching
+    // noc.async_write_barrier<NocOptions::TXN_ID>({.trid=save_trid}) downstream waits exactly
+    // for these writes — no risk of trid leaking to unrelated writes since the tag is local
+    // to each call.
 
     write_block_row_grouped_trid<all_output_rows_valid>(
-        cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes, sbh, save_trid);
+        noc, cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes, sbh, save_trid);
 
     // Bulk drain of max/sum
-    cb_wait_front(cb_max_out, Sq_chunk_t);
-    cb_wait_front(cb_sum_out, Sq_chunk_t);
+    CircularBuffer cb_max(cb_max_out);
+    CircularBuffer cb_sum(cb_sum_out);
+    cb_max.wait_front(Sq_chunk_t);
+    cb_sum.wait_front(Sq_chunk_t);
 
     const uint32_t stats_rows = stats_seq_end_tile - stats_seq_start_tile;
     issue_stats_column_writes(
-        stats_writer, stats_tile_logical, nb, nq, stats_seq_start_tile, stats_rows, cb_max_out, stats_tile_bytes);
+        noc,
+        stats_writer,
+        stats_tile_logical,
+        nb,
+        nq,
+        stats_seq_start_tile,
+        stats_rows,
+        cb_max_out,
+        stats_tile_bytes,
+        save_trid);
     issue_stats_column_writes(
+        noc,
         stats_writer,
         stats_tile_logical,
         nb,
@@ -239,16 +275,13 @@ void save_accumulators_with_trid(
         sum_offset + stats_seq_start_tile,
         stats_rows,
         cb_sum_out,
-        stats_tile_bytes);
+        stats_tile_bytes,
+        save_trid);
 
-    noc_async_write_flushed_with_trid(save_trid);
-    // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_block_row_grouped_trid on last ring iter).
-    // Without this, subsequent noc_async_write calls would inflate save_trid's outstanding count,
-    // causing noc_async_write_barrier_with_trid(save_trid) to wait for unrelated writes.
+    noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = save_trid});
     // cb_out was already popped per-group inside write_block_row_grouped_trid.
-    noc_async_write_set_trid(0);
-    cb_pop_front(cb_max_out, Sq_chunk_t);
-    cb_pop_front(cb_sum_out, Sq_chunk_t);
+    cb_max.pop_front(Sq_chunk_t);
+    cb_sum.pop_front(Sq_chunk_t);
 }
 
 // Eager-path writer: writes normalized output and LSE to DRAM every ring iteration.
@@ -271,6 +304,7 @@ void save_accumulators_with_trid(
 // @param stats_tile_bytes    Stats tile size in bytes
 template <typename CatAddrGeneratorType, typename TensorAccessorType, typename StatsShapeType>
 void write_output_and_lse(
+    Noc noc,
     const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
     const StatsShapeType& stats_tile_logical,
@@ -285,16 +319,22 @@ void write_output_and_lse(
     const uint32_t cb_lse_out,
     const uint32_t tile_bytes,
     const uint32_t stats_tile_bytes) {
-    write_block(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes);
+    write_block(noc, cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes);
 
-    cb_wait_front(cb_lse_out, Sq_chunk_t);
-    uint32_t lse_addr = get_read_ptr(cb_lse_out);
+    CircularBuffer cb_lse(cb_lse_out);
+    cb_lse.wait_front(Sq_chunk_t);
+    uint32_t lse_addr = cb_lse.get_read_ptr();
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_write_page(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
+        noc.async_write(
+            CoreLocalMem<uint32_t>(lse_addr),
+            stats_writer,
+            stats_tile_bytes,
+            {},
+            {.page_id = stats_tile_logical.id_of(nb, nq, i, 0)});
         lse_addr += stats_tile_bytes;
     }
-    noc_async_writes_flushed();
-    cb_pop_front(cb_lse_out, Sq_chunk_t);
+    noc.async_writes_flushed();
+    cb_lse.pop_front(Sq_chunk_t);
 }
 
 struct QChunkInfo {
@@ -436,6 +476,8 @@ void kernel_main() {
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     constexpr uint32_t stats_tile_bytes = get_tile_size(cb_max_in);
 
+    Noc noc;
+
     const auto out_writer = TensorAccessor(out_args, out_addr);
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr);
     const auto stats_writer = TensorAccessor(stats_args, stats_addr);
@@ -470,7 +512,7 @@ void kernel_main() {
     constexpr bool needs_lightweight_mask =
         (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
     if constexpr (needs_lightweight_mask) {
-        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in, diag_tile_enabled>();
+        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in, diag_tile_enabled>(noc);
     }
 
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
@@ -576,7 +618,7 @@ void kernel_main() {
             // barriers on pf_trid first to ensure the prior save with that TRID has landed.
             auto prefetch_for = [&](uint32_t pf_q_index, uint32_t pf_trid, bool barrier_first) {
                 if (barrier_first) {
-                    noc_async_write_barrier_with_trid(pf_trid);
+                    noc.async_write_barrier<NocOptions::TXN_ID>({.trid = pf_trid});
                 }
                 const uint32_t gq = remap_q_index(global_q_start + pf_q_index, num_q_chunks, use_zigzag_balancing);
                 const uint32_t nb_pf = gq / (NH * num_q_chunks);
@@ -593,6 +635,7 @@ void kernel_main() {
                     return out_generator;
                 }();
                 issue_restore_reads(
+                    noc,
                     gen_pf,
                     stats_writer,
                     stats_tile_logical,
@@ -637,6 +680,7 @@ void kernel_main() {
                     return out_generator;
                 }();
                 save_accumulators_with_trid<output_has_no_padding>(
+                    noc,
                     gen,
                     stats_writer,
                     stats_tile_logical,
@@ -677,9 +721,9 @@ void kernel_main() {
                 // First active iter has no prior save (matches compute's is_first_kv_for_this_q).
                 if (!single_q_chunk && !is_first_active_iter) {
                     if (balanced_skip_q && !is_last_ring_iter) {
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
                     } else {
-                        complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
+                        complete_restore(noc, cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
                     }
                 }
 
@@ -730,8 +774,9 @@ void kernel_main() {
                 // Wait for compute to signal last K-chunk start (multi-Q only).
                 // Normalize-only path also pushes this signal.
                 if (!single_q_chunk) {
-                    cb_wait_front(cb_signal, 1);
-                    cb_pop_front(cb_signal, 1);
+                    CircularBuffer cb_sig(cb_signal);
+                    cb_sig.wait_front(1);
+                    cb_sig.pop_front(1);
                 }
 
                 if (is_last_ring_iter) {
@@ -746,7 +791,7 @@ void kernel_main() {
                         return out_generator;
                     }();
                     write_block_row_grouped_trid<output_has_no_padding>(
-                        gen, qi.out_slice, end_seq_tile, cb_out, tile_bytes, out_subblock_h, /*flush_trid=*/0);
+                        noc, gen, qi.out_slice, end_seq_tile, cb_out, tile_bytes, out_subblock_h, /*flush_trid=*/0);
                 } else if (!single_q_chunk) {
                     deferred.pending = true;
                     deferred.trid = trid_for_q(q_index);
@@ -767,7 +812,7 @@ void kernel_main() {
             // Q loop for all of them to land in DRAM, before the outer ring-iter loop advances
             // or the op teardown runs. Previously this was a per-Q barrier inside the loop.
             if (is_last_ring_iter) {
-                noc_async_write_barrier();
+                noc.async_write_barrier();
             }
         } else {
             for (uint32_t q_iter = 0; q_iter + global_q_start < global_q_end; ++q_iter) {
@@ -803,6 +848,7 @@ void kernel_main() {
                 // No race condition because writer kernel writes previous output before reading it again
                 if (ring_iter > 0) {
                     read_prev_output_and_lse(
+                        noc,
                         gen,
                         stats_writer,
                         stats_tile_logical,
@@ -820,6 +866,7 @@ void kernel_main() {
                 }
 
                 write_output_and_lse(
+                    noc,
                     gen,
                     stats_writer,
                     stats_tile_logical,
@@ -835,7 +882,7 @@ void kernel_main() {
                     tile_bytes,
                     stats_tile_bytes);
             }
-            noc_async_write_barrier();  // Ensure writes of output and LSE complete before next iteration
+            noc.async_write_barrier();  // Ensure writes of output and LSE complete before next iteration
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -3,11 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NQH = get_compile_time_arg_val(1);
     constexpr uint32_t NKH = get_compile_time_arg_val(2);
@@ -90,15 +94,16 @@ void kernel_main() {
             /*joint_l*/ 0u,
             cb_mask_in,
             is_causal,
-            sliding_window_size>();
+            sliding_window_size>(noc);
     }
 
     if constexpr (is_chunked) {
         if (use_chunk_start_idx_tensor != 0) {
-            cb_wait_front(cb_chunk_start_idx, 1);
-            auto chunk_start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_chunk_start_idx));
+            CircularBuffer cb_chunk_start(cb_chunk_start_idx);
+            cb_chunk_start.wait_front(1);
+            auto chunk_start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_chunk_start.get_read_ptr());
             uint32_t chunk_start_idx = chunk_start_ptr[0];
-            cb_pop_front(cb_chunk_start_idx, 1);
+            cb_chunk_start.pop_front(1);
             const uint32_t q_chunk_size = Sq_chunk_t * tt::constants::TILE_HEIGHT;
             chunk_start_t_in_q_chunks_phase_1 = chunk_start_idx / q_chunk_size;
             if (num_phases == 2) {
@@ -129,7 +134,16 @@ void kernel_main() {
                 !use_provided_mask && !use_lightweight_mask &&
                 (is_causal || sliding_window_size > 0 || use_padded_mask)) {
                 generate_mask<is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
-                    Sq_chunk_t, Sk_chunk_t, q_chunk, chunk_start_t_in_q_chunks, true, false, unpadded_Sk, 0, is_causal);
+                    noc,
+                    Sq_chunk_t,
+                    Sk_chunk_t,
+                    q_chunk,
+                    chunk_start_t_in_q_chunks,
+                    true,
+                    false,
+                    unpadded_Sk,
+                    0,
+                    is_causal);
             }
 
             // Determine how many rows of OUT will be written. Both start and end rows are
@@ -143,6 +157,7 @@ void kernel_main() {
                 // Compute always pushes Sq_chunk_t rows; rows past out_row_tile_count
                 // are padding and get popped without being written.
                 write_block_row_grouped(
+                    noc,
                     out_writer,
                     cb_out,
                     Sq_chunk_t,
@@ -154,6 +169,7 @@ void kernel_main() {
                     barrier_threshold);
             } else {
                 write_block(
+                    noc,
                     out_writer,
                     cb_out,
                     out_chunk_tiles,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -6,6 +6,12 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include <vector>
 #include "../../../../sdpa/device/kernels/dataflow/dataflow_common.hpp"
 /******************************************************************************
@@ -19,8 +25,9 @@
  ******************************************************************************/
 template <uint32_t tile_bytes>
 void fill_tile(uint32_t cb_id, uint32_t tile_id, uint32_t val) {
+    Noc noc;
     if (val == 0) {
-        Noc noc;
+        // Arch-agnostic zeroing (#45450): async_write_zeros works on WH/BH/Quasar.
         CircularBuffer cb(cb_id);
         noc.async_write_zeros(cb, tile_bytes, {.offset_bytes = tile_id * tile_bytes});
         noc.write_zeros_l1_barrier();
@@ -92,7 +99,8 @@ void fill_tile_partial(uint32_t cb_id, uint32_t tile_id, uint32_t cur_pos_in_til
 }
 
 template <uint32_t tile_bytes>
-void fill_tile_partial_sliding_window(uint32_t cb_id, uint32_t tile_id, uint32_t window_start_pos_in_tile, uint32_t partial_val) {
+void fill_tile_partial_sliding_window(
+    uint32_t cb_id, uint32_t tile_id, uint32_t window_start_pos_in_tile, uint32_t partial_val) {
     /*
     For sliding window mask: fill positions 0 to window_start_pos_in_tile - 1 with partial_val (-inf)
     This is the inverse of fill_tile_partial which fills from cur_pos_in_tile + 1 to end
@@ -171,25 +179,28 @@ uint32_t read_mask_chunk(
     uint32_t mask_chunk_tiles,
     uint32_t mask_start_tile_id,
     const MaskReaderType& mask_reader) {
+    Noc noc;
     // Read mask chunk
-    cb_reserve_back(cb_mask_in, mask_chunk_tiles);
-    uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
+    CircularBuffer cb_mask(cb_mask_in);
+    cb_mask.reserve_back(mask_chunk_tiles);
+    uint32_t mask_write_ptr = cb_mask.get_write_ptr();
     uint32_t barrier_count = 0;
     for (uint32_t row = 0; row < PNHt; ++row) {
         uint32_t mask_tile_id = mask_start_tile_id + row * PSt;
         for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
-            noc_async_read_page(mask_tile_id, mask_reader, mask_write_ptr);
+            noc.async_read(
+                mask_reader, CoreLocalMem<uint32_t>(mask_write_ptr), mask_tile_bytes, {.page_id = mask_tile_id}, {});
             mask_tile_id++;
             mask_write_ptr += mask_tile_bytes;
 
             if (++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
                 barrier_count = 0;
             }
         }
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_mask_in, mask_chunk_tiles);
+    noc.async_read_barrier();
+    cb_mask.push_back(mask_chunk_tiles);
     // Advance by Sk_chunk_t (column stride), NOT mask_chunk_tiles (PNHt * Sk_chunk_t).
     // The mask tensor has shape (PNHt, St) with row stride PSt. Each chunk advances
     // Sk_chunk_t columns. Using mask_chunk_tiles would over-advance when PNHt > 1.
@@ -199,6 +210,7 @@ uint32_t read_mask_chunk(
 
 template <uint32_t cb_mask_in, uint32_t PNHt>
 void generate_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, uint32_t cur_pos) {
+    Noc noc;
     /*
     example 1: 64 seqlen at cur_pos 40, 2 cores, 32 chunk size
     k_num_chunks = 2
@@ -240,10 +252,10 @@ void generate_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, uint32_t cur_pos)
     uint32_t cur_pos_in_tile = cur_pos_in_chunk % 32;
     constexpr uint32_t NEG_INF = 0xFF80FF80;  // TODO: Make sure this is -inf
 
-    cb_reserve_back(cb_mask_in, total_read_tiles);
+    CircularBuffer cb_mask(cb_mask_in);
+    cb_mask.reserve_back(total_read_tiles);
 
-    uint64_t noc_read_addr_base = get_noc_addr(get_read_ptr(cb_mask_in));
-    uint32_t q_write_ptr_base = get_read_ptr(cb_mask_in);
+    uint32_t q_write_ptr_base = cb_mask.get_read_ptr();
     constexpr uint32_t tile_bytes = get_tile_size(cb_mask_in);
 
     for (uint32_t i = 0; i < Sk_chunk_t; ++i) {
@@ -253,9 +265,9 @@ void generate_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, uint32_t cur_pos)
                 fill_tile<tile_bytes>(cb_mask_in, i, 0);
             } else {
                 copy_tile<tile_bytes>(
-                    noc_read_addr_base, q_write_ptr_base, 0, i);  // copy from cb_mask_in[0] to cb_mask_in[i]
+                    noc, q_write_ptr_base, q_write_ptr_base, 0, i);  // copy from cb_mask_in[0] to cb_mask_in[i]
                 if (i == cur_pos_in_chunk_t - 1) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                 }
             }
         } else if (i == cur_pos_in_chunk_t) {
@@ -267,29 +279,31 @@ void generate_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, uint32_t cur_pos)
                 fill_tile<tile_bytes>(cb_mask_in, i, NEG_INF);
             } else {
                 copy_tile<tile_bytes>(
-                    noc_read_addr_base,
+                    noc,
+                    q_write_ptr_base,
                     q_write_ptr_base,
                     cur_pos_in_chunk_t + 1,
                     i);  // copy from cb_mask_in[cur_pos_in_chunk_t+1] to cb_mask_in[i]
                 if (i == Sk_chunk_t - 1) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                 }
             }
         }
         for (uint32_t j = 1; j < PNHt; ++j) {
             // copy from cb_mask_in[i] to cb_mask_in[j*Sk_chunk_t + i]
-            copy_tile<tile_bytes>(noc_read_addr_base, q_write_ptr_base, i, j * Sk_chunk_t + i);
+            copy_tile<tile_bytes>(noc, q_write_ptr_base, q_write_ptr_base, i, j * Sk_chunk_t + i);
             if (j == PNHt - 1) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
             }
         }
     }
 
-    cb_push_back(cb_mask_in, total_read_tiles);
+    cb_mask.push_back(total_read_tiles);
 }
 
 template <uint32_t cb_mask_in, uint32_t PNHt>
 void generate_sliding_window_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, uint32_t window_start) {
+    Noc noc;
     /*
     Generate sliding window mask for the first chunk:
     - Mask positions < window_start with -inf (sliding window start)
@@ -305,10 +319,10 @@ void generate_sliding_window_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, ui
     uint32_t window_start_in_tile = window_start_in_chunk % 32;
     constexpr uint32_t NEG_INF = 0xFF80FF80;  // TODO: Make sure this is -inf
 
-    cb_reserve_back(cb_mask_in, total_read_tiles);
+    CircularBuffer cb_mask(cb_mask_in);
+    cb_mask.reserve_back(total_read_tiles);
 
-    uint64_t noc_read_addr_base = get_noc_addr(get_read_ptr(cb_mask_in));
-    uint32_t q_write_ptr_base = get_read_ptr(cb_mask_in);
+    uint32_t q_write_ptr_base = cb_mask.get_read_ptr();
     constexpr uint32_t tile_bytes = get_tile_size(cb_mask_in);
 
     for (uint32_t i = 0; i < Sk_chunk_t; ++i) {
@@ -317,7 +331,7 @@ void generate_sliding_window_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, ui
             if (i == 0) {
                 fill_tile<tile_bytes>(cb_mask_in, i, NEG_INF);
             } else {
-                copy_tile<tile_bytes>(noc_read_addr_base, q_write_ptr_base, 0, i);
+                copy_tile<tile_bytes>(noc, q_write_ptr_base, q_write_ptr_base, 0, i);
             }
         } else if (i == window_start_in_chunk_t) {
             // Tile contains sliding window start - partial mask at beginning
@@ -329,26 +343,27 @@ void generate_sliding_window_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, ui
             } else {
                 // Copy from the first allowed tile
                 copy_tile<tile_bytes>(
-                    noc_read_addr_base,
+                    noc,
+                    q_write_ptr_base,
                     q_write_ptr_base,
                     window_start_in_chunk_t + 1,
                     i);  // copy from cb_mask_in[cur_pos_in_chunk_t+1] to cb_mask_in[i]
                 if (i == Sk_chunk_t - 1) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                 }
             }
         }
 
         // Copy to all heads
         for (uint32_t j = 1; j < PNHt; ++j) {
-            copy_tile<tile_bytes>(noc_read_addr_base, q_write_ptr_base, i, j * Sk_chunk_t + i);
+            copy_tile<tile_bytes>(noc, q_write_ptr_base, q_write_ptr_base, i, j * Sk_chunk_t + i);
             if (j == PNHt - 1) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
             }
         }
     }
 
-    cb_push_back(cb_mask_in, total_read_tiles);
+    cb_mask.push_back(total_read_tiles);
 }
 
 /*
@@ -359,28 +374,29 @@ void generate_sliding_window_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, ui
  */
 template <uint32_t cb_block_pad_mask, uint32_t PNHt>
 void generate_block_padding_mask(uint32_t Sk_chunk_t, uint32_t block_size) {
+    Noc noc;
     uint32_t total_tiles = PNHt * Sk_chunk_t;
     constexpr uint32_t tile_bytes = get_tile_size(cb_block_pad_mask);
     constexpr uint32_t NEG_INF = 0xFF80FF80;
 
-    cb_reserve_back(cb_block_pad_mask, total_tiles);
+    CircularBuffer cb_pad(cb_block_pad_mask);
+    cb_pad.reserve_back(total_tiles);
 
     for (uint32_t i = 0; i < Sk_chunk_t; ++i) {
         // fill_tile_partial: columns [0, block_size-1] = 0, columns [block_size, 31] = -inf
         fill_tile_partial<tile_bytes>(cb_block_pad_mask, i, block_size - 1, NEG_INF);
 
         // Copy to all heads
-        uint64_t noc_read_addr_base = get_noc_addr(get_read_ptr(cb_block_pad_mask));
-        uint32_t write_ptr_base = get_read_ptr(cb_block_pad_mask);
+        uint32_t write_ptr_base = cb_pad.get_read_ptr();
         for (uint32_t j = 1; j < PNHt; ++j) {
-            copy_tile<tile_bytes>(noc_read_addr_base, write_ptr_base, i, j * Sk_chunk_t + i);
+            copy_tile<tile_bytes>(noc, write_ptr_base, write_ptr_base, i, j * Sk_chunk_t + i);
             if (j == PNHt - 1) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
             }
         }
     }
 
-    cb_push_back(cb_block_pad_mask, total_tiles);
+    cb_pad.push_back(total_tiles);
 }
 
 /******************************************************************************
@@ -388,14 +404,16 @@ void generate_block_padding_mask(uint32_t Sk_chunk_t, uint32_t block_size) {
  ******************************************************************************/
 template <uint32_t cb_out, uint32_t out_chunk_tiles, uint32_t barrier_threshold, typename WriterType>
 uint32_t write_tiles_to_memory(uint32_t& out_tile_id, const WriterType& out_writer, uint32_t& barrier_count) {
+    Noc noc;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
-    uint32_t l1_read_addr = get_read_ptr(cb_out);
+    CircularBuffer cb(cb_out);
+    uint32_t l1_read_addr = cb.get_read_ptr();
     for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
-        noc_async_write_page(out_tile_id, out_writer, l1_read_addr);
+        noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), out_writer, tile_bytes, {}, {.page_id = out_tile_id});
         ++out_tile_id;
         l1_read_addr += tile_bytes;
         if (++barrier_count == barrier_threshold) {
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             barrier_count = 0;
         }
     }
@@ -410,6 +428,7 @@ uint32_t write_partial_tiles_to_memory(
     uint32_t cur_head,            // kv-head group index 0..num_kv_heads-1
     uint32_t num_heads_to_write,  // q-heads per kv-head group, e.g. 8
     uint32_t out_chunk_tiles) {   // total tiles = PNHt * vDHt
+    Noc noc;
     constexpr uint32_t FACE_HW = 16;
     constexpr uint32_t TILE_HW = 32;
     constexpr uint32_t FACE_ELEMENT_CNT = FACE_HW * FACE_HW;
@@ -417,7 +436,8 @@ uint32_t write_partial_tiles_to_memory(
     constexpr uint32_t FACE_LINE_BYTES = FACE_HW * ELEMENT_SIZE;
     const uint32_t num_hidden_tiles = out_chunk_tiles / PNHt;
 
-    uint32_t l1_base_addr = get_read_ptr(cb_out);
+    CircularBuffer cb(cb_out);
+    uint32_t l1_base_addr = cb.get_read_ptr();
 
     for (uint32_t hidden_tile = 0; hidden_tile < num_hidden_tiles; ++hidden_tile) {
         for (uint32_t head = 0; head < num_heads_to_write; ++head) {
@@ -434,21 +454,22 @@ uint32_t write_partial_tiles_to_memory(
             // L1: cb_out tile layout matches tile_index
             uint32_t l1_read_addr_head = l1_base_addr + tile_index * tile_bytes + in_tile_offset;
 
-            // DRAM tile: global index = out_tile_id + tile_index
-            uint64_t out_writer_tile_addr = out_writer.get_noc_addr(out_tile_id + tile_index);
-            uint64_t out_writer_noc_addr_head = out_writer_tile_addr + in_tile_offset;
-
-            // Write first phase
-            noc_async_write(l1_read_addr_head, out_writer_noc_addr_head, FACE_LINE_BYTES);
-
-            // Write second phase
-            noc_async_write(
-                l1_read_addr_head + FACE_ELEMENT_CNT * ELEMENT_SIZE,
-                out_writer_noc_addr_head + FACE_ELEMENT_CNT * ELEMENT_SIZE,
-                FACE_LINE_BYTES);
+            const uint32_t dram_tile_id = out_tile_id + tile_index;
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_read_addr_head),
+                out_writer,
+                FACE_LINE_BYTES,
+                {},
+                {.page_id = dram_tile_id, .offset_bytes = in_tile_offset});
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_read_addr_head + FACE_ELEMENT_CNT * ELEMENT_SIZE),
+                out_writer,
+                FACE_LINE_BYTES,
+                {},
+                {.page_id = dram_tile_id, .offset_bytes = in_tile_offset + FACE_ELEMENT_CNT * ELEMENT_SIZE});
 
             if (++barrier_count == barrier_threshold) {
-                noc_async_writes_flushed();
+                noc.async_writes_flushed();
                 barrier_count = 0;
             }
         }
@@ -482,48 +503,64 @@ void read_q(
     const QArgsType& q_args,
     uint32_t q_page_size_bytes,
     uint32_t q_batch_offset) {
+    Noc noc;
+    CircularBuffer cb_q(cb_q_in);
+    CircularBuffer cb_q_rm_buf(cb_q_rm);
     // If Q is locally available (pre-sharded to all cores), just reserve and push
     if (q_locally_available) {
         if constexpr (tilize_q) {
-            cb_reserve_back(cb_q_rm, q_chunk_tiles);
-            cb_push_back(cb_q_rm, q_chunk_tiles);
+            cb_q_rm_buf.reserve_back(q_chunk_tiles);
+            cb_q_rm_buf.push_back(q_chunk_tiles);
         } else {
-            cb_reserve_back(cb_q_in, q_chunk_tiles);
-            cb_push_back(cb_q_in, q_chunk_tiles);
+            cb_q.reserve_back(q_chunk_tiles);
+            cb_q.push_back(q_chunk_tiles);
         }
         return;
     }
 
     if constexpr (is_q_sharded) {
         // Q is sharded - read from output core's L1
-        uint64_t q_read_addr =
-            is_output_core ? get_noc_addr(q_addr) : get_noc_addr(output_core_noc_x, output_core_noc_y, q_addr);
+        const uint8_t noc_id = noc.get_noc_id();
+        const uint32_t src_noc_x = is_output_core ? my_x[noc_id] : output_core_noc_x;
+        const uint32_t src_noc_y = is_output_core ? my_y[noc_id] : output_core_noc_y;
+        uint32_t q_src_addr = q_addr;
 
         uint32_t q_write_ptr;
         if constexpr (tilize_q) {
-            cb_reserve_back(cb_q_rm, q_chunk_tiles);
-            q_write_ptr = get_write_ptr(cb_q_rm);
+            cb_q_rm_buf.reserve_back(q_chunk_tiles);
+            q_write_ptr = cb_q_rm_buf.get_write_ptr();
         } else {
-            cb_reserve_back(cb_q_in, q_chunk_tiles);
-            q_write_ptr = get_write_ptr(cb_q_in);
+            cb_q.reserve_back(q_chunk_tiles);
+            q_write_ptr = cb_q.get_write_ptr();
         }
 
+        UnicastEndpoint q_src;
         if constexpr (use_half_tile && !tilize_q) {
             // Q is stored as 32x32 tiles but we want 16x32 half tiles
             for (uint32_t tile = 0; tile < q_chunk_tiles; tile++) {
-                noc_async_read(q_read_addr, q_write_ptr, q_tile_bytes);
-                q_read_addr += 2 * q_tile_bytes;  // Skip bottom half of each tile
+                noc.async_read(
+                    q_src,
+                    CoreLocalMem<uint32_t>(q_write_ptr),
+                    q_tile_bytes,
+                    {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = q_src_addr},
+                    {});
+                q_src_addr += 2 * q_tile_bytes;  // Skip bottom half of each tile
                 q_write_ptr += q_tile_bytes;
             }
         } else {
-            noc_async_read(q_read_addr, q_write_ptr, q_chunk_size_bytes);
+            noc.async_read(
+                q_src,
+                CoreLocalMem<uint32_t>(q_write_ptr),
+                q_chunk_size_bytes,
+                {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = q_src_addr},
+                {});
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         if constexpr (tilize_q) {
-            cb_push_back(cb_q_rm, q_chunk_tiles);
+            cb_q_rm_buf.push_back(q_chunk_tiles);
         } else {
-            cb_push_back(cb_q_in, q_chunk_tiles);
+            cb_q.push_back(q_chunk_tiles);
         }
     } else {
         // Q is not sharded - read tiles from DRAM
@@ -532,35 +569,33 @@ void read_q(
         const auto q_reader = TensorAccessor(q_args, q_addr, q_page_size_bytes);
         uint32_t q_tile_id = q_batch_offset;
 
-        cb_reserve_back(cb_q_in, q_chunk_tiles);
-        uint32_t q_write_ptr = get_write_ptr(cb_q_in);
+        cb_q.reserve_back(q_chunk_tiles);
+        uint32_t q_write_ptr = cb_q.get_write_ptr();
         uint32_t barrier_count = 0;
 
         for (uint32_t tile = 0; tile < q_chunk_tiles; ++tile) {
-            uint64_t q_read_addr = q_reader.get_noc_addr(q_tile_id);
-            noc_async_read(q_read_addr, q_write_ptr, q_tile_bytes);
+            noc.async_read(q_reader, CoreLocalMem<uint32_t>(q_write_ptr), q_tile_bytes, {.page_id = q_tile_id}, {});
             q_tile_id += 1;
             q_write_ptr += q_tile_bytes;
 
             if (++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
                 barrier_count = 0;
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_q_in, q_chunk_tiles);
+        noc.async_read_barrier();
+        cb_q.push_back(q_chunk_tiles);
     }
 }
 
 // Multicast parameters for K streaming (vertical multicast along y, same x)
 struct KMcastParams {
-    bool do_mcast;                               // true = sender, false = receiver
-    uint32_t mcast_x;                            // x coordinate for multicast (fixed for vertical)
-    uint32_t mcast_y0;                           // y start for multicast range
-    uint32_t mcast_y1;                           // y end for multicast range
-    uint32_t num_dests;                          // number of multicast destinations
-    uint32_t mcast_sem_addr;                     // semaphore address for synchronization
-    volatile tt_l1_ptr uint32_t* mcast_sem_ptr;  // semaphore pointer
+    bool do_mcast;          // true = sender, false = receiver
+    uint32_t mcast_x;       // x coordinate for multicast (fixed for vertical)
+    uint32_t mcast_y0;      // y start for multicast range
+    uint32_t mcast_y1;      // y end for multicast range
+    uint32_t num_dests;     // number of multicast destinations
+    uint32_t mcast_sem_id;  // semaphore ID for synchronization (Semaphore<> takes this)
 };
 
 template <
@@ -574,7 +609,7 @@ template <
     bool use_mcast,
     uint32_t capacity_t,
     typename KReaderType>
-uint64_t read_k(
+uint32_t read_k(
     uint32_t k_chunk_tiles,
     uint32_t cur_head,
     uint32_t Sk_chunk_t_dynamic,
@@ -584,9 +619,11 @@ uint64_t read_k(
     volatile tt_l1_ptr uint32_t* page_table_ptr_u32,
     uint32_t& barrier_count,
     const KMcastParams& mcast_params = {}) {
-    cb_reserve_back(cb_k_in, k_chunk_tiles);
-    uint32_t k_write_ptr = get_write_ptr(cb_k_in);
-    uint64_t k_base_read_ptr = get_noc_addr(k_write_ptr);
+    Noc noc;
+    CircularBuffer cb_k(cb_k_in);
+    cb_k.reserve_back(k_chunk_tiles);
+    uint32_t k_write_ptr = cb_k.get_write_ptr();
+    uint32_t k_base_read_ptr = k_write_ptr;
     barrier_count = 0;
 
     if constexpr (use_mcast) {
@@ -608,49 +645,56 @@ uint64_t read_k(
                                                   DHt,
                                                   capacity_t>(virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
                 for (uint32_t col = 0; col < DHt; ++col) {
-                    noc_async_read_page(physical_k_tile_id, k_reader, k_write_ptr_col);
+                    noc.async_read(
+                        k_reader,
+                        CoreLocalMem<uint32_t>(k_write_ptr_col),
+                        k_tile_bytes,
+                        {.page_id = physical_k_tile_id},
+                        {});
                     physical_k_tile_id += 1;
                     k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;
                     if (++barrier_count == barrier_threshold) {
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
                         barrier_count = 0;
                     }
                 }
             }
-            noc_async_read_barrier();
+            noc.async_read_barrier();
             // Multicast the full K^T chunk to all receiver cores at once
-            uint64_t dst_mcast_addr = get_noc_multicast_addr(
-                mcast_params.mcast_x,   // x (same column)
-                mcast_params.mcast_y0,  // y_start
-                mcast_params.mcast_x,   // x (same column)
-                mcast_params.mcast_y1,  // y_end
-                k_write_ptr);
-            noc_async_write_multicast(
-                k_write_ptr,
-                dst_mcast_addr,
+            noc.async_write_multicast(
+                CoreLocalMem<uint32_t>(k_write_ptr),
+                MulticastEndpoint{},
                 k_chunk_tiles * k_tile_bytes,
                 mcast_params.num_dests,
-                /*linked=*/false);
+                {},
+                {.noc_x_start = mcast_params.mcast_x,
+                 .noc_y_start = mcast_params.mcast_y0,
+                 .noc_x_end = mcast_params.mcast_x,
+                 .noc_y_end = mcast_params.mcast_y1,
+                 .addr = k_write_ptr},
+                false);
             // Ensure data multicast is complete before signaling
-            noc_async_write_barrier();
+            noc.async_write_barrier();
             // Signal all receivers that the full K^T chunk is ready
             constexpr uint32_t VALID = 1;
-            noc_semaphore_set(mcast_params.mcast_sem_ptr, VALID);
-            uint64_t sem_mcast_addr = get_noc_multicast_addr(
+            Semaphore<> mcast_sem(mcast_params.mcast_sem_id);
+            mcast_sem.set(VALID);
+            mcast_sem.set_multicast(
+                noc,
                 mcast_params.mcast_x,
                 mcast_params.mcast_y0,
                 mcast_params.mcast_x,
                 mcast_params.mcast_y1,
-                mcast_params.mcast_sem_addr);
-            noc_semaphore_set_multicast(mcast_params.mcast_sem_addr, sem_mcast_addr, mcast_params.num_dests, false);
-            cb_push_back(cb_k_in, k_chunk_tiles);
-            noc_async_write_barrier();
+                mcast_params.num_dests);
+            cb_k.push_back(k_chunk_tiles);
+            noc.async_write_barrier();
         } else {
             // Wait for single signal that the full K^T chunk is ready
-            noc_semaphore_wait(mcast_params.mcast_sem_ptr, 1);
-            noc_semaphore_set(mcast_params.mcast_sem_ptr, 0);
-            noc_async_atomic_barrier();
-            cb_push_back(cb_k_in, k_chunk_tiles);
+            Semaphore<> mcast_sem(mcast_params.mcast_sem_id);
+            mcast_sem.wait(1);
+            mcast_sem.set(0);
+            noc.async_atomic_barrier();
+            cb_k.push_back(k_chunk_tiles);
         }
     } else {
         // Non-multicast path: original transposed read
@@ -664,18 +708,23 @@ uint64_t read_k(
                     : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt, capacity_t>(
                           virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < DHt; ++col) {
-                noc_async_read_page(physical_k_tile_id, k_reader, k_write_ptr_col);
+                noc.async_read(
+                    k_reader,
+                    CoreLocalMem<uint32_t>(k_write_ptr_col),
+                    k_tile_bytes,
+                    {.page_id = physical_k_tile_id},
+                    {});
                 physical_k_tile_id += 1;                               // Go to next tile in row
                 k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;  // Go to next column in CB
 
                 if (++barrier_count == barrier_threshold) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                     barrier_count = 0;
                 }
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_k_in, k_chunk_tiles);
+        noc.async_read_barrier();
+        cb_k.push_back(k_chunk_tiles);
     }
     return k_base_read_ptr;
 }
@@ -700,22 +749,33 @@ void read_v(
     volatile tt_l1_ptr uint16_t* page_table_ptr_u16,
     volatile tt_l1_ptr uint32_t* page_table_ptr_u32,
     uint32_t& barrier_count,
-    uint64_t k_base_read_ptr = 0,
+    uint32_t k_base_read_ptr = 0,
     uint32_t k_tile_bytes = 0) {
-    cb_reserve_back(cb_v_in, v_chunk_tiles);
-    uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+    Noc noc;
+    CircularBuffer cb_v(cb_v_in);
+    cb_v.reserve_back(v_chunk_tiles);
+    uint32_t v_write_ptr = cb_v.get_write_ptr();
     if constexpr (reuse_k) {
-        // Read V chunk (transpose of K), from K's L1 buffer
-        uint64_t k_read_ptr = k_base_read_ptr;
+        // Read V chunk (transpose of K), from K's L1 buffer (same core)
+        const uint8_t noc_id = noc.get_noc_id();
+        const uint32_t my_noc_x = my_x[noc_id];
+        const uint32_t my_noc_y = my_y[noc_id];
+        UnicastEndpoint v_src;
+        uint32_t k_read_ptr = k_base_read_ptr;
         for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {  // Row of V
             k_read_ptr = k_base_read_ptr + row * k_tile_bytes;     // Increment across K's Col
             for (uint32_t col = 0; col < vDHt; ++col) {            // Col of V
-                noc_async_read(k_read_ptr, v_write_ptr, v_tile_bytes);
+                noc.async_read(
+                    v_src,
+                    CoreLocalMem<uint32_t>(v_write_ptr),
+                    v_tile_bytes,
+                    {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = k_read_ptr},
+                    {});
                 v_write_ptr += v_tile_bytes;
                 k_read_ptr += Sk_chunk_t_dynamic * k_tile_bytes;  // Stride across K's width
             }
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
     } else {
         // Read V chunk in row major order, write in row-major order
         // V is an independent tensor with its own layout (width = vDHt, not DHt)
@@ -730,20 +790,21 @@ void read_v(
                     : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, vDHt, capacity_t>(
                           virtual_v_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < vDHt; ++col) {
-                noc_async_read_page(physical_v_tile_id, v_reader, v_write_ptr);
+                noc.async_read(
+                    v_reader, CoreLocalMem<uint32_t>(v_write_ptr), v_tile_bytes, {.page_id = physical_v_tile_id}, {});
                 physical_v_tile_id += 1;
                 v_write_ptr += v_tile_bytes;
 
                 if (++barrier_count == barrier_threshold) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                     barrier_count = 0;
                 }
             }
             // No padding to skip - V is an independent tensor with contiguous layout
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
     }
-    cb_push_back(cb_v_in, v_chunk_tiles);
+    cb_v.push_back(v_chunk_tiles);
 }
 
 template <
@@ -776,27 +837,34 @@ void read_kv_mask_chunks(
     uint32_t k_tile_bytes,
     uint32_t v_tile_bytes,
     uint32_t PSt) {
+    Noc noc;
+    CircularBuffer cb_k(cb_k_in);
+    CircularBuffer cb_v(cb_v_in);
+    const uint8_t noc_id = noc.get_noc_id();
+    const uint32_t my_noc_x = my_x[noc_id];
+    const uint32_t my_noc_y = my_y[noc_id];
+
     uint32_t barrier_count = 0;
     for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
         // Read K chunk transposed
-        cb_reserve_back(cb_k_in, k_chunk_tiles);
-        uint32_t k_write_ptr = get_write_ptr(cb_k_in);
-        uint64_t k_base_read_ptr = get_noc_addr(k_write_ptr);
+        cb_k.reserve_back(k_chunk_tiles);
+        uint32_t k_write_ptr = cb_k.get_write_ptr();
+        uint32_t k_base_read_ptr = k_write_ptr;
         barrier_count = 0;
         for (uint32_t col = 0; col < DHt; ++col) {
             uint32_t k_tile_id = k_start_tile_id + col;
             for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
-                noc_async_read_page(k_tile_id, k_reader, k_write_ptr);
+                noc.async_read(k_reader, CoreLocalMem<uint32_t>(k_write_ptr), k_tile_bytes, {.page_id = k_tile_id}, {});
                 if (++barrier_count == barrier_threshold) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                     barrier_count = 0;
                 }
                 k_tile_id += DHt;
                 k_write_ptr += k_tile_bytes;
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_k_in, k_chunk_tiles);
+        noc.async_read_barrier();
+        cb_k.push_back(k_chunk_tiles);
 
         if constexpr (use_attention_mask) {
             mask_start_tile_id = read_mask_chunk<cb_mask_in, mask_tile_bytes, barrier_threshold, PNHt>(
@@ -805,14 +873,20 @@ void read_kv_mask_chunks(
 
         // Read V chunk (transpose of K), from K's L1 buffer
         if constexpr (reuse_k) {
-            cb_reserve_back(cb_v_in, v_chunk_tiles);
-            uint32_t v_write_ptr = get_write_ptr(cb_v_in);
-            uint64_t k_read_ptr = k_base_read_ptr;
+            cb_v.reserve_back(v_chunk_tiles);
+            uint32_t v_write_ptr = cb_v.get_write_ptr();
+            UnicastEndpoint v_src;
+            uint32_t k_read_ptr = k_base_read_ptr;
             for (uint32_t row = 0; row < Sk_chunk_t; ++row) {       // Row of V
                 k_read_ptr = k_base_read_ptr + row * k_tile_bytes;  // Increment across K's Col
 
                 for (uint32_t col = 0; col < vDHt; ++col) {  // Col of V
-                    noc_async_read(k_read_ptr, v_write_ptr, v_tile_bytes);
+                    noc.async_read(
+                        v_src,
+                        CoreLocalMem<uint32_t>(v_write_ptr),
+                        v_tile_bytes,
+                        {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = k_read_ptr},
+                        {});
 
                     v_write_ptr += v_tile_bytes;
                     k_read_ptr += Sk_chunk_t * k_tile_bytes;  // Strid across K's width
@@ -820,15 +894,16 @@ void read_kv_mask_chunks(
             }
         } else {
             // V is an independent tensor with its own layout (width = vDHt)
-            cb_reserve_back(cb_v_in, v_chunk_tiles);
-            uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+            cb_v.reserve_back(v_chunk_tiles);
+            uint32_t v_write_ptr = cb_v.get_write_ptr();
             barrier_count = 0;
             uint32_t v_tile_id = v_start_tile_id;
             for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
                 for (uint32_t col = 0; col < vDHt; ++col) {
-                    noc_async_read_page(v_tile_id, v_reader, v_write_ptr);
+                    noc.async_read(
+                        v_reader, CoreLocalMem<uint32_t>(v_write_ptr), v_tile_bytes, {.page_id = v_tile_id}, {});
                     if (++barrier_count == barrier_threshold) {
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
                         barrier_count = 0;
                     }
                     v_tile_id++;
@@ -837,8 +912,8 @@ void read_kv_mask_chunks(
                 // No padding to skip - V is an independent tensor with contiguous layout
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_v_in, v_chunk_tiles);
+        noc.async_read_barrier();
+        cb_v.push_back(v_chunk_tiles);
 
         // Update the starting tile id for next iteration
         k_start_tile_id += k_chunk_tiles;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -4,12 +4,17 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include <vector>
 
 #include "ttnn/operations/transformer/sdpa_decode/device/kernels/rt_args_common.hpp"
 #include "dataflow_common.hpp"
 
 void kernel_main() {
+    Noc noc;
+
     /*
     In DRAM, Q is (B, PNHt, DHt), K is (B, St, DHt), V is (B, St, DHt), mask is (B, PNHt, PSt)
     We want to read for a particular batch cur_batch, and sequence length up to padded layer length.
@@ -117,20 +122,31 @@ void kernel_main() {
             // Reader fills cb_writer_cur_pos (c_8) first (from DRAM, or via the
             // aliased sharded buffer) then copies the same stick into
             // cb_compute_cur_pos (c_15) via an L1->L1 read.
-            cb_reserve_back(cb_writer_cur_pos, 1);
-            uint32_t index_cb_wr_ptr = get_write_ptr(cb_writer_cur_pos);
+            CircularBuffer cb_writer(cb_writer_cur_pos);
+            cb_writer.reserve_back(1);
+            uint32_t index_cb_wr_ptr = cb_writer.get_write_ptr();
             if constexpr (!is_cur_pos_tensor_sharded) {
                 const auto addrg = TensorAccessor(pos_args, pos_addr);
-                uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
-                noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-                noc_async_read_barrier();
+                // index_tensor has one page to read
+                noc.async_read(addrg, CoreLocalMem<uint32_t>(index_cb_wr_ptr), index_stick_size_B, {.page_id = 0}, {});
+                noc.async_read_barrier();
             }
-            cb_reserve_back(cb_compute_cur_pos, 1);
-            uint32_t index_cb_compute_wr_ptr = get_write_ptr(cb_compute_cur_pos);
-            noc_async_read(get_noc_addr(index_cb_wr_ptr), index_cb_compute_wr_ptr, index_stick_size_B);
-            noc_async_read_barrier();
-            cb_push_back(cb_writer_cur_pos, 1);
-            cb_push_back(cb_compute_cur_pos, 1);
+            CircularBuffer cb_compute(cb_compute_cur_pos);
+            cb_compute.reserve_back(1);
+            uint32_t index_cb_compute_wr_ptr = cb_compute.get_write_ptr();
+            const uint8_t noc_id = noc.get_noc_id();
+            const uint32_t my_noc_x = my_x[noc_id];
+            const uint32_t my_noc_y = my_y[noc_id];
+            UnicastEndpoint pos_src;
+            noc.async_read(
+                pos_src,
+                CoreLocalMem<uint32_t>(index_cb_compute_wr_ptr),
+                index_stick_size_B,
+                {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = index_cb_wr_ptr},
+                {});
+            noc.async_read_barrier();
+            cb_writer.push_back(1);
+            cb_compute.push_back(1);
             volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
             cur_pos = index_ptr[cur_batch / q_heads_parallel_factor];
         }
@@ -189,8 +205,6 @@ void kernel_main() {
     // Read Q entirely - always read into cb_q_in
     // When tilize_q is true, compute will tilize back to cb_q_in
     // When tilize_q is false, Q is already tilized
-    uint32_t k_mcast_sem_addr = get_semaphore(k_mcast_semaphore_id);
-    volatile tt_l1_ptr uint32_t* k_mcast_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(k_mcast_sem_addr);
     const uint32_t q_batch_offset = cur_batch * q_chunk_tiles;
 
     // Read Q
@@ -215,19 +229,24 @@ void kernel_main() {
     if constexpr (use_attention_sink) {
         const auto attention_sink_reader = TensorAccessor(attention_sink_args, attention_sink_addr);
 
-        cb_reserve_back(cb_attention_sink, PNHt);
-        uint32_t attention_sink_write_ptr = get_write_ptr(cb_attention_sink);
+        CircularBuffer cb_sink(cb_attention_sink);
+        cb_sink.reserve_back(PNHt);
+        uint32_t attention_sink_write_ptr = cb_sink.get_write_ptr();
 
         for (uint32_t tile = 0; tile < PNHt; ++tile) {
-            uint64_t sink_noc_addr = attention_sink_reader.get_noc_addr(tile);
-            // Use noc_async_read with explicit size instead of noc_async_read_page because
+            // Use noc.async_read with explicit size instead of noc.async_read_page because
             // the CB may use half tiles (16x32) while the DRAM buffer stores full tiles (32x32).
-            // noc_async_read_page would read buffer->aligned_page_size() bytes, overflowing the CB.
-            noc_async_read(sink_noc_addr, attention_sink_write_ptr, attention_sink_tile_bytes);
+            // noc.async_read_page would read buffer->aligned_page_size() bytes, overflowing the CB.
+            noc.async_read(
+                attention_sink_reader,
+                CoreLocalMem<uint32_t>(attention_sink_write_ptr),
+                attention_sink_tile_bytes,
+                {.page_id = tile},
+                {});
             attention_sink_write_ptr += attention_sink_tile_bytes;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_attention_sink, PNHt);
+        noc.async_read_barrier();
+        cb_sink.push_back(PNHt);
     }
 
     // Read page table
@@ -236,11 +255,13 @@ void kernel_main() {
     volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
     volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
     if constexpr (is_paged_attention) {
+        CircularBuffer cb_page_table(cb_id_page_table);
         uint32_t num_pages_to_read = is_page_table_sharded ? B : 1;
-        cb_reserve_back(cb_id_page_table, num_pages_to_read);
+        cb_page_table.reserve_back(num_pages_to_read);
         // Read page table from DRAM
         if constexpr (!is_page_table_sharded) {
             page_table_ptr = read_page_table_for_batch(
+                noc,
                 cb_id_page_table,
                 cur_batch / q_heads_parallel_factor,
                 page_table_args,
@@ -249,10 +270,10 @@ void kernel_main() {
             page_table_ptr_u32 = page_table_ptr;
         } else {  // Read page table from dynamically allocated L1 buffer
             page_table_cb_wr_ptr =
-                get_write_ptr(cb_id_page_table) + (cur_batch / q_heads_parallel_factor) * page_table_page_size;
+                cb_page_table.get_write_ptr() + (cur_batch / q_heads_parallel_factor) * page_table_page_size;
             page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_wr_ptr);
         }
-        cb_push_back(cb_id_page_table, num_pages_to_read);
+        cb_page_table.push_back(num_pages_to_read);
     }
 
     for (uint32_t cur_head = cur_head_group * num_heads_per_core;
@@ -268,8 +289,7 @@ void kernel_main() {
             .mcast_y0 = mcast_y0,
             .mcast_y1 = mcast_y1,
             .num_dests = num_dests,
-            .mcast_sem_addr = k_mcast_sem_addr,
-            .mcast_sem_ptr = k_mcast_sem_ptr};
+            .mcast_sem_id = k_mcast_semaphore_id};
 
         if constexpr (is_paged_attention) {
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -13,6 +15,8 @@
 #define MAX_TREE_REDUCTION_ROUNDS 6
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t B = get_compile_time_arg_val(0);     // batch size
     constexpr uint32_t PNHt = get_compile_time_arg_val(1);  // padded number of heads in tiles
     constexpr uint32_t St = get_compile_time_arg_val(2);    // full sequence length of kv cache in tiles
@@ -24,7 +28,8 @@ void kernel_main() {
     constexpr uint32_t scale_val = get_compile_time_arg_val(8);
     constexpr uint32_t num_cores_per_batch = get_compile_time_arg_val(9);           // num cores per batch
     constexpr uint32_t num_cores = get_compile_time_arg_val(10);                    // num running cores in total
-    uint32_t reducer_semaphore_addr = get_semaphore(get_compile_time_arg_val(11));  // semaphore for reducer
+    constexpr uint32_t reducer_semaphore_id = get_compile_time_arg_val(11);         // semaphore ID for reducer
+    uint32_t reducer_semaphore_addr = get_semaphore(reducer_semaphore_id);          // semaphore for reducer
     uint32_t output_semaphore_addr = get_semaphore(get_compile_time_arg_val(12));   // semaphore for sender
     constexpr bool is_out_sharded = get_compile_time_arg_val(13);
     constexpr uint32_t k_chunk_size = get_compile_time_arg_val(14);
@@ -118,11 +123,12 @@ void kernel_main() {
         if (cur_pos_arg != UINT32_MAX) {
             cur_pos = cur_pos_arg;
         } else {
-            cb_wait_front(cb_cur_pos, 1);
-            uint32_t index_cb_ptr = get_read_ptr(cb_cur_pos);
+            CircularBuffer cb_index(cb_cur_pos);
+            cb_index.wait_front(1);
+            uint32_t index_cb_ptr = cb_index.get_read_ptr();
             volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
             cur_pos = index_ptr[(uint32_t)(cur_batch / q_heads_parallel_factor)];
-            cb_pop_front(cb_cur_pos, 1);
+            cb_index.pop_front(1);
         }
 
         if (cur_pos == UINT32_MAX) {
@@ -249,7 +255,7 @@ void kernel_main() {
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_cores>();
     uint32_t barrier_count = 0;
 
-    noc_async_write_barrier();  // #19201 BH hang workaround
+    noc.async_write_barrier();  // #19201 BH hang workaround
 
     for (uint32_t cur_head = cur_head_group * num_heads_per_core;
          cur_head < cur_head_group * num_heads_per_core + num_heads_per_core;
@@ -284,29 +290,52 @@ void kernel_main() {
 
                     // Calculate offset based on round (child writes at round offset)
                     uint32_t block_offset = round * (out_chunk_tiles + 2 * PNHt) * tile_bytes_intermed;
-                    uint64_t intermed_l1_read_addr = get_noc_addr(get_read_ptr(cb_intermed_out)) + block_offset;
+                    CircularBuffer cb_intermed(cb_intermed_out);
+                    const uint8_t noc_id = noc.get_noc_id();
+                    const uint32_t my_noc_x = my_x[noc_id];
+                    const uint32_t my_noc_y = my_y[noc_id];
+                    uint32_t intermed_l1_read_addr = cb_intermed.get_read_ptr() + block_offset;
+                    UnicastEndpoint intermed_src;
 
                     // Reserve space in CBs and read data
                     // Order: l, m, o (same as sender writes)
-                    cb_reserve_back(cb_l_in, PNHt);
-                    uint32_t l_write_ptr = get_write_ptr(cb_l_in);
-                    noc_async_read(intermed_l1_read_addr, l_write_ptr, ml_read_size);
+                    CircularBuffer cb_l(cb_l_in);
+                    cb_l.reserve_back(PNHt);
+                    uint32_t l_write_ptr = cb_l.get_write_ptr();
+                    noc.async_read(
+                        intermed_src,
+                        CoreLocalMem<uint32_t>(l_write_ptr),
+                        ml_read_size,
+                        {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = intermed_l1_read_addr},
+                        {});
                     intermed_l1_read_addr += ml_read_size;
-                    noc_async_read_barrier();
-                    cb_push_back(cb_l_in, PNHt);
+                    noc.async_read_barrier();
+                    cb_l.push_back(PNHt);
 
-                    cb_reserve_back(cb_m_in, PNHt);
-                    uint32_t m_write_ptr = get_write_ptr(cb_m_in);
-                    noc_async_read(intermed_l1_read_addr, m_write_ptr, ml_read_size);
+                    CircularBuffer cb_m(cb_m_in);
+                    cb_m.reserve_back(PNHt);
+                    uint32_t m_write_ptr = cb_m.get_write_ptr();
+                    noc.async_read(
+                        intermed_src,
+                        CoreLocalMem<uint32_t>(m_write_ptr),
+                        ml_read_size,
+                        {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = intermed_l1_read_addr},
+                        {});
                     intermed_l1_read_addr += ml_read_size;
-                    noc_async_read_barrier();
-                    cb_push_back(cb_m_in, PNHt);
+                    noc.async_read_barrier();
+                    cb_m.push_back(PNHt);
 
-                    cb_reserve_back(cb_out_o, out_chunk_tiles);
-                    uint32_t o_write_ptr = get_write_ptr(cb_out_o);
-                    noc_async_read(intermed_l1_read_addr, o_write_ptr, o_read_size);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_out_o, out_chunk_tiles);
+                    CircularBuffer cb_o(cb_out_o);
+                    cb_o.reserve_back(out_chunk_tiles);
+                    uint32_t o_write_ptr = cb_o.get_write_ptr();
+                    noc.async_read(
+                        intermed_src,
+                        CoreLocalMem<uint32_t>(o_write_ptr),
+                        o_read_size,
+                        {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = intermed_l1_read_addr},
+                        {});
+                    noc.async_read_barrier();
+                    cb_o.push_back(out_chunk_tiles);
                 }
             }
         }
@@ -315,9 +344,13 @@ void kernel_main() {
         // We have data (checked at function start), so send it
         if (!is_tree_root && should_send_to_parent) {
             // Wait for compute to finish writing to cb_out_worker, cb_out_m, cb_out_l
-            cb_wait_front(cb_out_worker, out_chunk_tiles);
-            cb_wait_front(cb_out_m, PNHt);
-            cb_wait_front(cb_out_l, PNHt);
+            CircularBuffer cb_out_w(cb_out_worker);
+            CircularBuffer cb_out_m_buf(cb_out_m);
+            CircularBuffer cb_out_l_buf(cb_out_l);
+            CircularBuffer cb_intermed(cb_intermed_out);
+            cb_out_w.wait_front(out_chunk_tiles);
+            cb_out_m_buf.wait_front(PNHt);
+            cb_out_l_buf.wait_front(PNHt);
 
             constexpr uint32_t tile_bytes = get_tile_size(cb_out_worker);
             uint32_t block_offset = send_at_round * (out_chunk_tiles + 2 * PNHt) * tile_bytes;
@@ -327,24 +360,40 @@ void kernel_main() {
             // Get parent's NOC address
             uint32_t parent_noc_x = reduction_group_core_xs[parent_core_in_group];
             uint32_t parent_noc_y = reduction_group_core_ys[parent_core_in_group];
-            uint64_t output_write_addr =
-                get_noc_addr(parent_noc_x, parent_noc_y, get_write_ptr(cb_intermed_out)) + block_offset;
+            uint32_t output_write_addr = cb_intermed.get_write_ptr() + block_offset;
+            UnicastEndpoint output_dst;
 
             // Send l, m, o to parent (same order as original worker_compute)
-            noc_async_write(get_read_ptr(cb_out_l), output_write_addr, ml_write_size);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(cb_out_l_buf.get_read_ptr()),
+                output_dst,
+                ml_write_size,
+                {},
+                {.noc_x = parent_noc_x, .noc_y = parent_noc_y, .addr = output_write_addr});
             output_write_addr += ml_write_size;
-            noc_async_write(get_read_ptr(cb_out_m), output_write_addr, ml_write_size);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(cb_out_m_buf.get_read_ptr()),
+                output_dst,
+                ml_write_size,
+                {},
+                {.noc_x = parent_noc_x, .noc_y = parent_noc_y, .addr = output_write_addr});
             output_write_addr += ml_write_size;
-            noc_async_write(get_read_ptr(cb_out_worker), output_write_addr, o_write_size);
-            noc_async_write_barrier();
-            uint64_t parent_semaphore_noc_addr = get_noc_addr(parent_noc_x, parent_noc_y, reducer_semaphore_addr);
-            noc_semaphore_inc(parent_semaphore_noc_addr, step_semaphore_inc[send_at_round]);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(cb_out_w.get_read_ptr()),
+                output_dst,
+                o_write_size,
+                {},
+                {.noc_x = parent_noc_x, .noc_y = parent_noc_y, .addr = output_write_addr});
+            noc.async_write_barrier();
+            // Reducer semaphore lives at the same L1 offset on every core, so Semaphore<>::up()
+            // (which encodes the dst NoC addr from local_l1_addr_) is the correct fit here.
+            Semaphore<>(reducer_semaphore_id).up(noc, parent_noc_x, parent_noc_y, step_semaphore_inc[send_at_round]);
 
             // pop front
-            cb_pop_front(cb_out_worker, out_chunk_tiles);
-            cb_pop_front(cb_out_m, PNHt);
-            cb_pop_front(cb_out_l, PNHt);
-            noc_async_atomic_barrier();
+            cb_out_w.pop_front(out_chunk_tiles);
+            cb_out_m_buf.pop_front(PNHt);
+            cb_out_l_buf.pop_front(PNHt);
+            noc.async_atomic_barrier();
             // Senders can return, dont need to participate
             return;
         }
@@ -356,10 +405,11 @@ void kernel_main() {
         // ROOT CORE REMAINING WRITER WORK
         // Offset for current batch
         uint32_t out_tile_id = cur_batch * out_chunk_tiles;
+        CircularBuffer cb_out_buf(cb_out);
         if constexpr (num_kv_heads > 1 || !is_out_sharded) {
-            cb_wait_front(cb_out, out_chunk_tiles);
+            cb_out_buf.wait_front(out_chunk_tiles);
         }
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
 
         if constexpr (num_kv_heads > 1) {
             // if gqa, we will need to write partial outputs for each head
@@ -382,45 +432,54 @@ void kernel_main() {
 
                 uint32_t reduce_core_read_index_start = (cur_batch * num_cores_per_batch) / num_cores_per_head;
 
+                UnicastEndpoint out_src;
+                const uint32_t peer_l1_base = cb_out_buf.get_read_ptr();
                 for (uint32_t reduce_core_read_index = reduce_core_read_index_start + 1;
                      reduce_core_read_index < reduce_core_read_index_start + num_reducers_per_output;
                      reduce_core_read_index++) {
                     uint32_t reduce_core_read_noc_x = all_reducer_noc_x[reduce_core_read_index];
                     uint32_t reduce_core_read_noc_y = all_reducer_noc_y[reduce_core_read_index];
 
-                    uint64_t out_reader_base_noc_addr =
-                        get_noc_addr(reduce_core_read_noc_x, reduce_core_read_noc_y, get_read_ptr(cb_out));
-
                     for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
-                        uint32_t l1_write_addr = get_write_ptr(cb_out) + tile * tile_bytes;
-                        uint32_t out_reader_noc_addr = out_reader_base_noc_addr;
+                        uint32_t l1_write_addr = cb_out_buf.get_write_ptr() + tile * tile_bytes;
+                        uint32_t peer_tile_base = peer_l1_base + tile * tile_bytes;
                         // write partial output for each head
                         for (uint32_t head = 0; head < num_heads_to_write; ++head) {
                             uint32_t starting_row = cur_head * num_heads_to_write + head;
                             uint32_t in_tile_offset_by_starting_head =
                                 starting_row < 16 ? starting_row * SUBTILE_LINE_BYTES
                                                   : (starting_row - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
-                            uint32_t out_reader_noc_addr_head = out_reader_noc_addr + in_tile_offset_by_starting_head;
+                            uint32_t peer_addr_head = peer_tile_base + in_tile_offset_by_starting_head;
                             uint32_t l1_write_addr_head = l1_write_addr + in_tile_offset_by_starting_head;
 
-                            // Write first phase
-                            noc_async_read(out_reader_noc_addr_head, l1_write_addr_head, SUBTILE_LINE_BYTES);
+                            // First phase
+                            noc.async_read(
+                                out_src,
+                                CoreLocalMem<uint32_t>(l1_write_addr_head),
+                                SUBTILE_LINE_BYTES,
+                                {.noc_x = reduce_core_read_noc_x,
+                                 .noc_y = reduce_core_read_noc_y,
+                                 .addr = peer_addr_head},
+                                {});
 
-                            // Write second phase
-                            noc_async_read(
-                                out_reader_noc_addr_head + 256 * ELEMENT_SIZE,
-                                l1_write_addr_head + 256 * ELEMENT_SIZE,
-                                SUBTILE_LINE_BYTES);
+                            // Second phase
+                            noc.async_read(
+                                out_src,
+                                CoreLocalMem<uint32_t>(l1_write_addr_head + 256 * ELEMENT_SIZE),
+                                SUBTILE_LINE_BYTES,
+                                {.noc_x = reduce_core_read_noc_x,
+                                 .noc_y = reduce_core_read_noc_y,
+                                 .addr = peer_addr_head + 256 * ELEMENT_SIZE},
+                                {});
 
                             if (++barrier_count == barrier_threshold) {
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
                                 barrier_count = 0;
                             }
                         }
-                        out_reader_noc_addr += tile_bytes;
                     }
                 }
-                noc_async_read_barrier();
+                noc.async_read_barrier();
             } else {
                 // tell output core that its output is ready
                 uint32_t output_core_noc_x = all_output_noc_x[cur_batch];
@@ -438,8 +497,8 @@ void kernel_main() {
             }
         }
         if constexpr (num_kv_heads > 1 || !is_out_sharded) {
-            noc_async_write_barrier();
-            cb_pop_front(cb_out, out_chunk_tiles);
+            noc.async_write_barrier();
+            cb_out_buf.pop_front(out_chunk_tiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/array_view.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/array_view.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "api/dataflow/circular_buffer.h"
 #include "api/debug/assert.h"
 #include "api/debug/dprint_tile.h"
 #include "api/debug/dprint.h"
@@ -46,31 +47,32 @@ enum class CBAccessType : uint8_t { CB_FRONT_RW, CB_BACK_RW, CB_FRONT_RO, CB_BAC
  *   - size(): Get number of elements available in the buffer
  *
  * Example usage:
- *   ArrayView<uint32_t, cb_id, CBAccessType::CB_FRONT> view_rw;
+ *   CircularBuffer cb(cb_id);
+ *   ArrayView<uint32_t, CBAccessType::CB_FRONT_RW> view_rw(cb);
  *   view_rw[0] = 42; // write to front of CB
  *   uint32_t val = view_rw[1]; // read from front of CB
  *
- *   ArrayView<uint32_t, cb_id, CBAccessType::CB_FRONT_RO> view_ro;
+ *   ArrayView<uint32_t, CBAccessType::CB_FRONT_RO> view_ro(cb);
  *   uint32_t val = view_ro[0]; // read-only access
  *   // view_ro[0] = 42; // Compile error - no write access
  */
 template <typename T, CBAccessType _type>
 struct ArrayView {
-    ArrayView(uint32_t cb_id, uint32_t tile_id_offset = 0, uint32_t ntiles = 1) {
+    ArrayView(const CircularBuffer& cb, uint32_t tile_id_offset = 0, uint32_t ntiles = 1) {
         ASSERT(ntiles > 0);
 
-        auto tile_size = get_tile_size(cb_id);
+        auto tile_size = cb.get_tile_size();
         if constexpr (_type == CBAccessType::CB_FRONT_RW || _type == CBAccessType::CB_FRONT_RO) {
-            _ptr = reinterpret_cast<volatile tt_l1_ptr T*>(CB_RD_PTR(cb_id) + tile_id_offset * tile_size);
+            _ptr = reinterpret_cast<volatile tt_l1_ptr T*>(cb.get_read_ptr() + tile_id_offset * tile_size);
 
 #if defined(WATCHER_OVERHEAD_OK)
-            _base_addr = CB_RD_PTR(cb_id) + tile_id_offset * tile_size;
+            _base_addr = cb.get_read_ptr() + tile_id_offset * tile_size;
 #endif
         } else {
-            _ptr = reinterpret_cast<volatile tt_l1_ptr T*>(CB_WR_PTR(cb_id) + tile_id_offset * tile_size);
+            _ptr = reinterpret_cast<volatile tt_l1_ptr T*>(cb.get_write_ptr() + tile_id_offset * tile_size);
 
 #if defined(WATCHER_OVERHEAD_OK)
-            _base_addr = CB_WR_PTR(cb_id) + tile_id_offset * tile_size;
+            _base_addr = cb.get_write_ptr() + tile_id_offset * tile_size;
 #endif
         }
         _size = ntiles * tile_size / sizeof(T);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/reader_windowed.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/reader_windowed.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/transformer/sdpa_windowed/device/kernels/array_view.hpp"
@@ -11,9 +16,9 @@
 
 #if defined(WATCHER_OVERHEAD_OK)
 template <bool is_output_cb, bool is_wr_ptr>
-void dprint_cb_tile(uint32_t cb_id, uint32_t tile_id) {
-    noc_async_read_barrier();
-    noc_async_write_barrier();
+void dprint_cb_tile(Noc noc, uint32_t cb_id, uint32_t tile_id) {
+    noc.async_read_barrier();
+    noc.async_write_barrier();
     for (uint8_t i = 0; i < 32; ++i) {
         DPRINT(
             "{}",
@@ -113,7 +118,8 @@ inline void fill_diag_subtile_zeros_bfp4(
         uint32_exp_per_face * 4 + uint32_datums_per_face * 2,
         uint32_exp_per_face * 4 + uint32_datums_per_face * 3};
 
-    auto uint32_arr = ArrayView<uint32_t, CBAccessType::CB_BACK_RW>(cb_id, tile_id);
+    CircularBuffer cb(cb_id);
+    auto uint32_arr = ArrayView<uint32_t, CBAccessType::CB_BACK_RW>(cb, tile_id);
 
     // fill face 0 with both cases where the subtile is contained completely in the face or partially in the face
     if (row_start_idx < tt::constants::FACE_HEIGHT && col_start_idx < tt::constants::FACE_WIDTH) {
@@ -181,6 +187,8 @@ void kernel_main() {
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(9);
     constexpr uint32_t num_cores = get_compile_time_arg_val(10);
 
+    Noc noc;
+
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t k_addr = get_arg_val<uint32_t>(argidx++);
@@ -240,10 +248,15 @@ void kernel_main() {
     const auto k_tile_shape = TensorTileShape(B, NKH, valid_Skt, DHt);
 
     // load the entire cu_window_seqlens tensor into a circular buffer
-    cb_reserve_back(cb_cu_window_seqlens_in, 1);
-    uint64_t cu_window_noc_addr = cu_window_seqlens_reader.get_noc_addr(0);
-    noc_async_read(cu_window_noc_addr, get_write_ptr(cb_cu_window_seqlens_in), cu_window_seqlens_tile_bytes);
-    auto cb_cu_window_seqlens_ptr = ArrayView<uint32_t, CBAccessType::CB_BACK_RO>(cb_cu_window_seqlens_in);
+    CircularBuffer cb_cu_window_seqlens(cb_cu_window_seqlens_in);
+    cb_cu_window_seqlens.reserve_back(1);
+    noc.async_read(
+        cu_window_seqlens_reader,
+        CoreLocalMem<uint32_t>(cb_cu_window_seqlens.get_write_ptr()),
+        cu_window_seqlens_tile_bytes,
+        {.page_id = 0},
+        {});
+    auto cb_cu_window_seqlens_ptr = ArrayView<uint32_t, CBAccessType::CB_BACK_RO>(cb_cu_window_seqlens);
     auto get_cu_window_seqlens = [&](uint32_t idx) -> uint32_t {
         if constexpr (cu_window_seqlens_data_format == DataFormat::UInt32) {
             return cb_cu_window_seqlens_ptr[idx];
@@ -269,8 +282,8 @@ void kernel_main() {
         std::min((local_q_start + q_chunks_per_core) * Sq_chunk_t, valid_Sqt) * tt::constants::TILE_HEIGHT;
     uint32_t mask_windows_low_idx = 0;
     bool found_mask_windows = false;
-    noc_async_read_barrier();  // Wait until reads are done
-    cb_push_back(cb_cu_window_seqlens_in, 1);
+    noc.async_read_barrier();  // Wait until reads are done
+    cb_cu_window_seqlens.push_back(1);
     DPRINT_ARRAY_VIEW({
         DPRINT("cu_window_seqlens_eles: {}\n", cu_window_seqlens_eles);
         DPRINT("cu_window_seqlens:\n");
@@ -287,6 +300,8 @@ void kernel_main() {
             break;
         }
     }
+
+    CircularBuffer cb_mask(cb_mask_in);
 
     uint32_t q_high_idx_in_tiles = Skt;
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
@@ -330,9 +345,8 @@ void kernel_main() {
 
                     // [INFO] Generate windowed attention mask on-the-fly for q_row_tile_count x k_row_tile_count tiles
                     // [INFO] q_chunk_size and k_chunk_size can differ
-                    cb_reserve_back(cb_mask_in, mask_chunk_tiles);
-                    uint32_t mask_write_ptr_base = get_write_ptr(cb_mask_in);
-                    uint64_t noc_write_addr_base = get_noc_addr(mask_write_ptr_base);
+                    cb_mask.reserve_back(mask_chunk_tiles);
+                    uint32_t mask_write_ptr_base = cb_mask.get_write_ptr();
 
                     int zero_tile_idx = -1;
                     int inf_tile_idx = -1;
@@ -367,10 +381,10 @@ void kernel_main() {
                             if (q_start_idx >= window_low_idx && q_end_idx <= window_high_idx &&
                                 k_start_idx >= window_low_idx && k_end_idx <= window_high_idx) {
                                 if (zero_tile_idx == -1) {
-                                    fill_tile_zeros<mask_tile_bytes, false>(cb_mask_in, in_mask_tile_id);
+                                    fill_tile_zeros<mask_tile_bytes, false>(noc, cb_mask_in, in_mask_tile_id);
                                 } else {
                                     copy_tile<mask_tile_bytes>(
-                                        noc_write_addr_base, mask_write_ptr_base, zero_tile_idx, in_mask_tile_id);
+                                        noc, mask_write_ptr_base, mask_write_ptr_base, zero_tile_idx, in_mask_tile_id);
                                 }
                                 // save most recent zero'ed tile as the source of copy_tile in the future
                                 zero_tile_idx = in_mask_tile_id;
@@ -384,7 +398,7 @@ void kernel_main() {
                                 fill_neginf_tile<mask_tile_bytes>(cb_mask_in, in_mask_tile_id);
                             } else {
                                 copy_tile<mask_tile_bytes>(
-                                    noc_write_addr_base, mask_write_ptr_base, inf_tile_idx, in_mask_tile_id);
+                                    noc, mask_write_ptr_base, mask_write_ptr_base, inf_tile_idx, in_mask_tile_id);
                             }
                             if (!found_mask_windows || k_end_idx <= window_low_idx || k_start_idx >= window_high_idx ||
                                 window_low_idx >= window_high_idx) {
@@ -428,14 +442,15 @@ void kernel_main() {
 
                             DPRINT_ARRAY_VIEW({
                                 DPRINT("  [COL ITER] WINDOW tile: in_mask_tile_id: {}\n", in_mask_tile_id);
-                                (dprint_cb_tile<true, true>(cb_mask_in, in_mask_tile_id));
+                                (dprint_cb_tile<true, true>(noc, cb_mask_in, in_mask_tile_id));
                             });
                         }
                     }
                     // sync up the read and writes, push back the mask cb, after processing each chunk
-                    noc_async_read_barrier();  // syncs up the reads of k_chunk and the ones used by mask generation
-                    cb_push_back(cb_k_in, k_chunk_ntiles);
-                    cb_push_back(cb_mask_in, mask_chunk_tiles);
+                    noc.async_read_barrier();  // syncs up the reads of k_chunk and the ones used by mask generation
+                    CircularBuffer cb_k(cb_k_in);
+                    cb_k.push_back(k_chunk_ntiles);
+                    cb_mask.push_back(mask_chunk_tiles);
 
                     // Read V chunk
                     read_chunk_with_padding<v_tile_bytes>(


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

  Migrates 17 kernel files in transformer/{sdpa, sdpa_decode, sdpa_windowed} and one in reduction/sampling from the legacy
  free-function dataflow API to the typed device-2.0 wrappers. First work item in #45003.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

  - Focus areas: the chain-mcast paths in reader_interleaved.cpp, exp_ring_joint_reader.cpp, and chain_link.hpp — these are the only spots with non-mechanical changes (sem-id wiring, participant guard).
  - No algorithmic change: tile counts, NoC traffic, transaction-counter semantics unchanged.
  - Commit 2 fix: chain-mcast sem-id mismatch (sender/receiver participated with the wrong sem IDs)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/transformer-device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/transformer-device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/transformer-device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/transformer-device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/transformer-device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/transformer-device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/transformer-device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/transformer-device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/transformer-device_2_0)