### PR TITLE
sdpa: migrate kernels off deprecated dst and noc-tile APIs

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -53,12 +53,14 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
     cb_wait_front(in0, num_tiles);
     cb_wait_front(in1, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst();
+        tile_regs_acquire();
         copy_tile(in0, i, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
         binary_max_tile(dst_reg_0, dst_reg_1, dst_reg_0, VectorMode::C);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(dst_reg_0, in0);
-        release_dst();
+        tile_regs_release();
     }
     cb_pop_front(in0, num_tiles);
     cb_reserve_back(in0, num_tiles);
@@ -80,12 +82,14 @@ void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) 
     cb_wait_front(in1, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst();
+        tile_regs_acquire();
         copy_tile(in0, i, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
         binary_max_tile(dst_reg_0, dst_reg_1, dst_reg_0, vector_mode);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(dst_reg_0, out_cb, i);
-        release_dst();
+        tile_regs_release();
     }
     cb_push_back(out_cb, num_tiles);
 }
@@ -129,7 +133,7 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
     uint32_t row_start_idx = 0;
     for (uint32_t g = 0; g < granularity; g++) {
         cb_wait_front(in0_cb, in0_wait_tiles);
-        acquire_dst();
+        tile_regs_acquire();
 
         if (do_eltwise_max) {
             cb_wait_front(prev_cb, g * dst_tiles);
@@ -155,11 +159,13 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
         }
         reduce_block_max_row_uninit(in0_cb);
 
+        tile_regs_commit();
+        tile_regs_wait();
         for (uint32_t i = 0; i < dst_tiles; i++) {
             const uint32_t cur_max_dst_idx = i;
             pack_tile<true>(cur_max_dst_idx, out_cb, (row_start_idx + i));
         }
-        release_dst();
+        tile_regs_release();
 
         row_start_idx += dst_tiles;
         in0_wait_tiles += num_tiles_to_wait;
@@ -198,7 +204,7 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
     constexpr uint32_t prev_max_dst_idx = 1;
 
     for (uint32_t i = 0; i < rows; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         reduce_init<pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
         for (uint32_t j = 0; j < cols; j++) {
             reduce_tile<pool_type, reduce_dim>(in0_cb, scale_cb, i * cols + j, 0, reduce_dst_idx);
@@ -210,8 +216,10 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
             binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx, vector_mode);
         }
 
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(reduce_dst_idx, out_cb);
-        release_dst();
+        tile_regs_release();
     }
 
     cb_push_back(out_cb, rows);
@@ -278,11 +286,13 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
 
     cb_wait_front(in_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst();
+        tile_regs_acquire();
         copy_tile(in_cb, i, 0);
         MATH((recip_tile_first_column(0)));
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, in_cb);
-        release_dst();
+        tile_regs_release();
     }
     cb_pop_front(in_cb, num_tiles);
     cb_reserve_back(in_cb, num_tiles);
@@ -409,13 +419,15 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
         static_assert(!pack_accumulate, "Unsupported parameter configuration");
         for (uint32_t i = 0; i < rows; ++i) {
             for (uint32_t j = 0; j < cols; ++j) {
-                acquire_dst();
+                tile_regs_acquire();
                 mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
+                tile_regs_commit();
                 cb_pop_front(in0_cb, 1);
                 cb_reserve_back(out_cb, 1);
+                tile_regs_wait();
                 pack_tile(0, out_cb);
+                tile_regs_release();
                 cb_push_back(out_cb, 1);
-                release_dst();
             }
         }
         cb_pop_front(in1_cb, rows);
@@ -524,15 +536,17 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_cb) {
     cb_wait_front(in1_scalar_cb, 1);
     uint32_t in0_index = 0;
     for (uint32_t g = 0; g < granularity; ++g) {
-        acquire_dst();
+        tile_regs_acquire();
         for (uint32_t i = 0; i < dst_tiles; ++i) {
             mul_tiles_bcast_scalar(in0_cb, in1_scalar_cb, in0_index, 0, i);
             in0_index++;
         }
+        tile_regs_commit();
+        tile_regs_wait();
         for (uint32_t i = 0; i < dst_tiles; ++i) {
             pack_tile(i, in0_cb);
         }
-        release_dst();
+        tile_regs_release();
     }
     cb_pop_front(in0_cb, num_tiles);
     cb_reserve_back(in0_cb, num_tiles);
@@ -552,10 +566,12 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         add_tiles(in0_cb, in1_cb, i, i, 0);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, in0_cb);
-        release_dst();
+        tile_regs_release();
     }
 
     cb_pop_front(in0_cb, num_tiles);
@@ -579,13 +595,15 @@ void mul_tiles_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
+        tile_regs_commit();
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
+        tile_regs_wait();
         pack_tile(0, in0_cb);
+        tile_regs_release();
         cb_push_back(in0_cb, 1);
-        release_dst();
     }
 }
 
@@ -602,13 +620,15 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
         invalidate_l1_cache();
-        acquire_dst();
+        tile_regs_acquire();
         mul_tiles(in0_cb, in1_cb, 0, i, 0);
+        tile_regs_commit();
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
+        tile_regs_wait();
         pack_tile(0, in0_cb);
+        tile_regs_release();
         cb_push_back(in0_cb, 1);
-        release_dst();
     }
 }
 
@@ -872,12 +892,14 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
 
     for (uint32_t i = 0; i < num_tiles; i++) {
         invalidate_l1_cache();
-        acquire_dst();
+        tile_regs_acquire();
         sub_tiles(in0_cb, in1_cb, i, i, 0);
         MATH((exp_tile_first_column<EXP_APPROX_MODE, scale_bf16>(0)));
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, out_cb);
+        tile_regs_release();
         cb_push_back(out_cb, 1);
-        release_dst();
     }
 }
 
@@ -978,7 +1000,7 @@ void correction_block(
     constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
 
     for (uint32_t i = 0; i < num_head_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         copy_tile_to_dst_init_short(cb_worker_max);
         exp_tile_init<EXP_APPROX_MODE>();
         copy_tile(cb_prev_max, i, dst_reg_0);
@@ -986,15 +1008,17 @@ void correction_block(
         copy_tile(cb_prev_sum, i, dst_reg_3);
         copy_tile(cb_worker_sum, i, dst_reg_4);
         MATH((fused_max_sub_exp_add_tile<EXP_APPROX_MODE, vector_mode>(0, scale_bf16)));
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(dst_reg_0, cb_exp_max_diff);
         pack_tile(dst_reg_1, cb_exp_max_diff_2);
         pack_tile(dst_reg_2, cb_cur_max);
         pack_tile(dst_reg_3, cb_cur_sum);
+        tile_regs_release();
         cb_push_back(cb_cur_max, 1);
         cb_push_back(cb_cur_sum, 1);
         cb_push_back(cb_exp_max_diff, 1);
         cb_push_back(cb_exp_max_diff_2, 1);
-        release_dst();
     }
     cb_pop_front(cb_prev_sum, num_head_tiles);
     cb_pop_front(cb_worker_sum, num_head_tiles);
@@ -1017,11 +1041,13 @@ void move_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
 
 #pragma GCC unroll 0
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         copy_tile(in_cb, i, 0 /*dst*/);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, out_cb);
+        tile_regs_release();
         cb_push_back(out_cb, 1);
-        release_dst();
     }
     if (pop_in_cb) {
         cb_pop_front(in_cb, num_tiles);
@@ -1038,11 +1064,13 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
     cb_reserve_back(out_cb, num_tiles);
 #pragma GCC unroll 0
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         copy_tile(in_cb, i, 0 /*dst*/);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, out_cb);
+        tile_regs_release();
         cb_push_back(out_cb, 1);
-        release_dst();
     }
     cb_pop_front(in_cb, num_tiles);
 }
@@ -1054,12 +1082,14 @@ void log_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
     cb_reserve_back(out_cb, num_tiles);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         copy_tile(in_cb, i, 0 /*dst*/);
         log_tile(0);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, out_cb);
+        tile_regs_release();
         cb_push_back(out_cb, 1);
-        release_dst();
     }
 }
 
@@ -1087,7 +1117,7 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
     MATH((ckernel::sfpu::sfpu_reciprocal_init<false>()));
 
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         sub_tiles(in0_cb, in1_cb, i, i, 0);
         // exp_tile<false, true /*SCALE_EN*/>(0, (int)VectorMode::C, (uint16_t)0xBF80 /*bf16(-1.0) scale*/);
         MATH((exp_tile_first_column<false /*APPROX_MODE*/, (uint16_t)0xBF80 /*bf16(-1.0) scale*/>(0)));
@@ -1096,8 +1126,10 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
             0 /*dst_index*/, 0x3F800000 /*scalar*/, VectorMode::C)));
         // recip_tile<false>(0, (int)VectorMode::C);
         MATH((recip_tile_first_column<false>(0 /*dst_index*/)));
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, out_cb);
-        release_dst();
+        tile_regs_release();
     }
     cb_push_back(out_cb, num_tiles);
 }
@@ -1136,7 +1168,7 @@ void logsigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
     constexpr uint32_t const_20_fp32 = 0x41A00000;
 
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         // Negate input to softplus by swapping inputs to sub
         sub_tiles(in1_cb, in0_cb, i, i, 0);
         // softplus_tile(0, 0x3F800000, 0x3F800000, 0x41A00000);  // beta, beta_reciprocal, threshold
@@ -1150,8 +1182,10 @@ void logsigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
         MATH((softplus_tile_first_column(0, const_1_fp32, const_1_fp32, const_20_fp32)));
         // Negate the output of softplus
         negative_tile(0);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, out_cb);
-        release_dst();
+        tile_regs_release();
     }
     cb_push_back(out_cb, num_tiles);
 }
@@ -1167,10 +1201,12 @@ __attribute__((optimize("Os"))) void sub_block(uint32_t in0_cb, uint32_t in1_cb,
     sub_tiles_init(in0_cb, in1_cb);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         sub_tiles(in0_cb, in1_cb, i, i, 0);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, out_cb);
-        release_dst();
+        tile_regs_release();
     }
     cb_push_back(out_cb, num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -128,7 +128,7 @@ uint32_t read_chunk_with_padding(
     for (uint32_t row = 0; row < src_rows; ++row) {
         uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
-            noc_async_read_tile(start_tile_id, reader, write_ptr);
+            noc_async_read_page(start_tile_id, reader, write_ptr);
             start_tile_id += 1;
             write_ptr += inner_ptr_stride;
 
@@ -185,7 +185,7 @@ FORCE_INLINE void read_q_subblock(
 
         if (row < src_rows) {
             for (uint32_t col = 0; col < src_cols; ++col) {
-                noc_async_read_tile(start_tile_id++, reader, write_ptr);
+                noc_async_read_page(start_tile_id++, reader, write_ptr);
                 write_ptr += tile_bytes;
                 if (++barrier_count == barrier_threshold) {
                     noc_async_read_barrier();
@@ -239,7 +239,7 @@ void read_paged_chunk_with_padding(
             virtual_row_num, cur_head, page_table_ptr);
 
         for (uint32_t col = 0; col < src_cols; ++col) {
-            noc_async_read_tile(physical_tile_id, reader, write_ptr);
+            noc_async_read_page(physical_tile_id, reader, write_ptr);
             physical_tile_id += 1;
             write_ptr += inner_ptr_stride;
 
@@ -893,7 +893,7 @@ void generate_noncausal_padded_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, ui
     cb_push_back(cb_mask_in, mask_size_tiles);
 }
 
-// Issue noc_async_read_tile for a (num_rows × cols) tile block. tile_id starts at base_tile_id,
+// Issue noc_async_read_page for a (num_rows × cols) tile block. tile_id starts at base_tile_id,
 // advances by ++ per col and by row_stride per row (i.e., tile_id += row_stride - cols after each
 // inner col loop). dst starts at dst_addr + dst_row_origin * outer_stride, advances by
 // inner_stride per col and outer_stride per row. No barrier — caller must noc_async_read_barrier().
@@ -915,7 +915,7 @@ inline void issue_block_reads(
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;
         for (uint32_t col = 0; col < cols; ++col) {
-            noc_async_read_tile(tile_id, reader, dst);
+            noc_async_read_page(tile_id, reader, dst);
             ++tile_id;
             dst += inner_stride;
             if (barrier_threshold > 0 && ++barrier_count == barrier_threshold) {
@@ -953,7 +953,7 @@ inline void zero_fill_block(
     }
 }
 
-// Issue noc_async_write_tile for a (num_rows × cols) tile block. Same tile_id/src arithmetic
+// Issue noc_async_write_page for a (num_rows × cols) tile block. Same tile_id/src arithmetic
 // as issue_block_reads (with src instead of dst). No barrier — caller must noc_async_write_barrier().
 template <typename WriterType>
 inline void issue_block_writes(
@@ -970,7 +970,7 @@ inline void issue_block_writes(
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t src = src_addr + (src_row_origin + r) * outer_stride;
         for (uint32_t col = 0; col < cols; ++col) {
-            noc_async_write_tile(tile_id, writer, src);
+            noc_async_write_page(tile_id, writer, src);
             ++tile_id;
             src += inner_stride;
         }
@@ -1303,7 +1303,7 @@ void write_block(
     uint32_t l1_read_addr = get_read_ptr(cb_out);
     for (uint32_t row = 0; row < rows; ++row) {
         for (uint32_t col = 0; col < cols; ++col) {
-            noc_async_write_tile(tile_id, out_writer, l1_read_addr);
+            noc_async_write_page(tile_id, out_writer, l1_read_addr);
             ++tile_id;
             l1_read_addr += tile_bytes;
 
@@ -1351,7 +1351,7 @@ void write_block_row_grouped(
             const uint32_t row = rg * sbh + r;
             if (row < write_rows) {
                 for (uint32_t col = 0; col < cols; ++col) {
-                    noc_async_write_tile(tile_id, out_writer, l1_read_addr + col * tile_bytes);
+                    noc_async_write_page(tile_id, out_writer, l1_read_addr + col * tile_bytes);
                     ++tile_id;
                     if (++barrier_count == barrier_threshold) {
                         noc_async_write_flushed_with_trid(default_trid);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -25,7 +25,7 @@ FORCE_INLINE void read_chunk_for_forwarding(
     for (uint32_t row = 0; row < src_rows; ++row) {
         uint32_t write_ptr = dst_addr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
-            noc_async_read_tile(tile_id++, reader, write_ptr);
+            noc_async_read_page(tile_id++, reader, write_ptr);
             write_ptr += inner_ptr_stride;
         }
         tile_id += skip_src_cols;
@@ -324,7 +324,7 @@ void kernel_main() {
                 cb_reserve_back(cb_attention_sink, Sq_chunk_t);
                 uint32_t attention_sink_write_ptr = get_write_ptr(cb_attention_sink);
                 const uint32_t sink_tile_id = attention_sink_tile_shape.id_of(0, decoded.nq, 0, 0);
-                noc_async_read_tile(sink_tile_id, attention_sink_reader, attention_sink_write_ptr);
+                noc_async_read_page(sink_tile_id, attention_sink_reader, attention_sink_write_ptr);
                 noc_async_read_barrier();
                 fill_attention_sink_tiles<attention_sink_tile_bytes>(
                     cb_attention_sink, Sq_chunk_t, attention_sink_write_ptr);
@@ -485,7 +485,7 @@ void kernel_main() {
                             const uint32_t global_k_tile = k_chunk * Sk_chunk_t + col;
                             const bool k_valid = !use_padded_mask || (global_k_tile < valid_Skt);
                             if (q_valid && k_valid) {
-                                noc_async_read_tile(mask_row_start + global_k_tile, mask_reader, mask_write_ptr);
+                                noc_async_read_page(mask_row_start + global_k_tile, mask_reader, mask_write_ptr);
                             } else {
                                 fill_neginf_tile<mask_tile_bytes>(cb_mask_in, tile_idx);
                             }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -49,7 +49,7 @@ void read_prev_output_and_lse(
     cb_reserve_back(cb_lse_in, Sq_chunk_t);
     uint32_t lse_addr = get_write_ptr(cb_lse_in);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_read_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
+        noc_async_read_page(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
         lse_addr += stats_tile_bytes;
     }
     noc_async_read_barrier();
@@ -108,7 +108,7 @@ void issue_restore_reads(
     uint32_t max_tile_id = stats_tile_logical.id_of(nb, nq, stats_seq_start_tile, 0);
     uint32_t max_addr = get_write_ptr(cb_max_in);
     for (uint32_t r = 0; r < stats_rows; ++r) {
-        noc_async_read_tile(max_tile_id, stats_writer, max_addr);
+        noc_async_read_page(max_tile_id, stats_writer, max_addr);
         max_tile_id += stats_row_stride;
         max_addr += stats_tile_bytes;
     }
@@ -118,7 +118,7 @@ void issue_restore_reads(
     uint32_t sum_tile_id = stats_tile_logical.id_of(nb, nq, sum_offset + stats_seq_start_tile, 0);
     uint32_t sum_addr = get_write_ptr(cb_sum_in);
     for (uint32_t r = 0; r < stats_rows; ++r) {
-        noc_async_read_tile(sum_tile_id, stats_writer, sum_addr);
+        noc_async_read_page(sum_tile_id, stats_writer, sum_addr);
         sum_tile_id += stats_row_stride;
         sum_addr += stats_tile_bytes;
     }
@@ -181,13 +181,13 @@ void save_accumulators_with_trid(
 
     uint32_t max_write_addr = get_read_ptr(cb_max_out);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_write_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_write_addr);
+        noc_async_write_page(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_write_addr);
         max_write_addr += stats_tile_bytes;
     }
 
     uint32_t sum_write_addr = get_read_ptr(cb_sum_out);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_write_tile(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_write_addr);
+        noc_async_write_page(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_write_addr);
         sum_write_addr += stats_tile_bytes;
     }
 
@@ -240,7 +240,7 @@ void write_output_and_lse(
     cb_wait_front(cb_lse_out, Sq_chunk_t);
     uint32_t lse_addr = get_read_ptr(cb_lse_out);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_write_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
+        noc_async_write_page(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
         lse_addr += stats_tile_bytes;
     }
     noc_async_writes_flushed();


### PR DESCRIPTION
## Reason

JIT compile of every SDPA compute and dataflow kernel emitted two large `-Wdeprecated-declarations` walls:

-`'ckernel::acquire_dst()'` / `'ckernel::release_dst()'` is deprecated — use `tile_regs_acquire()` / `tile_regs_release()` (from `compute_common.hpp`, pulled into every SDPA compute kernel).
-`'noc_async_read_tile' / 'noc_async_write_tile'` is deprecated — use `<typename AddrGen> noc_async_read_page / noc_async_write_page` (from `dataflow_common.hpp` + `ring_joint_writer.cpp` + `reader_interleaved.cpp`).

## Solution

Mechanical rename to the new APIs, no semantic change:

- `acquire_dst()` → `tile_regs_acquire(); tile_regs_wait();`
- `release_dst()` → `tile_regs_commit(); tile_regs_release();`
- `noc_async_read_tile(id, addrgen, dst)` → `noc_async_read_page(id, addrgen, dst)`
- `noc_async_write_tile(id, addrgen, src)` → `noc_async_write_page(id, addrgen, src)` (the new API's `size=0` default resolves to `addrgen.get_aligned_page_size()`, exactly what the deprecated wrapper did)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sdpa_kernels_kill_deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa_kernels_kill_deprecations)