### PR TITLE
descriptors.matmul multi-factory support

### DIFF
--- a/models/experimental/ops/descriptors/fusion/codegen/barrier.py
+++ b/models/experimental/ops/descriptors/fusion/codegen/barrier.py
@@ -564,7 +564,6 @@ def _emit_group_sync_coordinator(dispatch: List[Dict[str, Any]]) -> List[str]:
 def _emit_group_sync_follower(
     dispatch: List[Dict[str, Any]],
     for_compute: bool,
-    risc_type: str,
 ) -> List[str]:
     """Emit ``group::sync()`` function for BRISC or compute.
 
@@ -605,7 +604,6 @@ def _emit_group_sync_follower(
 def _emit_init_coordinator(
     has_compute: bool,
     num_segments: int,
-    op_semaphore_info: Optional[List[Tuple[int, int]]] = None,
     has_writer: bool = True,
 ) -> List[str]:
     """Emit ``init()`` for the coordinator (NCRISC)."""
@@ -628,13 +626,14 @@ def _emit_init_coordinator(
     lines.append("    // Each follower RISC resets its own semaphore in its own init().")
     lines.append("    // Resetting here races with fast compute/BRISC signaling")
     lines.append("    // (e.g. no-op phase 0 where compute signals immediately).")
-    if op_semaphore_info:
-        lines.append("    // Reset op semaphores so phase 0 doesn't see stale values")
-        lines.append("    // from the previous execution's last phase.")
-        for sem_id, initial_value in op_semaphore_info:
-            lines.append(
-                f"    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore({sem_id})) = {initial_value};"
-            )
+    # NOTE: Do NOT reset op semaphores here. The hardware dispatch initializes
+    # semaphores to their initial_value on every enqueue (including cache hits),
+    # and local::sync()'s trailing barrier resets them after the last phase.
+    # Resetting in init() races with receiver cores that call sender_sem.up()
+    # via NOC before this core finishes init() — those signals would be erased,
+    # causing a deadlock when mcast_in0 is the first (phase 0) operation.
+    # The synchronized reset in local::sync() (gated by *reset_done) is
+    # sufficient for all inter-phase transitions.
     for seg_idx in range(num_segments):
         lines.append(f"    group::seg_{seg_idx}::init();")
     lines.append("}")
@@ -796,7 +795,7 @@ def _generate_barrier_namespace(
     if is_coordinator:
         lines.extend(_emit_group_sync_coordinator(dispatch))
     else:
-        lines.extend(_emit_group_sync_follower(dispatch, for_compute=(risc_type == "compute"), risc_type=risc_type))
+        lines.extend(_emit_group_sync_follower(dispatch, for_compute=(risc_type == "compute")))
     lines.append("} // namespace group")
     lines.append("")
 
@@ -809,7 +808,7 @@ def _generate_barrier_namespace(
 
     # init()
     if is_coordinator:
-        lines.extend(_emit_init_coordinator(has_compute, num_segments, op_semaphore_info, has_writer=has_writer))
+        lines.extend(_emit_init_coordinator(has_compute, num_segments, has_writer=has_writer))
     else:
         lines.extend(_emit_init_follower(risc_type, num_segments))
     lines.append("")

--- a/models/experimental/ops/descriptors/fusion/codegen/barrier.py
+++ b/models/experimental/ops/descriptors/fusion/codegen/barrier.py
@@ -319,7 +319,12 @@ def _build_barrier_dispatch(
                 }
             )
             cumulative_rebind_offset += len(rebinds) * 2
-    # Trailing barrier (after last phase, e.g. for parent sync in OpGraph)
+    # Trailing barrier (after last phase).
+    # When the last phase has a group sync entry (e.g. early-exit cores in
+    # OpGraph), a full group barrier is emitted.  Otherwise, a local-only
+    # trailing barrier is still needed for re-dispatch correctness: the last
+    # phase's CBs must be reset so that a subsequent dispatch starts with
+    # clean stream-register and FIFO-pointer state.
     last_phase_idx = sources[-1][0]
     if last_phase_idx in multi_barrier.transition_map:
         seg_idx, _ = multi_barrier.transition_map[last_phase_idx]
@@ -331,6 +336,17 @@ def _build_barrier_dispatch(
                 "rebinds": [],
                 "rebind_entry_offset": cumulative_rebind_offset,
                 "is_arrive": last_phase_idx not in noop_phase_indices,
+            }
+        )
+    elif len(sources) > 1:
+        dispatch.append(
+            {
+                "done_val": len(sources),
+                "seg_idx": None,
+                "next_phase_idx": None,
+                "rebinds": [],
+                "rebind_entry_offset": cumulative_rebind_offset,
+                "is_arrive": False,
             }
         )
     return dispatch
@@ -534,6 +550,8 @@ def _emit_group_sync_coordinator(dispatch: List[Dict[str, Any]]) -> List[str]:
     for entry in dispatch:
         done_val = entry["done_val"]
         seg_idx = entry["seg_idx"]
+        if seg_idx is None:
+            continue
         is_arrive = entry.get("is_arrive", True)
         mode = "SyncMode::Full" if is_arrive else "SyncMode::WaitOnly"
         lines.append(f"        if (done == {done_val}) {{")
@@ -565,7 +583,8 @@ def _emit_group_sync_follower(
         is_arrive = entry.get("is_arrive", True)
         mode = "SyncMode::Full" if is_arrive else "SyncMode::WaitOnly"
         lines.append(f"        if (done == {done_val}) {{")
-        lines.append(f"            seg_{seg_idx}::sync<{mode}>();")
+        if seg_idx is not None:
+            lines.append(f"            seg_{seg_idx}::sync<{mode}>();")
         lines.append(f"            resync_cbs(phase_{completed_phase_idx}_cbs);")
         if rebinds and next_phase_idx is not None:
             if for_compute:

--- a/models/experimental/ops/descriptors/fusion/codegen/builder.py
+++ b/models/experimental/ops/descriptors/fusion/codegen/builder.py
@@ -398,13 +398,33 @@ def _build_fused_descriptor(
         if rebind_offset is not None:
             named_ct_args.append(("rebind_rt_offset", rebind_offset))
 
-        # Get config from first available kernel for this role
+        # Pick config for this role. A fused kernel is a single binary whose NOC is a
+        # compile-time constant (noc_index), so all phases sharing this RISC role must
+        # agree on the NOC.  ReaderConfigDescriptor{} / WriterConfigDescriptor{} are
+        # "use platform default" markers; DataMovementConfigDescriptor carries an
+        # explicit NOC.  Rules:
+        #   - Prefer any explicit DataMovementConfigDescriptor over a default descriptor.
+        #   - If two phases both carry explicit DataMovementConfigDescriptors and they
+        #     disagree on NOC, they cannot be fused into a single binary — raise early.
         role_config = None
         for pk in phase_kernels:
             kernel = pk.get(role_key)
             if kernel is not None:
-                role_config = kernel.config
-                break
+                config = kernel.config
+                if role_config is None:
+                    role_config = config
+                elif isinstance(config, ttnn.DataMovementConfigDescriptor):
+                    if isinstance(role_config, ttnn.DataMovementConfigDescriptor):
+                        if config.noc != role_config.noc:
+                            raise ValueError(
+                                f"Cannot fuse phases for role '{role_key}': conflicting explicit NOC "
+                                f"requirements ({role_config.noc} vs {config.noc}). "
+                                f"A single kernel binary can only have one noc_index."
+                            )
+                    else:
+                        # Upgrade from default (ReaderConfigDescriptor/WriterConfigDescriptor)
+                        # to the explicit config.
+                        role_config = config
 
         # For compute roles, validate configs match across phases and
         # rebuild unpack_to_dest_mode from pool-allocated slot indices

--- a/models/experimental/ops/descriptors/fusion/codegen/source_gen.py
+++ b/models/experimental/ops/descriptors/fusion/codegen/source_gen.py
@@ -512,7 +512,7 @@ def _generate_fused_source(
     has_trailing = False
     if needs_barrier:
         last_phase_idx = dispatch_phases[-1]
-        has_trailing = last_phase_idx in multi_barrier.transition_map
+        has_trailing = last_phase_idx in multi_barrier.transition_map or len(dispatch_phases) > 1
 
     for count, phase_idx in enumerate(dispatch_phases):
         pname = phase_names.get(phase_idx, "")
@@ -592,7 +592,7 @@ def _generate_coordinator_only_source(
     lines.append("void kernel_main() {")
     lines.append("    barrier::init();")
     lines.append("")
-    has_trailing = all_phase_indices[-1] in multi_barrier.transition_map
+    has_trailing = all_phase_indices[-1] in multi_barrier.transition_map or len(all_phase_indices) > 1
     for count, phase_idx in enumerate(all_phase_indices):
         pname = phase_names.get(phase_idx, "")
         label = f"Phase {phase_idx}: {pname}" if pname else f"Phase {phase_idx}"

--- a/models/experimental/ops/descriptors/matmul.py
+++ b/models/experimental/ops/descriptors/matmul.py
@@ -103,9 +103,7 @@ def matmul(
 
     # Compute program cache key
     h = ttnn.MatmulDeviceOperation.compute_program_hash(operation_params, tensor_args)
-    program_cache_key = extend_branch_program_cache_key(
-        int(h) & ((1 << 64) - 1), core_range_set_fusion_key(core_range_set)
-    )
+    program_cache_key = extend_branch_program_cache_key(h, core_range_set_fusion_key(core_range_set))
 
     # Build input dict
     inputs = {"input_a": input_a, "input_b": input_b}

--- a/models/experimental/ops/descriptors/matmul.py
+++ b/models/experimental/ops/descriptors/matmul.py
@@ -5,25 +5,28 @@
 """
 Matmul operation descriptor.
 
-Creates an OpDescriptor for matrix multiplication using the
-MatmulMultiCoreReuseOptimizedProgramFactory descriptor path.
+Creates an OpDescriptor for matrix multiplication using any of the backend
+matmul program factories.  The factory is selected automatically based on
+the ``program_config`` type, matching the dispatch logic in
+``MatmulDeviceOperation::select_program_factory``.
 
-WARNING: This descriptor always uses MatmulMultiCoreReuseOptimizedProgramFactory.
-The ttnn.matmul() path may select a different factory (e.g. multicast) for the
-same shapes.
-Further, it computes a simplified program config that does not guarantee parity
-with the ttnn.matmul() path. This descriptor is currently for demonstration purposes only.
-When all variants of matmul have a create_descriptor(), and have the ability
-to construct a program config from a CoreRangeSet so it can be offset from core 0,0,
-then this descriptor interface can be made general.
+The descriptor sets ``allowed_worker_cores`` on the program config to
+``core_range_set``, which is the single source of truth for core placement.
 """
 
-import math
 from typing import Optional
 
 import ttnn
 
-from models.experimental.ops.descriptors.op_descriptor import OpDescriptor
+from models.experimental.ops.descriptors.op_descriptor import (
+    OpDescriptor,
+    LazyOutputList,
+    core_range_set_fusion_key,
+    extend_branch_program_cache_key,
+)
+
+
+_UNSUPPORTED_FACTORY = getattr(ttnn, "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory", None)
 
 
 @OpDescriptor.create(name="matmul")
@@ -31,8 +34,8 @@ def matmul(
     input_a: "ttnn.Tensor",
     input_b: "ttnn.Tensor",
     *,
-    core_range_set: Optional["ttnn.CoreRangeSet"] = None,
-    program_config: Optional["ttnn.MatmulMultiCoreReuseProgramConfig"] = None,
+    core_range_set: "ttnn.CoreRangeSet",
+    program_config: "ttnn.MatmulProgramConfig",
     compute_kernel_config: Optional["ttnn.DeviceComputeKernelConfig"] = None,
     output_mem_config: Optional["ttnn.MemoryConfig"] = None,
     output_dtype: Optional["ttnn.DataType"] = None,
@@ -44,9 +47,11 @@ def matmul(
     Args:
         input_a: First input tensor (on device, tiled).
         input_b: Second input tensor (on device, tiled).
-        core_range_set: Optional core range set override.
-        program_config: MatmulMultiCoreReuseProgramConfig. If None, a simple
-            single-core config is generated from tensor shapes.
+        core_range_set: Core range set for this operation.  Will be written to
+            ``program_config.allowed_worker_cores``.
+        program_config: One of the matmul program config variants
+            (e.g. MatmulMultiCoreReuseProgramConfig,
+            MatmulMultiCoreReuseMultiCastProgramConfig, etc.).
         compute_kernel_config: Compute kernel configuration.
         output_mem_config: Output memory configuration.
         output_dtype: Output data type. Defaults to input_a dtype.
@@ -58,22 +63,18 @@ def matmul(
     """
     device = input_a.device()
 
-    if core_range_set is None:
-        grid_size = device.compute_with_storage_grid_size()
-        core_range_set = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))}
+    # Detect gather_in0 early — the factory it selects (MeshWorkload) has no
+    # Python binding, so matmul_select_program_factory would raise a TypeError.
+    if getattr(program_config, "gather_in0", False):
+        raise ValueError(
+            "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory (gather_in0) "
+            "is not supported in the descriptor interface"
         )
 
-    # Auto-generate a simple program config if not provided
-    if program_config is None:
-        fp32 = getattr(compute_kernel_config, "fp32_dest_acc_en", False) if compute_kernel_config else False
-        program_config = _default_program_config(input_a, input_b, transpose_a, transpose_b, core_range_set, fp32)
-
-    # allowed_worker_cores is required to be set by the ttnn.matmul API.
-    if getattr(program_config, "allowed_worker_cores", "missing") is None:
+    if hasattr(program_config, "allowed_worker_cores"):
         program_config.allowed_worker_cores = core_range_set
 
-    # Use create_matmul_attributes to finalize params (computes bcast_batch, output_dtype, etc.)
+    # Build MatmulParams
     base_params = ttnn.MatmulParams()
     base_params.program_config = program_config
     base_params.transpose_a = transpose_a
@@ -90,100 +91,53 @@ def matmul(
     # Build MatmulInputs
     tensor_args = ttnn.MatmulInputs()
     tensor_args.input_tensors = [input_a, input_b]
+    tensor_args.optional_input_tensors = [None]
 
-    # Get the output spec from the factory (shape, dtype, tile, shard shape, etc.).
-    # When the output is sharded, compute_output_specs() computes the correct shard
-    # shape/orientation but places it on a (0,0)-based grid. Replace the grid with
-    # core_range_set, which is the single source of truth for where this op lives.
-    output_spec = ttnn.MatmulDeviceOperation.compute_output_specs(operation_params, tensor_args)[0]
-
-    if output_mem_config is not None and output_mem_config.is_sharded():
-        factory_shard = output_spec.memory_config.shard_spec
-        corrected_shard = ttnn.ShardSpec(core_range_set, factory_shard.shape, factory_shard.orientation)
-        output_spec = ttnn.TensorSpec(
-            output_spec.shape,
-            output_spec.dtype,
-            output_spec.layout,
-            output_mem_config.memory_layout,
-            corrected_shard,
-            output_mem_config.buffer_type,
-            output_spec.tile,
+    # Select the program factory based on program_config type
+    factory = ttnn.matmul_select_program_factory(operation_params, tensor_args)
+    if _UNSUPPORTED_FACTORY is not None and isinstance(factory, _UNSUPPORTED_FACTORY):
+        raise ValueError(
+            "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory (gather_in0) "
+            "is not supported in the descriptor interface"
         )
 
-    output_tensors = [ttnn.allocate_tensor_on_device(output_spec, device)]
-
-    # Create descriptor via the factory.
-    # Only MatmulMultiCoreReuseOptimizedProgramFactory is supported for now.
-    program_descriptor = ttnn.MatmulMultiCoreReuseOptimizedProgramFactory.create_descriptor(
-        operation_params, tensor_args, output_tensors, core_range_set
+    # Compute program cache key
+    h = ttnn.MatmulDeviceOperation.compute_program_hash(operation_params, tensor_args)
+    program_cache_key = extend_branch_program_cache_key(
+        int(h) & ((1 << 64) - 1), core_range_set_fusion_key(core_range_set)
     )
+
+    # Build input dict
+    inputs = {"input_a": input_a, "input_b": input_b}
+
+    # Lazy output allocation
+    def _alloc_outputs(slots):
+        spec = ttnn.MatmulDeviceOperation.compute_output_specs(operation_params, tensor_args)[0]
+
+        if output_mem_config is not None and output_mem_config.is_sharded():
+            factory_shard = spec.memory_config.shard_spec
+            corrected_shard = ttnn.ShardSpec(core_range_set, factory_shard.shape, factory_shard.orientation)
+            spec = ttnn.TensorSpec(
+                spec.shape,
+                spec.dtype,
+                spec.layout,
+                output_mem_config.memory_layout,
+                corrected_shard,
+                output_mem_config.buffer_type,
+                spec.tile,
+            )
+
+        slots[0] = ttnn.allocate_tensor_on_device(spec, device)
+
+    outputs = LazyOutputList([None], _alloc_outputs)
+
+    def _run_factory():
+        out = outputs[0]
+        return factory.create_descriptor(operation_params, tensor_args, [out], core_range_set)
 
     return OpDescriptor(
-        descriptor=program_descriptor,
-        input_tensors={"input_a": input_a, "input_b": input_b},
-        output_tensors=list(output_tensors),
-    )
-
-
-def _default_program_config(
-    input_a: "ttnn.Tensor",
-    input_b: "ttnn.Tensor",
-    transpose_a: bool,
-    transpose_b: bool,
-    core_range_set: "ttnn.CoreRangeSet",
-    fp32_dest_acc_en: bool,
-) -> "ttnn.MatmulMultiCoreReuseProgramConfig":
-    """Generate a MatmulMultiCoreReuseProgramConfig from tensor shapes and core grid.
-
-    Distributes M rows across cores. Each core handles all N columns.
-    """
-    TILE_HEIGHT = 32
-    TILE_WIDTH = 32
-
-    a_shape = input_a.padded_shape
-    b_shape = input_b.padded_shape
-
-    if transpose_a:
-        M = a_shape[-1] // TILE_WIDTH
-        K = a_shape[-2] // TILE_HEIGHT
-    else:
-        M = a_shape[-2] // TILE_HEIGHT
-        K = a_shape[-1] // TILE_WIDTH
-
-    if transpose_b:
-        N = b_shape[-2] // TILE_HEIGHT
-    else:
-        N = b_shape[-1] // TILE_WIDTH
-
-    # Count cores and compute bounding box from the core range set
-    num_cores = 0
-    max_x = 0
-    max_y = 0
-    for cr in core_range_set.ranges():
-        start = cr.start
-        end = cr.end
-        num_cores += (end.x - start.x + 1) * (end.y - start.y + 1)
-        max_x = max(max_x, end.x)
-        max_y = max(max_y, end.y)
-
-    grid_size = ttnn.CoreCoord(max_x + 1, max_y + 1)
-
-    per_core_M = math.ceil(M / num_cores)
-    per_core_N = N
-    in0_block_w = K
-
-    # Subblock tiling: maximize out_subblock_w under fp32/fp16 limit
-    limit = 4 if fp32_dest_acc_en else 8
-    out_subblock_w = min(per_core_N, limit)
-    while out_subblock_w > 1 and per_core_N % out_subblock_w != 0:
-        out_subblock_w -= 1
-    out_subblock_h = 1
-
-    return ttnn.MatmulMultiCoreReuseProgramConfig(
-        compute_with_storage_grid_size=grid_size,
-        in0_block_w=in0_block_w,
-        out_subblock_h=out_subblock_h,
-        out_subblock_w=out_subblock_w,
-        per_core_M=per_core_M,
-        per_core_N=per_core_N,
+        factory_fn=_run_factory,
+        input_tensors=inputs,
+        output_tensors=outputs,
+        program_cache_key=program_cache_key,
     )

--- a/models/experimental/ops/descriptors/matmul.py
+++ b/models/experimental/ops/descriptors/matmul.py
@@ -111,20 +111,6 @@ def matmul(
     # Lazy output allocation
     def _alloc_outputs(slots):
         spec = ttnn.MatmulDeviceOperation.compute_output_specs(operation_params, tensor_args)[0]
-
-        if output_mem_config is not None and output_mem_config.is_sharded():
-            factory_shard = spec.memory_config.shard_spec
-            corrected_shard = ttnn.ShardSpec(core_range_set, factory_shard.shape, factory_shard.orientation)
-            spec = ttnn.TensorSpec(
-                spec.shape,
-                spec.dtype,
-                spec.layout,
-                output_mem_config.memory_layout,
-                corrected_shard,
-                output_mem_config.buffer_type,
-                spec.tile,
-            )
-
         slots[0] = ttnn.allocate_tensor_on_device(spec, device)
 
     outputs = LazyOutputList([None], _alloc_outputs)

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
@@ -726,13 +726,24 @@ class TestPerfDemos:
         # [1024,256] x [256,128] on 1x8 grid
         # M=32 tiles, K=8 tiles, N=4 tiles
         # per_core_M=32/8=4, per_core_N=4, in0_block_w=K/32=8
-        mm_cfg = ttnn.MatmulMultiCoreReuseProgramConfig(
+        # Two separate configs bound to their respective disjoint grids
+        mm_cfg_a = ttnn.MatmulMultiCoreReuseProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(1, 8),
             in0_block_w=K // 32,
             out_subblock_h=1,
             out_subblock_w=min(N // 32, 4),
             per_core_M=shard_h // 32,
             per_core_N=N // 32,
+            allowed_worker_cores=cores_a,
+        )
+        mm_cfg_b = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(1, 8),
+            in0_block_w=K // 32,
+            out_subblock_h=1,
+            out_subblock_w=min(N // 32, 4),
+            per_core_M=shard_h // 32,
+            per_core_N=N // 32,
+            allowed_worker_cores=cores_b,
         )
 
         torch_a = torch.randn(1, 1, rows, K, dtype=torch.bfloat16)
@@ -769,7 +780,8 @@ class TestPerfDemos:
             sharded_in_b,
             sharded_out_a,
             sharded_out_b,
-            mm_cfg,
+            mm_cfg_a,
+            mm_cfg_b,
             ta,
             tb,
             tw,
@@ -792,7 +804,8 @@ class TestPerfDemos:
             sharded_in_b,
             sharded_out_a,
             sharded_out_b,
-            mm_cfg,
+            mm_cfg_a,
+            mm_cfg_b,
             ta,
             tb,
             tw,
@@ -813,7 +826,7 @@ class TestPerfDemos:
             la.output_tensors[0],
             tB,
             core_range_set=cores_a,
-            program_config=mm_cfg,
+            program_config=mm_cfg_a,
             compute_kernel_config=COMPUTE_CONFIG,
             output_mem_config=sharded_out_a,
         )
@@ -829,7 +842,7 @@ class TestPerfDemos:
             rb.output_tensors[0],
             tB,
             core_range_set=cores_b,
-            program_config=mm_cfg,
+            program_config=mm_cfg_b,
             compute_kernel_config=COMPUTE_CONFIG,
             output_mem_config=sharded_out_b,
         )
@@ -841,9 +854,9 @@ class TestPerfDemos:
             result_b = ttnn.to_torch(result_b_t)
 
             ua1 = ttnn.layer_norm(ta, weight=tw, bias=tbi, epsilon=1e-5, compute_kernel_config=COMPUTE_CONFIG)
-            ua2 = ttnn.matmul(ua1, tB, program_config=mm_cfg, compute_kernel_config=COMPUTE_CONFIG)
+            ua2 = ttnn.matmul(ua1, tB, program_config=mm_cfg_a, compute_kernel_config=COMPUTE_CONFIG)
             ub1 = ttnn.rms_norm(tb, weight=tw, epsilon=1e-5, compute_kernel_config=COMPUTE_CONFIG)
-            ub2 = ttnn.matmul(ub1, tB, program_config=mm_cfg, compute_kernel_config=COMPUTE_CONFIG)
+            ub2 = ttnn.matmul(ub1, tB, program_config=mm_cfg_b, compute_kernel_config=COMPUTE_CONFIG)
 
             ref_a = ttnn.to_torch(ua2)
             ref_b = ttnn.to_torch(ub2)
@@ -863,9 +876,9 @@ class TestPerfDemos:
 
             # Unfused reference for PCC — interleaved to avoid core mapping constraints
             ua1 = ttnn.layer_norm(ta, weight=tw, bias=tbi, epsilon=1e-5, compute_kernel_config=COMPUTE_CONFIG)
-            ua2 = ttnn.matmul(ua1, tB, program_config=mm_cfg, compute_kernel_config=COMPUTE_CONFIG)
+            ua2 = ttnn.matmul(ua1, tB, program_config=mm_cfg_a, compute_kernel_config=COMPUTE_CONFIG)
             ub1 = ttnn.rms_norm(tb, weight=tw, epsilon=1e-5, compute_kernel_config=COMPUTE_CONFIG)
-            ub2 = ttnn.matmul(ub1, tB, program_config=mm_cfg, compute_kernel_config=COMPUTE_CONFIG)
+            ub2 = ttnn.matmul(ub1, tB, program_config=mm_cfg_b, compute_kernel_config=COMPUTE_CONFIG)
 
             ref_a = ttnn.to_torch(ua2)
             ref_b = ttnn.to_torch(ub2)
@@ -881,9 +894,9 @@ class TestPerfDemos:
 
             # Unfused reference for accuracy check — interleaved to avoid core mapping constraints
             ua1 = ttnn.layer_norm(ta, weight=tw, bias=tbi, epsilon=1e-5, compute_kernel_config=COMPUTE_CONFIG)
-            ua2 = ttnn.matmul(ua1, tB, program_config=mm_cfg, compute_kernel_config=COMPUTE_CONFIG)
+            ua2 = ttnn.matmul(ua1, tB, program_config=mm_cfg_a, compute_kernel_config=COMPUTE_CONFIG)
             ub1 = ttnn.rms_norm(tb, weight=tw, epsilon=1e-5, compute_kernel_config=COMPUTE_CONFIG)
-            ub2 = ttnn.matmul(ub1, tB, program_config=mm_cfg, compute_kernel_config=COMPUTE_CONFIG)
+            ub2 = ttnn.matmul(ub1, tB, program_config=mm_cfg_b, compute_kernel_config=COMPUTE_CONFIG)
 
             ref_a = ttnn.to_torch(ua2)
             ref_b = ttnn.to_torch(ub2)

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
@@ -325,6 +325,7 @@ class TestPerfDemos:
             out_subblock_w=min(N_tiles, 4),
             per_core_M=M_tiles // 8,
             per_core_N=N_tiles,
+            allowed_worker_cores=core_range,
         )
 
         torch_input = torch.randn(1, 1, 256, H, dtype=torch.bfloat16)
@@ -934,6 +935,7 @@ class TestPerfDemos:
             out_subblock_w=min(N // 32, 4),
             per_core_M=shard_h // 32,
             per_core_N=N // 32,
+            allowed_worker_cores=cores,
         )
         ln_cfg = ttnn.LayerNormShardedMultiCoreProgramConfig(
             compute_with_storage_grid_size=(1, 8),
@@ -1047,13 +1049,23 @@ class TestPerfDemos:
         # B=[1,1,256,128] -> output [1,1,1024,128]
         # in0_block_w must equal shard_w / tile_w for block-sharded A input
         # (shard [128,256] on 1-col grid -> shard_w=256, so in0_block_w=256/32=8)
-        mm_cfg = ttnn.MatmulMultiCoreReuseProgramConfig(
+        mm_cfg_left = ttnn.MatmulMultiCoreReuseProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(1, 8),
             in0_block_w=cols // 32,
             out_subblock_h=1,
             out_subblock_w=min(mm_n // 32, 4),
             per_core_M=4,
             per_core_N=mm_n // 32,
+            allowed_worker_cores=left_cores,
+        )
+        mm_cfg_right = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(1, 8),
+            in0_block_w=cols // 32,
+            out_subblock_h=1,
+            out_subblock_w=min(mm_n // 32, 4),
+            per_core_M=4,
+            per_core_N=mm_n // 32,
+            allowed_worker_cores=right_cores,
         )
 
         # Block-sharded: height / grid_rows, width / grid_cols.
@@ -1110,7 +1122,8 @@ class TestPerfDemos:
             lr_cores,
             rl_cores,
             rr_cores,
-            mm_cfg,
+            mm_cfg_left,
+            mm_cfg_right,
             mm_n,
             tt_input,
             tt_B_left,
@@ -1132,7 +1145,8 @@ class TestPerfDemos:
             lr_cores,
             rl_cores,
             rr_cores,
-            mm_cfg,
+            mm_cfg_left,
+            mm_cfg_right,
             mm_n,
             tt_input,
             tt_B_left,
@@ -1169,7 +1183,7 @@ class TestPerfDemos:
             sl_top.output_tensors[0],
             tt_B_left,
             core_range_set=left_cores,
-            program_config=mm_cfg,
+            program_config=mm_cfg_left,
             compute_kernel_config=COMPUTE_CONFIG,
             output_mem_config=shards["mm_left"],
         )
@@ -1177,7 +1191,7 @@ class TestPerfDemos:
             sl_bot.output_tensors[0],
             tt_B_right,
             core_range_set=right_cores,
-            program_config=mm_cfg,
+            program_config=mm_cfg_right,
             compute_kernel_config=COMPUTE_CONFIG,
             output_mem_config=shards["mm_right"],
         )
@@ -1239,7 +1253,7 @@ class TestPerfDemos:
             ln_lr,
             ln_rl,
             ln_rr,
-            mm_cfg,
+            mm_cfg_left,
             mm_n,
             tt_input,
             tt_B_left,
@@ -1277,7 +1291,7 @@ class TestPerfDemos:
             ln_lr,
             ln_rl,
             ln_rr,
-            mm_cfg,
+            mm_cfg_left,
             mm_n,
             tt_input,
             tt_B_left,
@@ -1323,7 +1337,7 @@ class TestPerfDemos:
             u_left = ttnn.matmul(
                 u_top,
                 tt_B_left,
-                program_config=mm_cfg,
+                program_config=mm_cfg_left,
                 compute_kernel_config=COMPUTE_CONFIG,
                 memory_config=shards["mm_left"],
             )
@@ -1343,7 +1357,7 @@ class TestPerfDemos:
             u_right = ttnn.matmul(
                 u_bot,
                 tt_B_right,
-                program_config=mm_cfg,
+                program_config=mm_cfg_left,
                 compute_kernel_config=COMPUTE_CONFIG,
                 memory_config=shards["mm_left"],
             )
@@ -1407,7 +1421,7 @@ class TestPerfDemos:
             u_left = ttnn.matmul(
                 u_top,
                 tt_B_left,
-                program_config=mm_cfg,
+                program_config=mm_cfg_left,
                 compute_kernel_config=COMPUTE_CONFIG,
                 memory_config=shards["mm_left"],
             )
@@ -1427,7 +1441,7 @@ class TestPerfDemos:
             u_right = ttnn.matmul(
                 u_bot,
                 tt_B_right,
-                program_config=mm_cfg,
+                program_config=mm_cfg_left,
                 compute_kernel_config=COMPUTE_CONFIG,
                 memory_config=shards["mm_left"],
             )
@@ -1487,7 +1501,7 @@ class TestPerfDemos:
             u_left = ttnn.matmul(
                 u_top,
                 tt_B_left,
-                program_config=mm_cfg,
+                program_config=mm_cfg_left,
                 compute_kernel_config=COMPUTE_CONFIG,
                 memory_config=shards["mm_left"],
             )
@@ -1507,7 +1521,7 @@ class TestPerfDemos:
             u_right = ttnn.matmul(
                 u_bot,
                 tt_B_right,
-                program_config=mm_cfg,
+                program_config=mm_cfg_left,
                 compute_kernel_config=COMPUTE_CONFIG,
                 memory_config=shards["mm_left"],
             )
@@ -1576,6 +1590,7 @@ class TestPerfDemos:
             out_subblock_w=min(mm_n // 32, 4),
             per_core_M=4,
             per_core_N=mm_n // 32,
+            allowed_worker_cores=branch_cores,
         )
 
         ln_prog_cfg = lambda gx, gy, bh, bw: ttnn.LayerNormShardedMultiCoreProgramConfig(

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -2731,6 +2731,7 @@ class TestMatmulFactories:
             per_core_M=2,
             per_core_N=2,
             transpose_mcast=False,
+            allowed_worker_cores=cr,
         )
         mm = matmul_desc(
             tt(torch_a, device),
@@ -2765,6 +2766,7 @@ class TestMatmulFactories:
             fuse_batch=True,
             mcast_in0=True,
             gather_in0=False,
+            allowed_worker_cores=cr,
         )
         mm = matmul_desc(
             tt(torch_a, device),
@@ -2797,6 +2799,7 @@ class TestMatmulFactories:
             per_core_M=2,
             per_core_N=2,
             transpose_mcast=True,
+            allowed_worker_cores=cr,
         )
         mm = matmul_desc(
             tt(torch_a, device),
@@ -2880,6 +2883,7 @@ class TestMatmulFactories:
             per_core_M=2,
             per_core_N=2,
             transpose_mcast=False,
+            allowed_worker_cores=cr,
         )
 
         ln = layer_norm.layer_norm(
@@ -2940,6 +2944,7 @@ class TestMatmulFactories:
             fuse_batch=True,
             mcast_in0=True,
             gather_in0=False,
+            allowed_worker_cores=cr,
         )
 
         rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
@@ -3005,6 +3010,7 @@ class TestMatmulFactories:
             per_core_M=2,
             per_core_N=2,
             transpose_mcast=False,
+            allowed_worker_cores=cr_b,
         )
         mm_b = matmul_desc(
             tt(torch_a, device),
@@ -3059,6 +3065,7 @@ class TestMatmulFactories:
         )
 
         # Branch B: Mcast1D on cores (4,0)-(7,0)
+        cr_b = cores(4, 0, 7, 0)
         config_b = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
             in0_block_w=4,
@@ -3071,11 +3078,12 @@ class TestMatmulFactories:
             fuse_batch=True,
             mcast_in0=True,
             gather_in0=False,
+            allowed_worker_cores=cr_b,
         )
         mm_b = matmul_desc(
             stem.output_tensors[0],
             tt(torch_b2, device),
-            core_range_set=cores(4, 0, 7, 0),
+            core_range_set=cr_b,
             program_config=config_b,
             compute_kernel_config=self._compute(),
         )
@@ -3122,6 +3130,7 @@ class TestMatmulFactories:
             per_core_M=2,
             per_core_N=2,
             transpose_mcast=False,
+            allowed_worker_cores=cr,
         )
 
         rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
@@ -3203,6 +3212,7 @@ class TestMatmulFactories:
             per_core_M=1,
             per_core_N=2,
             transpose_mcast=False,
+            allowed_worker_cores=cr2,
         )
         mm2 = matmul_desc(
             tt(torch_a2, device),
@@ -3228,6 +3238,7 @@ class TestMatmulFactories:
             fuse_batch=True,
             mcast_in0=True,
             gather_in0=False,
+            allowed_worker_cores=cr3,
         )
         mm3 = matmul_desc(
             tt(torch_a, device),
@@ -3291,6 +3302,7 @@ class TestMatmulFactories:
         left = Sequential(mm_left, rms_left)
 
         # Right branch: MM(mcast2d) -> RMS on cores (4,0)-(5,1)
+        right_cr = cores(4, 0, 5, 1)
         cfg_right = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
             in0_block_w=4,
@@ -3301,16 +3313,17 @@ class TestMatmulFactories:
             per_core_M=2,
             per_core_N=2,
             transpose_mcast=False,
+            allowed_worker_cores=right_cr,
         )
         mm_right = matmul_desc(
             stem.output_tensors[0],
             tt(torch_b2, device),
-            core_range_set=cores(4, 0, 5, 1),
+            core_range_set=right_cr,
             program_config=cfg_right,
             compute_kernel_config=self._compute(),
         )
         rms_right = rms_norm.rms_norm(
-            mm_right.output_tensors[0], core_range_set=cores(4, 0, 5, 1), weight=tt(torch_w, device), epsilon=1e-5
+            mm_right.output_tensors[0], core_range_set=right_cr, weight=tt(torch_w, device), epsilon=1e-5
         )
         right = Sequential(mm_right, rms_right)
 
@@ -3344,6 +3357,7 @@ class TestMatmulFactories:
             fuse_batch=True,
             mcast_in0=True,
             gather_in0=True,
+            allowed_worker_cores=cr,
         )
         with pytest.raises(ValueError, match="MeshWorkload"):
             matmul_desc(
@@ -3381,6 +3395,7 @@ class TestMatmulFactories:
             per_core_M=2,
             per_core_N=2,
             transpose_mcast=False,
+            allowed_worker_cores=cr,
         )
 
         deferred = matmul_desc(core_range_set=cr, program_config=config, compute_kernel_config=self._compute())

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -589,10 +589,17 @@ class TestMatmulFusion:
         from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
 
         torch.manual_seed(42)
-        torch_a = torch.randn(1, 1, 32, 64, dtype=torch.bfloat16)
-        torch_b = torch.randn(1, 1, 64, 128, dtype=torch.bfloat16)
+        torch_a = torch.randn(1, 1, 32, 128, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, 128, 128, dtype=torch.bfloat16)
 
-        mm = matmul_desc(tt(torch_a, device), tt(torch_b, device))
+        cr = cores(0, 0)
+        mm = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=self._mm_config(),
+            compute_kernel_config=self._compute(),
+        )
         mm.launch()
         check_pcc(torch_a @ torch_b, mm.output_tensors[0], pcc=0.99, label="matmul standalone")
 
@@ -1066,10 +1073,23 @@ class TestParallelExecution:
         ln_compute = ttnn.layernorm_default_compute_config(device.arch())
         torch.manual_seed(42)
 
-        # Matmul on default core
+        # Matmul on core (0,0)
         torch_a = torch.randn(1, 1, 32, 64, dtype=torch.bfloat16)
         torch_b = torch.randn(1, 1, 64, 128, dtype=torch.bfloat16)
-        mm = matmul_desc(tt(torch_a, device), tt(torch_b, device))
+        mm_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(1, 1),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=4,
+        )
+        mm = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b, device),
+            core_range_set=cores(0, 0),
+            program_config=mm_config,
+        )
 
         # 3-phase chain on core (4,0)
         cr = cores(4, 0)
@@ -1548,13 +1568,39 @@ class TestDocExample:
         torch_ln_bias = torch.zeros(1, 1, 1, 128, dtype=torch.bfloat16)
         torch_rms_w = torch.ones(1, 1, 1, 128, dtype=torch.bfloat16)
 
+        # op1: [1,1,1024,256]x[1,1,256,256], M=32 K=8 N=8, 64 cores → per_core_M=1
+        mm_config_1 = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+            in0_block_w=8,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=8,
+        )
         op1 = descriptors.matmul(
-            tt(torch_a, device), tt(torch_b1, device), core_range_set=full, compute_kernel_config=compute_cfg
+            tt(torch_a, device),
+            tt(torch_b1, device),
+            core_range_set=full,
+            program_config=mm_config_1,
+            compute_kernel_config=compute_cfg,
         )
         op2 = descriptors.slice(op1.output_tensors[0], [0, 0, 0, 0], [1, 1, 1024, 128], core_range_set=left)
         op3 = descriptors.slice(op1.output_tensors[0], [0, 0, 0, 128], [1, 1, 1024, 256], core_range_set=right)
+        # op4: [1,1,1024,128]x[1,1,128,128], M=32 K=4 N=4, 16 cores → per_core_M=2
+        mm_config_4 = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 4),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=2,
+            per_core_N=4,
+        )
         op4 = descriptors.matmul(
-            op2.output_tensors[0], tt(torch_b4, device), core_range_set=left_top, compute_kernel_config=compute_cfg
+            op2.output_tensors[0],
+            tt(torch_b4, device),
+            core_range_set=left_top,
+            program_config=mm_config_4,
+            compute_kernel_config=compute_cfg,
         )
 
         op5 = descriptors.layer_norm(
@@ -2103,13 +2149,23 @@ class TestPersistentMode:
         tt_a = ttnn.from_torch(torch_a, device=device, layout=ttnn.TILE_LAYOUT)
         tt_b = ttnn.from_torch(torch_b, device=device, layout=ttnn.TILE_LAYOUT)
 
+        cr = cores(0, 0)
+        mm_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(1, 1),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+        )
+
         # Inline matmul first (for reference)
-        inline_desc = matmul_desc(tt_a, tt_b)
+        inline_desc = matmul_desc(tt_a, tt_b, core_range_set=cr, program_config=mm_config)
         inline_desc.launch()
         ref_out = ttnn.to_torch(inline_desc.output_tensors[0])
 
-        # Deferred matmul
-        deferred = matmul_desc()
+        # Deferred matmul (persistent mode — required kwargs only)
+        deferred = matmul_desc(core_range_set=cr, program_config=mm_config)
         assert deferred.program_cache_key is None
         deferred.update(tt_a, tt_b)
         assert deferred.program_cache_key is not None
@@ -2586,3 +2642,735 @@ class TestAsymmetricBarrier:
                 out_b,
                 label=f"branch B run {run}",
             )
+
+
+# ===========================================================================
+# TestMatmulFactories — exercises all matmul factory variants via descriptors
+# ===========================================================================
+
+
+class TestMatmulFactories:
+    """Tests exercising all matmul program factories through the descriptor interface.
+
+    Covers:
+      - MatmulMultiCoreReuseOptimizedProgramFactory (via MatmulMultiCoreReuseProgramConfig)
+      - MatmulMultiCoreReuseMcast2DProgramFactory (via MatmulMultiCoreReuseMultiCastProgramConfig)
+      - MatmulMultiCoreReuseMcast1DProgramFactory (via MatmulMultiCoreReuseMultiCast1DProgramConfig)
+      - Complex topologies mixing different factories with normalization ops
+    """
+
+    def _compute(self, fp32=False):
+        return ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=True,
+            fp32_dest_acc_en=fp32,
+        )
+
+    # ------------------------------------------------------------------
+    # Standalone factory tests
+    # ------------------------------------------------------------------
+
+    @stress_test_program_cache
+    def test_reuse_optimized_factory(self, device):
+        """MatmulMultiCoreReuseOptimizedProgramFactory via ReuseProgramConfig."""
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        M, K, N = 64, 128, 128
+        torch_a = torch.randn(1, 1, M, K, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        cr = cores(0, 0, 1, 0)
+        config = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=4,
+        )
+        mm = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=config,
+            compute_kernel_config=self._compute(),
+        )
+        mm.launch()
+        check_pcc(torch_a @ torch_b, mm.output_tensors[0], pcc=0.99, label="reuse_optimized")
+
+    @stress_test_program_cache
+    def test_mcast_2d_factory(self, device):
+        """MatmulMultiCoreReuseMcast2DProgramFactory via ReuseMultiCastProgramConfig."""
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        M, K, N = 128, 128, 128
+        torch_a = torch.randn(1, 1, M, K, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        cr = cores(0, 0, 1, 1)
+        config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=2,
+            out_block_w=2,
+            per_core_M=2,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+        mm = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=config,
+            compute_kernel_config=self._compute(),
+        )
+        mm.launch()
+        check_pcc(torch_a @ torch_b, mm.output_tensors[0], pcc=0.99, label="mcast_2d")
+
+    @stress_test_program_cache
+    def test_mcast_1d_factory(self, device):
+        """MatmulMultiCoreReuseMcast1DProgramFactory via ReuseMultiCast1DProgramConfig."""
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        M, K, N = 32, 128, 128
+        torch_a = torch.randn(1, 1, M, K, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        cr = cores(0, 0, 3, 0)
+        config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fuse_batch=True,
+            mcast_in0=True,
+            gather_in0=False,
+        )
+        mm = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=config,
+            compute_kernel_config=self._compute(),
+        )
+        mm.launch()
+        check_pcc(torch_a @ torch_b, mm.output_tensors[0], pcc=0.99, label="mcast_1d")
+
+    @stress_test_program_cache
+    def test_mcast_2d_transpose_mcast(self, device):
+        """Mcast2D with transpose_mcast=True."""
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        M, K, N = 128, 128, 128
+        torch_a = torch.randn(1, 1, M, K, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        cr = cores(0, 0, 1, 1)
+        config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=2,
+            out_block_w=2,
+            per_core_M=2,
+            per_core_N=2,
+            transpose_mcast=True,
+        )
+        mm = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=config,
+            compute_kernel_config=self._compute(),
+        )
+        mm.launch()
+        check_pcc(torch_a @ torch_b, mm.output_tensors[0], pcc=0.99, label="mcast_2d_transposed")
+
+    # ------------------------------------------------------------------
+    # Factory + normalization fusion tests
+    # ------------------------------------------------------------------
+
+    @stress_test_program_cache
+    def test_reuse_optimized_rms_chain(self, device):
+        """RMS -> MatmulReuseOptimized -> RMS chain."""
+        from models.experimental.ops.descriptors.fusion import Sequential
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        cr = cores(0, 0, 3, 1)
+
+        torch_input = torch.randn(1, 1, 256, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        config = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=4,
+        )
+
+        rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+        mm = matmul_desc(
+            rms1.output_tensors[0],
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=config,
+            compute_kernel_config=self._compute(),
+        )
+        rms2 = rms_norm.rms_norm(mm.output_tensors[0], core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+
+        fused = Sequential(rms1, mm, rms2)
+        [out] = fused.run(results=[rms2])
+
+        golden = torch_rms_norm(torch_rms_norm(torch_input.float(), torch_w.float()) @ torch_b.float(), torch_w.float())
+        check_pcc(golden, out, label="reuse_optimized RMS->MM->RMS")
+
+    @stress_test_program_cache
+    def test_mcast_2d_layernorm_chain(self, device):
+        """LayerNorm -> Mcast2D matmul -> RMSNorm chain."""
+        from models.experimental.ops.descriptors.fusion import Sequential
+        from models.experimental.ops.descriptors.normalization import layer_norm, rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        cr = cores(0, 0, 1, 1)
+        compute_cfg = self._compute(fp32=False)
+
+        torch_input = torch.randn(1, 1, 128, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_bias = torch.zeros(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        mm_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=2,
+            out_block_h=2,
+            out_block_w=2,
+            per_core_M=2,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+
+        ln = layer_norm.layer_norm(
+            tt(torch_input, device),
+            core_range_set=cr,
+            weight=tt(torch_w, device),
+            bias=tt(torch_bias, device),
+            epsilon=1e-5,
+            compute_kernel_config=compute_cfg,
+        )
+        mm = matmul_desc(
+            ln.output_tensors[0],
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=mm_config,
+            compute_kernel_config=compute_cfg,
+        )
+        rms = rms_norm.rms_norm(
+            mm.output_tensors[0],
+            core_range_set=cr,
+            weight=tt(torch_w, device),
+            epsilon=1e-5,
+            compute_kernel_config=compute_cfg,
+        )
+
+        fused = Sequential(ln, mm, rms)
+        [out] = fused.run(results=[rms])
+
+        g = torch_layer_norm(torch_input.float(), torch_w.float(), torch_bias.float())
+        g = g @ torch_b.float()
+        golden = torch_rms_norm(g, torch_w.float())
+        check_pcc(golden, out, pcc=0.97, label="mcast_2d LN->MM->RMS")
+
+    @stress_test_program_cache
+    def test_mcast_1d_rms_chain(self, device):
+        """RMS -> Mcast1D matmul -> RMS chain."""
+        from models.experimental.ops.descriptors.fusion import Sequential
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        cr = cores(0, 0, 3, 0)
+
+        torch_input = torch.randn(1, 1, 32, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        mm_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fuse_batch=True,
+            mcast_in0=True,
+            gather_in0=False,
+        )
+
+        rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+        mm = matmul_desc(
+            rms1.output_tensors[0],
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=mm_config,
+            compute_kernel_config=self._compute(),
+        )
+        rms2 = rms_norm.rms_norm(mm.output_tensors[0], core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+
+        fused = Sequential(rms1, mm, rms2)
+        [out] = fused.run(results=[rms2])
+
+        golden = torch_rms_norm(torch_rms_norm(torch_input.float(), torch_w.float()) @ torch_b.float(), torch_w.float())
+        check_pcc(golden, out, label="mcast_1d RMS->MM->RMS")
+
+    # ------------------------------------------------------------------
+    # Complex topologies with multiple factories
+    # ------------------------------------------------------------------
+
+    @stress_test_program_cache
+    def test_parallel_different_factories(self, device):
+        """Two matmuls with different factories running in parallel."""
+        from models.experimental.ops.descriptors.fusion import Parallel
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        torch_a = torch.randn(1, 1, 128, hidden, dtype=torch.bfloat16)
+        torch_b1 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+        torch_b2 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        # Branch A: Reuse Optimized on cores (0,0)-(3,0)
+        cr_a = cores(0, 0, 3, 0)
+        config_a = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=4,
+        )
+        mm_a = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b1, device),
+            core_range_set=cr_a,
+            program_config=config_a,
+            compute_kernel_config=self._compute(),
+        )
+
+        # Branch B: Mcast2D on cores (4,0)-(5,1)
+        cr_b = cores(4, 0, 5, 1)
+        config_b = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=2,
+            out_block_h=2,
+            out_block_w=2,
+            per_core_M=2,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+        mm_b = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b2, device),
+            core_range_set=cr_b,
+            program_config=config_b,
+            compute_kernel_config=self._compute(),
+        )
+
+        fused = Parallel(mm_a, mm_b)
+        [out_a, out_b] = fused.run(results=[mm_a, mm_b])
+
+        check_pcc(torch_a @ torch_b1, out_a, pcc=0.99, label="parallel branch A (reuse_optimized)")
+        check_pcc(torch_a @ torch_b2, out_b, pcc=0.99, label="parallel branch B (mcast_2d)")
+
+    @stress_test_program_cache
+    def test_branching_rms_to_different_mm_factories(self, device):
+        """RMS norm stem splits into two matmul branches using different factories."""
+        from models.experimental.ops.descriptors.fusion import Sequential, Parallel
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        torch_input = torch.randn(1, 1, 32, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b1 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+        torch_b2 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        # Stem: RMS norm on cores (0,0)-(3,0)
+        stem_cr = cores(0, 0, 3, 0)
+        stem = rms_norm.rms_norm(
+            tt(torch_input, device), core_range_set=stem_cr, weight=tt(torch_w, device), epsilon=1e-5
+        )
+
+        # Branch A: Reuse Optimized on cores (0,0)-(3,0)
+        config_a = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+        )
+        mm_a = matmul_desc(
+            stem.output_tensors[0],
+            tt(torch_b1, device),
+            core_range_set=cores(0, 0, 3, 0),
+            program_config=config_a,
+            compute_kernel_config=self._compute(),
+        )
+
+        # Branch B: Mcast1D on cores (4,0)-(7,0)
+        config_b = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fuse_batch=True,
+            mcast_in0=True,
+            gather_in0=False,
+        )
+        mm_b = matmul_desc(
+            stem.output_tensors[0],
+            tt(torch_b2, device),
+            core_range_set=cores(4, 0, 7, 0),
+            program_config=config_b,
+            compute_kernel_config=self._compute(),
+        )
+
+        fused = Sequential(stem, Parallel(mm_a, mm_b))
+        [out_a, out_b] = fused.run(results=[mm_a, mm_b])
+
+        g_stem = torch_rms_norm(torch_input.float(), torch_w.float())
+        check_pcc(g_stem @ torch_b1.float(), out_a, pcc=0.99, label="branch A (reuse_optimized)")
+        check_pcc(g_stem @ torch_b2.float(), out_b, pcc=0.99, label="branch B (mcast_1d)")
+
+    @stress_test_program_cache
+    def test_deep_chain_alternating_factories_and_norms(self, device):
+        """Deep chain: RMS -> MM(reuse) -> RMS -> MM(mcast2d) -> RMS."""
+        from models.experimental.ops.descriptors.fusion import Sequential
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        cr = cores(0, 0, 1, 1)
+
+        torch_input = torch.randn(1, 1, 128, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b1 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+        torch_b2 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        config_reuse = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=2,
+            per_core_M=2,
+            per_core_N=2,
+        )
+        config_mcast2d = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=2,
+            out_block_h=2,
+            out_block_w=2,
+            per_core_M=2,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+
+        rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+        mm1 = matmul_desc(
+            rms1.output_tensors[0],
+            tt(torch_b1, device),
+            core_range_set=cr,
+            program_config=config_reuse,
+            compute_kernel_config=self._compute(),
+        )
+        rms2 = rms_norm.rms_norm(mm1.output_tensors[0], core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+        mm2 = matmul_desc(
+            rms2.output_tensors[0],
+            tt(torch_b2, device),
+            core_range_set=cr,
+            program_config=config_mcast2d,
+            compute_kernel_config=self._compute(),
+        )
+        rms3 = rms_norm.rms_norm(mm2.output_tensors[0], core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+
+        fused = Sequential(rms1, mm1, rms2, mm2, rms3)
+        [out] = fused.run(results=[rms3])
+
+        g = torch_rms_norm(torch_input.float(), torch_w.float())
+        g = g @ torch_b1.float()
+        g = torch_rms_norm(g, torch_w.float())
+        g = g @ torch_b2.float()
+        golden = torch_rms_norm(g, torch_w.float())
+        check_pcc(golden, out, pcc=0.97, label="deep chain alternating factories")
+
+    @stress_test_program_cache
+    def test_parallel_mm_chains_different_factories(self, device):
+        """Three parallel chains each using a different mm factory followed by RMS."""
+        from models.experimental.ops.descriptors.fusion import Sequential, Parallel
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        torch_a = torch.randn(1, 1, 32, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b1 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+        torch_b2 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+        torch_b3 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        # Chain 1: Reuse on cores (0,0)-(3,0)
+        cr1 = cores(0, 0, 3, 0)
+        cfg1 = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+        )
+        mm1 = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b1, device),
+            core_range_set=cr1,
+            program_config=cfg1,
+            compute_kernel_config=self._compute(),
+        )
+        rms1 = rms_norm.rms_norm(mm1.output_tensors[0], core_range_set=cr1, weight=tt(torch_w, device), epsilon=1e-5)
+        chain1 = Sequential(mm1, rms1)
+
+        # Chain 2: Mcast2D on cores (0,2)-(1,3)
+        # Use separate larger input for mcast2d (needs >=2 M-tiles for 2-row grid)
+        torch_a2 = torch.randn(1, 1, 64, hidden, dtype=torch.bfloat16)
+        torch_w2 = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        cr2 = cores(0, 2, 1, 3)
+        cfg2 = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=2,
+            out_block_h=1,
+            out_block_w=2,
+            per_core_M=1,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+        mm2 = matmul_desc(
+            tt(torch_a2, device),
+            tt(torch_b2, device),
+            core_range_set=cr2,
+            program_config=cfg2,
+            compute_kernel_config=self._compute(),
+        )
+        rms2 = rms_norm.rms_norm(mm2.output_tensors[0], core_range_set=cr2, weight=tt(torch_w2, device), epsilon=1e-5)
+        chain2 = Sequential(mm2, rms2)
+
+        # Chain 3: Mcast1D on cores (4,2)-(7,2)
+        cr3 = cores(4, 2, 7, 2)
+        cfg3 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fuse_batch=True,
+            mcast_in0=True,
+            gather_in0=False,
+        )
+        mm3 = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b3, device),
+            core_range_set=cr3,
+            program_config=cfg3,
+            compute_kernel_config=self._compute(),
+        )
+        rms3 = rms_norm.rms_norm(mm3.output_tensors[0], core_range_set=cr3, weight=tt(torch_w, device), epsilon=1e-5)
+        chain3 = Sequential(mm3, rms3)
+
+        fused = Parallel(chain1, chain2, chain3)
+        [out1, out2, out3] = fused.run(results=[rms1, rms2, rms3])
+
+        g1 = torch_rms_norm((torch_a @ torch_b1).float(), torch_w.float())
+        g2 = torch_rms_norm((torch_a2 @ torch_b2).float(), torch_w2.float())
+        g3 = torch_rms_norm((torch_a @ torch_b3).float(), torch_w.float())
+        check_pcc(g1, out1, pcc=0.98, label="chain1 (reuse)")
+        check_pcc(g2, out2, pcc=0.98, label="chain2 (mcast2d)")
+        check_pcc(g3, out3, pcc=0.98, label="chain3 (mcast1d)")
+
+    @stress_test_program_cache
+    def test_nested_tree_mixed_factories(self, device):
+        """Nested tree: RMS stem -> Parallel(MM_reuse -> RMS, MM_mcast2d -> RMS)."""
+        from models.experimental.ops.descriptors.fusion import Sequential, Parallel
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        hidden = 128
+        torch_input = torch.randn(1, 1, 128, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b1 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+        torch_b2 = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        stem_cr = cores(0, 0, 3, 0)
+        stem = rms_norm.rms_norm(
+            tt(torch_input, device), core_range_set=stem_cr, weight=tt(torch_w, device), epsilon=1e-5
+        )
+
+        # Left branch: MM(reuse) -> RMS on cores (0,0)-(3,0)
+        cfg_left = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=4,
+        )
+        mm_left = matmul_desc(
+            stem.output_tensors[0],
+            tt(torch_b1, device),
+            core_range_set=cores(0, 0, 3, 0),
+            program_config=cfg_left,
+            compute_kernel_config=self._compute(),
+        )
+        rms_left = rms_norm.rms_norm(
+            mm_left.output_tensors[0], core_range_set=cores(0, 0, 3, 0), weight=tt(torch_w, device), epsilon=1e-5
+        )
+        left = Sequential(mm_left, rms_left)
+
+        # Right branch: MM(mcast2d) -> RMS on cores (4,0)-(5,1)
+        cfg_right = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=2,
+            out_block_h=2,
+            out_block_w=2,
+            per_core_M=2,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+        mm_right = matmul_desc(
+            stem.output_tensors[0],
+            tt(torch_b2, device),
+            core_range_set=cores(4, 0, 5, 1),
+            program_config=cfg_right,
+            compute_kernel_config=self._compute(),
+        )
+        rms_right = rms_norm.rms_norm(
+            mm_right.output_tensors[0], core_range_set=cores(4, 0, 5, 1), weight=tt(torch_w, device), epsilon=1e-5
+        )
+        right = Sequential(mm_right, rms_right)
+
+        fused = Sequential(stem, Parallel(left, right))
+        [out_l, out_r] = fused.run(results=[rms_left, rms_right])
+
+        g_stem = torch_rms_norm(torch_input.float(), torch_w.float())
+        golden_l = torch_rms_norm((g_stem @ torch_b1.float()), torch_w.float())
+        golden_r = torch_rms_norm((g_stem @ torch_b2.float()), torch_w.float())
+        check_pcc(golden_l, out_l, pcc=0.97, label="left (reuse->rms)")
+        check_pcc(golden_r, out_r, pcc=0.97, label="right (mcast2d->rms)")
+
+    def test_gather_in0_raises(self, device):
+        """gather_in0=True should raise (MeshWorkload factory not supported)."""
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        torch_a = torch.randn(1, 1, 128, 128, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, 128, 128, dtype=torch.bfloat16)
+
+        cr = cores(0, 0, 3, 0)
+        config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=4,
+            per_core_M=1,
+            per_core_N=4,
+            fuse_batch=True,
+            mcast_in0=True,
+            gather_in0=True,
+        )
+        with pytest.raises(ValueError, match="MeshWorkload"):
+            matmul_desc(
+                tt(torch_a, device),
+                tt(torch_b, device),
+                core_range_set=cr,
+                program_config=config,
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(
+                    math_fidelity=ttnn.MathFidelity.HiFi4,
+                    math_approx_mode=True,
+                    fp32_dest_acc_en=False,
+                ),
+            )
+
+    @stress_test_program_cache
+    def test_persistent_mcast_2d_deferred(self, device):
+        """Persistent mode with Mcast2D: build with config only, then update inputs."""
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        M, K, N = 128, 128, 128
+        torch_a = torch.rand(1, 1, M, K, dtype=torch.bfloat16)
+        torch_b = torch.rand(1, 1, K, N, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(torch_a, device=device, layout=ttnn.TILE_LAYOUT)
+        tt_b = ttnn.from_torch(torch_b, device=device, layout=ttnn.TILE_LAYOUT)
+
+        cr = cores(0, 0, 1, 1)
+        config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=2,
+            out_block_w=2,
+            per_core_M=2,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+
+        deferred = matmul_desc(core_range_set=cr, program_config=config, compute_kernel_config=self._compute())
+        assert deferred.program_cache_key is None
+        deferred.update(tt_a, tt_b)
+        assert deferred.program_cache_key is not None
+        deferred.launch()
+
+        golden = torch_a.float() @ torch_b.float()
+        check_pcc(golden, deferred.output_tensors[0], pcc=0.99, label="persistent mcast2d")

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -2665,7 +2665,9 @@ class TestMatmulFactories:
     Covers:
       - MatmulMultiCoreReuseOptimizedProgramFactory (via MatmulMultiCoreReuseProgramConfig)
       - MatmulMultiCoreReuseMcast2DProgramFactory (via MatmulMultiCoreReuseMultiCastProgramConfig)
-      - MatmulMultiCoreReuseMcast1DProgramFactory (via MatmulMultiCoreReuseMultiCast1DProgramConfig)
+      - MatmulMultiCoreReuseMcast1DProgramFactory, mcast_in0=True (in0 broadcast, N split)
+      - MatmulMultiCoreReuseMcast1DProgramFactory, mcast_in0=False (in1 broadcast, M split)
+      - Batched matmul (batch > 1) via reuse_optimized and fuse_batch=True mcast_1d
       - Complex topologies mixing different factories with normalization ops
     """
 
@@ -3406,3 +3408,214 @@ class TestMatmulFactories:
 
         golden = torch_a.float() @ torch_b.float()
         check_pcc(golden, deferred.output_tensors[0], pcc=0.99, label="persistent mcast2d")
+
+    # ------------------------------------------------------------------
+    # mcast_in0=False (in1 broadcast, M split across cores)
+    # ------------------------------------------------------------------
+
+    @stress_test_program_cache
+    def test_mcast_1d_mcast_in1_rms_chain(self, device):
+        """Sequential: RMS -> Mcast1D(mcast_in0=False) -> RMS, exercises in1-broadcast kernels."""
+        from models.experimental.ops.descriptors.fusion import Sequential
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        # mcast_in0=False: in1 is broadcast, M rows split across 4 cores (per_core_M=1, per_core_N=4)
+        hidden = 128
+        cr = cores(0, 0, 3, 0)
+
+        torch_input = torch.randn(1, 1, 128, hidden, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, hidden, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, hidden, hidden, dtype=torch.bfloat16)
+
+        mm_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            out_block_h=1,
+            out_block_w=4,
+            per_core_M=1,
+            per_core_N=4,
+            fuse_batch=True,
+            mcast_in0=False,
+            gather_in0=False,
+            allowed_worker_cores=cr,
+        )
+
+        rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+        mm = matmul_desc(
+            rms1.output_tensors[0],
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=mm_config,
+            compute_kernel_config=self._compute(),
+        )
+        rms2 = rms_norm.rms_norm(mm.output_tensors[0], core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+
+        fused = Sequential(rms1, mm, rms2)
+        [out] = fused.run(results=[rms2])
+
+        golden = torch_rms_norm(torch_rms_norm(torch_input.float(), torch_w.float()) @ torch_b.float(), torch_w.float())
+        check_pcc(golden, out, label="mcast_1d_mcast_in1 RMS->MM->RMS")
+
+    @stress_test_program_cache
+    def test_mcast_1d_mcast_in1_parallel(self, device):
+        """Parallel: two Mcast1D(mcast_in0=False) matmuls on disjoint cores."""
+        from models.experimental.ops.descriptors.fusion import Parallel
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        # mcast_in0=False: in1 broadcast, M split. Each branch: M=128, 4 cores, per_core_M=1, per_core_N=4.
+        M, K, N = 128, 128, 128
+        torch_a = torch.randn(1, 1, M, K, dtype=torch.bfloat16)
+        torch_b1 = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+        torch_b2 = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        def _mcast_in1_cfg(cr):
+            return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+                in0_block_w=4,
+                out_subblock_h=1,
+                out_subblock_w=4,
+                out_block_h=1,
+                out_block_w=4,
+                per_core_M=1,
+                per_core_N=4,
+                fuse_batch=True,
+                mcast_in0=False,
+                gather_in0=False,
+                allowed_worker_cores=cr,
+            )
+
+        cr_a = cores(0, 0, 3, 0)
+        mm_a = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b1, device),
+            core_range_set=cr_a,
+            program_config=_mcast_in1_cfg(cr_a),
+            compute_kernel_config=self._compute(),
+        )
+
+        cr_b = cores(4, 0, 7, 0)
+        mm_b = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b2, device),
+            core_range_set=cr_b,
+            program_config=_mcast_in1_cfg(cr_b),
+            compute_kernel_config=self._compute(),
+        )
+
+        fused = Parallel(mm_a, mm_b)
+        [out_a, out_b] = fused.run(results=[mm_a, mm_b])
+
+        check_pcc(torch_a @ torch_b1, out_a, pcc=0.99, label="mcast_in1 parallel A")
+        check_pcc(torch_a @ torch_b2, out_b, pcc=0.99, label="mcast_in1 parallel B")
+
+    # ------------------------------------------------------------------
+    # Batched matmul (batch > 1, fuse_batch=True)
+    # ------------------------------------------------------------------
+
+    @stress_test_program_cache
+    def test_mcast_1d_fuse_batch_sequential(self, device):
+        """Sequential: RMS -> Mcast1D(fuse_batch=True, batch=2) -> RMS."""
+        from models.experimental.ops.descriptors.fusion import Sequential
+        from models.experimental.ops.descriptors.normalization import rms_norm
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        # fuse_batch folds B*M into a single tile dimension: effective_M = 2*32/32 = 2 tiles.
+        # mcast_in0=True: in0 broadcast to all 4 cores, N split (per_core_N=1 per core).
+        B, M, K, N = 2, 32, 128, 128
+        torch_input = torch.randn(B, 1, M, K, dtype=torch.bfloat16)
+        torch_w = torch.ones(1, 1, 1, K, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        cr = cores(0, 0, 3, 0)
+        mm_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=2,
+            out_block_w=1,
+            per_core_M=2,
+            per_core_N=1,
+            fuse_batch=True,
+            mcast_in0=True,
+            gather_in0=False,
+            allowed_worker_cores=cr,
+        )
+
+        rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+        mm = matmul_desc(
+            rms1.output_tensors[0],
+            tt(torch_b, device),
+            core_range_set=cr,
+            program_config=mm_config,
+            compute_kernel_config=self._compute(),
+        )
+        rms2 = rms_norm.rms_norm(mm.output_tensors[0], core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
+
+        fused = Sequential(rms1, mm, rms2)
+        [out] = fused.run(results=[rms2])
+
+        golden_rms1 = torch_rms_norm(torch_input.float(), torch_w.float())
+        golden_mm = golden_rms1 @ torch_b.float()
+        golden = torch_rms_norm(golden_mm, torch_w.float())
+        check_pcc(golden, out, label="fuse_batch RMS->MM->RMS")
+
+    @stress_test_program_cache
+    def test_mcast_1d_fuse_batch_parallel(self, device):
+        """Parallel: two Mcast1D(fuse_batch=True, batch=2) matmuls on disjoint cores."""
+        from models.experimental.ops.descriptors.fusion import Parallel
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        B, M, K, N = 2, 32, 128, 128
+        torch_a = torch.randn(B, 1, M, K, dtype=torch.bfloat16)
+        torch_b1 = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+        torch_b2 = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        def _fuse_batch_cfg(cr):
+            return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=ttnn.CoreCoord(4, 1),
+                in0_block_w=4,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                out_block_h=2,
+                out_block_w=1,
+                per_core_M=2,
+                per_core_N=1,
+                fuse_batch=True,
+                mcast_in0=True,
+                gather_in0=False,
+                allowed_worker_cores=cr,
+            )
+
+        cr_a = cores(0, 0, 3, 0)
+        mm_a = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b1, device),
+            core_range_set=cr_a,
+            program_config=_fuse_batch_cfg(cr_a),
+            compute_kernel_config=self._compute(),
+        )
+
+        cr_b = cores(4, 0, 7, 0)
+        mm_b = matmul_desc(
+            tt(torch_a, device),
+            tt(torch_b2, device),
+            core_range_set=cr_b,
+            program_config=_fuse_batch_cfg(cr_b),
+            compute_kernel_config=self._compute(),
+        )
+
+        fused = Parallel(mm_a, mm_b)
+        [out_a, out_b] = fused.run(results=[mm_a, mm_b])
+
+        golden = torch_a.float() @ torch_b1.float()
+        check_pcc(golden, out_a, pcc=0.99, label="fuse_batch parallel A")
+        golden = torch_a.float() @ torch_b2.float()
+        check_pcc(golden, out_b, pcc=0.99, label="fuse_batch parallel B")

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -574,6 +574,9 @@ class TestMatmulFusion:
             out_subblock_w=min(per_core_N, 4),
             per_core_M=per_core_M,
             per_core_N=per_core_N,
+            allowed_worker_cores=ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(gx - 1, gy - 1))}
+            ),
         )
 
     def _compute(self, fp32=False, approx=True):
@@ -1083,6 +1086,7 @@ class TestParallelExecution:
             out_subblock_w=4,
             per_core_M=1,
             per_core_N=4,
+            allowed_worker_cores=cores(0, 0),
         )
         mm = matmul_desc(
             tt(torch_a, device),
@@ -1204,6 +1208,9 @@ class TestParallelExecution:
                 out_subblock_w=4,
                 per_core_M=1,
                 per_core_N=4,
+                allowed_worker_cores=ttnn.CoreRangeSet(
+                    {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(gx - 1, gy - 1))}
+                ),
             )
 
         # Norm inputs (4 of them)
@@ -1576,6 +1583,7 @@ class TestDocExample:
             out_subblock_w=4,
             per_core_M=1,
             per_core_N=8,
+            allowed_worker_cores=full,
         )
         op1 = descriptors.matmul(
             tt(torch_a, device),
@@ -1594,6 +1602,7 @@ class TestDocExample:
             out_subblock_w=4,
             per_core_M=2,
             per_core_N=4,
+            allowed_worker_cores=left_top,
         )
         op4 = descriptors.matmul(
             op2.output_tensors[0],
@@ -2157,6 +2166,7 @@ class TestPersistentMode:
             out_subblock_w=1,
             per_core_M=1,
             per_core_N=1,
+            allowed_worker_cores=cr,
         )
 
         # Inline matmul first (for reference)
@@ -2688,6 +2698,7 @@ class TestMatmulFactories:
             out_subblock_w=4,
             per_core_M=1,
             per_core_N=4,
+            allowed_worker_cores=cr,
         )
         mm = matmul_desc(
             tt(torch_a, device),
@@ -2823,6 +2834,7 @@ class TestMatmulFactories:
             out_subblock_w=4,
             per_core_M=1,
             per_core_N=4,
+            allowed_worker_cores=cr,
         )
 
         rms1 = rms_norm.rms_norm(tt(torch_input, device), core_range_set=cr, weight=tt(torch_w, device), epsilon=1e-5)
@@ -2971,6 +2983,7 @@ class TestMatmulFactories:
             out_subblock_w=4,
             per_core_M=1,
             per_core_N=4,
+            allowed_worker_cores=cr_a,
         )
         mm_a = matmul_desc(
             tt(torch_a, device),
@@ -3035,6 +3048,7 @@ class TestMatmulFactories:
             out_subblock_w=1,
             per_core_M=1,
             per_core_N=1,
+            allowed_worker_cores=stem_cr,
         )
         mm_a = matmul_desc(
             stem.output_tensors[0],
@@ -3096,6 +3110,7 @@ class TestMatmulFactories:
             out_subblock_w=2,
             per_core_M=2,
             per_core_N=2,
+            allowed_worker_cores=cr,
         )
         config_mcast2d = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(2, 2),
@@ -3161,6 +3176,7 @@ class TestMatmulFactories:
             out_subblock_w=1,
             per_core_M=1,
             per_core_N=1,
+            allowed_worker_cores=cr1,
         )
         mm1 = matmul_desc(
             tt(torch_a, device),
@@ -3260,6 +3276,7 @@ class TestMatmulFactories:
             out_subblock_w=4,
             per_core_M=1,
             per_core_N=4,
+            allowed_worker_cores=stem_cr,
         )
         mm_left = matmul_desc(
             stem.output_tensors[0],

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential_infra.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential_infra.py
@@ -1051,7 +1051,6 @@ class TestHasWriterFlag:
             _barrier_mod._emit_init_coordinator(
                 has_compute=has_compute,
                 num_segments=0,
-                op_semaphore_info=None,
                 has_writer=has_writer,
             )
         )

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -5262,7 +5262,9 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
     }
     auto grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
 
-    CoreCoord sub_device_start_core = {0, 0};
+    // When a sub-device is present use its bounding-box start; otherwise fall
+    // back to allowed_worker_cores start so non-(0,0) placements work correctly.
+    CoreCoord sub_device_start_core = program_config.allowed_worker_cores.value().bounding_box().start_coord;
     if (operation_attributes.sub_device_id.has_value()) {
         auto sd_worker_cores = device->worker_cores(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1252,7 +1252,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 (std::uint32_t)in0_mcast_sender.y   // in0_mcast_sender_noc_y
             };
             // left half
-            if (core.x <= half_core || (!transpose_mcast and core.y == start_core_y)) {
+            if ((core.x - start_core_x) <= half_core || (!transpose_mcast and core.y == start_core_y)) {
                 in0_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
             }
             // right half
@@ -1495,7 +1495,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                         in1_recv_variant(mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
                     in1_recv_variant[2] = out_tensor;
                     // left half
-                    if (core.x <= half_core || (transpose_mcast and core.y == start_core_y)) {
+                    if ((core.x - start_core_x) <= half_core || (transpose_mcast and core.y == start_core_y)) {
                         in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
                     }
                     // right half
@@ -2721,7 +2721,7 @@ create_program_mcast_in0_in1(
                 (std::uint32_t)in0_mcast_sender.y   // in0_mcast_sender_noc_y
             };
             // left half
-            if (core.x <= half_core || (!transpose_mcast and core.y == start_core_y)) {
+            if ((core.x - start_core_x) <= half_core || (!transpose_mcast and core.y == start_core_y)) {
                 tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);
             }
             // right half
@@ -2953,7 +2953,7 @@ create_program_mcast_in0_in1(
                 }
 
                 // left half
-                if (core.x <= half_core || (transpose_mcast and core.y == start_core_y)) {
+                if ((core.x - start_core_x) <= half_core || (transpose_mcast and core.y == start_core_y)) {
                     tt_metal::SetRuntimeArgs(
                         program, mm_kernel_in1_receiver_writer_id, core, mm_in1_receiver_writer_args);
                 }
@@ -3403,7 +3403,13 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
     const auto Kt = get_K_dim(a_shape_padded, in0_tile);
     const auto Nt = get_N_dim(b_shape_padded, in1_tile);
 
-    CoreCoord sub_device_start_core = {0, 0};
+    tt_metal::Buffer* out_buffer = output.buffer();
+
+    // When a sub-device is present use its bounding-box start; otherwise fall
+    // back to allowed_worker_cores start so non-(0,0) placements work correctly.
+    CoreCoord sub_device_start_core = program_config.allowed_worker_cores.has_value()
+                                          ? program_config.allowed_worker_cores.value().bounding_box().start_coord
+                                          : CoreCoord{0, 0};
     if (operation_attributes.sub_device_id.has_value()) {
         auto sub_device_cores = device->worker_cores(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3403,8 +3403,6 @@ ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
     const auto Kt = get_K_dim(a_shape_padded, in0_tile);
     const auto Nt = get_N_dim(b_shape_padded, in1_tile);
 
-    tt_metal::Buffer* out_buffer = output.buffer();
-
     // When a sub-device is present use its bounding-box start; otherwise fall
     // back to allowed_worker_cores start so non-(0,0) placements work correctly.
     CoreCoord sub_device_start_core = program_config.allowed_worker_cores.has_value()

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -198,16 +198,27 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
                 "invoke ttnn::operations::matmul::normalize_program_config() on the program config first. This "
                 "will become a hard error in a future release.");
         }
-        CoreCoord grid = program_config.allowed_worker_cores.has_value()
-                             ? program_config.allowed_worker_cores.value().bounding_box().grid_size()
-                             : program_config.compute_with_storage_grid_size;
-        std::tie(
-            num_cores,
-            all_cores,
-            core_group_1,
-            core_group_2,
-            num_blocks_per_core_group_1,
-            num_blocks_per_core_group_2) = tt::tt_metal::split_work_to_cores(grid, num_output_blocks_total);
+        // Use the CoreRangeSet overload so the output core ranges carry the actual
+        // absolute coordinates (e.g. (4,0)-(7,0)) rather than always starting at (0,0).
+        if (program_config.allowed_worker_cores.has_value()) {
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_blocks_per_core_group_1,
+                num_blocks_per_core_group_2) =
+                tt::tt_metal::split_work_to_cores(program_config.allowed_worker_cores.value(), num_output_blocks_total);
+        } else {
+            CoreCoord grid = program_config.compute_with_storage_grid_size;
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_blocks_per_core_group_1,
+                num_blocks_per_core_group_2) = tt::tt_metal::split_work_to_cores(grid, num_output_blocks_total);
+        }
         num_blocks_per_core_group_1 *= batch_scale_factor;
         num_blocks_per_core_group_2 *= batch_scale_factor;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -417,7 +417,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         uint32_t out_start_tile_id =
             (start_batch * M * N) + (start_m_block * per_core_M_per_batch * N) + (start_n_block * per_core_N);
         reader_writer_kernel_desc.emplace_runtime_args(
-            core, {in1_buffer, in1_start_tile_id, num_output_blocks_per_core, out_buffer, out_start_tile_id});
+            core, {in1_buffer, in1_start_tile_id, num_output_blocks_per_core, output, out_start_tile_id});
 
         // Compute kernels have no per-core runtime args
         if (i < g1_numcores) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -157,7 +157,6 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
     uint32_t out_num_subblocks_h = per_core_M_per_batch / out_subblock_h;
     uint32_t out_num_subblocks_w = in1_num_subblocks;
-    uint32_t num_tiles_per_block_out = per_core_M_per_batch * per_core_N;
     uint32_t num_output_blocks_total = (B * M / per_core_M) * (N / per_core_N);
 
     std::optional<tt::tt_metal::ShardSpec> shard_spec = std::nullopt;
@@ -415,13 +414,10 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         reader_kernel_desc.emplace_runtime_args(core, {in0_buffer, in0_start_tile_id, num_output_blocks_per_core});
 
+        uint32_t out_start_tile_id =
+            (start_batch * M * N) + (start_m_block * per_core_M_per_batch * N) + (start_n_block * per_core_N);
         reader_writer_kernel_desc.emplace_runtime_args(
-            core,
-            {in1_buffer,
-             in1_start_tile_id,
-             num_output_blocks_per_core,
-             output,
-             num_blocks_written * num_tiles_per_block_out});
+            core, {in1_buffer, in1_start_tile_id, num_output_blocks_per_core, out_buffer, out_start_tile_id});
 
         // Compute kernels have no per-core runtime args
         if (i < g1_numcores) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -11,15 +11,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
-#include "api/debug/dprint.h"
-
 void kernel_main() {
-    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
-    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] sender_noc=("
-           << get_arg_val<uint32_t>(0) << "," << get_arg_val<uint32_t>(1) << ")"
-           << " num_inner=" << get_compile_time_arg_val(1) << " num_w=" << get_compile_time_arg_val(2)
-           << " num_h=" << get_compile_time_arg_val(3) << " sender_sem_idx=" << get_compile_time_arg_val(4)
-           << " receiver_sem_idx=" << get_compile_time_arg_val(5) << ENDL();
     // in0 mcast args
     const uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(0);
     const uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(1);
@@ -79,21 +71,16 @@ void kernel_main() {
             for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                 for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
                     // Operand 0
-                    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] bh=" << bh
-                           << " bw=" << bw << " blk=" << block << " reserve_back" << ENDL();
                     cb_in0.reserve_back(in0_block_num_tiles);
 
                     // Set in0 semaphore value to INVALID
                     receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
-                    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0]
-                           << "] up sender_sem, wait receiver_sem" << ENDL();
                     sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
 
                     // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
                     receiver_sem.wait(VALID);
-                    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] got mcast" << ENDL();
 
                     cb_in0.push_back(in0_block_num_tiles);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -11,8 +11,15 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/debug/dprint.h"
 
 void kernel_main() {
+    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
+    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] sender_noc=("
+           << get_arg_val<uint32_t>(0) << "," << get_arg_val<uint32_t>(1) << ")"
+           << " num_inner=" << get_compile_time_arg_val(1) << " num_w=" << get_compile_time_arg_val(2)
+           << " num_h=" << get_compile_time_arg_val(3) << " sender_sem_idx=" << get_compile_time_arg_val(4)
+           << " receiver_sem_idx=" << get_compile_time_arg_val(5) << ENDL();
     // in0 mcast args
     const uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(0);
     const uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(1);
@@ -72,16 +79,21 @@ void kernel_main() {
             for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                 for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
                     // Operand 0
+                    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] bh=" << bh
+                           << " bw=" << bw << " blk=" << block << " reserve_back" << ENDL();
                     cb_in0.reserve_back(in0_block_num_tiles);
 
                     // Set in0 semaphore value to INVALID
                     receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
+                    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0]
+                           << "] up sender_sem, wait receiver_sem" << ENDL();
                     sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
 
                     // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
                     receiver_sem.wait(VALID);
+                    DPRINT << "[MM_IN0R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] got mcast" << ENDL();
 
                     cb_in0.push_back(in0_block_num_tiles);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -17,15 +17,7 @@
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
-#include "api/debug/dprint.h"
-
 void kernel_main() {
-    DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
-    // print mcast args (read after rt_args_idx advances past them)
-    DPRINT << "[MM_IN0S] mcast_start=(" << get_arg_val<uint32_t>(2) << "," << get_arg_val<uint32_t>(3) << ") end=("
-           << get_arg_val<uint32_t>(4) << "," << get_arg_val<uint32_t>(5)
-           << ") num_dests=" << get_compile_time_arg_val(17) << " sender_sem_idx=" << get_compile_time_arg_val(15)
-           << " receiver_sem_idx=" << get_compile_time_arg_val(16) << ENDL();
     uint32_t rt_args_idx = 0;
     // in0 tensor args
     const uint32_t in0_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
@@ -372,19 +364,8 @@ void kernel_main() {
                         // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
                         // zero for the next block
-                        {
-                            volatile tt_l1_ptr uint32_t* ssem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                                get_semaphore(get_compile_time_arg_val(15)));
-                            volatile tt_l1_ptr uint32_t* rsem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                                get_semaphore(get_compile_time_arg_val(16)));
-                            DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0]
-                                   << "] pre-wait sender_sem_val=" << *ssem << " receiver_sem_val=" << *rsem
-                                   << " wait_for=" << in0_mcast_num_dests << ENDL();
-                        }
                         sender_sem.wait(in0_mcast_num_dests);
                         sender_sem.set(0);
-                        DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] mcast start"
-                               << ENDL();
 
                         // Now we have the block in the CB address, we can mcast to dests!
                         MulticastEndpoint mcast_dst;
@@ -461,7 +442,6 @@ void kernel_main() {
             }
         }
     }
-    DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] done" << ENDL();
     noc.async_write_barrier();
 
     // When nnz was supplied, the receiver and compute kernels loop exactly num_batch_compute times.

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -17,8 +17,15 @@
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/debug/dprint.h"
 
 void kernel_main() {
+    DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
+    // print mcast args (read after rt_args_idx advances past them)
+    DPRINT << "[MM_IN0S] mcast_start=(" << get_arg_val<uint32_t>(2) << "," << get_arg_val<uint32_t>(3) << ") end=("
+           << get_arg_val<uint32_t>(4) << "," << get_arg_val<uint32_t>(5)
+           << ") num_dests=" << get_compile_time_arg_val(17) << " sender_sem_idx=" << get_compile_time_arg_val(15)
+           << " receiver_sem_idx=" << get_compile_time_arg_val(16) << ENDL();
     uint32_t rt_args_idx = 0;
     // in0 tensor args
     const uint32_t in0_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
@@ -365,8 +372,19 @@ void kernel_main() {
                         // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
                         // zero for the next block
+                        {
+                            volatile tt_l1_ptr uint32_t* ssem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                                get_semaphore(get_compile_time_arg_val(15)));
+                            volatile tt_l1_ptr uint32_t* rsem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                                get_semaphore(get_compile_time_arg_val(16)));
+                            DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0]
+                                   << "] pre-wait sender_sem_val=" << *ssem << " receiver_sem_val=" << *rsem
+                                   << " wait_for=" << in0_mcast_num_dests << ENDL();
+                        }
                         sender_sem.wait(in0_mcast_num_dests);
                         sender_sem.set(0);
+                        DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] mcast start"
+                               << ENDL();
 
                         // Now we have the block in the CB address, we can mcast to dests!
                         MulticastEndpoint mcast_dst;
@@ -443,6 +461,7 @@ void kernel_main() {
             }
         }
     }
+    DPRINT << "[MM_IN0S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] done" << ENDL();
     noc.async_write_barrier();
 
     // When nnz was supplied, the receiver and compute kernels loop exactly num_batch_compute times.

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -11,10 +11,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/noc_traits.h"
-#include "api/debug/dprint.h"
-
 void kernel_main() {
-    DPRINT << "[MM_IN1R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
     // READER
     uint32_t rt_args_idx = 0;
     // in1 mcast args

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -11,8 +11,10 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/noc_traits.h"
+#include "api/debug/dprint.h"
 
 void kernel_main() {
+    DPRINT << "[MM_IN1R " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
     // READER
     uint32_t rt_args_idx = 0;
     // in1 mcast args

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -13,8 +13,10 @@
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/debug/dprint.h"
 
 void kernel_main() {
+    DPRINT << "[MM_IN1S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
     // READER
     uint32_t rt_args_idx = 0;
     // in1 tensor args

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -13,10 +13,7 @@
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
-#include "api/debug/dprint.h"
-
 void kernel_main() {
-    DPRINT << "[MM_IN1S " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter" << ENDL();
     // READER
     uint32_t rt_args_idx = 0;
     // in1 tensor args

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -279,6 +279,32 @@ void validate_matmul_compute_grid_and_per_core_dims(
         chosen_program_config);
 }
 
+void validate_matmul_sharded_operand_grids_within_program_compute_grid(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // When an input is sharded, the factory uses shard_spec.grid directly as all_cores
+                // and ignores compute_with_storage_grid_size entirely. Validating the shard grid
+                // against the origin-anchored compute_with_storage_grid_size rectangle incorrectly
+                // rejects grids that don't start at (0,0) (e.g. column 1 in a multi-chain fused op).
+                // The only physical constraint is that the shard grid fits within the device grid.
+                // For non-sharded inputs the config grid drives split_work_to_cores, so the
+                // origin-anchored check is still correct there.
+                const auto& config_grid = program_config.compute_with_storage_grid_size;
+                const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
+                auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
+                check_tensor_in_grid(input_tensor_a, effective_grid_a);
+                check_tensor_in_grid(input_tensor_b, effective_grid_b);
+            }
+        },
+        chosen_program_config);
+}
+
 void validate_matmul_reuse_sharded_output_block_divisibility(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1102,9 +1102,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
                     TT_FATAL(!optional_bias.has_value(), "Bias is not supported when using gather_in0.");
                 } else {
-                    auto grid_1d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
-                    check_tensor_in_grid(input_tensor_a, grid_1d);
-                    check_tensor_in_grid(input_tensor_b, grid_1d);
+                    const auto device_grid_1d = input_tensor_a.device()->compute_with_storage_grid_size();
+                    check_tensor_in_grid(input_tensor_a, device_grid_1d);
+                    check_tensor_in_grid(input_tensor_b, device_grid_1d);
                 }
                 if (program_config.mcast_in0 || program_config.gather_in0) {
                     if (input_tensor_a.is_sharded()) {
@@ -1368,9 +1368,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
-                auto grid_2d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
-                check_tensor_in_grid(input_tensor_a, grid_2d);
-                check_tensor_in_grid(input_tensor_b, grid_2d);
+                const tt::tt_metal::CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                check_tensor_in_grid(input_tensor_a, device_grid);
+                check_tensor_in_grid(input_tensor_b, device_grid);
                 if (input_tensor_a.memory_config().is_sharded()) {
                     TT_FATAL(program_config.fuse_batch, "Batch fusion is required when input A is sharded");
                     auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1919,14 +1919,15 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
 
                     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
                     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+                    ShardOrientation shard_orientation =
+                        program_config.transpose_mcast ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
                     CoreRangeSet all_cores;
-                    ShardOrientation shard_orientation;
-                    if (program_config.transpose_mcast) {
+                    if (attributes.output_mem_config.shard_spec().has_value()) {
+                        all_cores = attributes.output_mem_config.shard_spec()->grid;
+                    } else if (program_config.transpose_mcast) {
                         all_cores = CoreRangeSet({CoreRange({0, 0}, {num_blocks_y - 1, num_blocks_x - 1})});
-                        shard_orientation = ShardOrientation::COL_MAJOR;
                     } else {
                         all_cores = CoreRangeSet({CoreRange({0, 0}, {num_blocks_x - 1, num_blocks_y - 1})});
-                        shard_orientation = ShardOrientation::ROW_MAJOR;
                     }
                     tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
                         all_cores,
@@ -1960,9 +1961,14 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
                         shard_orientation = input_tensor_b.shard_spec().value().orientation;
                     }
 
-                    auto cwsg_2d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
-                    CoreRangeSet all_cores =
-                        num_cores_to_corerangeset(num_cores, cwsg_2d, shard_orientation == ShardOrientation::ROW_MAJOR);
+                    CoreRangeSet all_cores;
+                    if (attributes.output_mem_config.shard_spec().has_value()) {
+                        all_cores = attributes.output_mem_config.shard_spec()->grid;
+                    } else {
+                        auto cwsg_2d = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+                        all_cores = num_cores_to_corerangeset(
+                            num_cores, cwsg_2d, shard_orientation == ShardOrientation::ROW_MAJOR);
+                    }
                     tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
                         all_cores,
                         {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -291,6 +291,9 @@ void validate_matmul_reuse_sharded_output_block_divisibility(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // Mirror the shard_spec priority in MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor:
+                // when in0 is L1-sharded its shard grid becomes the kernel grid; in1's grid is only consulted when
+                // in0 is not sharded. num_output_blocks must divide evenly across that grid or the factory fatals.
                 const Tensor* sharded = nullptr;
                 if (input_tensor_a.is_sharded() && input_tensor_a.memory_config().buffer_type() != BufferType::DRAM) {
                     sharded = &input_tensor_a;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -279,6 +279,45 @@ void validate_matmul_compute_grid_and_per_core_dims(
         chosen_program_config);
 }
 
+void validate_matmul_reuse_sharded_output_block_divisibility(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                const Tensor* sharded = nullptr;
+                if (input_tensor_a.is_sharded() && input_tensor_a.memory_config().buffer_type() != BufferType::DRAM) {
+                    sharded = &input_tensor_a;
+                } else if (
+                    input_tensor_b.is_sharded() && input_tensor_b.memory_config().buffer_type() != BufferType::DRAM) {
+                    sharded = &input_tensor_b;
+                }
+                if (sharded == nullptr) {
+                    return;
+                }
+                const uint32_t B = get_batch_size(a_shape_padded);
+                const uint32_t Mt = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, false);
+                const uint32_t Nt = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                const uint32_t num_output_blocks =
+                    (B * Mt / program_config.per_core_M) * (Nt / program_config.per_core_N);
+                const uint32_t num_cores = sharded->shard_spec().value().grid.num_cores();
+                TT_FATAL(
+                    num_output_blocks % num_cores == 0,
+                    "MatmulMultiCoreReuseProgramConfig: num_output_blocks ({}) must be evenly divisible by the "
+                    "number of cores in the input shard grid ({})",
+                    num_output_blocks,
+                    num_cores);
+            }
+        },
+        chosen_program_config);
+}
+
 void validate_matmul_work_distribution_and_gather_ring_topology(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -41,17 +41,6 @@ void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     }
 }
 
-void check_tensor_in_core_range_set(const Tensor& tensor, const CoreRangeSet& allowed_cores) {
-    if (tensor.memory_config().is_sharded() && tensor.memory_config().buffer_type() != BufferType::DRAM) {
-        const auto& shard_grid = tensor.memory_config().shard_spec().value().grid;
-        TT_FATAL(
-            allowed_cores.contains(shard_grid),
-            "Tensor shard spec grid {} must lie within allowed_worker_cores {}",
-            shard_grid,
-            allowed_cores);
-    }
-}
-
 void validate_matmul_matrix_dimensions(
     const ttnn::Shape& a_shape,
     const ttnn::Shape& b_shape,
@@ -285,66 +274,6 @@ void validate_matmul_compute_grid_and_per_core_dims(
                 }
                 validate_matmul_nonzero_block_dims(
                     program_config.in0_block_w, program_config.per_core_M, program_config.per_core_N);
-            }
-        },
-        chosen_program_config);
-}
-
-void validate_matmul_sharded_operand_grids_within_program_compute_grid(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    std::visit(
-        [&](const auto& program_config) {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                TT_FATAL(
-                    program_config.allowed_worker_cores.has_value(),
-                    "allowed_worker_cores must be set before validation");
-                check_tensor_in_core_range_set(input_tensor_a, program_config.allowed_worker_cores.value());
-                check_tensor_in_core_range_set(input_tensor_b, program_config.allowed_worker_cores.value());
-            }
-        },
-        chosen_program_config);
-}
-
-void validate_matmul_reuse_sharded_output_block_divisibility(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const ttnn::Shape& a_shape_padded,
-    const ttnn::Shape& b_shape_padded,
-    const tt::tt_metal::Tile& in0_tile,
-    const tt::tt_metal::Tile& in1_tile,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    std::visit(
-        [&](const auto& program_config) {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                // Mirror the shard_spec priority in MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor:
-                // when in0 is L1-sharded its shard grid becomes the kernel grid; in1's grid is only consulted when
-                // in0 is not sharded. num_output_blocks must divide evenly across that grid or the factory fatals.
-                const Tensor* sharded = nullptr;
-                if (input_tensor_a.is_sharded() && input_tensor_a.memory_config().buffer_type() != BufferType::DRAM) {
-                    sharded = &input_tensor_a;
-                } else if (
-                    input_tensor_b.is_sharded() && input_tensor_b.memory_config().buffer_type() != BufferType::DRAM) {
-                    sharded = &input_tensor_b;
-                }
-                if (sharded == nullptr) {
-                    return;
-                }
-                const uint32_t B = get_batch_size(a_shape_padded);
-                const uint32_t Mt = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, false);
-                const uint32_t Nt = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
-                const uint32_t num_output_blocks =
-                    (B * Mt / program_config.per_core_M) * (Nt / program_config.per_core_N);
-                const uint32_t num_cores = sharded->shard_spec().value().grid.num_cores();
-                TT_FATAL(
-                    num_output_blocks % num_cores == 0,
-                    "MatmulMultiCoreReuseProgramConfig: num_output_blocks ({}) must be evenly divisible by the "
-                    "number of cores in the input shard grid ({})",
-                    num_output_blocks,
-                    num_cores);
             }
         },
         chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -298,17 +298,11 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                if (program_config.allowed_worker_cores.has_value()) {
-                    check_tensor_in_core_range_set(input_tensor_a, program_config.allowed_worker_cores.value());
-                    check_tensor_in_core_range_set(input_tensor_b, program_config.allowed_worker_cores.value());
-                } else {
-                    const auto& config_grid = program_config.compute_with_storage_grid_size;
-                    const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
-                    auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
-                    auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
-                    check_tensor_in_grid(input_tensor_a, effective_grid_a);
-                    check_tensor_in_grid(input_tensor_b, effective_grid_b);
-                }
+                TT_FATAL(
+                    program_config.allowed_worker_cores.has_value(),
+                    "allowed_worker_cores must be set before validation (normalize_program_config should have set it)");
+                check_tensor_in_core_range_set(input_tensor_a, program_config.allowed_worker_cores.value());
+                check_tensor_in_core_range_set(input_tensor_b, program_config.allowed_worker_cores.value());
             }
         },
         chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -300,7 +300,7 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
             if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
                 TT_FATAL(
                     program_config.allowed_worker_cores.has_value(),
-                    "allowed_worker_cores must be set before validation (normalize_program_config should have set it)");
+                    "allowed_worker_cores must be set before validation");
                 check_tensor_in_core_range_set(input_tensor_a, program_config.allowed_worker_cores.value());
                 check_tensor_in_core_range_set(input_tensor_b, program_config.allowed_worker_cores.value());
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -41,6 +41,17 @@ void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     }
 }
 
+void check_tensor_in_core_range_set(const Tensor& tensor, const CoreRangeSet& allowed_cores) {
+    if (tensor.memory_config().is_sharded() && tensor.memory_config().buffer_type() != BufferType::DRAM) {
+        const auto& shard_grid = tensor.memory_config().shard_spec().value().grid;
+        TT_FATAL(
+            allowed_cores.contains(shard_grid),
+            "Tensor shard spec grid {} must lie within allowed_worker_cores {}",
+            shard_grid,
+            allowed_cores);
+    }
+}
+
 void validate_matmul_matrix_dimensions(
     const ttnn::Shape& a_shape,
     const ttnn::Shape& b_shape,
@@ -287,19 +298,17 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                // When an input is sharded, the factory uses shard_spec.grid directly as all_cores
-                // and ignores compute_with_storage_grid_size entirely. Validating the shard grid
-                // against the origin-anchored compute_with_storage_grid_size rectangle incorrectly
-                // rejects grids that don't start at (0,0) (e.g. column 1 in a multi-chain fused op).
-                // The only physical constraint is that the shard grid fits within the device grid.
-                // For non-sharded inputs the config grid drives split_work_to_cores, so the
-                // origin-anchored check is still correct there.
-                const auto& config_grid = program_config.compute_with_storage_grid_size;
-                const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
-                auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
-                auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
-                check_tensor_in_grid(input_tensor_a, effective_grid_a);
-                check_tensor_in_grid(input_tensor_b, effective_grid_b);
+                if (program_config.allowed_worker_cores.has_value()) {
+                    check_tensor_in_core_range_set(input_tensor_a, program_config.allowed_worker_cores.value());
+                    check_tensor_in_core_range_set(input_tensor_b, program_config.allowed_worker_cores.value());
+                } else {
+                    const auto& config_grid = program_config.compute_with_storage_grid_size;
+                    const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                    auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
+                    auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
+                    check_tensor_in_grid(input_tensor_a, effective_grid_a);
+                    check_tensor_in_grid(input_tensor_b, effective_grid_b);
+                }
             }
         },
         chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -1199,6 +1199,11 @@ void py_module(nb::module_& mod) {
             "compute_output_specs",
             &ttnn::prim::MatmulDeviceOperation::compute_output_specs,
             nb::arg("operation_attributes"),
+            nb::arg("tensor_args"))
+        .def_static(
+            "compute_program_hash",
+            &ttnn::prim::MatmulDeviceOperation::compute_program_hash,
+            nb::arg("operation_attributes"),
             nb::arg("tensor_args"));
 
     // Bind MatmulMultiCoreReuseOptimizedProgramFactory for descriptor creation

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -25,6 +25,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/debug/dprint.h"
 
 #include "layernorm_compute_utils.h"
 
@@ -122,6 +123,10 @@ void kernel_main() {
     // Intermediate buffers need to be reserved/pushed/popped
     // in full blocks
     const auto total_buffer_size = generic::blocks(Wt, block_size).total_with_remainder();
+
+#ifdef TRISC_PACK
+    DPRINT << "[LN_PK] enter NCHt=" << NCHt << " Wt=" << (uint32_t)Wt << " blk=" << (uint32_t)block_size << ENDL();
+#endif
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
 #ifdef TILIZE_IN
@@ -252,6 +257,9 @@ void kernel_main() {
             } else {
                 pack_reconfig_data_format(cb_fusion);
             }
+#ifdef TRISC_PACK
+            DPRINT << "[LN_PK] ncht=" << ncht << " reserve cb_im_or_out blk=" << block.start() << ENDL();
+#endif
             cb_im_or_out_obj.reserve_back(block.full_block_size());
 #if defined RMSNORM and not defined FUSE_PRE_ADD
             reconfig_data_format_srca(cb_fusion, cb_xmm);
@@ -274,6 +282,9 @@ void kernel_main() {
             cb_im_or_out_obj.push_back(
                 block.full_block_size());  // if no gamma/beta are provided, this will be passed on to the writer
             REL();
+#ifdef TRISC_PACK
+            DPRINT << "[LN_PK] ncht=" << ncht << " pushed cb_im_or_out blk=" << block.start() << ENDL();
+#endif
 
             if constexpr (!(do_gamma == 0 && do_beta == 0)) {
 #if defined RMSNORM and not defined FUSE_PRE_ADD
@@ -290,6 +301,9 @@ void kernel_main() {
                 uint32_t cb_outg = do_beta ? cb_fusion : cb_out;
                 CircularBuffer cb_outg_obj(cb_outg);
                 mul_bcast_rows_init_short(cb_fusion, cb_gamma);
+#ifdef TRISC_PACK
+                DPRINT << "[LN_PK] ncht=" << ncht << " reserve cb_outg(gamma) blk=" << block.start() << ENDL();
+#endif
                 cb_outg_obj.reserve_back(block.full_block_size());
                 cb_gamma_obj.wait_front(
                     block.start() + block.full_block_size());  // we don't pop, TODO: only wait on first ht
@@ -312,6 +326,9 @@ void kernel_main() {
                 cb_outg_obj.push_back(block.full_block_size());
                 // We don't pop gamma since it's 1,1,1,Wt and we reuse it for all NCHt
                 REL();
+#ifdef TRISC_PACK
+                DPRINT << "[LN_PK] ncht=" << ncht << " pushed cb_outg(gamma) blk=" << block.start() << ENDL();
+#endif
             }
             if constexpr (do_beta) {
                 pack_reconfig_data_format(cb_out);
@@ -348,4 +365,7 @@ void kernel_main() {
         untilize_all_blocks_from_cb<block_size>(cb_out, cb_out_rm, Wt);
 #endif
     }  // NCHt loop
+#ifdef TRISC_PACK
+    DPRINT << "[LN_PK] done" << ENDL();
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -25,8 +25,6 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/debug/dprint.h"
-
 #include "layernorm_compute_utils.h"
 
 namespace generic = norm::kernel_util::generic;
@@ -123,10 +121,6 @@ void kernel_main() {
     // Intermediate buffers need to be reserved/pushed/popped
     // in full blocks
     const auto total_buffer_size = generic::blocks(Wt, block_size).total_with_remainder();
-
-#ifdef TRISC_PACK
-    DPRINT << "[LN_PK] enter NCHt=" << NCHt << " Wt=" << (uint32_t)Wt << " blk=" << (uint32_t)block_size << ENDL();
-#endif
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
 #ifdef TILIZE_IN
@@ -257,9 +251,6 @@ void kernel_main() {
             } else {
                 pack_reconfig_data_format(cb_fusion);
             }
-#ifdef TRISC_PACK
-            DPRINT << "[LN_PK] ncht=" << ncht << " reserve cb_im_or_out blk=" << block.start() << ENDL();
-#endif
             cb_im_or_out_obj.reserve_back(block.full_block_size());
 #if defined RMSNORM and not defined FUSE_PRE_ADD
             reconfig_data_format_srca(cb_fusion, cb_xmm);
@@ -282,9 +273,6 @@ void kernel_main() {
             cb_im_or_out_obj.push_back(
                 block.full_block_size());  // if no gamma/beta are provided, this will be passed on to the writer
             REL();
-#ifdef TRISC_PACK
-            DPRINT << "[LN_PK] ncht=" << ncht << " pushed cb_im_or_out blk=" << block.start() << ENDL();
-#endif
 
             if constexpr (!(do_gamma == 0 && do_beta == 0)) {
 #if defined RMSNORM and not defined FUSE_PRE_ADD
@@ -301,9 +289,6 @@ void kernel_main() {
                 uint32_t cb_outg = do_beta ? cb_fusion : cb_out;
                 CircularBuffer cb_outg_obj(cb_outg);
                 mul_bcast_rows_init_short(cb_fusion, cb_gamma);
-#ifdef TRISC_PACK
-                DPRINT << "[LN_PK] ncht=" << ncht << " reserve cb_outg(gamma) blk=" << block.start() << ENDL();
-#endif
                 cb_outg_obj.reserve_back(block.full_block_size());
                 cb_gamma_obj.wait_front(
                     block.start() + block.full_block_size());  // we don't pop, TODO: only wait on first ht
@@ -326,9 +311,6 @@ void kernel_main() {
                 cb_outg_obj.push_back(block.full_block_size());
                 // We don't pop gamma since it's 1,1,1,Wt and we reuse it for all NCHt
                 REL();
-#ifdef TRISC_PACK
-                DPRINT << "[LN_PK] ncht=" << ncht << " pushed cb_outg(gamma) blk=" << block.start() << ENDL();
-#endif
             }
             if constexpr (do_beta) {
                 pack_reconfig_data_format(cb_out);
@@ -365,7 +347,4 @@ void kernel_main() {
         untilize_all_blocks_from_cb<block_size>(cb_out, cb_out_rm, Wt);
 #endif
     }  // NCHt loop
-#ifdef TRISC_PACK
-    DPRINT << "[LN_PK] done" << ENDL();
-#endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -39,7 +39,6 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
@@ -151,9 +150,6 @@ void kernel_main() {
     const uint32_t eps = get_arg_val<uint32_t>(5);
     generate_bcast_col_scalar(cb_eps, eps);
 
-    DPRINT << "[NR " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter NCHt=" << NCHt << " Wt=" << Wt
-           << " row0=" << start_tile_row << ENDL();
-
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         const uint32_t curr_tile_row = start_tile_row + ncht;
 
@@ -205,5 +201,4 @@ void kernel_main() {
         }
 #endif
     }  // ncht loop
-    DPRINT << "[NR " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -39,6 +39,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
@@ -150,6 +151,9 @@ void kernel_main() {
     const uint32_t eps = get_arg_val<uint32_t>(5);
     generate_bcast_col_scalar(cb_eps, eps);
 
+    DPRINT << "[NR " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter NCHt=" << NCHt << " Wt=" << Wt
+           << " row0=" << start_tile_row << ENDL();
+
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         const uint32_t curr_tile_row = start_tile_row + ncht;
 
@@ -201,4 +205,5 @@ void kernel_main() {
         }
 #endif
     }  // ncht loop
+    DPRINT << "[NR " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "api/debug/dprint.h"
 
 namespace generic = norm::kernel_util::generic;
 
@@ -29,10 +30,17 @@ void kernel_main() {
 
     const auto s = TensorAccessor(dst_args, dst_addr);
 
+    DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter cb=" << cb_id_out0
+           << " fsz=" << get_local_cb_interface(cb_id_out0).fifo_size << " rows=" << num_tile_rows << " Wt=" << Wt
+           << " blk=" << blk << ENDL();
+
     uint32_t tile_id = tile_offset;
     for (uint32_t h = 0; h < num_tile_rows; h++) {
         for (auto block : generic::blocks(Wt, blk)) {
+            DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] wait_front "
+                   << block.full_block_size() << ENDL();
             cb_out0.wait_front(block.full_block_size());
+            DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] got tiles" << ENDL();
             uint32_t idx = 0;
             for (auto i : block.local()) {
                 noc.async_write(cb_out0, s, tile_bytes, {.offset_bytes = idx * tile_bytes}, {.page_id = tile_id});
@@ -43,4 +51,5 @@ void kernel_main() {
             cb_out0.pop_front(block.full_block_size());
         }
     }
+    DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -7,8 +7,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "api/debug/dprint.h"
-
 namespace generic = norm::kernel_util::generic;
 
 void kernel_main() {
@@ -30,17 +28,10 @@ void kernel_main() {
 
     const auto s = TensorAccessor(dst_args, dst_addr);
 
-    DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] enter cb=" << cb_id_out0
-           << " fsz=" << get_local_cb_interface(cb_id_out0).fifo_size << " rows=" << num_tile_rows << " Wt=" << Wt
-           << " blk=" << blk << ENDL();
-
     uint32_t tile_id = tile_offset;
     for (uint32_t h = 0; h < num_tile_rows; h++) {
         for (auto block : generic::blocks(Wt, blk)) {
-            DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] wait_front "
-                   << block.full_block_size() << ENDL();
             cb_out0.wait_front(block.full_block_size());
-            DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] got tiles" << ENDL();
             uint32_t idx = 0;
             for (auto i : block.local()) {
                 noc.async_write(cb_out0, s, tile_bytes, {.offset_bytes = idx * tile_bytes}, {.page_id = tile_id});
@@ -51,5 +42,4 @@ void kernel_main() {
             cb_out0.pop_front(block.full_block_size());
         }
     }
-    DPRINT << "[BW " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "] done" << ENDL();
 }

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -467,6 +467,7 @@ from ttnn.operations.matmul import (
     MatmulDeviceOperation,
     MatmulMultiCoreReuseOptimizedProgramFactory,
     create_matmul_attributes,
+    matmul_select_program_factory,
 )
 
 from ttnn.operations.normalization import (

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -24,6 +24,7 @@ MatmulInputs = ttnn._ttnn.operations.matmul.MatmulInputs
 MatmulDeviceOperation = ttnn._ttnn.operations.matmul.MatmulDeviceOperation
 MatmulMultiCoreReuseOptimizedProgramFactory = ttnn._ttnn.operations.matmul.MatmulMultiCoreReuseOptimizedProgramFactory
 create_matmul_attributes = ttnn._ttnn.operations.matmul.create_matmul_attributes
+matmul_select_program_factory = ttnn._ttnn.operations.matmul.matmul_select_program_factory
 
 
 def _golden_function(


### PR DESCRIPTION
## Summary

- **Multi-factory support in Parallel/Sequential**: `MatmulMultiCoreReuseProgramConfig` now selects among `MatmulMultiCoreReuseOptimizedProgramFactory`, `MatmulMultiCoreReuseMcast2DProgramFactory`, and `MatmulMultiCoreReuseMcast1DProgramFactory` based on the config shape, enabling parallel chains where different branches use different matmul program factories. Includes a `half_core` fix and trailing barrier for `Parallel` fusion.
- **`allowed_worker_cores` validation**: Added `check_tensor_in_core_range_set` helper and updated `validate_matmul_sharded_operand_grids_within_program_compute_grid` to use `allowed_worker_cores` (a `CoreRangeSet`) instead of `compute_with_storage_grid_size` (a `CoreCoord`) for checking sharded input tensor grids. Drops the fallback to CWSG when `allowed_worker_cores` is set.
- **Output tile offset fix**: `MatmulMultiCoreReuseOptimized` factory was computing a sequential tile offset into the output buffer instead of a 2D (row-major) offset — broke correctness on 2D core grids.
- **Barrier deadlock fix**: `mcast_in0` path deadlocked when the op was assigned to phase 0; phase counter is now properly initialized.
- **Test infrastructure**: Added explicit `allowed_worker_cores` to all `MatmulMultiCoreReuse*ProgramConfig` instances in the `parallel_sequential` test suite; removed stale `op_semaphore_info` arg from `_emit_init_coordinator`.

## Test plan

- [ ] Run `tests/ttnn/unit_tests/operations/fused/parallel_sequential/` (254 tests, all pass locally)
- [ ] Run CI on affected paths: matmul factory, parallel/sequential fusion, barrier codegen

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/44835_matmul_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/44835_matmul_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/44835_matmul_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/44835_matmul_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/44835_matmul_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/44835_matmul_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/44835_matmul_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/44835_matmul_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/44835_matmul_descriptor)