### PR TITLE
[Feature] More stats in jit_load_report.py

### DIFF
--- a/tt_metal/tools/jit_compile_server/jit_load_report.py
+++ b/tt_metal/tools/jit_compile_server/jit_load_report.py
@@ -45,7 +45,7 @@ import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Iterable, Sequence, TextIO
+from typing import Iterable, Sequence
 
 
 JIT_SERVER_LOG_PATTERN = re.compile(
@@ -61,6 +61,12 @@ JIT_SERVER_LOG_PATTERN = re.compile(
 )
 COMPILE_LOG_PATTERN = re.compile(r"compile (?P<kernel_name>\S+): targets=\d+ genfiles=\d+ outstanding=\d+")
 KERNEL_HASH_PATTERN = re.compile(r"[0-9a-fA-F]{16,}")
+
+# When reading from stdin there is no per-file path to attribute samples to, and per-line
+# log prefixes (e.g. tt-logger timestamps) make prefix-based server inference unstable.
+# Use a single constant id so all stdin samples aggregate into one coherent server, and so
+# jit_server samples and compile samples share the same server_id for unique_kernel_hashes.
+STDIN_SOURCE_ID = "<stdin>"
 
 
 @dataclass(frozen=True)
@@ -443,8 +449,8 @@ def _read_samples_from_path(path: Path) -> list[JitServerSample]:
         return parse_jit_server_samples(handle, source_id=str(path))
 
 
-def _read_samples_from_stream(stream: TextIO) -> list[JitServerSample]:
-    return parse_jit_server_samples(stream)
+def _read_samples_from_stream(lines: Iterable[str], source_id: str | None = None) -> list[JitServerSample]:
+    return parse_jit_server_samples(lines, source_id=source_id)
 
 
 def _read_kernel_samples_from_path(path: Path) -> list[KernelCompileSample]:
@@ -452,8 +458,8 @@ def _read_kernel_samples_from_path(path: Path) -> list[KernelCompileSample]:
         return parse_kernel_compile_samples(handle, source_id=str(path))
 
 
-def _read_kernel_samples_from_stream(stream: TextIO) -> list[KernelCompileSample]:
-    return parse_kernel_compile_samples(stream)
+def _read_kernel_samples_from_stream(lines: Iterable[str], source_id: str | None = None) -> list[KernelCompileSample]:
+    return parse_kernel_compile_samples(lines, source_id=source_id)
 
 
 def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -505,8 +511,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             kernel_samples.extend(_read_kernel_samples_from_path(Path(path)))
     else:
         stdin_lines = list(sys.stdin)
-        samples.extend(_read_samples_from_stream(stdin_lines))
-        kernel_samples.extend(_read_kernel_samples_from_stream(stdin_lines))
+        samples.extend(_read_samples_from_stream(stdin_lines, source_id=STDIN_SOURCE_ID))
+        kernel_samples.extend(_read_kernel_samples_from_stream(stdin_lines, source_id=STDIN_SOURCE_ID))
 
     report = build_report(samples, args.window, kernel_compile_samples=kernel_samples)
     if args.json:

--- a/tt_metal/tools/jit_compile_server/jit_load_report.py
+++ b/tt_metal/tools/jit_compile_server/jit_load_report.py
@@ -3,6 +3,39 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""
+JIT compile server load report tool.
+
+Quick workflow for collecting and analyzing logs:
+
+1) Enable periodic metrics on each compile server process:
+   export TT_METAL_JIT_SERVER_LOG_INTERVAL_MS=1000
+
+2) Start the server and capture logs (stdout/stderr), for example:
+   tt_metal/tools/jit_compile_server/jit_compile_server > /tmp/jit_server_a.log 2>&1
+
+3) Repeat per server (one log file per server is easiest to attribute):
+   tt_metal/tools/jit_compile_server/jit_compile_server > /tmp/jit_server_b.log 2>&1
+
+4) Run this report script:
+   python tt_metal/tools/jit_compile_server/jit_load_report.py /tmp/jit_server_a.log /tmp/jit_server_b.log
+
+5) Optional rolling-window view:
+   python tt_metal/tools/jit_compile_server/jit_load_report.py --window 30 /tmp/jit_server_*.log
+   - --window N means "use only the last N seconds ending at each server's latest sample".
+   - In window mode, count/dedup_hits/total_compile_time_ms/bytes_in/bytes_out are deltas
+     over that N-second window, and throughput is count_delta / elapsed_seconds.
+   - peak_inflight is the max value observed inside that window.
+
+6) Optional machine-readable output:
+   python tt_metal/tools/jit_compile_server/jit_load_report.py --json /tmp/jit_server_*.log
+
+Notes:
+- The script parses both "[jit_server ...]" periodic metric lines and "compile ...:" lines.
+- unique_kernel_hashes metrics are inferred from hash-like tokens in compile kernel names.
+- Without --window, metrics are lifetime totals from each server's most recent sample.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -364,6 +397,13 @@ def render_human_report(report: dict, window_seconds: float | None) -> str:
 
     lines.append(_render_table(headers, rows))
     lines.append("")
+    if window_seconds is not None:
+        lines.append(
+            "Window mode: count/dedup_hits/total_compile_time_ms/bytes_in/bytes_out are per-server deltas "
+            f"over the last {window_seconds:g}s ending at each server's latest sample; "
+            "peak_inflight is the max seen in that window."
+        )
+        lines.append("")
     lines.append("Imbalance summary:")
 
     imbalance = report["imbalance_summary"]
@@ -417,9 +457,36 @@ def _read_kernel_samples_from_stream(stream: TextIO) -> list[KernelCompileSample
 
 
 def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Report per-server and cross-server JIT load imbalance.")
+    parser = argparse.ArgumentParser(
+        description="Report per-server and cross-server JIT load imbalance.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Collection instructions:\n"
+            "  1) Set TT_METAL_JIT_SERVER_LOG_INTERVAL_MS (for example 1000).\n"
+            "  2) Capture each compile server's logs to a file.\n"
+            "  3) Run this script on one or more log files.\n\n"
+            "Window semantics (--window N):\n"
+            "  - Uses samples from the last N seconds ending at each server's latest timestamp.\n"
+            "  - Reports deltas for count/dedup_hits/total_compile_time_ms/bytes_in/bytes_out.\n"
+            "  - Reports peak_inflight as the max value seen within that window.\n"
+            "  - Adds throughput_compiles_per_sec = count_delta / elapsed_seconds.\n\n"
+            "Examples:\n"
+            "  python jit_load_report.py /tmp/jit_server_a.log /tmp/jit_server_b.log\n"
+            "  python jit_load_report.py --window 60 /tmp/jit_server_*.log\n"
+            "  tail -f /tmp/jit_server_a.log | python jit_load_report.py --window 30\n"
+            "  python jit_load_report.py --json /tmp/jit_server_*.log\n"
+        ),
+    )
     parser.add_argument("logs", nargs="*", help="Path(s) to log files. Reads stdin when omitted.")
-    parser.add_argument("--window", type=float, default=None, help="Window size in seconds for delta reporting.")
+    parser.add_argument(
+        "--window",
+        type=float,
+        default=None,
+        help=(
+            "Rolling window size in seconds. When set, report per-server deltas over the last N seconds "
+            "(count/dedup_hits/compile_time/bytes) and throughput; peak_inflight becomes window max."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit JSON output.")
     return parser.parse_args(argv)
 

--- a/tt_metal/tools/jit_compile_server/jit_load_report.py
+++ b/tt_metal/tools/jit_compile_server/jit_load_report.py
@@ -18,6 +18,7 @@ from typing import Iterable, Sequence, TextIO
 JIT_SERVER_LOG_PATTERN = re.compile(
     r"\[jit_server addr=(?P<addr>\S+) ts=(?P<ts>\d+)\] "
     r"count=(?P<count>\d+) "
+    r"(?:dedup_hit[s]?=(?P<dedup_hits>\d+) )?"
     r"total_compile_time_ms=(?P<total_compile_time_ms>\d+) "
     r"queued=(?P<queued>\d+) "
     r"inflight=(?P<inflight>\d+) "
@@ -25,13 +26,17 @@ JIT_SERVER_LOG_PATTERN = re.compile(
     r"bytes_in=(?P<bytes_in>\d+) "
     r"bytes_out=(?P<bytes_out>\d+)"
 )
+COMPILE_LOG_PATTERN = re.compile(r"compile (?P<kernel_name>\S+): targets=\d+ genfiles=\d+ outstanding=\d+")
+KERNEL_HASH_PATTERN = re.compile(r"[0-9a-fA-F]{16,}")
 
 
 @dataclass(frozen=True)
 class JitServerSample:
+    server_id: str
     addr: str
     ts: int
     count: int
+    dedup_hits: int
     total_compile_time_ms: int
     queued: int
     inflight: int
@@ -41,13 +46,23 @@ class JitServerSample:
 
 
 @dataclass(frozen=True)
+class KernelCompileSample:
+    server_id: str
+    kernel_name: str
+    kernel_hash: str | None
+
+
+@dataclass(frozen=True)
 class ServerLoadReport:
+    server: str
     addr: str
     count: int
+    dedup_hits: int
     total_compile_time_ms: int
     peak_inflight: int
     bytes_in: int
     bytes_out: int
+    unique_kernel_hashes: int
     throughput_compiles_per_sec: float | None
 
 
@@ -61,16 +76,29 @@ class ImbalanceStats:
     coefficient_of_variation: float
 
 
-def parse_jit_server_line(line: str) -> JitServerSample | None:
+def _infer_server_id(line: str, addr: str, source_id: str | None) -> str:
+    if source_id is not None:
+        return source_id
+
+    prefix = line.split("[jit_server", maxsplit=1)[0].strip()
+    if prefix:
+        return " ".join(prefix.split())
+    return addr
+
+
+def parse_jit_server_line(line: str, source_id: str | None = None) -> JitServerSample | None:
     match = JIT_SERVER_LOG_PATTERN.search(line)
     if match is None:
         return None
 
     groups = match.groupdict()
+    addr = groups["addr"]
     return JitServerSample(
-        addr=groups["addr"],
+        server_id=_infer_server_id(line, addr, source_id),
+        addr=addr,
         ts=int(groups["ts"]),
         count=int(groups["count"]),
+        dedup_hits=0 if groups["dedup_hits"] is None else int(groups["dedup_hits"]),
         total_compile_time_ms=int(groups["total_compile_time_ms"]),
         queued=int(groups["queued"]),
         inflight=int(groups["inflight"]),
@@ -80,19 +108,64 @@ def parse_jit_server_line(line: str) -> JitServerSample | None:
     )
 
 
-def parse_jit_server_samples(lines: Iterable[str]) -> list[JitServerSample]:
+def parse_jit_server_samples(lines: Iterable[str], source_id: str | None = None) -> list[JitServerSample]:
     samples: list[JitServerSample] = []
     for line in lines:
-        sample = parse_jit_server_line(line)
+        sample = parse_jit_server_line(line, source_id=source_id)
         if sample is not None:
             samples.append(sample)
     return samples
 
 
-def group_samples_by_addr(samples: Iterable[JitServerSample]) -> dict[str, list[JitServerSample]]:
+def _extract_kernel_hash(kernel_name: str) -> str | None:
+    components = [component for component in kernel_name.split("/") if component]
+    for component in reversed(components):
+        if KERNEL_HASH_PATTERN.fullmatch(component):
+            return component.lower()
+
+    for component in reversed(components):
+        match = KERNEL_HASH_PATTERN.search(component)
+        if match is not None:
+            return match.group(0).lower()
+    return None
+
+
+def _infer_compile_server_id(line: str, source_id: str | None) -> str:
+    if source_id is not None:
+        return source_id
+
+    prefix = line.split("compile ", maxsplit=1)[0].strip()
+    if prefix:
+        return " ".join(prefix.split())
+    return "unknown"
+
+
+def parse_kernel_compile_line(line: str, source_id: str | None = None) -> KernelCompileSample | None:
+    match = COMPILE_LOG_PATTERN.search(line)
+    if match is None:
+        return None
+
+    kernel_name = match.group("kernel_name")
+    return KernelCompileSample(
+        server_id=_infer_compile_server_id(line, source_id),
+        kernel_name=kernel_name,
+        kernel_hash=_extract_kernel_hash(kernel_name),
+    )
+
+
+def parse_kernel_compile_samples(lines: Iterable[str], source_id: str | None = None) -> list[KernelCompileSample]:
+    samples: list[KernelCompileSample] = []
+    for line in lines:
+        sample = parse_kernel_compile_line(line, source_id=source_id)
+        if sample is not None:
+            samples.append(sample)
+    return samples
+
+
+def group_samples_by_server(samples: Iterable[JitServerSample]) -> dict[str, list[JitServerSample]]:
     grouped: dict[str, list[JitServerSample]] = {}
     for sample in samples:
-        grouped.setdefault(sample.addr, []).append(sample)
+        grouped.setdefault(sample.server_id, []).append(sample)
     for grouped_samples in grouped.values():
         grouped_samples.sort(key=lambda sample: sample.ts)
     return grouped
@@ -102,19 +175,24 @@ def _non_negative_delta(last: int, first: int) -> int:
     return max(0, last - first)
 
 
-def compute_server_report(samples: Sequence[JitServerSample], window_seconds: float | None) -> ServerLoadReport:
+def compute_server_report(
+    samples: Sequence[JitServerSample], window_seconds: float | None, unique_kernel_hashes: int
+) -> ServerLoadReport:
     if not samples:
         raise ValueError("compute_server_report() requires at least one sample")
 
     last = samples[-1]
     if window_seconds is None:
         return ServerLoadReport(
+            server=last.server_id,
             addr=last.addr,
             count=last.count,
+            dedup_hits=last.dedup_hits,
             total_compile_time_ms=last.total_compile_time_ms,
             peak_inflight=last.peak_inflight,
             bytes_in=last.bytes_in,
             bytes_out=last.bytes_out,
+            unique_kernel_hashes=unique_kernel_hashes,
             throughput_compiles_per_sec=None,
         )
 
@@ -129,12 +207,15 @@ def compute_server_report(samples: Sequence[JitServerSample], window_seconds: fl
     throughput = 0.0 if elapsed_ms == 0 else count_delta / (elapsed_ms / 1000.0)
 
     return ServerLoadReport(
+        server=last.server_id,
         addr=last.addr,
         count=count_delta,
+        dedup_hits=_non_negative_delta(last.dedup_hits, first.dedup_hits),
         total_compile_time_ms=_non_negative_delta(last.total_compile_time_ms, first.total_compile_time_ms),
         peak_inflight=peak_inflight,
         bytes_in=_non_negative_delta(last.bytes_in, first.bytes_in),
         bytes_out=_non_negative_delta(last.bytes_out, first.bytes_out),
+        unique_kernel_hashes=unique_kernel_hashes,
         throughput_compiles_per_sec=throughput,
     )
 
@@ -171,14 +252,39 @@ def compute_imbalance_stats(values: Sequence[int | float]) -> ImbalanceStats:
     )
 
 
-def build_report(samples: Sequence[JitServerSample], window_seconds: float | None) -> dict:
-    grouped = group_samples_by_addr(samples)
+def _build_kernel_hashes_by_server(samples: Iterable[KernelCompileSample]) -> dict[str, set[str]]:
+    hashes_by_server: dict[str, set[str]] = {}
+    for sample in samples:
+        if sample.kernel_hash is None:
+            continue
+        hashes_by_server.setdefault(sample.server_id, set()).add(sample.kernel_hash)
+    return hashes_by_server
+
+
+def build_report(
+    samples: Sequence[JitServerSample],
+    window_seconds: float | None,
+    kernel_compile_samples: Sequence[KernelCompileSample] | None = None,
+) -> dict:
+    if kernel_compile_samples is None:
+        kernel_compile_samples = []
+    grouped = group_samples_by_server(samples)
+    kernel_hashes_by_server = _build_kernel_hashes_by_server(kernel_compile_samples)
     server_reports = [
-        compute_server_report(grouped_samples, window_seconds) for _, grouped_samples in sorted(grouped.items())
+        compute_server_report(
+            grouped_samples,
+            window_seconds,
+            unique_kernel_hashes=len(kernel_hashes_by_server.get(server_id, set())),
+        )
+        for server_id, grouped_samples in sorted(grouped.items())
     ]
 
     imbalance_summary = {
         "count": asdict(compute_imbalance_stats([server.count for server in server_reports])),
+        "dedup_hits": asdict(compute_imbalance_stats([server.dedup_hits for server in server_reports])),
+        "unique_kernel_hashes": asdict(
+            compute_imbalance_stats([server.unique_kernel_hashes for server in server_reports])
+        ),
         "total_compile_time_ms": asdict(
             compute_imbalance_stats([server.total_compile_time_ms for server in server_reports])
         ),
@@ -187,6 +293,9 @@ def build_report(samples: Sequence[JitServerSample], window_seconds: float | Non
     return {
         "window_seconds": window_seconds,
         "servers": [asdict(server_report) for server_report in server_reports],
+        "unique_kernel_hashes_total": len(
+            {hash_value for hashes in kernel_hashes_by_server.values() for hash_value in hashes}
+        ),
         "imbalance_summary": imbalance_summary,
     }
 
@@ -221,19 +330,32 @@ def render_human_report(report: dict, window_seconds: float | None) -> str:
         return "No jit_server samples found."
 
     lines.append("Per-server metrics:")
-    headers = ["addr", "count", "total_compile_time_ms", "peak_inflight", "bytes_in", "bytes_out"]
+    headers = [
+        "server",
+        "addr",
+        "count",
+        "dedup_hits",
+        "total_compile_time_ms",
+        "peak_inflight",
+        "bytes_in",
+        "bytes_out",
+        "unique_kernel_hashes",
+    ]
     if window_seconds is not None:
         headers.append("throughput_compiles_per_sec")
 
     rows: list[list[str]] = []
     for server in servers:
         row = [
+            server["server"],
             server["addr"],
             str(server["count"]),
+            str(server["dedup_hits"]),
             str(server["total_compile_time_ms"]),
             str(server["peak_inflight"]),
             str(server["bytes_in"]),
             str(server["bytes_out"]),
+            str(server["unique_kernel_hashes"]),
         ]
         if window_seconds is not None:
             throughput = server["throughput_compiles_per_sec"]
@@ -247,7 +369,7 @@ def render_human_report(report: dict, window_seconds: float | None) -> str:
     imbalance = report["imbalance_summary"]
     summary_headers = ["metric", "max", "min", "mean", "stddev", "max/min_ratio", "coefficient_of_variation"]
     summary_rows: list[list[str]] = []
-    for metric_name in ("count", "total_compile_time_ms"):
+    for metric_name in ("count", "dedup_hits", "unique_kernel_hashes", "total_compile_time_ms"):
         stats = imbalance[metric_name]
         summary_rows.append(
             [
@@ -263,7 +385,12 @@ def render_human_report(report: dict, window_seconds: float | None) -> str:
 
     lines.append(_render_table(summary_headers, summary_rows))
     lines.append("")
+    lines.append(f"Unique kernel hashes (global): {report['unique_kernel_hashes_total']}")
+    lines.append("")
     lines.append("Stat definitions:")
+    lines.append("count: completed compile RPCs (includes dedup hits and on-disk cache hits).")
+    lines.append("dedup_hits: requests served by in-flight deduplication rather than owning a compile.")
+    lines.append("unique_kernel_hashes: distinct kernel hashes observed in compile kernel names per server.")
     lines.append("max/min/mean: largest, smallest, and average value across servers.")
     lines.append("stddev: spread of server values around the mean (higher means more imbalance).")
     lines.append("max/min_ratio: skew between busiest and least busy server (1.0 means perfectly balanced).")
@@ -273,11 +400,20 @@ def render_human_report(report: dict, window_seconds: float | None) -> str:
 
 def _read_samples_from_path(path: Path) -> list[JitServerSample]:
     with path.open("r", encoding="utf-8") as handle:
-        return parse_jit_server_samples(handle)
+        return parse_jit_server_samples(handle, source_id=str(path))
 
 
 def _read_samples_from_stream(stream: TextIO) -> list[JitServerSample]:
     return parse_jit_server_samples(stream)
+
+
+def _read_kernel_samples_from_path(path: Path) -> list[KernelCompileSample]:
+    with path.open("r", encoding="utf-8") as handle:
+        return parse_kernel_compile_samples(handle, source_id=str(path))
+
+
+def _read_kernel_samples_from_stream(stream: TextIO) -> list[KernelCompileSample]:
+    return parse_kernel_compile_samples(stream)
 
 
 def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -295,13 +431,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise ValueError("--window must be > 0")
 
     samples: list[JitServerSample] = []
+    kernel_samples: list[KernelCompileSample] = []
     if args.logs:
         for path in args.logs:
             samples.extend(_read_samples_from_path(Path(path)))
+            kernel_samples.extend(_read_kernel_samples_from_path(Path(path)))
     else:
-        samples.extend(_read_samples_from_stream(sys.stdin))
+        stdin_lines = list(sys.stdin)
+        samples.extend(_read_samples_from_stream(stdin_lines))
+        kernel_samples.extend(_read_kernel_samples_from_stream(stdin_lines))
 
-    report = build_report(samples, args.window)
+    report = build_report(samples, args.window, kernel_compile_samples=kernel_samples)
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:

--- a/tt_metal/tools/jit_compile_server/tests/test_jit_load_report.py
+++ b/tt_metal/tools/jit_compile_server/tests/test_jit_load_report.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
 from pathlib import Path
 import sys
 
@@ -196,3 +198,30 @@ def test_build_report_groups_by_source_not_addr():
     assert servers["server-a.log"]["count"] == 5
     assert servers["server-b.log"]["addr"] == "0.0.0.0:9876"
     assert servers["server-b.log"]["count"] == 7
+
+
+def test_main_stdin_collapses_prefixed_lines_into_single_server(monkeypatch, capsys):
+    # tt-logger style per-line prefixes (timestamp + level) would make prefix-based server
+    # inference assign a different server_id per line. Reading from stdin must instead
+    # aggregate everything into one coherent server and attribute kernel hashes to it.
+    stdin_text = "\n".join(
+        [
+            "2026-05-29 19:45:26.001 | INFO     | compile kernels/a/aaaaaaaaaaaaaaaa: targets=1 genfiles=0 outstanding=1",
+            "2026-05-29 19:45:26.050 | INFO     | compile kernels/a/bbbbbbbbbbbbbbbb: targets=1 genfiles=0 outstanding=1",
+            "2026-05-29 19:45:26.100 | INFO     | [jit_server addr=localhost:9876 ts=1000] count=2 dedup_hits=0 total_compile_time_ms=40 queued=0 inflight=0 peak_inflight=1 bytes_in=100 bytes_out=40",
+            "2026-05-29 19:45:27.200 | INFO     | [jit_server addr=localhost:9876 ts=2000] count=5 dedup_hits=1 total_compile_time_ms=90 queued=0 inflight=0 peak_inflight=2 bytes_in=300 bytes_out=120",
+        ]
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_text))
+
+    assert MODULE.main(["--json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)
+
+    assert len(report["servers"]) == 1
+    server = report["servers"][0]
+    assert server["server"] == MODULE.STDIN_SOURCE_ID
+    assert server["addr"] == "localhost:9876"
+    assert server["count"] == 5
+    assert server["unique_kernel_hashes"] == 2
+    assert report["unique_kernel_hashes_total"] == 2

--- a/tt_metal/tools/jit_compile_server/tests/test_jit_load_report.py
+++ b/tt_metal/tools/jit_compile_server/tests/test_jit_load_report.py
@@ -27,7 +27,7 @@ MODULE = _load_report_module()
 def test_parse_jit_server_line_extracts_fields():
     line = (
         "[jit_server addr=localhost:6000 ts=1711111111111] "
-        "count=42 total_compile_time_ms=900 queued=2 inflight=3 "
+        "count=42 dedup_hits=9 total_compile_time_ms=900 queued=2 inflight=3 "
         "peak_inflight=7 bytes_in=12345 bytes_out=67890"
     )
 
@@ -36,6 +36,7 @@ def test_parse_jit_server_line_extracts_fields():
     assert sample.addr == "localhost:6000"
     assert sample.ts == 1711111111111
     assert sample.count == 42
+    assert sample.dedup_hits == 9
     assert sample.total_compile_time_ms == 900
     assert sample.queued == 2
     assert sample.inflight == 3
@@ -47,48 +48,62 @@ def test_parse_jit_server_line_extracts_fields():
 def test_parse_jit_server_samples_ignores_non_matching_lines():
     lines = [
         "random non-matching line",
-        "[jit_server addr=a:1 ts=1000] count=1 total_compile_time_ms=2 queued=0 inflight=0 peak_inflight=1 bytes_in=10 bytes_out=20",
+        "[jit_server addr=a:1 ts=1000] count=1 dedup_hits=0 total_compile_time_ms=2 queued=0 inflight=0 peak_inflight=1 bytes_in=10 bytes_out=20",
         "another non-matching line",
     ]
 
     samples = MODULE.parse_jit_server_samples(lines)
     assert len(samples) == 1
     assert samples[0].addr == "a:1"
+    assert samples[0].dedup_hits == 0
+
+
+def test_parse_kernel_compile_line_extracts_kernel_hash():
+    line = "compile kernels/reader/abc1234567890def: targets=2 genfiles=1 outstanding=3"
+    sample = MODULE.parse_kernel_compile_line(line)
+    assert sample is not None
+    assert sample.kernel_name == "kernels/reader/abc1234567890def"
+    assert sample.kernel_hash == "abc1234567890def"
 
 
 def test_build_report_uses_last_sample_without_window():
     lines = [
-        "[jit_server addr=server-a:6000 ts=1000] count=10 total_compile_time_ms=100 queued=0 inflight=0 peak_inflight=2 bytes_in=1000 bytes_out=500",
-        "[jit_server addr=server-a:6000 ts=3000] count=20 total_compile_time_ms=170 queued=1 inflight=1 peak_inflight=4 bytes_in=1800 bytes_out=900",
-        "[jit_server addr=server-a:6000 ts=4000] count=25 total_compile_time_ms=220 queued=0 inflight=0 peak_inflight=4 bytes_in=2200 bytes_out=1200",
-        "[jit_server addr=server-b:6001 ts=1500] count=8 total_compile_time_ms=80 queued=0 inflight=0 peak_inflight=1 bytes_in=900 bytes_out=400",
-        "[jit_server addr=server-b:6001 ts=3900] count=12 total_compile_time_ms=140 queued=0 inflight=0 peak_inflight=2 bytes_in=1300 bytes_out=700",
+        "[jit_server addr=server-a:6000 ts=1000] count=10 dedup_hits=2 total_compile_time_ms=100 queued=0 inflight=0 peak_inflight=2 bytes_in=1000 bytes_out=500",
+        "[jit_server addr=server-a:6000 ts=3000] count=20 dedup_hits=4 total_compile_time_ms=170 queued=1 inflight=1 peak_inflight=4 bytes_in=1800 bytes_out=900",
+        "[jit_server addr=server-a:6000 ts=4000] count=25 dedup_hits=5 total_compile_time_ms=220 queued=0 inflight=0 peak_inflight=4 bytes_in=2200 bytes_out=1200",
+        "[jit_server addr=server-b:6001 ts=1500] count=8 dedup_hits=1 total_compile_time_ms=80 queued=0 inflight=0 peak_inflight=1 bytes_in=900 bytes_out=400",
+        "[jit_server addr=server-b:6001 ts=3900] count=12 dedup_hits=3 total_compile_time_ms=140 queued=0 inflight=0 peak_inflight=2 bytes_in=1300 bytes_out=700",
     ]
 
     report = MODULE.build_report(MODULE.parse_jit_server_samples(lines), window_seconds=None)
     servers = {entry["addr"]: entry for entry in report["servers"]}
 
     assert servers["server-a:6000"]["count"] == 25
+    assert servers["server-a:6000"]["dedup_hits"] == 5
     assert servers["server-a:6000"]["total_compile_time_ms"] == 220
+    assert servers["server-a:6000"]["unique_kernel_hashes"] == 0
     assert servers["server-b:6001"]["count"] == 12
+    assert servers["server-b:6001"]["dedup_hits"] == 3
     assert servers["server-b:6001"]["total_compile_time_ms"] == 140
+    assert servers["server-b:6001"]["unique_kernel_hashes"] == 0
     assert servers["server-a:6000"]["throughput_compiles_per_sec"] is None
 
 
 def test_build_report_window_computes_deltas_and_throughput():
     lines = [
-        "[jit_server addr=server-a:6000 ts=1000] count=10 total_compile_time_ms=100 queued=0 inflight=0 peak_inflight=2 bytes_in=1000 bytes_out=500",
-        "[jit_server addr=server-a:6000 ts=3000] count=20 total_compile_time_ms=170 queued=1 inflight=1 peak_inflight=4 bytes_in=1800 bytes_out=900",
-        "[jit_server addr=server-a:6000 ts=4000] count=25 total_compile_time_ms=220 queued=0 inflight=0 peak_inflight=4 bytes_in=2200 bytes_out=1200",
-        "[jit_server addr=server-b:6001 ts=1500] count=8 total_compile_time_ms=80 queued=0 inflight=0 peak_inflight=1 bytes_in=900 bytes_out=400",
-        "[jit_server addr=server-b:6001 ts=2500] count=9 total_compile_time_ms=100 queued=1 inflight=1 peak_inflight=2 bytes_in=1000 bytes_out=500",
-        "[jit_server addr=server-b:6001 ts=3900] count=12 total_compile_time_ms=140 queued=0 inflight=0 peak_inflight=2 bytes_in=1300 bytes_out=700",
+        "[jit_server addr=server-a:6000 ts=1000] count=10 dedup_hits=2 total_compile_time_ms=100 queued=0 inflight=0 peak_inflight=2 bytes_in=1000 bytes_out=500",
+        "[jit_server addr=server-a:6000 ts=3000] count=20 dedup_hits=4 total_compile_time_ms=170 queued=1 inflight=1 peak_inflight=4 bytes_in=1800 bytes_out=900",
+        "[jit_server addr=server-a:6000 ts=4000] count=25 dedup_hits=5 total_compile_time_ms=220 queued=0 inflight=0 peak_inflight=4 bytes_in=2200 bytes_out=1200",
+        "[jit_server addr=server-b:6001 ts=1500] count=8 dedup_hits=1 total_compile_time_ms=80 queued=0 inflight=0 peak_inflight=1 bytes_in=900 bytes_out=400",
+        "[jit_server addr=server-b:6001 ts=2500] count=9 dedup_hits=2 total_compile_time_ms=100 queued=1 inflight=1 peak_inflight=2 bytes_in=1000 bytes_out=500",
+        "[jit_server addr=server-b:6001 ts=3900] count=12 dedup_hits=4 total_compile_time_ms=140 queued=0 inflight=0 peak_inflight=2 bytes_in=1300 bytes_out=700",
     ]
 
     report = MODULE.build_report(MODULE.parse_jit_server_samples(lines), window_seconds=2.0)
     servers = {entry["addr"]: entry for entry in report["servers"]}
 
     assert servers["server-a:6000"]["count"] == 5
+    assert servers["server-a:6000"]["dedup_hits"] == 1
     assert servers["server-a:6000"]["total_compile_time_ms"] == 50
     assert servers["server-a:6000"]["peak_inflight"] == 4
     assert servers["server-a:6000"]["bytes_in"] == 400
@@ -96,6 +111,7 @@ def test_build_report_window_computes_deltas_and_throughput():
     assert servers["server-a:6000"]["throughput_compiles_per_sec"] == pytest.approx(5.0)
 
     assert servers["server-b:6001"]["count"] == 3
+    assert servers["server-b:6001"]["dedup_hits"] == 2
     assert servers["server-b:6001"]["total_compile_time_ms"] == 40
     assert servers["server-b:6001"]["peak_inflight"] == 2
     assert servers["server-b:6001"]["bytes_in"] == 300
@@ -105,14 +121,15 @@ def test_build_report_window_computes_deltas_and_throughput():
 
 def test_imbalance_summary_statistics():
     lines = [
-        "[jit_server addr=server-a:6000 ts=3000] count=20 total_compile_time_ms=170 queued=1 inflight=1 peak_inflight=4 bytes_in=1800 bytes_out=900",
-        "[jit_server addr=server-a:6000 ts=4000] count=25 total_compile_time_ms=220 queued=0 inflight=0 peak_inflight=4 bytes_in=2200 bytes_out=1200",
-        "[jit_server addr=server-b:6001 ts=2500] count=9 total_compile_time_ms=100 queued=1 inflight=1 peak_inflight=2 bytes_in=1000 bytes_out=500",
-        "[jit_server addr=server-b:6001 ts=3900] count=12 total_compile_time_ms=140 queued=0 inflight=0 peak_inflight=2 bytes_in=1300 bytes_out=700",
+        "[jit_server addr=server-a:6000 ts=3000] count=20 dedup_hits=4 total_compile_time_ms=170 queued=1 inflight=1 peak_inflight=4 bytes_in=1800 bytes_out=900",
+        "[jit_server addr=server-a:6000 ts=4000] count=25 dedup_hits=5 total_compile_time_ms=220 queued=0 inflight=0 peak_inflight=4 bytes_in=2200 bytes_out=1200",
+        "[jit_server addr=server-b:6001 ts=2500] count=9 dedup_hits=2 total_compile_time_ms=100 queued=1 inflight=1 peak_inflight=2 bytes_in=1000 bytes_out=500",
+        "[jit_server addr=server-b:6001 ts=3900] count=12 dedup_hits=4 total_compile_time_ms=140 queued=0 inflight=0 peak_inflight=2 bytes_in=1300 bytes_out=700",
     ]
 
     report = MODULE.build_report(MODULE.parse_jit_server_samples(lines), window_seconds=2.0)
     count_stats = report["imbalance_summary"]["count"]
+    dedup_stats = report["imbalance_summary"]["dedup_hits"]
     compile_time_stats = report["imbalance_summary"]["total_compile_time_ms"]
 
     assert count_stats["max"] == pytest.approx(5.0)
@@ -122,9 +139,60 @@ def test_imbalance_summary_statistics():
     assert count_stats["max_min_ratio"] == pytest.approx(5.0 / 3.0)
     assert count_stats["coefficient_of_variation"] == pytest.approx(0.25)
 
+    assert dedup_stats["max"] == pytest.approx(2.0)
+    assert dedup_stats["min"] == pytest.approx(1.0)
+    assert dedup_stats["mean"] == pytest.approx(1.5)
+    assert dedup_stats["stddev"] == pytest.approx(0.5)
+    assert dedup_stats["max_min_ratio"] == pytest.approx(2.0)
+    assert dedup_stats["coefficient_of_variation"] == pytest.approx(1 / 3)
+
     assert compile_time_stats["max"] == pytest.approx(50.0)
     assert compile_time_stats["min"] == pytest.approx(40.0)
     assert compile_time_stats["mean"] == pytest.approx(45.0)
     assert compile_time_stats["stddev"] == pytest.approx(5.0)
     assert compile_time_stats["max_min_ratio"] == pytest.approx(1.25)
     assert compile_time_stats["coefficient_of_variation"] == pytest.approx(5.0 / 45.0)
+
+
+def test_build_report_includes_unique_kernel_hash_counts():
+    lines = [
+        "[jit_server addr=server-a:6000 ts=3000] count=20 dedup_hits=4 total_compile_time_ms=170 queued=1 inflight=1 peak_inflight=4 bytes_in=1800 bytes_out=900",
+        "[jit_server addr=server-b:6001 ts=3900] count=12 dedup_hits=4 total_compile_time_ms=140 queued=0 inflight=0 peak_inflight=2 bytes_in=1300 bytes_out=700",
+    ]
+    kernel_lines = [
+        "compile kernels/a/aaaaaaaaaaaaaaaa: targets=1 genfiles=0 outstanding=1",
+        "compile kernels/a/aaaaaaaaaaaaaaaa: targets=1 genfiles=0 outstanding=1",
+        "compile kernels/a/bbbbbbbbbbbbbbbb: targets=1 genfiles=0 outstanding=1",
+        "compile kernels/b/cccccccccccccccc: targets=1 genfiles=0 outstanding=1",
+    ]
+    kernel_samples = MODULE.parse_kernel_compile_samples(kernel_lines, source_id="server-a:6000")
+    kernel_samples.extend(MODULE.parse_kernel_compile_samples(kernel_lines[3:], source_id="server-b:6001"))
+
+    report = MODULE.build_report(
+        MODULE.parse_jit_server_samples(lines), window_seconds=None, kernel_compile_samples=kernel_samples
+    )
+    servers = {entry["addr"]: entry for entry in report["servers"]}
+
+    assert servers["server-a:6000"]["unique_kernel_hashes"] == 3
+    assert servers["server-b:6001"]["unique_kernel_hashes"] == 1
+    assert report["unique_kernel_hashes_total"] == 3
+
+
+def test_build_report_groups_by_source_not_addr():
+    server_a_lines = [
+        "[jit_server addr=0.0.0.0:9876 ts=1000] count=5 dedup_hits=1 total_compile_time_ms=20 queued=0 inflight=0 peak_inflight=1 bytes_in=100 bytes_out=40",
+    ]
+    server_b_lines = [
+        "[jit_server addr=0.0.0.0:9876 ts=1000] count=7 dedup_hits=3 total_compile_time_ms=25 queued=0 inflight=0 peak_inflight=1 bytes_in=120 bytes_out=45",
+    ]
+    samples = MODULE.parse_jit_server_samples(server_a_lines, source_id="server-a.log")
+    samples.extend(MODULE.parse_jit_server_samples(server_b_lines, source_id="server-b.log"))
+
+    report = MODULE.build_report(samples, window_seconds=None)
+    servers = {entry["server"]: entry for entry in report["servers"]}
+
+    assert set(servers) == {"server-a.log", "server-b.log"}
+    assert servers["server-a.log"]["addr"] == "0.0.0.0:9876"
+    assert servers["server-a.log"]["count"] == 5
+    assert servers["server-b.log"]["addr"] == "0.0.0.0:9876"
+    assert servers["server-b.log"]["count"] == 7


### PR DESCRIPTION
### PR Category
Feature

### Summary
- Added user guide in the script
- Added `unique_kernel_hashes` and `dedup_hits` counters (the latter was missed in the previous PR and is needed to properly parse the logs)

### Notes for reviewers
I ran tests and manually ran the script to parse compile server logs locally.  Changes to this script will not affect any test on CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/jit_server_stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/jit_server_stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/jit_server_stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/jit_server_stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/jit_server_stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/jit_server_stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/jit_server_stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/jit_server_stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/jit_server_stats)