### PR TITLE
[Bug fix] Fix unpack reconfig zero-src flag leaky state (#43882 follow-up)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -92,6 +92,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         "Unsupported unpacker to register conversion.");
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
+
+    // Snapshot prev dst format before the REG2 write below; used by the zero-src-flag logic.
+    volatile std::uint32_t tt_reg_ptr *cfg     = get_cfg_pointer();
+    const std::uint32_t prev_unpack_dst_format = cfg[THCON_SEC0_REG2_Out_data_format_ADDR32] & THCON_SEC0_REG2_Out_data_format_MASK;
+
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
@@ -126,10 +131,17 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
     }
 
-    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
-    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    // Zero-src flag is set entering UInt16 and cleared leaving it; other transitions leave it
+    // alone so paths like reduce-init with enforce_fp32_accumulation aren't clobbered.
+    const bool was_uint16 = (prev_unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    const bool is_uint16  = (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    if (is_uint16)
     {
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    else if (was_uint16)
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }
 }
 
@@ -150,6 +162,11 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         "Unsupported unpacker to register conversion.");
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
+
+    // Snapshot prev dst format before the REG2 write below; used by the zero-src-flag logic.
+    volatile std::uint32_t tt_reg_ptr *cfg     = get_cfg_pointer();
+    const std::uint32_t prev_unpack_dst_format = cfg[THCON_SEC1_REG2_Out_data_format_ADDR32] & THCON_SEC1_REG2_Out_data_format_MASK;
+
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
@@ -180,10 +197,16 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         TT_SETADCXX(p_setadc::UNP_B, (unpack_face_r_dim << 4) - 1, 0x0);
     }
 
-    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
-    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    // Zero-src flag: see _llk_unpack_reconfig_data_format_srca_impl_.
+    const bool was_uint16 = (prev_unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    const bool is_uint16  = (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    if (is_uint16)
     {
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    else if (was_uint16)
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -93,6 +93,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         "Unsupported unpacker to register conversion.");
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
+
+    // Snapshot prev dst format before the REG2 write below; used by the zero-src-flag logic.
+    volatile std::uint32_t tt_reg_ptr *cfg     = get_cfg_pointer();
+    const std::uint32_t prev_unpack_dst_format = cfg[THCON_SEC0_REG2_Out_data_format_ADDR32] & THCON_SEC0_REG2_Out_data_format_MASK;
+
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
@@ -124,10 +129,17 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
     }
 
-    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
-    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    // Zero-src flag is set entering UInt16 and cleared leaving it; other transitions leave it
+    // alone so paths like reduce-init with enforce_fp32_accumulation aren't clobbered.
+    const bool was_uint16 = (prev_unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    const bool is_uint16  = (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    if (is_uint16)
     {
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    else if (was_uint16)
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }
 }
 
@@ -148,6 +160,11 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         "Unsupported unpacker to register conversion.");
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
+
+    // Snapshot prev dst format before the REG2 write below; used by the zero-src-flag logic.
+    volatile std::uint32_t tt_reg_ptr *cfg     = get_cfg_pointer();
+    const std::uint32_t prev_unpack_dst_format = cfg[THCON_SEC1_REG2_Out_data_format_ADDR32] & THCON_SEC1_REG2_Out_data_format_MASK;
+
     if constexpr (to_from_int8)
     {
         static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
@@ -175,10 +192,16 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         TT_SETADCXX(p_setadc::UNP_B, (unpack_face_r_dim << 4) - 1, 0x0);
     }
 
-    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
-    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    // Zero-src flag: see _llk_unpack_reconfig_data_format_srca_impl_.
+    const bool was_uint16 = (prev_unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    const bool is_uint16  = (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    if (is_uint16)
     {
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    else if (was_uint16)
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }
 }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Fixes a leaky-state regression introduced by #43882.

That PR correctly set `ALU_ACC_CTRL_Zero_Flag_disabled_src = 1` when reconfiguring unpack to `UInt16` (to prevent the hardware zero-src predicate from silently zeroing values whose low byte is `0x00`). However, it never cleared the flag when reconfiguring *away* from `UInt16`, so the flag stayed set for all subsequent ops — corrupting data and causing PCC failures like:

```
AssertionError: Weights PCC is 0.9693, expected >= 0.97
models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_grouped_topk.py:126
```

**Fix:** snapshot the current dst format before the REG2 write, then apply symmetric logic:
- `UInt16` -> set flag
- leaving `UInt16` -> clear flag
- all other transitions -> leave flag alone

Applied to both SrcA and SrcB reconfig paths on Wormhole B0 and Blackhole.

Relates to #43882

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/unpack_reconfig_zero_src_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/unpack_reconfig_zero_src_fix)