### PR TITLE
[Test Only] Fix moreh cumsum backward tests: replace unpad_from_tile with ttnn.to_torch

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -120,13 +120,8 @@ def test_moreh_cumsum_backward(input_shape, dim, device):
     torch_output = torch.cumsum(torch_input, dim)
     torch_output.backward(torch_output_grad)
 
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_input_grad_cpu = (
+    tt_input_grad_cpu = ttnn.to_torch(
         ttnn.operations.moreh.cumsum_backward(tt_output_grad, dim, input_grad=tt_input_grad)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(input_shape)
-        .to_torch()
     )
 
     # test for equivalance
@@ -225,13 +220,8 @@ def test_moreh_cumsum_backward(input_shape, dim, device):
     torch_output = torch.cumsum(torch_input, dim)
     torch_output.backward(torch_output_grad)
 
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_input_grad_cpu = (
+    tt_input_grad_cpu = ttnn.to_torch(
         ttnn.operations.moreh.cumsum_backward(tt_output_grad, dim, input_grad=tt_input_grad)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(input_shape)
-        .to_torch()
     )
 
     # test for equivalance
@@ -303,3 +293,4 @@ def test_moreh_cumsum_backward_callback(input_shape, dim, device):
 
             assert passing
         assert device.num_program_cache_entries() >= 1
+

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -293,4 +293,3 @@ def test_moreh_cumsum_backward_callback(input_shape, dim, device):
 
             assert passing
         assert device.num_program_cache_entries() >= 1
-


### PR DESCRIPTION
### PR Category
Test only Bug fix

### Summary

moreh cumsum backward tests are failing on L2 nightly. #44283 fixed the forward test but missed both backward variants.


### Verification run

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/fix-moreh-cumsum-backward)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/fix-moreh-cumsum-backward)