### PR TITLE
[CCL] Expose Device 2.0 API headers via sharding_addrgen.hpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -9,6 +9,12 @@
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 #endif
 
@@ -263,6 +269,10 @@ struct ShardedAddrGen {
         return return_val;
     }
 
+    // Legacy shim (#45003 item 4): uses the legacy noc_async_read primitive
+    // because get_sharded_addr produces a precomposed 64-bit noc address.
+    // Consumers migrating to Device 2.0 should use get_noc_addr() / its
+    // components together with Noc::async_read directly.
     FORCE_INLINE
     void noc_async_read_page(
         const uint32_t id, const uint32_t dest_addr, const uint32_t offset = 0, uint8_t noc = noc_index) const {


### PR DESCRIPTION
Part of #45003 item 4 (helper pre-work, PR-2).

The helper's only NoC primitive call (the noc_async_read inside ShardedAddrGen::noc_async_read_page) operates on a precomposed 64-bit NoC address produced by get_sharded_addr. The new Noc::async_read API requires structured endpoint args (noc_x/noc_y/addr); a clean migration of this convenience method would force callers to decompose the 64-bit addr or restructure the address computation. Defer that to a follow-up once consumers migrate; mark the existing call as a legacy shim.

Adds the Device 2.0 kernel API headers (noc, circular_buffer, noc_semaphore, endpoints, core_local_mem, noc_traits) inside the existing KERNEL_BUILD/FW_BUILD guard so consumer kernels including this header get them transitively. Host debug build passes.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ccl-helper-sharding-addrgen-device2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ccl-helper-sharding-addrgen-device2)