### PR TITLE
DS Prefill :: Dispatch performance optimization

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -75,7 +75,7 @@ void create_tensor_cb(
 
 namespace {
 
-// Tile-layout path: TILE inputs, fused untilize across sender + idle cores.
+// Tile-layout path: TILE inputs, fused untilize across sender + untilize cores.
 ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_layout(
     const DispatchParams& operation_attributes,
     const MeshCoordinate& mesh_coordinate,
@@ -141,8 +141,10 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
 
     uint32_t num_cores = effective_num_links;
 
-    // ==================== Core layout: senders + idle groups ====================
+    // ==================== Core layout: senders + untilize cores ====================
     // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
+    // Each sender owns exactly one untilize core: cores are paired (sender, untilize)
+    // consecutively along x.
     uint32_t sender_row_y = subdevice_cores.at(0).y;
     std::vector<CoreCoord> all_row_cores;
     for (const auto& core : subdevice_cores) {
@@ -155,75 +157,58 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
 
     uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
     TT_FATAL(
-        total_row_cores > num_cores,
-        "Same-row has only {} cores for {} senders — need at least one idle core per sender",
+        total_row_cores >= 2 * num_cores,
+        "Same-row has only {} cores for {} senders — need one untilize core per sender (>= {} required)",
         total_row_cores,
-        num_cores);
-
-    // Divide total_row_cores into num_cores groups.
-    // Within each group: center core = sender, surrounding cores = that sender's idle cores.
-    uint32_t base_group_size = total_row_cores / num_cores;
-    uint32_t extra_groups = total_row_cores % num_cores;
+        num_cores,
+        2 * num_cores);
 
     std::vector<CoreCoord> sender_cores;
     sender_cores.reserve(num_cores);
-    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
-    std::vector<CoreCoord> all_idle_cores;
-    std::vector<uint32_t> idle_sender_map;
+    std::vector<std::vector<CoreCoord>> sender_untilize_groups(num_cores);
+    std::vector<CoreCoord> all_untilize_cores;
+    all_untilize_cores.reserve(num_cores);
+    std::vector<uint32_t> untilize_sender_map;
+    untilize_sender_map.reserve(num_cores);
 
-    {
-        uint32_t pos = 0;
-        for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
-            uint32_t sender_offset = group_size / 2;
-            for (uint32_t j = 0; j < group_size; j++, pos++) {
-                if (j == sender_offset) {
-                    sender_cores.push_back(all_row_cores[pos]);
-                } else {
-                    sender_idle_groups[s].push_back(all_row_cores[pos]);
-                    all_idle_cores.push_back(all_row_cores[pos]);
-                    idle_sender_map.push_back(s);
-                }
-            }
-        }
+    for (uint32_t s = 0; s < num_cores; s++) {
+        sender_cores.push_back(all_row_cores[2 * s]);
+        sender_untilize_groups[s].push_back(all_row_cores[2 * s + 1]);
+        all_untilize_cores.push_back(all_row_cores[2 * s + 1]);
+        untilize_sender_map.push_back(s);
     }
 
-    uint32_t num_idle_cores = static_cast<uint32_t>(all_idle_cores.size());
-    TT_FATAL(
-        num_idle_cores >= num_cores,
-        "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
-        num_idle_cores,
-        num_cores);
+    uint32_t num_untilize_cores = static_cast<uint32_t>(all_untilize_cores.size());
 
-    // Build sender_core_grid and idle_core_grid CoreRangeSets
+    // Build sender_core_grid and untilize_core_grid CoreRangeSets
     std::set<CoreRange> sender_ranges_set;
     for (const auto& sc : sender_cores) {
         sender_ranges_set.insert(CoreRange(sc));
     }
     auto sender_core_grid = CoreRangeSet(sender_ranges_set);
 
-    std::set<CoreRange> idle_ranges_set;
-    for (const auto& ic : all_idle_cores) {
-        idle_ranges_set.insert(CoreRange(ic));
+    std::set<CoreRange> untilize_ranges_set;
+    for (const auto& ic : all_untilize_cores) {
+        untilize_ranges_set.insert(CoreRange(ic));
     }
-    CoreRangeSet idle_core_grid(idle_ranges_set);
+    CoreRangeSet untilize_core_grid(untilize_ranges_set);
 
     // Combined grid for shared semaphores
-    std::set<CoreRange> sender_and_idle_ranges;
+    std::set<CoreRange> sender_and_untilize_ranges;
     for (const auto& cr : sender_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
+        sender_and_untilize_ranges.insert(cr);
     }
-    for (const auto& cr : idle_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
+    for (const auto& cr : untilize_core_grid.ranges()) {
+        sender_and_untilize_ranges.insert(cr);
     }
-    CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
+    CoreRangeSet sender_and_untilize_grid(sender_and_untilize_ranges);
 
     log_debug(
         tt::LogOp,
-        "Dispatch program: num_links: {} num_cores(senders): {} num_idle_cores: {} tokens_per_device: {}",
+        "Dispatch program: num_links: {} num_cores(senders): {} num_untilize_cores: {} tokens_per_device: {}",
         num_links,
         num_cores,
-        num_idle_cores,
+        num_untilize_cores,
         tokens_per_device);
 
     constexpr uint32_t read_batch_size = 32;
@@ -231,41 +216,76 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
     uint32_t total_batches = (tokens_per_device + read_batch_size - 1) / read_batch_size;
 
-    // ==================== Semaphores for inter-core sync ====================
-    // One data_ready + one start semaphore per sender (created on sender+idle grid)
-    std::vector<uint32_t> data_ready_semaphore_ids;
-    std::vector<uint32_t> start_semaphore_ids;
-    data_ready_semaphore_ids.reserve(num_cores);
-    start_semaphore_ids.reserve(num_cores);
+    // ==================== Semaphores ====================
+    // Per-entry pipeline (untilize → sender writer CB → fabric):
+    //   Sender writer CBs (c_4/c_5/c_6) are writer_cb_size slots deep (one batch worth).
+    //   data_avail_semaphore_ids[s] (on sender L1, init=0): untilize NOC-incs per entry
+    //       written into the sender slot. Sender writer polls locally.
+    //   space_avail_semaphore_ids[s] (on untilize L1, init=writer_cb_size): sender writer
+    //       NOC-incs per entry that has been fabric-sent (slot is safe to overwrite). The
+    //       initial value seeds untilize so it can fill all slots before the first writer
+    //       credit lands.
+    // Address handshake (sender writer → untilize):
+    //   addr_ready_semaphore_id: signals untilize that writer CB base addresses are valid.
+    //   cross_c{4,5,6}_addr_semaphore_id: hold the writer CB (c_4/c_5/c_6) L1 base
+    //       addresses (used as 1×u32 scratch on both sides).
+    constexpr uint32_t writer_cb_size = read_batch_size;  // 32 slots — one batch deep, per-entry handshake
+    std::vector<uint32_t> data_avail_semaphore_ids;
+    std::vector<uint32_t> space_avail_semaphore_ids;
+    data_avail_semaphore_ids.reserve(num_cores);
+    space_avail_semaphore_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
-        start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        data_avail_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_untilize_grid, 0));
+        space_avail_semaphore_ids.push_back(
+            tt::tt_metal::CreateSemaphore(program, sender_and_untilize_grid, writer_cb_size));
     }
-    // addr_ready semaphore: sender signals idle cores after writing receive buffer address
-    auto addr_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    // addr_value semaphore: holds the sender's c_18 L1 address (written via noc_async_write)
-    auto addr_value_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    // mbox_ready semaphore (per sender): idle cores signal this after NOC-writing their mailbox address.
-    // Sender waits for count == num_idle_cores_in_group before reading its own scratch buffer.
-    std::vector<uint32_t> mbox_ready_semaphore_ids;
-    mbox_ready_semaphore_ids.reserve(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        mbox_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
-    }
-    // mbox_scratch_addr semaphore: sender writes its route-table scratch base address here and
-    // multicasts it to idle cores alongside addr_ready.  Idle cores read it after addr_ready fires,
-    // then NOC-write their mailbox L1 address into the sender's scratch slot (core_id * 4 offset).
-    auto mbox_scratch_addr_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto addr_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_untilize_grid, 0);
+    auto cross_c4_addr_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_untilize_grid, 0);
+    auto cross_c5_addr_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_untilize_grid, 0);
+    auto cross_c6_addr_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_untilize_grid, 0);
 
-    // ==================== Circular Buffers for IDLE cores ====================
+    // ==================== Circular Buffers for untilize cores ====================
+    // Routing decisions and offsets[] live on the untilize core now — sender is fabric-only.
     // c_0: tiled input stripe (reader → compute)
     detail::create_tensor_cb(
         program,
-        idle_core_grid,
+        untilize_core_grid,
         input_tensor,
         /*buffering_factor=*/16,
         /*cb_id=*/tt::CBIndex::c_0,
-        "idle_input_scratch");
+        "untilize_input_scratch");
+    // c_1: indices scratch (untilize reader does per-batch DRAM reads)
+    detail::create_tensor_cb(
+        program,
+        untilize_core_grid,
+        indices_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_1,
+        "untilize_indices_scratch");
+    // c_2: weights scratch
+    detail::create_tensor_cb(
+        program,
+        untilize_core_grid,
+        weights_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_2,
+        "untilize_weights_scratch");
+    // c_3: offsets (full tensor, loaded once at startup, mutated in place per batch)
+    detail::create_tensor_cb(
+        program,
+        untilize_core_grid,
+        offsets_tensor,
+        /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
+        /*cb_id=*/tt::CBIndex::c_3,
+        "untilize_offsets_tensor");
+    // c_9: dispatch_table (full tensor, loaded once at startup)
+    detail::create_tensor_cb(
+        program,
+        untilize_core_grid,
+        dispatch_table_tensor,
+        /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
+        /*cb_id=*/tt::CBIndex::c_9,
+        "untilize_dispatch_table_tensor");
     // c_10: signal CB (reader → compute)
     {
         uint32_t signal_page_size = l1_alignment;
@@ -274,102 +294,77 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
             tt::tt_metal::CircularBufferConfig(
                 signal_buffering * signal_page_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt32}})
                 .set_page_size(tt::CBIndex::c_10, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+        tt::tt_metal::CreateCircularBuffer(program, untilize_core_grid, signal_cb_config);
     }
     // c_11: untilize output (compute → writer)
-    // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
+    // Double-buffered at batch granularity: two slots of read_batch_size tokens so compute can
+    // pack the next batch while the writer is still draining the previous one.
     detail::create_tensor_cb(
         program,
-        idle_core_grid,
+        untilize_core_grid,
         output_tensor,
-        /*buffering_factor=*/read_batch_size,
+        /*buffering_factor=*/2 * read_batch_size,
         /*cb_id=*/tt::CBIndex::c_11,
-        "idle_untilize_output");
-    // c_12: route table mailbox (sender writes before start_semaphore; writer reads after)
-    // Layout: [entry_count u32] [entry_0..N × 6 u32s each]
-    {
-        uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
-        uint32_t mailbox_page_size = tt::round_up(
-            static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
-            l1_alignment);
-        tt::tt_metal::CircularBufferConfig mailbox_cb_config =
-            tt::tt_metal::CircularBufferConfig(mailbox_page_size, {{tt::CBIndex::c_12, tt::DataFormat::UInt32}})
-                .set_page_size(tt::CBIndex::c_12, mailbox_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, mailbox_cb_config);
-    }
-    // c_13: metadata scratch (idle writer builds metadata here before NOC-writing to DRAM)
+        "untilize_untilize_output");
+    // c_13: metadata scratch (untilize writer builds metadata here before NOC-writing).
+    // Layout: meta_scratch_slots local-path ring slots followed by 1 cross-device scratch slot.
+    //   slots 0..meta_scratch_slots-1: local-path ring (worst-case sized so we never wrap
+    //     within a batch; one noc_async_writes_flushed() at batch end covers source reuse)
+    //   slot meta_scratch_slots:       cross-device-path scratch (per-entry barrier already
+    //     drains the source, so a single slot is enough — kept distinct from the local ring
+    //     to avoid clobbering pending local writes when entries interleave)
     detail::create_tensor_cb(
         program,
-        idle_core_grid,
+        untilize_core_grid,
         metadata_tensor,
-        /*buffering_factor=*/1,
+        /*buffering_factor=*/(read_batch_size * operation_attributes.num_experts_per_tok) + 1,
         /*cb_id=*/tt::CBIndex::c_13,
-        "idle_metadata_scratch");
+        "untilize_metadata_scratch");
+    // c_15: route_info scratch (16B = l1_alignment). Untilize writer builds the 4-u32
+    // route_info entry [route, distance, page_idx, 0] here, then NOC-writes the whole
+    // block as a single noc_async_write to the sender's c_4 slot (replaces 4× inline_dw).
+    {
+        uint32_t route_info_scratch_size = l1_alignment;
+        tt::tt_metal::CircularBufferConfig route_info_scratch_cb_config =
+            tt::tt_metal::CircularBufferConfig(route_info_scratch_size, {{tt::CBIndex::c_15, tt::DataFormat::UInt32}})
+                .set_page_size(tt::CBIndex::c_15, route_info_scratch_size);
+        tt::tt_metal::CreateCircularBuffer(program, untilize_core_grid, route_info_scratch_cb_config);
+    }
+    // c_14: per-batch route plan (reader RISC → writer RISC, on same untilize core).
+    // Layout: [entry_count u32][padding to 32B][entries × 8 u32 each]
+    {
+        constexpr uint32_t plan_entry_u32s = 8;
+        uint32_t max_plan_entries = read_batch_size * operation_attributes.num_experts_per_tok;
+        uint32_t plan_page_size = tt::round_up(
+            32u + max_plan_entries * plan_entry_u32s * static_cast<uint32_t>(sizeof(uint32_t)), l1_alignment);
+        constexpr uint32_t plan_buffering = 2;
+        tt::tt_metal::CircularBufferConfig plan_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                plan_buffering * plan_page_size, {{tt::CBIndex::c_14, tt::DataFormat::UInt32}})
+                .set_page_size(tt::CBIndex::c_14, plan_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, untilize_core_grid, plan_cb_config);
+    }
 
     // ==================== Circular Buffers for SENDER cores ====================
-    // c_0: tiled input stripe for self-untilize (reader → compute on sender)
-    // Double-buffered blocks of 8 tiles (compute processes 8 at a time)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        input_tensor,
-        /*buffering_factor=*/16,
-        /*cb_id=*/tt::CBIndex::c_0,
-        "sender_input_scratch");
-    // c_10: signal CB for self-untilize (reader → compute on sender)
+    // Direct-consume pipeline on sender:
+    //   c_4/c_5/c_6 = the only data CBs. Untilize NOC-writes per-entry directly into
+    //                 these slots; sender writer (RISCV_0) consumes them via local
+    //                 semaphore wait + manual slot math and fabric-sends. Sized
+    //                 writer_cb_size = read_batch_size (one batch worth, per-entry handshake).
     {
-        uint32_t signal_page_size = l1_alignment;
-        constexpr uint32_t signal_buffering = 2;
-        tt::tt_metal::CircularBufferConfig sender_signal_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                signal_buffering * signal_page_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt32}})
-                .set_page_size(tt::CBIndex::c_10, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, sender_signal_cb_config);
-    }
-    // c_1: indices scratch
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        indices_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_1,
-        "indices_scratch");
-    // c_2: weights scratch
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        weights_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_2,
-        "weights_scratch");
-    // c_3: offsets (full tensor)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        offsets_tensor,
-        /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
-        /*cb_id=*/tt::CBIndex::c_3,
-        "offsets_tensor");
-
-    // c_4, c_5, c_6: reader→writer CBs for (route_info, payload, metadata) per remote entry.
-    // The reader pushes all three per entry in lockstep, so small buffering (2) suffices
-    // for the writer to drain concurrently. No large buffering needed.
-    {
-        constexpr uint32_t rw_buffering = 2;
-
         uint32_t route_info_page_size = l1_alignment;
 
-        tt::tt_metal::CircularBufferConfig route_info_cb_config =
+        tt::tt_metal::CircularBufferConfig writer_route_info_cb_config =
             tt::tt_metal::CircularBufferConfig(
-                rw_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
+                writer_cb_size * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
                 .set_page_size(tt::CBIndex::c_4, route_info_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, writer_route_info_cb_config);
 
         detail::create_tensor_cb(
             program,
             sender_core_grid,
             output_tensor,
-            /*buffering_factor=*/rw_buffering,
+            /*buffering_factor=*/writer_cb_size,
             /*cb_id=*/tt::CBIndex::c_5,
             "payload_for_writer");
 
@@ -377,46 +372,9 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
             program,
             sender_core_grid,
             metadata_tensor,
-            /*buffering_factor=*/rw_buffering,
+            /*buffering_factor=*/writer_cb_size,
             /*cb_id=*/tt::CBIndex::c_6,
             "metadata_for_writer");
-    }
-
-    // c_7: metadata_temp (reader-only, for constructing metadata locally)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        metadata_tensor,
-        /*buffering_factor=*/1,
-        /*cb_id=*/tt::CBIndex::c_7,
-        "metadata_temp_buffer");
-    // c_9: dispatch_table (full tensor)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        dispatch_table_tensor,
-        /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
-        /*cb_id=*/tt::CBIndex::c_9,
-        "dispatch_table_tensor");
-    // c_18: receive buffer for untilized data from idle cores (also sender self-untilize output)
-    // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_18,
-        "receive_untilized");
-    // c_19: route table scratch (sender builds local-expert route table here before NOC-writing to idle)
-    {
-        uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
-        uint32_t mailbox_page_size = tt::round_up(
-            static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
-            l1_alignment);
-        tt::tt_metal::CircularBufferConfig route_table_cb_config =
-            tt::tt_metal::CircularBufferConfig(mailbox_page_size, {{tt::CBIndex::c_19, tt::DataFormat::UInt32}})
-                .set_page_size(tt::CBIndex::c_19, mailbox_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_table_cb_config);
     }
 
     const auto [neighbors, directions] =
@@ -451,7 +409,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
     // ==================== Compile-time args shared by sender reader and writer ====================
     std::vector<uint32_t> compile_time_args = {
         // CB IDs (10)
-        static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id (used by sender reader for self-untilize)
+        static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id (row-major path only)
         static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
         static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_weights_id
         static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
@@ -538,38 +496,18 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         fabric_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
     }
 
-    // ==================== Per-sender reader kernels ====================
-    // Each sender gets its own reader kernel with per-sender idle core count baked in.
-    auto reader_defines = fabric_defines;
-    reader_defines["IS_TILE_LAYOUT"] = "1";
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
-    reader_kernel_ids.reserve(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
-        uint32_t total_workers = k_s + 1;  // idle cores + sender itself
-        auto per_sender_compile_args = compile_time_args;
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id (receive buf)
-        per_sender_compile_args.push_back(
-            detail::get_aligned_page_size(output_tensor));  // aligned_row_major_input_page_size
-        per_sender_compile_args.push_back(k_s);             // num_idle_cores
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_10));  // cb_signal_id
-        per_sender_compile_args.push_back(total_workers);                             // total_workers
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_19));  // cb_route_table_scratch_id
+    // ==================== Sender writer kernel ====================
+    // Tile-layout: no sender reader RISC. The writer (RISCV_0) owns:
+    //   * Startup address handshake to untilize (publishes c_4/c_5/c_6 base L1 addresses,
+    //     NOC-incs untilize addr_ready).
+    //   * Fabric init + per-entry fabric send.
+    //   * Per-entry direct credit to untilize space_avail after each fabric send.
+    auto writer_defines = fabric_defines;
+    writer_defines["IS_TILE_LAYOUT"] = "1";
 
-        CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
-        reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-            "reader_dispatch.cpp",
-            single_sender_core,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                .compile_args = per_sender_compile_args,
-                .defines = reader_defines}));
-    }
+    std::vector<uint32_t> writer_compile_time_args = compile_time_args;
+    writer_compile_time_args.push_back(writer_cb_size);  // sender writer CB depth
 
-    // ==================== Sender writer kernel (shared across all senders) ====================
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
@@ -578,111 +516,120 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-            .compile_args = compile_time_args,
-            .defines = fabric_defines});
+            .compile_args = writer_compile_time_args,
+            .defines = writer_defines});
 
-    // ==================== Idle core kernels ====================
-    // Reader and writer kernels run on the two data-movement RISCs of each idle core
+    // ==================== untilize core kernels ====================
+    // Reader and writer kernels run on the two data-movement RISCs of each untilize core
     // so that DRAM reads for the next batch overlap with the NOC write of the previous
     // batch to the owning sender's receive buffer.
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     std::vector<tt::tt_metal::KernelHandle> writer_untilize_kernel_ids;
-    reader_untilize_kernel_ids.reserve(num_idle_cores);
-    writer_untilize_kernel_ids.reserve(num_idle_cores);
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        uint32_t s = idle_sender_map[j];
-        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
-        // Compute local core_id within this sender's idle group
-        uint32_t local_core_id = 0;
-        for (uint32_t g = 0; g < k_s; g++) {
-            if (sender_idle_groups[s][g] == all_idle_cores[j]) {
-                local_core_id = g;
-                break;
-            }
-        }
+    reader_untilize_kernel_ids.reserve(num_untilize_cores);
+    writer_untilize_kernel_ids.reserve(num_untilize_cores);
+    for (uint32_t j = 0; j < num_untilize_cores; j++) {
+        uint32_t s = untilize_sender_map[j];
+        // 1:1 sender ↔ untilize pairing — each untilize core processes ALL its sender's batches.
+        constexpr uint32_t local_core_id = 0;
+        constexpr uint32_t total_workers = 1;
 
-        uint32_t total_workers = k_s + 1;  // idle cores + sender itself
-
-        // Reader compile args (DRAM-read side)
-        std::vector<uint32_t> idle_reader_compile_args = {
-            static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_input_id
-            static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-            (uint32_t)hidden_size,
-            detail::get_aligned_page_size(input_tensor),  // aligned_input_page_size
-            total_batches,
-            local_core_id,  // core_id within sender group
-            total_workers,  // batch stride (idle cores + sender)
+        // ===== Reader compile args =====
+        // Routing decision lives here: needs the same tensors and parameters the old sender
+        // reader had, plus c_14 (route plan published to writer on the same core).
+        std::vector<uint32_t> untilize_reader_compile_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_0),               // 0: cb_input_id
+            static_cast<uint32_t>(tt::CBIndex::c_10),              // 1: cb_signal_id
+            (uint32_t)hidden_size,                                 // 2
+            detail::get_aligned_page_size(input_tensor),           // 3: aligned_input_page_size
+            total_batches,                                         // 4
+            local_core_id,                                         // 5
+            total_workers,                                         // 6
+            static_cast<uint32_t>(tt::CBIndex::c_1),               // 7: cb_indices_id
+            static_cast<uint32_t>(tt::CBIndex::c_2),               // 8: cb_weights_id
+            static_cast<uint32_t>(tt::CBIndex::c_3),               // 9: cb_offsets_id
+            static_cast<uint32_t>(tt::CBIndex::c_9),               // 10: cb_dispatch_table_id
+            static_cast<uint32_t>(tt::CBIndex::c_14),              // 11: cb_plan_id
+            read_batch_size,                                       // 12
+            detail::get_aligned_page_size(indices_tensor),         // 13
+            detail::get_aligned_page_size(weights_tensor),         // 14
+            detail::get_aligned_page_size(offsets_tensor),         // 15
+            detail::get_aligned_page_size(dispatch_table_tensor),  // 16
+            detail::get_num_pages(offsets_tensor),                 // 17: offsets_pages
+            detail::get_num_pages(dispatch_table_tensor),          // 18: dispatch_table_pages
+            operation_attributes.num_experts_per_tok,              // 19
+            operation_attributes.num_routed_experts,               // 20: n_routed_experts
+            operation_attributes.max_dispatch_buffer_token_size,   // 21
+            s,                                                     // 22: dispatch_core_idx
+            num_cores,                                             // 23: num_dispatch_cores
+            mesh_view.num_devices(),                               // 24: num_devices
+            mesh_view.num_rows(),                                  // 25
+            mesh_view.num_cols(),                                  // 26
+            linearized_mesh_coord,                                 // 27
+            static_cast<uint32_t>(topology),                       // 28
         };
-        // Append TensorAccessorArgs for input tensor only
-        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(idle_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(dispatch_table_tensor.buffer()).append_to(untilize_reader_compile_args);
 
-        // Writer compile args (NOC-write side)
-        std::vector<uint32_t> idle_writer_compile_args = {
-            static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
-            read_batch_size,
-            detail::get_aligned_page_size(output_tensor),  // aligned_output_page_size
-            total_batches,
-            local_core_id,
-            total_workers,
-            // New: direct-DRAM-write support
-            static_cast<uint32_t>(tt::CBIndex::c_12),        // cb_mailbox_id
-            static_cast<uint32_t>(tt::CBIndex::c_13),        // cb_metadata_scratch_id
-            detail::get_aligned_page_size(metadata_tensor),  // aligned_metadata_page_size
-            operation_attributes.num_experts_per_tok,
-            linearized_mesh_coord,
+        // ===== Writer compile args =====
+        // Data movement only — drains c_14 plan and executes local/cross-device writes.
+        std::vector<uint32_t> untilize_writer_compile_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_11),        // 0: cb_untilize_id
+            read_batch_size,                                 // 1
+            detail::get_aligned_page_size(output_tensor),    // 2: aligned_output_page_size
+            total_batches,                                   // 3
+            local_core_id,                                   // 4
+            total_workers,                                   // 5
+            static_cast<uint32_t>(tt::CBIndex::c_13),        // 6: cb_metadata_scratch_id
+            detail::get_aligned_page_size(metadata_tensor),  // 7: aligned_metadata_page_size
+            static_cast<uint32_t>(tt::CBIndex::c_14),        // 8: cb_plan_id
+            linearized_mesh_coord,                           // 9
+            l1_alignment,                                    // 10: route_info slot stride
+            writer_cb_size,                                  // 11: sender writer CB size (== read_batch_size)
+            static_cast<uint32_t>(tt::CBIndex::c_15),        // 12: cb_route_info_scratch_id
+            read_batch_size * operation_attributes.num_experts_per_tok,  // 13: meta_scratch_slots
         };
-        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(idle_writer_compile_args);
-        tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(idle_writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(untilize_writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(untilize_writer_compile_args);
 
-        CoreRangeSet single_idle_core({CoreRange(all_idle_cores[j])});
+        auto untilize_kernel_defines = fabric_defines;  // carries AXIS define if set
+
+        CoreRangeSet single_untilize_core({CoreRange(all_untilize_cores[j])});
         reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
             "reader_untilize_dispatch.cpp",
-            single_idle_core,
+            single_untilize_core,
             tt::tt_metal::DataMovementConfig{
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                .compile_args = idle_reader_compile_args}));
+                .compile_args = untilize_reader_compile_args,
+                .defines = untilize_kernel_defines}));
 
         writer_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
             "writer_untilize_dispatch.cpp",
-            single_idle_core,
+            single_untilize_core,
             tt::tt_metal::DataMovementConfig{
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-                .compile_args = idle_writer_compile_args}));
+                .compile_args = untilize_writer_compile_args}));
     }
 
-    // Compute kernel on idle cores
+    // Compute kernel on untilize cores
     tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
         "untilize_dispatch.cpp",
-        idle_core_grid,
+        untilize_core_grid,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
             .compile_args = {
                 static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
                 static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
-                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                (uint32_t)hidden_size,
-                read_batch_size,
-            }});
-
-    // Compute kernel on sender cores for self-untilize (output goes to c_18)
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
-        "untilize_dispatch.cpp",
-        sender_core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
-            .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
                 static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
                 (uint32_t)hidden_size,
                 read_batch_size,
@@ -695,27 +642,27 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
     }
 
-    // Per-sender multicast/idle info
-    struct SenderIdleCfg {
-        std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
+    // Per-sender multicast/untilize info
+    struct SenderuntilizeCfg {
+        std::vector<std::pair<uint32_t, uint32_t>> untilize_noc_coords;
         uint32_t mcast_x_start = 0, mcast_y_start = 0, mcast_x_end = 0, mcast_y_end = 0;
     };
-    std::vector<SenderIdleCfg> sender_idle_cfgs(num_cores);
+    std::vector<SenderuntilizeCfg> sender_untilize_cfgs(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
         bool first = true;
-        for (const auto& ic : sender_idle_groups[s]) {
+        for (const auto& ic : sender_untilize_groups[s]) {
             auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
             uint32_t nx = (uint32_t)noc.x, ny = (uint32_t)noc.y;
-            sender_idle_cfgs[s].idle_noc_coords.emplace_back(nx, ny);
+            sender_untilize_cfgs[s].untilize_noc_coords.emplace_back(nx, ny);
             if (first) {
-                sender_idle_cfgs[s].mcast_x_start = sender_idle_cfgs[s].mcast_x_end = nx;
-                sender_idle_cfgs[s].mcast_y_start = sender_idle_cfgs[s].mcast_y_end = ny;
+                sender_untilize_cfgs[s].mcast_x_start = sender_untilize_cfgs[s].mcast_x_end = nx;
+                sender_untilize_cfgs[s].mcast_y_start = sender_untilize_cfgs[s].mcast_y_end = ny;
                 first = false;
             } else {
-                sender_idle_cfgs[s].mcast_x_start = std::min(sender_idle_cfgs[s].mcast_x_start, nx);
-                sender_idle_cfgs[s].mcast_x_end = std::max(sender_idle_cfgs[s].mcast_x_end, nx);
-                sender_idle_cfgs[s].mcast_y_start = std::min(sender_idle_cfgs[s].mcast_y_start, ny);
-                sender_idle_cfgs[s].mcast_y_end = std::max(sender_idle_cfgs[s].mcast_y_end, ny);
+                sender_untilize_cfgs[s].mcast_x_start = std::min(sender_untilize_cfgs[s].mcast_x_start, nx);
+                sender_untilize_cfgs[s].mcast_x_end = std::max(sender_untilize_cfgs[s].mcast_x_end, nx);
+                sender_untilize_cfgs[s].mcast_y_start = std::min(sender_untilize_cfgs[s].mcast_y_start, ny);
+                sender_untilize_cfgs[s].mcast_y_end = std::max(sender_untilize_cfgs[s].mcast_y_end, ny);
             }
         }
     }
@@ -739,35 +686,35 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
 
     uint32_t core_idx = 0;
     for (const auto& sender_core : sender_cores) {
-        std::vector<uint32_t> reader_runtime_args = base_runtime_args;
+        // The j-th untilize core in all_untilize_cores corresponds to sender core_idx via the
+        // untilize_sender_map built earlier (1:1). Find it for NOC coord access.
+        uint32_t untilize_idx = 0;
+        for (uint32_t j = 0; j < num_untilize_cores; j++) {
+            if (untilize_sender_map[j] == core_idx) {
+                untilize_idx = j;
+                break;
+            }
+        }
+        auto untilize_noc =
+            mesh_device->virtual_core_from_logical_core(all_untilize_cores[untilize_idx], tt::CoreType::WORKER);
+        uint32_t untilize_noc_x = (uint32_t)untilize_noc.x;
+        uint32_t untilize_noc_y = (uint32_t)untilize_noc.y;
+
         std::vector<uint32_t> writer_runtime_args = base_runtime_args;
+        writer_runtime_args[11] = core_idx;  // dispatch_core_idx
 
-        reader_runtime_args[11] = core_idx;  // dispatch_core_idx
-        writer_runtime_args[11] = core_idx;
-
-        // Writer-only: exit semaphore address (separate from init_semaphore to avoid
-        // init/exit reuse race where a fast peer's exit-inc lands during the post-init
-        // set(0) window).
+        // Writer-only: exit semaphore address (avoids init/exit reuse race).
         writer_runtime_args.push_back((uint32_t)exit_semaphore.address());
 
-        // Inter-core sync args for reader
-        reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(addr_ready_semaphore_id);
-        reader_runtime_args.push_back(addr_value_semaphore_id);
-        reader_runtime_args.push_back(mbox_ready_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(mbox_scratch_addr_semaphore_id);
-
-        // Pass NOC coords of this sender's idle cores (for per-batch unicast start signal)
-        for (const auto& [noc_x, noc_y] : sender_idle_cfgs[core_idx].idle_noc_coords) {
-            reader_runtime_args.push_back(noc_x);
-            reader_runtime_args.push_back(noc_y);
-        }
-        // Bounding box for multicast of addr_value / addr_ready to the idle group
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_x_start);
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_y_start);
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_x_end);
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_y_end);
+        // ===== Sender writer (tile-layout): handshake + per-entry fabric send + credit =====
+        writer_runtime_args.push_back(addr_ready_semaphore_id);
+        writer_runtime_args.push_back(cross_c4_addr_semaphore_id);
+        writer_runtime_args.push_back(cross_c5_addr_semaphore_id);
+        writer_runtime_args.push_back(cross_c6_addr_semaphore_id);
+        writer_runtime_args.push_back(untilize_noc_x);
+        writer_runtime_args.push_back(untilize_noc_y);
+        writer_runtime_args.push_back(data_avail_semaphore_ids[core_idx]);
+        writer_runtime_args.push_back(space_avail_semaphore_ids[core_idx]);
 
         if (operation_attributes.num_links > 0) {
             uint32_t core_link = core_idx % num_links;
@@ -795,56 +742,58 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
             }
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[core_idx], sender_core, reader_runtime_args);
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
         core_idx++;
     }
 
-    // ==================== Runtime args for idle cores ====================
-    // The sender's c_18 L1 address is communicated at runtime: sender uses noc_async_write
-    // to copy it to each idle core's addr_value_sem, then signals addr_ready_sem.
-    // Reader only needs the input tensor address; writer owns the sender-sync semaphores
-    // and NOC coords.
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        uint32_t s = idle_sender_map[j];
+    // ==================== Runtime args for untilize cores ====================
+    for (uint32_t j = 0; j < num_untilize_cores; j++) {
+        uint32_t s = untilize_sender_map[j];
 
-        std::vector<uint32_t> idle_reader_rt_args = {
+        // Reader: tensor base addresses + token range
+        std::vector<uint32_t> untilize_reader_rt_args = {
             input_tensor.buffer()->address(),
+            indices_tensor.buffer()->address(),
+            weights_tensor.buffer()->address(),
+            offsets_tensor.buffer()->address(),
+            dispatch_table_tensor.buffer()->address(),
+            0u,                           // token_start_idx
+            (uint32_t)tokens_per_device,  // token_end_idx
         };
-        tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], all_idle_cores[j], idle_reader_rt_args);
+        tt::tt_metal::SetRuntimeArgs(
+            program, reader_untilize_kernel_ids[j], all_untilize_cores[j], untilize_reader_rt_args);
 
-        std::vector<uint32_t> idle_writer_rt_args = {
-            data_ready_semaphore_ids[s],
-            start_semaphore_ids[s],
+        // Writer: sender NOC coords, address-handshake semaphores, data_avail/space_avail, output/metadata tensors.
+        std::vector<uint32_t> untilize_writer_rt_args = {
             sender_noc_coords[s].first,
             sender_noc_coords[s].second,
             addr_ready_semaphore_id,
-            addr_value_semaphore_id,
-            // New:
+            cross_c4_addr_semaphore_id,
+            cross_c5_addr_semaphore_id,
+            cross_c6_addr_semaphore_id,
+            data_avail_semaphore_ids[s],
+            space_avail_semaphore_ids[s],
             output_tensor.buffer()->address(),
             metadata_tensor.buffer()->address(),
-            mbox_ready_semaphore_ids[s],
-            mbox_scratch_addr_semaphore_id,
         };
-        tt::tt_metal::SetRuntimeArgs(program, writer_untilize_kernel_ids[j], all_idle_cores[j], idle_writer_rt_args);
+        tt::tt_metal::SetRuntimeArgs(
+            program, writer_untilize_kernel_ids[j], all_untilize_cores[j], untilize_writer_rt_args);
     }
 
     return {
         std::move(program),
-        {.reader_kernel_ids = std::move(reader_kernel_ids),
+        {.reader_kernel_ids = {},
          .writer_kernel_id = writer_kernel_id,
          .reader_untilize_kernel_ids = std::move(reader_untilize_kernel_ids),
          .writer_untilize_kernel_ids = std::move(writer_untilize_kernel_ids),
          .cores = sender_cores,
-         .idle_cores = all_idle_cores,
+         .untilize_cores = all_untilize_cores,
          .init_semaphore = init_semaphore,
          .exit_semaphore = exit_semaphore,
-         .cross_device_semaphore = cross_device_semaphore,
-         .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
-         .start_semaphore_ids = std::move(start_semaphore_ids)}};
+         .cross_device_semaphore = cross_device_semaphore}};
 }
 
-// Row-major path: ROW_MAJOR inputs, single reader kernel per sender, no idle cores.
+// Row-major path: ROW_MAJOR inputs, single reader kernel per sender, no untilize cores.
 ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_major(
     const DispatchParams& operation_attributes,
     const MeshCoordinate& mesh_coordinate,
@@ -1222,12 +1171,10 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_maj
          .reader_untilize_kernel_ids = {},
          .writer_untilize_kernel_ids = {},
          .cores = sender_cores,
-         .idle_cores = {},
+         .untilize_cores = {},
          .init_semaphore = init_semaphore,
          .exit_semaphore = exit_semaphore,
-         .cross_device_semaphore = cross_device_semaphore,
-         .data_ready_semaphore_ids = {},
-         .start_semaphore_ids = {}}};
+         .cross_device_semaphore = cross_device_semaphore}};
 }
 
 }  // namespace
@@ -1323,19 +1270,22 @@ void DispatchProgramFactory::override_runtime_arguments(
 
         for (size_t s = 0; s < cores.size(); s++) {
             const auto& core = cores[s];
-            auto& reader_runtime_args =
-                tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_ids[s], core);
+            // Tile-layout has no sender reader RISC (writer drives both handshake and consume),
+            // so reader_kernel_ids is empty there.
+            if (!shared_variables.reader_kernel_ids.empty()) {
+                auto& reader_runtime_args =
+                    tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_ids[s], core);
+                reader_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
+                reader_runtime_args.at(1) = tensor_args.indices_tensor.buffer()->address();
+                reader_runtime_args.at(2) = tensor_args.weights_tensor.buffer()->address();
+                reader_runtime_args.at(3) = tensor_args.expert_offsets_tensor.buffer()->address();
+                reader_runtime_args.at(4) = output_tensor.buffer()->address();
+                reader_runtime_args.at(5) = metadata_tensor.buffer()->address();
+                reader_runtime_args.at(6) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
+                reader_runtime_args.at(7) = (uint32_t)shared_variables.cross_device_semaphore.address();
+                reader_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore.address();
+            }
             auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
-
-            reader_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
-            reader_runtime_args.at(1) = tensor_args.indices_tensor.buffer()->address();
-            reader_runtime_args.at(2) = tensor_args.weights_tensor.buffer()->address();
-            reader_runtime_args.at(3) = tensor_args.expert_offsets_tensor.buffer()->address();
-            reader_runtime_args.at(4) = output_tensor.buffer()->address();
-            reader_runtime_args.at(5) = metadata_tensor.buffer()->address();
-            reader_runtime_args.at(6) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
-            reader_runtime_args.at(7) = (uint32_t)shared_variables.cross_device_semaphore.address();
-            reader_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore.address();
 
             writer_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
             writer_runtime_args.at(1) = tensor_args.indices_tensor.buffer()->address();
@@ -1351,17 +1301,23 @@ void DispatchProgramFactory::override_runtime_arguments(
             writer_runtime_args.at(13) = (uint32_t)shared_variables.exit_semaphore.address();
         }
 
-        // Idle cores only exist on the tile-layout path.
+        // untilize cores only exist on the tile-layout path.
         if (is_tile_layout) {
-            for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
-                auto& idle_reader_rt_args = tt::tt_metal::GetRuntimeArgs(
-                    program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-                idle_reader_rt_args.at(0) = tensor_args.input_tensor.buffer()->address();
+            for (size_t i = 0; i < shared_variables.untilize_cores.size(); i++) {
+                auto& untilize_reader_rt_args = tt::tt_metal::GetRuntimeArgs(
+                    program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.untilize_cores[i]);
+                // Indices 0..4 = input, indices, weights, offsets, dispatch_table addresses.
+                untilize_reader_rt_args.at(0) = tensor_args.input_tensor.buffer()->address();
+                untilize_reader_rt_args.at(1) = tensor_args.indices_tensor.buffer()->address();
+                untilize_reader_rt_args.at(2) = tensor_args.weights_tensor.buffer()->address();
+                untilize_reader_rt_args.at(3) = tensor_args.expert_offsets_tensor.buffer()->address();
+                untilize_reader_rt_args.at(4) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
 
-                auto& idle_writer_rt_args = tt::tt_metal::GetRuntimeArgs(
-                    program, shared_variables.writer_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-                idle_writer_rt_args.at(6) = output_tensor.buffer()->address();
-                idle_writer_rt_args.at(7) = metadata_tensor.buffer()->address();
+                auto& untilize_writer_rt_args = tt::tt_metal::GetRuntimeArgs(
+                    program, shared_variables.writer_untilize_kernel_ids[i], shared_variables.untilize_cores[i]);
+                // Indices 8, 9 = output, metadata tensor addresses (after the 8 sync args).
+                untilize_writer_rt_args.at(8) = output_tensor.buffer()->address();
+                untilize_writer_rt_args.at(9) = metadata_tensor.buffer()->address();
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.hpp
@@ -20,13 +20,11 @@ struct DispatchSharedVariables {
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     std::vector<tt::tt_metal::KernelHandle> writer_untilize_kernel_ids;
     std::vector<CoreCoord> cores;
-    std::vector<CoreCoord> idle_cores;
+    std::vector<CoreCoord> untilize_cores;
     GlobalSemaphore init_semaphore;          // Initialized in create_at()
     GlobalSemaphore exit_semaphore;          // Separate sem for the exit handshake (avoids
                                              // init/exit reuse race; mirrors combine fix)
     GlobalSemaphore cross_device_semaphore;  // Initialized in create_at()
-    std::vector<uint32_t> data_ready_semaphore_ids;
-    std::vector<uint32_t> start_semaphore_ids;
 };
 
 struct DispatchProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -10,6 +10,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "api/debug/dprint.h"
+#include "tools/profiler/kernel_profiler.hpp"
 
 #define ENABLE_DISPATCH_DEBUG 0
 
@@ -48,16 +49,20 @@ void kernel_main() {
 
     while (true) {
         cb_reserve_back(cb_untilize_id, read_batch_size);
-        cb_wait_front(cb_signal_id, 1);
-        uint32_t val = read_tile_value(cb_signal_id, 0, 0);
-        cb_pop_front(cb_signal_id, 1);
-        if (val == ROUTE_INFO_SENTINEL) {
-            break;
+        {
+            DeviceZoneScopedN("compute_is_waiting") cb_wait_front(cb_signal_id, 1);
+            uint32_t val = read_tile_value(cb_signal_id, 0, 0);
+            cb_pop_front(cb_signal_id, 1);
+            if (val == ROUTE_INFO_SENTINEL) {
+                break;
+            }
         }
-        for (uint32_t block = 0; block < num_blocks; block++) {
-            cb_wait_front(cb_in_id, block_ct_dim);
-            pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in_id, 1, cb_untilize_id, block);
-            cb_pop_front(cb_in_id, block_ct_dim);
+        {
+            DeviceZoneScopedN("pack_untilize_block") for (uint32_t block = 0; block < num_blocks; block++) {
+                cb_wait_front(cb_in_id, block_ct_dim);
+                pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in_id, 1, cb_untilize_id, block);
+                cb_pop_front(cb_in_id, block_ct_dim);
+            }
         }
 
         cb_push_back(cb_untilize_id, read_batch_size);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -2,12 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//
+// Sender RISCV_1 kernel — row-major path only.
+//
+// This kernel is created only on the row-major dispatch path; the tile-layout path
+// runs without a sender reader RISC (the sender writer drives the address handshake
+// and credits untilize directly).
+//
+// Reads input/indices/weights, builds (route_info, payload, metadata) entries and
+// pushes them locally via cb_push_back for the fabric writer to drain.
+//
+
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
-
+#include "tools/profiler/kernel_profiler.hpp"
 #define ENABLE_DISPATCH_DEBUG 0
 
 #if ENABLE_DISPATCH_DEBUG
@@ -24,7 +35,6 @@ void kernel_main() {
     using namespace ttnn::operations::ccl::common;
 
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-9)
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_indices_id = get_compile_time_arg_val(1);
     constexpr uint32_t cb_weights_id = get_compile_time_arg_val(2);
@@ -36,7 +46,6 @@ void kernel_main() {
     constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(8);
     constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(9);
 
-    // Page counts (indices 10-16)
     constexpr uint32_t input_pages = get_compile_time_arg_val(10);
     constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
     constexpr uint32_t weights_pages = get_compile_time_arg_val(12);
@@ -45,14 +54,12 @@ void kernel_main() {
     constexpr uint32_t metadata_pages = get_compile_time_arg_val(15);
     constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(16);
 
-    // Page sizes (indices 17-23)
     constexpr uint32_t input_page_size = get_compile_time_arg_val(17);
     constexpr uint32_t indices_page_size = get_compile_time_arg_val(18);
     constexpr uint32_t weights_page_size = get_compile_time_arg_val(19);
     constexpr uint32_t output_page_size = get_compile_time_arg_val(21);
     constexpr uint32_t metadata_page_size = get_compile_time_arg_val(22);
 
-    // Operation parameters (indices 24-30)
     constexpr uint32_t num_devices = get_compile_time_arg_val(24);
     constexpr uint32_t hidden_size = get_compile_time_arg_val(25);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(26);
@@ -61,14 +68,12 @@ void kernel_main() {
     constexpr uint32_t metadata_len = get_compile_time_arg_val(29);
     constexpr uint32_t tokens_per_device = get_compile_time_arg_val(30);
 
-    // Mesh information (indices 31-35)
     constexpr uint32_t src_mesh_id = get_compile_time_arg_val(31);
     constexpr uint32_t src_chip_id = get_compile_time_arg_val(32);
     constexpr uint32_t mesh_rows = get_compile_time_arg_val(33);
     constexpr uint32_t mesh_cols = get_compile_time_arg_val(34);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(35);
 
-    // Aligned page sizes (indices 36-42)
     constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(36);
     constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(37);
     constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(38);
@@ -77,20 +82,14 @@ void kernel_main() {
     constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(41);
     constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(42);
 
-    // Fabric configuration (indices 43-46)
     constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(43);
     constexpr uint32_t l1_alignment = get_compile_time_arg_val(44);
     constexpr uint32_t num_links = get_compile_time_arg_val(45);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(46);
 
-    // Batch configuration (index 47)
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(47);
-
-    // Total dispatch buffer token capacity (shared across all local experts).
     constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(48);
 
-    // TensorAccessorArgs for all 7 tensors (starting at index 49, after the
-    // trailing max_dispatch_buffer_token_size arg).
     constexpr auto input_args = TensorAccessorArgs<49>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
@@ -98,25 +97,6 @@ void kernel_main() {
     constexpr auto output_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<metadata_args.next_compile_time_args_offset()>();
-
-#ifdef IS_TILE_LAYOUT
-    // Reader-only compile-time args (appended after TensorAccessorArgs)
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset());
-    constexpr uint32_t aligned_row_major_input_page_size =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 1);
-    constexpr uint32_t num_idle_cores =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 2);
-    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 3);
-    constexpr uint32_t total_workers =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 4);
-    constexpr uint32_t cb_route_table_scratch_id =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 5);
-
-    constexpr uint32_t tiles_per_row = hidden_size / 32;
-    constexpr uint32_t writer_page_size = aligned_row_major_input_page_size;
-#else
-    constexpr uint32_t writer_page_size = aligned_input_page_size;
-#endif
 
     // ===== Runtime Args =====
     uint32_t rt_args = 0;
@@ -135,43 +115,6 @@ void kernel_main() {
     uint32_t num_dispatch_cores = get_arg_val<uint32_t>(rt_args++);
     uint32_t core_mask = num_dispatch_cores - 1;
 
-#ifdef IS_TILE_LAYOUT
-    // Inter-core sync args
-    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t addr_value_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mbox_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mbox_scratch_addr_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-
-    volatile tt_l1_ptr uint32_t* data_ready_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(data_ready_semaphore_id));
-    uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
-    uint32_t addr_ready_sem_l1_offset = get_semaphore(addr_ready_semaphore_id);
-    uint32_t addr_value_sem_l1_offset = get_semaphore(addr_value_semaphore_id);
-
-    // Read per-idle-core NOC addresses for per-batch start signaling (unicast)
-    // x/y kept separately to build idle_mailbox_noc_addrs after the mbox_ready rendezvous.
-    uint64_t idle_start_noc_addrs[num_idle_cores];
-    uint32_t idle_noc_xs[num_idle_cores];
-    uint32_t idle_noc_ys[num_idle_cores];
-    for (uint32_t c = 0; c < num_idle_cores; c++) {
-        idle_noc_xs[c] = get_arg_val<uint32_t>(rt_args++);
-        idle_noc_ys[c] = get_arg_val<uint32_t>(rt_args++);
-        idle_start_noc_addrs[c] = get_noc_addr(idle_noc_xs[c], idle_noc_ys[c], start_sem_l1_offset);
-    }
-
-    // Bounding box covering all idle cores in this sender's group (for multicast)
-    uint32_t mcast_x_start = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mcast_y_start = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mcast_x_end = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mcast_y_end = get_arg_val<uint32_t>(rt_args++);
-    uint64_t mcast_addr_value_noc_addr =
-        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, addr_value_sem_l1_offset);
-    uint64_t mcast_addr_ready_noc_addr =
-        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, addr_ready_sem_l1_offset);
-#endif
-
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
     constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
@@ -187,14 +130,6 @@ void kernel_main() {
     constexpr uint32_t device_stride = 1;
 #endif
 
-    DPRINT_DISPATCH << "Reader kernel: tokens=[" << token_start_idx << "," << token_end_idx << ")"
-                    << " dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores
-#ifdef IS_TILE_LAYOUT
-                    << " num_idle_cores=" << num_idle_cores
-#endif
-                    << ENDL();
-
-    // Read offsets into local scratch
     const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address);
     cb_reserve_back(cb_offsets_id, offsets_pages);
     uint32_t offsets_base_addr = get_write_ptr(cb_offsets_id);
@@ -204,7 +139,6 @@ void kernel_main() {
     noc_async_read_barrier();
     tt_l1_ptr uint32_t* offsets = reinterpret_cast<tt_l1_ptr uint32_t*>(offsets_base_addr);
 
-    // Read dispatch table into local scratch
     const auto dispatch_table_addr_gen = TensorAccessor(dispatch_table_args, dispatch_table_tensor_address);
     cb_reserve_back(cb_dispatch_table_id, dispatch_table_pages);
     uint32_t dispatch_table_base_addr = get_write_ptr(cb_dispatch_table_id);
@@ -215,21 +149,10 @@ void kernel_main() {
     noc_async_read_barrier();
     tt_l1_ptr int32_t* expert_dispatch_table = reinterpret_cast<tt_l1_ptr int32_t*>(dispatch_table_base_addr);
 
-    // Reserve scratch space once — these CBs are not used as FIFOs. Each batch
-    // overwrites the same region at offsets [0, batch_count) without push/pop.
-    // DRAM reads are batched to saturate DRAM bandwidth, while the L1-to-writer-CB
-    // copies below are done one page at a time — this avoids CB FIFO pointer wrapping
     cb_reserve_back(cb_indices_id, read_batch_size);
     uint32_t indices_base = get_write_ptr(cb_indices_id);
     cb_reserve_back(cb_weights_id, read_batch_size);
     uint32_t weights_base = get_write_ptr(cb_weights_id);
-
-#ifdef IS_TILE_LAYOUT
-    const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, aligned_indices_page_size);
-    const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address, aligned_weights_page_size);
-    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address, aligned_output_page_size);
-    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, aligned_metadata_page_size);
-#else
     cb_reserve_back(cb_input_id, read_batch_size);
     uint32_t input_base = get_write_ptr(cb_input_id);
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address);
@@ -237,57 +160,10 @@ void kernel_main() {
     const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address);
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
-#endif
 
     cb_reserve_back(cb_metadata_temp_id, 1);
     uint32_t metadata_temp_addr = get_write_ptr(cb_metadata_temp_id);
 
-#ifdef IS_TILE_LAYOUT
-    uint32_t untilize_base = get_write_ptr(cb_untilize_id);
-    uint32_t rt_scratch_base = get_write_ptr(cb_route_table_scratch_id);
-
-    // Multicast two addresses to all idle cores in this sender's group before signaling addr_ready:
-    //   1. receive buffer address (c_18 base) → idle cores write untilized data here
-    //   2. route-table scratch base → idle cores NOC-write their mailbox L1 address into
-    //      slot [core_id * 4] of this buffer so the sender can read it locally (no NOC read).
-    volatile tt_l1_ptr uint32_t* addr_value_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr_value_sem_l1_offset);
-    *addr_value_ptr = untilize_base;
-    noc_async_write_multicast(addr_value_sem_l1_offset, mcast_addr_value_noc_addr, sizeof(uint32_t), num_idle_cores);
-
-    uint32_t mbox_scratch_addr_sem_l1_offset = get_semaphore(mbox_scratch_addr_semaphore_id);
-    volatile tt_l1_ptr uint32_t* mbox_scratch_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mbox_scratch_addr_sem_l1_offset);
-    *mbox_scratch_addr_ptr = rt_scratch_base;
-    uint64_t mcast_mbox_scratch_noc_addr =
-        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, mbox_scratch_addr_sem_l1_offset);
-    noc_async_write_multicast(
-        mbox_scratch_addr_sem_l1_offset, mcast_mbox_scratch_noc_addr, sizeof(uint32_t), num_idle_cores);
-    noc_async_write_barrier();
-    noc_semaphore_inc_multicast(mcast_addr_ready_noc_addr, 1, num_idle_cores);
-    noc_async_atomic_barrier();
-
-    // Wait for all idle cores to NOC-write their mailbox L1 addresses into rt_scratch_base.
-    // Because idle cores use noc_inline_dw_write (ordered before noc_semaphore_inc on the NOC),
-    // each slot is guaranteed to be visible in local L1 once mbox_ready reaches num_idle_cores.
-    volatile tt_l1_ptr uint32_t* mbox_ready_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(mbox_ready_semaphore_id));
-    noc_semaphore_wait(mbox_ready_sem_ptr, num_idle_cores);
-    noc_semaphore_set(mbox_ready_sem_ptr, 0);
-
-    // Read idle mailbox addresses directly from own L1 scratch — no NOC reads needed.
-    volatile tt_l1_ptr uint32_t* rt_scratch_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(rt_scratch_base);
-    uint64_t idle_mailbox_noc_addrs[num_idle_cores];
-    for (uint32_t c = 0; c < num_idle_cores; c++) {
-        idle_mailbox_noc_addrs[c] = get_noc_addr(idle_noc_xs[c], idle_noc_ys[c], rt_scratch_ptr[c]);
-    }
-
-    // Self-untilize setup: TensorAccessor for reading tiles from DRAM
-    const auto self_input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
-    constexpr uint32_t block_ct_dim = 8;
-    constexpr uint32_t num_tile_blocks = tiles_per_row / block_ct_dim;
-#else
-    // Prefetch first batch of DRAM reads
     uint32_t first_batch_end =
         (token_start_idx + read_batch_size < token_end_idx) ? token_start_idx + read_batch_size : token_end_idx;
     uint32_t first_batch_count = first_batch_end - token_start_idx;
@@ -299,9 +175,7 @@ void kernel_main() {
         }
         noc_async_read_barrier();
     }
-#endif
 
-    // ===== Unified batch loop =====
     uint32_t total_batches = (token_end_idx - token_start_idx + read_batch_size - 1) / read_batch_size;
     for (uint32_t B = 0; B < total_batches; B++) {
         uint32_t batch_start = token_start_idx + B * read_batch_size;
@@ -310,139 +184,12 @@ void kernel_main() {
         uint32_t batch_count = batch_end - batch_start;
         bool batch_did_local_write = false;
 
-#ifdef IS_TILE_LAYOUT
-        // Batch prep: delegate to idle core, or self-untilize locally.
-        uint32_t C = B % total_workers;
-
-        if (C < num_idle_cores) {
-            // ---- Worker-batch: delegate to idle core C ----
-            // Read indices/weights before building the route table so routing
-            // decisions are known before we signal the idle core.
-            for (uint32_t t = 0; t < batch_count; t++) {
-                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
-                noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
-            }
-            noc_async_read_barrier();
-
-            // Build local-expert route table into the route table scratch CB.
-            // Only LOCAL entries go in the mailbox; cross-device entries are
-            // handled by the sender's main routing loop as normal.
-            // We track per-expert offset increments locally to mirror the main
-            // loop without touching the shared offsets[] array.
-            uint32_t local_offset_delta[n_routed_experts] = {};
-            volatile tt_l1_ptr uint32_t* rt = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(rt_scratch_base);
-            uint32_t entry_count = 0;
-            bool has_non_local = false;
-
-            for (uint32_t t = 0; t < batch_count; t++) {
-                tt_l1_ptr int32_t* indices_t =
-                    reinterpret_cast<tt_l1_ptr int32_t*>(indices_base + t * aligned_indices_page_size);
-                tt_l1_ptr uint16_t* weights_t =
-                    reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
-                for (uint32_t k = 0; k < num_experts_per_tok; k++) {
-                    auto routed_expert = indices_t[k];
-                    if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
-                        continue;
-                    }
-                    auto expert_chip_og = expert_dispatch_table[routed_expert];
-                    if (expert_chip_og == -1) {
-                        continue;
-                    }
-                    // Mirror offset++ from main loop (covers both overflow and valid paths)
-                    uint32_t effective_offset = offsets[routed_expert] + local_offset_delta[routed_expert];
-                    local_offset_delta[routed_expert]++;
-
-                    if (effective_offset >= max_dispatch_buffer_token_size) {
-                        continue;
-                    }
-                    auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
-                    if (expert_chip != linearized_mesh_coord) {
-                        has_non_local = true;
-                        continue;  // cross-device: sender handles in main routing loop
-                    }
-                    auto page_idx = effective_offset;
-
-                    uint32_t base = 1 + entry_count * 6;
-                    rt[base + 0] = t;
-                    rt[base + 1] = (uint32_t)page_idx;
-                    rt[base + 2] = batch_start + t;
-                    rt[base + 3] = k;
-                    rt[base + 4] = (uint32_t)routed_expert;
-                    rt[base + 5] = (uint32_t)(int32_t)(int16_t)weights_t[k];
-                    entry_count++;
-                }
-            }
-            // High bit signals the idle core whether to bulk-send back to us.
-            rt[0] = entry_count | (has_non_local ? 0x80000000u : 0u);
-
-            // Write route table to idle core's mailbox, then signal start.
-            uint32_t mailbox_write_bytes = sizeof(uint32_t) + entry_count * 6 * sizeof(uint32_t);
-            noc_async_write(rt_scratch_base, idle_mailbox_noc_addrs[C], mailbox_write_bytes);
-            noc_async_write_barrier();
-
-            noc_semaphore_inc(idle_start_noc_addrs[C], 1);
-            noc_async_atomic_barrier();
-
-            // Only wait if the idle core will actually send data back.
-            if (has_non_local) {
-                DPRINT_DISPATCH << "Waiting for idle core " << C << " batch " << B << ENDL();
-                noc_semaphore_wait(data_ready_sem_ptr, 1);
-                noc_semaphore_set(data_ready_sem_ptr, 0);
-                DPRINT_DISPATCH << "Got batch " << B << " from idle core " << C << ENDL();
-            }
-        } else {
-            // ---- Self-batch: read tiles, untilize locally, no NOC transfer ----
-            DPRINT_DISPATCH << "Self-untilize batch " << B << ENDL();
-            uint32_t tile_base_page = B * tiles_per_row;
-
-            // Signal compute to untilize (before streaming tiles so compute is ready)
-            cb_reserve_back(cb_signal_id, 1);
-            volatile tt_l1_ptr uint32_t* signal_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-            signal_ptr[0] = 0x00000000;
-            cb_push_back(cb_signal_id, 1);
-
-            // Stream tiles in blocks of 8 — compute consumes each block as it arrives
-            for (uint32_t blk = 0; blk < num_tile_blocks; blk++) {
-                cb_reserve_back(cb_input_id, block_ct_dim);
-                uint32_t blk_write_ptr = get_write_ptr(cb_input_id);
-                uint32_t blk_start = tile_base_page + blk * block_ct_dim;
-                for (uint32_t col = 0; col < block_ct_dim; col++) {
-                    noc_async_read_page(
-                        blk_start + col, self_input_addr_gen, blk_write_ptr + col * aligned_input_page_size);
-                }
-                noc_async_read_barrier();
-                cb_push_back(cb_input_id, block_ct_dim);
-            }
-
-            // Overlap reads with compute
-            for (uint32_t t = 0; t < batch_count; t++) {
-                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
-                noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
-            }
-
-            // Wait for compute to finish (it writes untilized data into cb_untilize_id / c_18)
-            cb_wait_front(cb_untilize_id, read_batch_size);
-            noc_async_read_barrier();
-            DPRINT_DISPATCH << "Self-untilize batch " << B << " done" << ENDL();
-        }
-#endif
-
-        // ---- Common inner token loop ----
-#ifdef IS_TILE_LAYOUT
-        bool is_delegated_batch = (C < num_idle_cores);
-#endif
         for (uint32_t t = 0; t < batch_count; t++) {
             uint32_t token_idx = batch_start + t;
-#ifdef IS_TILE_LAYOUT
-            uint32_t token_input_addr = untilize_base + t * writer_page_size;
-#else
             uint32_t token_input_addr = input_base + t * aligned_input_page_size;
-#endif
-            tt_l1_ptr int32_t* indices =
-                reinterpret_cast<tt_l1_ptr int32_t*>(indices_base + t * aligned_indices_page_size);
-            tt_l1_ptr uint16_t* weights =
-                reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
+
+            int32_t* indices = (int32_t*)(indices_base + t * aligned_indices_page_size);
+            uint16_t* weights = (uint16_t*)(weights_base + t * aligned_weights_page_size);
 
             for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
                 auto routed_expert = indices[k];
@@ -458,19 +205,12 @@ void kernel_main() {
                 auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
                 auto& offset = offsets[routed_expert];
                 if (offset >= max_dispatch_buffer_token_size) {
-                    // Token would overflow the dispatch buffer - skip to prevent
-                    // out-of-bounds DRAM writes that corrupt memory and cause hangs.
                     offset++;
                     continue;
                 }
                 auto page_idx = offset;
 
                 if (expert_chip == linearized_mesh_coord) {
-#ifdef IS_TILE_LAYOUT
-                    // For delegated batches the idle core's writer kernel handles
-                    // local DRAM writes directly; skip them here.
-                    if (!is_delegated_batch)
-#endif
                     {
                         volatile tt_l1_ptr int32_t* metadata =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
@@ -502,7 +242,7 @@ void kernel_main() {
 
                         cb_reserve_back(cb_payload_for_writer_id, 1);
                         uint32_t payload_dst = get_write_ptr(cb_payload_for_writer_id);
-                        noc_async_read(get_noc_addr(token_input_addr), payload_dst, writer_page_size);
+                        noc_async_read(get_noc_addr(token_input_addr), payload_dst, aligned_input_page_size);
                         noc_async_read_barrier();
                         cb_push_back(cb_payload_for_writer_id, 1);
 
@@ -522,16 +262,6 @@ void kernel_main() {
             }
         }
 
-#ifdef IS_TILE_LAYOUT
-        if (batch_did_local_write) {
-            noc_async_write_barrier();
-        }
-        // Release CB after self-batch so compute can reuse it next time
-        if (C >= num_idle_cores) {
-            cb_pop_front(cb_untilize_id, read_batch_size);
-        }
-#else
-        // Issue next batch DRAM reads BEFORE write barrier to overlap read/write NOC channels
         uint32_t next_batch_start = batch_start + read_batch_size;
         bool has_next_batch = (next_batch_start < token_end_idx);
         if (has_next_batch) {
@@ -555,25 +285,15 @@ void kernel_main() {
         if (has_next_batch) {
             noc_async_read_barrier();
         }
-#endif
     }
 
-#ifdef IS_TILE_LAYOUT
-    // Signal compute to exit
-    cb_reserve_back(cb_signal_id, 1);
-    volatile tt_l1_ptr uint32_t* signal_sentinel =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-    signal_sentinel[0] = ROUTE_INFO_SENTINEL;
-    cb_push_back(cb_signal_id, 1);
-#endif
-
-    // Push sentinel to signal writer that all dispatches are done
+    // Sentinel: row-major sender reader still drives the local writer through c_4 sentinel.
     cb_reserve_back(cb_route_info_id, 1);
-    volatile tt_l1_ptr uint32_t* route_info =
+    volatile tt_l1_ptr uint32_t* sentinel_route_info =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
-    route_info[0] = ROUTE_INFO_SENTINEL;
-    route_info[1] = 0;
-    route_info[2] = 0;
-    route_info[3] = 0;
+    sentinel_route_info[0] = ROUTE_INFO_SENTINEL;
+    sentinel_route_info[1] = 0;
+    sentinel_route_info[2] = 0;
+    sentinel_route_info[3] = 0;
     cb_push_back(cb_route_info_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -3,23 +3,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Reader kernel for idle (worker) cores in the dispatch op.
-// Pairs with writer_untilize_dispatch.cpp running on the other data-movement
-// RISC — this kernel focuses on streaming tiled input from DRAM so the writer
-// can overlap NOC-writes to the owning sender with the next batch's reads.
+// Untilize core RISCV_1 — input prefetch + per-token routing.
 //
-// Token batches are distributed round-robin across total_workers (k_s idle
-// cores + the sender itself). Core i processes batches i, i+total_workers, …
+// At startup: read the full expert offsets[] and expert dispatch_table[] tensors
+// from DRAM into local L1 scratch (c_3, c_9). offsets[] is owned and mutated
+// exclusively by this RISC — there is no cross-core synchronization because each
+// sender (and thus its single owning untilize core) processes a disjoint set of
+// experts via the dispatch_core_idx & core_mask filter.
 //
-// For each assigned batch:
-//   1. Signal compute to start untilizing this batch (cb_signal_id).
-//   2. Read tiled input stripe from DRAM → cb_input_id, block_ct_dim tiles at a time.
+// Per batch:
+//   1. Signal compute to untilize this batch (existing).
+//   2. Stream tiled input from DRAM → c_0 (existing).
+//   3. Read this batch's indices and weights pages from DRAM → c_1, c_2.
+//   4. Walk each token's top-k:
+//        * filter out experts not handled by this sender (core_mask),
+//        * filter out experts with dispatch_table == -1,
+//        * compute page_idx from the local offsets[expert] counter (mirrors what
+//          the old sender's main routing loop did),
+//        * classify local vs cross-device, record route/distance for cross-device.
+//      Build the per-batch route plan into c_14.
+//   5. cb_push_back(c_14) — writer RISC drains the plan and executes the data
+//      movement (NOC1 → DRAM for local, 2-slot push to sender c_4/c_5/c_6 for
+//      cross-device).
+//
+// After the last batch: push a single sentinel entry on c_14 so the writer
+// knows to forward the final ROUTE_INFO_SENTINEL to the sender.
 //
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
-
+#include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
 #define ENABLE_DISPATCH_DEBUG 0
 #if ENABLE_DISPATCH_DEBUG
 #define DPRINT_DISPATCH DPRINT
@@ -30,8 +46,25 @@
 #endif
 
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;
+constexpr uint32_t PLAN_FLAG_END = 0x80000000u;
+constexpr uint32_t PLAN_ENTRY_U32S = 8;
+
+// Plan entry layout (8 u32 = 32 bytes):
+//   [0] flags (bit 0: is_local, bit 31: end-of-plan sentinel)
+//   [1] token_t           (offset in c_11 batch — 0..read_batch_size-1)
+//   [2] routed_expert
+//   [3] page_idx          (DRAM page for local + remote)
+//   [4] token_idx         (global token index, for metadata)
+//   [5] (k << 16) | (weight & 0xFFFF)
+//   [6] route             (cross-device only)
+//   [7] distance          (cross-device only)
+//
+// Page layout: [entry_count u32][padding][entries...]
 
 void kernel_main() {
+    using namespace ttnn::operations::ccl::common;
+
     // ===== Compile-time args =====
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(1);
@@ -40,21 +73,104 @@ void kernel_main() {
     constexpr uint32_t total_batches = get_compile_time_arg_val(4);
     constexpr uint32_t core_id = get_compile_time_arg_val(5);
     constexpr uint32_t total_workers = get_compile_time_arg_val(6);
-    constexpr auto input_args = TensorAccessorArgs<7>();
+
+    constexpr uint32_t cb_indices_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_weights_id = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_plan_id = get_compile_time_arg_val(11);
+
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(12);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(14);
+    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(16);
+
+    constexpr uint32_t offsets_pages = get_compile_time_arg_val(17);
+    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(18);
+
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(19);
+    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(20);
+    constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(21);
+    constexpr uint32_t dispatch_core_idx = get_compile_time_arg_val(22);
+    constexpr uint32_t num_dispatch_cores = get_compile_time_arg_val(23);
+    constexpr uint32_t core_mask = num_dispatch_cores - 1;
+
+    constexpr uint32_t num_devices = get_compile_time_arg_val(24);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(25);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(26);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(27);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(28);
+
+    constexpr auto input_args = TensorAccessorArgs<29>();
+    constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+    constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
+    constexpr auto dispatch_table_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t tiles_per_row = hidden_size / 32;
     constexpr uint32_t block_ct_dim = 8;
     constexpr uint32_t num_tile_blocks = tiles_per_row / block_ct_dim;
 
+#ifdef AXIS
+    constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
+    constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
+    constexpr uint32_t col = linearized_mesh_coord % mesh_cols;
+    constexpr uint32_t device_begin_idx = axis == ReplicateGroup::COLS ? col : row * mesh_cols;
+    constexpr uint32_t device_stride = axis == ReplicateGroup::COLS ? mesh_cols : 1;
+#else
+    constexpr ReplicateGroup axis = ReplicateGroup::NONE;
+    constexpr uint32_t device_begin_idx = 0;
+    constexpr uint32_t device_stride = 1;
+#endif
+
     // ===== Runtime args =====
-    uint32_t input_tensor_address = get_arg_val<uint32_t>(0);
+    uint32_t rt_idx = 0;
+    uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t weights_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t offsets_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t dispatch_table_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t token_start_idx = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t token_end_idx = get_arg_val<uint32_t>(rt_idx++);
 
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
+    const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, aligned_indices_page_size);
+    const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address, aligned_weights_page_size);
+    const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address);
+    const auto dispatch_table_addr_gen = TensorAccessor(dispatch_table_args, dispatch_table_tensor_address);
 
+    // ===== Startup: load offsets[] and dispatch_table[] into local L1 =====
+    cb_reserve_back(cb_offsets_id, offsets_pages);
+    uint32_t offsets_base_addr = get_write_ptr(cb_offsets_id);
+    for (uint32_t i = 0; i < offsets_pages; i++) {
+        noc_async_read_page(i, offsets_addr_gen, offsets_base_addr + i * aligned_offsets_page_size);
+    }
+    cb_reserve_back(cb_dispatch_table_id, dispatch_table_pages);
+    uint32_t dispatch_table_base_addr = get_write_ptr(cb_dispatch_table_id);
+    for (uint32_t i = 0; i < dispatch_table_pages; i++) {
+        noc_async_read_page(
+            i, dispatch_table_addr_gen, dispatch_table_base_addr + i * aligned_dispatch_table_page_size);
+    }
+    noc_async_read_barrier();
+    uint32_t* offsets = reinterpret_cast<uint32_t*>(offsets_base_addr);
+    int32_t* expert_dispatch_table = reinterpret_cast<int32_t*>(dispatch_table_base_addr);
+
+    // ===== Indices / weights scratch (overwritten per batch, single page slot used) =====
+    cb_reserve_back(cb_indices_id, read_batch_size);
+    uint32_t indices_base = get_write_ptr(cb_indices_id);
+    cb_reserve_back(cb_weights_id, read_batch_size);
+    uint32_t weights_base = get_write_ptr(cb_weights_id);
+
+    // ===== Per-batch loop — this core handles batches core_id, core_id+total_workers, ... =====
     for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
         uint32_t tile_base_page = batch_idx * tiles_per_row;
+        uint32_t batch_start = batch_idx * read_batch_size;
+        uint32_t batch_end =
+            (batch_start + read_batch_size < token_end_idx) ? batch_start + read_batch_size : token_end_idx;
+        uint32_t batch_count = batch_end - batch_start;
 
-        // 1. Signal compute to untilize this batch (before streaming tiles so compute is ready)
+        // 1. Signal compute to start untilizing this batch
         cb_reserve_back(cb_signal_id, 1);
         volatile tt_l1_ptr uint32_t* signal_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
@@ -62,22 +178,112 @@ void kernel_main() {
         cb_push_back(cb_signal_id, 1);
 
         // 2. Stream tiled input stripe from DRAM in blocks of 8 tiles
-        for (uint32_t blk = 0; blk < num_tile_blocks; blk++) {
-            cb_reserve_back(cb_input_id, block_ct_dim);
-            uint32_t blk_write_ptr = get_write_ptr(cb_input_id);
-            uint32_t blk_start = tile_base_page + blk * block_ct_dim;
-            for (uint32_t col = 0; col < block_ct_dim; col++) {
-                noc_async_read_page(blk_start + col, input_addr_gen, blk_write_ptr + col * aligned_input_page_size);
+        {
+            DeviceZoneScopedN("read_input_for_current_batch") for (uint32_t blk = 0; blk < num_tile_blocks; blk++) {
+                cb_reserve_back(cb_input_id, block_ct_dim);
+                uint32_t blk_write_ptr = get_write_ptr(cb_input_id);
+                uint32_t blk_start = tile_base_page + blk * block_ct_dim;
+                for (uint32_t col = 0; col < block_ct_dim; col++) {
+                    noc_async_read_page(blk_start + col, input_addr_gen, blk_write_ptr + col * aligned_input_page_size);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_input_id, block_ct_dim);
+            }
+        }
+
+        // 3. Read this batch's indices and weights pages
+        {
+            DeviceZoneScopedN("read_indices_and_weights") for (uint32_t t = 0; t < batch_count; t++) {
+                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
+                noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
             }
             noc_async_read_barrier();
-            cb_push_back(cb_input_id, block_ct_dim);
         }
+
+        // 4. Build per-batch route plan into c_14.
+        cb_reserve_back(cb_plan_id, 1);
+        uint32_t plan_addr = get_write_ptr(cb_plan_id);
+        volatile tt_l1_ptr uint32_t* plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(plan_addr);
+        uint32_t entry_count = 0;
+        uint32_t entry_off = 8;  // entries start at u32 offset 8 (32B header)
+
+        {
+            DeviceZoneScopedN("build_plan_for_32_tokens") for (uint32_t t = 0; t < batch_count; t++) {
+                int32_t* indices_t = reinterpret_cast<int32_t*>(indices_base + t * aligned_indices_page_size);
+                uint16_t* weights_t = reinterpret_cast<uint16_t*>(weights_base + t * aligned_weights_page_size);
+                uint32_t token_idx = batch_start + t;
+
+                for (uint32_t k = 0; k < num_experts_per_tok; k++) {
+                    int32_t routed_expert = indices_t[k];
+                    if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
+                        continue;
+                    }
+                    int32_t expert_chip_og = expert_dispatch_table[routed_expert];
+                    if (expert_chip_og == -1) {
+                        continue;
+                    }
+
+                    uint32_t& offset = offsets[routed_expert];
+                    if (offset >= max_dispatch_buffer_token_size) {
+                        offset++;
+                        continue;
+                    }
+                    uint32_t page_idx = offset;
+                    offset++;
+
+                    uint32_t expert_chip = device_begin_idx + (uint32_t)expert_chip_og * device_stride;
+                    bool is_local = (expert_chip == linearized_mesh_coord);
+                    int16_t weight = (int16_t)weights_t[k];
+
+                    uint32_t base = entry_off;
+                    plan[base + 0] = is_local ? PLAN_FLAG_LOCAL : 0;
+                    plan[base + 1] = t;
+                    plan[base + 2] = (uint32_t)routed_expert;
+                    plan[base + 3] = page_idx;
+                    plan[base + 4] = token_idx;
+                    plan[base + 5] = (k << 16) | ((uint32_t)(uint16_t)weight);
+
+                    if (!is_local) {
+                        if constexpr (is_1d_topology<topology>()) {
+                            uint32_t route =
+                                get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
+                            uint32_t distance =
+                                manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
+                            plan[base + 6] = route;
+                            plan[base + 7] = distance;
+                        } else {
+                            plan[base + 6] = 0;
+                            plan[base + 7] = 0;
+                        }
+                    } else {
+                        plan[base + 6] = 0;
+                        plan[base + 7] = 0;
+                    }
+
+                    entry_count++;
+                    entry_off += PLAN_ENTRY_U32S;
+                }
+            }
+        }
+
+        plan[0] = entry_count;
+        cb_push_back(cb_plan_id, 1);
+
+        DPRINT_DISPATCH << "Reader untilize batch=" << batch_idx << " entries=" << entry_count << ENDL();
     }
 
-    // Send sentinel to compute to break out of its loop
+    // Send sentinel to compute so it breaks out of its loop
     cb_reserve_back(cb_signal_id, 1);
     volatile tt_l1_ptr uint32_t* signal_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
     signal_ptr[0] = ROUTE_INFO_SENTINEL;
     cb_push_back(cb_signal_id, 1);
+
+    // Push end-of-plan sentinel for the writer so it forwards ROUTE_INFO_SENTINEL to sender.
+    cb_reserve_back(cb_plan_id, 1);
+    uint32_t sentinel_addr = get_write_ptr(cb_plan_id);
+    volatile tt_l1_ptr uint32_t* sentinel_plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sentinel_addr);
+    sentinel_plan[0] = 0;  // entry_count
+    sentinel_plan[8] = PLAN_FLAG_END;
+    cb_push_back(cb_plan_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -2,6 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//
+// Sender RISCV_0 kernel — fabric writer.
+//
+// Tile layout (IS_TILE_LAYOUT): per-entry pipeline with no sender reader RISC. This
+// kernel owns:
+//   1. Startup address handshake to the untilize core (publishes c_4/c_5/c_6 base
+//      L1 addresses, then NOC-incs untilize's addr_ready semaphore).
+//   2. Fabric init / send.
+//   3. Per-entry direct-consume of writer CBs (c_4/c_5/c_6, writer_cb_size slots each):
+//        - noc_semaphore_wait_min(data_avail, consumed+1)
+//        - read route_info[0] at slot = consumed % writer_cb_size
+//        - ROUTE_INFO_SENTINEL: break.
+//        - regular: fabric-send payload + metadata from the slot; flush; NOC-inc
+//          untilize's space_avail directly so the slot becomes refillable.
+//
+// Row-major layout (no IS_TILE_LAYOUT): standard cb_wait_front / cb_pop_front on
+// c_4 / c_5 / c_6 pushed by the row-major sender reader.
+//
+
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
@@ -9,7 +28,7 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
-
+#include "tools/profiler/kernel_profiler.hpp"
 #define ENABLE_DISPATCH_DEBUG 0
 
 #if ENABLE_DISPATCH_DEBUG
@@ -26,7 +45,6 @@ void kernel_main() {
     using namespace ttnn::operations::ccl::common;
 
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-9)
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_indices_id = get_compile_time_arg_val(1);
     constexpr uint32_t cb_weights_id = get_compile_time_arg_val(2);
@@ -38,7 +56,6 @@ void kernel_main() {
     constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(8);
     constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(9);
 
-    // Page counts (indices 10-16)
     constexpr uint32_t input_pages = get_compile_time_arg_val(10);
     constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
     constexpr uint32_t weights_pages = get_compile_time_arg_val(12);
@@ -47,7 +64,6 @@ void kernel_main() {
     constexpr uint32_t metadata_pages = get_compile_time_arg_val(15);
     constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(16);
 
-    // Page sizes (indices 17-23)
     constexpr uint32_t input_page_size = get_compile_time_arg_val(17);
     constexpr uint32_t indices_page_size = get_compile_time_arg_val(18);
     constexpr uint32_t weights_page_size = get_compile_time_arg_val(19);
@@ -56,7 +72,6 @@ void kernel_main() {
     constexpr uint32_t metadata_page_size = get_compile_time_arg_val(22);
     constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(23);
 
-    // Operation parameters (indices 24-30)
     constexpr uint32_t num_devices = get_compile_time_arg_val(24);
     constexpr uint32_t hidden_size = get_compile_time_arg_val(25);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(26);
@@ -65,14 +80,12 @@ void kernel_main() {
     constexpr uint32_t metadata_len = get_compile_time_arg_val(29);
     constexpr uint32_t tokens_per_device = get_compile_time_arg_val(30);
 
-    // Mesh information (indices 31-35)
     constexpr uint32_t src_mesh_id = get_compile_time_arg_val(31);
     constexpr uint32_t src_chip_id = get_compile_time_arg_val(32);
     constexpr uint32_t mesh_rows = get_compile_time_arg_val(33);
     constexpr uint32_t mesh_cols = get_compile_time_arg_val(34);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(35);
 
-    // Aligned page sizes (indices 36-42)
     constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(36);
     constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(37);
     constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(38);
@@ -81,16 +94,11 @@ void kernel_main() {
     constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(41);
     constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(42);
 
-    // Fabric configuration (indices 43-46)
     constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(43);
     constexpr uint32_t l1_alignment = get_compile_time_arg_val(44);
     constexpr uint32_t num_links = get_compile_time_arg_val(45);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(46);
 
-    // Batch configuration (index 47) — read_batch_size not used by writer
-    // Index 48 — max_dispatch_buffer_token_size (used by reader only)
-
-    // TensorAccessorArgs for all 7 tensors (starting at index 49)
     constexpr auto input_args = TensorAccessorArgs<49>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
@@ -98,6 +106,13 @@ void kernel_main() {
     constexpr auto output_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<metadata_args.next_compile_time_args_offset()>();
+
+#ifdef IS_TILE_LAYOUT
+    // Writer-only tile-layout extras appended after the shared TensorAccessorArgs prefix.
+    constexpr uint32_t writer_extra_args_base = dispatch_table_args.next_compile_time_args_offset();
+    constexpr uint32_t writer_cb_size = get_compile_time_arg_val(writer_extra_args_base + 0);  // == read_batch_size
+    constexpr uint32_t route_info_slot_stride = l1_alignment;
+#endif
 
     // ===== Runtime Args =====
     size_t rt_args_idx = 0;
@@ -114,11 +129,18 @@ void kernel_main() {
     uint32_t token_end_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t dispatch_core_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t num_dispatch_cores = get_arg_val<uint32_t>(rt_args_idx++);
-    // Separate semaphore for the exit handshake. Reusing init_semaphore_address
-    // for both phases is racy: a fast partner's exit-inc can land inside the
-    // post-init noc_semaphore_set(0) window and get wiped, deadlocking the
-    // pair on dispatch_devices==2 (mesh-2x4 column pair). Mirrors the combine fix.
     uint32_t exit_semaphore_address = get_arg_val<uint32_t>(rt_args_idx++);
+
+#ifdef IS_TILE_LAYOUT
+    uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t cross_c4_addr_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t cross_c5_addr_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t cross_c6_addr_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t untilize_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t untilize_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t data_avail_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t space_avail_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+#endif
 
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
@@ -130,6 +152,40 @@ void kernel_main() {
 
     DPRINT_DISPATCH << "Writer kernel: dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores
                     << " dispatch_devices=" << dispatch_devices << ENDL();
+
+#ifdef IS_TILE_LAYOUT
+    // c_4/c_5/c_6 base addresses (slot s at base + s * <stride>).
+    uint32_t writer_route_base = get_write_ptr(cb_route_info_id);
+    uint32_t writer_payload_base = get_write_ptr(cb_payload_for_writer_id);
+    uint32_t writer_metadata_base = get_write_ptr(cb_metadata_for_writer_id);
+
+    // Address handshake to untilize: stash bases into the local cross_c{4,5,6}_addr
+    // scratch slots (used as 1×u32 mailboxes), NOC-write them into the matching
+    // slots on untilize's L1, then NOC-inc untilize's addr_ready semaphore.
+    uint32_t addr_ready_sem_l1_offset = get_semaphore(addr_ready_semaphore_id);
+    uint32_t cross_c4_addr_sem_l1_offset = get_semaphore(cross_c4_addr_semaphore_id);
+    uint32_t cross_c5_addr_sem_l1_offset = get_semaphore(cross_c5_addr_semaphore_id);
+    uint32_t cross_c6_addr_sem_l1_offset = get_semaphore(cross_c6_addr_semaphore_id);
+
+    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cross_c4_addr_sem_l1_offset) = writer_route_base;
+    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cross_c5_addr_sem_l1_offset) = writer_payload_base;
+    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cross_c6_addr_sem_l1_offset) = writer_metadata_base;
+
+    uint64_t untilize_c4_addr_noc_addr = get_noc_addr(untilize_noc_x, untilize_noc_y, cross_c4_addr_sem_l1_offset);
+    uint64_t untilize_c5_addr_noc_addr = get_noc_addr(untilize_noc_x, untilize_noc_y, cross_c5_addr_sem_l1_offset);
+    uint64_t untilize_c6_addr_noc_addr = get_noc_addr(untilize_noc_x, untilize_noc_y, cross_c6_addr_sem_l1_offset);
+    noc_async_write(cross_c4_addr_sem_l1_offset, untilize_c4_addr_noc_addr, sizeof(uint32_t));
+    noc_async_write(cross_c5_addr_sem_l1_offset, untilize_c5_addr_noc_addr, sizeof(uint32_t));
+    noc_async_write(cross_c6_addr_sem_l1_offset, untilize_c6_addr_noc_addr, sizeof(uint32_t));
+    noc_async_write_barrier();
+
+    uint64_t untilize_addr_ready_noc_addr = get_noc_addr(untilize_noc_x, untilize_noc_y, addr_ready_sem_l1_offset);
+    noc_semaphore_inc(untilize_addr_ready_noc_addr, 1);
+    noc_async_atomic_barrier();
+
+    DPRINT_DISPATCH << "Sender writer: addr handshake complete to untilize (" << untilize_noc_x << "," << untilize_noc_y
+                    << ")" << ENDL();
+#endif
 
 #ifdef DEST_CHIP_ID
     constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
@@ -146,7 +202,6 @@ void kernel_main() {
 
     open_direction_connections_barrier(directions, fabric_connections);
 
-    // Init semaphore exchange
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
     send_init_semaphore_to_configured_targets<
         linearized_mesh_coord,
@@ -160,14 +215,67 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
     noc_semaphore_wait(init_sem_ptr, dispatch_devices - 1);
     noc_semaphore_set(init_sem_ptr, 0);
-
     DPRINT_DISPATCH << "Fabric setup complete" << ENDL();
 #endif
 
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
 
-    // Sentinel-terminated fabric send loop
+#ifdef IS_TILE_LAYOUT
+    volatile tt_l1_ptr uint32_t* data_avail_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(data_avail_semaphore_id));
+    uint64_t untilize_space_avail_noc_addr =
+        get_noc_addr(untilize_noc_x, untilize_noc_y, get_semaphore(space_avail_semaphore_id));
+
+    uint32_t consumed_count = 0;
+    while (true) {
+        noc_semaphore_wait_min(data_avail_sem_ptr, consumed_count + 1);
+
+        uint32_t slot = consumed_count % writer_cb_size;
+        uint32_t route_addr = writer_route_base + slot * route_info_slot_stride;
+        volatile tt_l1_ptr uint32_t* route_info = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(route_addr);
+        uint32_t route = route_info[0];
+
+        if (route == ROUTE_INFO_SENTINEL) {
+            break;
+        }
+
+        uint32_t distance = route_info[1];
+        uint32_t page_idx = route_info[2];
+        uint32_t payload_addr = writer_payload_base + slot * aligned_output_page_size;
+        uint32_t metadata_addr = writer_metadata_base + slot * aligned_metadata_page_size;
+
+        DPRINT_DISPATCH << "Fabric send: route=" << route << " distance=" << distance << " page_idx=" << page_idx
+                        << ENDL();
+
+#ifdef DEST_CHIP_ID
+        fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
+        fabric_send_noc_unicast<fabric_max_packet_size>(
+            output_addr_gen,
+            fabric_connections[route],
+            unicast_packet_header,
+            payload_addr,
+            page_idx,
+            (int)aligned_output_page_size,
+            l1_alignment);
+
+        fabric_send_noc_unicast<fabric_max_packet_size>(
+            metadata_addr_gen,
+            fabric_connections[route],
+            unicast_packet_header,
+            metadata_addr,
+            page_idx,
+            (int)aligned_metadata_page_size,
+            l1_alignment);
+
+        noc_async_writes_flushed();  // ensures fabric has read payload+metadata out of L1
+#endif
+
+        noc_semaphore_inc<true>(untilize_space_avail_noc_addr, 1);
+        consumed_count++;
+    }
+#else
+    // ===== Row-major path: standard CB protocol on c_4/c_5/c_6 pushed by the sender reader.
     while (true) {
         cb_wait_front(cb_route_info_id, 1);
         volatile tt_l1_ptr uint32_t* route_info =
@@ -191,7 +299,6 @@ void kernel_main() {
                         << ENDL();
 
 #ifdef DEST_CHIP_ID
-        // Send payload
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             output_addr_gen,
@@ -202,7 +309,6 @@ void kernel_main() {
             (int)aligned_output_page_size,
             l1_alignment);
 
-        // Send metadata
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             metadata_addr_gen,
@@ -212,27 +318,18 @@ void kernel_main() {
             page_idx,
             (int)aligned_metadata_page_size,
             l1_alignment);
-        noc_async_writes_flushed();  // Ensure payload+metadata departed L1 before freeing CB slots
 
+        noc_async_writes_flushed();
 #endif
 
         cb_pop_front(cb_payload_for_writer_id, 1);
         cb_pop_front(cb_metadata_for_writer_id, 1);
     }
+#endif
 
 #ifdef DEST_CHIP_ID
-    // Defensive: drain any pending local NOC writes before fabric atomic-inc traffic,
-    // so the exit-sem signal cannot reach peers ahead of the last metadata/payload writes.
     noc_async_write_barrier();
 
-    // Exit semaphore exchange - uses a dedicated semaphore (exit_semaphore_address) and
-    // the dedicated sem_packet_header. flush=true (vs the init handshake which uses the
-    // default flush=false): the EDM on the receiver holds this atomic-inc until our prior
-    // fabric writes (payload + metadata) to that chip have committed there. Without it the
-    // small atomic-inc packet can overtake the larger data writes on B's local NOC and the
-    // peer would observe sem-reached-threshold before the data has landed in DRAM. At init
-    // there are no prior writes to order against, so flush=false saves one EDM round-trip
-    // check.
     {
         const uint64_t exit_noc_semaphore_addr = get_noc_addr(exit_semaphore_address);
         send_init_semaphore_to_configured_targets<
@@ -256,14 +353,6 @@ void kernel_main() {
         noc_semaphore_set(exit_sem_ptr, 0);
     }
 
-    // send_init_semaphore_to_configured_targets calls fabric_send_chip_unicast_noc_unicast_semaphore_only[_1d]
-    // which calls send_payload_flush_blocking_from_address -> send_payload_from_address_impl<FLUSH_BLOCKING>,
-    // which only calls noc_async_writes_flushed on the packet-header write. It confirms the the write departed
-    // worker's NIU but does not mean the write landed in EDM's L1 inbox.
-    // If we exit the kernel and close_direction_connections runs while the write is still mid-flight toward EDM's L1,
-    // EDM might process its slot bookkeeping before the actual packet bytes have landed.
-    // A full barrier ensures all writes have completed, as well as atomics which is purely defensive here and
-    // future-proof.
     noc_async_full_barrier();
 
     close_direction_connections(directions, fabric_connections);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -3,31 +3,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Writer kernel for idle (worker) cores in the dispatch op.
-// Runs on the data-movement RISC opposite the reader so that the reader can
-// prefetch the next batch's DRAM tiles into cb_input_id while this kernel is
-// waiting for compute / the owning sender and performing the NOC write.
+// Untilize core RISCV_0 — data movement.
 //
-// Each idle core is permanently bound to ONE sender core (its owning sender).
-// Token batches are distributed round-robin across total_workers (k_s idle
-// cores + the sender itself).  Core i processes batches i, i+total_workers, …
+// At startup: receive the L1 base addresses of the owning sender's writer CBs
+// (c_4/c_5/c_6) via addr-handshake semaphores written by the sender's reader RISC.
 //
-// For each assigned batch:
-//   1. Wait for compute to finish (cb_wait_front on cb_untilize_id).
-//   2. Wait for the owning sender's "send now" signal (start_semaphore).
-//      The sender also writes a route table to cb_mailbox_id before signaling,
-//      so the table is ready to read immediately after the semaphore fires.
-//   3. For each local route entry in the mailbox: write output data and metadata
-//      directly to DRAM using NOC1, bypassing the sender entirely.
-//   4. Bulk-write the full untilized batch to the sender's receive buffer so
-//      the sender can forward cross-device tokens via the fabric writer.
-//   5. Signal the sender that data has landed (data_ready_semaphore).
-//   6. Release the untilize CB (cb_pop_front).
+// Per batch: drain the per-batch route plan published by the reader (this same core,
+// RISCV_1) on c_14 and execute the data movement:
+//
+//   * Local entries: noc_async_write_page payload + metadata directly to DRAM.
+//   * Cross-device entries: per-entry into sender writer CBs (c_4/c_5/c_6, writer_cb_size
+//     slots each — sized to one batch worth, == read_batch_size).
+//     Synchronization:
+//       data_avail (sender L1, init=0): untilize NOC-incs per entry written.
+//       space_avail (this core's L1, init=writer_cb_size): sender writer NOC-incs per entry
+//         that has been fabric-sent (slot free to overwrite). Initial writer_cb_size seeds
+//         untilize so it can fill all slots before the first sender credit lands.
+//     Per-data-entry steps:
+//       1. noc_semaphore_wait_min(local space_avail, produced + 1)
+//       2. slot = produced % writer_cb_size
+//       3. Build route_info[4] in local L1 scratch (c_15, 16B), then one noc_async_write
+//          of 16B → sender c_4 slot [route,distance,page_idx,0]
+//       4. noc_async_write payload → sender c_5 slot
+//       5. Build metadata in c_13, noc_async_write metadata → sender c_6 slot
+//       6. noc_async_write_barrier (no atomic_barrier — no atomics, only async writes)
+//       7. noc_semaphore_inc(sender data_avail, 1)
+//       8. produced++
+//
+// After the last cross-device entry: write ROUTE_INFO_SENTINEL into the next available
+// slot. Sender writer sees SENTINEL and exits the fabric send loop.
 //
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
 
 #define ENABLE_DISPATCH_DEBUG 0
 #if ENABLE_DISPATCH_DEBUG
@@ -38,6 +48,14 @@
     DebugPrinter()
 #endif
 
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;
+constexpr uint32_t PLAN_FLAG_END = 0x80000000u;
+constexpr uint32_t PLAN_ENTRY_U32S = 8;
+// Transaction ID for cross-device NOC writes — lets the per-entry barrier wait only on
+// the c_4/c_5/c_6 writes for this entry, while in-flight local DRAM writes keep flying.
+constexpr uint32_t TRID_NON_LOCAL_WRITE = 1;
+
 void kernel_main() {
     // ===== Compile-time args =====
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(0);
@@ -46,137 +64,209 @@ void kernel_main() {
     constexpr uint32_t total_batches = get_compile_time_arg_val(3);
     constexpr uint32_t core_id = get_compile_time_arg_val(4);
     constexpr uint32_t total_workers = get_compile_time_arg_val(5);
-    // New: direct-DRAM-write support
-    constexpr uint32_t cb_mailbox_id = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_metadata_scratch_id = get_compile_time_arg_val(7);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(8);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(9);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(10);
-    constexpr auto output_args = TensorAccessorArgs<11>();
-    constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
 
-    constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
+    constexpr uint32_t cb_metadata_scratch_id = get_compile_time_arg_val(6);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_plan_id = get_compile_time_arg_val(8);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(9);
+
+    // Per-entry CB protocol on sender side (sender writer CBs sized to one batch worth).
+    constexpr uint32_t route_info_slot_stride = get_compile_time_arg_val(10);    // l1_alignment
+    constexpr uint32_t writer_cb_size = get_compile_time_arg_val(11);            // == read_batch_size
+    constexpr uint32_t cb_route_info_scratch_id = get_compile_time_arg_val(12);  // 16B local scratch
+    constexpr uint32_t meta_scratch_slots = get_compile_time_arg_val(13);
+
+    constexpr auto output_args = TensorAccessorArgs<14>();
+    constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
 
     // ===== Runtime args =====
     uint32_t rt_idx = 0;
-    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
     uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
     uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t addr_value_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    // New:
+    uint32_t cross_c4_addr_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t cross_c5_addr_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t cross_c6_addr_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t data_avail_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t space_avail_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_idx++);
     uint32_t metadata_tensor_address = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t mbox_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t mbox_scratch_addr_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
 
-    uint64_t sender_data_ready_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
-    volatile tt_l1_ptr uint32_t* start_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
+    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
+    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
 
-    // ===== Startup: receive buffer address exchange (existing) =====
+    // ===== Startup: wait for sender to multicast c_4/c_5/c_6 L1 base addresses =====
     volatile tt_l1_ptr uint32_t* addr_ready_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_ready_semaphore_id));
     noc_semaphore_wait(addr_ready_sem_ptr, 1);
     noc_semaphore_set(addr_ready_sem_ptr, 0);
-    volatile tt_l1_ptr uint32_t* addr_value_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_value_semaphore_id));
-    uint32_t sender_receive_buf_l1_addr = *addr_value_ptr;
-    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_receive_buf_l1_addr);
 
-    // ===== Startup: NOC-write mailbox L1 address into sender's scratch slot =====
-    // addr_ready also signals that the sender has multicast its rt_scratch_base into the
-    // mbox_scratch_addr semaphore slot on every core.  We read it here, then use
-    // noc_inline_dw_write to push our mailbox address into the sender's scratch buffer at
-    // slot [core_id * 4].  noc_inline_dw_write is ordered before the subsequent
-    // noc_semaphore_inc on the NOC, so the sender's local L1 read is safe after mbox_ready fires.
-    uint32_t mailbox_l1_addr = get_write_ptr(cb_mailbox_id);
-    volatile tt_l1_ptr uint32_t* mbox_scratch_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(mbox_scratch_addr_semaphore_id));
-    uint32_t sender_scratch_base = *mbox_scratch_addr_ptr;
-    uint64_t sender_scratch_slot_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, sender_scratch_base + core_id * sizeof(uint32_t));
-    noc_inline_dw_write(sender_scratch_slot_noc_addr, mailbox_l1_addr);
-    noc_async_write_barrier();  // ensure mailbox L1 addr has landed before atomic wakes sender
-    uint64_t sender_mbox_ready_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(mbox_ready_semaphore_id));
-    noc_semaphore_inc(sender_mbox_ready_noc_addr, 1);
-    noc_async_atomic_barrier();
+    uint32_t sender_c4_l1_addr =
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(cross_c4_addr_semaphore_id));
+    uint32_t sender_c5_l1_addr =
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(cross_c5_addr_semaphore_id));
+    uint32_t sender_c6_l1_addr =
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(cross_c6_addr_semaphore_id));
 
-    // ===== Addr gens for direct DRAM writes =====
-    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
-    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
+    uint64_t sender_c4_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c4_l1_addr);
+    uint64_t sender_c5_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c5_l1_addr);
+    uint64_t sender_c6_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c6_l1_addr);
+    uint64_t sender_data_avail_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_avail_semaphore_id));
+
+    volatile tt_l1_ptr uint32_t* space_avail_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(space_avail_semaphore_id));
+
     uint32_t metadata_scratch_addr = get_write_ptr(cb_metadata_scratch_id);
+    // Cross-device entries get a dedicated scratch slot past the local ring so their
+    // per-entry barrier doesn't have to fight with in-flight local NoC reads of slot 0.
+    uint32_t xdev_metadata_scratch_addr = metadata_scratch_addr + meta_scratch_slots * aligned_metadata_page_size;
+    uint32_t route_info_scratch_addr = get_write_ptr(cb_route_info_scratch_id);
+    volatile tt_l1_ptr uint32_t* route_info_scratch =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(route_info_scratch_addr);
+    // Per-entry CB credits: sender writer NOC-incs space_avail per entry consumed by fabric.
+    // Before producing slot N (= produced_count), wait for space_avail >= produced_count + 1.
+    uint32_t produced_count = 0;
+    // Per-batch local-entry index into the metadata scratch ring (meta_scratch_slots deep,
+    // sized for worst-case local entries per batch). Reset after the batch-end flush.
+    uint32_t local_count = 0;
 
+    DPRINT_DISPATCH << "Writer untilize: handshake done c4=" << sender_c4_l1_addr << " c5=" << sender_c5_l1_addr
+                    << " c6=" << sender_c6_l1_addr << ENDL();
+
+    // ===== Per-batch loop — drains the route plan published by the reader RISC =====
     for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
-        // 1. Wait for compute to finish untilizing this batch
-        cb_wait_front(cb_untilize_id, read_batch_size);
-
-        // 2. Wait for the sender's "send now" signal
-        //    The sender writes the route table to cb_mailbox_id before incrementing this semaphore,
-        //    so the table is guaranteed to be visible once we clear the semaphore.
-        noc_semaphore_wait(start_sem_ptr, 1);
-        noc_semaphore_set(start_sem_ptr, 0);
-
+        // Wait for compute to finish untilizing this batch
+        {
+            DeviceZoneScopedN("wait_for_32_tokens") cb_wait_front(cb_untilize_id, read_batch_size);
+        }
         uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
 
-        // 3. Write local-expert tokens directly to DRAM (NOC1), skipping the sender.
-        //    Mailbox layout: [entry_count | has_non_local_flag (u32)] [entry_0..entry_N]
-        //    Each entry: token_t, page_idx, token_idx, k, routed_expert, weight (6 × u32)
-        //    High bit of mbox[0]: 1 = cross-device tokens exist → must bulk-send back to sender.
-        //                         0 = all local → skip bulk-send entirely.
-        volatile tt_l1_ptr uint32_t* mbox = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mailbox_l1_addr);
-        uint32_t raw = mbox[0];
-        bool has_non_local = (raw & 0x80000000u) != 0;
-        uint32_t entry_count = raw & 0x7FFFFFFFu;
-        for (uint32_t e = 0; e < entry_count; e++) {
-            uint32_t base = 1 + e * 6;
-            uint32_t token_t = mbox[base + 0];
-            uint32_t page_idx = mbox[base + 1];
-            int32_t token_idx = (int32_t)mbox[base + 2];
-            int32_t k = (int32_t)mbox[base + 3];
-            int32_t routed_exp = (int32_t)mbox[base + 4];
-            int16_t weight = (int16_t)mbox[base + 5];
+        // Wait for reader to publish the per-batch route plan
+        cb_wait_front(cb_plan_id, 1);
+        uint32_t plan_addr = get_read_ptr(cb_plan_id);
+        volatile tt_l1_ptr uint32_t* plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(plan_addr);
+        uint32_t entry_count = plan[0];
 
-            uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;
+        {
+            for (uint32_t e = 0; e < entry_count; e++) {
+                uint32_t base = 8 + e * PLAN_ENTRY_U32S;
+                uint32_t flags = plan[base + 0];
+                uint32_t token_t = plan[base + 1];
+                uint32_t routed_expert = plan[base + 2];
+                uint32_t page_idx = plan[base + 3];
+                uint32_t token_idx = plan[base + 4];
+                uint32_t kw = plan[base + 5];
+                uint32_t k = kw >> 16;
+                int16_t weight = (int16_t)(kw & 0xFFFF);
 
-            noc_async_write_page(page_idx, output_addr_gen, src_addr);
+                uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;
+                bool is_local = (flags & PLAN_FLAG_LOCAL) != 0;
 
-            volatile tt_l1_ptr int32_t* meta = reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_scratch_addr);
-            meta[0] = (int32_t)linearized_mesh_coord;
-            meta[1] = token_idx;
-            meta[2] = k;
-            meta[3] = routed_exp;
-            meta[4] = (int32_t)weight;
-            noc_async_write_page(page_idx, metadata_addr_gen, metadata_scratch_addr);
-            noc_async_writes_flushed();
-        }
+                if (is_local) {
+                    DeviceZoneScopedN("local_write")
+                        // Local: NOC1 write payload + metadata directly to DRAM.
+                        // No in-loop flush — payload source (src_addr) is unique per token,
+                        // and metadata source rotates through meta_scratch_slots ring slots.
+                        // Single noc_async_writes_flushed() at batch end covers reuse.
+                        noc_async_write_page(page_idx, output_addr_gen, src_addr);
+                    uint32_t meta_addr =
+                        metadata_scratch_addr + (local_count % meta_scratch_slots) * aligned_metadata_page_size;
+                    volatile tt_l1_ptr int32_t* meta = reinterpret_cast<volatile tt_l1_ptr int32_t*>(meta_addr);
+                    meta[0] = (int32_t)linearized_mesh_coord;
+                    meta[1] = (int32_t)token_idx;
+                    meta[2] = (int32_t)k;
+                    meta[3] = (int32_t)routed_expert;
+                    meta[4] = (int32_t)weight;
+                    noc_async_write_page(page_idx, metadata_addr_gen, meta_addr);
+                    local_count++;
+                } else {
+                    uint32_t route = plan[base + 6];
+                    uint32_t distance = plan[base + 7];
 
-        // 4. Bulk-write full untilized batch to sender's receive buffer (cross-device tokens).
-        //    Skipped entirely when all tokens are local — no round-trip to sender needed.
-        if (has_non_local) {
-            uint32_t off = 0;
-            while (off < total_transfer_size) {
-                uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
-                                     ? (uint32_t)NOC_MAX_BURST_SIZE
-                                     : (total_transfer_size - off);
-                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
-                off += chunk;
+                    // Per-entry credit: wait until the sender has fabric-sent the slot we're
+                    // about to overwrite (sender writer inc's space_avail once per slot freed).
+                    {
+                        DeviceZoneScopedN("wait_for_space_avail")
+                            noc_semaphore_wait_min(space_avail_sem_ptr, produced_count + 1);
+                    }
+
+                    {
+                        DeviceZoneScopedN("send_cross_device") uint32_t slot = produced_count % writer_cb_size;
+
+                        // Build route_info (4 × u32) in local scratch, send as one NOC write.
+                        route_info_scratch[0] = route;
+                        route_info_scratch[1] = distance;
+                        route_info_scratch[2] = page_idx;
+                        route_info_scratch[3] = 0;
+                        uint64_t c4_slot = sender_c4_base_noc_addr + slot * route_info_slot_stride;
+                        noc_async_write_one_packet_with_trid(
+                            route_info_scratch_addr, c4_slot, route_info_slot_stride, TRID_NON_LOCAL_WRITE);
+
+                        // Payload: chunk to NOC_MAX_BURST_SIZE packets, each tagged with TRID.
+                        uint64_t c5_slot = sender_c5_base_noc_addr + slot * aligned_output_page_size;
+                        uint32_t off = 0;
+                        while (off < aligned_output_page_size) {
+                            uint32_t chunk = (aligned_output_page_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
+                                                 ? (uint32_t)NOC_MAX_BURST_SIZE
+                                                 : (aligned_output_page_size - off);
+                            noc_async_write_one_packet_with_trid(
+                                src_addr + off, c5_slot + off, chunk, TRID_NON_LOCAL_WRITE);
+                            off += chunk;
+                        }
+
+                        volatile tt_l1_ptr int32_t* meta =
+                            reinterpret_cast<volatile tt_l1_ptr int32_t*>(xdev_metadata_scratch_addr);
+                        meta[0] = (int32_t)linearized_mesh_coord;
+                        meta[1] = (int32_t)token_idx;
+                        meta[2] = (int32_t)k;
+                        meta[3] = (int32_t)routed_expert;
+                        meta[4] = (int32_t)weight;
+                        uint64_t c6_slot = sender_c6_base_noc_addr + slot * aligned_metadata_page_size;
+                        noc_async_write_one_packet_with_trid(
+                            xdev_metadata_scratch_addr, c6_slot, aligned_metadata_page_size, TRID_NON_LOCAL_WRITE);
+
+                        // Wait only on this entry's cross-device writes — in-flight local
+                        // DRAM writes are tagged-out by TRID and keep flying.
+                        noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
+                    }
+
+                    {
+                        DeviceZoneScopedN("signal_sender_core") noc_semaphore_inc<true>(sender_data_avail_noc_addr, 1);
+                    }
+
+                    produced_count++;
+                }
             }
-            noc_async_write_barrier();
-
-            // 5. Signal the sender that all data has landed
-            noc_semaphore_inc(sender_data_ready_noc_addr, 1);
-            noc_async_atomic_barrier();
         }
 
-        // 6. Release untilize CB
+        // Drain all local NOC writes issued during this batch before the scratch ring or
+        // untilize CB get reused. Cross-device entries already barriered per-entry.
+        noc_async_writes_flushed();
+        local_count = 0;
+
+        cb_pop_front(cb_plan_id, 1);
         cb_pop_front(cb_untilize_id, read_batch_size);
     }
-    // Ensure all in-flight NOC traffic has landed before kernel exit. The all-local path only
-    // calls noc_async_writes_flushed (departure-from-source); without this barrier its
-    // noc_async_write_page DRAM writes can still be in flight at program end.
+
+    // After the last data entry: write ROUTE_INFO_SENTINEL as one final entry into the
+    // next slot. Must wait for space_avail like any regular entry.
+    cb_wait_front(cb_plan_id, 1);
+    cb_pop_front(cb_plan_id, 1);
+
+    noc_semaphore_wait_min(space_avail_sem_ptr, produced_count + 1);
+
+    uint32_t sentinel_slot = produced_count % writer_cb_size;
+    route_info_scratch[0] = ROUTE_INFO_SENTINEL;
+    route_info_scratch[1] = 0;
+    route_info_scratch[2] = 0;
+    route_info_scratch[3] = 0;
+    uint64_t sentinel_c4_slot = sender_c4_base_noc_addr + sentinel_slot * route_info_slot_stride;
+    noc_async_write_one_packet_with_trid(
+        route_info_scratch_addr, sentinel_c4_slot, route_info_slot_stride, TRID_NON_LOCAL_WRITE);
+    noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
+    noc_semaphore_inc(sender_data_avail_noc_addr, 1);
+
+    // noc_async_full_barrier flushes everything in-flight (including the inc) before exit.
     noc_async_full_barrier();
 }


### PR DESCRIPTION
- This PR improves the performance of the dispatch module
- Changes that have been made (for tile layout path, row-major path is untouched):
1. Renamed `idle` cores to `untilizer` cores
2. Changed that there is only 1 untilizer core per sender core
3. Removed the part of code where the sender core acts as as the untilizer core and does the untilization since that created a gap in fabric sends -> we don't want that, we want fabric to send tokens and metadata non-stop
4. Moved the token, metadata, indices and weights loading from the sender core to the untilizer -> in other works, the sender core now just receives token from the untilizer and sends it to destination chips
5. The `cb_untilize_id` buffer that holds 32 untilized tokens is now double buffered - while the sender core is busy sending tokens from batchN to fabric, the untilizer core untilizes batchN+1 so when the sender finishes sending batchN, it instantly has new data from batchN+1 ; untilization is faster then fabric sends ( we are fabric bound ) 

## Best perf improvement across 5 runs

Linear-8 mesh - `test_prefill_dispatch` - test - perf_no_pcc

| Link  | Best % improvement | Δ (μs) | Optimized (μs) | Main (μs) |
|-------|--------------------|--------|----------------|-----------|
| 1link | 2.78%              | 147    | 5,143          | 5,290     |
| 2link | 10.11%             | 295    | 2,623          | 2,918     |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch_perf_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/dispatch_perf_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/dispatch_perf_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch_perf_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/dispatch_perf_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/dispatch_perf_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/dispatch_perf_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/dispatch_perf_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/dispatch_perf_optimization)