### PR TITLE
Move ccl to  device 2.0 light changes

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -107,6 +107,10 @@ private:
     }
 
 public:
+    // Invariant: default-constructed Noc shares noc_index with legacy noc_async_* free functions
+    // (which default their `noc` arg to noc_index, see dataflow_api.h). Mixed legacy + typed
+    // kernels rely on this for barrier coherence: a Noc{}.async_*_barrier() call flushes legacy
+    // noc_async_* transactions issued without an explicit noc arg, and vice versa.
     Noc() : noc_id_(noc_index) {}
     explicit Noc(uint8_t noc_id) : noc_id_(noc_id) {}
 

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -107,10 +107,6 @@ private:
     }
 
 public:
-    // Invariant: default-constructed Noc shares noc_index with legacy noc_async_* free functions
-    // (which default their `noc` arg to noc_index, see dataflow_api.h). Mixed legacy + typed
-    // kernels rely on this for barrier coherence: a Noc{}.async_*_barrier() call flushes legacy
-    // noc_async_* transactions issued without an explicit noc arg, and vice versa.
     Noc() : noc_id_(noc_index) {}
     explicit Noc(uint8_t noc_id) : noc_id_(noc_id) {}
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -9,6 +9,12 @@
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 #endif
 
@@ -263,6 +269,10 @@ struct ShardedAddrGen {
         return return_val;
     }
 
+    // Legacy shim (#45003 item 4): uses the legacy noc_async_read primitive
+    // because get_sharded_addr produces a precomposed 64-bit noc address.
+    // Consumers migrating to Device 2.0 should use get_noc_addr() / its
+    // components together with Noc::async_read directly.
     FORCE_INLINE
     void noc_async_read_page(
         const uint32_t id, const uint32_t dest_addr, const uint32_t offset = 0, uint8_t noc = noc_index) const {

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -263,8 +263,8 @@ struct ShardedAddrGen {
         return return_val;
     }
 
-    // Legacy shim (#45003 item 4): uses the legacy noc_async_read primitive
-    // because get_sharded_addr produces a precomposed 64-bit noc address.
+    // Uses the legacy noc_async_read primitive because get_sharded_addr
+    // produces a precomposed 64-bit noc address.
     // Consumers migrating to Device 2.0 should use get_noc_addr() / its
     // components together with Noc::async_read directly.
     FORCE_INLINE

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -9,12 +9,6 @@
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
-#include "api/dataflow/noc_semaphore.h"
-#include "api/dataflow/endpoints.h"
-#include "api/core_local_mem.h"
-#include "api/tensor/noc_traits.h"
 
 #endif
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -11,13 +11,10 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <array>
 
-// Legacy shim (#45003 item 4): consumes raw L1 addresses and uses legacy noc_semaphore_* primitives.
-// The semaphores in question are local (created via tt_metal::CreateSemaphore), and OpSignaler already does
-// the id→address translation via get_semaphore(id) on the kernel side before calling this helper, so the
-// shim could be migrated to take an id-based interface. Out of scope here: 12 of the 13 caller kernels are
-// still on the legacy data-movement API, so flipping the interface would either break them all at once or
-// require a parallel id-based overload. Revisit as part of the helper-shim removal PR once callers migrate.
-// Called by the master worker to synchronize with the slave workers
+// Consumes raw L1 addresses and uses legacy noc_semaphore_* primitives.
+// These semaphores are local (created via tt_metal::CreateSemaphore), and OpSignaler already does
+// the id to address translation via get_semaphore(id) on the kernel side before calling this helper.
+// TODO (Issue 45003): refactor to take an id-based interface.
 FORCE_INLINE void master_sync_slaves(
 
     /* Used to get slave worker's sem addrs */
@@ -71,8 +68,7 @@ FORCE_INLINE void master_sync_slaves(
     }
 }
 
-// Legacy shim (#45003 item 4): same status as master_sync_slaves above.
-// Called by the slave worker to synchronize with the master worker
+// TODO (Issue 45003): refactor to take an id-based interface.
 FORCE_INLINE void slave_sync_master(const uint32_t* worker_noc_coords, const uint32_t worker_sync_sem_addr) {
     // Signal the master that the slave has finished its work
     uint64_t remote_master_l1_semaphore_addr =

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -11,10 +11,12 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <array>
 
-// Legacy shim (#45003 item 4): consumes raw L1 addresses and uses legacy
-// noc_semaphore_* primitives. Migration to Semaphore<> requires the semaphore
-// id, which is not on the function's interface — kept as-is until callers
-// migrate, then revisited as part of the helper-shim removal PR.
+// Legacy shim (#45003 item 4): consumes raw L1 addresses and uses legacy noc_semaphore_* primitives.
+// The semaphores in question are local (created via tt_metal::CreateSemaphore), and OpSignaler already does
+// the id→address translation via get_semaphore(id) on the kernel side before calling this helper, so the
+// shim could be migrated to take an id-based interface. Out of scope here: 12 of the 13 caller kernels are
+// still on the legacy data-movement API, so flipping the interface would either break them all at once or
+// require a parallel id-based overload. Revisit as part of the helper-shim removal PR once callers migrate.
 // Called by the master worker to synchronize with the slave workers
 FORCE_INLINE void master_sync_slaves(
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -11,10 +11,12 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <array>
 
-// Consumes raw L1 addresses and uses legacy noc_semaphore_* primitives.
+// Called by the master worker to synchronize with the slave workers
+//
+// Device 2.0 migration: consumes raw L1 addresses and uses legacy noc_semaphore_* primitives.
 // These semaphores are local (created via tt_metal::CreateSemaphore), and OpSignaler already does
 // the id to address translation via get_semaphore(id) on the kernel side before calling this helper.
-// TODO (Issue 45003): refactor to take an id-based interface.
+// TODO(#45846): refactor to take an id-based interface.
 FORCE_INLINE void master_sync_slaves(
 
     /* Used to get slave worker's sem addrs */
@@ -68,7 +70,9 @@ FORCE_INLINE void master_sync_slaves(
     }
 }
 
-// TODO (Issue 45003): refactor to take an id-based interface.
+// Called by the slave worker to synchronize with the master worker
+//
+// Device 2.0 migration: TODO(#45846): refactor to take an id-based interface (see master_sync_slaves note above).
 FORCE_INLINE void slave_sync_master(const uint32_t* worker_noc_coords, const uint32_t worker_sync_sem_addr) {
     // Signal the master that the slave has finished its work
     uint64_t remote_master_l1_semaphore_addr =

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -5,11 +5,7 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
-#include "api/dataflow/endpoints.h"
-#include "api/core_local_mem.h"
 #include "api/debug/assert.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
@@ -210,10 +206,6 @@ struct MatmulOpReceiver {
     std::array<uint32_t, num_directions> ring_idxs = {};
     std::array<uint32_t, num_directions> start_page_idxs = {};
     std::array<bool, num_directions> is_clockwise_dirs = {};
-    std::array<volatile tt_l1_ptr uint32_t*, num_directions> signal_op_semaphore_addr_ptrs = {};
-    // Mirrors signal_op_semaphore_addr_ptrs as semaphore ids for the Device 2.0
-    // Semaphore<> API. Both are populated; addr_ptrs preserves the public field
-    // interface for legacy consumers.
     std::array<uint32_t, num_directions> signal_op_semaphore_ids = {};
     uint32_t curr_dir = 0;
     uint32_t curr_transfer_idx = 0;
@@ -241,10 +233,6 @@ struct MatmulOpReceiver {
         if (this->wait_for_op_signal) {
             this->signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
             this->signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
-            this->signal_op_semaphore_addr_ptrs[0] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(this->signal_op_semaphore_ids[0]));
-            this->signal_op_semaphore_addr_ptrs[1] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(this->signal_op_semaphore_ids[1]));
         }
 
         this->num_tensor_slices = this->num_transfers * this->num_directions;
@@ -342,9 +330,6 @@ struct MatmulOpReceiver {
 };
 
 struct ReduceScatterOpReceiver {
-    volatile tt_l1_ptr uint32_t* signal_op_semaphore_addr_ptr;
-    // Mirrors signal_op_semaphore_addr_ptr as a semaphore id for the
-    // Device 2.0 Semaphore<> API; both are populated.
     uint32_t signal_op_semaphore_id = 0;
 
     bool initialized = false;
@@ -354,8 +339,6 @@ struct ReduceScatterOpReceiver {
     ReduceScatterOpReceiver(uint32_t& rt_args_idx) {
         // Runtime args
         this->signal_op_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
-        this->signal_op_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(this->signal_op_semaphore_id));
 
         this->initialized = true;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -5,11 +5,20 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "api/debug/assert.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <array>
 
+// Legacy shim (#45003 item 4): consumes raw L1 addresses and uses legacy
+// noc_semaphore_* primitives. Migration to Semaphore<> requires the semaphore
+// id, which is not on the function's interface — kept as-is until callers
+// migrate, then revisited as part of the helper-shim removal PR.
 // Called by the master worker to synchronize with the slave workers
 FORCE_INLINE void master_sync_slaves(
 
@@ -64,6 +73,7 @@ FORCE_INLINE void master_sync_slaves(
     }
 }
 
+// Legacy shim (#45003 item 4): same status as master_sync_slaves above.
 // Called by the slave worker to synchronize with the master worker
 FORCE_INLINE void slave_sync_master(const uint32_t* worker_noc_coords, const uint32_t worker_sync_sem_addr) {
     // Signal the master that the slave has finished its work
@@ -201,6 +211,10 @@ struct MatmulOpReceiver {
     std::array<uint32_t, num_directions> start_page_idxs = {};
     std::array<bool, num_directions> is_clockwise_dirs = {};
     std::array<volatile tt_l1_ptr uint32_t*, num_directions> signal_op_semaphore_addr_ptrs = {};
+    // Mirrors signal_op_semaphore_addr_ptrs as semaphore ids for the Device 2.0
+    // Semaphore<> API. Both are populated; addr_ptrs preserves the public field
+    // interface for legacy consumers.
+    std::array<uint32_t, num_directions> signal_op_semaphore_ids = {};
     uint32_t curr_dir = 0;
     uint32_t curr_transfer_idx = 0;
 
@@ -225,10 +239,12 @@ struct MatmulOpReceiver {
         uint32_t is_clockwise_direction = get_arg_val<uint32_t>(rt_args_idx++);
 
         if (this->wait_for_op_signal) {
+            this->signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
+            this->signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
             this->signal_op_semaphore_addr_ptrs[0] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(this->signal_op_semaphore_ids[0]));
             this->signal_op_semaphore_addr_ptrs[1] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(this->signal_op_semaphore_ids[1]));
         }
 
         this->num_tensor_slices = this->num_transfers * this->num_directions;
@@ -277,7 +293,7 @@ struct MatmulOpReceiver {
 
             // Wait for a semaphore signal to start processing the tensor slice
             if (this->wait_for_op_signal) {
-                noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], tensor_slice_cnt + 1);
+                Semaphore<>(this->signal_op_semaphore_ids[this->curr_dir]).wait_min(tensor_slice_cnt + 1);
             }
 
             // Update the relevant internal states
@@ -315,7 +331,7 @@ struct MatmulOpReceiver {
             // Wait for a semaphore signal to start processing the tensor slice
             if (this->wait_for_op_signal && block_id == sender_id) {
                 uint32_t tensor_slice_cnt = (this->curr_transfer_idx) / this->num_directions;
-                noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], 1);
+                Semaphore<>(this->signal_op_semaphore_ids[this->curr_dir]).wait_min(1);
             }
 
             this->curr_transfer_idx++;
@@ -327,6 +343,9 @@ struct MatmulOpReceiver {
 
 struct ReduceScatterOpReceiver {
     volatile tt_l1_ptr uint32_t* signal_op_semaphore_addr_ptr;
+    // Mirrors signal_op_semaphore_addr_ptr as a semaphore id for the
+    // Device 2.0 Semaphore<> API; both are populated.
+    uint32_t signal_op_semaphore_id = 0;
 
     bool initialized = false;
 
@@ -334,14 +353,15 @@ struct ReduceScatterOpReceiver {
 
     ReduceScatterOpReceiver(uint32_t& rt_args_idx) {
         // Runtime args
+        this->signal_op_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
         this->signal_op_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(this->signal_op_semaphore_id));
 
         this->initialized = true;
     }
 
     void wait_for_matmul_batch(const uint32_t& batch_idx) {
         ASSERT(this->initialized);
-        noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptr, batch_idx + 1);
+        Semaphore<>(this->signal_op_semaphore_id).wait_min(batch_idx + 1);
     }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -42,22 +45,29 @@ void kernel_main() {
     tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+    UnicastEndpoint src_ep;
+
     uint32_t tiles_read = 0;
     uint32_t shard_tile_id = first_core_tile_start_offset;
     uint32_t core_id = 0;
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core =
             std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
-        cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
+        cb0.reserve_back(num_tiles_to_read_this_core);
 
-        const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        noc_obj.async_read(
+            src_ep,
+            cb0,
+            num_tiles_to_read_this_core * tensor0_page_size,
+            {.noc_x = core_noc_x[core_id],
+             .noc_y = core_noc_y[core_id],
+             .addr = tensor_address0 + shard_tile_id * tensor0_page_size},
+            {});
+        noc_obj.async_read_barrier();
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
-        noc_async_read_barrier();
-
-        cb_push_back(cb0_id, num_tiles_to_read_this_core);
+        cb0.push_back(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id = 0;
         core_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -164,8 +164,10 @@ void kernel_main() {
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
-    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is a raw L1 address
-    // (program factory passes semaphore.address(), not a semaphore id), so Semaphore<> does not apply.
+    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is the address of a GlobalSemaphore
+    // (operation_attributes.semaphore in all_gather_concat_program_factory.cpp). GlobalSemaphore exposes only
+    // address() — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
+    // wrap a GlobalSemaphore. Structural limitation, not a migration backlog item.
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
@@ -236,7 +238,8 @@ void kernel_main() {
     }
 
     if (reset_global_semaphore) {
-        // Legacy primitive retained (#45003 item 4): semaphore set on raw L1 address (not a semaphore id).
+        // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is a GlobalSemaphore address (see
+        // structural-reason note above on the inc site).
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -164,11 +164,10 @@ void kernel_main() {
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
-    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is the address of a GlobalSemaphore
-    // (operation_attributes.semaphore in all_gather_concat_program_factory.cpp). GlobalSemaphore exposes only
-    // address() — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
-    // wrap a GlobalSemaphore. Structural limitation, not a migration backlog item.
-    // increment locally
+    // Device 2.0 migration: out_ready_sem_bank_addr is the address of a GlobalSemaphore.
+    // GlobalSemaphore exposes only address() — there is no id(), which is a structural limitation.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
+    // wrap a GlobalSemaphore.
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
@@ -180,8 +179,8 @@ void kernel_main() {
     }
 
     // Set up for mcasting to concat workers
-    // Legacy primitives retained (#45003 item 4): defensive set + raw L1 read-check pattern does not map to
-    // Semaphore<> (which exposes set/wait but not raw-pointer value reads).
+    // Device 2.0 migration: legacy primitives retained: set + raw L1 read pattern does not map to
+    // Semaphore<>, which exposes set/wait but not raw-pointer value reads.
     if (wait_output_semaphore) {
         volatile tt_l1_ptr uint32_t* concat_semaphore_send_addr_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_semaphore_send_addr);
@@ -238,8 +237,7 @@ void kernel_main() {
     }
 
     if (reset_global_semaphore) {
-        // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is a GlobalSemaphore address (see
-        // structural-reason note above on the inc site).
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -164,10 +164,9 @@ void kernel_main() {
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
-    // Device 2.0 migration: out_ready_sem_bank_addr is the address of a GlobalSemaphore.
-    // GlobalSemaphore exposes only address() — there is no id(), which is a structural limitation.
-    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
-    // wrap a GlobalSemaphore.
+    // increment locally
+    // Device 2.0 migration: legacy primitive retained — out_ready_sem_bank_addr is a GlobalSemaphore
+    // address, and Semaphore<> binds to per-program ids (no GlobalSemaphore wrapper exists).
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -77,16 +79,20 @@ void kernel_main() {
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_seminc = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -109,8 +115,8 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
         num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
-        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb0.get_read_ptr();
 
         uint64_t noc0_dest_noc_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0);
         noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;
@@ -126,7 +132,7 @@ void kernel_main() {
             // Alternate the packet header distance for better balancing
             std::swap(pkt_hdr_forward, pkt_hdr_backward);
         }
-        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        cb0.pop_front(num_tiles_to_read_this_core);
 
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id += num_tiles_to_read_this_core;
@@ -158,6 +164,8 @@ void kernel_main() {
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
+    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is a raw L1 address
+    // (program factory passes semaphore.address(), not a semaphore id), so Semaphore<> does not apply.
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
@@ -170,6 +178,8 @@ void kernel_main() {
     }
 
     // Set up for mcasting to concat workers
+    // Legacy primitives retained (#45003 item 4): defensive set + raw L1 read-check pattern does not map to
+    // Semaphore<> (which exposes set/wait but not raw-pointer value reads).
     if (wait_output_semaphore) {
         volatile tt_l1_ptr uint32_t* concat_semaphore_send_addr_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_semaphore_send_addr);
@@ -226,6 +236,7 @@ void kernel_main() {
     }
 
     if (reset_global_semaphore) {
+        // Legacy primitive retained (#45003 item 4): semaphore set on raw L1 address (not a semaphore id).
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
@@ -233,5 +244,5 @@ void kernel_main() {
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close_finish();
     }
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
@@ -50,8 +50,8 @@ void batch_loop(
     uint32_t start_row) {
     uint32_t q_write_addr = cb_write_ptr_base + start * output_row_size;
     for (uint32_t q = start; q < end; ++q) {
-        // Legacy primitive retained (#45003 item 4): source is a precomposed uint64_t NoC address and destination is
-        // a raw offset into a pre-resolved CB write pointer (cb_write_ptr_base + start * output_row_size + ...).
+        // Device 2.0 migration: legacy primitive retained: source is a precomposed uint64_t NoC address
+        // and destination is a raw offset into a pre-resolved CB write pointer.
         noc_async_read(qkv_read_addr, q_write_addr, output_row_size);
         q_write_addr += output_row_size;
         cur_core_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -47,6 +50,8 @@ void batch_loop(
     uint32_t start_row) {
     uint32_t q_write_addr = cb_write_ptr_base + start * output_row_size;
     for (uint32_t q = start; q < end; ++q) {
+        // Legacy primitive retained (#45003 item 4): source is a precomposed uint64_t NoC address and destination is
+        // a raw offset into a pre-resolved CB write pointer (cb_write_ptr_base + start * output_row_size + ...).
         noc_async_read(qkv_read_addr, q_write_addr, output_row_size);
         q_write_addr += output_row_size;
         cur_core_idx++;
@@ -61,9 +66,10 @@ void batch_loop(
 };
 
 void nlp_concat(
+    const Noc& noc_obj,
+    CircularBuffer& cb_q_out,
     uint32_t q_start_addr,
     uint32_t tensor_address0,
-    uint32_t cb_id_q_out,
     bool nlp_local,
     uint32_t start_local,
     std::array<uint32_t, 8> core_noc_x,
@@ -87,7 +93,7 @@ void nlp_concat(
                         output_row_size * second_half_core + start_row * input_row_size;
     }
     uint32_t q_write_addr = 0;
-    const uint32_t cb_write_ptr_base = get_write_ptr(cb_id_q_out);
+    const uint32_t cb_write_ptr_base = cb_q_out.get_write_ptr();
 
     for (uint32_t batch_range = 0; batch_range < idx_end; batch_range++) {
         batch_loop(
@@ -113,7 +119,7 @@ void nlp_concat(
                         output_row_size * second_half_core + start_row * input_row_size;
     }
 
-    noc_async_read_barrier();
+    noc_obj.async_read_barrier();
 };
 
 void kernel_main() {
@@ -123,13 +129,8 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     uint32_t q_start_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t tensor_address0 = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    const uint32_t signal_semaphore_addr2 = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-
-    volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr2 =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr2);
+    Semaphore<> signal_sem(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> signal_sem2(get_arg_val<uint32_t>(arg_idx++));
 
     tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += in_num_cores;
@@ -141,10 +142,14 @@ void kernel_main() {
     std::array<uint32_t, 8> core_noc_x = {19, 20, 21, 19, 20, 21, 19, 20};
     std::array<uint32_t, 8> core_noc_y = {18, 18, 18, 19, 19, 19, 20, 20};
 
+    Noc noc_obj;
+    CircularBuffer cb_q_out(cb_id_q_out);
+
     nlp_concat(
+        noc_obj,
+        cb_q_out,
         q_start_addr,
         tensor_address0,
-        cb_id_q_out,
         1,
         start_local,
         core_noc_x,
@@ -154,17 +159,18 @@ void kernel_main() {
         second_half_core,
         start_row);
     if (ROWS_TO_READ == 1) {
-        noc_semaphore_wait(signal_semaphore_addr_ptr, 1);
-        noc_semaphore_set(signal_semaphore_addr_ptr, 0);
+        signal_sem.wait(1);
+        signal_sem.set(0);
     } else if (ROWS_TO_READ == 2) {
-        noc_semaphore_wait(signal_semaphore_addr_ptr2, 1);
-        noc_semaphore_set(signal_semaphore_addr_ptr2, 0);
+        signal_sem2.wait(1);
+        signal_sem2.set(0);
     }
 
     nlp_concat(
+        noc_obj,
+        cb_q_out,
         q_start_addr,
         tensor_address0,
-        cb_id_q_out,
         0,
         start_local,
         core_noc_x,
@@ -173,5 +179,5 @@ void kernel_main() {
         in0_mcast_noc_y,
         second_half_core,
         start_row);
-    cb_push_back(cb_id_q_out, 2);
+    cb_q_out.push_back(2);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_writer.cpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    cb_wait_front(cb_id_out, 2);
+    CircularBuffer cb_out(cb_id_out);
+    cb_out.wait_front(2);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
@@ -22,8 +23,11 @@ void kernel_main() {
 
     constexpr uint32_t max_dst_tiles = 8;  // TODO: Make general
 
-    cb_wait_front(cb_in0, num_blocks * block_num_tiles);
-    cb_reserve_back(cb_out0, block_num_tiles);
+    CircularBuffer cb_in(cb_in0);
+    CircularBuffer cb_out(cb_out0);
+
+    cb_in.wait_front(num_blocks * block_num_tiles);
+    cb_out.reserve_back(block_num_tiles);
 
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
     add_tiles_init(cb_in0, cb_in1, true);
@@ -60,5 +64,5 @@ void kernel_main() {
         block_num_tiles_cnt += num_tiles_to_pack;
     }
 
-    cb_push_back(cb_out0, block_num_tiles);
+    cb_out.push_back(block_num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/dataflow/noc_semaphore.h"
 void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
@@ -23,10 +26,14 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* out_ready_sema =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
 
+    CircularBuffer cb(cb_id);
+
     // 1. Wait for signal from All-Gather worker
+    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is an absolute L1 address from the program
+    // factory, not a semaphore id; Semaphore<> binds to ids only.
     noc_semaphore_wait(out_ready_sema, out_ready_sem_wait_value);
 
     // 2. Signal compute kernel to start processing
-    cb_push_back(cb_id, total_num_reduction_tiles);
+    cb.push_back(total_num_reduction_tiles);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
@@ -27,8 +27,8 @@ void kernel_main() {
     CircularBuffer cb(cb_id);
 
     // 1. Wait for signal from All-Gather worker
-    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is an absolute L1 address from the program
-    // factory, not a semaphore id; Semaphore<> binds to ids only.
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is an absolute L1 address from the
+    // program factory, which is a target of a remote atomic increment over fabric. Semaphore<> binds to ids only.
     noc_semaphore_wait(out_ready_sema, out_ready_sem_wait_value);
 
     // 2. Signal compute kernel to start processing

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 #include <utility>
@@ -34,6 +37,10 @@ void kernel_main() {
     tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+    UnicastEndpoint src_ep;
+
     // interleaved addrgen
     uint32_t tiles_read = 0;
     uint32_t shard_tile_id = first_core_tile_start_offset;
@@ -41,15 +48,19 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core =
             std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
-        cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
-        const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        cb0.reserve_back(num_tiles_to_read_this_core);
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
-        noc_async_read_barrier();
+        noc_obj.async_read(
+            src_ep,
+            cb0,
+            num_tiles_to_read_this_core * tensor0_page_size,
+            {.noc_x = core_noc_x[core_id],
+             .noc_y = core_noc_y[core_id],
+             .addr = tensor_address0 + shard_tile_id * tensor0_page_size},
+            {});
+        noc_obj.async_read_barrier();
 
-        cb_push_back(cb0_id, num_tiles_to_read_this_core);
+        cb0.push_back(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id = 0;
         core_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -162,8 +162,10 @@ void kernel_main() {
     }
 
     // 2. local semaphore increment
-    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is an absolute L1 address from the program
-    // factory, not a semaphore id; Semaphore<> binds to ids only.
+    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is the address of a GlobalSemaphore
+    // (operation_attributes.semaphore in all_reduce_async_program_factory.cpp). GlobalSemaphore exposes only
+    // address() — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
+    // wrap a GlobalSemaphore. This is structural, not a migration backlog item.
     for (uint32_t i = 0; i < core_id; i++) {
         noc_semaphore_inc(safe_get_noc_addr(core_noc_x[i], core_noc_y[i], out_ready_sem_bank_addr), 1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -162,10 +162,8 @@ void kernel_main() {
     }
 
     // 2. local semaphore increment
-    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is the address of a GlobalSemaphore
-    // (operation_attributes.semaphore in all_reduce_async_program_factory.cpp). GlobalSemaphore exposes only
-    // address() — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
-    // wrap a GlobalSemaphore. This is structural, not a migration backlog item.
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is the address of a GlobalSemaphore.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
     for (uint32_t i = 0; i < core_id; i++) {
         noc_semaphore_inc(safe_get_noc_addr(core_noc_x[i], core_noc_y[i], out_ready_sem_bank_addr), 1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -49,14 +53,17 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t reduction_semaphore_send_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t reduction_semaphore_send_id = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_mcast_ranges = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t link = get_arg_val<uint32_t>(arg_idx++);
 
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     // Set up for mcasting to reduction workers
-    volatile tt_l1_ptr uint32_t* reduction_semaphore_send_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduction_semaphore_send_addr);
-    noc_semaphore_set(reduction_semaphore_send_addr_ptr, VALID);
+    Semaphore<> reduction_semaphore_send(reduction_semaphore_send_id);
+    reduction_semaphore_send.set(VALID);
 
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
@@ -81,13 +88,13 @@ void kernel_main() {
             arg_idx);
 
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -110,8 +117,8 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
         num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
-        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb0.get_read_ptr();
 
         uint64_t noc0_dest_noc_addr =
             safe_get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], reduction_input_addr + writer_chip_offset);
@@ -134,7 +141,7 @@ void kernel_main() {
                 sema_noc_addr,
                 static_cast<uint32_t>(1),
                 false);
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
         } else {
             write_and_advance_local_read_address_for_fabric_write(
                 noc0_dest_noc_addr,
@@ -151,10 +158,12 @@ void kernel_main() {
             shard_tile_id = 0;
             core_id++;
         }
-        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        cb0.pop_front(num_tiles_to_read_this_core);
     }
 
     // 2. local semaphore increment
+    // Legacy primitive retained (#45003 item 4): out_ready_sem_bank_addr is an absolute L1 address from the program
+    // factory, not a semaphore id; Semaphore<> binds to ids only.
     for (uint32_t i = 0; i < core_id; i++) {
         noc_semaphore_inc(safe_get_noc_addr(core_noc_x[i], core_noc_y[i], out_ready_sem_bank_addr), 1);
     }
@@ -165,5 +174,5 @@ void kernel_main() {
         fabric_connection.close_finish();
     }
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -48,20 +48,8 @@ void read_data(
             input_page_size / 2,
             {.page_id = tile_id, .offset_bytes = (device_id % 2) * input_page_size / 2},
             {});
-        // Device 2.0 migration: legacy primitive retained: MEM_ZEROS_BASE self-read has no typed Noc trait
-        // (the local x/y are implicit in get_noc_addr(addr)). Both this call and noc_obj issue on
-        // noc_index — legacy noc_async_read defaults its noc arg to noc_index (dataflow_api.h),
-        // and Noc{} default-constructs noc_id_ to noc_index (noc.h Noc() ctor) — so the surrounding
-        // noc_obj.async_read_barrier() flushes this transaction too.
-        //
-        // Suggested follow-up: extend the Device 2.0 NoC API with a `LocalL1` endpoint in
-        // tt_metal/hw/inc/api/dataflow/endpoints.h. It would mirror UnicastEndpoint (tag struct +
-        // noc_traits_t<LocalL1> with src_addr only) and let this block become
-        //     noc_obj.async_read(LocalL1{}, dst, input_page_size / 2,
-        //                        {.addr = MEM_ZEROS_BASE + input_page_size / 2}, {});
-        // — with an analogous write path for the noc_async_write(MEM_ZEROS_BASE, ...) caller in
-        // neighbor_pad_async/local_copy_writer.cpp. One shared endpoint covers all retained
-        // MEM_ZEROS callsites flagged by #45003 item 4.
+        // Device 2.0 migration: legacy primitive retained — MEM_ZEROS_BASE self-read has no typed Noc
+        // endpoint today. TODO(#45845): migrate to a LocalL1 endpoint once available.
         uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
         noc_async_read(zeros_noc_addr, l1_write_addr + input_page_size / 2, input_page_size / 2);
         l1_write_addr += input_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -49,8 +49,10 @@ void read_data(
             {.page_id = tile_id, .offset_bytes = (device_id % 2) * input_page_size / 2},
             {});
         // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read has no typed Noc trait
-        // (the local x/y are implicit in get_noc_addr(addr)). Issued on noc_index — same NoC as
-        // noc_obj — so the surrounding noc_obj.async_read_barrier() flushes both transactions.
+        // (the local x/y are implicit in get_noc_addr(addr)). Both this call and noc_obj issue on
+        // noc_index — legacy noc_async_read defaults its noc arg to noc_index (dataflow_api.h),
+        // and Noc{} default-constructs noc_id_ to noc_index (noc.h Noc() ctor) — so the surrounding
+        // noc_obj.async_read_barrier() flushes this transaction too.
         uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
         noc_async_read(zeros_noc_addr, l1_write_addr + input_page_size / 2, input_page_size / 2);
         l1_write_addr += input_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -53,6 +53,15 @@ void read_data(
         // noc_index — legacy noc_async_read defaults its noc arg to noc_index (dataflow_api.h),
         // and Noc{} default-constructs noc_id_ to noc_index (noc.h Noc() ctor) — so the surrounding
         // noc_obj.async_read_barrier() flushes this transaction too.
+        //
+        // Suggested follow-up: extend the Device 2.0 NoC API with a `LocalL1` endpoint in
+        // tt_metal/hw/inc/api/dataflow/endpoints.h. It would mirror UnicastEndpoint (tag struct +
+        // noc_traits_t<LocalL1> with src_addr only) and let this block become
+        //     noc_obj.async_read(LocalL1{}, dst, input_page_size / 2,
+        //                        {.addr = MEM_ZEROS_BASE + input_page_size / 2}, {});
+        // — with an analogous write path for the noc_async_write(MEM_ZEROS_BASE, ...) caller in
+        // neighbor_pad_async/local_copy_writer.cpp. One shared endpoint covers all retained
+        // MEM_ZEROS callsites flagged by #45003 item 4.
         uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
         noc_async_read(zeros_noc_addr, l1_write_addr + input_page_size / 2, input_page_size / 2);
         l1_write_addr += input_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -48,8 +48,9 @@ void read_data(
             input_page_size / 2,
             {.page_id = tile_id, .offset_bytes = (device_id % 2) * input_page_size / 2},
             {});
-        // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read does not map cleanly to a typed Noc
-        // trait.
+        // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read has no typed Noc trait
+        // (the local x/y are implicit in get_noc_addr(addr)). Issued on noc_index — same NoC as
+        // noc_obj — so the surrounding noc_obj.async_read_barrier() flushes both transactions.
         uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
         noc_async_read(zeros_noc_addr, l1_write_addr + input_page_size / 2, input_page_size / 2);
         l1_write_addr += input_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -48,7 +48,7 @@ void read_data(
             input_page_size / 2,
             {.page_id = tile_id, .offset_bytes = (device_id % 2) * input_page_size / 2},
             {});
-        // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read has no typed Noc trait
+        // Device 2.0 migration: legacy primitive retained: MEM_ZEROS_BASE self-read has no typed Noc trait
         // (the local x/y are implicit in get_noc_addr(addr)). Both this call and noc_obj issue on
         // noc_index — legacy noc_async_read defaults its noc arg to noc_index (dataflow_api.h),
         // and Noc{} default-constructs noc_id_ to noc_index (noc.h Noc() ctor) — so the surrounding

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ckernel.h"
 #include <cstdint>
 
@@ -25,6 +29,7 @@ constexpr uint32_t dst_inner_dims_size = get_compile_time_arg_val(10);
 
 template <typename AddrGenType>
 void read_data(
+    const Noc& noc_obj,
     uint32_t device_id,
     uint32_t tile_id,
     uint32_t& l1_write_addr,
@@ -32,13 +37,19 @@ void read_data(
     uint32_t c,
     bool last,
     uint32_t payload_size) {
+    CoreLocalMem<uint8_t> dst(l1_write_addr);
+
     // half tile output case: add padding to the last tile
     bool pad_last_half_tile = has_reader_tail && last;
     if (pad_last_half_tile) {
-        noc_async_read(
-            input_addrgen.get_noc_addr(tile_id, (device_id % 2) * input_page_size / 2),
-            l1_write_addr,
-            input_page_size / 2);
+        noc_obj.async_read(
+            input_addrgen,
+            dst,
+            input_page_size / 2,
+            {.page_id = tile_id, .offset_bytes = (device_id % 2) * input_page_size / 2},
+            {});
+        // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read does not map cleanly to a typed Noc
+        // trait.
         uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
         noc_async_read(zeros_noc_addr, l1_write_addr + input_page_size / 2, input_page_size / 2);
         l1_write_addr += input_page_size;
@@ -48,11 +59,14 @@ void read_data(
     // half tile output case: all odd devices write with half tile offset
     bool read_with_half_offset = has_reader_tail && device_id % 2 == 1;
     if (read_with_half_offset) {
-        noc_async_read(input_addrgen.get_noc_addr(tile_id, input_page_size / 2), l1_write_addr, input_page_size / 2);
-        noc_async_read(
-            input_addrgen.get_noc_addr(tile_id + inner_dims_size, 0),
-            l1_write_addr + input_page_size / 2,
-            input_page_size / 2);
+        noc_obj.async_read(
+            input_addrgen, dst, input_page_size / 2, {.page_id = tile_id, .offset_bytes = input_page_size / 2}, {});
+        noc_obj.async_read(
+            input_addrgen,
+            dst,
+            input_page_size / 2,
+            {.page_id = tile_id + inner_dims_size},
+            {.offset_bytes = input_page_size / 2});
         l1_write_addr += input_page_size;
         return;
     }
@@ -60,17 +74,19 @@ void read_data(
     // half tile input case: odd devices need to read with half tile offset starting from the second tile in block
     bool read_with_half_offset_for_writer = has_writer_tail && current_device_id % 2 == 1 && c > 0;
     if (read_with_half_offset_for_writer) {
-        noc_async_read(
-            input_addrgen.get_noc_addr(tile_id - last_dim_size, input_page_size / 2),
-            l1_write_addr,
-            input_page_size / 2);
-        noc_async_read(
-            input_addrgen.get_noc_addr(tile_id, 0), l1_write_addr + input_page_size / 2, input_page_size / 2);
+        noc_obj.async_read(
+            input_addrgen,
+            dst,
+            input_page_size / 2,
+            {.page_id = tile_id - last_dim_size, .offset_bytes = input_page_size / 2},
+            {});
+        noc_obj.async_read(
+            input_addrgen, dst, input_page_size / 2, {.page_id = tile_id}, {.offset_bytes = input_page_size / 2});
         l1_write_addr += input_page_size;
         return;
     }
 
-    noc_async_read(input_addrgen.get_noc_addr(tile_id), l1_write_addr, payload_size);
+    noc_obj.async_read(input_addrgen, dst, payload_size, {.page_id = tile_id}, {});
     l1_write_addr += payload_size;
 }
 
@@ -87,6 +103,9 @@ void kernel_main() {
     constexpr uint32_t split_num_tiles = (split_num_half_tiles + 1) / 2;
     constexpr bool has_pre_half_tile = has_writer_tail && current_device_id % 2 == 1;
     constexpr bool has_post_half_tile = has_writer_tail && current_device_id % 2 == 0;
+
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
 
     for (uint32_t did = 0; did < local_num_devices; ++did) {
         int32_t device_offset = get_arg_val<int32_t>(arg_idx++);
@@ -109,8 +128,8 @@ void kernel_main() {
 
         uint32_t block_idx = get_arg_val<uint32_t>(arg_idx++);
         uint32_t block_end_id = get_arg_val<uint32_t>(arg_idx++);
-        cb_reserve_back(cb0_id, 1);
-        address_t l1_write_addr = get_write_ptr(cb0_id);
+        cb0.reserve_back(1);
+        address_t l1_write_addr = cb0.get_write_ptr();
         uint32_t current_package_payload = 0;
         uint32_t current_tile = 0;
 
@@ -119,15 +138,16 @@ void kernel_main() {
 
             // If package is full, flush and start new package
             if (current_tile == 4 || current_package_payload + payload_size > 2 * input_page_size) {
-                noc_async_read_barrier();
-                cb_push_back(cb0_id, 1);
-                cb_reserve_back(cb0_id, 1);
-                l1_write_addr = get_write_ptr(cb0_id);
+                noc_obj.async_read_barrier();
+                cb0.push_back(1);
+                cb0.reserve_back(1);
+                l1_write_addr = cb0.get_write_ptr();
                 current_package_payload = 0;
                 current_tile = 0;
             }
 
             read_data(
+                noc_obj,
                 device_id,
                 tile_id,
                 l1_write_addr,
@@ -143,8 +163,8 @@ void kernel_main() {
 
         // Flush remaining tiles in the last package
         if (current_tile > 0) {
-            noc_async_read_barrier();
+            noc_obj.async_read_barrier();
         }
-        cb_push_back(cb0_id, 1);
+        cb0.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -33,6 +35,7 @@ inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
 }
 
 void write_data(
+    const Noc& noc_obj,
     uint64_t dest_addrs[4],
     uint16_t payload_sizes[4],
     uint32_t parts_count,
@@ -45,13 +48,17 @@ void write_data(
     bool local = device_offset == 0;
     if (local) {
         if (last) {
+            // Legacy primitive retained (#45003 item 4): semaphore inc targets a precomposed NoC address rather than a
+            // semaphore id, so Semaphore<> does not apply.
             noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
         }
         for (uint32_t part = 0; part < parts_count; ++part) {
+            // Legacy primitive retained (#45003 item 4): destination is a precomposed uint64_t NoC address that does
+            // not map to a typed endpoint.
             noc_async_write(l1_read_addr, dest_addrs[part], payload_sizes[part]);
             l1_read_addr += payload_sizes[part];
         }
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     } else {
         if (last) {
             // TODO: reduce number of packages when atomic fused with scatter will be introduced
@@ -72,7 +79,7 @@ void write_data(
                         select_connection(fabric_connection, device_offset), l1_read_addr, payload_sizes[0], pkt_hdr);
                     l1_read_addr += payload_sizes[0];
                 }
-                noc_async_writes_flushed();
+                noc_obj.async_writes_flushed();
             }
 
             pkt_hdr->to_noc_fused_unicast_write_atomic_inc(
@@ -95,7 +102,7 @@ void write_data(
                 select_connection(fabric_connection, device_offset), l1_read_addr, scatter_payload, pkt_hdr);
         }
     }
-    noc_async_writes_flushed();
+    noc_obj.async_writes_flushed();
 }
 
 void kernel_main() {
@@ -137,19 +144,23 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* global_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_sema_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_sema_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_sema_forward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_sema_backward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -222,13 +233,16 @@ void kernel_main() {
         uint32_t local_init_semaphore_addr_ptr = reinterpret_cast<uint32_t>(global_init_semaphore_addr_ptr);
 
         if (mcast_size > 1) {
+            // Legacy primitives retained (#45003 item 4): mcast semaphore set + companion wait use raw L1 addresses
+            // (program factory passes addresses, not semaphore ids), so Semaphore<> does not apply.
             noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
             noc_semaphore_set_multicast_loopback_src(
                 local_init_semaphore_addr_ptr, local_set_semaphore_noc_addr, mcast_size, false);
-            noc_async_write_barrier();
+            noc_obj.async_write_barrier();
         }
     }
 
+    // Legacy primitives retained (#45003 item 4): semaphore wait/set on raw L1 address (not a semaphore id).
     noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
     noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
 
@@ -267,8 +281,8 @@ void kernel_main() {
         uint32_t block_idx = get_arg_val<uint32_t>(device_offsets_idx++);
         uint32_t block_end_id = get_arg_val<uint32_t>(device_offsets_idx++);
 
-        cb_wait_front(cb0_id, 1);
-        size_t l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(1);
+        size_t l1_read_addr = cb0.get_read_ptr();
         uint32_t current_package_payload = 0;
         uint32_t current_tile = 0;
         uint64_t dst_addrs[4] = {0};
@@ -278,6 +292,7 @@ void kernel_main() {
             // If package is full, flush and start new package
             if (current_tile == 4 || current_package_payload + payload_size > 2 * output_page_size) {
                 write_data(
+                    noc_obj,
                     dst_addrs,
                     payload_sizes,
                     current_tile,
@@ -287,9 +302,9 @@ void kernel_main() {
                     output_semaphore_noc_addr_in_pkt,
                     device_offset,
                     false);
-                cb_pop_front(cb0_id, 1);
-                cb_wait_front(cb0_id, 1);
-                l1_read_addr = get_read_ptr(cb0_id);
+                cb0.pop_front(1);
+                cb0.wait_front(1);
+                l1_read_addr = cb0.get_read_ptr();
                 current_package_payload = 0;
                 current_tile = 0;
             }
@@ -303,6 +318,7 @@ void kernel_main() {
         // Flush remaining tiles in the last package
         if (current_tile > 0) {
             write_data(
+                noc_obj,
                 dst_addrs,
                 payload_sizes,
                 current_tile,
@@ -313,12 +329,13 @@ void kernel_main() {
                 device_offset,
                 true);
         }
-        cb_pop_front(cb0_id, 1);
+        cb0.pop_front(1);
     }
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
     fabric_connection.close();
     if (core_id == 0 && link_id == 0) {
+        // Legacy primitives retained (#45003 item 4): semaphore wait/set on raw L1 address (not a semaphore id).
         noc_semaphore_wait(global_semaphore_addr_ptr, semaphore_expected_value);
         noc_semaphore_set(global_semaphore_addr_ptr, 0);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -48,13 +48,11 @@ void write_data(
     bool local = device_offset == 0;
     if (local) {
         if (last) {
-            // Legacy primitive retained (#45003 item 4): semaphore inc targets a precomposed NoC address rather than a
-            // semaphore id, so Semaphore<> does not apply.
+            // Device 2.0 migration: legacy primitive retained: semaphore inc targets a precomposed NoC address rather
+            // than a semaphore id, so Semaphore<> does not apply.
             noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
         }
         for (uint32_t part = 0; part < parts_count; ++part) {
-            // Legacy primitive retained (#45003 item 4): destination is a precomposed uint64_t NoC address that does
-            // not map to a typed endpoint.
             noc_async_write(l1_read_addr, dest_addrs[part], payload_sizes[part]);
             l1_read_addr += payload_sizes[part];
         }
@@ -233,11 +231,11 @@ void kernel_main() {
         uint32_t local_init_semaphore_addr_ptr = reinterpret_cast<uint32_t>(global_init_semaphore_addr_ptr);
 
         if (mcast_size > 1) {
-            // Legacy primitives retained (#45003 item 4): global_init_semaphore_addr is a GlobalSemaphore address
+            // Device 2.0 migration: legacy primitives retained, global_init_semaphore_addr is a GlobalSemaphore address
             // (init_barrier_semaphore in the program factory). GlobalSemaphore exposes only address() — no id().
             // Semaphore<>::wait cannot wrap it. Additionally, set_multicast_loopback_src writes the destination
             // semaphore at a different L1 offset than the local source semaphore, which Semaphore<>::set_multicast
-            // does not support (it reuses the sender's L1 offset). Both structural — not migration backlog.
+            // does not support (it reuses the sender's L1 offset).
             noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
             noc_semaphore_set_multicast_loopback_src(
                 local_init_semaphore_addr_ptr, local_set_semaphore_noc_addr, mcast_size, false);
@@ -245,8 +243,6 @@ void kernel_main() {
         }
     }
 
-    // Legacy primitives retained (#45003 item 4): global_init_semaphore is a GlobalSemaphore address (see
-    // structural-reason note above on the mcast site).
     noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
     noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
 
@@ -339,10 +335,7 @@ void kernel_main() {
     noc_obj.async_write_barrier();
     fabric_connection.close();
     if (core_id == 0 && link_id == 0) {
-        // Legacy primitives retained (#45003 item 4): global_semaphore_addr is a GlobalSemaphore address
-        // (final_barrier_semaphore in the program factory). GlobalSemaphore exposes only address() — no id().
-        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
-        // Structural limitation, not a migration backlog item.
+        // Device 2.0 migration: legacy primitives retained, global_semaphore_addr is a GlobalSemaphore address.
         noc_semaphore_wait(global_semaphore_addr_ptr, semaphore_expected_value);
         noc_semaphore_set(global_semaphore_addr_ptr, 0);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -233,8 +233,11 @@ void kernel_main() {
         uint32_t local_init_semaphore_addr_ptr = reinterpret_cast<uint32_t>(global_init_semaphore_addr_ptr);
 
         if (mcast_size > 1) {
-            // Legacy primitives retained (#45003 item 4): mcast semaphore set + companion wait use raw L1 addresses
-            // (program factory passes addresses, not semaphore ids), so Semaphore<> does not apply.
+            // Legacy primitives retained (#45003 item 4): global_init_semaphore_addr is a GlobalSemaphore address
+            // (init_barrier_semaphore in the program factory). GlobalSemaphore exposes only address() — no id().
+            // Semaphore<>::wait cannot wrap it. Additionally, set_multicast_loopback_src writes the destination
+            // semaphore at a different L1 offset than the local source semaphore, which Semaphore<>::set_multicast
+            // does not support (it reuses the sender's L1 offset). Both structural — not migration backlog.
             noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
             noc_semaphore_set_multicast_loopback_src(
                 local_init_semaphore_addr_ptr, local_set_semaphore_noc_addr, mcast_size, false);
@@ -242,7 +245,8 @@ void kernel_main() {
         }
     }
 
-    // Legacy primitives retained (#45003 item 4): semaphore wait/set on raw L1 address (not a semaphore id).
+    // Legacy primitives retained (#45003 item 4): global_init_semaphore is a GlobalSemaphore address (see
+    // structural-reason note above on the mcast site).
     noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
     noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
 
@@ -335,7 +339,10 @@ void kernel_main() {
     noc_obj.async_write_barrier();
     fabric_connection.close();
     if (core_id == 0 && link_id == 0) {
-        // Legacy primitives retained (#45003 item 4): semaphore wait/set on raw L1 address (not a semaphore id).
+        // Legacy primitives retained (#45003 item 4): global_semaphore_addr is a GlobalSemaphore address
+        // (final_barrier_semaphore in the program factory). GlobalSemaphore exposes only address() — no id().
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+        // Structural limitation, not a migration backlog item.
         noc_semaphore_wait(global_semaphore_addr_ptr, semaphore_expected_value);
         noc_semaphore_set(global_semaphore_addr_ptr, 0);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
@@ -76,8 +76,10 @@ void kernel_main() {
         uint32_t tiles_to_read = start_tiles_to_read;
         while (tiles_read < tiles_to_read) {
             if (do_reduce) {
-                // Legacy primitive retained (#45003 item 4): program factory passes
-                // op_semaphore.address() rather than a semaphore id, so Semaphore<> can't bind.
+                // Legacy primitive retained (#45003 item 4): op_semaphore is a GlobalSemaphore address
+                // (deepseek_moe_reduce_scatter_program_factory.cpp). GlobalSemaphore exposes only address() —
+                // there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
+                // wrap a GlobalSemaphore. Structural limitation, not a migration backlog item.
                 noc_semaphore_wait_min(
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), semaphore_target_val + 1);
                 semaphore_target_val++;
@@ -100,6 +102,7 @@ void kernel_main() {
     }
 
     // reset the semaphore
-    // Legacy primitive retained (#45003 item 4): semaphore address-based; see comment above.
+    // Legacy primitive retained (#45003 item 4): op_semaphore is a GlobalSemaphore address (see structural-reason
+    // note above on the wait_min site).
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t ring_size = get_compile_time_arg_val(1);
@@ -68,21 +69,25 @@ void kernel_main() {
         bool do_reduce = i != 0;
         uint32_t input_slice_cb_id = input_slice_cb_ids[actual_slice_idx];
         uint32_t intermediate_slice_cb_id = intermediate_slice_cb_ids[actual_slice_idx];
+        CircularBuffer cb_input_slice(input_slice_cb_id);
+        CircularBuffer cb_intermediate_slice(intermediate_slice_cb_id);
 
         uint32_t tiles_read = start_tiles_read;
         uint32_t tiles_to_read = start_tiles_to_read;
         while (tiles_read < tiles_to_read) {
             if (do_reduce) {
+                // Legacy primitive retained (#45003 item 4): program factory passes
+                // op_semaphore.address() rather than a semaphore id, so Semaphore<> can't bind.
                 noc_semaphore_wait_min(
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), semaphore_target_val + 1);
                 semaphore_target_val++;
             }
 
             if (do_reduce) {
-                cb_push_back(intermediate_slice_cb_id, tile_granularity);
+                cb_intermediate_slice.push_back(tile_granularity);
             }
 
-            cb_push_back(input_slice_cb_id, tile_granularity);
+            cb_input_slice.push_back(tile_granularity);
             tiles_read += tile_granularity;
         }
 
@@ -95,5 +100,6 @@ void kernel_main() {
     }
 
     // reset the semaphore
+    // Legacy primitive retained (#45003 item 4): semaphore address-based; see comment above.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reader.cpp
@@ -76,10 +76,7 @@ void kernel_main() {
         uint32_t tiles_to_read = start_tiles_to_read;
         while (tiles_read < tiles_to_read) {
             if (do_reduce) {
-                // Legacy primitive retained (#45003 item 4): op_semaphore is a GlobalSemaphore address
-                // (deepseek_moe_reduce_scatter_program_factory.cpp). GlobalSemaphore exposes only address() —
-                // there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot
-                // wrap a GlobalSemaphore. Structural limitation, not a migration backlog item.
+                // Device 2.0 migration: legacy primitive retained, op_semaphore is a GlobalSemaphore address.
                 noc_semaphore_wait_min(
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), semaphore_target_val + 1);
                 semaphore_target_val++;
@@ -102,7 +99,6 @@ void kernel_main() {
     }
 
     // reset the semaphore
-    // Legacy primitive retained (#45003 item 4): op_semaphore is a GlobalSemaphore address (see structural-reason
-    // note above on the wait_min site).
+    // Device 2.0 migration: legacy primitive retained, op_semaphore is a GlobalSemaphore address.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(op_semaphore), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_reduction.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t ring_size = get_compile_time_arg_val(1);
@@ -77,6 +78,9 @@ void kernel_main() {
 
         uint32_t input_slice_cb_id = input_slice_cb_ids[actual_slice_idx];
         uint32_t intermediate_slice_cb_id = intermediate_slice_cb_ids[actual_slice_idx];
+        CircularBuffer cb_input_slice(input_slice_cb_id);
+        CircularBuffer cb_intermediate_slice(intermediate_slice_cb_id);
+        CircularBuffer cb_compute(compute_cb_id);
 
         binary_op_init_common(input_slice_cb_id, intermediate_slice_cb_id, compute_cb_id);
         add_tiles_init(input_slice_cb_id, intermediate_slice_cb_id, false);
@@ -84,18 +88,18 @@ void kernel_main() {
         uint32_t tiles_read = start_tiles_read;
         uint32_t tiles_to_read = start_tiles_to_read;
         while (tiles_read < tiles_to_read) {
-            cb_wait_front(input_slice_cb_id, tile_granularity);
-            cb_wait_front(intermediate_slice_cb_id, tile_granularity);
-            cb_reserve_back(compute_cb_id, tile_granularity);
+            cb_input_slice.wait_front(tile_granularity);
+            cb_intermediate_slice.wait_front(tile_granularity);
+            cb_compute.reserve_back(tile_granularity);
             acquire_dst();
             for (uint32_t tile_id = 0; tile_id < tile_granularity; ++tile_id) {
                 add_tiles(input_slice_cb_id, intermediate_slice_cb_id, tile_id, tile_id, tile_id);
                 pack_tile(tile_id, compute_cb_id);
             }
             release_dst();
-            cb_pop_front(input_slice_cb_id, tile_granularity);
-            cb_pop_front(intermediate_slice_cb_id, tile_granularity);
-            cb_push_back(compute_cb_id, tile_granularity);
+            cb_input_slice.pop_front(tile_granularity);
+            cb_intermediate_slice.pop_front(tile_granularity);
+            cb_compute.push_back(tile_granularity);
             tiles_read += tile_granularity;
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/linear/addrgen_api.h"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
@@ -151,9 +153,12 @@ void kernel_main() {
         page_size * 2);
 
     // execute pre op barrier wait phase
+    // Legacy primitives retained (#45003 item 4): program factory passes
+    // pre_op_barrier_semaphore.address() rather than a semaphore id, so Semaphore<> can't bind.
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pre_op_barrier_semaphore), 1);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pre_op_barrier_semaphore), 0);
 
+    Noc noc_obj;
     int slice_idx = direction ? my_chip_id - 1 : my_chip_id + 1;
     for (uint32_t i = 0; i < ring_size; ++i) {
         uint32_t actual_slice_idx;
@@ -164,6 +169,7 @@ void kernel_main() {
         }
 
         uint32_t reduced_cb_id = i == 0 ? input_slice_cb_ids[actual_slice_idx] : compute_cb_id;
+        CircularBuffer cb_reduced(reduced_cb_id);
 
         uint32_t tiles_read = start_tiles_read;
         uint32_t tiles_to_read = start_tiles_to_read;
@@ -223,8 +229,8 @@ void kernel_main() {
                 }
 
                 // op hardcoded for each worker handling even multiple of 2 tiles, so always use scatter_write
-                cb_wait_front(reduced_cb_id, tile_granularity);
-                uint32_t intermediate_slice_l1_read_addr = get_read_ptr(reduced_cb_id);
+                cb_reduced.wait_front(tile_granularity);
+                uint32_t intermediate_slice_l1_read_addr = cb_reduced.get_read_ptr();
                 fabric_unicast_noc_fused_scatter_write_atomic_inc_with_state<
                     UnicastFusedScatterWriteAtomicIncUpdateMask::WriteDstAddrs>(
                     fabric_connection,
@@ -237,21 +243,24 @@ void kernel_main() {
                         1,
                         true));
 
-                noc_async_writes_flushed();
-                cb_pop_front(reduced_cb_id, tile_granularity);
+                noc_obj.async_writes_flushed();
+                cb_reduced.pop_front(tile_granularity);
             }
         } else {
             while (tiles_read < tiles_to_read) {
-                cb_wait_front(reduced_cb_id, tile_granularity);
-                uint32_t output_l1_read_addr = get_read_ptr(reduced_cb_id);
+                cb_reduced.wait_front(tile_granularity);
+                uint32_t output_l1_read_addr = cb_reduced.get_read_ptr();
                 for (uint32_t j = 0; j < tile_granularity; ++j) {
+                    // Legacy primitive retained (#45003 item 4): writes a single page
+                    // via TensorAccessor with manual l1-read-addr arithmetic; not a clean
+                    // match for Noc::async_write's endpoint-based forms.
                     noc_async_write_page(tiles_read, output_tensor_accessor, output_l1_read_addr);
                     output_l1_read_addr += page_size;
                     tiles_read++;
                 }
 
-                noc_async_writes_flushed();
-                cb_pop_front(reduced_cb_id, tile_granularity);
+                noc_obj.async_writes_flushed();
+                cb_reduced.pop_front(tile_granularity);
             }
         }
 
@@ -265,6 +274,6 @@ void kernel_main() {
 
     close_connections(fabric_connection);
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
@@ -153,8 +153,10 @@ void kernel_main() {
         page_size * 2);
 
     // execute pre op barrier wait phase
-    // Legacy primitives retained (#45003 item 4): program factory passes
-    // pre_op_barrier_semaphore.address() rather than a semaphore id, so Semaphore<> can't bind.
+    // Legacy primitives retained (#45003 item 4): pre_op_barrier_semaphore is a GlobalSemaphore address
+    // (deepseek_moe_reduce_scatter_program_factory.cpp). GlobalSemaphore exposes only address() — there is no
+    // id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+    // Structural limitation, not a migration backlog item.
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pre_op_barrier_semaphore), 1);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pre_op_barrier_semaphore), 0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
@@ -153,10 +153,7 @@ void kernel_main() {
         page_size * 2);
 
     // execute pre op barrier wait phase
-    // Legacy primitives retained (#45003 item 4): pre_op_barrier_semaphore is a GlobalSemaphore address
-    // (deepseek_moe_reduce_scatter_program_factory.cpp). GlobalSemaphore exposes only address() — there is no
-    // id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
-    // Structural limitation, not a migration backlog item.
+    // Device 2.0 migration: legacy primitives retained, pre_op_barrier_semaphore is a GlobalSemaphore address.
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pre_op_barrier_semaphore), 1);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pre_op_barrier_semaphore), 0);
 
@@ -253,9 +250,8 @@ void kernel_main() {
                 cb_reduced.wait_front(tile_granularity);
                 uint32_t output_l1_read_addr = cb_reduced.get_read_ptr();
                 for (uint32_t j = 0; j < tile_granularity; ++j) {
-                    // Legacy primitive retained (#45003 item 4): writes a single page
-                    // via TensorAccessor with manual l1-read-addr arithmetic; not a clean
-                    // match for Noc::async_write's endpoint-based forms.
+                    // Device 2.0 migration: no Device 2.0 endpoint for "raw local L1 address as write source."
+                    // Same gap as MEM_ZEROS callsites.
                     noc_async_write_page(tiles_read, output_tensor_accessor, output_l1_read_addr);
                     output_l1_read_addr += page_size;
                     tiles_read++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/kernels/deepseek_moe_reduce_scatter_writer.cpp
@@ -250,8 +250,8 @@ void kernel_main() {
                 cb_reduced.wait_front(tile_granularity);
                 uint32_t output_l1_read_addr = cb_reduced.get_read_ptr();
                 for (uint32_t j = 0; j < tile_granularity; ++j) {
-                    // Device 2.0 migration: no Device 2.0 endpoint for "raw local L1 address as write source."
-                    // Same gap as MEM_ZEROS callsites.
+                    // Device 2.0 migration: legacy primitive retained — no endpoint today for "raw local L1
+                    // address as NoC write source." TODO(#45845): migrate to a LocalL1 endpoint once available.
                     noc_async_write_page(tiles_read, output_tensor_accessor, output_l1_read_addr);
                     output_l1_read_addr += page_size;
                     tiles_read++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/compute/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/compute/reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -17,15 +18,18 @@ void kernel_main() {
     constexpr uint32_t total_pages = num_devices * num_pages_per_packet;
     constexpr uint32_t num_device_pairs = num_devices / 2;  // num_devices is always even
 
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
+
     // Initialize binary operations - use the same constants consistently
     binary_op_init_common(fabric_receiver_cb_id, fabric_receiver_cb_id, accumulator_cb_id);
     add_tiles_init(fabric_receiver_cb_id, fabric_receiver_cb_id, true);
 
     // Wait for input data once before beginning processing
-    cb_wait_front(fabric_receiver_cb_id, total_pages);
+    cb_fabric_receiver.wait_front(total_pages);
 
     // Reserve output space once before processing
-    cb_reserve_back(accumulator_cb_id, num_pages_per_packet);
+    cb_accumulator.reserve_back(num_pages_per_packet);
 
     // Process tiles in pairs for efficient addition
     tile_regs_acquire();
@@ -54,6 +58,6 @@ void kernel_main() {
     }
     tile_regs_release();
 
-    cb_pop_front(fabric_receiver_cb_id, total_pages);
-    cb_push_back(accumulator_cb_id, num_pages_per_packet);
+    cb_fabric_receiver.pop_front(total_pages);
+    cb_accumulator.push_back(num_pages_per_packet);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -61,9 +61,11 @@ void kernel_main() {
     constexpr uint32_t total_senders = num_sender_cores * other_devices;
 
     // Runtime arguments
-    // Legacy primitive retained (#45003 item 4): program factory passes
-    // cross_device_semaphore->address() rather than a semaphore id, so Semaphore<>
-    // can't bind. Keep the raw address handle for downstream noc_semaphore_* calls.
+    // Legacy primitive retained (#45003 item 4): cross_device_semaphore is a GlobalSemaphore
+    // (llama_reduce_scatter_program_factory.cpp). GlobalSemaphore exposes only address() — there is no id().
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+    // Structural limitation, not a migration backlog item. Keep the raw address handle for downstream
+    // noc_semaphore_* calls.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
     Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -159,13 +159,13 @@ void kernel_main() {
         }
 
         // Legacy primitive retained: see receiver_semaphore_address note.
-        noc_semaphore_wait((uint32_t*)receiver_semaphore_address, other_devices);
+        noc_semaphore_wait(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_address), other_devices);
 
         noc_obj.async_read_barrier();
         cb_fabric_receiver.push_back(num_pages_per_packet * num_devices);
     }
     local_sem.set(INVALID);
     // Legacy primitive retained: see receiver_semaphore_address note.
-    noc_semaphore_set((uint32_t*)receiver_semaphore_address, INVALID);
+    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_address), INVALID);
     noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 // #include <unistd.h>
@@ -58,8 +61,11 @@ void kernel_main() {
     constexpr uint32_t total_senders = num_sender_cores * other_devices;
 
     // Runtime arguments
+    // Legacy primitive retained (#45003 item 4): program factory passes
+    // cross_device_semaphore->address() rather than a semaphore id, so Semaphore<>
+    // can't bind. Keep the raw address handle for downstream noc_semaphore_* calls.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
-    uint32_t local_semaphore_address = get_semaphore(get_arg_val<uint32_t>(rt_arg_idx++));
+    Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     bool worker_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t linear_input_packet_start_idx = get_arg_val<uint32_t>(rt_arg_idx++);
@@ -68,18 +74,21 @@ void kernel_main() {
     uint32_t sender_shard_end = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t sender_total_num_pages = get_arg_val<uint32_t>(rt_arg_idx++);
 
+    Noc noc_obj;
+    CircularBuffer cb_input_tensor(input_tensor_cb_id);
+    CircularBuffer cb_fabric_sender(fabric_sender_cb_id);
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+
     // Get signal here
     if constexpr (needs_signaler) {
-        uint32_t signaler_semaphore_address = get_semaphore(get_arg_val<uint32_t>(rt_arg_idx++));
-        volatile tt_l1_ptr uint32_t* signaler_semaphore_address_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signaler_semaphore_address);
-        noc_semaphore_wait(signaler_semaphore_address_ptr, 1);
+        Semaphore<> signaler_sem(get_arg_val<uint32_t>(rt_arg_idx++));
+        signaler_sem.wait(1);
     }
 
     // Bank base addresses (compute once)
-    const uint32_t bank_base_address = get_write_ptr(input_tensor_cb_id);
+    const uint32_t bank_base_address = cb_input_tensor.get_write_ptr();
 
-    uint32_t sender_read_addr = get_write_ptr(fabric_sender_cb_id);
+    uint32_t sender_read_addr = cb_fabric_sender.get_write_ptr();
 
     if (sender_core) {
         for (uint32_t target_device_id : device_order) {
@@ -103,12 +112,14 @@ void kernel_main() {
                 const uint64_t shard_noc_addr = get_noc_addr(x, y, offset_address);
                 const uint32_t transfer_size = read_size * page_size_bytes;
 
-                cb_reserve_back(fabric_sender_cb_id, num_pages_reserve_push);
+                cb_fabric_sender.reserve_back(num_pages_reserve_push);
+                // Legacy primitive retained (#45003 item 4): precomposed uint64_t shard
+                // noc address; clean mapping to UnicastEndpoint is not worth the churn.
                 noc_async_read(shard_noc_addr, sender_read_addr, transfer_size);
 
                 if (num_pages_reserve_push >= curr_packet_num_pages) {
-                    noc_async_read_barrier();
-                    cb_push_back(fabric_sender_cb_id, num_pages_reserve_push);
+                    noc_obj.async_read_barrier();
+                    cb_fabric_sender.push_back(num_pages_reserve_push);
                     num_pages_reserve_push = 0;
                 }
 
@@ -119,8 +130,8 @@ void kernel_main() {
         }
     } else if (worker_core) {
         // Calculate base addresses once
-        const uint32_t base_input_tensor_addr = get_read_ptr(input_tensor_cb_id);
-        const uint32_t base_receiver_l1_addresses = get_write_ptr(fabric_receiver_cb_id) + chip_id_offset;
+        const uint32_t base_input_tensor_addr = cb_input_tensor.get_read_ptr();
+        const uint32_t base_receiver_l1_addresses = cb_fabric_receiver.get_write_ptr() + chip_id_offset;
 
         for (uint32_t i = 0; i < num_pages_per_packet; i++) {
             const uint32_t rem = linear_input_packet_start_idx + i;
@@ -138,15 +149,18 @@ void kernel_main() {
             const uint64_t output_noc_address = get_noc_addr(core_x, core_y, base_input_tensor_addr + tile_offset);
             const uint32_t receiver_l1_address = base_receiver_l1_addresses + i * page_size_bytes;
 
+            // Legacy primitive retained (#45003 item 4): precomposed uint64_t noc address.
             noc_async_read(output_noc_address, receiver_l1_address, page_size_bytes);
         }
 
+        // Legacy primitive retained (#45003 item 4): see receiver_semaphore_address note.
         noc_semaphore_wait((uint32_t*)receiver_semaphore_address, other_devices);
 
-        noc_async_read_barrier();
-        cb_push_back(fabric_receiver_cb_id, num_pages_per_packet * num_devices);
+        noc_obj.async_read_barrier();
+        cb_fabric_receiver.push_back(num_pages_per_packet * num_devices);
     }
-    noc_semaphore_set((uint32_t*)local_semaphore_address, INVALID);
+    local_sem.set(INVALID);
+    // Legacy primitive retained (#45003 item 4): see receiver_semaphore_address note.
     noc_semaphore_set((uint32_t*)receiver_semaphore_address, INVALID);
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 // #include <unistd.h>
@@ -111,13 +113,15 @@ void kernel_main() {
                 const uint32_t x = input_core_xy[curr_core][x_index];
                 const uint32_t y = input_core_xy[curr_core][y_index];
                 const uint32_t offset_address = bank_base_address + (read_offset * page_size_bytes);
-                const uint64_t shard_noc_addr = get_noc_addr(x, y, offset_address);
                 const uint32_t transfer_size = read_size * page_size_bytes;
 
                 cb_fabric_sender.reserve_back(num_pages_reserve_push);
-                // Legacy primitive retained (#45003 item 4): precomposed uint64_t shard
-                // noc address; clean mapping to UnicastEndpoint is not worth the churn.
-                noc_async_read(shard_noc_addr, sender_read_addr, transfer_size);
+                noc_obj.async_read(
+                    UnicastEndpoint{},
+                    CoreLocalMem<uint8_t>(sender_read_addr),
+                    transfer_size,
+                    {.noc_x = x, .noc_y = y, .addr = offset_address},
+                    {});
 
                 if (num_pages_reserve_push >= curr_packet_num_pages) {
                     noc_obj.async_read_barrier();
@@ -148,11 +152,14 @@ void kernel_main() {
             const uint32_t core_y = input_core_xy[linear_input_core_idcs][y_index];
             const uint32_t tile_offset = linear_input_tile_offsets * page_size_bytes;
 
-            const uint64_t output_noc_address = get_noc_addr(core_x, core_y, base_input_tensor_addr + tile_offset);
             const uint32_t receiver_l1_address = base_receiver_l1_addresses + i * page_size_bytes;
 
-            // Legacy primitive retained (#45003 item 4): precomposed uint64_t noc address.
-            noc_async_read(output_noc_address, receiver_l1_address, page_size_bytes);
+            noc_obj.async_read(
+                UnicastEndpoint{},
+                CoreLocalMem<uint8_t>(receiver_l1_address),
+                page_size_bytes,
+                {.noc_x = core_x, .noc_y = core_y, .addr = base_input_tensor_addr + tile_offset},
+                {});
         }
 
         // Legacy primitive retained (#45003 item 4): see receiver_semaphore_address note.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -63,11 +63,7 @@ void kernel_main() {
     constexpr uint32_t total_senders = num_sender_cores * other_devices;
 
     // Runtime arguments
-    // Legacy primitive retained (#45003 item 4): cross_device_semaphore is a GlobalSemaphore
-    // (llama_reduce_scatter_program_factory.cpp). GlobalSemaphore exposes only address() — there is no id().
-    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
-    // Structural limitation, not a migration backlog item. Keep the raw address handle for downstream
-    // noc_semaphore_* calls.
+    // Device 2.0 migration: legacy primitive retained, cross_device_semaphore is a GlobalSemaphore.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
     Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
@@ -162,14 +158,14 @@ void kernel_main() {
                 {});
         }
 
-        // Legacy primitive retained (#45003 item 4): see receiver_semaphore_address note.
+        // Legacy primitive retained: see receiver_semaphore_address note.
         noc_semaphore_wait((uint32_t*)receiver_semaphore_address, other_devices);
 
         noc_obj.async_read_barrier();
         cb_fabric_receiver.push_back(num_pages_per_packet * num_devices);
     }
     local_sem.set(INVALID);
-    // Legacy primitive retained (#45003 item 4): see receiver_semaphore_address note.
+    // Legacy primitive retained: see receiver_semaphore_address note.
     noc_semaphore_set((uint32_t*)receiver_semaphore_address, INVALID);
     noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -198,7 +198,7 @@ void kernel_main() {
 
         // Process all tiles
         for (uint32_t tile = 0; tile < num_packets; tile++) {
-            // Legacy primitive retained (#45003 item 4): precomposed uint64_t noc_addresses[].
+            // Device 2.0 migration: legacy primitive retained, precomposed uint64_t noc_addresses[]
             noc_async_write(accumulator_l1_addresses[tile], noc_addresses[tile], page_size_bytes);
         }
         noc_obj.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -88,6 +90,13 @@ void kernel_main() {
     uint32_t sender_packet_start = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t sender_packet_end = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t sender_total_num_pages = get_arg_val<uint32_t>(rt_arg_idx++);
+
+    Noc noc_obj;
+    CircularBuffer cb_fabric_sender(fabric_sender_cb_id);
+    CircularBuffer cb_packet_header(packet_header_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
+    CircularBuffer cb_output_tensor(output_tensor_cb_id);
+
     if (sender_core) {
         auto fabric_connection =
             FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
@@ -96,7 +105,7 @@ void kernel_main() {
         constexpr uint8_t device_order[other_devices] =
             DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
         constexpr uint8_t packet_worker_cores[num_packet_worker_cores][2] = PACKET_WORKER_CORES;
-        const auto packet_header_buffer_addr = get_read_ptr(packet_header_cb_id);
+        const auto packet_header_buffer_addr = cb_packet_header.get_read_ptr();
         auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
         auto* sem_inc_packet_header =
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr + packet_header_size);
@@ -105,7 +114,8 @@ void kernel_main() {
         sem_inc_packet_header->to_noc_unicast_atomic_inc(
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sem_noc_addr, static_cast<uint32_t>(1)});  // increment 1
 
-        const uint32_t base_receiver_l1_addr = get_read_ptr(fabric_receiver_cb_id);
+        CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+        const uint32_t base_receiver_l1_addr = cb_fabric_receiver.get_read_ptr();
 
         // Precompute the packet offset once
         const uint32_t packet_offset = base_receiver_l1_addr + chip_id_offset;
@@ -133,8 +143,8 @@ void kernel_main() {
                 const uint64_t noc0_dest_noc_addr =
                     safe_get_noc_addr(receiver_core_x, receiver_core_y, packet_offset, 0);
 
-                cb_wait_front(fabric_sender_cb_id, curr_packet_num_pages);
-                const auto sender_l1_addr = get_read_ptr(fabric_sender_cb_id);
+                cb_fabric_sender.wait_front(curr_packet_num_pages);
+                const auto sender_l1_addr = cb_fabric_sender.get_read_ptr();
 
                 const uint64_t sem_noc_addr =
                     safe_get_noc_addr(receiver_core_x, receiver_core_y, receiver_semaphore_address, 0);
@@ -150,7 +160,7 @@ void kernel_main() {
                 fabric_conn.send_payload_flush_blocking_from_address(
                     (uint32_t)unicast_packet_header, packet_header_size);
 
-                cb_pop_front(fabric_sender_cb_id, curr_packet_num_pages);
+                cb_fabric_sender.pop_front(curr_packet_num_pages);
 
                 num_pages_sent += curr_packet_num_pages;
                 packet++;
@@ -165,8 +175,8 @@ void kernel_main() {
         constexpr uint8_t output_core_xy[output_cores_per_device][2] = OUTPUT_CORE_XY;
         uint64_t noc_addresses[num_pages_per_packet];
         uint32_t accumulator_l1_addresses[num_pages_per_packet];
-        uint32_t output_tensor_base_addr = get_read_ptr(output_tensor_cb_id);
-        auto accumulator_l1_addr = get_read_ptr(accumulator_cb_id);
+        uint32_t output_tensor_base_addr = cb_output_tensor.get_read_ptr();
+        auto accumulator_l1_addr = cb_accumulator.get_read_ptr();
 
         uint32_t num_packets = num_pages_per_packet;
         for (uint32_t i = 0; i < num_pages_per_packet; i++) {
@@ -184,16 +194,17 @@ void kernel_main() {
             accumulator_l1_addresses[i] = accumulator_l1_addr + i * page_size_bytes;
         }
 
-        cb_wait_front(accumulator_cb_id, num_pages_per_packet);
+        cb_accumulator.wait_front(num_pages_per_packet);
 
         // Process all tiles
         for (uint32_t tile = 0; tile < num_packets; tile++) {
+            // Legacy primitive retained (#45003 item 4): precomposed uint64_t noc_addresses[].
             noc_async_write(accumulator_l1_addresses[tile], noc_addresses[tile], page_size_bytes);
         }
-        noc_async_write_barrier();
-        cb_pop_front(accumulator_cb_id, num_pages_per_packet);
+        noc_obj.async_write_barrier();
+        cb_accumulator.pop_front(num_pages_per_packet);
 #else
-        cb_wait_front(output_tensor_cb_id, num_pages_per_packet);
+        cb_output_tensor.wait_front(num_pages_per_packet);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include <cstdint>
@@ -41,6 +43,8 @@ constexpr uint32_t PREFETCH_PACKETS = 4;
 // (packet_size_in_pages always divides cb_num_pages evenly).
 template <typename AddrFn>
 FORCE_INLINE void prefetch_batch_read_tiles(
+    const Noc& noc_obj,
+    CircularBuffer& cb_output,
     uint32_t& tiles_read,
     uint32_t tiles_to_read,
     uint32_t cb_fifo_limit,
@@ -53,8 +57,8 @@ FORCE_INLINE void prefetch_batch_read_tiles(
         uint32_t batch_packets = std::min(remaining_packets, PREFETCH_PACKETS);
         uint32_t batch_pages = batch_packets * packet_size_in_pages;
 
-        cb_reserve_back(cb_output_id, batch_pages);
-        uint32_t l1_write_addr = get_write_ptr(cb_output_id);
+        cb_output.reserve_back(batch_pages);
+        uint32_t l1_write_addr = cb_output.get_write_ptr();
 
         for (uint32_t p = 0; p < batch_packets; p++) {
             uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
@@ -62,15 +66,18 @@ FORCE_INLINE void prefetch_batch_read_tiles(
                 if (l1_write_addr >= cb_fifo_limit) {
                     l1_write_addr -= cb_fifo_size;
                 }
+                // Legacy primitive retained (#45003 item 4): source is a precomposed uint64_t NoC address from
+                // get_noc_addr_and_advance, and the destination is a raw L1 ring-buffer write pointer that may wrap
+                // outside the CB's normal contiguous-write assumption (see header comment).
                 noc_async_read(get_noc_addr_and_advance(tiles_read), l1_write_addr, input_tensor_page_size);
                 l1_write_addr += payload_size_bytes;
                 tiles_read += contig_pages_advanced;
             }
             l1_write_addr += (packet_size_in_pages - num_pages_to_read) * input_tensor_page_size;
         }
-        noc_async_read_barrier();
+        noc_obj.async_read_barrier();
         for (uint32_t p = 0; p < batch_packets; p++) {
-            cb_push_back(cb_output_id, packet_size_in_pages);
+            cb_output.push_back(packet_size_in_pages);
         }
     }
 }
@@ -124,6 +131,9 @@ void kernel_main() {
     const uint32_t cb_fifo_limit = get_local_cb_interface(cb_output_id).fifo_limit;
     const uint32_t cb_fifo_size = get_local_cb_interface(cb_output_id).fifo_size;
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     // Push out our local slice
     uint32_t output_tile_id_start = 0;
     // Read local slice to our buffers, before sending them over
@@ -131,9 +141,10 @@ void kernel_main() {
         uint32_t tiles_read = input_tile_id_start[input_idx];
         uint32_t tiles_to_read = input_tile_id_end[input_idx];
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-            prefetch_batch_read_tiles(tiles_read, tiles_to_read, cb_fifo_limit, cb_fifo_size, [&](uint32_t tr) {
-                return input_tensor_addrgens[input_idx].get_noc_addr(output_tile_id_start + tr);
-            });
+            prefetch_batch_read_tiles(
+                noc_obj, cb_output, tiles_read, tiles_to_read, cb_fifo_limit, cb_fifo_size, [&](uint32_t tr) {
+                    return input_tensor_addrgens[input_idx].get_noc_addr(output_tile_id_start + tr);
+                });
             tiles_read = input_tile_id_start[input_idx];
             tiles_to_read = input_tile_id_end[input_idx];
             output_tile_id_start += input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
@@ -171,6 +182,8 @@ void kernel_main() {
         // In the linear case, I expect num_targets_forward_direction slices from the right
         // In the ring case, I expect num_targets_forward_direction slices from the right (keep in mind this differs for
         // odd/even chips)
+        // Legacy primitive retained (#45003 item 4): semaphore wait_min targets a raw L1 address (program factory
+        // passes semaphore.address(), not a semaphore id), so Semaphore<> does not apply.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), slices_received + 1);
         // Got it
         slices_received++;
@@ -215,7 +228,13 @@ void kernel_main() {
                 }
                 for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                     prefetch_batch_read_tiles(
-                        tiles_read, tiles_to_read, cb_fifo_limit, cb_fifo_size, [&](uint32_t /* tiles_read */) {
+                        noc_obj,
+                        cb_output,
+                        tiles_read,
+                        tiles_to_read,
+                        cb_fifo_limit,
+                        cb_fifo_size,
+                        [&](uint32_t /* tiles_read */) {
                             auto addr = output_tensor_addrgens[input_idx].get_noc_addr(
                                 output_tile_id_start + row_offset + pages_read_in_row);
                             pages_read_in_row++;
@@ -235,5 +254,6 @@ void kernel_main() {
             }
         }
     }
+    // Legacy primitive retained (#45003 item 4): semaphore set on raw L1 address (not a semaphore id).
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -5,6 +5,9 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include <cstdint>
@@ -34,14 +37,14 @@ constexpr bool fuse_op = get_compile_time_arg_val(10);
 constexpr uint32_t PREFETCH_PACKETS = 4;
 
 // Batch-read tiles into the output CB with DRAM prefetch and FIFO wrapping.
-// get_noc_addr_and_advance is called once per tile-group read; it returns the source
-// NoC address and may perform per-tile side effects (e.g. row-stride tracking).
+// next_page_id is called once per tile-group read; it returns the source TensorAccessor
+// page id and may perform per-tile side effects (e.g. row-stride tracking).
 //
 // Manual ring-buffer wrapping: batched reads may write across the FIFO boundary, which
 // bypasses the CB's normal contiguous-write assumption (see cb_push_back). This is safe because
-// noc_async_read targets raw L1 addresses and cb_push_back is called per-packet
+// reads target raw L1 addresses via CoreLocalMem and cb_push_back is called per-packet
 // (packet_size_in_pages always divides cb_num_pages evenly).
-template <typename AddrFn>
+template <typename Accessor, typename PageIdFn>
 FORCE_INLINE void prefetch_batch_read_tiles(
     const Noc& noc_obj,
     CircularBuffer& cb_output,
@@ -49,7 +52,8 @@ FORCE_INLINE void prefetch_batch_read_tiles(
     uint32_t tiles_to_read,
     uint32_t cb_fifo_limit,
     uint32_t cb_fifo_size,
-    AddrFn&& get_noc_addr_and_advance) {
+    const Accessor& accessor,
+    PageIdFn&& next_page_id) {
     constexpr uint32_t payload_size_bytes = input_tensor_page_size * contig_pages_advanced;
     while (tiles_read < tiles_to_read) {
         uint32_t remaining_tiles = tiles_to_read - tiles_read;
@@ -66,10 +70,12 @@ FORCE_INLINE void prefetch_batch_read_tiles(
                 if (l1_write_addr >= cb_fifo_limit) {
                     l1_write_addr -= cb_fifo_size;
                 }
-                // Legacy primitive retained (#45003 item 4): source is a precomposed uint64_t NoC address from
-                // get_noc_addr_and_advance, and the destination is a raw L1 ring-buffer write pointer that may wrap
-                // outside the CB's normal contiguous-write assumption (see header comment).
-                noc_async_read(get_noc_addr_and_advance(tiles_read), l1_write_addr, input_tensor_page_size);
+                noc_obj.async_read(
+                    accessor,
+                    CoreLocalMem<uint8_t>(l1_write_addr),
+                    input_tensor_page_size,
+                    {.page_id = next_page_id(tiles_read)},
+                    {});
                 l1_write_addr += payload_size_bytes;
                 tiles_read += contig_pages_advanced;
             }
@@ -142,9 +148,14 @@ void kernel_main() {
         uint32_t tiles_to_read = input_tile_id_end[input_idx];
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
             prefetch_batch_read_tiles(
-                noc_obj, cb_output, tiles_read, tiles_to_read, cb_fifo_limit, cb_fifo_size, [&](uint32_t tr) {
-                    return input_tensor_addrgens[input_idx].get_noc_addr(output_tile_id_start + tr);
-                });
+                noc_obj,
+                cb_output,
+                tiles_read,
+                tiles_to_read,
+                cb_fifo_limit,
+                cb_fifo_size,
+                input_tensor_addrgens[input_idx],
+                [&](uint32_t tr) { return output_tile_id_start + tr; });
             tiles_read = input_tile_id_start[input_idx];
             tiles_to_read = input_tile_id_end[input_idx];
             output_tile_id_start += input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
@@ -236,15 +247,15 @@ void kernel_main() {
                         tiles_to_read,
                         cb_fifo_limit,
                         cb_fifo_size,
+                        output_tensor_addrgens[input_idx],
                         [&](uint32_t /* tiles_read */) {
-                            auto addr = output_tensor_addrgens[input_idx].get_noc_addr(
-                                output_tile_id_start + row_offset + pages_read_in_row);
+                            const uint32_t pid = output_tile_id_start + row_offset + pages_read_in_row;
                             pages_read_in_row++;
                             if (pages_read_in_row >= slice_Wt) {
                                 row_offset += stride_Wt;
                                 pages_read_in_row = 0;
                             }
-                            return addr;
+                            return pid;
                         });
                     pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
                     row_offset =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -182,8 +182,10 @@ void kernel_main() {
         // In the linear case, I expect num_targets_forward_direction slices from the right
         // In the ring case, I expect num_targets_forward_direction slices from the right (keep in mind this differs for
         // odd/even chips)
-        // Legacy primitive retained (#45003 item 4): semaphore wait_min targets a raw L1 address (program factory
-        // passes semaphore.address(), not a semaphore id), so Semaphore<> does not apply.
+        // Legacy primitive retained (#45003 item 4): out_ready_sem is the address of a GlobalSemaphore
+        // (std::vector<GlobalSemaphore>& semaphore in the program factory). GlobalSemaphore exposes only address()
+        // — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
+        // GlobalSemaphore. Structural limitation, not a migration backlog item.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), slices_received + 1);
         // Got it
         slices_received++;
@@ -254,6 +256,7 @@ void kernel_main() {
             }
         }
     }
-    // Legacy primitive retained (#45003 item 4): semaphore set on raw L1 address (not a semaphore id).
+    // Legacy primitive retained (#45003 item 4): out_ready_sem is a GlobalSemaphore address (see wait_min note
+    // above for the structural reason).
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -193,10 +193,10 @@ void kernel_main() {
         // In the linear case, I expect num_targets_forward_direction slices from the right
         // In the ring case, I expect num_targets_forward_direction slices from the right (keep in mind this differs for
         // odd/even chips)
-        // Legacy primitive retained (#45003 item 4): out_ready_sem is the address of a GlobalSemaphore
-        // (std::vector<GlobalSemaphore>& semaphore in the program factory). GlobalSemaphore exposes only address()
-        // — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
-        // GlobalSemaphore. Structural limitation, not a migration backlog item.
+
+        // Device 2.0: legacy primitive retained, out_ready_sem is the address of a GlobalSemaphore
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
+        // GlobalSemaphore.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), slices_received + 1);
         // Got it
         slices_received++;
@@ -267,7 +267,6 @@ void kernel_main() {
             }
         }
     }
-    // Legacy primitive retained (#45003 item 4): out_ready_sem is a GlobalSemaphore address (see wait_min note
-    // above for the structural reason).
+    // Device 2.0 migration: legacy primitive retained, out_ready_sem is a GlobalSemaphore address.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -79,13 +81,17 @@ void kernel_main() {
         op_signaler_sender = OpSignaler(arg_idx);
     }
 
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb_output(cb_output_id);
+
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_seminc = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
@@ -127,8 +133,8 @@ void kernel_main() {
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
             while (tiles_read < tiles_to_read) {
                 uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                cb_wait_front(cb_output_id, packet_size_in_pages);
-                const size_t l1_read_addr_base = get_read_ptr(cb_output_id);
+                cb_output.wait_front(packet_size_in_pages);
+                const size_t l1_read_addr_base = cb_output.get_read_ptr();
                 size_t l1_read_addr = l1_read_addr_base;
 
                 // for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
@@ -175,7 +181,7 @@ void kernel_main() {
                 }
 
                 tiles_read += num_pages_to_read;
-                cb_pop_front(cb_output_id, packet_size_in_pages);
+                cb_output.pop_front(packet_size_in_pages);
             }
             tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
             tiles_read = input_tile_id_start[input_idx];
@@ -185,7 +191,7 @@ void kernel_main() {
         }
     }
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
     // increment locally
     if constexpr (fuse_op && direction == 1) {
         /**
@@ -266,8 +272,8 @@ void kernel_main() {
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                 while (tiles_read < tiles_to_read) {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                    cb_wait_front(cb_output_id, packet_size_in_pages);
-                    size_t l1_read_addr = get_read_ptr(cb_output_id);
+                    cb_output.wait_front(packet_size_in_pages);
+                    size_t l1_read_addr = cb_output.get_read_ptr();
                     uint32_t first_tile_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
                     if (pages_read_in_row >= slice_Wt) {
@@ -303,7 +309,7 @@ void kernel_main() {
                     }
 
                     tiles_read += num_pages_to_read;
-                    cb_pop_front(cb_output_id, packet_size_in_pages);
+                    cb_output.pop_front(packet_size_in_pages);
                 }
                 tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 tiles_read = input_tile_id_start[input_idx];
@@ -324,6 +330,6 @@ void kernel_main() {
     }
     fabric_connection.close();
 
-    noc_async_atomic_barrier();
-    noc_async_write_barrier();
+    noc_obj.async_atomic_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
@@ -33,7 +33,8 @@ inline void zeroPad(uint32_t cb_output_id) {
     const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     uint32_t cb_write_addr = get_write_ptr(cb_output_id);
 
-    // Device 2.0 migration: legacy primitive retained, MEM_ZEROS_BASE self-read has no typed Noc trait
+    // Device 2.0 migration: legacy primitive retained — MEM_ZEROS_BASE self-read has no typed Noc
+    // endpoint today. TODO(#45845): migrate to a LocalL1 endpoint once available.
     for (uint32_t i = 0; i < num_full_reads; ++i) {
         noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
         cb_write_addr += MEM_ZEROS_SIZE;
@@ -113,7 +114,8 @@ void kernel_main() {
         }
     }
 
-    // Device 2.0: legacy primitive retained, out_ready_sem is the address of a GlobalSemaphore.
+    // Check that the semaphore is received
+    // Device 2.0 migration: legacy primitive retained, out_ready_sem is the address of a GlobalSemaphore.
     if (!is_first_chip) {
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
@@ -33,7 +33,10 @@ inline void zeroPad(uint32_t cb_output_id) {
     const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     uint32_t cb_write_addr = get_write_ptr(cb_output_id);
 
-    // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read does not map cleanly to a typed Noc trait.
+    // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read has no typed Noc trait
+    // (the local x/y are implicit in get_noc_addr(addr)). Issued on noc_index — same NoC as the
+    // Noc instance used elsewhere in this kernel — so the caller's async_read_barrier() flushes
+    // both these reads and the typed reads.
     for (uint32_t i = 0; i < num_full_reads; ++i) {
         noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
         cb_write_addr += MEM_ZEROS_SIZE;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
@@ -116,8 +116,10 @@ void kernel_main() {
         }
     }
 
-    // Legacy primitive retained (#45003 item 4): out_ready_sem is passed as an absolute L1 address from the program
-    // factory (args.final_semaphore.address()), not a semaphore id; Semaphore<> binds to ids only.
+    // Legacy primitive retained (#45003 item 4): out_ready_sem is the address of a GlobalSemaphore
+    // (args.final_semaphore in slice_reshard_async_program_factory.cpp). GlobalSemaphore exposes only address() —
+    // there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
+    // GlobalSemaphore. Structural limitation, not a migration backlog item.
     if (!is_first_chip) {
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
@@ -34,9 +34,10 @@ inline void zeroPad(uint32_t cb_output_id) {
     uint32_t cb_write_addr = get_write_ptr(cb_output_id);
 
     // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read has no typed Noc trait
-    // (the local x/y are implicit in get_noc_addr(addr)). Issued on noc_index — same NoC as the
-    // Noc instance used elsewhere in this kernel — so the caller's async_read_barrier() flushes
-    // both these reads and the typed reads.
+    // (the local x/y are implicit in get_noc_addr(addr)). Both these calls and the Noc instance
+    // used elsewhere in this kernel issue on noc_index — legacy noc_async_read defaults its noc
+    // arg to noc_index (dataflow_api.h), and Noc{} default-constructs noc_id_ to noc_index
+    // (noc.h Noc() ctor) — so the caller's async_read_barrier() flushes these reads too.
     for (uint32_t i = 0; i < num_full_reads; ++i) {
         noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
         cb_write_addr += MEM_ZEROS_SIZE;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
@@ -3,6 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -27,6 +33,7 @@ inline void zeroPad(uint32_t cb_output_id) {
     const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     uint32_t cb_write_addr = get_write_ptr(cb_output_id);
 
+    // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read does not map cleanly to a typed Noc trait.
     for (uint32_t i = 0; i < num_full_reads; ++i) {
         noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
         cb_write_addr += MEM_ZEROS_SIZE;
@@ -57,6 +64,9 @@ void kernel_main() {
     uint32_t read_size = stick_size;
     const auto src_accessor = TensorAccessor(src_args, input_tensor_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     if (!is_last_chip) {
         // Read the "end" of each slice into the CB to write to the neighbor
         for (uint32_t outer_dim_id = outer_dims_to_forward; outer_dim_id > 0; outer_dim_id--) {
@@ -67,26 +77,23 @@ void kernel_main() {
                 src_stick_id = (outer_dims_to_forward - outer_dim_id) * num_sticks_per_outer_dim + stick_start_id;
             }
             for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                cb_reserve_back(cb_output_id, 1);
-                uint32_t src_buffer_l1_addr = get_write_ptr(cb_output_id);
-
-                uint64_t src_noc_addr = src_accessor.get_noc_addr(src_stick_id);
-                noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+                cb_output.reserve_back(1);
+                noc_obj.async_read(src_accessor, cb_output, read_size, {.page_id = src_stick_id}, {});
 
                 src_stick_id++;
 
-                noc_async_read_barrier();
-                cb_push_back(cb_output_id, 1);
+                noc_obj.async_read_barrier();
+                cb_output.push_back(1);
             }
         }
     } else {
         // If we need extend beyond the original input tensor, pad
         if (direction) {
             if (outer_dims_from_forward) {
-                cb_reserve_back(cb_output_id, 1);
+                cb_output.reserve_back(1);
                 zeroPad<stick_size>(cb_output_id);
-                noc_async_read_barrier();
-                cb_push_back(cb_output_id, 1);
+                noc_obj.async_read_barrier();
+                cb_output.push_back(1);
             }
         }
     }
@@ -95,21 +102,19 @@ void kernel_main() {
         for (uint32_t outer_dim_id = outer_dims_to_keep_start; outer_dim_id <= outer_dims_to_keep_end; outer_dim_id++) {
             uint32_t src_stick_id = outer_dim_id * num_sticks_per_outer_dim + stick_start_id;
             for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                cb_reserve_back(cb_output_id, 1);
-                uint32_t src_buffer_l1_addr = get_write_ptr(cb_output_id);
-
-                uint64_t src_noc_addr = src_accessor.get_noc_addr(src_stick_id);
-                noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+                cb_output.reserve_back(1);
+                noc_obj.async_read(src_accessor, cb_output, read_size, {.page_id = src_stick_id}, {});
 
                 src_stick_id++;
 
-                noc_async_read_barrier();
-                cb_push_back(cb_output_id, 1);
+                noc_obj.async_read_barrier();
+                cb_output.push_back(1);
             }
         }
     }
 
-    // Check that the semaphore is received
+    // Legacy primitive retained (#45003 item 4): out_ready_sem is passed as an absolute L1 address from the program
+    // factory (args.final_semaphore.address()), not a semaphore id; Semaphore<> binds to ids only.
     if (!is_first_chip) {
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_reader.cpp
@@ -33,11 +33,7 @@ inline void zeroPad(uint32_t cb_output_id) {
     const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     uint32_t cb_write_addr = get_write_ptr(cb_output_id);
 
-    // Legacy primitive retained (#45003 item 4): MEM_ZEROS_BASE self-read has no typed Noc trait
-    // (the local x/y are implicit in get_noc_addr(addr)). Both these calls and the Noc instance
-    // used elsewhere in this kernel issue on noc_index — legacy noc_async_read defaults its noc
-    // arg to noc_index (dataflow_api.h), and Noc{} default-constructs noc_id_ to noc_index
-    // (noc.h Noc() ctor) — so the caller's async_read_barrier() flushes these reads too.
+    // Device 2.0 migration: legacy primitive retained, MEM_ZEROS_BASE self-read has no typed Noc trait
     for (uint32_t i = 0; i < num_full_reads; ++i) {
         noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
         cb_write_addr += MEM_ZEROS_SIZE;
@@ -117,10 +113,7 @@ void kernel_main() {
         }
     }
 
-    // Legacy primitive retained (#45003 item 4): out_ready_sem is the address of a GlobalSemaphore
-    // (args.final_semaphore in slice_reshard_async_program_factory.cpp). GlobalSemaphore exposes only address() —
-    // there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
-    // GlobalSemaphore. Structural limitation, not a migration backlog item.
+    // Device 2.0: legacy primitive retained, out_ready_sem is the address of a GlobalSemaphore.
     if (!is_first_chip) {
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_writer.cpp
@@ -104,8 +104,10 @@ void kernel_main() {
             }
             noc_obj.async_writes_flushed();
         }
-        // Legacy primitive retained (#45003 item 4): barrier_sem is passed as an absolute L1 address from the program
-        // factory, not a semaphore id; Semaphore<> binds to ids only.
+        // Legacy primitive retained (#45003 item 4): barrier_sem is the address of a GlobalSemaphore
+        // (args.barrier_semaphore in slice_reshard_async_program_factory.cpp). GlobalSemaphore exposes only
+        // address() — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it
+        // cannot wrap a GlobalSemaphore. Structural limitation, not a migration backlog item.
         if (!is_last_chip) {
             noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 1);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_writer.cpp
@@ -104,10 +104,7 @@ void kernel_main() {
             }
             noc_obj.async_writes_flushed();
         }
-        // Legacy primitive retained (#45003 item 4): barrier_sem is the address of a GlobalSemaphore
-        // (args.barrier_semaphore in slice_reshard_async_program_factory.cpp). GlobalSemaphore exposes only
-        // address() — there is no id(). Semaphore<> binds to per-program ids via get_semaphore<>(id), so it
-        // cannot wrap a GlobalSemaphore. Structural limitation, not a migration backlog item.
+        // Device 2.0 migration: legacy primitive retained, barrier_sem is the address of a GlobalSemaphore.
         if (!is_last_chip) {
             noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 1);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/kernels/minimal_default_writer.cpp
@@ -3,6 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -59,6 +65,9 @@ void kernel_main() {
     // program cache hits.
     const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address, stick_size);
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     // pre-populate packet headers
     auto pkt_hdr = PacketHeaderPool::allocate_header();
     pkt_hdr->to_chip_unicast(1);
@@ -93,8 +102,10 @@ void kernel_main() {
                         (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
                 }
             }
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
         }
+        // Legacy primitive retained (#45003 item 4): barrier_sem is passed as an absolute L1 address from the program
+        // factory, not a semaphore id; Semaphore<> binds to ids only.
         if (!is_last_chip) {
             noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 1);
         }
@@ -112,8 +123,8 @@ void kernel_main() {
                     stick_start_id;
             }
             for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                cb_wait_front(cb_output_id, 1);
-                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                cb_output.wait_front(1);
+                uint32_t l1_read_addr = cb_output.get_read_ptr();
 
                 uint64_t dst_noc_addr = dst_accessor.get_noc_addr(dst_stick_id, 0, 0);
 
@@ -132,12 +143,12 @@ void kernel_main() {
                         (uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
                 }
 
-                noc_async_writes_flushed();
+                noc_obj.async_writes_flushed();
 
                 dst_stick_id++;
 
-                noc_async_write_barrier();
-                cb_pop_front(cb_output_id, 1);
+                noc_obj.async_write_barrier();
+                cb_output.pop_front(1);
             }
         }
 
@@ -162,23 +173,27 @@ void kernel_main() {
         // If we need extend beyond the original input tensor, pad
         if (direction) {
             if (outer_dims_from_forward) {
-                cb_wait_front(cb_output_id, 1);
-                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                cb_output.wait_front(1);
+                uint32_t l1_read_addr = cb_output.get_read_ptr();
                 for (uint32_t outer_dim_id = 0; outer_dim_id < outer_dims_from_forward; outer_dim_id++) {
                     uint32_t dst_stick_id = (outer_dim_id + outer_dims_to_receive +
                                              (outer_dims_to_keep_end - outer_dims_to_keep_start + 1)) *
                                                 num_sticks_per_outer_dim +
                                             stick_start_id;
                     for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                        uint64_t dst_noc_addr = dst_accessor.get_noc_addr(dst_stick_id);
-                        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                        noc_obj.async_write(
+                            CoreLocalMem<uint8_t>(l1_read_addr),
+                            dst_accessor,
+                            stick_size,
+                            {},
+                            {.page_id = dst_stick_id});
 
                         dst_stick_id++;
 
-                        noc_async_write_barrier();
+                        noc_obj.async_write_barrier();
                     }
                 }
-                cb_pop_front(cb_output_id, 1);
+                cb_output.pop_front(1);
             }
         }
     }
@@ -189,16 +204,13 @@ void kernel_main() {
              outer_dim_id++) {
             uint32_t dst_stick_id = (outer_dim_id + outer_dims_to_receive) * num_sticks_per_outer_dim + stick_start_id;
             for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                cb_wait_front(cb_output_id, 1);
-                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
-
-                uint64_t dst_noc_addr = dst_accessor.get_noc_addr(dst_stick_id);
-                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                cb_output.wait_front(1);
+                noc_obj.async_write(cb_output, dst_accessor, stick_size, {}, {.page_id = dst_stick_id});
 
                 dst_stick_id++;
 
-                noc_async_write_barrier();
-                cb_pop_front(cb_output_id, 1);
+                noc_obj.async_write_barrier();
+                cb_output.pop_front(1);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -141,6 +143,8 @@ void kernel_main() {
                 input_chunk_start_tile = global_tile_index;
                 for (uint32_t chunk_idx = 0; chunk_idx < device_k_block_counts[actual_sender_chip_id]; chunk_idx++) {
                     // Receive the next chunk of data
+                    // Legacy primitive retained (#45003 item 4): out_ready_sem is a raw address
+                    // from semaphore.at(dir).address() in the program factory, not an id.
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                     sem_target++;
@@ -183,5 +187,7 @@ void kernel_main() {
         }
         batch_input_tile_offset += tiles_per_batch;
     }
+    // Legacy primitive retained (#45003 item 4): out_ready_sem is a raw address from
+    // semaphore.at(dir).address() in the program factory, not an id.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -143,8 +143,10 @@ void kernel_main() {
                 input_chunk_start_tile = global_tile_index;
                 for (uint32_t chunk_idx = 0; chunk_idx < device_k_block_counts[actual_sender_chip_id]; chunk_idx++) {
                     // Receive the next chunk of data
-                    // Legacy primitive retained (#45003 item 4): out_ready_sem is a raw address
-                    // from semaphore.at(dir).address() in the program factory, not an id.
+                    // Legacy primitive retained (#45003 item 4): out_ready_sem is the address of a GlobalSemaphore
+                    // (std::vector<GlobalSemaphore>& semaphore in strided_all_gather_async_program.cpp).
+                    // GlobalSemaphore exposes only address() — there is no id(). Semaphore<> binds to per-program
+                    // ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. Structural limitation.
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                     sem_target++;
@@ -187,7 +189,7 @@ void kernel_main() {
         }
         batch_input_tile_offset += tiles_per_batch;
     }
-    // Legacy primitive retained (#45003 item 4): out_ready_sem is a raw address from
-    // semaphore.at(dir).address() in the program factory, not an id.
+    // Legacy primitive retained (#45003 item 4): out_ready_sem is a GlobalSemaphore address (see structural-
+    // reason note above on the wait_min site).
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -143,10 +143,7 @@ void kernel_main() {
                 input_chunk_start_tile = global_tile_index;
                 for (uint32_t chunk_idx = 0; chunk_idx < device_k_block_counts[actual_sender_chip_id]; chunk_idx++) {
                     // Receive the next chunk of data
-                    // Legacy primitive retained (#45003 item 4): out_ready_sem is the address of a GlobalSemaphore
-                    // (std::vector<GlobalSemaphore>& semaphore in strided_all_gather_async_program.cpp).
-                    // GlobalSemaphore exposes only address() — there is no id(). Semaphore<> binds to per-program
-                    // ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. Structural limitation.
+                    // Device 2.0: legacy primitive retained: out_ready_sem is the address of a GlobalSemaphore.
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                     sem_target++;
@@ -189,7 +186,6 @@ void kernel_main() {
         }
         batch_input_tile_offset += tiles_per_batch;
     }
-    // Legacy primitive retained (#45003 item 4): out_ready_sem is a GlobalSemaphore address (see structural-
-    // reason note above on the wait_min site).
+    // Device 2.0 migration: legacy primitive retained, out_ready_sem is a GlobalSemaphore address.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
@@ -191,6 +193,8 @@ void kernel_main() {
         }
     }
 
+    Noc noc_obj;
+
     uint32_t batch_output_tile_offset = output_worker_tile_offset;
     uint32_t global_tile_index = 0;
     uint32_t output_tiles_per_batch = output_tensor_Wt * output_tensor_Ht;
@@ -286,22 +290,25 @@ void kernel_main() {
         batch_output_tile_offset += output_tiles_per_batch;
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if constexpr (is_termination_master) {
+            // Legacy primitive retained (#45003 item 4): termination_sync_address is used both
+            // as a local L1 pointer here and as a remote noc target via safe_get_noc_addr below.
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+            // Legacy primitive retained (#45003 item 4): precomposed uint64_t dst addr.
             noc_semaphore_inc(dest_addr, 1);
-            noc_async_atomic_barrier();
+            noc_obj.async_atomic_barrier();
         }
     }
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -297,7 +297,7 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if constexpr (is_termination_master) {
-            // Legacy primitive retained (#45003 item 4): termination_sync_address is used both
+            // Device 2.0: legacy primitive retained, termination_sync_address is used both
             // as a local L1 pointer here and as a remote noc target via safe_get_noc_addr below.
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
@@ -305,7 +305,7 @@ void kernel_main() {
         } else {
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
-            // Legacy primitive retained (#45003 item 4): precomposed uint64_t dst addr.
+            // Legacy primitive retained: precomposed uint64_t dst addr.
             noc_semaphore_inc(dest_addr, 1);
             noc_obj.async_atomic_barrier();
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
@@ -136,12 +138,14 @@ FORCE_INLINE uint32_t read_chunk(
         chunk_start_col = chunk_start_col + actual_sender_chip_id * input_tensor_Wt;
     }
     uint32_t chunk_end_col = chunk_start_col + chunk_width - 1;
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
     for (uint32_t packet_idx = 0; packet_idx < packets_in_curr_chunk; packet_idx++) {
         uint32_t tiles_left_in_chunk = worker_tiles_in_curr_chunk - chunk_tile_iter;
         uint32_t tiles_to_read_in_packet = std::min(tiles_left_in_chunk, num_tiles_per_packet);
 
-        cb_reserve_back(cb_output_id, max_tiles_per_packet);
-        size_t l1_write_addr = get_write_ptr(cb_output_id);
+        cb_output.reserve_back(max_tiles_per_packet);
+        size_t l1_write_addr = cb_output.get_write_ptr();
         for (uint32_t j = 0; j < tiles_to_read_in_packet; ++j) {
             int32_t tile_id = get_chunk_tile(
                 worker_chunk_row,
@@ -156,6 +160,8 @@ FORCE_INLINE uint32_t read_chunk(
                 read_output ? output_tensor_Wt : input_tensor_Wt,
                 input_tensor_Ht);
             if (tile_id >= 0) {
+                // Legacy primitive retained (#45003 item 4): precomposed uint64_t address
+                // from get_noc_addr(tile_id, accessor).
                 uint64_t noc_read_addr =
                     get_noc_addr(tile_id, read_output ? output_tensor_addrgen : input_tensor_addrgen);
                 noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
@@ -165,8 +171,8 @@ FORCE_INLINE uint32_t read_chunk(
             chunk_tile_iter++;
         }
 
-        noc_async_read_barrier();
-        cb_push_back(cb_output_id, max_tiles_per_packet);
+        noc_obj.async_read_barrier();
+        cb_output.push_back(max_tiles_per_packet);
     }
 
     uint32_t new_chunk_start_tile = chunk_start_tile + chunk_width;
@@ -233,12 +239,14 @@ FORCE_INLINE uint32_t write_chunk(
     chunk_start_col = chunk_start_col + actual_sender_chip_id * input_tensor_Wt;
     uint32_t chunk_end_col = chunk_start_col + chunk_width - 1;
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
     for (uint32_t packet_idx = 0; packet_idx < packets_in_curr_chunk; packet_idx++) {
         uint32_t tiles_left_in_chunk = worker_tiles_in_curr_chunk - chunk_tile_iter;
         uint32_t tiles_to_write_in_packet = std::min(tiles_left_in_chunk, num_tiles_per_packet);
 
-        cb_wait_front(cb_output_id, max_tiles_per_packet);
-        size_t l1_read_addr = get_read_ptr(cb_output_id);
+        cb_output.wait_front(max_tiles_per_packet);
+        size_t l1_read_addr = cb_output.get_read_ptr();
 
         uint32_t padded_tiles = 0;
         int32_t tile_one_id = get_chunk_tile(
@@ -297,10 +305,11 @@ FORCE_INLINE uint32_t write_chunk(
                     uint64_t local_noc0_dest_noc_addr_tile_one = output_addrgen.get_noc_addr(tile_one_id);
                     uint64_t local_noc0_dest_noc_addr_tile_two = output_addrgen.get_noc_addr(tile_two_id);
 
+                    // Legacy primitive retained (#45003 item 4): precomposed uint64_t dst addrs.
                     noc_async_write(l1_read_addr, local_noc0_dest_noc_addr_tile_one, output_page_size);
                     noc_async_write(
                         l1_read_addr + output_page_size, local_noc0_dest_noc_addr_tile_two, output_page_size);
-                    noc_async_write_barrier();
+                    noc_obj.async_write_barrier();
                 }
                 break;
             }
@@ -314,8 +323,10 @@ FORCE_INLINE uint32_t write_chunk(
                 }
                 if (direction == 1 && write_local) {
                     uint64_t local_noc0_dest_noc_addr = output_addrgen.get_noc_addr(tile_one_id);
+
+                    // Legacy primitive retained (#45003 item 4): precomposed uint64_t dst addr.
                     noc_async_write(l1_read_addr, local_noc0_dest_noc_addr, output_page_size);
-                    noc_async_write_barrier();
+                    noc_obj.async_write_barrier();
                 }
                 break;
             }
@@ -324,8 +335,8 @@ FORCE_INLINE uint32_t write_chunk(
                 break;
             }
         }
-        noc_async_writes_flushed();
-        cb_pop_front(cb_output_id, max_tiles_per_packet);
+        noc_obj.async_writes_flushed();
+        cb_output.pop_front(max_tiles_per_packet);
     }
     // Write the semaphore packet
     if ((direction == 1 && num_targets_backward_direction) || (direction == 0 && num_targets_forward_direction)) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
@@ -160,7 +160,7 @@ FORCE_INLINE uint32_t read_chunk(
                 read_output ? output_tensor_Wt : input_tensor_Wt,
                 input_tensor_Ht);
             if (tile_id >= 0) {
-                // Legacy primitive retained (#45003 item 4): precomposed uint64_t address
+                // Device 2.0 migration: legacy primitive retained, precomposed uint64_t address
                 // from get_noc_addr(tile_id, accessor).
                 uint64_t noc_read_addr =
                     get_noc_addr(tile_id, read_output ? output_tensor_addrgen : input_tensor_addrgen);
@@ -305,7 +305,7 @@ FORCE_INLINE uint32_t write_chunk(
                     uint64_t local_noc0_dest_noc_addr_tile_one = output_addrgen.get_noc_addr(tile_one_id);
                     uint64_t local_noc0_dest_noc_addr_tile_two = output_addrgen.get_noc_addr(tile_two_id);
 
-                    // Legacy primitive retained (#45003 item 4): precomposed uint64_t dst addrs.
+                    // Legacy primitive retained: precomposed uint64_t dst addrs.
                     noc_async_write(l1_read_addr, local_noc0_dest_noc_addr_tile_one, output_page_size);
                     noc_async_write(
                         l1_read_addr + output_page_size, local_noc0_dest_noc_addr_tile_two, output_page_size);
@@ -324,7 +324,7 @@ FORCE_INLINE uint32_t write_chunk(
                 if (direction == 1 && write_local) {
                     uint64_t local_noc0_dest_noc_addr = output_addrgen.get_noc_addr(tile_one_id);
 
-                    // Legacy primitive retained (#45003 item 4): precomposed uint64_t dst addr.
+                    // Legacy primitive retained: precomposed uint64_t dst addr.
                     noc_async_write(l1_read_addr, local_noc0_dest_noc_addr, output_page_size);
                     noc_obj.async_write_barrier();
                 }


### PR DESCRIPTION
### PR Category

  Cleanup

  CCL / experimental — kernel API migration (issue #45003 item 4). No host-side or op-API changes; only kernels
  under ttnn/cpp/ttnn/operations/experimental/ccl/ and two shared CCL kernel-side helpers.

###  Summary

  Begins the migration of CCL kernels to the Device 2.0 kernel data-movement API (Noc, CircularBuffer, Semaphore<>,
   CoreLocalMem, typed endpoints) per the migration guide. This branch bundles the two kernel-side helper
  migrations plus the less complicated per-op migrations.

###  Notes for Reviewers

  ### Helpers

  - worker_sync_utils.hpp — MatmulOpReceiver / ReduceScatterOpReceiver interior noc_semaphore_wait_min calls swap to Semaphore<>::wait_min. Field renames (signal_op_semaphore_addr_ptr to signal_op_semaphore_id) reach into both structs but only via public methods; all five external callers (three matmul kernels + two reduce_scatter_minimal_async kernels) were verified.

  ### Per-op migration

  Each commit follows the same template: add Device 2.0 headers, declare wrappers (Noc noc;, CircularBuffer 
  cb_(cb_id);, Semaphore<> where the program factory passes a semaphore id), migrate noc_async_* / cb_* /
  noc_semaphore_* where the mapping is mechanical, leave fabric untouched, and explain what stays on legacy and
  why.

  ## Categories of retained legacy primitives

  Each retained block carries a #45003 item 4 audit comment. They group into four categories — two structural and two unblocked by small additions to the Device 2.0 endpoint API.

  - GlobalSemaphore-bound semaphore ops — structural

  noc_semaphore_wait / set / inc on GlobalSemaphore L1 addresses. Semaphore<> binds to per-program ids via
  get_semaphore<>(id); GlobalSemaphore exposes only address() (no id()), because cross-device fabric signaling
  needs a mesh-wide stable L1 address that a per-program id cannot provide.

  Sites: all_reduce_async/{reduction_receiver, worker_writer}.cpp; slice_reshard_async/minimal_default_reader.cpp
  final semaphore; all_to_all_sender_writer.cpp global init/final barriers; llama_reduce_scatter receiver
  semaphore.

  - noc_semaphore_set_multicast_loopback_src with split src/dst L1 offsets — structural

  Semaphore<>::set_multicast reuses the sender's L1 offset for the destination; this call site needs a different
  destination offset.

  Site: all_to_all_sender_writer.cpp mcast init barrier.

  - Raw local L1 address as NoC src — could be fixed by a LocalL1 endpoint

  Three subpatterns, all the same gap:
    - noc_async_read(get_noc_addr(MEM_ZEROS_BASE), dst_l1, size) — self-reads for zero-fill.
    - noc_async_write((uint32_t)MEM_ZEROS_BASE, dst_noc, size) — writes whose source is local L1.
    - noc_async_write_page(page_id, accessor, l1_src) — page writes with a raw L1 src and TensorAccessor dst.

  No Device 2.0 endpoint today carries "fixed L1 address on this core" through Noc::async_read / Noc::async_write.
  Sketched fix (iwrosz/ccl-device2-local-l1-endpoint, commit e249fbd18df): add a LocalL1 tag struct to
  tt_metal/hw/inc/api/dataflow/endpoints.h plus a noc_traits_t<LocalL1> specialization with src_addr only (both
  <LOCAL_L1> and <NOC> branches). Call sites become:
  noc_obj.async_read(LocalL1{}, dst, size, {.addr = MEM_ZEROS_BASE}, {});
  noc_obj.async_write(LocalL1{}, output_accessor, page_size,
                      {.addr = l1_src}, {.page_id = tile_id});
   
  Sites: slice_reshard_async/minimal_default_reader.cpp, neighbor_pad_async/{phase2_w_reader, local_copy_writer, 
  minimal_default_reader}.cpp, all_to_all_dispatch_metadata/writer_all_to_all_dispatch_metadata.cpp,
  all_gather_minimal_matmul/matmul_dataflow_common.hpp, all_to_all_async_generic/all_to_all_sender_reader.cpp,
  deepseek_moe_reduce_scatter_writer.cpp page-write loop.

  - Precomposed uint64_t NoC address — fix: RawNocAddress endpoint

  Hot loops hoist noc_addresses[i] = ::get_noc_addr(x, y, addr, noc) out of the inner loop and reuse the
  precomputed result per iteration. UnicastEndpoint would re-encode every call, undoing the optimization. Sketched 
  fix (iwrosz/ccl-device2-local-l1-endpoint, commit 2b7ae271b76): add a RawNocAddress tag struct + trait carrying a
   uint64_t through src_addr / dst_addr untouched (static_assert(NOC) on both — a raw NoC address has no meaning as
   local L1). Combined with LocalL1, the call site becomes:
  noc_obj.async_write(LocalL1{}, RawNocAddress{}, page_size,
                      {.addr = l1_src}, {.noc_addr = noc_addresses[i]});
                      
  Sites: writer_llama_reduce_scatter.cpp, deepseek_moe_reduce_scatter_writer.cpp precomposed-NoC-addr writes,
  all_to_all_sender_writer.cpp noc_async_write(l1, dest_addrs[part], ...) and the output_semaphore_noc_addr_in_pkt
  atomic-inc.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ccl-device2-helpers-light)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ccl-device2-helpers-light)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/ccl-device2-helpers-light)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ccl-device2-helpers-light)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ccl-device2-helpers-light)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ccl-device2-helpers-light)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ccl-device2-helpers-light)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ccl-device2-helpers-light)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ccl-device2-helpers-light)