### PR TITLE
[skip ci] Disable consistently failing tests in t3000-perf-tests 

### DIFF
--- a/models/demos/multimodal/gemma3/tests/test_perf_vision_cross_attention_transformer.py
+++ b/models/demos/multimodal/gemma3/tests/test_perf_vision_cross_attention_transformer.py
@@ -24,7 +24,7 @@ TARGETS_JSON_FILENAME = (
 )
 
 
-@pytest.mark.skip(reason="Disabled by issue #44770: OSError loading gemma-3-27b-it model from MLPerf mount")
+@pytest.mark.skip(reason="Disabled by issue #44770")
 @pytest.mark.parametrize("device_params", [{"fabric_config": True, "l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/demos/multimodal/gemma3/tests/test_perf_vision_cross_attention_transformer.py
+++ b/models/demos/multimodal/gemma3/tests/test_perf_vision_cross_attention_transformer.py
@@ -24,6 +24,7 @@ TARGETS_JSON_FILENAME = (
 )
 
 
+@pytest.mark.skip(reason="Disabled by issue #44770: OSError loading gemma-3-27b-it model from MLPerf mount")
 @pytest.mark.parametrize("device_params", [{"fabric_config": True, "l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer.py
+++ b/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer.py
@@ -15,7 +15,7 @@ from models.demos.multimodal.gemma3.tt.model_config import ModelArgs
 from models.tt_transformers.tt.ccl import TT_CCL
 
 
-@pytest.mark.skip(reason="Disabled by issue #44770: OSError loading gemma-3-27b-it model from MLPerf mount")
+@pytest.mark.skip(reason="Disabled by issue #44770")
 @pytest.mark.parametrize("device_params", [{"fabric_config": True, "l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer.py
+++ b/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer.py
@@ -15,6 +15,7 @@ from models.demos.multimodal.gemma3.tt.model_config import ModelArgs
 from models.tt_transformers.tt.ccl import TT_CCL
 
 
+@pytest.mark.skip(reason="Disabled by issue #44770: OSError loading gemma-3-27b-it model from MLPerf mount")
 @pytest.mark.parametrize("device_params", [{"fabric_config": True, "l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer_perf_ops.py
+++ b/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer_perf_ops.py
@@ -222,6 +222,7 @@ def target_maker():
         json.dump(margin_values, f, indent=2)
 
 
+@pytest.mark.skip(reason="Disabled by issue #44770: depends on test_gemma_vision which fails due to missing MLPerf model files")
 @pytest.mark.models_device_performance_bare_metal
 def test_op_to_op_perf_gemma_vision():
     # If you want to make new targets, just changed this variable to True by simply changing the code make_new_targets = True, but DO NOT MERGE that part into PR made with new targets,

--- a/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer_perf_ops.py
+++ b/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer_perf_ops.py
@@ -222,9 +222,7 @@ def target_maker():
         json.dump(margin_values, f, indent=2)
 
 
-@pytest.mark.skip(
-    reason="Disabled by issue #44770: depends on test_gemma_vision which fails due to missing MLPerf model files"
-)
+@pytest.mark.skip(reason="Disabled by issue #44770")
 @pytest.mark.models_device_performance_bare_metal
 def test_op_to_op_perf_gemma_vision():
     # If you want to make new targets, just changed this variable to True by simply changing the code make_new_targets = True, but DO NOT MERGE that part into PR made with new targets,

--- a/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer_perf_ops.py
+++ b/models/demos/multimodal/gemma3/tests/test_vision_cross_attention_transformer_perf_ops.py
@@ -222,7 +222,9 @@ def target_maker():
         json.dump(margin_values, f, indent=2)
 
 
-@pytest.mark.skip(reason="Disabled by issue #44770: depends on test_gemma_vision which fails due to missing MLPerf model files")
+@pytest.mark.skip(
+    reason="Disabled by issue #44770: depends on test_gemma_vision which fails due to missing MLPerf model files"
+)
 @pytest.mark.models_device_performance_bare_metal
 def test_op_to_op_perf_gemma_vision():
     # If you want to make new targets, just changed this variable to True by simply changing the code make_new_targets = True, but DO NOT MERGE that part into PR made with new targets,

--- a/models/tt_dit/tests/models/motif/test_performance_motif.py
+++ b/models/tt_dit/tests/models/motif/test_performance_motif.py
@@ -34,9 +34,7 @@ from ....pipelines.motif.pipeline_motif import MotifPipeline
             (4, 1),
             ttnn.Topology.Linear,
             1,
-            marks=pytest.mark.skip(
-                reason="Disabled by issue #44770"
-            ),
+            marks=pytest.mark.skip(reason="Disabled by issue #44770"),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],
     ],

--- a/models/tt_dit/tests/models/motif/test_performance_motif.py
+++ b/models/tt_dit/tests/models/motif/test_performance_motif.py
@@ -26,8 +26,17 @@ from ....pipelines.motif.pipeline_motif import MotifPipeline
     [
         # [(2, 4), (2, 1), (2, 0), (2, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
         pytest.param(
-            (2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1,
-            marks=pytest.mark.skip(reason="Disabled by issue #44770: perf regression clip_encoding/denoising/total_time exceeds targets"),
+            (2, 4),
+            (2, 0),
+            (1, 0),
+            (4, 1),
+            (4, 1),
+            (4, 1),
+            ttnn.Topology.Linear,
+            1,
+            marks=pytest.mark.skip(
+                reason="Disabled by issue #44770: perf regression clip_encoding/denoising/total_time exceeds targets"
+            ),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],
     ],

--- a/models/tt_dit/tests/models/motif/test_performance_motif.py
+++ b/models/tt_dit/tests/models/motif/test_performance_motif.py
@@ -25,7 +25,10 @@ from ....pipelines.motif.pipeline_motif import MotifPipeline
     "mesh_device, cfg, sp, tp, encoder_tp, vae_tp, topology, num_links",
     [
         # [(2, 4), (2, 1), (2, 0), (2, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
-        [(2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
+        pytest.param(
+            [(2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
+            marks=pytest.mark.skip(reason="Disabled by issue #44770: perf regression clip_encoding/denoising/total_time exceeds targets"),
+        ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],
     ],
     ids=[

--- a/models/tt_dit/tests/models/motif/test_performance_motif.py
+++ b/models/tt_dit/tests/models/motif/test_performance_motif.py
@@ -35,7 +35,7 @@ from ....pipelines.motif.pipeline_motif import MotifPipeline
             ttnn.Topology.Linear,
             1,
             marks=pytest.mark.skip(
-                reason="Disabled by issue #44770: perf regression clip_encoding/denoising/total_time exceeds targets"
+                reason="Disabled by issue #44770"
             ),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],

--- a/models/tt_dit/tests/models/motif/test_performance_motif.py
+++ b/models/tt_dit/tests/models/motif/test_performance_motif.py
@@ -26,7 +26,7 @@ from ....pipelines.motif.pipeline_motif import MotifPipeline
     [
         # [(2, 4), (2, 1), (2, 0), (2, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
         pytest.param(
-            [(2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
+            (2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1,
             marks=pytest.mark.skip(reason="Disabled by issue #44770: perf regression clip_encoding/denoising/total_time exceeds targets"),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -32,9 +32,7 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline
             (4, 1),
             ttnn.Topology.Linear,
             1,
-            marks=pytest.mark.skip(
-                reason="Disabled by issue #44770"
-            ),
+            marks=pytest.mark.skip(reason="Disabled by issue #44770"),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],
     ],

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -23,7 +23,10 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline
 @pytest.mark.parametrize(
     "mesh_device, cfg, sp, tp, encoder_tp, vae_tp, topology, num_links",
     [
-        [(2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
+        pytest.param(
+            [(2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
+            marks=pytest.mark.skip(reason="Disabled by issue #44770: vae_decoding_time perf regression (expected 0.75s, actual 2.69s)"),
+        ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],
     ],
     ids=[

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -24,8 +24,17 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline
     "mesh_device, cfg, sp, tp, encoder_tp, vae_tp, topology, num_links",
     [
         pytest.param(
-            (2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1,
-            marks=pytest.mark.skip(reason="Disabled by issue #44770: vae_decoding_time perf regression (expected 0.75s, actual 2.69s)"),
+            (2, 4),
+            (2, 0),
+            (1, 0),
+            (4, 1),
+            (4, 1),
+            (4, 1),
+            ttnn.Topology.Linear,
+            1,
+            marks=pytest.mark.skip(
+                reason="Disabled by issue #44770: vae_decoding_time perf regression (expected 0.75s, actual 2.69s)"
+            ),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],
     ],

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -24,7 +24,7 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline
     "mesh_device, cfg, sp, tp, encoder_tp, vae_tp, topology, num_links",
     [
         pytest.param(
-            [(2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
+            (2, 4), (2, 0), (1, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1,
             marks=pytest.mark.skip(reason="Disabled by issue #44770: vae_decoding_time perf regression (expected 0.75s, actual 2.69s)"),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -33,7 +33,7 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline
             ttnn.Topology.Linear,
             1,
             marks=pytest.mark.skip(
-                reason="Disabled by issue #44770: vae_decoding_time perf regression (expected 0.75s, actual 2.69s)"
+                reason="Disabled by issue #44770"
             ),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 4],

--- a/models/tt_dit/tests/models/sd35/test_performance_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_performance_sd35.py
@@ -53,7 +53,7 @@ def get_expected_metrics(mesh_device):
             (2, 1),
             ttnn.Topology.Linear,
             1,
-            marks=pytest.mark.skip(reason="Disabled by issue #44770: device hang TT_THROW TIMEOUT in fetch queue wait"),
+            marks=pytest.mark.skip(reason="Disabled by issue #44770"),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), ttnn.Topology.Linear, 4],
     ],

--- a/models/tt_dit/tests/models/sd35/test_performance_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_performance_sd35.py
@@ -47,7 +47,7 @@ def get_expected_metrics(mesh_device):
     "mesh_device, cfg, sp, tp, topology, num_links",
     [
         pytest.param(
-            [(2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1],
+            (2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1,
             marks=pytest.mark.skip(reason="Disabled by issue #44770: device hang TT_THROW TIMEOUT in fetch queue wait"),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), ttnn.Topology.Linear, 4],

--- a/models/tt_dit/tests/models/sd35/test_performance_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_performance_sd35.py
@@ -46,7 +46,10 @@ def get_expected_metrics(mesh_device):
 @pytest.mark.parametrize(
     "mesh_device, cfg, sp, tp, topology, num_links",
     [
-        [(2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1],
+        pytest.param(
+            [(2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1],
+            marks=pytest.mark.skip(reason="Disabled by issue #44770: device hang TT_THROW TIMEOUT in fetch queue wait"),
+        ),
         [(4, 8), (2, 1), (4, 0), (4, 1), ttnn.Topology.Linear, 4],
     ],
     ids=[

--- a/models/tt_dit/tests/models/sd35/test_performance_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_performance_sd35.py
@@ -47,7 +47,12 @@ def get_expected_metrics(mesh_device):
     "mesh_device, cfg, sp, tp, topology, num_links",
     [
         pytest.param(
-            (2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1,
+            (2, 4),
+            (2, 1),
+            (2, 0),
+            (2, 1),
+            ttnn.Topology.Linear,
+            1,
             marks=pytest.mark.skip(reason="Disabled by issue #44770: device hang TT_THROW TIMEOUT in fetch queue wait"),
         ),
         [(4, 8), (2, 1), (4, 0), (4, 1), ttnn.Topology.Linear, 4],


### PR DESCRIPTION
duplicate of https://github.com/tenstorrent/tt-metal/pull/44771 to allow codeowners bypass

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/disable-failing-tests-t3000-perf-tests-20260519)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/disable-failing-tests-t3000-perf-tests-20260519)