### PR TITLE
Device 2.0 Semaphore: add relay_unicast / relay_multicast

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+
+// Sender semaphore kernel (device 2.0 API).
+// Mirrors sender_multicast_sem.cpp but uses Noc::async_write_multicast for data and
+// the new Semaphore<>::set_multicast(dst_sem, ...) overload to signal receivers at a
+// different sem L1 offset than the sender's local valid_sem.
+void kernel_main() {
+    // Compile-time arguments
+    constexpr uint32_t mst_base_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t sub_base_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
+    constexpr uint32_t pages_per_transaction = get_compile_time_arg_val(3);
+    constexpr uint32_t bytes_per_page = get_compile_time_arg_val(4);
+    constexpr uint32_t test_id = get_compile_time_arg_val(5);
+    constexpr uint32_t num_subordinates = get_compile_time_arg_val(6);
+    constexpr bool is_linked = get_compile_time_arg_val(7);
+    constexpr bool loopback = get_compile_time_arg_val(8);
+    uint32_t start_x = get_compile_time_arg_val(9);
+    uint32_t start_y = get_compile_time_arg_val(10);
+    uint32_t end_x = get_compile_time_arg_val(11);
+    uint32_t end_y = get_compile_time_arg_val(12);
+
+    // Specific for Multicast Schemes
+    constexpr uint32_t multicast_scheme_type = get_compile_time_arg_val(13);
+    constexpr uint32_t sub_grid_size_x = get_compile_time_arg_val(14);
+    constexpr uint32_t sub_grid_size_y = get_compile_time_arg_val(15);
+
+    // Semaphore arguments
+    constexpr uint32_t sender_sem_id = get_compile_time_arg_val(16);
+    constexpr uint32_t sender_valid_sem_id = get_compile_time_arg_val(17);
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(18);
+
+    // Derivative values
+    constexpr uint32_t bytes_per_transaction = pages_per_transaction * bytes_per_page;
+    constexpr uint32_t bytes = bytes_per_transaction * num_of_transactions;
+
+    if (noc_index == 1) {
+        std::swap(start_x, end_x);
+        std::swap(start_y, end_y);
+    }
+
+    Noc noc(noc_index);
+    UnicastEndpoint unicast_endpoint;
+    MulticastEndpoint multicast_endpoint;
+
+    Semaphore<> sender_sem(sender_sem_id);
+    Semaphore<> sender_valid_sem(sender_valid_sem_id);
+    Semaphore<> receiver_sem(receiver_sem_id);
+
+    constexpr Noc::McastMode mcast_mode = loopback ? Noc::McastMode::INCLUDE_SRC : Noc::McastMode::EXCLUDE_SRC;
+
+    {
+        DeviceZoneScopedN("RISCV0");
+
+        for (uint32_t i = 0; i < num_of_transactions - 1; i++) {
+            sender_sem.wait(num_subordinates);
+            sender_sem.set(0);
+
+            noc.async_write_multicast<mcast_mode>(
+                unicast_endpoint,
+                multicast_endpoint,
+                bytes_per_transaction,
+                num_subordinates,
+                {.addr = mst_base_addr},
+                {.noc_x_start = start_x,
+                 .noc_y_start = start_y,
+                 .noc_x_end = end_x,
+                 .noc_y_end = end_y,
+                 .addr = sub_base_addr},
+                is_linked);
+
+            sender_valid_sem.template set_multicast<mcast_mode>(
+                noc, receiver_sem, start_x, start_y, end_x, end_y, num_subordinates, is_linked);
+        }
+
+        // Last transaction must unlink so the next workload can reserve its own path on the VC.
+        sender_sem.wait(num_subordinates);
+        sender_sem.set(0);
+
+        noc.async_write_multicast<mcast_mode>(
+            unicast_endpoint,
+            multicast_endpoint,
+            bytes_per_transaction,
+            num_subordinates,
+            {.addr = mst_base_addr},
+            {.noc_x_start = start_x,
+             .noc_y_start = start_y,
+             .noc_x_end = end_x,
+             .noc_y_end = end_y,
+             .addr = sub_base_addr});
+
+        sender_valid_sem.template set_multicast<mcast_mode>(
+            noc, receiver_sem, start_x, start_y, end_x, end_y, num_subordinates, false);
+    }
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("NoC Index", noc_index);
+    if constexpr (multicast_scheme_type != 0) {
+        DeviceTimestampedData("Multicast Scheme Type", multicast_scheme_type);
+        DeviceTimestampedData("Subordinate Grid Size X", sub_grid_size_x);
+        DeviceTimestampedData("Subordinate Grid Size Y", sub_grid_size_y);
+    }
+    DeviceTimestampedData("Number of subordinates", num_subordinates);
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
@@ -8,7 +8,7 @@
 
 // Sender semaphore kernel (device 2.0 API).
 // Mirrors sender_multicast_sem.cpp but uses Noc::async_write_multicast for data and
-// the new Semaphore<>::set_multicast(dst_sem, ...) overload to signal receivers at a
+// the new Semaphore<>::relay_multicast(dst_sem, ...) method to signal receivers at a
 // different sem L1 offset than the sender's local valid_sem.
 void kernel_main() {
     // Compile-time arguments
@@ -75,7 +75,7 @@ void kernel_main() {
                  .addr = sub_base_addr},
                 is_linked);
 
-            sender_valid_sem.template set_multicast<mcast_mode>(
+            sender_valid_sem.template relay_multicast<mcast_mode>(
                 noc, receiver_sem, start_x, start_y, end_x, end_y, num_subordinates, is_linked);
         }
 
@@ -95,7 +95,7 @@ void kernel_main() {
              .noc_y_end = end_y,
              .addr = sub_base_addr});
 
-        sender_valid_sem.template set_multicast<mcast_mode>(
+        sender_valid_sem.template relay_multicast<mcast_mode>(
             noc, receiver_sem, start_x, start_y, end_x, end_y, num_subordinates, false);
     }
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
@@ -9,7 +9,7 @@
 // Sender unicast semaphore kernel (device 2.0 API).
 // Per transaction, waits for all subordinates to signal readiness, then for each
 // subordinate: unicasts data via Noc::async_write and signals that subordinate's
-// receiver_sem via the new Semaphore<>::set_unicast(dst_sem, ...) overload (which
+// receiver_sem via the new Semaphore<>::relay_unicast(dst_sem, ...) method (which
 // targets the receiver's distinct L1 offset, not the sender's local valid_sem slot).
 void kernel_main() {
     // Compile-time arguments
@@ -59,7 +59,7 @@ void kernel_main() {
                     {.noc_x = dest_coord_x, .noc_y = dest_coord_y, .addr = sub_base_addr},
                     current_virtual_channel);
 
-                sender_valid_sem.set_unicast(noc, receiver_sem, dest_coord_x, dest_coord_y);
+                sender_valid_sem.relay_unicast(noc, receiver_sem, dest_coord_x, dest_coord_y);
             }
         }
         noc.async_write_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+
+// Sender unicast semaphore kernel (device 2.0 API).
+// Per transaction, waits for all subordinates to signal readiness, then for each
+// subordinate: unicasts data via Noc::async_write and signals that subordinate's
+// receiver_sem via the new Semaphore<>::set_unicast(dst_sem, ...) overload (which
+// targets the receiver's distinct L1 offset, not the sender's local valid_sem slot).
+void kernel_main() {
+    // Compile-time arguments
+    constexpr uint32_t mst_base_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t sub_base_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
+    constexpr uint32_t pages_per_transaction = get_compile_time_arg_val(3);
+    constexpr uint32_t bytes_per_page = get_compile_time_arg_val(4);
+    constexpr uint32_t test_id = get_compile_time_arg_val(5);
+    constexpr uint32_t num_subordinates = get_compile_time_arg_val(6);
+    constexpr uint32_t num_virtual_channels = get_compile_time_arg_val(7);
+
+    // Semaphore arguments
+    constexpr uint32_t sender_sem_id = get_compile_time_arg_val(8);
+    constexpr uint32_t sender_valid_sem_id = get_compile_time_arg_val(9);
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(10);
+
+    // Derivative values
+    constexpr uint32_t bytes_per_transaction = pages_per_transaction * bytes_per_page;
+
+    Noc noc(noc_index);
+    UnicastEndpoint unicast_endpoint;
+
+    Semaphore<> sender_sem(sender_sem_id);
+    Semaphore<> sender_valid_sem(sender_valid_sem_id);
+    Semaphore<> receiver_sem(receiver_sem_id);
+
+    {
+        DeviceZoneScopedN("RISCV0");
+
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            sender_sem.wait(num_subordinates);
+            sender_sem.set(0);
+
+            for (uint32_t subordinate_num = 0; subordinate_num < num_subordinates; subordinate_num++) {
+                uint32_t dest_coord_packed = get_arg_val<uint32_t>(subordinate_num);
+                uint32_t dest_coord_x = dest_coord_packed >> 16;
+                uint32_t dest_coord_y = dest_coord_packed & 0xFFFF;
+
+                uint32_t current_virtual_channel = i % num_virtual_channels;
+
+                noc.async_write(
+                    unicast_endpoint,
+                    unicast_endpoint,
+                    bytes_per_transaction,
+                    {.addr = mst_base_addr},
+                    {.noc_x = dest_coord_x, .noc_y = dest_coord_y, .addr = sub_base_addr},
+                    current_virtual_channel);
+
+                sender_valid_sem.set_unicast(noc, receiver_sem, dest_coord_x, dest_coord_y);
+            }
+        }
+        noc.async_write_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
+    DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
+    DeviceTimestampedData("NoC Index", noc_index);
+    DeviceTimestampedData("Number of subordinates", num_subordinates);
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
@@ -59,6 +59,10 @@ void kernel_main() {
                     {.noc_x = dest_coord_x, .noc_y = dest_coord_y, .addr = sub_base_addr},
                     current_virtual_channel);
 
+                // Flush: async_write uses caller-supplied VC; relay_unicast goes through
+                // noc_semaphore_set_remote which hardcodes NOC_UNICAST_WRITE_VC. Same NoC,
+                // different VC has no ordering guarantee, so the sem could overtake the data.
+                noc.async_writes_flushed();
                 sender_valid_sem.relay_unicast(noc, receiver_sem, dest_coord_x, dest_coord_y);
             }
         }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -179,6 +179,14 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
     } else {  // Unicast Sender Kernel
         sender_compile_args.push_back((uint32_t)test_config.num_virtual_channels);
         sender_kernel_path += "sender_unicast";
+
+        if (test_config.use_semaphore) {
+            sender_compile_args.insert(
+                sender_compile_args.end(),
+                {(uint32_t)sender_sem_id, (uint32_t)sender_valid_sem_id, (uint32_t)receiver_sem_id});
+
+            sender_kernel_path += "_sem";
+        }
     }
 
     if (test_config.use_2_0_api) {
@@ -1175,5 +1183,134 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
         noc_id,
         0,  // multicast_scheme_type (not used here)
         true);
+}
+
+/* ========== MULTICAST WITH SEMAPHORE 2.0 ========== */
+//
+// Exercises the new Semaphore<>::set_multicast(dst_sem, ...) overload added in
+// noc_semaphore.h. The sender's `valid_sem` and the receivers' `receiver_sem` are
+// distinct semaphore ids — i.e. they live at different L1 offsets. If the API
+// resolved the multicast NoC addr from the sender's L1 offset (the regression we
+// are guarding against), the receivers would never see an increment at
+// `receiver_sem`'s slot and the kernels would deadlock at Finish.
+//
+
+/* ========== 2x2, non-linked, EXCLUDE_SRC ========== */
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSemaphore2x22_0) {
+    uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 10;
+
+    auto mesh_device = get_mesh_device();
+    auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+        .test_id = test_case_id,
+        .mst_core_coord = {0, 0},
+        .sub_start_core_coord = {0, 0},
+        .sub_grid_size = {2, 2},
+        .num_of_transactions = 4,
+        .pages_per_transaction = 1,
+        .bytes_per_page = bytes_per_page,
+        .l1_data_format = DataFormat::Float16_b,
+        .noc_id = NOC::NOC_0,
+        .loopback = false,
+        .is_multicast = true,
+        .is_linked = false,
+        .use_2_0_api = true,
+        .use_semaphore = true,
+    };
+
+    EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+}
+
+/* ========== 2x2, linked, INCLUDE_SRC (loopback) ========== */
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphoreLoopback2x22_0) {
+    uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 11;
+
+    auto mesh_device = get_mesh_device();
+    auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+        .test_id = test_case_id,
+        .mst_core_coord = {0, 0},
+        .sub_start_core_coord = {0, 0},
+        .sub_grid_size = {2, 2},
+        .num_of_transactions = 4,
+        .pages_per_transaction = 1,
+        .bytes_per_page = bytes_per_page,
+        .l1_data_format = DataFormat::Float16_b,
+        .noc_id = NOC::NOC_0,
+        .loopback = true,
+        .is_multicast = true,
+        .is_linked = true,
+        .use_2_0_api = true,
+        .use_semaphore = true,
+    };
+
+    EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+}
+
+/* ========== 5x5, linked, EXCLUDE_SRC ========== */
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore5x52_0) {
+    uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 12;
+
+    auto mesh_device = get_mesh_device();
+    auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+        .test_id = test_case_id,
+        .mst_core_coord = {0, 0},
+        .sub_start_core_coord = {0, 0},
+        .sub_grid_size = {5, 5},
+        .num_of_transactions = 4,
+        .pages_per_transaction = 1,
+        .bytes_per_page = bytes_per_page,
+        .l1_data_format = DataFormat::Float16_b,
+        .noc_id = NOC::NOC_0,
+        .loopback = false,
+        .is_multicast = true,
+        .is_linked = true,
+        .use_2_0_api = true,
+        .use_semaphore = true,
+    };
+
+    EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+}
+
+/* ========== UNICAST WITH SEMAPHORE 2.0 ========== */
+//
+// Exercises the new Semaphore<>::set_unicast(dst_sem, ...) method added in
+// noc_semaphore.h. Same dst-sem-L1-offset guarantee as the multicast variant.
+//
+
+/* ========== 2x2 ========== */
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastSemaphore2x22_0) {
+    uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 13;
+
+    auto mesh_device = get_mesh_device();
+    auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+        .test_id = test_case_id,
+        .mst_core_coord = {0, 0},
+        .sub_start_core_coord = {0, 0},
+        .sub_grid_size = {2, 2},
+        .num_of_transactions = 4,
+        .pages_per_transaction = 1,
+        .bytes_per_page = bytes_per_page,
+        .l1_data_format = DataFormat::Float16_b,
+        .noc_id = NOC::NOC_0,
+        .loopback = false,
+        .is_multicast = false,
+        .is_linked = false,
+        .num_virtual_channels = 1,
+        .use_2_0_api = true,
+        .use_semaphore = true,
+    };
+
+    EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
 }
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -1185,14 +1185,11 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
         true);
 }
 
-/* ========== MULTICAST WITH SEMAPHORE 2.0 ========== */
+/* ========== MULTICAST WITH SEMAPHORE ========== */
 //
-// Exercises the new Semaphore<>::set_multicast(dst_sem, ...) overload added in
-// noc_semaphore.h. The sender's `valid_sem` and the receivers' `receiver_sem` are
-// distinct semaphore ids — i.e. they live at different L1 offsets. If the API
-// resolved the multicast NoC addr from the sender's L1 offset (the regression we
-// are guarding against), the receivers would never see an increment at
-// `receiver_sem`'s slot and the kernels would deadlock at Finish.
+// Exercises the Semaphore<>::set_multicast(dst_sem, ...) overload.
+// The sender's `valid_sem` and the receivers' `receiver_sem` are
+// distinct semaphore ids — i.e. they live at different L1 offsets.
 //
 
 /* ========== 2x2, non-linked, EXCLUDE_SRC ========== */

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -1193,7 +1193,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
 //
 
 /* ========== 2x2, non-linked, EXCLUDE_SRC ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSemaphore2x22_0) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSemaphore2x2_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 10;
 
     auto mesh_device = get_mesh_device();
@@ -1221,7 +1221,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSemaphore2x2
 }
 
 /* ========== 2x2, linked, INCLUDE_SRC (loopback) ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphoreLoopback2x22_0) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphoreLoopback2x2_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 11;
 
     auto mesh_device = get_mesh_device();
@@ -1249,7 +1249,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 }
 
 /* ========== 5x5, linked, EXCLUDE_SRC ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore5x52_0) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore5x5_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 12;
 
     auto mesh_device = get_mesh_device();
@@ -1283,7 +1283,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 //
 
 /* ========== 2x2 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastSemaphore2x22_0) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastSemaphore2x2_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 13;
 
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -1187,7 +1187,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
 
 /* ========== MULTICAST WITH SEMAPHORE ========== */
 //
-// Exercises the Semaphore<>::set_multicast(dst_sem, ...) overload.
+// Exercises the Semaphore<>::relay_multicast(dst_sem, ...) method.
 // The sender's `valid_sem` and the receivers' `receiver_sem` are
 // distinct semaphore ids — i.e. they live at different L1 offsets.
 //
@@ -1278,7 +1278,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 
 /* ========== UNICAST WITH SEMAPHORE 2.0 ========== */
 //
-// Exercises the new Semaphore<>::set_unicast(dst_sem, ...) method added in
+// Exercises the new Semaphore<>::relay_unicast(dst_sem, ...) method added in
 // noc_semaphore.h. Same dst-sem-L1-offset guarantee as the multicast variant.
 //
 

--- a/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
+++ b/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
@@ -6,6 +6,7 @@
 
 #include "dev_mem_map.h"
 #include "api/dataflow/noc.h"
+#include "api/debug/assert.h"
 
 /**
  * @brief Semaphore synchronization primitive for programmable cores.
@@ -30,11 +31,12 @@
  *  - set(value): Set the semaphore to the specified value.
  *  - set_multicast(...): Set the semaphore value on multiple cores.
  *  - set_multicast_loopback_src(...): Set the semaphore value on multiple cores including the source.
+ *  - relay_unicast(dst_sem, ...): Set a different remote semaphore on one core to this semaphore's local value.
+ *  - relay_multicast(dst_sem, ...): Multicast this semaphore's local value into a different destination semaphore.
  */
 template <ProgrammableCoreType core_type = ProgrammableCoreType::TENSIX>
 class Semaphore {
-    // Lets set_multicast(dst_sem) / set_unicast(dst_sem)
-    // read dst_sem.local_l1_addr_ without a public accessor.
+    // Lets relay_unicast / relay_multicast read dst_sem's private members without a public accessor.
     template <ProgrammableCoreType OT>
     friend class Semaphore;
 
@@ -116,10 +118,11 @@ public:
     }
 
     /**
-     * @brief Set a remote semaphore on a single core to this semaphore's local value.
-     * @note The destination semaphore is identified by dst_sem and typically has a different sem id
-     *       (i.e. a different L1 offset) than this Semaphore. Writes 4 bytes from this->local_l1_addr_
-     *       to dst_sem.local_l1_addr_ on the remote core (noc_x, noc_y).
+     * @brief Relay this semaphore's local value into a different remote semaphore on a single core.
+     * @note dst_sem must be a different Semaphore than this one (a different L1 offset). To bump the
+     *       same semaphore on a remote core, use up(noc, noc_x, noc_y, value) instead.
+     *       Writes 4 bytes from this->local_l1_addr_ to dst_sem.local_l1_addr_ on the remote core
+     *       (noc_x, noc_y).
      *
      * @param noc The Noc object representing the NoC to use for the transaction.
      * @param dst_sem The destination Semaphore whose L1 offset receives the value.
@@ -128,16 +131,10 @@ public:
      * @tparam dst_core_type Programmable core type of the destination (defaults to this Semaphore's core_type).
      */
     template <ProgrammableCoreType dst_core_type = core_type>
-    void set_unicast(const Noc& noc, const Semaphore<dst_core_type>& dst_sem, uint32_t noc_x, uint32_t noc_y) {
-#ifdef ARCH_QUASAR
-        const uintptr_t src_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
-        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_ - MEM_L1_UNCACHED_BASE;
-#else
-        const uintptr_t src_l1_addr = local_l1_addr_;
-        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_;
-#endif
-        const uint64_t dst_noc_addr = ::get_noc_addr(noc_x, noc_y, dst_l1_addr, noc.get_noc_id());
-        noc_semaphore_set_remote(src_l1_addr, dst_noc_addr, noc.get_noc_id());
+    void relay_unicast(const Noc& noc, const Semaphore<dst_core_type>& dst_sem, uint32_t noc_x, uint32_t noc_y) {
+        ASSERT(local_l1_addr_ != dst_sem.local_l1_addr_);
+        const uint64_t dst_noc_addr = ::get_noc_addr(noc_x, noc_y, dst_sem.get_l1_addr(), noc.get_noc_id());
+        noc_semaphore_set_remote(get_l1_addr(), dst_noc_addr, noc.get_noc_id());
     }
 
     /**
@@ -164,23 +161,18 @@ public:
         bool linked = false) {
         const uint64_t multicast_addr =
             get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, noc.get_noc_id());
-#ifdef ARCH_QUASAR
-        const uintptr_t local_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
-#else
-        const uintptr_t local_l1_addr = local_l1_addr_;
-#endif
+        const uintptr_t src_l1_addr = get_l1_addr();
         if constexpr (mcast_mode == Noc::McastMode::INCLUDE_SRC) {
-            noc_semaphore_set_multicast_loopback_src(
-                local_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
+            noc_semaphore_set_multicast_loopback_src(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         } else if constexpr (mcast_mode == Noc::McastMode::EXCLUDE_SRC) {
-            noc_semaphore_set_multicast(local_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
+            noc_semaphore_set_multicast(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         }
     }
 
     /**
-     * @brief Multicast this semaphore's local value into a different destination semaphore on a rectangular region.
-     * @note The destination semaphore L1 slot is identified by dst_sem and typically has a different sem id
-     *       than this Semaphore. Each core in the region receives the 4-byte write at dst_sem's L1 offset.
+     * @brief Relay this semaphore's local value into a different destination semaphore on a rectangular region.
+     * @note dst_sem must be a different Semaphore than this one (a different L1 offset). Each core in the region
+     *       receives the 4-byte write at dst_sem's L1 offset.
      * @note Sender cannot be part of the multicast destinations unless mcast_mode is INCLUDE_SRC.
      *
      * @param noc The Noc object representing the NoC to use for the transaction.
@@ -195,7 +187,7 @@ public:
      * @tparam dst_core_type Programmable core type of the destination (defaults to this Semaphore's core_type).
      */
     template <Noc::McastMode mcast_mode = Noc::McastMode::EXCLUDE_SRC, ProgrammableCoreType dst_core_type = core_type>
-    void set_multicast(
+    void relay_multicast(
         const Noc& noc,
         const Semaphore<dst_core_type>& dst_sem,
         uint32_t noc_x_start,
@@ -204,15 +196,10 @@ public:
         uint32_t noc_y_end,
         uint32_t num_dests,
         bool linked = false) {
-#ifdef ARCH_QUASAR
-        const uintptr_t src_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
-        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_ - MEM_L1_UNCACHED_BASE;
-#else
-        const uintptr_t src_l1_addr = local_l1_addr_;
-        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_;
-#endif
-        const uint64_t multicast_addr =
-            ::get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, dst_l1_addr, noc.get_noc_id());
+        ASSERT(local_l1_addr_ != dst_sem.local_l1_addr_);
+        const uint64_t multicast_addr = ::get_noc_multicast_addr(
+            noc_x_start, noc_y_start, noc_x_end, noc_y_end, dst_sem.get_l1_addr(), noc.get_noc_id());
+        const uintptr_t src_l1_addr = get_l1_addr();
         if constexpr (mcast_mode == Noc::McastMode::INCLUDE_SRC) {
             noc_semaphore_set_multicast_loopback_src(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         } else if constexpr (mcast_mode == Noc::McastMode::EXCLUDE_SRC) {
@@ -248,21 +235,21 @@ public:
 private:
     uintptr_t local_l1_addr_;
 
-    uint64_t get_noc_multicast_addr(
-        uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint8_t noc) const {
+    // L1 offset of this semaphore as a NoC-addressable address (strips the QUASAR uncached alias).
+    uintptr_t get_l1_addr() const {
 #ifdef ARCH_QUASAR
-        return ::get_noc_multicast_addr(
-            noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_ - MEM_L1_UNCACHED_BASE, noc);
+        return local_l1_addr_ - MEM_L1_UNCACHED_BASE;
 #else
-        return ::get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_, noc);
+        return local_l1_addr_;
 #endif
     }
 
+    uint64_t get_noc_multicast_addr(
+        uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint8_t noc) const {
+        return ::get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, get_l1_addr(), noc);
+    }
+
     uint64_t get_noc_addr(uint32_t noc_x, uint32_t noc_y, uint8_t noc) const {
-#ifdef ARCH_QUASAR
-        return ::get_noc_addr(noc_x, noc_y, local_l1_addr_ - MEM_L1_UNCACHED_BASE, noc);
-#else
-        return ::get_noc_addr(noc_x, noc_y, local_l1_addr_, noc);
-#endif
+        return ::get_noc_addr(noc_x, noc_y, get_l1_addr(), noc);
     }
 };

--- a/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
+++ b/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
@@ -33,6 +33,12 @@
  */
 template <ProgrammableCoreType core_type = ProgrammableCoreType::TENSIX>
 class Semaphore {
+    // Cross-instantiation friend: lets set_multicast(dst_sem) / set_unicast(dst_sem)
+    // read dst_sem.local_l1_addr_ without a public accessor (which would leak the
+    // ARCH_QUASAR uncached-base adjustment to callers).
+    template <ProgrammableCoreType OT>
+    friend class Semaphore;
+
 public:
     explicit Semaphore(uint32_t semaphore_id) : local_l1_addr_(get_semaphore<core_type>(semaphore_id)) {
 #ifdef ARCH_QUASAR
@@ -111,6 +117,31 @@ public:
     }
 
     /**
+     * @brief Set a remote semaphore on a single core to this semaphore's local value.
+     * @note The destination semaphore is identified by dst_sem and typically has a different sem id
+     *       (i.e. a different L1 offset) than this Semaphore. Writes 4 bytes from this->local_l1_addr_
+     *       to dst_sem.local_l1_addr_ on the remote core (noc_x, noc_y).
+     *
+     * @param noc The Noc object representing the NoC to use for the transaction.
+     * @param dst_sem The destination Semaphore whose L1 offset receives the value.
+     * @param noc_x The X coordinate of the remote core in the NoC.
+     * @param noc_y The Y coordinate of the remote core in the NoC.
+     * @tparam dst_core_type Programmable core type of the destination (defaults to this Semaphore's core_type).
+     */
+    template <ProgrammableCoreType dst_core_type = core_type>
+    void set_unicast(const Noc& noc, const Semaphore<dst_core_type>& dst_sem, uint32_t noc_x, uint32_t noc_y) {
+#ifdef ARCH_QUASAR
+        const uintptr_t src_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
+        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_ - MEM_L1_UNCACHED_BASE;
+#else
+        const uintptr_t src_l1_addr = local_l1_addr_;
+        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_;
+#endif
+        const uint64_t dst_noc_addr = ::get_noc_addr(noc_x, noc_y, dst_l1_addr, noc.get_noc_id());
+        noc_semaphore_set_remote(src_l1_addr, dst_noc_addr, noc.get_noc_id());
+    }
+
+    /**
      * @brief Set the semaphore value on multiple cores in a specified rectangular region of the NoC.
      * @note Sender cannot be part of the multicast destinations.
      *
@@ -144,6 +175,49 @@ public:
                 local_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         } else if constexpr (mcast_mode == Noc::McastMode::EXCLUDE_SRC) {
             noc_semaphore_set_multicast(local_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
+        }
+    }
+
+    /**
+     * @brief Multicast this semaphore's local value into a different destination semaphore on a rectangular region.
+     * @note The destination semaphore L1 slot is identified by dst_sem and typically has a different sem id
+     *       than this Semaphore. Each core in the region receives the 4-byte write at dst_sem's L1 offset.
+     * @note Sender cannot be part of the multicast destinations unless mcast_mode is INCLUDE_SRC.
+     *
+     * @param noc The Noc object representing the NoC to use for the transaction.
+     * @param dst_sem The destination Semaphore whose L1 offset receives the value on each core in the region.
+     * @param noc_x_start The starting X coordinate of the region (inclusive).
+     * @param noc_y_start The starting Y coordinate of the region (inclusive).
+     * @param noc_x_end The ending X coordinate of the region (inclusive).
+     * @param noc_y_end The ending Y coordinate of the region (inclusive).
+     * @param num_dests The number of destination cores in the region.
+     * @param linked Whether to link this operation with the next (default is false).
+     * @tparam mcast_mode Indicates whether to include the sender in the multicast (default is EXCLUDE_SRC).
+     * @tparam dst_core_type Programmable core type of the destination (defaults to this Semaphore's core_type).
+     */
+    template <Noc::McastMode mcast_mode = Noc::McastMode::EXCLUDE_SRC, ProgrammableCoreType dst_core_type = core_type>
+    void set_multicast(
+        const Noc& noc,
+        const Semaphore<dst_core_type>& dst_sem,
+        uint32_t noc_x_start,
+        uint32_t noc_y_start,
+        uint32_t noc_x_end,
+        uint32_t noc_y_end,
+        uint32_t num_dests,
+        bool linked = false) {
+#ifdef ARCH_QUASAR
+        const uintptr_t src_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
+        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_ - MEM_L1_UNCACHED_BASE;
+#else
+        const uintptr_t src_l1_addr = local_l1_addr_;
+        const uintptr_t dst_l1_addr = dst_sem.local_l1_addr_;
+#endif
+        const uint64_t multicast_addr =
+            ::get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, dst_l1_addr, noc.get_noc_id());
+        if constexpr (mcast_mode == Noc::McastMode::INCLUDE_SRC) {
+            noc_semaphore_set_multicast_loopback_src(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
+        } else if constexpr (mcast_mode == Noc::McastMode::EXCLUDE_SRC) {
+            noc_semaphore_set_multicast(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         }
     }
 

--- a/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
+++ b/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
@@ -33,9 +33,8 @@
  */
 template <ProgrammableCoreType core_type = ProgrammableCoreType::TENSIX>
 class Semaphore {
-    // Cross-instantiation friend: lets set_multicast(dst_sem) / set_unicast(dst_sem)
-    // read dst_sem.local_l1_addr_ without a public accessor (which would leak the
-    // ARCH_QUASAR uncached-base adjustment to callers).
+    // Lets set_multicast(dst_sem) / set_unicast(dst_sem)
+    // read dst_sem.local_l1_addr_ without a public accessor.
     template <ProgrammableCoreType OT>
     friend class Semaphore;
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
 Relates to  https://github.com/tenstorrent/tt-metal/issues/45003, https://github.com/tenstorrent/tt-metal/pull/45015

The existing Semaphore<>::set_multicast(MulticastEndpoint, num_dests) writes to the same L1 offset on remote cores as the sender's local sem (it uses local_l1_addr_ for both src and dst). Chain-mcast patterns where sender reads valid_sem and writes a distinct receiver_sem cannot use it. Add overloads that take a destination Semaphore<> and resolve the multicast/unicast NoC address from dst_sem.local_l1_addr_, while sourcing the value from this->local_l1_addr_.

Also add Semaphore<>::set_unicast — Semaphore<> previously had no unicast-set equivalent of noc_semaphore_set_remote.


### Notes for reviewers

   This PR will support legacy calls remaining in PR #45015. There are two patterns, appearing in reader_interleaved.cpp, ring_joint_reader.cpp, sdpa dataflow_common.hpp, exp_ring_joint_reader.cpp, sdpa_decode, dataflow_common.hpp):

  A. Sem mcast in a chain-link pair (after a linked=true write):
  const uint64_t mcast_sem_noc_addr = ::get_noc_multicast_addr(
      x0,y0,x1,y1, receiver_semaphore_l1_addr, noc.get_noc_id());
  noc_semaphore_set_multicast(
      valid_semaphore_l1_addr, mcast_sem_noc_addr, num_dests, false, noc.get_noc_id());

  B. Unicast signal to remote receiver_sem at a different sem id:
  const uint64_t remote_receiver_noc_addr =
      ::get_noc_addr(next_x, next_y, receiver_semaphore_l1_addr, noc.get_noc_id());
  noc_semaphore_set_remote(valid_semaphore_l1_addr, remote_receiver_noc_addr,
  noc.get_noc_id());

Implementation notes:
Friend declaration on Semaphore<> lets the new methods read the destination's private local_l1_addr_ without exposing a public accessor.

Tests: add sender_multicast_sem_2_0.cpp / sender_unicast_sem_2_0.cpp kernels and 4 gtest cases under one_to_all that exercise the new overloads with distinct sender_valid_sem and receiver_sem ids. If the API resolved the dst NoC address from the sender's L1 offset, receivers would deadlock polling at the wrong slot — so a passing test proves the dst-sem targeting is correct. Covers EXCLUDE_SRC (2x2 / 5x5 linked), INCLUDE_SRC loopback (2x2 linked), and unicast.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/device_2_0_multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/device_2_0_multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/device_2_0_multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/device_2_0_multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/device_2_0_multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/device_2_0_multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/device_2_0_multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/device_2_0_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/device_2_0_multicast)