### PR TITLE
Performance : Gemma4 on device embedding

### DIFF
--- a/models/demos/gemma4/demo/text_demo.py
+++ b/models/demos/gemma4/demo/text_demo.py
@@ -361,26 +361,25 @@ def run_generation(
         trace_device_inputs = None
 
         # ── Decode helpers ─────────────────────────────────────────────────
-        # Embedding + PLI computed on host (fast for single-token decode),
-        # transferred as ROW_MAJOR to device.  Trace captures decoder layers onward.
+        # Token IDs (+ optional PLI) staged on host; embedding lookup runs on
+        # device inside ``ttnn_decode_forward``. Trace captures decoder onward.
         # Sampling: SamplingGenerator for TP >= 2, host torch.argmax for TP = 1.
         on_device_sampling = model.sampling is not None
 
         def _make_decode_inputs(tok, pos):
             """Create host tensors for one decode iteration."""
-            embeds_torch, pli_torch = model.compute_host_embeddings(tok)
-            # ROW_MAJOR on host — TILE conversion happens on device inside the trace.
-            embeds_h = ttnn.from_torch(
-                embeds_torch,
+            pli_torch = model.compute_host_pli(tok)
+            tokens_h = ttnn.from_torch(
+                torch.tensor([[tok]], dtype=torch.int32),
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                dtype=ttnn.bfloat16,
+                dtype=ttnn.uint32,
                 mesh_mapper=replicate,
             )
             pos_padded = torch.nn.functional.pad(
                 torch.tensor([pos], dtype=torch.int32).reshape(1, 1), (0, 31), "constant", 0
             )
             inputs = {
-                "embeds": embeds_h,
+                "tokens": tokens_h,
                 "position": ttnn.from_torch(
                     pos_padded,
                     layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -396,7 +395,7 @@ def run_generation(
             }
             if pli_torch is not None:
                 inputs["pli"] = ttnn.from_torch(
-                    pli_torch,
+                    pli_torch.to(torch.bfloat16),
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                     dtype=ttnn.bfloat16,
                     mesh_mapper=replicate,
@@ -405,7 +404,7 @@ def run_generation(
 
         def _fwd(device_inputs):
             return model.ttnn_decode_forward(
-                x=device_inputs["embeds"],
+                x=device_inputs["tokens"],
                 current_pos=device_inputs["position"],
                 rot_mat_idxs=device_inputs["position_int32"],  # pos_int32 passed as rot_mat_idxs
                 page_table=page_table_tt,
@@ -434,7 +433,8 @@ def run_generation(
 
         sample_mode = "device" if on_device_sampling else "host"
         logger.info(
-            f"Decoding (trace={'ON' if enable_decode_trace else 'OFF'}, " f"embedding=host, sampling={sample_mode})..."
+            f"Decoding (trace={'ON' if enable_decode_trace else 'OFF'}, "
+            f"embedding=device, sampling={sample_mode})..."
         )
         profiler.start(f"inference_decode", iteration=prompt_idx)
 

--- a/models/demos/gemma4/tests/pcc_thresholds.json
+++ b/models/demos/gemma4/tests/pcc_thresholds.json
@@ -18,7 +18,8 @@
       "test_attention_prefill[wormhole_b0-seq1024-global-1x1]": 0.98,
       "test_attention_prefill[wormhole_b0-seq4096-global-1x1]": 0.98,
       "test_attention_prefill[blackhole-seq4096-global-1x1]": 0.97,
-      "test_full_model[wormhole_b0-1x1]": 0.95
+      "test_full_model[wormhole_b0-1x1]": 0.95,
+      "test_full_model[blackhole-1x1]": 0.96
     },
     "1x2": {
       "test_attention_prefill[blackhole-seq4096-global-1x2]": 0.97,

--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -878,19 +878,23 @@ def _decode_step_inputs(model, mesh_device, token_id, position):
     """Build the host-side decode inputs both paths consume.
 
     Mirrors what ``Gemma4Model.prepare_decode_inputs_host`` packs into
-    its return tuple. Returns ``(embeds, pos_uint32, pos_int32, pli)``;
+    its return tuple. Returns ``(tokens, pos_uint32, pos_int32, pli)``;
     ``pli`` is ``None`` when the model has no PLI configured. Caller is
     responsible for deallocating the returned device tensors after
     each step.
     """
     import torch.nn.functional as F
 
-    embeds, pli = model.compute_host_embeddings(token_id)
+    pli = model.compute_host_pli(token_id)
     is_mesh = hasattr(mesh_device, "shape") and mesh_device.get_num_devices() > 1
     mapper = ttnn.ReplicateTensorToMesh(mesh_device) if is_mesh else None
 
-    embeds_tt = ttnn.from_torch(
-        embeds, device=mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=mapper
+    tokens_tt = ttnn.from_torch(
+        torch.tensor([[token_id]], dtype=torch.int32),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint32,
+        mesh_mapper=mapper,
     )
     pos_padded = F.pad(torch.tensor([position], dtype=torch.int32).reshape(1, 1), (0, 31), "constant", 0)
     pos_tt = ttnn.from_torch(
@@ -912,7 +916,7 @@ def _decode_step_inputs(model, mesh_device, token_id, position):
             dtype=ttnn.bfloat16,
             mesh_mapper=mapper,
         )
-    return embeds_tt, pos_tt, pos_int32_tt, pli_tt
+    return tokens_tt, pos_tt, pos_int32_tt, pli_tt
 
 
 def _page_table_to_tt(page_table_torch, mesh_device):

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -97,12 +97,10 @@ def create_rope_caches(mesh_device, hf_config, max_seq_len):
 
 
 class Gemma4Model:
-    # Generator-interface flags. Decode inputs are recomputed on host every
-    # token (host embedding + PLI), so the captured trace's input buffers
-    # have to be refreshed on every replay rather than just on the first
-    # call after a token-shape change. On-device sampling stays off until
-    # the host-sampling path is solid; flip this once the on-device path
-    # is verified end-to-end.
+    # Generator-interface flags. Decode refreshes host-staged token IDs (+ PLI
+    # when enabled) every step, so trace input buffers are updated on every
+    # replay rather than only after a shape change. On-device sampling stays
+    # off until the host-sampling path is solid; flip once verified end-to-end.
     _tt_vllm_always_refresh_decode_trace_inputs = True
     _supports_on_device_sampling = False
 
@@ -514,7 +512,7 @@ class Gemma4Model:
             )
 
         # Compute per-layer inputs (E2B/E4B)
-        # Decode: pre-computed on host via compute_host_embeddings (pli_combined)
+        # Decode: PLI pre-computed on host (pli_combined); main embed on device
         # Prefill: computed on CPU from input_ids_torch / embeds_torch
         pli_combined_tt = None
         per_layer_inputs = None
@@ -667,11 +665,32 @@ class Gemma4Model:
             embeds = ccl_allgather(embeds, self.mesh_config, self.ccl_manager)
         return embeds
 
-    def compute_host_embeddings(self, token_id):
-        """Compute token embedding + PLI entirely on CPU for a single decode token.
+    def compute_host_pli(self, token_id):
+        """Compute per-layer input (PLI) on CPU for a single decode token.
 
-        Embedding and PLI are computed on host to keep them off the device trace,
-        reducing traced op count and improving decode throughput on 1x1 mesh.
+        Main token embeddings are looked up on device via ``embed_tokens``;
+        this path only builds the E2B/E4B PLI tensor still computed on host.
+
+        Returns:
+            pli_combined: torch.Tensor [1, 1, n_layers, pli_size] bfloat16, or None
+        """
+        import torch.nn.functional as F
+
+        if not self.hidden_size_per_layer_input or not self.per_layer_input_weights:
+            return None
+
+        token_tensor = torch.tensor([[token_id]], dtype=torch.long)
+        embeds = F.embedding(token_tensor, self._embed_weight_cpu).float() * self.embed_scale
+        pli_list = self._compute_per_layer_inputs(token_tensor.int(), embeds)
+        if pli_list is None:
+            return None
+        return torch.stack(pli_list, dim=2)  # [1, 1, n_layers, pli_size]
+
+    def compute_host_embeddings(self, token_id):
+        """Host token embedding + PLI (legacy fallback).
+
+        Decode should use ``embed_tokens`` on device plus ``compute_host_pli``.
+        Kept for callers/tests that still compare against the old host path.
 
         Returns:
             (embeds, pli_combined) where:
@@ -681,17 +700,8 @@ class Gemma4Model:
         import torch.nn.functional as F
 
         token_tensor = torch.tensor([[token_id]], dtype=torch.long)
-
-        # Token embedding (mirrors embed_tokens but on CPU)
         embeds = F.embedding(token_tensor, self._embed_weight_cpu).float() * self.embed_scale
-
-        # Per-layer input (E2B/E4B)
-        pli_combined = None
-        if self.hidden_size_per_layer_input and self.per_layer_input_weights:
-            pli_list = self._compute_per_layer_inputs(token_tensor.int(), embeds)
-            if pli_list is not None:
-                pli_combined = torch.stack(pli_list, dim=2)  # [1, 1, n_layers, pli_size]
-
+        pli_combined = self.compute_host_pli(token_id)
         embeds = embeds.reshape(1, 1, 1, self.hidden_size).to(torch.bfloat16)
         return embeds, pli_combined
 
@@ -961,10 +971,13 @@ class Gemma4Model:
         """Generator compatibility — no prefetcher to reinitialize."""
 
     def prepare_decode_inputs_host(self, tokens, current_pos, page_table=None):
-        """Create host tensors for one decode step, including pre-computed embedding + PLI.
+        """Create host tensors for one decode step (token IDs + optional PLI).
 
         Called by Generator._capture_decode_trace_text and _decode_forward_trace_text.
         Returns tuple of host ttnn tensors that copy_host_to_device will transfer.
+
+        Index 0 is a uint32 token tensor (not precomputed embeddings). Embedding
+        lookup runs on device inside ``ttnn_decode_forward`` via ``embed_tokens``.
 
         Args:
             tokens: torch.Tensor [batch] of token IDs
@@ -978,11 +991,15 @@ class Gemma4Model:
             ttnn.ReplicateTensorToMesh(self.mesh_device) if is_mesh and self.mesh_device.get_num_devices() > 1 else None
         )
 
-        # Host embedding + PLI (keeps these off the device trace)
         token_id = tokens[0].item()
-        embeds, pli = self.compute_host_embeddings(token_id)
+        pli = self.compute_host_pli(token_id)
 
-        embeds_tt = ttnn.from_torch(embeds, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=replicate)
+        tokens_tt = ttnn.from_torch(
+            torch.tensor([[token_id]], dtype=torch.int32),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.uint32,
+            mesh_mapper=replicate,
+        )
 
         # Position: [1, 32] uint32 padded (for RoPE embedding lookup)
         pos = current_pos[0].item() if hasattr(current_pos, "item") else int(current_pos[0])
@@ -1014,7 +1031,7 @@ class Gemma4Model:
                 pli.to(torch.bfloat16), layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=replicate
             )
 
-        return (embeds_tt, pos_tt, pos_int32_tt, page_table_tt, pli_tt)
+        return (tokens_tt, pos_tt, pos_int32_tt, page_table_tt, pli_tt)
 
     def prepare_inputs_decode(self, tokens, current_pos, page_table=None):
         """Wrapper: prepare_decode_inputs_host + copy to device."""
@@ -1056,11 +1073,11 @@ class Gemma4Model:
     ):
         """Decode forward — matches tt_transformers Generator interface.
 
-        x is pre-computed embeddings from prepare_decode_inputs_host (ROW_MAJOR).
+        x is a uint32 token tensor from prepare_decode_inputs_host (ROW_MAJOR).
         Generator calls: prepare_decode_inputs_host → copy_host_to_device → ttnn_decode_forward.
 
         Args:
-            x: [1,1,1,hidden_size] ROW_MAJOR device tensor (pre-computed embedding).
+            x: [1,1,1,1] or [1,1] uint32 ROW_MAJOR device tensor (decode token id).
             current_pos: [1,32] uint32 position tensor for RoPE embedding lookup.
             rot_mat_idxs: Unused (RoPE computed internally from current_pos).
             page_table: Optional paged attention table.
@@ -1073,8 +1090,10 @@ class Gemma4Model:
                 ``self._active_page_tables_per_layer`` (set by the vLLM hybrid bridge,
                 since ``Generator``'s decode path doesn't thread the kwarg).
         """
-        # Convert ROW_MAJOR host data to TILE on device
-        input_embeds = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+        input_embeds = self.embed_tokens(x)
+        if len(input_embeds.shape) == 3:
+            input_embeds = ttnn.unsqueeze_to_4D(input_embeds)
+        input_embeds = ttnn.to_layout(input_embeds, ttnn.TILE_LAYOUT)
 
         # RoPE: always use internal 2D caches with on-device embedding lookup
         token_index = None if self.rope_caches_2d else 0


### PR DESCRIPTION
**Branch:** `dwadhwaniTT-44952-gemma4-on-device-embedding`  
**Base:** `handrews/gemma4-hybrid-kvc`  
**Ticket:** #44952
---

## PR Category : Performance
---

## Summary
Fixes #44952
Today, Gemma4 decode runs the main token embedding lookup on the CPU with PyTorch, then uploads a large bfloat16 tensor to the device on every decode step. This pull request moves that lookup onto the device using the existing `embed_tokens()` path, which matches how prefill already works.
The decode path now passes a single token ID (as a uint32 tensor) from the host instead of a precomputed embedding. The model looks up the embedding on device inside `ttnn_decode_forward`. Per-layer input (PLI) for E2B and E4B is still computed on the host in this version; only the main embedding moved.
**What changed:**
- **`models/demos/gemma4/tt/model.py`**
  - Added `compute_host_pli()` for host-side PLI only.
  - Updated `prepare_decode_inputs_host()` so the first input slot is a token ID, not an embedding tensor.
  - Updated `ttnn_decode_forward()` to call `embed_tokens()` on device before the rest of the forward pass.
  - Kept `compute_host_embeddings()` as a legacy helper for tests and callers that still compare against the old host path.
- **`models/demos/gemma4/demo/text_demo.py`**
  - The decode loop now stages token IDs and PLI instead of host-computed embeddings.
- **`models/demos/gemma4/tests/unit/test_vllm_parity.py`**
  - Decode test inputs now provide token IDs instead of precomputed embeddings.
- **`models/demos/gemma4/tests/pcc_thresholds.json`**
  - Added a threshold of 0.96 for E4B `test_full_model[blackhole-1x1]` in accordance with similar benchmark thresholds for the same model on a blackhole 1x4 mesh to prevent defaulting to 0.99. 

---

## Notes for reviewers
The most important thing to review is the decode input contract in `prepare_decode_inputs_host()`.
Before this change, the first input was a bfloat16 embedding tensor computed on the host. After this change, it is a uint32 token ID, and embedding happens on device in `ttnn_decode_forward()`. 
Please check that callers of `prepare_decode_inputs_host()` and `ttnn_decode_forward()` assume token IDs rather than embeddings. The E4B PCC threshold update reflects measured accuracy on blackhole 1×1, not a known functional bug.

---

## Test plan
- [x] E2B `test_full_model` blackhole 1×1 — passed
- [x] E4B `test_full_model` blackhole 1×1 — passed (PCC ~0.976)
- [x] E4B `test_demo` 1×4 — passed

```bash
export HF_HUB_OFFLINE=1 HF_HOME=~/.cache/huggingface
export HF_MODEL=google/gemma-4-E2B-it   # or google/gemma-4-E4B-it
export TT_CACHE_PATH=$HF_HOME/tt_cache/google--gemma-4-E2B-it
pytest models/demos/gemma4/tests/unit/test_model.py -k "test_full_model and 1x1"
pytest models/demos/gemma4/demo/text_demo.py::test_demo -k "1x1"
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dwadhwaniTT-44952-gemma4-on-device-embedding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dwadhwaniTT-44952-gemma4-on-device-embedding)