### PR TITLE
[Feature] Metal 2.0 ergonomics and AI usability improvements

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -41,7 +41,7 @@ namespace tt::tt_metal {
 namespace {
 
 using namespace experimental;
-using namespace experimental::metal2_host_api;
+using namespace experimental;
 
 constexpr const char* ALIAS_PRODUCER_KERNEL =
     "tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -114,12 +114,12 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
 
     // DM kernel configs (Gen1 + Gen2 variants so the same spec runs everywhere).
     const DataMovementConfiguration producer_cfg{
-        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_0},
-        .gen2 = DataMovementConfiguration::Gen2{},
+        .gen1 = DataMovementConfiguration::Gen1DM{.processor = DataMovementProcessor::RISCV_0},
+        .gen2 = DataMovementConfiguration::Gen2DM{},
     };
     const DataMovementConfiguration consumer_cfg{
-        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_1},
-        .gen2 = DataMovementConfiguration::Gen2{},
+        .gen1 = DataMovementConfiguration::Gen1DM{.processor = DataMovementProcessor::RISCV_1},
+        .gen2 = DataMovementConfiguration::Gen2DM{},
     };
 
     DataflowBufferSpec dfb_a{
@@ -310,12 +310,12 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         *mesh_device, make_alias_l1_tensor_spec(entry_size, num_entries), TensorTopology{});
 
     const DataMovementConfiguration producer_cfg{
-        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_0},
-        .gen2 = DataMovementConfiguration::Gen2{},
+        .gen1 = DataMovementConfiguration::Gen1DM{.processor = DataMovementProcessor::RISCV_0},
+        .gen2 = DataMovementConfiguration::Gen2DM{},
     };
     const DataMovementConfiguration consumer_cfg{
-        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_1},
-        .gen2 = DataMovementConfiguration::Gen2{},
+        .gen1 = DataMovementConfiguration::Gen1DM{.processor = DataMovementProcessor::RISCV_1},
+        .gen2 = DataMovementConfiguration::Gen2DM{},
     };
 
     // dfb_borrowed: backed by ring_tensor (L1)

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -114,14 +114,12 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
 
     // DM kernel configs (Gen1 + Gen2 variants so the same spec runs everywhere).
     const DataMovementConfiguration producer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_0},
+        .gen2 = DataMovementConfiguration::Gen2{},
     };
     const DataMovementConfiguration consumer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_1},
+        .gen2 = DataMovementConfiguration::Gen2{},
     };
 
     DataflowBufferSpec dfb_a{
@@ -142,54 +140,64 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
     };
 
     KernelSpec producer{
-        .unique_id   = "producer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_PRODUCER_KERNEL},
+        .unique_id = "producer",
+        .source = ALIAS_PRODUCER_KERNEL,
         .num_threads = num_producers,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_a", .local_accessor_name = "out_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_b", .local_accessor_name = "out_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
-            {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_producer_a", epp_a},
-            {"num_entries_per_producer_b", epp_b},
-            {"num_producers",              static_cast<uint32_t>(num_producers)},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_a",
+                 .local_accessor_name = "out_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_b",
+                 .local_accessor_name = "out_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
+                {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_producer_a", epp_a},
+                {"num_entries_per_producer_b", epp_b},
+                {"num_producers", static_cast<uint32_t>(num_producers)},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = producer_cfg,
     };
 
     KernelSpec consumer{
-        .unique_id   = "consumer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_CONSUMER_KERNEL},
+        .unique_id = "consumer",
+        .source = ALIAS_CONSUMER_KERNEL,
         .num_threads = num_consumers,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_a", .local_accessor_name = "in_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_b", .local_accessor_name = "in_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
-            {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_consumer_a", epc_a},
-            {"num_entries_per_consumer_b", epc_b},
-            {"num_consumers",              static_cast<uint32_t>(num_consumers)},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_a",
+                 .local_accessor_name = "in_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_b",
+                 .local_accessor_name = "in_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
+                {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_consumer_a", epc_a},
+                {"num_entries_per_consumer_b", epc_b},
+                {"num_consumers", static_cast<uint32_t>(num_consumers)},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = consumer_cfg,
     };
 
@@ -315,14 +323,12 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         *mesh_device, make_alias_l1_tensor_spec(entry_size, num_entries), TensorTopology{});
 
     const DataMovementConfiguration producer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_0},
+        .gen2 = DataMovementConfiguration::Gen2{},
     };
     const DataMovementConfiguration consumer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1 = DataMovementConfiguration::Gen1{.processor = DataMovementProcessor::RISCV_1},
+        .gen2 = DataMovementConfiguration::Gen2{},
     };
 
     // dfb_borrowed: backed by ring_tensor (L1)
@@ -346,57 +352,67 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
     };
 
     KernelSpec producer{
-        .unique_id   = "producer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_PRODUCER_KERNEL},
+        .unique_id = "producer",
+        .source = ALIAS_PRODUCER_KERNEL,
         .num_threads = 1,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_borrowed", .local_accessor_name = "out_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_alias", .local_accessor_name = "out_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "in_tensor_a",  .accessor_name = "src_a"},
-            {.tensor_parameter_name = "in_tensor_b",  .accessor_name = "src_b"},
-            // ring_tensor must be bound to at least one kernel even though the
-            // kernel doesn't access it directly (required by TensorParameter rules).
-            {.tensor_parameter_name = "ring_tensor",  .accessor_name = "ring"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_producer_a", epp},
-            {"num_entries_per_producer_b", epp},
-            {"num_producers",              1u},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_borrowed",
+                 .local_accessor_name = "out_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_alias",
+                 .local_accessor_name = "out_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
+                {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
+                // ring_tensor must be bound to at least one kernel even though the
+                // kernel doesn't access it directly (required by TensorParameter rules).
+                {.tensor_parameter_name = "ring_tensor", .accessor_name = "ring"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_producer_a", epp},
+                {"num_entries_per_producer_b", epp},
+                {"num_producers", 1u},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = producer_cfg,
     };
 
     KernelSpec consumer{
-        .unique_id   = "consumer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_CONSUMER_KERNEL},
+        .unique_id = "consumer",
+        .source = ALIAS_CONSUMER_KERNEL,
         .num_threads = 1,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_borrowed", .local_accessor_name = "in_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_alias", .local_accessor_name = "in_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
-            {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_consumer_a", epc},
-            {"num_entries_per_consumer_b", epc},
-            {"num_consumers",              1u},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_borrowed",
+                 .local_accessor_name = "in_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_alias",
+                 .local_accessor_name = "in_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
+                {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_consumer_a", epc},
+                {"num_entries_per_consumer_b", epc},
+                {"num_consumers", 1u},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = consumer_cfg,
     };
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -145,14 +145,8 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .num_threads = num_producers,
         .dfb_bindings =
             {
-                {.dfb_spec_name = "dfb_a",
-                 .local_accessor_name = "out_a",
-                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
-                {.dfb_spec_name = "dfb_b",
-                 .local_accessor_name = "out_b",
-                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
+                ProducerOf("dfb_a", "out_a"),
+                ProducerOf("dfb_b", "out_b"),
             },
         .tensor_bindings =
             {
@@ -176,14 +170,8 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .num_threads = num_consumers,
         .dfb_bindings =
             {
-                {.dfb_spec_name = "dfb_a",
-                 .local_accessor_name = "in_a",
-                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
-                {.dfb_spec_name = "dfb_b",
-                 .local_accessor_name = "in_b",
-                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
+                ConsumerOf("dfb_a", "in_a"),
+                ConsumerOf("dfb_b", "in_b"),
             },
         .tensor_bindings =
             {
@@ -357,14 +345,8 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_threads = 1,
         .dfb_bindings =
             {
-                {.dfb_spec_name = "dfb_borrowed",
-                 .local_accessor_name = "out_a",
-                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
-                {.dfb_spec_name = "dfb_alias",
-                 .local_accessor_name = "out_b",
-                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
+                ProducerOf("dfb_borrowed", "out_a"),
+                ProducerOf("dfb_alias", "out_b"),
             },
         .tensor_bindings =
             {
@@ -391,14 +373,8 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_threads = 1,
         .dfb_bindings =
             {
-                {.dfb_spec_name = "dfb_borrowed",
-                 .local_accessor_name = "in_a",
-                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
-                {.dfb_spec_name = "dfb_alias",
-                 .local_accessor_name = "in_b",
-                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = DFBAccessPattern::STRIDED},
+                ConsumerOf("dfb_borrowed", "in_a"),
+                ConsumerOf("dfb_alias", "in_b"),
             },
         .tensor_bindings =
             {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -245,9 +245,9 @@ void run_alias_dfb_program(
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer", .runtime_args = rtas(num_entries_a, num_entries_b)},
     };
-    run_params.tensor_args = {
-        {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
-        {.tensor_parameter_name = "in_tensor_b",  .tensor = std::cref(in_b)},
+    run_params.tensor_arguments = {
+        {.tensor_parameter_name = "in_tensor_a", .tensor = std::cref(in_a)},
+        {.tensor_parameter_name = "in_tensor_b", .tensor = std::cref(in_b)},
         {.tensor_parameter_name = "out_tensor_a", .tensor = std::cref(out_a)},
         {.tensor_parameter_name = "out_tensor_b", .tensor = std::cref(out_b)},
     };
@@ -560,12 +560,12 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
         ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .runtime_args = rtas()},
         ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .runtime_args = rtas()},
     };
-    run_params.tensor_args = {
-        {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
-        {.tensor_parameter_name = "in_tensor_b",  .tensor = std::cref(in_b)},
+    run_params.tensor_arguments = {
+        {.tensor_parameter_name = "in_tensor_a", .tensor = std::cref(in_a)},
+        {.tensor_parameter_name = "in_tensor_b", .tensor = std::cref(in_b)},
         {.tensor_parameter_name = "out_tensor_a", .tensor = std::cref(out_a)},
         {.tensor_parameter_name = "out_tensor_b", .tensor = std::cref(out_b)},
-        {.tensor_parameter_name = "ring_tensor",  .tensor = std::cref(ring)},
+        {.tensor_parameter_name = "ring_tensor", .tensor = std::cref(ring)},
     };
     SetProgramRunParameters(program, run_params);
 
@@ -612,12 +612,12 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
         ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .runtime_args = rtas()},
         ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .runtime_args = rtas()},
     };
-    run_params.tensor_args = {
-        {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
-        {.tensor_parameter_name = "in_tensor_b",  .tensor = std::cref(in_b)},
+    run_params.tensor_arguments = {
+        {.tensor_parameter_name = "in_tensor_a", .tensor = std::cref(in_a)},
+        {.tensor_parameter_name = "in_tensor_b", .tensor = std::cref(in_b)},
         {.tensor_parameter_name = "out_tensor_a", .tensor = std::cref(out_a)},
         {.tensor_parameter_name = "out_tensor_b", .tensor = std::cref(out_b)},
-        {.tensor_parameter_name = "ring_tensor",  .tensor = std::cref(ring)},
+        {.tensor_parameter_name = "ring_tensor", .tensor = std::cref(ring)},
     };
     SetProgramRunParameters(program, run_params);
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -190,18 +190,19 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
     };
 
     ProgramSpec spec{
-        .program_id       = "alias_dfb",
-        .kernels          = {producer, consumer},
+        .name = "alias_dfb",
+        .kernels = {producer, consumer},
         .dataflow_buffers = {dfb_a, dfb_b},
-        .tensor_parameters = {
-            {.unique_id = "in_tensor_a",  .spec = in_a.tensor_spec()},
-            {.unique_id = "in_tensor_b",  .spec = in_b.tensor_spec()},
-            {.unique_id = "out_tensor_a", .spec = out_a.tensor_spec()},
-            {.unique_id = "out_tensor_b", .spec = out_b.tensor_spec()},
-        },
+        .tensor_parameters =
+            {
+                {.unique_id = "in_tensor_a", .spec = in_a.tensor_spec()},
+                {.unique_id = "in_tensor_b", .spec = in_b.tensor_spec()},
+                {.unique_id = "out_tensor_a", .spec = out_a.tensor_spec()},
+                {.unique_id = "out_tensor_b", .spec = out_b.tensor_spec()},
+            },
         .work_units = {WorkUnitSpec{
-            .unique_id    = "wu",
-            .kernels      = {"producer", "consumer"},
+            .name = "wu",
+            .kernels = {"producer", "consumer"},
             .target_nodes = node,
         }},
     };
@@ -391,19 +392,20 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
     };
 
     ProgramSpec spec{
-        .program_id        = "alias_borrowed_dfb",
-        .kernels           = {producer, consumer},
-        .dataflow_buffers  = {dfb_borrowed, dfb_alias_spec},
-        .tensor_parameters = {
-            {.unique_id = "in_tensor_a",  .spec = in_a.tensor_spec()},
-            {.unique_id = "in_tensor_b",  .spec = in_b.tensor_spec()},
-            {.unique_id = "out_tensor_a", .spec = out_a.tensor_spec()},
-            {.unique_id = "out_tensor_b", .spec = out_b.tensor_spec()},
-            {.unique_id = "ring_tensor",  .spec = ring.tensor_spec()},
-        },
+        .name = "alias_borrowed_dfb",
+        .kernels = {producer, consumer},
+        .dataflow_buffers = {dfb_borrowed, dfb_alias_spec},
+        .tensor_parameters =
+            {
+                {.unique_id = "in_tensor_a", .spec = in_a.tensor_spec()},
+                {.unique_id = "in_tensor_b", .spec = in_b.tensor_spec()},
+                {.unique_id = "out_tensor_a", .spec = out_a.tensor_spec()},
+                {.unique_id = "out_tensor_b", .spec = out_b.tensor_spec()},
+                {.unique_id = "ring_tensor", .spec = ring.tensor_spec()},
+            },
         .work_units = {WorkUnitSpec{
-            .unique_id    = "wu",
-            .kernels      = {"producer", "consumer"},
+            .name = "wu",
+            .kernels = {"producer", "consumer"},
             .target_nodes = node,
         }},
     };

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -153,14 +153,14 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
                 {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
                 {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_producer_a", epp_a},
                 {"num_entries_per_producer_b", epp_b},
                 {"num_producers", static_cast<uint32_t>(num_producers)},
             },
         .runtime_arguments_schema =
-            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+            {.runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = producer_cfg,
     };
 
@@ -178,14 +178,14 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
                 {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
                 {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_consumer_a", epc_a},
                 {"num_entries_per_consumer_b", epc_b},
                 {"num_consumers", static_cast<uint32_t>(num_consumers)},
             },
         .runtime_arguments_schema =
-            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+            {.runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = consumer_cfg,
     };
 
@@ -227,12 +227,12 @@ void run_alias_dfb_program(
 
     Program program = MakeProgramFromSpec(*mesh_device, spec);
 
-    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeRuntimeArgs = ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
     auto rtas = [&](uint32_t epc_a, uint32_t epc_b) {
-        return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+        return std::vector<NodeRuntimeArgs>{NodeRuntimeArgs{
             node,
-            {{"chunk_offset_a",     0u},
-             {"chunk_offset_b",     0u},
+            {{"chunk_offset_a", 0u},
+             {"chunk_offset_b", 0u},
              {"entries_per_core_a", epc_a},
              {"entries_per_core_b", epc_b}}}};
     };
@@ -240,11 +240,9 @@ void run_alias_dfb_program(
     ProgramRunParams run_params;
     run_params.kernel_run_params = {
         ProgramRunParams::KernelRunParams{
-            .kernel_spec_name = "producer",
-            .named_runtime_args = rtas(num_entries_a, num_entries_b)},
+            .kernel_spec_name = "producer", .runtime_args = rtas(num_entries_a, num_entries_b)},
         ProgramRunParams::KernelRunParams{
-            .kernel_spec_name = "consumer",
-            .named_runtime_args = rtas(num_entries_a, num_entries_b)},
+            .kernel_spec_name = "consumer", .runtime_args = rtas(num_entries_a, num_entries_b)},
     };
     run_params.tensor_args = {
         {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
@@ -356,14 +354,14 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
                 // kernel doesn't access it directly (required by TensorParameter rules).
                 {.tensor_parameter_name = "ring_tensor", .accessor_name = "ring"},
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_producer_a", epp},
                 {"num_entries_per_producer_b", epp},
                 {"num_producers", 1u},
             },
         .runtime_arguments_schema =
-            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+            {.runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = producer_cfg,
     };
 
@@ -381,14 +379,14 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
                 {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
                 {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_consumer_a", epc},
                 {"num_entries_per_consumer_b", epc},
                 {"num_consumers", 1u},
             },
         .runtime_arguments_schema =
-            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+            {.runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = consumer_cfg,
     };
 
@@ -546,19 +544,19 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(device);
 
-    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeRuntimeArgs = ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
     auto rtas = [&]() {
-        return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+        return std::vector<NodeRuntimeArgs>{NodeRuntimeArgs{
             node,
-            {{"chunk_offset_a",     0u},
-             {"chunk_offset_b",     0u},
+            {{"chunk_offset_a", 0u},
+             {"chunk_offset_b", 0u},
              {"entries_per_core_a", kNumEntries},
              {"entries_per_core_b", kNumEntries}}}};
     };
     ProgramRunParams run_params;
     run_params.kernel_run_params = {
-        ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .named_runtime_args = rtas()},
-        ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .named_runtime_args = rtas()},
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .runtime_args = rtas()},
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .runtime_args = rtas()},
     };
     run_params.tensor_args = {
         {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},
@@ -598,19 +596,19 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
 
     Program program = MakeProgramFromSpec(*devices_.at(0), spec);
 
-    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeRuntimeArgs = ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
     auto rtas = [&]() {
-        return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+        return std::vector<NodeRuntimeArgs>{NodeRuntimeArgs{
             node,
-            {{"chunk_offset_a",     0u},
-             {"chunk_offset_b",     0u},
+            {{"chunk_offset_a", 0u},
+             {"chunk_offset_b", 0u},
              {"entries_per_core_a", kNumEntries},
              {"entries_per_core_b", kNumEntries}}}};
     };
     ProgramRunParams run_params;
     run_params.kernel_run_params = {
-        ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .named_runtime_args = rtas()},
-        ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .named_runtime_args = rtas()},
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "producer", .runtime_args = rtas()},
+        ProgramRunParams::KernelRunParams{.kernel_spec_name = "consumer", .runtime_args = rtas()},
     };
     run_params.tensor_args = {
         {.tensor_parameter_name = "in_tensor_a",  .tensor = std::cref(in_a)},

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -110,7 +110,7 @@ void run_borrowed_memory_dfb_program(
     KernelSpec producer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("producer", static_cast<uint8_t>(cfg.num_producers))
         : MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer_spec.source = KernelSpec::SourceFilePath{DFB_PRODUCER_KERNEL};
+    producer_spec.source = DFB_PRODUCER_KERNEL;
     producer_spec.compile_time_arg_bindings = {
         {"num_entries_per_producer", entries_per_producer},
         {"implicit_sync",            implicit_sync},
@@ -133,7 +133,7 @@ void run_borrowed_memory_dfb_program(
         consumer_spec = (arch == ARCH::QUASAR)
             ? MakeMinimalComputeKernel("consumer", static_cast<uint8_t>(cfg.num_consumers))
             : MakeMinimalComputeKernel("consumer");
-        consumer_spec.source = KernelSpec::SourceFilePath{DFB_TENSIX_CONSUMER_KERNEL};
+        consumer_spec.source = DFB_TENSIX_CONSUMER_KERNEL;
         consumer_spec.compile_time_arg_bindings = {
             {"num_entries_per_consumer", entries_per_consumer},
         };
@@ -142,7 +142,7 @@ void run_borrowed_memory_dfb_program(
         consumer_spec = (arch == ARCH::QUASAR)
             ? MakeMinimalDMKernel("consumer", static_cast<uint8_t>(cfg.num_consumers))
             : MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-        consumer_spec.source = KernelSpec::SourceFilePath{DFB_DM_CONSUMER_KERNEL};
+        consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
         consumer_spec.compile_time_arg_bindings = {
             {"num_entries_per_consumer", entries_per_consumer},
             {"blocked_consumer",         static_cast<uint32_t>(is_all ? 1u : 0u)},
@@ -267,7 +267,7 @@ void run_update_address_test(
     KernelSpec producer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("producer")
         : MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer_spec.source = KernelSpec::SourceFilePath{DFB_PRODUCER_KERNEL};
+    producer_spec.source = DFB_PRODUCER_KERNEL;
     producer_spec.compile_time_arg_bindings = {
         {"num_entries_per_producer", num_entries},
         {"implicit_sync",            implicit_sync},
@@ -283,7 +283,7 @@ void run_update_address_test(
     KernelSpec consumer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("consumer")
         : MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer_spec.source = KernelSpec::SourceFilePath{DFB_DM_CONSUMER_KERNEL};
+    consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
     consumer_spec.compile_time_arg_bindings = {
         {"num_entries_per_consumer", num_entries},
         {"blocked_consumer",         0u},

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -219,11 +219,11 @@ void run_borrowed_memory_dfb_program(
             .runtime_args = {dm_rtas},
         });
     }
-    params.tensor_args.push_back({.tensor_parameter_name = "src_tensor", .tensor = std::cref(src_tensor)});
+    params.tensor_arguments.push_back({.tensor_parameter_name = "src_tensor", .tensor = std::cref(src_tensor)});
     if (!cfg.tensix_consumer) {
-        params.tensor_args.push_back({.tensor_parameter_name = "dst_tensor", .tensor = std::cref(*dst_tensor)});
+        params.tensor_arguments.push_back({.tensor_parameter_name = "dst_tensor", .tensor = std::cref(*dst_tensor)});
     }
-    params.tensor_args.push_back({.tensor_parameter_name = "dfb_ring_tensor", .tensor = std::cref(ring_tensor)});
+    params.tensor_arguments.push_back({.tensor_parameter_name = "dfb_ring_tensor", .tensor = std::cref(ring_tensor)});
     SetProgramRunParameters(program, params);
 
     // -----------------------------------------------------------------------
@@ -247,7 +247,7 @@ void run_borrowed_memory_dfb_program(
     }
 }
 
-// Verifies that UpdateTensorArgs can redirect a borrowed DFB ring to a different
+// Verifies that UpdateTensorArguments can redirect a borrowed DFB ring to a different
 // L1 tensor between runs on the same compiled program.
 void run_update_address_test(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
@@ -345,9 +345,9 @@ void run_update_address_test(
         {.kernel_spec_name = "producer", .runtime_args = {dm_rtas}},
         {.kernel_spec_name = "consumer", .runtime_args = {dm_rtas}},
     };
-    params1.tensor_args = {
-        {.tensor_parameter_name = "src_tensor",      .tensor = std::cref(src_tensor)},
-        {.tensor_parameter_name = "dst_tensor",      .tensor = std::cref(dst_tensor)},
+    params1.tensor_arguments = {
+        {.tensor_parameter_name = "src_tensor", .tensor = std::cref(src_tensor)},
+        {.tensor_parameter_name = "dst_tensor", .tensor = std::cref(dst_tensor)},
         {.tensor_parameter_name = "dfb_ring_tensor", .tensor = std::cref(ring_tensor_a)},
     };
     SetProgramRunParameters(program, params1);
@@ -362,16 +362,18 @@ void run_update_address_test(
         EXPECT_EQ(input_a, output);
     }
 
-    // --- Run 2: ring redirected to ring_tensor_b via UpdateTensorArgs ---
+    // --- Run 2: ring redirected to ring_tensor_b via UpdateTensorArguments ---
     std::vector<uint32_t> input_b(total_words);
     std::iota(input_b.begin(), input_b.end(), total_words);  // distinct from run 1
     detail::WriteToBuffer(*src_tensor.mesh_buffer().get_reference_buffer(), input_b);
 
-    UpdateTensorArgs(program, std::vector<ProgramRunParams::TensorArg>{
-        {.tensor_parameter_name = "src_tensor",      .tensor = std::cref(src_tensor)},
-        {.tensor_parameter_name = "dst_tensor",      .tensor = std::cref(dst_tensor)},
-        {.tensor_parameter_name = "dfb_ring_tensor", .tensor = std::cref(ring_tensor_b)},
-    });
+    UpdateTensorArguments(
+        program,
+        std::vector<ProgramRunParams::TensorArgument>{
+            {.tensor_parameter_name = "src_tensor", .tensor = std::cref(src_tensor)},
+            {.tensor_parameter_name = "dst_tensor", .tensor = std::cref(dst_tensor)},
+            {.tensor_parameter_name = "dfb_ring_tensor", .tensor = std::cref(ring_tensor_b)},
+        });
     detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
 
     EXPECT_EQ(

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -110,12 +110,12 @@ void run_borrowed_memory_dfb_program(
         ? MakeMinimalDMKernel("producer", static_cast<uint8_t>(cfg.num_producers))
         : MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer_spec.source = DFB_PRODUCER_KERNEL;
-    producer_spec.compile_time_arg_bindings = {
+    producer_spec.compile_time_args = {
         {"num_entries_per_producer", entries_per_producer},
-        {"implicit_sync",            implicit_sync},
-        {"num_producers",            cfg.num_producers},
+        {"implicit_sync", implicit_sync},
+        {"num_producers", cfg.num_producers},
     };
-    producer_spec.runtime_arguments_schema.named_runtime_args = {"chunk_offset", "entries_per_core"};
+    producer_spec.runtime_arguments_schema.runtime_args = {"chunk_offset", "entries_per_core"};
     producer_spec.tensor_bindings = {
         {.tensor_parameter_name = "src_tensor",      .accessor_name = "src_tensor"},
         // dfb_ring_tensor backs the borrowed DFB; the kernel does not access it directly,
@@ -132,7 +132,7 @@ void run_borrowed_memory_dfb_program(
             ? MakeMinimalComputeKernel("consumer", static_cast<uint8_t>(cfg.num_consumers))
             : MakeMinimalComputeKernel("consumer");
         consumer_spec.source = DFB_TENSIX_CONSUMER_KERNEL;
-        consumer_spec.compile_time_arg_bindings = {
+        consumer_spec.compile_time_args = {
             {"num_entries_per_consumer", entries_per_consumer},
         };
     } else {
@@ -141,13 +141,13 @@ void run_borrowed_memory_dfb_program(
             ? MakeMinimalDMKernel("consumer", static_cast<uint8_t>(cfg.num_consumers))
             : MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
         consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
-        consumer_spec.compile_time_arg_bindings = {
+        consumer_spec.compile_time_args = {
             {"num_entries_per_consumer", entries_per_consumer},
-            {"blocked_consumer",         static_cast<uint32_t>(is_all ? 1u : 0u)},
-            {"implicit_sync",            implicit_sync},
-            {"num_consumers",            cfg.num_consumers},
+            {"blocked_consumer", static_cast<uint32_t>(is_all ? 1u : 0u)},
+            {"implicit_sync", implicit_sync},
+            {"num_consumers", cfg.num_consumers},
         };
-        consumer_spec.runtime_arguments_schema.named_runtime_args = {"chunk_offset", "entries_per_core"};
+        consumer_spec.runtime_arguments_schema.runtime_args = {"chunk_offset", "entries_per_core"};
         consumer_spec.tensor_bindings = {{
             .tensor_parameter_name = "dst_tensor",
             .accessor_name         = "dst_tensor",
@@ -203,20 +203,20 @@ void run_borrowed_memory_dfb_program(
     // -----------------------------------------------------------------------
     // Build and apply run params
     // -----------------------------------------------------------------------
-    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
-    const NodeNamedRTAs dm_rtas{node, {{"chunk_offset", 0u}, {"entries_per_core", entries_per_core}}};
+    using NodeRuntimeArgs = ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
+    const NodeRuntimeArgs dm_rtas{node, {{"chunk_offset", 0u}, {"entries_per_core", entries_per_core}}};
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
-        .kernel_spec_name  = "producer",
-        .named_runtime_args = {dm_rtas},
+        .kernel_spec_name = "producer",
+        .runtime_args = {dm_rtas},
     });
     if (cfg.tensix_consumer) {
         params.kernel_run_params.push_back({.kernel_spec_name = "consumer"});
     } else {
         params.kernel_run_params.push_back({
-            .kernel_spec_name   = "consumer",
-            .named_runtime_args = {dm_rtas},
+            .kernel_spec_name = "consumer",
+            .runtime_args = {dm_rtas},
         });
     }
     params.tensor_args.push_back({.tensor_parameter_name = "src_tensor", .tensor = std::cref(src_tensor)});
@@ -270,12 +270,12 @@ void run_update_address_test(
         ? MakeMinimalDMKernel("producer")
         : MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer_spec.source = DFB_PRODUCER_KERNEL;
-    producer_spec.compile_time_arg_bindings = {
+    producer_spec.compile_time_args = {
         {"num_entries_per_producer", num_entries},
-        {"implicit_sync",            implicit_sync},
-        {"num_producers",            1u},
+        {"implicit_sync", implicit_sync},
+        {"num_producers", 1u},
     };
-    producer_spec.runtime_arguments_schema.named_runtime_args = {"chunk_offset", "entries_per_core"};
+    producer_spec.runtime_arguments_schema.runtime_args = {"chunk_offset", "entries_per_core"};
     producer_spec.tensor_bindings = {
         {.tensor_parameter_name = "src_tensor",      .accessor_name = "src_tensor"},
         {.tensor_parameter_name = "dfb_ring_tensor", .accessor_name = "dfb_ring"},
@@ -286,13 +286,13 @@ void run_update_address_test(
         ? MakeMinimalDMKernel("consumer")
         : MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
-    consumer_spec.compile_time_arg_bindings = {
+    consumer_spec.compile_time_args = {
         {"num_entries_per_consumer", num_entries},
-        {"blocked_consumer",         0u},
-        {"implicit_sync",            implicit_sync},
-        {"num_consumers",            1u},
+        {"blocked_consumer", 0u},
+        {"implicit_sync", implicit_sync},
+        {"num_consumers", 1u},
     };
-    consumer_spec.runtime_arguments_schema.named_runtime_args = {"chunk_offset", "entries_per_core"};
+    consumer_spec.runtime_arguments_schema.runtime_args = {"chunk_offset", "entries_per_core"};
     consumer_spec.tensor_bindings = {{
         .tensor_parameter_name = "dst_tensor",
         .accessor_name         = "dst_tensor",
@@ -332,8 +332,8 @@ void run_update_address_test(
     ASSERT_NE(ring_tensor_a.address(), ring_tensor_b.address())
         << "Test pre-condition: two separate L1 allocations must have distinct addresses";
 
-    using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
-    const NodeNamedRTAs dm_rtas{node, {{"chunk_offset", 0u}, {"entries_per_core", num_entries}}};
+    using NodeRuntimeArgs = ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
+    const NodeRuntimeArgs dm_rtas{node, {{"chunk_offset", 0u}, {"entries_per_core", num_entries}}};
 
     // --- Run 1: ring at ring_tensor_a ---
     std::vector<uint32_t> input_a(total_words);
@@ -342,8 +342,8 @@ void run_update_address_test(
 
     ProgramRunParams params1;
     params1.kernel_run_params = {
-        {.kernel_spec_name = "producer", .named_runtime_args = {dm_rtas}},
-        {.kernel_spec_name = "consumer", .named_runtime_args = {dm_rtas}},
+        {.kernel_spec_name = "producer", .runtime_args = {dm_rtas}},
+        {.kernel_spec_name = "consumer", .runtime_args = {dm_rtas}},
     };
     params1.tensor_args = {
         {.tensor_parameter_name = "src_tensor",      .tensor = std::cref(src_tensor)},

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -103,7 +103,7 @@ void run_borrowed_memory_dfb_program(
     // Build ProgramSpec
     // -----------------------------------------------------------------------
     ProgramSpec spec;
-    spec.program_id = "borrowed_memory_dfb_test";
+    spec.name = "borrowed_memory_dfb_test";
 
     // --- Producer kernel (dfb_producer.cpp) ---
     KernelSpec producer_spec = (arch == ARCH::QUASAR)
@@ -264,7 +264,7 @@ void run_update_address_test(
     // Build ProgramSpec
     // -----------------------------------------------------------------------
     ProgramSpec spec;
-    spec.program_id = "borrowed_dfb_update_address";
+    spec.name = "borrowed_dfb_update_address";
 
     KernelSpec producer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("producer")

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -33,7 +33,6 @@ namespace tt::tt_metal {
 namespace {
 
 using namespace experimental;
-using test_helpers::BindDFBToKernel;
 using test_helpers::MakeMinimalComputeKernel;
 using test_helpers::MakeMinimalDMKernel;
 using test_helpers::MakeMinimalGen1DMKernel;
@@ -123,8 +122,7 @@ void run_borrowed_memory_dfb_program(
         // but every TensorParameter must be bound to at least one kernel.
         {.tensor_parameter_name = "dfb_ring_tensor", .accessor_name = "dfb_ring"},
     };
-    BindDFBToKernel(producer_spec, "borrowed_dfb", "out",
-                    KernelSpec::DFBEndpointType::PRODUCER, DFBAccessPattern::STRIDED);
+    producer_spec.dfb_bindings.push_back(ProducerOf("borrowed_dfb", "out"));
 
     // --- Consumer kernel ---
     KernelSpec consumer_spec;
@@ -155,8 +153,12 @@ void run_borrowed_memory_dfb_program(
             .accessor_name         = "dst_tensor",
         }};
     }
-    BindDFBToKernel(consumer_spec, "borrowed_dfb", "in",
-                    KernelSpec::DFBEndpointType::CONSUMER, cfg.cap);
+    consumer_spec.dfb_bindings.push_back(DFBBinding{
+        .dfb_spec_name = "borrowed_dfb",
+        .local_accessor_name = "in",
+        .endpoint_type = DFBEndpointType::CONSUMER,
+        .access_pattern = cfg.cap,
+    });
 
     // --- Borrowed DFB spec ---
     DataflowBufferSpec dfb_spec{
@@ -278,7 +280,7 @@ void run_update_address_test(
         {.tensor_parameter_name = "src_tensor",      .accessor_name = "src_tensor"},
         {.tensor_parameter_name = "dfb_ring_tensor", .accessor_name = "dfb_ring"},
     };
-    BindDFBToKernel(producer_spec, "borrowed_dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    producer_spec.dfb_bindings.push_back(ProducerOf("borrowed_dfb", "out"));
 
     KernelSpec consumer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("consumer")
@@ -295,7 +297,7 @@ void run_update_address_test(
         .tensor_parameter_name = "dst_tensor",
         .accessor_name         = "dst_tensor",
     }};
-    BindDFBToKernel(consumer_spec, "borrowed_dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    consumer_spec.dfb_bindings.push_back(ConsumerOf("borrowed_dfb", "in"));
 
     DataflowBufferSpec dfb_spec{
         .unique_id             = "borrowed_dfb",

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -32,7 +32,7 @@
 namespace tt::tt_metal {
 namespace {
 
-using namespace experimental::metal2_host_api;
+using namespace experimental;
 using test_helpers::BindDFBToKernel;
 using test_helpers::MakeMinimalComputeKernel;
 using test_helpers::MakeMinimalDMKernel;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -241,12 +241,7 @@ void run_single_dfb_program(
             .unique_id = PRODUCER,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
-            .dfb_bindings = {{
-                .dfb_spec_name = DFB_NAME,
-                .local_accessor_name = "out",
-                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::DFBAccessPattern::STRIDED,
-            }},
+            .dfb_bindings = {experimental::ProducerOf(DFB_NAME, "out")},
             .tensor_bindings = {{
                 .tensor_parameter_name = IN_TENSOR,
                 .accessor_name = "src_tensor",  // kernel: ta::src_tensor
@@ -265,12 +260,7 @@ void run_single_dfb_program(
             .unique_id = PRODUCER,
             .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
-            .dfb_bindings = {{
-                .dfb_spec_name = DFB_NAME,
-                .local_accessor_name = "out",
-                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::DFBAccessPattern::STRIDED,
-            }},
+            .dfb_bindings = {experimental::ProducerOf(DFB_NAME, "out")},
             .compile_time_arg_bindings = {{"num_entries_per_producer", num_entries_per_producer}},
             .config_spec = experimental::ComputeConfiguration{},
         };
@@ -636,12 +626,7 @@ void run_concurrent_dfbs_program(
             .unique_id = producer_name,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp",
             .num_threads = 1,
-            .dfb_bindings = {{
-                .dfb_spec_name = dfb_name,
-                .local_accessor_name = "out",
-                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::DFBAccessPattern::STRIDED,
-            }},
+            .dfb_bindings = {experimental::ProducerOf(dfb_name, "out")},
             .tensor_bindings = {{
                 .tensor_parameter_name = IN_TENSOR,
                 .accessor_name = "src_tensor",
@@ -661,12 +646,7 @@ void run_concurrent_dfbs_program(
             .unique_id = consumer_name,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp",
             .num_threads = 1,
-            .dfb_bindings = {{
-                .dfb_spec_name = dfb_name,
-                .local_accessor_name = "in",
-                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                .access_pattern = experimental::DFBAccessPattern::STRIDED,
-            }},
+            .dfb_bindings = {experimental::ConsumerOf(dfb_name, "in")},
             .tensor_bindings = {{
                 .tensor_parameter_name = OUT_TENSOR,
                 .accessor_name = "dst_tensor",
@@ -782,12 +762,8 @@ void run_concurrent_tensix_dm_dfbs_program(
         .config_spec = experimental::ComputeConfiguration{},
     };
     for (uint32_t i = 0; i < num_dfbs; ++i) {
-        producer_spec.dfb_bindings.push_back(experimental::KernelSpec::DFBBinding{
-            .dfb_spec_name = "dfb_" + std::to_string(i),
-            .local_accessor_name = "dfb_" + std::to_string(i),
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        });
+        producer_spec.dfb_bindings.push_back(
+            experimental::ProducerOf("dfb_" + std::to_string(i), "dfb_" + std::to_string(i)));
     }
 
     // DM concurrent consumers: one 1-thread kernel instance per DFB, each binding
@@ -827,12 +803,7 @@ void run_concurrent_tensix_dm_dfbs_program(
             .unique_id = consumer_name,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp",
             .num_threads = 1,
-            .dfb_bindings = {{
-                .dfb_spec_name = dfb_name,
-                .local_accessor_name = "in",
-                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                .access_pattern = experimental::DFBAccessPattern::STRIDED,
-            }},
+            .dfb_bindings = {experimental::ConsumerOf(dfb_name, "in")},
             .tensor_bindings = {{
                 .tensor_parameter_name = out_tensor_name,
                 .accessor_name = "dst_tensor",
@@ -1049,12 +1020,7 @@ void run_sequential_dfbs_program(
             .spec = out_tensors[i].tensor_spec(),
         });
 
-        producer_spec.dfb_bindings.push_back(experimental::KernelSpec::DFBBinding{
-            .dfb_spec_name = dfb_name,
-            .local_accessor_name = "dfb_" + idx,
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        });
+        producer_spec.dfb_bindings.push_back(experimental::ProducerOf(dfb_name, "dfb_" + idx));
         producer_spec.tensor_bindings.push_back(experimental::KernelSpec::TensorBinding{
             .tensor_parameter_name = in_tensor_name,
             .accessor_name = "src_" + idx,
@@ -1185,12 +1151,7 @@ void run_in_dfb_out_dfb_program(
         .unique_id = PRODUCER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = static_cast<uint8_t>(dm2tensix_config.num_producers),
-        .dfb_bindings = {{
-            .dfb_spec_name = IN_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(IN_DFB, "out")},
         .tensor_bindings = {{
             .tensor_parameter_name = IN_TENSOR,
             .accessor_name = "src_tensor",
@@ -1218,12 +1179,7 @@ void run_in_dfb_out_dfb_program(
                     .access_pattern =
                         in_is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED,
                 },
-                {
-                    .dfb_spec_name = OUT_DFB,
-                    .local_accessor_name = "out",
-                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
-                },
+                experimental::ProducerOf(OUT_DFB, "out"),
             },
         .compile_time_arg_bindings = {{"num_entries", num_entries_per_unpacker}},
         .config_spec = experimental::ComputeConfiguration{},
@@ -1862,18 +1818,8 @@ static void run_intra_tensix_dfb_program(
         .num_threads = static_cast<uint8_t>(num_threads),
         .dfb_bindings =
             {
-                {
-                    .dfb_spec_name = INTRA_DFB,
-                    .local_accessor_name = "out",
-                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
-                },
-                {
-                    .dfb_spec_name = INTRA_DFB,
-                    .local_accessor_name = "in",
-                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
-                },
+                experimental::ProducerOf(INTRA_DFB, "out"),
+                experimental::ConsumerOf(INTRA_DFB, "in"),
             },
         .compile_time_arg_bindings =
             {
@@ -2003,12 +1949,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .unique_id = DM_PRODUCER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = REMAPPER_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(REMAPPER_DFB, "out")},
         .tensor_bindings = {{
             .tensor_parameter_name = IN_TENSOR,
             .accessor_name = "src_tensor",
@@ -2032,24 +1973,9 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .num_threads = static_cast<uint8_t>(num_neos),
         .dfb_bindings =
             {
-                {
-                    .dfb_spec_name = REMAPPER_DFB,
-                    .local_accessor_name = "remapper_in",
-                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                    .access_pattern = experimental::DFBAccessPattern::ALL,
-                },
-                {
-                    .dfb_spec_name = INTRA_DFB,
-                    .local_accessor_name = "intra_out",
-                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
-                },
-                {
-                    .dfb_spec_name = INTRA_DFB,
-                    .local_accessor_name = "intra_in",
-                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
-                },
+                experimental::AllConsumerOf(REMAPPER_DFB, "remapper_in"),
+                experimental::ProducerOf(INTRA_DFB, "intra_out"),
+                experimental::ConsumerOf(INTRA_DFB, "intra_in"),
             },
         .compile_time_arg_bindings =
             {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -1021,10 +1021,7 @@ void run_sequential_dfbs_program(
         });
 
         producer_spec.dfb_bindings.push_back(experimental::ProducerOf(dfb_name, "dfb_" + idx));
-        producer_spec.tensor_bindings.push_back(experimental::KernelSpec::TensorBinding{
-            .tensor_parameter_name = in_tensor_name,
-            .accessor_name = "src_" + idx,
-        });
+        producer_spec.tensor_bindings.push_back(UseTensor(in_tensor_name, "src_" + idx));
 
         consumer_spec.dfb_bindings.push_back(experimental::KernelSpec::DFBBinding{
             .dfb_spec_name = dfb_name,
@@ -1032,10 +1029,7 @@ void run_sequential_dfbs_program(
             .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
             .access_pattern = is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED,
         });
-        consumer_spec.tensor_bindings.push_back(experimental::KernelSpec::TensorBinding{
-            .tensor_parameter_name = out_tensor_name,
-            .accessor_name = "dst_" + idx,
-        });
+        consumer_spec.tensor_bindings.push_back(UseTensor(out_tensor_name, "dst_" + idx));
         consumer_spec.compile_time_args.push_back({"entries_per_consumer_" + idx, epc});
         consumer_spec.compile_time_args.push_back({"is_blocked_" + idx, static_cast<uint32_t>(is_all ? 1u : 0u)});
     }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -355,10 +355,10 @@ void run_single_dfb_program(
     }
     run_params.kernel_run_params = {producer_params, consumer_params};
     if (need_in_tensor) {
-        run_params.tensor_args.push_back({.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(*in_tensor)});
+        run_params.tensor_arguments.push_back({.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(*in_tensor)});
     }
     if (need_out_tensor) {
-        run_params.tensor_args.push_back({.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(*out_tensor)});
+        run_params.tensor_arguments.push_back({.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(*out_tensor)});
     }
     experimental::SetProgramRunParameters(program, run_params);
 
@@ -690,7 +690,7 @@ void run_concurrent_dfbs_program(
         run_params.kernel_run_params.push_back(
             experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = name});
     }
-    run_params.tensor_args = {
+    run_params.tensor_arguments = {
         {.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(out_tensor)},
     };
@@ -841,9 +841,9 @@ void run_concurrent_tensix_dm_dfbs_program(
         run_params.kernel_run_params.push_back(
             experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = name});
     }
-    run_params.tensor_args.reserve(num_dfbs);
+    run_params.tensor_arguments.reserve(num_dfbs);
     for (uint32_t i = 0; i < num_dfbs; ++i) {
-        run_params.tensor_args.push_back(
+        run_params.tensor_arguments.push_back(
             {.tensor_parameter_name = "out_tensor_" + std::to_string(i), .tensor = std::cref(out_tensors[i])});
     }
     experimental::SetProgramRunParameters(program, run_params);
@@ -1057,12 +1057,12 @@ void run_sequential_dfbs_program(
         experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = PRODUCER},
         experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = CONSUMER},
     };
-    run_params.tensor_args.reserve(2 * num_dfbs);
+    run_params.tensor_arguments.reserve(2 * num_dfbs);
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         const std::string idx = std::to_string(i);
-        run_params.tensor_args.push_back(
+        run_params.tensor_arguments.push_back(
             {.tensor_parameter_name = "in_tensor_" + idx, .tensor = std::cref(in_tensors[i])});
-        run_params.tensor_args.push_back(
+        run_params.tensor_arguments.push_back(
             {.tensor_parameter_name = "out_tensor_" + idx, .tensor = std::cref(out_tensors[i])});
     }
     experimental::SetProgramRunParameters(program, run_params);
@@ -1243,7 +1243,7 @@ void run_in_dfb_out_dfb_program(
 
     experimental::ProgramRunParams run_params;
     run_params.kernel_run_params = {producer_params, compute_params, consumer_params};
-    run_params.tensor_args = {
+    run_params.tensor_arguments = {
         {.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(out_tensor)},
     };
@@ -2009,7 +2009,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
 
     experimental::ProgramRunParams run_params;
     run_params.kernel_run_params = {dm_producer_params, compute_params};
-    run_params.tensor_args = {{.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)}};
+    run_params.tensor_arguments = {{.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)}};
     experimental::SetProgramRunParameters(program, run_params);
 
     // L1 layout follows DFB creation order:

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -225,25 +225,23 @@ void run_single_dfb_program(
     // DM kernel configs supply both Gen1 (BRISC for producer / NCRISC for consumer) and
     // Gen2 (auto-assigned) variants so the same KernelSpec runs on WH/BH and Quasar.
     const experimental::metal2_host_api::DataMovementConfiguration dm_producer_cfg{
-        .gen1_data_movement_config =
-            experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
+        .gen1 =
+            experimental::metal2_host_api::DataMovementConfiguration::Gen1{
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_0},
-        .gen2_data_movement_config = experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{},
     };
     const experimental::metal2_host_api::DataMovementConfiguration dm_consumer_cfg{
-        .gen1_data_movement_config =
-            experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
+        .gen1 =
+            experimental::metal2_host_api::DataMovementConfiguration::Gen1{
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_1},
-        .gen2_data_movement_config = experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{},
     };
 
     experimental::metal2_host_api::KernelSpec producer_spec;
     if (producer_type == DFBPorCType::DM) {
         producer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = PRODUCER,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -267,9 +265,7 @@ void run_single_dfb_program(
     } else {
         producer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = PRODUCER,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -286,9 +282,7 @@ void run_single_dfb_program(
     if (consumer_type == DFBPorCType::DM) {
         consumer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = CONSUMER,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -313,9 +307,7 @@ void run_single_dfb_program(
     } else {
         consumer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = CONSUMER,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -644,9 +636,7 @@ void run_concurrent_dfbs_program(
 
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = producer_name,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
@@ -666,16 +656,13 @@ void run_concurrent_dfbs_program(
                 },
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
         });
         kernel_names.push_back(producer_name);
 
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = consumer_name,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
@@ -695,8 +682,7 @@ void run_concurrent_dfbs_program(
                 },
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
         });
         kernel_names.push_back(consumer_name);
     }
@@ -793,9 +779,7 @@ void run_concurrent_tensix_dm_dfbs_program(
     // via risc_common.h on DM kernel builds).
     experimental::metal2_host_api::KernelSpec producer_spec{
         .unique_id = PRODUCER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings = {{"num_entries_per_producer", entries_per_dfb}},
@@ -845,9 +829,7 @@ void run_concurrent_tensix_dm_dfbs_program(
 
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = consumer_name,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
@@ -866,8 +848,7 @@ void run_concurrent_tensix_dm_dfbs_program(
                 },
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
         });
         kernel_names.push_back(consumer_name);
     }
@@ -1015,9 +996,7 @@ void run_sequential_dfbs_program(
     // colliding with dfb::NUM_DFBS in dataflow_buffer_config.h.
     experimental::metal2_host_api::KernelSpec producer_spec{
         .unique_id = PRODUCER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp",
         .num_threads = num_producers,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings =
@@ -1028,17 +1007,14 @@ void run_sequential_dfbs_program(
             },
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
     };
 
     // Consumer kernel: same layout, plus per-DFB entries_per_consumer_<i> /
     // is_blocked_<i> CTAs (per-DFB cap is host-known so they collapse to CTAs).
     experimental::metal2_host_api::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp",
         .num_threads = num_consumers,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings =
@@ -1048,8 +1024,7 @@ void run_sequential_dfbs_program(
             },
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
     };
 
     // Build per-DFB DataflowBufferSpec, TensorParameter, and bindings (dfb_<i> /
@@ -1218,9 +1193,7 @@ void run_in_dfb_out_dfb_program(
 
     experimental::metal2_host_api::KernelSpec producer_spec{
         .unique_id = PRODUCER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = static_cast<uint8_t>(dm2tensix_config.num_producers),
         .dfb_bindings = {{
             .dfb_spec_name = IN_DFB,
@@ -1241,15 +1214,12 @@ void run_in_dfb_out_dfb_program(
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp",
         .num_threads = 1,
         .dfb_bindings =
             {
@@ -1273,9 +1243,7 @@ void run_in_dfb_out_dfb_program(
 
     experimental::metal2_host_api::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
         .num_threads = static_cast<uint8_t>(tensix2dm_config.num_consumers),
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
@@ -1298,8 +1266,7 @@ void run_in_dfb_out_dfb_program(
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
     };
 
     experimental::metal2_host_api::WorkUnitSpec wu{
@@ -1905,9 +1872,7 @@ static void run_intra_tensix_dfb_program(
     // The kernel only references dfb::out; both bindings resolve to the same DFB.
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp",
         .num_threads = static_cast<uint8_t>(num_threads),
         .dfb_bindings =
             {
@@ -2050,9 +2015,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
 
     experimental::metal2_host_api::KernelSpec dm_producer_spec{
         .unique_id = DM_PRODUCER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = REMAPPER_DFB,
@@ -2073,8 +2036,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
     };
 
     // Combined compute kernel: BLOCKED consumer of remapper DFB ("remapper_in"),
@@ -2082,9 +2044,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
     // kernel only references dfb::intra_out).
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp",
         .num_threads = static_cast<uint8_t>(num_neos),
         .dfb_bindings =
             {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -226,13 +226,13 @@ void run_single_dfb_program(
     // Gen2 (auto-assigned) variants so the same KernelSpec runs on WH/BH and Quasar.
     const experimental::DataMovementConfiguration dm_producer_cfg{
         .gen1 =
-            experimental::DataMovementConfiguration::Gen1{.processor = tt::tt_metal::DataMovementProcessor::RISCV_0},
-        .gen2 = experimental::DataMovementConfiguration::Gen2{},
+            experimental::DataMovementConfiguration::Gen1DM{.processor = tt::tt_metal::DataMovementProcessor::RISCV_0},
+        .gen2 = experimental::DataMovementConfiguration::Gen2DM{},
     };
     const experimental::DataMovementConfiguration dm_consumer_cfg{
         .gen1 =
-            experimental::DataMovementConfiguration::Gen1{.processor = tt::tt_metal::DataMovementProcessor::RISCV_1},
-        .gen2 = experimental::DataMovementConfiguration::Gen2{},
+            experimental::DataMovementConfiguration::Gen1DM{.processor = tt::tt_metal::DataMovementProcessor::RISCV_1},
+        .gen2 = experimental::DataMovementConfiguration::Gen2DM{},
     };
 
     experimental::KernelSpec producer_spec;
@@ -638,7 +638,7 @@ void run_concurrent_dfbs_program(
                     {"chunk_offset", chunk_offset},
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         });
         kernel_names.push_back(producer_name);
 
@@ -658,7 +658,7 @@ void run_concurrent_dfbs_program(
                     {"chunk_offset", chunk_offset},
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         });
         kernel_names.push_back(consumer_name);
     }
@@ -814,7 +814,7 @@ void run_concurrent_tensix_dm_dfbs_program(
                     {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         });
         kernel_names.push_back(consumer_name);
     }
@@ -971,7 +971,8 @@ void run_sequential_dfbs_program(
                 {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
                 {"num_producers", num_producers},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     // Consumer kernel: same layout, plus per-DFB entries_per_consumer_<i> /
@@ -986,7 +987,8 @@ void run_sequential_dfbs_program(
                 {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
                 {"num_consumers", num_consumers},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     // Build per-DFB DataflowBufferSpec, TensorParameter, and bindings (dfb_<i> /
@@ -1156,7 +1158,8 @@ void run_in_dfb_out_dfb_program(
                 {"num_producers", dm2tensix_config.num_producers},
             },
         .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec compute_spec{
@@ -1201,7 +1204,8 @@ void run_in_dfb_out_dfb_program(
                 {"num_consumers", tensix2dm_config.num_consumers},
             },
         .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec wu{
@@ -1954,7 +1958,8 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
                 {"num_producers", 1u},
             },
         .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     // Combined compute kernel: BLOCKED consumer of remapper DFB ("remapper_in"),

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -309,7 +309,7 @@ void run_single_dfb_program(
     }
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {PRODUCER, CONSUMER},
         .target_nodes = core_range_set,
     };
@@ -323,7 +323,7 @@ void run_single_dfb_program(
     }
 
     experimental::ProgramSpec spec{
-        .program_id = "single_dfb",
+        .name = "single_dfb",
         .kernels = {producer_spec, consumer_spec},
         .dataflow_buffers = {dfb_spec},
         .tensor_parameters = tensor_parameters,
@@ -664,13 +664,13 @@ void run_concurrent_dfbs_program(
     }
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = kernel_names,
         .target_nodes = core_range_set,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "concurrent_dfbs",
+        .name = "concurrent_dfbs",
         .kernels = kernel_specs,
         .dataflow_buffers = dfb_specs,
         .tensor_parameters =
@@ -820,13 +820,13 @@ void run_concurrent_tensix_dm_dfbs_program(
     }
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = kernel_names,
         .target_nodes = core_range_set,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "concurrent_tensix_dm_dfbs",
+        .name = "concurrent_tensix_dm_dfbs",
         .kernels = kernel_specs,
         .dataflow_buffers = dfb_specs,
         .tensor_parameters = tensor_parameters,
@@ -1035,13 +1035,13 @@ void run_sequential_dfbs_program(
     }
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {PRODUCER, CONSUMER},
         .target_nodes = core_range_set,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "sequential_dfbs",
+        .name = "sequential_dfbs",
         .kernels = {producer_spec, consumer_spec},
         .dataflow_buffers = dfb_specs,
         .tensor_parameters = tensor_parameters,
@@ -1205,13 +1205,13 @@ void run_in_dfb_out_dfb_program(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {PRODUCER, COMPUTE, CONSUMER},
         .target_nodes = core_range_set,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "in_dfb_out_dfb",
+        .name = "in_dfb_out_dfb",
         .kernels = {producer_spec, compute_spec, consumer_spec},
         .dataflow_buffers = {in_dfb_spec, out_dfb_spec},
         .tensor_parameters =
@@ -1823,13 +1823,13 @@ static void run_intra_tensix_dfb_program(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {COMPUTE},
         .target_nodes = core_range_set,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "intra_tensix_dfb",
+        .name = "intra_tensix_dfb",
         .kernels = {compute_spec},
         .dataflow_buffers = {intra_dfb_spec},
         .work_units = {wu},
@@ -1980,13 +1980,13 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_PRODUCER, COMPUTE},
         .target_nodes = core_range_set,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "intra_and_remapper",
+        .name = "intra_and_remapper",
         .kernels = {dm_producer_spec, compute_spec},
         .dataflow_buffers = {remapper_dfb_spec, intra_dfb_spec},
         .tensor_parameters = {{.unique_id = IN_TENSOR, .spec = in_tensor.tensor_spec()}},

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -209,12 +209,12 @@ void run_single_dfb_program(
             out_tensor->mesh_buffer().get_reference_buffer()->size());
     }
 
-    const auto consumer_pattern = is_all ? experimental::metal2_host_api::DFBAccessPattern::ALL
-                                         : experimental::metal2_host_api::DFBAccessPattern::STRIDED;
+    const auto consumer_pattern =
+        is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED;
 
     // enable_implicit_sync: true  -> default disable_implicit_sync = false (implicit sync ON)
     // enable_implicit_sync: false -> disable_implicit_sync = true
-    experimental::metal2_host_api::DataflowBufferSpec dfb_spec{
+    experimental::DataflowBufferSpec dfb_spec{
         .unique_id = DFB_NAME,
         .entry_size = entry_size,
         .num_entries = dfb_config.num_entries,
@@ -224,30 +224,28 @@ void run_single_dfb_program(
 
     // DM kernel configs supply both Gen1 (BRISC for producer / NCRISC for consumer) and
     // Gen2 (auto-assigned) variants so the same KernelSpec runs on WH/BH and Quasar.
-    const experimental::metal2_host_api::DataMovementConfiguration dm_producer_cfg{
+    const experimental::DataMovementConfiguration dm_producer_cfg{
         .gen1 =
-            experimental::metal2_host_api::DataMovementConfiguration::Gen1{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0},
-        .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{},
+            experimental::DataMovementConfiguration::Gen1{.processor = tt::tt_metal::DataMovementProcessor::RISCV_0},
+        .gen2 = experimental::DataMovementConfiguration::Gen2{},
     };
-    const experimental::metal2_host_api::DataMovementConfiguration dm_consumer_cfg{
+    const experimental::DataMovementConfiguration dm_consumer_cfg{
         .gen1 =
-            experimental::metal2_host_api::DataMovementConfiguration::Gen1{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1},
-        .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{},
+            experimental::DataMovementConfiguration::Gen1{.processor = tt::tt_metal::DataMovementProcessor::RISCV_1},
+        .gen2 = experimental::DataMovementConfiguration::Gen2{},
     };
 
-    experimental::metal2_host_api::KernelSpec producer_spec;
+    experimental::KernelSpec producer_spec;
     if (producer_type == DFBPorCType::DM) {
-        producer_spec = experimental::metal2_host_api::KernelSpec{
+        producer_spec = experimental::KernelSpec{
             .unique_id = PRODUCER,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "out",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                .access_pattern = experimental::DFBAccessPattern::STRIDED,
             }},
             .tensor_bindings = {{
                 .tensor_parameter_name = IN_TENSOR,
@@ -263,31 +261,31 @@ void run_single_dfb_program(
             .config_spec = dm_producer_cfg,
         };
     } else {
-        producer_spec = experimental::metal2_host_api::KernelSpec{
+        producer_spec = experimental::KernelSpec{
             .unique_id = PRODUCER,
             .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "out",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                .access_pattern = experimental::DFBAccessPattern::STRIDED,
             }},
             .compile_time_arg_bindings = {{"num_entries_per_producer", num_entries_per_producer}},
-            .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+            .config_spec = experimental::ComputeConfiguration{},
         };
     }
 
-    experimental::metal2_host_api::KernelSpec consumer_spec;
+    experimental::KernelSpec consumer_spec;
     if (consumer_type == DFBPorCType::DM) {
-        consumer_spec = experimental::metal2_host_api::KernelSpec{
+        consumer_spec = experimental::KernelSpec{
             .unique_id = CONSUMER,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "in",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
                 .access_pattern = consumer_pattern,
             }},
             .tensor_bindings = {{
@@ -305,28 +303,28 @@ void run_single_dfb_program(
             .config_spec = dm_consumer_cfg,
         };
     } else {
-        consumer_spec = experimental::metal2_host_api::KernelSpec{
+        consumer_spec = experimental::KernelSpec{
             .unique_id = CONSUMER,
             .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "in",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
                 .access_pattern = consumer_pattern,
             }},
             .compile_time_arg_bindings = {{"num_entries_per_consumer", num_entries_per_consumer}},
-            .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+            .config_spec = experimental::ComputeConfiguration{},
         };
     }
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {PRODUCER, CONSUMER},
         .target_nodes = core_range_set,
     };
 
-    std::vector<experimental::metal2_host_api::TensorParameter> tensor_parameters;
+    std::vector<experimental::TensorParameter> tensor_parameters;
     if (need_in_tensor) {
         tensor_parameters.push_back({.unique_id = IN_TENSOR, .spec = in_tensor->tensor_spec()});
     }
@@ -334,7 +332,7 @@ void run_single_dfb_program(
         tensor_parameters.push_back({.unique_id = OUT_TENSOR, .spec = out_tensor->tensor_spec()});
     }
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "single_dfb",
         .kernels = {producer_spec, consumer_spec},
         .dataflow_buffers = {dfb_spec},
@@ -342,26 +340,26 @@ void run_single_dfb_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    using NodeNamedRTAs = experimental::metal2_host_api::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeNamedRTAs = experimental::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
     auto build_dm_named_rtas = [&]() {
         std::vector<NodeNamedRTAs> result;
         result.reserve(core_to_chunk_offset.size());
         for (const auto& [core, chunk_offset] : core_to_chunk_offset) {
             result.push_back(NodeNamedRTAs{
-                experimental::metal2_host_api::NodeCoord{core.x, core.y},
+                experimental::NodeCoord{core.x, core.y},
                 {{"chunk_offset", chunk_offset}, {"entries_per_core", entries_per_core}}});
         }
         return result;
     };
 
-    experimental::metal2_host_api::ProgramRunParams run_params;
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams producer_params{.kernel_spec_name = PRODUCER};
+    experimental::ProgramRunParams run_params;
+    experimental::ProgramRunParams::KernelRunParams producer_params{.kernel_spec_name = PRODUCER};
     if (producer_type == DFBPorCType::DM) {
         producer_params.named_runtime_args = build_dm_named_rtas();
     }
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams consumer_params{.kernel_spec_name = CONSUMER};
+    experimental::ProgramRunParams::KernelRunParams consumer_params{.kernel_spec_name = CONSUMER};
     if (consumer_type == DFBPorCType::DM) {
         consumer_params.named_runtime_args = build_dm_named_rtas();
     }
@@ -372,7 +370,7 @@ void run_single_dfb_program(
     if (need_out_tensor) {
         run_params.tensor_args.push_back({.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(*out_tensor)});
     }
-    experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
+    experimental::SetProgramRunParameters(program, run_params);
 
     // Generate input once; shared by tensor/buffer write, L1 pre-fill, and verification.
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_buffer_size / sizeof(uint32_t));
@@ -613,8 +611,8 @@ void run_concurrent_dfbs_program(
     // Each kernel instance binds to exactly its own DFB; this matches num_producers=1
     // / num_consumers=1 in the per-DFB config.  A shared kernel bound to N DFBs would
     // erroneously register all N threads as producers for every DFB.
-    std::vector<experimental::metal2_host_api::DataflowBufferSpec> dfb_specs;
-    std::vector<experimental::metal2_host_api::KernelSpec> kernel_specs;
+    std::vector<experimental::DataflowBufferSpec> dfb_specs;
+    std::vector<experimental::KernelSpec> kernel_specs;
     std::vector<std::string> kernel_names;
     dfb_specs.reserve(num_dfbs);
     kernel_specs.reserve(2 * num_dfbs);
@@ -626,7 +624,7 @@ void run_concurrent_dfbs_program(
         const std::string producer_name = "producer_" + std::to_string(i);
         const std::string consumer_name = "consumer_" + std::to_string(i);
 
-        dfb_specs.push_back(experimental::metal2_host_api::DataflowBufferSpec{
+        dfb_specs.push_back(experimental::DataflowBufferSpec{
             .unique_id = dfb_name,
             .entry_size = entry_size,
             .num_entries = entries_per_dfb,
@@ -634,15 +632,15 @@ void run_concurrent_dfbs_program(
             .disable_implicit_sync = !dfb_config.enable_implicit_sync,
         });
 
-        kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
+        kernel_specs.push_back(experimental::KernelSpec{
             .unique_id = producer_name,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
                 .local_accessor_name = "out",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                .access_pattern = experimental::DFBAccessPattern::STRIDED,
             }},
             .tensor_bindings = {{
                 .tensor_parameter_name = IN_TENSOR,
@@ -655,20 +653,19 @@ void run_concurrent_dfbs_program(
                     {"chunk_offset", chunk_offset},
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         });
         kernel_names.push_back(producer_name);
 
-        kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
+        kernel_specs.push_back(experimental::KernelSpec{
             .unique_id = consumer_name,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
                 .local_accessor_name = "in",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                .access_pattern = experimental::DFBAccessPattern::STRIDED,
             }},
             .tensor_bindings = {{
                 .tensor_parameter_name = OUT_TENSOR,
@@ -681,19 +678,18 @@ void run_concurrent_dfbs_program(
                     {"chunk_offset", chunk_offset},
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         });
         kernel_names.push_back(consumer_name);
     }
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = kernel_names,
         .target_nodes = core_range_set,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "concurrent_dfbs",
         .kernels = kernel_specs,
         .dataflow_buffers = dfb_specs,
@@ -705,20 +701,20 @@ void run_concurrent_dfbs_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     // No per-instance runtime args needed (chunk_offset is a CTA).
-    experimental::metal2_host_api::ProgramRunParams run_params;
+    experimental::ProgramRunParams run_params;
     run_params.kernel_run_params.reserve(kernel_names.size());
     for (const auto& name : kernel_names) {
         run_params.kernel_run_params.push_back(
-            experimental::metal2_host_api::ProgramRunParams::KernelRunParams{.kernel_spec_name = name});
+            experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = name});
     }
     run_params.tensor_args = {
         {.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(out_tensor)},
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
+    experimental::SetProgramRunParameters(program, run_params);
 
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
         0, 100, total_buf_size / sizeof(uint32_t));
@@ -777,29 +773,29 @@ void run_concurrent_tensix_dm_dfbs_program(
     // matching the number of DFB bindings declared here. Name is prefixed to avoid
     // colliding with dfb::NUM_DFBS in dataflow_buffer_config.h (transitively included
     // via risc_common.h on DM kernel builds).
-    experimental::metal2_host_api::KernelSpec producer_spec{
+    experimental::KernelSpec producer_spec{
         .unique_id = PRODUCER,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings = {{"num_entries_per_producer", entries_per_dfb}},
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
     for (uint32_t i = 0; i < num_dfbs; ++i) {
-        producer_spec.dfb_bindings.push_back(experimental::metal2_host_api::KernelSpec::DFBBinding{
+        producer_spec.dfb_bindings.push_back(experimental::KernelSpec::DFBBinding{
             .dfb_spec_name = "dfb_" + std::to_string(i),
             .local_accessor_name = "dfb_" + std::to_string(i),
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         });
     }
 
     // DM concurrent consumers: one 1-thread kernel instance per DFB, each binding
     // its own per-DFB OUT_TENSOR_<i>.
-    std::vector<experimental::metal2_host_api::KernelSpec> kernel_specs;
+    std::vector<experimental::KernelSpec> kernel_specs;
     std::vector<std::string> kernel_names;
-    std::vector<experimental::metal2_host_api::DataflowBufferSpec> dfb_specs;
-    std::vector<experimental::metal2_host_api::TensorParameter> tensor_parameters;
+    std::vector<experimental::DataflowBufferSpec> dfb_specs;
+    std::vector<experimental::TensorParameter> tensor_parameters;
     kernel_specs.reserve(1 + num_dfbs);
     kernel_names.reserve(1 + num_dfbs);
     dfb_specs.reserve(num_dfbs);
@@ -814,7 +810,7 @@ void run_concurrent_tensix_dm_dfbs_program(
         const std::string consumer_name = "consumer_" + std::to_string(i);
         const std::string out_tensor_name = "out_tensor_" + std::to_string(i);
 
-        dfb_specs.push_back(experimental::metal2_host_api::DataflowBufferSpec{
+        dfb_specs.push_back(experimental::DataflowBufferSpec{
             .unique_id = dfb_name,
             .entry_size = entry_size,
             .num_entries = entries_per_dfb,
@@ -822,20 +818,20 @@ void run_concurrent_tensix_dm_dfbs_program(
             .disable_implicit_sync = !dfb_config.enable_implicit_sync,
         });
 
-        tensor_parameters.push_back(experimental::metal2_host_api::TensorParameter{
+        tensor_parameters.push_back(experimental::TensorParameter{
             .unique_id = out_tensor_name,
             .spec = out_tensors[i].tensor_spec(),
         });
 
-        kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
+        kernel_specs.push_back(experimental::KernelSpec{
             .unique_id = consumer_name,
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
                 .local_accessor_name = "in",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                .access_pattern = experimental::DFBAccessPattern::STRIDED,
             }},
             .tensor_bindings = {{
                 .tensor_parameter_name = out_tensor_name,
@@ -847,19 +843,18 @@ void run_concurrent_tensix_dm_dfbs_program(
                     {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         });
         kernel_names.push_back(consumer_name);
     }
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = kernel_names,
         .target_nodes = core_range_set,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "concurrent_tensix_dm_dfbs",
         .kernels = kernel_specs,
         .dataflow_buffers = dfb_specs,
@@ -867,20 +862,20 @@ void run_concurrent_tensix_dm_dfbs_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams run_params;
+    experimental::ProgramRunParams run_params;
     run_params.kernel_run_params.reserve(kernel_names.size());
     for (const auto& name : kernel_names) {
         run_params.kernel_run_params.push_back(
-            experimental::metal2_host_api::ProgramRunParams::KernelRunParams{.kernel_spec_name = name});
+            experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = name});
     }
     run_params.tensor_args.reserve(num_dfbs);
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         run_params.tensor_args.push_back(
             {.tensor_parameter_name = "out_tensor_" + std::to_string(i), .tensor = std::cref(out_tensors[i])});
     }
-    experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
+    experimental::SetProgramRunParameters(program, run_params);
 
     // Pre-fill each DFB's L1 ring with its input slice.
     // DFBs are allocated consecutively starting at the base L1 allocator address;
@@ -994,7 +989,7 @@ void run_sequential_dfbs_program(
     // TEST_NUM_DFBS compiler define gates the per-DFB unrolled blocks; it must equal the
     // number of dfb_bindings / tensor_bindings registered here. Name is prefixed to avoid
     // colliding with dfb::NUM_DFBS in dataflow_buffer_config.h.
-    experimental::metal2_host_api::KernelSpec producer_spec{
+    experimental::KernelSpec producer_spec{
         .unique_id = PRODUCER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp",
         .num_threads = num_producers,
@@ -1005,14 +1000,12 @@ void run_sequential_dfbs_program(
                 {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
                 {"num_producers", num_producers},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
     // Consumer kernel: same layout, plus per-DFB entries_per_consumer_<i> /
     // is_blocked_<i> CTAs (per-DFB cap is host-known so they collapse to CTAs).
-    experimental::metal2_host_api::KernelSpec consumer_spec{
+    experimental::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp",
         .num_threads = num_consumers,
@@ -1022,15 +1015,13 @@ void run_sequential_dfbs_program(
                 {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
                 {"num_consumers", num_consumers},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
     // Build per-DFB DataflowBufferSpec, TensorParameter, and bindings (dfb_<i> /
     // src_<i> / dst_<i> / in_tensor_<i> / out_tensor_<i>).
-    std::vector<experimental::metal2_host_api::DataflowBufferSpec> dfb_specs;
-    std::vector<experimental::metal2_host_api::TensorParameter> tensor_parameters;
+    std::vector<experimental::DataflowBufferSpec> dfb_specs;
+    std::vector<experimental::TensorParameter> tensor_parameters;
     dfb_specs.reserve(num_dfbs);
     tensor_parameters.reserve(2 * num_dfbs);
 
@@ -1042,41 +1033,40 @@ void run_sequential_dfbs_program(
         const bool is_all = (configs[i].cap == dfb::AccessPattern::ALL);
         const uint32_t epc = is_all ? num_entries : (num_entries + num_consumers - 1) / num_consumers;
 
-        dfb_specs.push_back(experimental::metal2_host_api::DataflowBufferSpec{
+        dfb_specs.push_back(experimental::DataflowBufferSpec{
             .unique_id = dfb_name,
             .entry_size = entry_size,
             .num_entries = num_entries,
             .data_format_metadata = configs[i].data_format,
             .disable_implicit_sync = !configs[i].enable_implicit_sync,
         });
-        tensor_parameters.push_back(experimental::metal2_host_api::TensorParameter{
+        tensor_parameters.push_back(experimental::TensorParameter{
             .unique_id = in_tensor_name,
             .spec = in_tensors[i].tensor_spec(),
         });
-        tensor_parameters.push_back(experimental::metal2_host_api::TensorParameter{
+        tensor_parameters.push_back(experimental::TensorParameter{
             .unique_id = out_tensor_name,
             .spec = out_tensors[i].tensor_spec(),
         });
 
-        producer_spec.dfb_bindings.push_back(experimental::metal2_host_api::KernelSpec::DFBBinding{
+        producer_spec.dfb_bindings.push_back(experimental::KernelSpec::DFBBinding{
             .dfb_spec_name = dfb_name,
             .local_accessor_name = "dfb_" + idx,
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         });
-        producer_spec.tensor_bindings.push_back(experimental::metal2_host_api::KernelSpec::TensorBinding{
+        producer_spec.tensor_bindings.push_back(experimental::KernelSpec::TensorBinding{
             .tensor_parameter_name = in_tensor_name,
             .accessor_name = "src_" + idx,
         });
 
-        consumer_spec.dfb_bindings.push_back(experimental::metal2_host_api::KernelSpec::DFBBinding{
+        consumer_spec.dfb_bindings.push_back(experimental::KernelSpec::DFBBinding{
             .dfb_spec_name = dfb_name,
             .local_accessor_name = "dfb_" + idx,
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = is_all ? experimental::metal2_host_api::DFBAccessPattern::ALL
-                                     : experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED,
         });
-        consumer_spec.tensor_bindings.push_back(experimental::metal2_host_api::KernelSpec::TensorBinding{
+        consumer_spec.tensor_bindings.push_back(experimental::KernelSpec::TensorBinding{
             .tensor_parameter_name = out_tensor_name,
             .accessor_name = "dst_" + idx,
         });
@@ -1085,13 +1075,13 @@ void run_sequential_dfbs_program(
             {"is_blocked_" + idx, static_cast<uint32_t>(is_all ? 1u : 0u)});
     }
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {PRODUCER, CONSUMER},
         .target_nodes = core_range_set,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "sequential_dfbs",
         .kernels = {producer_spec, consumer_spec},
         .dataflow_buffers = dfb_specs,
@@ -1099,12 +1089,12 @@ void run_sequential_dfbs_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams run_params;
+    experimental::ProgramRunParams run_params;
     run_params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{.kernel_spec_name = PRODUCER},
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{.kernel_spec_name = CONSUMER},
+        experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = PRODUCER},
+        experimental::ProgramRunParams::KernelRunParams{.kernel_spec_name = CONSUMER},
     };
     run_params.tensor_args.reserve(2 * num_dfbs);
     for (uint32_t i = 0; i < num_dfbs; ++i) {
@@ -1114,7 +1104,7 @@ void run_sequential_dfbs_program(
         run_params.tensor_args.push_back(
             {.tensor_parameter_name = "out_tensor_" + idx, .tensor = std::cref(out_tensors[i])});
     }
-    experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
+    experimental::SetProgramRunParameters(program, run_params);
 
     detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
 
@@ -1176,14 +1166,14 @@ void run_in_dfb_out_dfb_program(
     constexpr const char* IN_TENSOR = "in_tensor";
     constexpr const char* OUT_TENSOR = "out_tensor";
 
-    experimental::metal2_host_api::DataflowBufferSpec in_dfb_spec{
+    experimental::DataflowBufferSpec in_dfb_spec{
         .unique_id = IN_DFB,
         .entry_size = entry_size,
         .num_entries = num_entries,
         .data_format_metadata = dm2tensix_config.data_format,
         .disable_implicit_sync = !dm2tensix_config.enable_implicit_sync,
     };
-    experimental::metal2_host_api::DataflowBufferSpec out_dfb_spec{
+    experimental::DataflowBufferSpec out_dfb_spec{
         .unique_id = OUT_DFB,
         .entry_size = entry_size,
         .num_entries = num_entries,
@@ -1191,15 +1181,15 @@ void run_in_dfb_out_dfb_program(
         .disable_implicit_sync = !tensix2dm_config.enable_implicit_sync,
     };
 
-    experimental::metal2_host_api::KernelSpec producer_spec{
+    experimental::KernelSpec producer_spec{
         .unique_id = PRODUCER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = static_cast<uint8_t>(dm2tensix_config.num_producers),
         .dfb_bindings = {{
             .dfb_spec_name = IN_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .tensor_bindings = {{
             .tensor_parameter_name = IN_TENSOR,
@@ -1212,12 +1202,10 @@ void run_in_dfb_out_dfb_program(
                 {"num_producers", dm2tensix_config.num_producers},
             },
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp",
         .num_threads = 1,
@@ -1226,31 +1214,31 @@ void run_in_dfb_out_dfb_program(
                 {
                     .dfb_spec_name = IN_DFB,
                     .local_accessor_name = "in",
-                    .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                    .access_pattern = in_is_all ? experimental::metal2_host_api::DFBAccessPattern::ALL
-                                                : experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                    .access_pattern =
+                        in_is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED,
                 },
                 {
                     .dfb_spec_name = OUT_DFB,
                     .local_accessor_name = "out",
-                    .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                    .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
                 },
             },
         .compile_time_arg_bindings = {{"num_entries", num_entries_per_unpacker}},
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::KernelSpec consumer_spec{
+    experimental::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
         .num_threads = static_cast<uint8_t>(tensix2dm_config.num_consumers),
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = out_is_all ? experimental::metal2_host_api::DFBAccessPattern::ALL
-                                         : experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern =
+                out_is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED,
         }},
         .tensor_bindings = {{
             .tensor_parameter_name = OUT_TENSOR,
@@ -1264,18 +1252,16 @@ void run_in_dfb_out_dfb_program(
                 {"num_consumers", tensix2dm_config.num_consumers},
             },
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {PRODUCER, COMPUTE, CONSUMER},
         .target_nodes = core_range_set,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "in_dfb_out_dfb",
         .kernels = {producer_spec, compute_spec, consumer_spec},
         .dataflow_buffers = {in_dfb_spec, out_dfb_spec},
@@ -1287,28 +1273,28 @@ void run_in_dfb_out_dfb_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    using NodeNamedRTAs = experimental::metal2_host_api::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeNamedRTAs = experimental::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
     auto build_named_rtas = [&]() {
         return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
-            experimental::metal2_host_api::NodeCoord{logical_core.x, logical_core.y},
+            experimental::NodeCoord{logical_core.x, logical_core.y},
             {{"chunk_offset", 0u}, {"entries_per_core", num_entries}}}};
     };
 
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams producer_params{.kernel_spec_name = PRODUCER};
+    experimental::ProgramRunParams::KernelRunParams producer_params{.kernel_spec_name = PRODUCER};
     producer_params.named_runtime_args = build_named_rtas();
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams compute_params{.kernel_spec_name = COMPUTE};
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams consumer_params{.kernel_spec_name = CONSUMER};
+    experimental::ProgramRunParams::KernelRunParams compute_params{.kernel_spec_name = COMPUTE};
+    experimental::ProgramRunParams::KernelRunParams consumer_params{.kernel_spec_name = CONSUMER};
     consumer_params.named_runtime_args = build_named_rtas();
 
-    experimental::metal2_host_api::ProgramRunParams run_params;
+    experimental::ProgramRunParams run_params;
     run_params.kernel_run_params = {producer_params, compute_params, consumer_params};
     run_params.tensor_args = {
         {.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(out_tensor)},
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
+    experimental::SetProgramRunParameters(program, run_params);
 
     auto input =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, num_entries * entry_size / sizeof(uint32_t));
@@ -1860,7 +1846,7 @@ static void run_intra_tensix_dfb_program(
     constexpr const char* INTRA_DFB = "intra_dfb";
     constexpr const char* COMPUTE = "compute";
 
-    experimental::metal2_host_api::DataflowBufferSpec intra_dfb_spec{
+    experimental::DataflowBufferSpec intra_dfb_spec{
         .unique_id = INTRA_DFB,
         .entry_size = entry_size,
         .num_entries = num_entries,
@@ -1870,7 +1856,7 @@ static void run_intra_tensix_dfb_program(
 
     // Self-looped: register both PRODUCER and CONSUMER bindings on the same kernel.
     // The kernel only references dfb::out; both bindings resolve to the same DFB.
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp",
         .num_threads = static_cast<uint8_t>(num_threads),
@@ -1879,14 +1865,14 @@ static void run_intra_tensix_dfb_program(
                 {
                     .dfb_spec_name = INTRA_DFB,
                     .local_accessor_name = "out",
-                    .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                    .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
                 },
                 {
                     .dfb_spec_name = INTRA_DFB,
                     .local_accessor_name = "in",
-                    .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                    .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
                 },
             },
         .compile_time_arg_bindings =
@@ -1894,27 +1880,27 @@ static void run_intra_tensix_dfb_program(
                 {"entries_per_neo", entries_per_neo},
                 {"words_per_entry", words_per_entry},
             },
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {COMPUTE},
         .target_nodes = core_range_set,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "intra_tensix_dfb",
         .kernels = {compute_spec},
         .dataflow_buffers = {intra_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams run_params;
+    experimental::ProgramRunParams run_params;
     run_params.kernel_run_params = {{.kernel_spec_name = COMPUTE}};
-    experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
+    experimental::SetProgramRunParameters(program, run_params);
 
     const uint32_t total_size = num_entries * entry_size;
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
@@ -1998,14 +1984,14 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
     constexpr const char* COMPUTE = "compute";
     constexpr const char* IN_TENSOR = "in_tensor";
 
-    experimental::metal2_host_api::DataflowBufferSpec remapper_dfb_spec{
+    experimental::DataflowBufferSpec remapper_dfb_spec{
         .unique_id = REMAPPER_DFB,
         .entry_size = entry_size,
         .num_entries = num_entries,
         .data_format_metadata = remapper_dfb_config.data_format,
         .disable_implicit_sync = !remapper_dfb_config.enable_implicit_sync,
     };
-    experimental::metal2_host_api::DataflowBufferSpec intra_dfb_spec{
+    experimental::DataflowBufferSpec intra_dfb_spec{
         .unique_id = INTRA_DFB,
         .entry_size = entry_size,
         .num_entries = num_entries,
@@ -2013,15 +1999,15 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .disable_implicit_sync = !intra_dfb_config.enable_implicit_sync,
     };
 
-    experimental::metal2_host_api::KernelSpec dm_producer_spec{
+    experimental::KernelSpec dm_producer_spec{
         .unique_id = DM_PRODUCER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = REMAPPER_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .tensor_bindings = {{
             .tensor_parameter_name = IN_TENSOR,
@@ -2034,15 +2020,13 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
                 {"num_producers", 1u},
             },
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
     // Combined compute kernel: BLOCKED consumer of remapper DFB ("remapper_in"),
     // self-looped on intra DFB (PRODUCER "intra_out" + CONSUMER "intra_in"; the
     // kernel only references dfb::intra_out).
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp",
         .num_threads = static_cast<uint8_t>(num_neos),
@@ -2051,20 +2035,20 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
                 {
                     .dfb_spec_name = REMAPPER_DFB,
                     .local_accessor_name = "remapper_in",
-                    .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                    .access_pattern = experimental::metal2_host_api::DFBAccessPattern::ALL,
+                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                    .access_pattern = experimental::DFBAccessPattern::ALL,
                 },
                 {
                     .dfb_spec_name = INTRA_DFB,
                     .local_accessor_name = "intra_out",
-                    .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                    .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
                 },
                 {
                     .dfb_spec_name = INTRA_DFB,
                     .local_accessor_name = "intra_in",
-                    .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                    .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                    .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                    .access_pattern = experimental::DFBAccessPattern::STRIDED,
                 },
             },
         .compile_time_arg_bindings =
@@ -2073,16 +2057,16 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
                 {"entries_per_neo", entries_per_neo},
                 {"words_per_entry", words_per_entry},
             },
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {DM_PRODUCER, COMPUTE},
         .target_nodes = core_range_set,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "intra_and_remapper",
         .kernels = {dm_producer_spec, compute_spec},
         .dataflow_buffers = {remapper_dfb_spec, intra_dfb_spec},
@@ -2090,20 +2074,19 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*this->devices_.at(0), spec);
+    Program program = experimental::MakeProgramFromSpec(*this->devices_.at(0), spec);
 
-    using NodeNamedRTAs = experimental::metal2_host_api::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams dm_producer_params{
-        .kernel_spec_name = DM_PRODUCER};
+    using NodeNamedRTAs = experimental::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    experimental::ProgramRunParams::KernelRunParams dm_producer_params{.kernel_spec_name = DM_PRODUCER};
     dm_producer_params.named_runtime_args = std::vector<NodeNamedRTAs>{NodeNamedRTAs{
-        experimental::metal2_host_api::NodeCoord{logical_core.x, logical_core.y},
+        experimental::NodeCoord{logical_core.x, logical_core.y},
         {{"chunk_offset", 0u}, {"entries_per_core", num_entries}}}};
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams compute_params{.kernel_spec_name = COMPUTE};
+    experimental::ProgramRunParams::KernelRunParams compute_params{.kernel_spec_name = COMPUTE};
 
-    experimental::metal2_host_api::ProgramRunParams run_params;
+    experimental::ProgramRunParams run_params;
     run_params.kernel_run_params = {dm_producer_params, compute_params};
     run_params.tensor_args = {{.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)}};
-    experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
+    experimental::SetProgramRunParameters(program, run_params);
 
     // L1 layout follows DFB creation order:
     //   [l1_base + 0              ] -> remapper DFB ring  (num_entries * entry_size bytes)

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -1023,7 +1023,7 @@ void run_sequential_dfbs_program(
         });
 
         producer_spec.dfb_bindings.push_back(experimental::ProducerOf(dfb_name, "dfb_" + idx));
-        producer_spec.tensor_bindings.push_back(UseTensor(in_tensor_name, "src_" + idx));
+        producer_spec.tensor_bindings.push_back({in_tensor_name, "src_" + idx});
 
         consumer_spec.dfb_bindings.push_back(experimental::KernelSpec::DFBBinding{
             .dfb_spec_name = dfb_name,
@@ -1031,7 +1031,7 @@ void run_sequential_dfbs_program(
             .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
             .access_pattern = is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED,
         });
-        consumer_spec.tensor_bindings.push_back(UseTensor(out_tensor_name, "dst_" + idx));
+        consumer_spec.tensor_bindings.push_back({out_tensor_name, "dst_" + idx});
         consumer_spec.compile_time_args.push_back({"entries_per_consumer_" + idx, epc});
         consumer_spec.compile_time_args.push_back({"is_blocked_" + idx, static_cast<uint32_t>(is_all ? 1u : 0u)});
     }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -246,13 +246,13 @@ void run_single_dfb_program(
                 .tensor_parameter_name = IN_TENSOR,
                 .accessor_name = "src_tensor",  // kernel: ta::src_tensor
             }},
-            .compile_time_arg_bindings =
+            .compile_time_args =
                 {
                     {"num_entries_per_producer", num_entries_per_producer},
                     {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
                     {"num_producers", dfb_config.num_producers},
                 },
-            .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
+            .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
             .config_spec = dm_producer_cfg,
         };
     } else {
@@ -261,7 +261,7 @@ void run_single_dfb_program(
             .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
             .dfb_bindings = {experimental::ProducerOf(DFB_NAME, "out")},
-            .compile_time_arg_bindings = {{"num_entries_per_producer", num_entries_per_producer}},
+            .compile_time_args = {{"num_entries_per_producer", num_entries_per_producer}},
             .config_spec = experimental::ComputeConfiguration{},
         };
     }
@@ -282,14 +282,14 @@ void run_single_dfb_program(
                 .tensor_parameter_name = OUT_TENSOR,
                 .accessor_name = "dst_tensor",  // kernel: ta::dst_tensor
             }},
-            .compile_time_arg_bindings =
+            .compile_time_args =
                 {
                     {"num_entries_per_consumer", num_entries_per_consumer},
                     {"blocked_consumer", static_cast<uint32_t>(is_all ? 1u : 0u)},
                     {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
                     {"num_consumers", dfb_config.num_consumers},
                 },
-            .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
+            .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
             .config_spec = dm_consumer_cfg,
         };
     } else {
@@ -303,7 +303,7 @@ void run_single_dfb_program(
                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
                 .access_pattern = consumer_pattern,
             }},
-            .compile_time_arg_bindings = {{"num_entries_per_consumer", num_entries_per_consumer}},
+            .compile_time_args = {{"num_entries_per_consumer", num_entries_per_consumer}},
             .config_spec = experimental::ComputeConfiguration{},
         };
     }
@@ -332,12 +332,12 @@ void run_single_dfb_program(
 
     Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    using NodeNamedRTAs = experimental::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeRuntimeArgs = experimental::ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
     auto build_dm_named_rtas = [&]() {
-        std::vector<NodeNamedRTAs> result;
+        std::vector<NodeRuntimeArgs> result;
         result.reserve(core_to_chunk_offset.size());
         for (const auto& [core, chunk_offset] : core_to_chunk_offset) {
-            result.push_back(NodeNamedRTAs{
+            result.push_back(NodeRuntimeArgs{
                 experimental::NodeCoord{core.x, core.y},
                 {{"chunk_offset", chunk_offset}, {"entries_per_core", entries_per_core}}});
         }
@@ -347,11 +347,11 @@ void run_single_dfb_program(
     experimental::ProgramRunParams run_params;
     experimental::ProgramRunParams::KernelRunParams producer_params{.kernel_spec_name = PRODUCER};
     if (producer_type == DFBPorCType::DM) {
-        producer_params.named_runtime_args = build_dm_named_rtas();
+        producer_params.runtime_args = build_dm_named_rtas();
     }
     experimental::ProgramRunParams::KernelRunParams consumer_params{.kernel_spec_name = CONSUMER};
     if (consumer_type == DFBPorCType::DM) {
-        consumer_params.named_runtime_args = build_dm_named_rtas();
+        consumer_params.runtime_args = build_dm_named_rtas();
     }
     run_params.kernel_run_params = {producer_params, consumer_params};
     if (need_in_tensor) {
@@ -631,7 +631,7 @@ void run_concurrent_dfbs_program(
                 .tensor_parameter_name = IN_TENSOR,
                 .accessor_name = "src_tensor",
             }},
-            .compile_time_arg_bindings =
+            .compile_time_args =
                 {
                     {"num_entries_per_producer", entries_per_dfb},
                     {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
@@ -651,7 +651,7 @@ void run_concurrent_dfbs_program(
                 .tensor_parameter_name = OUT_TENSOR,
                 .accessor_name = "dst_tensor",
             }},
-            .compile_time_arg_bindings =
+            .compile_time_args =
                 {
                     {"num_entries_per_consumer", entries_per_dfb},
                     {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
@@ -758,7 +758,7 @@ void run_concurrent_tensix_dm_dfbs_program(
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
-        .compile_time_arg_bindings = {{"num_entries_per_producer", entries_per_dfb}},
+        .compile_time_args = {{"num_entries_per_producer", entries_per_dfb}},
         .config_spec = experimental::ComputeConfiguration{},
     };
     for (uint32_t i = 0; i < num_dfbs; ++i) {
@@ -808,7 +808,7 @@ void run_concurrent_tensix_dm_dfbs_program(
                 .tensor_parameter_name = out_tensor_name,
                 .accessor_name = "dst_tensor",
             }},
-            .compile_time_arg_bindings =
+            .compile_time_args =
                 {
                     {"num_entries_per_consumer", num_entries_per_consumer},
                     {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
@@ -965,7 +965,7 @@ void run_sequential_dfbs_program(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp",
         .num_threads = num_producers,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_producer", num_entries_per_producer},
                 {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
@@ -981,7 +981,7 @@ void run_sequential_dfbs_program(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp",
         .num_threads = num_consumers,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
                 {"num_consumers", num_consumers},
@@ -1036,9 +1036,8 @@ void run_sequential_dfbs_program(
             .tensor_parameter_name = out_tensor_name,
             .accessor_name = "dst_" + idx,
         });
-        consumer_spec.compile_time_arg_bindings.push_back({"entries_per_consumer_" + idx, epc});
-        consumer_spec.compile_time_arg_bindings.push_back(
-            {"is_blocked_" + idx, static_cast<uint32_t>(is_all ? 1u : 0u)});
+        consumer_spec.compile_time_args.push_back({"entries_per_consumer_" + idx, epc});
+        consumer_spec.compile_time_args.push_back({"is_blocked_" + idx, static_cast<uint32_t>(is_all ? 1u : 0u)});
     }
 
     experimental::WorkUnitSpec wu{
@@ -1156,13 +1155,13 @@ void run_in_dfb_out_dfb_program(
             .tensor_parameter_name = IN_TENSOR,
             .accessor_name = "src_tensor",
         }},
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_producer", num_entries_per_producer},
                 {"implicit_sync", static_cast<uint32_t>(dm2tensix_config.enable_implicit_sync ? 1u : 0u)},
                 {"num_producers", dm2tensix_config.num_producers},
             },
-        .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
+        .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -1181,7 +1180,7 @@ void run_in_dfb_out_dfb_program(
                 },
                 experimental::ProducerOf(OUT_DFB, "out"),
             },
-        .compile_time_arg_bindings = {{"num_entries", num_entries_per_unpacker}},
+        .compile_time_args = {{"num_entries", num_entries_per_unpacker}},
         .config_spec = experimental::ComputeConfiguration{},
     };
 
@@ -1200,14 +1199,14 @@ void run_in_dfb_out_dfb_program(
             .tensor_parameter_name = OUT_TENSOR,
             .accessor_name = "dst_tensor",
         }},
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_consumer", num_entries_per_consumer},
                 {"blocked_consumer", static_cast<uint32_t>(out_is_all ? 1u : 0u)},
                 {"implicit_sync", static_cast<uint32_t>(tensix2dm_config.enable_implicit_sync ? 1u : 0u)},
                 {"num_consumers", tensix2dm_config.num_consumers},
             },
-        .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
+        .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -1231,18 +1230,18 @@ void run_in_dfb_out_dfb_program(
 
     Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    using NodeNamedRTAs = experimental::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeRuntimeArgs = experimental::ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
     auto build_named_rtas = [&]() {
-        return std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+        return std::vector<NodeRuntimeArgs>{NodeRuntimeArgs{
             experimental::NodeCoord{logical_core.x, logical_core.y},
             {{"chunk_offset", 0u}, {"entries_per_core", num_entries}}}};
     };
 
     experimental::ProgramRunParams::KernelRunParams producer_params{.kernel_spec_name = PRODUCER};
-    producer_params.named_runtime_args = build_named_rtas();
+    producer_params.runtime_args = build_named_rtas();
     experimental::ProgramRunParams::KernelRunParams compute_params{.kernel_spec_name = COMPUTE};
     experimental::ProgramRunParams::KernelRunParams consumer_params{.kernel_spec_name = CONSUMER};
-    consumer_params.named_runtime_args = build_named_rtas();
+    consumer_params.runtime_args = build_named_rtas();
 
     experimental::ProgramRunParams run_params;
     run_params.kernel_run_params = {producer_params, compute_params, consumer_params};
@@ -1821,7 +1820,7 @@ static void run_intra_tensix_dfb_program(
                 experimental::ProducerOf(INTRA_DFB, "out"),
                 experimental::ConsumerOf(INTRA_DFB, "in"),
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"entries_per_neo", entries_per_neo},
                 {"words_per_entry", words_per_entry},
@@ -1954,13 +1953,13 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
             .tensor_parameter_name = IN_TENSOR,
             .accessor_name = "src_tensor",
         }},
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_per_producer", num_entries},  // 1 producer owns all entries
                 {"implicit_sync", 1u},
                 {"num_producers", 1u},
             },
-        .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
+        .runtime_arguments_schema = {.runtime_args = {"chunk_offset", "entries_per_core"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -1977,7 +1976,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
                 experimental::ProducerOf(INTRA_DFB, "intra_out"),
                 experimental::ConsumerOf(INTRA_DFB, "intra_in"),
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_entries_consumer", num_entries},
                 {"entries_per_neo", entries_per_neo},
@@ -2002,9 +2001,9 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
 
     Program program = experimental::MakeProgramFromSpec(*this->devices_.at(0), spec);
 
-    using NodeNamedRTAs = experimental::ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+    using NodeRuntimeArgs = experimental::ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
     experimental::ProgramRunParams::KernelRunParams dm_producer_params{.kernel_spec_name = DM_PRODUCER};
-    dm_producer_params.named_runtime_args = std::vector<NodeNamedRTAs>{NodeNamedRTAs{
+    dm_producer_params.runtime_args = std::vector<NodeRuntimeArgs>{NodeRuntimeArgs{
         experimental::NodeCoord{logical_core.x, logical_core.y},
         {{"chunk_offset", 0u}, {"entries_per_core", num_entries}}}};
     experimental::ProgramRunParams::KernelRunParams compute_params{.kernel_spec_name = COMPUTE};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -131,7 +131,7 @@ inline WorkUnitSpec MakeMinimalWorkUnit(
     const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes,
     const std::vector<KernelSpecName>& kernels) {
     return WorkUnitSpec{
-        .unique_id = name,
+        .name = name,
         .kernels = kernels,
         .target_nodes = nodes,
     };
@@ -164,7 +164,7 @@ inline ProgramSpec MakeMinimalGen1ValidProgramSpec() {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel", tt::tt_metal::DataMovementProcessor::RISCV_0);
     auto compute_kernel = MakeMinimalComputeKernel("compute_kernel");
@@ -187,7 +187,7 @@ inline ProgramSpec MakeMinimalValidProgramSpec() {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Create a DM kernel (producer) and compute kernel (consumer)
     auto dm_kernel = MakeMinimalDMKernel("dm_kernel");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -156,10 +156,7 @@ inline TensorParameter MakeMinimalTensorParameter(
 // Helper to add a TensorBinding to a kernel.
 inline void BindTensorParameterToKernel(
     KernelSpec& kernel, const std::string& tensor_parameter_name, const std::string& accessor_name) {
-    kernel.tensor_bindings.push_back(KernelSpec::TensorBinding{
-        .tensor_parameter_name = tensor_parameter_name,
-        .accessor_name = accessor_name,
-    });
+    kernel.tensor_bindings.push_back(UseTensor(tensor_parameter_name, accessor_name));
 }
 
 // Helper to create a minimal valid ProgramSpec for Gen1 (WH/BH): DM producer (RISCV_0) + compute consumer

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -137,21 +137,6 @@ inline WorkUnitSpec MakeMinimalWorkUnit(
     };
 }
 
-// Helper to bind a DFB to a kernel as producer or consumer
-inline void BindDFBToKernel(
-    KernelSpec& kernel,
-    const std::string& dfb_name,
-    const std::string& accessor_name,
-    KernelSpec::DFBEndpointType endpoint_type,
-    DFBAccessPattern access_pattern = DFBAccessPattern::STRIDED) {
-    kernel.dfb_bindings.push_back(KernelSpec::DFBBinding{
-        .dfb_spec_name = dfb_name,
-        .local_accessor_name = accessor_name,
-        .endpoint_type = endpoint_type,
-        .access_pattern = access_pattern,
-    });
-}
-
 // Helper to create a minimal valid TensorParameter.
 // Default layout: BFLOAT16, ROW_MAJOR, interleaved, shape {1, 32}. Hardware-agnostic;
 // works on any mock device (alignment + virtualized cores resolved by MakeProgramFromSpec).
@@ -190,8 +175,8 @@ inline ProgramSpec MakeMinimalGen1ValidProgramSpec() {
     auto dfb = MakeMinimalDFB("dfb_0");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(dm_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+    dm_kernel.dfb_bindings.push_back(ProducerOf("dfb_0", "input_dfb"));
+    compute_kernel.dfb_bindings.push_back(ConsumerOf("dfb_0", "input_dfb"));
 
     spec.kernels = {dm_kernel, compute_kernel};
     spec.dataflow_buffers = {dfb};
@@ -216,8 +201,8 @@ inline ProgramSpec MakeMinimalValidProgramSpec() {
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
     // Bind the DFB
-    BindDFBToKernel(dm_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+    dm_kernel.dfb_bindings.push_back(ProducerOf("dfb_0", "input_dfb"));
+    compute_kernel.dfb_bindings.push_back(ConsumerOf("dfb_0", "input_dfb"));
 
     spec.kernels = {dm_kernel, compute_kernel};
     spec.dataflow_buffers = {dfb};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -28,7 +28,7 @@
 // See the Metal 2.0 Host API documentation and programming examples for
 // recommended patterns for constructing ProgramSpec objects in production code.
 
-namespace tt::tt_metal::experimental::metal2_host_api::test_helpers {
+namespace tt::tt_metal::experimental::test_helpers {
 
 // ============================================================================
 // Test environment helpers
@@ -228,4 +228,4 @@ inline ProgramSpec MakeMinimalValidProgramSpec() {
     return spec;
 }
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api::test_helpers
+}  // namespace tt::tt_metal::experimental::test_helpers

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -82,7 +82,7 @@ inline KernelSpec MakeMinimalDMKernel(const std::string& name, uint8_t num_threa
         .num_threads = num_threads,
         .config_spec =
             DataMovementConfiguration{
-                .gen2 = DataMovementConfiguration::Gen2{},
+                .gen2 = DataMovementConfiguration::Gen2DM{},
             },
     };
 }
@@ -98,7 +98,7 @@ inline KernelSpec MakeMinimalGen1DMKernel(
         .config_spec =
             DataMovementConfiguration{
                 .gen1 =
-                    DataMovementConfiguration::Gen1{
+                    DataMovementConfiguration::Gen1DM{
                         .processor = processor,
                     },
             },

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -127,9 +127,7 @@ inline DataflowBufferSpec MakeMinimalDFB(
 
 // Helper to create a minimal valid WorkUnitSpec
 inline WorkUnitSpec MakeMinimalWorkUnit(
-    const std::string& name,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes,
-    const std::vector<KernelSpecName>& kernels) {
+    const std::string& name, const Nodes& nodes, const std::vector<KernelSpecName>& kernels) {
     return WorkUnitSpec{
         .name = name,
         .kernels = kernels,

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -82,7 +82,7 @@ inline KernelSpec MakeMinimalDMKernel(const std::string& name, uint8_t num_threa
         .num_threads = num_threads,
         .config_spec =
             DataMovementConfiguration{
-                .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+                .gen2 = DataMovementConfiguration::Gen2{},
             },
     };
 }
@@ -97,8 +97,8 @@ inline KernelSpec MakeMinimalGen1DMKernel(
         .num_threads = 1,
         .config_spec =
             DataMovementConfiguration{
-                .gen1_data_movement_config =
-                    DataMovementConfiguration::Gen1DataMovementConfig{
+                .gen1 =
+                    DataMovementConfiguration::Gen1{
                         .processor = processor,
                     },
             },

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -154,7 +154,7 @@ inline TensorParameter MakeMinimalTensorParameter(
 // Helper to add a TensorBinding to a kernel.
 inline void BindTensorParameterToKernel(
     KernelSpec& kernel, const std::string& tensor_parameter_name, const std::string& accessor_name) {
-    kernel.tensor_bindings.push_back(UseTensor(tensor_parameter_name, accessor_name));
+    kernel.tensor_bindings.push_back({tensor_parameter_name, accessor_name});
 }
 
 // Helper to create a minimal valid ProgramSpec for Gen1 (WH/BH): DM producer (RISCV_0) + compute consumer

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -637,8 +637,8 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
 inline ProgramSpec MakeSpecWithNamedArgs(
     const NodeCoord& node, const std::vector<std::string>& named_rtas, const std::vector<std::string>& named_crtas) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_runtime_args = named_rtas;
-    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = named_crtas;
+    spec.kernels[0].runtime_arguments_schema.runtime_args = named_rtas;
+    spec.kernels[0].runtime_arguments_schema.common_runtime_args = named_crtas;
     (void)node;  // node inherited from MakeMinimalValidProgramSpec (0,0)
     return spec;
 }
@@ -651,8 +651,8 @@ TEST_F(ProgramRunParamsTestQuasar, NamedRTAsAndCRTAsSucceed) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}, {"output_ptr", 0x2000}}}},
-        .named_common_runtime_args = {{"tile_count", 64}},
+        .runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}, {"output_ptr", 0x2000}}}},
+        .common_runtime_args = {{"tile_count", 64}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -667,14 +667,14 @@ TEST_F(ProgramRunParamsTestQuasar, MissingNamedRTAForNodeFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        // No named_runtime_args for node (0,0) at all — but schema declares one.
+        // No runtime_args for node (0,0) at all — but schema declares one.
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("has named RTAs declared but no named_runtime_args provided for node")));
+            ::testing::HasSubstr("has named RTAs declared but no runtime_args provided for node")));
 }
 
 TEST_F(ProgramRunParamsTestQuasar, MissingDeclaredNamedRTANameFails) {
@@ -686,7 +686,7 @@ TEST_F(ProgramRunParamsTestQuasar, MissingDeclaredNamedRTANameFails) {
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
         // Only one name provided — output_ptr missing.
-        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
+        .runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -704,7 +704,7 @@ TEST_F(ProgramRunParamsTestQuasar, UndeclaredNamedRTAFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}, {"not_in_schema", 0}}}},
+        .runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}, {"not_in_schema", 0}}}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -723,7 +723,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedCRTACountMismatchFails) {
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
         // Only one CRTA provided; schema declares two.
-        .named_common_runtime_args = {{"tile_count", 4}},
+        .common_runtime_args = {{"tile_count", 4}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -930,8 +930,8 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
 // cleanly — no missing-schema TT_FATALs, no empty-buffer write attempts, no validation errors.
 TEST_F(ProgramRunParamsTestQuasar, AllEmptySchemaSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    // spec.kernels already default to empty named_runtime_args / named_common_runtime_args /
-    // compile_time_arg_bindings, num_runtime_varargs = 0, num_common_runtime_varargs = 0,
+    // spec.kernels already default to empty runtime_args / common_runtime_args /
+    // compile_time_args, num_runtime_varargs = 0, num_common_runtime_varargs = 0,
     // num_runtime_varargs_per_node = nullopt.
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
@@ -946,14 +946,14 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
     // A kernel with both named RTAs (schema) and varargs (num_runtime_varargs).
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr"};
+    spec.kernels[0].runtime_arguments_schema.runtime_args = {"input_ptr"};
     spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 3;
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
+        .runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
         .runtime_varargs = {{node, {7, 8, 9}}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
@@ -1466,7 +1466,7 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
     auto binding = MakeMinimalTensorParameter("input_tensor");
     spec.tensor_parameters = {binding};
     // Schema with a named CRTA preceding the binding-address section.
-    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"tile_count"};
+    spec.kernels[0].runtime_arguments_schema.common_runtime_args = {"tile_count"};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -1476,7 +1476,7 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .named_common_runtime_args = {{"tile_count", kNamedCRTAValue}},
+        .common_runtime_args = {{"tile_count", kNamedCRTAValue}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
     params.tensor_args = {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -973,7 +973,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
 //   2. finalize_dataflow_buffer_configs (would normally run inside the dispatch pipeline at
 //                                first enqueue) populates per-DFB `groups[].l1_by_core`
 //                                entries with placeholder addr = 0.
-//   3. SetProgramRunParameters / UpdateTensorArgs → AttachBorrowedDFBBuffers resolves the
+//   3. SetProgramRunParameters / UpdateTensorArguments → AttachBorrowedDFBBuffers resolves the
 //                                bound MeshTensor, extracts its reference-buffer address, and
 //                                calls dfb->set_borrowed_memory_base_addr(addr), which
 //                                overwrites every `groups[].l1_by_core` entry (and any
@@ -1016,7 +1016,7 @@ inline ProgramSpec MakeBorrowedDFBProgramSpecForRunParams(
 
 // Helper: build minimal ProgramRunParams for the borrowed-DFB spec above. Both kernels are
 // MakeMinimalDMKernel (no per-node or common args required), so kernel_run_params entries
-// are empty schemas. Caller supplies the tensor_args entry separately.
+// are empty schemas. Caller supplies the tensor_arguments entry separately.
 inline ProgramRunParams MakeBorrowedDFBRunParams() {
     NodeCoord node{0, 0};
     ProgramRunParams params;
@@ -1061,8 +1061,8 @@ TEST_F(ProgramRunParamsTestQuasar, BorrowedDFB_AttachWritesTensorAddressToDFB) {
     // Allocate the borrowed tensor and attach via SetProgramRunParameters.
     MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
     ProgramRunParams params = MakeBorrowedDFBRunParams();
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "borrowed_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "borrowed_tensor", .tensor = std::cref(tensor)},
     };
     SetProgramRunParameters(program, params);
 
@@ -1071,7 +1071,7 @@ TEST_F(ProgramRunParamsTestQuasar, BorrowedDFB_AttachWritesTensorAddressToDFB) {
 }
 
 TEST_F(ProgramRunParamsTestQuasar, BorrowedDFB_UpdateTensorArgsRefreshesAddress) {
-    // The cache-hit path: UpdateTensorArgs should re-attach the borrowed Buffer, refreshing
+    // The cache-hit path: UpdateTensorArguments should re-attach the borrowed Buffer, refreshing
     // the DFB's base address to the new MeshTensor's address.
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunParams();
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -1080,8 +1080,8 @@ TEST_F(ProgramRunParamsTestQuasar, BorrowedDFB_UpdateTensorArgsRefreshesAddress)
     MeshTensor tensor1 =
         MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
     ProgramRunParams params = MakeBorrowedDFBRunParams();
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "borrowed_tensor", .tensor = std::cref(tensor1)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "borrowed_tensor", .tensor = std::cref(tensor1)},
     };
     SetProgramRunParameters(program, params);
     ASSERT_EQ(PeekBorrowedDFBAddress(program, "dfb"), static_cast<uint32_t>(tensor1.address()));
@@ -1091,12 +1091,12 @@ TEST_F(ProgramRunParamsTestQuasar, BorrowedDFB_UpdateTensorArgsRefreshesAddress)
     ASSERT_NE(tensor1.address(), tensor2.address())
         << "Test pre-condition: two separate allocations should yield distinct addresses";
 
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "borrowed_tensor", .tensor = std::cref(tensor2)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "borrowed_tensor", .tensor = std::cref(tensor2)},
     };
-    EXPECT_NO_THROW(UpdateTensorArgs(program, tensor_args));
+    EXPECT_NO_THROW(UpdateTensorArguments(program, tensor_arguments));
     EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb"), static_cast<uint32_t>(tensor2.address()))
-        << "DFB base addr should refresh to the new MeshTensor's address after UpdateTensorArgs";
+        << "DFB base addr should refresh to the new MeshTensor's address after UpdateTensorArguments";
 }
 
 // ============================================================================
@@ -1176,7 +1176,7 @@ TEST_F(ProgramRunParamsTestGen1, WrongRuntimeArgsCountFails) {
 // Metal 2.0 TensorAccessor binding feature.
 
 TEST_F(ProgramRunParamsTestGen1, MissingTensorArgFails) {
-    // Spec declares a TensorParameter; user supplies no TensorArg entry for it.
+    // Spec declares a TensorParameter; user supplies no TensorArgument entry for it.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor")};
@@ -1184,13 +1184,13 @@ TEST_F(ProgramRunParamsTestGen1, MissingTensorArgFails) {
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
-    // Run params with no tensor_args entries.
+    // Run params with no tensor_arguments entries.
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
 
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
-            "TensorParameter 'input_tensor' is declared in the Program but has no TensorArg entry")));
+            "TensorParameter 'input_tensor' is declared in the Program but has no TensorArgument entry")));
 }
 
 TEST_F(ProgramRunParamsTestGen1, DuplicateTensorArgFails) {
@@ -1202,13 +1202,13 @@ TEST_F(ProgramRunParamsTestGen1, DuplicateTensorArgFails) {
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
-    // Allocate one MeshTensor; reference it twice in tensor_args under the same name.
+    // Allocate one MeshTensor; reference it twice in tensor_arguments under the same name.
     MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, binding.spec, TensorTopology{});
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
 
     EXPECT_THAT(
@@ -1230,14 +1230,14 @@ TEST_F(ProgramRunParamsTestGen1, UnknownTensorParameterInRunParamsFails) {
 
     // tensor_parameter_name doesn't match any TensorParameter in the spec.
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "ghost_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "ghost_tensor", .tensor = std::cref(tensor)},
     };
 
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("TensorArg references unknown TensorParameter 'ghost_tensor'")));
+            ::testing::HasSubstr("TensorArgument references unknown TensorParameter 'ghost_tensor'")));
 }
 
 TEST_F(ProgramRunParamsTestGen1, TensorSpecMismatchFails) {
@@ -1259,20 +1259,20 @@ TEST_F(ProgramRunParamsTestGen1, TensorSpecMismatchFails) {
     MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec, TensorTopology{});
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
 
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
-            "TensorArg for binding 'input_tensor' supplied a MeshTensor whose TensorSpec does not match")));
+            "TensorArgument for binding 'input_tensor' supplied a MeshTensor whose TensorSpec does not match")));
 }
 
 // ============================================================================
-// SECTION: UpdateTensorArgs Tests (Gen1 / WH)
+// SECTION: UpdateTensorArguments Tests (Gen1 / WH)
 // ============================================================================
-// UpdateTensorArgs is the partial-update fast path: it patches only the tensor binding
+// UpdateTensorArguments is the partial-update fast path: it patches only the tensor binding
 // address slots in the per-kernel CRTA buffer, leaving everything else (named CRTAs,
 // vararg CRTAs, all RTAs) statefully unchanged from the most recent SetProgramRunParameters
 // call.
@@ -1283,7 +1283,7 @@ inline MeshTensor AllocateTensorForBinding(distributed::MeshDevice& mesh_device,
 }
 
 // Helper: read the patched tensor binding address out of a kernel's CRTA buffer.
-// Mirrors the offset arithmetic UpdateTensorArgs uses internally, so a regression in either
+// Mirrors the offset arithmetic UpdateTensorArguments uses internally, so a regression in either
 // site shows up as a test failure.
 inline uint32_t ReadBindingAddressFromCRTA(
     const Program& program, const KernelSpecName& kernel_name, const std::string& tensor_parameter_name) {
@@ -1307,15 +1307,15 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_BeforeSetProgramRunParametersF
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
 
     // No SetProgramRunParameters call before the partial update.
     EXPECT_THAT(
-        [&] { UpdateTensorArgs(program, tensor_args); },
+        [&] { UpdateTensorArguments(program, tensor_arguments); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("UpdateTensorArgs called on Program before SetProgramRunParameters")));
+            ::testing::HasSubstr("UpdateTensorArguments called on Program before SetProgramRunParameters")));
 }
 
 TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_MissingTensorArgFails) {
@@ -1330,17 +1330,17 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_MissingTensorArgFails) {
     // Establish baseline state.
     MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
     SetProgramRunParameters(program, params);
 
-    // Empty tensor_args fails the completeness check.
-    std::vector<ProgramRunParams::TensorArg> empty;
+    // Empty tensor_arguments fails the completeness check.
+    std::vector<ProgramRunParams::TensorArgument> empty;
     EXPECT_THAT(
-        [&] { UpdateTensorArgs(program, empty); },
+        [&] { UpdateTensorArguments(program, empty); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
-            "TensorParameter 'input_tensor' is declared in the Program but has no TensorArg entry")));
+            "TensorParameter 'input_tensor' is declared in the Program but has no TensorArgument entry")));
 }
 
 TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_DuplicateTensorArgFails) {
@@ -1354,17 +1354,17 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_DuplicateTensorArgFails) {
 
     MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
     SetProgramRunParameters(program, params);
 
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
     EXPECT_THAT(
-        [&] { UpdateTensorArgs(program, tensor_args); },
+        [&] { UpdateTensorArguments(program, tensor_arguments); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Duplicate tensor_parameter_name 'input_tensor'")));
 }
@@ -1380,18 +1380,18 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_UnknownTensorParameterFails) {
 
     MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
     SetProgramRunParameters(program, params);
 
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "ghost_tensor", .tensor = std::cref(tensor)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "ghost_tensor", .tensor = std::cref(tensor)},
     };
     EXPECT_THAT(
-        [&] { UpdateTensorArgs(program, tensor_args); },
+        [&] { UpdateTensorArguments(program, tensor_arguments); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("TensorArg references unknown TensorParameter 'ghost_tensor'")));
+            ::testing::HasSubstr("TensorArgument references unknown TensorParameter 'ghost_tensor'")));
 }
 
 TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_TensorSpecMismatchFails) {
@@ -1405,8 +1405,8 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_TensorSpecMismatchFails) {
 
     MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
     };
     SetProgramRunParameters(program, params);
 
@@ -1418,13 +1418,13 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_TensorSpecMismatchFails) {
     auto wrong_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 64}, tensor_layout);
     MeshTensor wrong_tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec, TensorTopology{});
 
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(wrong_tensor)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(wrong_tensor)},
     };
     EXPECT_THAT(
-        [&] { UpdateTensorArgs(program, tensor_args); },
+        [&] { UpdateTensorArguments(program, tensor_arguments); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
-            "TensorArg for binding 'input_tensor' supplied a MeshTensor whose TensorSpec does not match")));
+            "TensorArgument for binding 'input_tensor' supplied a MeshTensor whose TensorSpec does not match")));
 }
 
 TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesBindingAddress) {
@@ -1439,8 +1439,8 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesBindingAddress) {
     // First enqueue: full SetProgramRunParameters with tensor T1.
     MeshTensor tensor1 = AllocateTensorForBinding(*mesh_device_, binding);
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor1)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor1)},
     };
     SetProgramRunParameters(program, params);
     ASSERT_EQ(
@@ -1451,10 +1451,10 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesBindingAddress) {
     ASSERT_NE(tensor1.address(), tensor2.address())
         << "Test pre-condition: two separate allocations should yield distinct addresses";
 
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor2)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor2)},
     };
-    EXPECT_NO_THROW(UpdateTensorArgs(program, tensor_args));
+    EXPECT_NO_THROW(UpdateTensorArguments(program, tensor_arguments));
 
     EXPECT_EQ(
         ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor2.address()));
@@ -1479,8 +1479,8 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
         .common_runtime_args = {{"tile_count", kNamedCRTAValue}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor1)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor1)},
     };
     SetProgramRunParameters(program, params);
 
@@ -1491,14 +1491,14 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
 
     // Partial update.
     MeshTensor tensor2 = AllocateTensorForBinding(*mesh_device_, binding);
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor2)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor2)},
     };
-    UpdateTensorArgs(program, tensor_args);
+    UpdateTensorArguments(program, tensor_arguments);
 
     // Named CRTA preserved; binding address patched.
     const auto* crta_data_after = dm_kernel->common_runtime_args_data().data();
-    EXPECT_EQ(crta_data_after[0], kNamedCRTAValue) << "named CRTA must be untouched by UpdateTensorArgs";
+    EXPECT_EQ(crta_data_after[0], kNamedCRTAValue) << "named CRTA must be untouched by UpdateTensorArguments";
     EXPECT_EQ(
         ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor2.address()));
 }
@@ -1516,16 +1516,16 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTe
 
     MeshTensor tensor1 = AllocateTensorForBinding(*mesh_device_, binding);
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "shared_tensor", .tensor = std::cref(tensor1)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "shared_tensor", .tensor = std::cref(tensor1)},
     };
     SetProgramRunParameters(program, params);
 
     MeshTensor tensor2 = AllocateTensorForBinding(*mesh_device_, binding);
-    std::vector<ProgramRunParams::TensorArg> tensor_args{
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "shared_tensor", .tensor = std::cref(tensor2)},
+    std::vector<ProgramRunParams::TensorArgument> tensor_arguments{
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "shared_tensor", .tensor = std::cref(tensor2)},
     };
-    UpdateTensorArgs(program, tensor_args);
+    UpdateTensorArguments(program, tensor_arguments);
 
     EXPECT_EQ(
         ReadBindingAddressFromCRTA(program, "dm_kernel", "shared_tensor"), static_cast<uint32_t>(tensor2.address()));

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -44,7 +44,7 @@
 #include "impl/program/program_impl.hpp"
 #include "test_helpers.hpp"
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 namespace {
 
 // Import shared test helpers
@@ -1536,4 +1536,4 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTe
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -534,7 +534,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     NodeRangeSet all_nodes(std::set<NodeRange>{NodeRange{node0, node0}, NodeRange{node1, node1}});
 
     ProgramSpec spec;
-    spec.program_id = "multi_node_program";
+    spec.name = "multi_node_program";
 
     // Kernels span both nodes
     auto producer = MakeMinimalDMKernel("producer");
@@ -581,7 +581,7 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     NodeRangeSet all_nodes(std::set<NodeRange>{NodeRange{node0, node0}, NodeRange{node1, node1}});
 
     ProgramSpec spec;
-    spec.program_id = "multi_node_program";
+    spec.name = "multi_node_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
@@ -752,7 +752,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     NodeRangeSet nodes{std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}}};
 
     ProgramSpec spec;
-    spec.program_id = "vararg_differing_counts";
+    spec.name = "vararg_differing_counts";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
     spec.kernels = {kernel};
@@ -781,7 +781,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
         std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}, NodeRange{node_c, node_c}}};
 
     ProgramSpec spec;
-    spec.program_id = "vararg_mixed_entry_types";
+    spec.name = "vararg_mixed_entry_types";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     // Nodes a and b share count 3 (declared via a NodeRangeSet entry).
     // Node c has count 5 (declared via a NodeCoord entry).
@@ -810,7 +810,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds
         std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}, NodeRange{node_c, node_c}}};
 
     ProgramSpec spec;
-    spec.program_id = "vararg_scalar_with_sparse_override";
+    spec.name = "vararg_scalar_with_sparse_override";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // default for unlisted nodes
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
@@ -842,7 +842,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) 
     NodeRangeSet both{std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}}};
 
     ProgramSpec spec;
-    spec.program_id = "vararg_zero_override";
+    spec.name = "vararg_zero_override";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs = 3;
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
@@ -885,7 +885,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
     NodeRangeSet nodes{std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}}};
 
     ProgramSpec spec;
-    spec.program_id = "vararg_missing_node";
+    spec.name = "vararg_missing_node";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // uniform across both nodes
     spec.kernels = {kernel};
@@ -994,7 +994,7 @@ inline ProgramSpec MakeBorrowedDFBProgramSpecForRunParams(
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "borrowed_dfb_test_program";
+    spec.name = "borrowed_dfb_test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -48,7 +48,6 @@ namespace tt::tt_metal::experimental {
 namespace {
 
 // Import shared test helpers
-using test_helpers::BindDFBToKernel;
 using test_helpers::BindTensorParameterToKernel;
 using test_helpers::MakeMinimalDFB;
 using test_helpers::MakeMinimalDMKernel;
@@ -550,8 +549,8 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     // Single DFB spanning all nodes
     auto dfb = MakeMinimalDFB("dfb");
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -594,8 +593,8 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     // Single DFB spanning all nodes
     auto dfb = MakeMinimalDFB("dfb");
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1002,8 +1001,8 @@ inline ProgramSpec MakeBorrowedDFBProgramSpecForRunParams(
     auto dfb = MakeMinimalDFB("dfb", dfb_entry_size, dfb_num_entries);
     dfb.borrowed_from = tensor_param_name;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     auto tensor_param = MakeMinimalTensorParameter(tensor_param_name, tt::tt_metal::BufferType::L1);
     BindTensorParameterToKernel(producer, tensor_param_name, "borrowed_t");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -150,7 +150,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateWorkUnitNameFails) {
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Two kernels on different nodes
     auto kernel0 = MakeMinimalDMKernel("kernel0");
@@ -171,7 +171,7 @@ TEST_F(ProgramSpecTestQuasar, SharedLocalAccessorNameForDifferentDFBsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     auto dfb0 = MakeMinimalDFB("dfb_0");
@@ -196,7 +196,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateProducerBindingForSameLocalAccessorNameFa
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer_kernel = MakeMinimalDMKernel("producer");
     auto consumer_kernel = MakeMinimalDMKernel("consumer");
@@ -222,7 +222,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopWithSharedLocalAccessorNameSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // A kernel that both produces and consumes the same DFB may share a single
     // local_accessor_name across the PRODUCER and CONSUMER bindings.
@@ -257,7 +257,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
 
     for (const auto& bad_name : invalid_names) {
         ProgramSpec spec;
-        spec.program_id = "test_program";
+        spec.name = "test_program";
 
         auto kernel = MakeMinimalDMKernel("kernel");
         auto dfb = MakeMinimalDFB("dfb");
@@ -280,7 +280,7 @@ TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     // Bind to a DFB that doesn't exist
@@ -299,7 +299,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithNoBindingsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Create a kernel with no DFB bindings
     auto kernel = MakeMinimalDMKernel("kernel");
@@ -321,7 +321,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyProducerFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     auto dfb = MakeMinimalDFB("dfb");
@@ -342,7 +342,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     auto dfb = MakeMinimalDFB("dfb");
@@ -363,7 +363,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInSameWorkUnitFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer1 = MakeMinimalDMKernel("producer1");
     auto producer2 = MakeMinimalDMKernel("producer2");
@@ -393,7 +393,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer1 = MakeMinimalComputeKernel("consumer1");
@@ -422,7 +422,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInDifferentWorkUnitsSuccee
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer1 = MakeMinimalComputeKernel("consumer1");
@@ -451,7 +451,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInDifferentWorkUnitsSuccee
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer1 = MakeMinimalDMKernel("producer1");
     auto producer2 = MakeMinimalDMKernel("producer2");
@@ -479,7 +479,7 @@ TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
@@ -508,7 +508,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingAccessPatternMismatchFails) {
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer1 = MakeMinimalComputeKernel("consumer1");
@@ -539,7 +539,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingNumThreadsMismatchFails) {
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer1 = MakeMinimalComputeKernel("consumer1", /*num_threads=*/1);
@@ -570,7 +570,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) 
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Two self-looping kernels on disjoint WUs. Each binds "dfb" as both producer and
     // consumer; producer set equals consumer set = {self_loop_1, self_loop_2}. At each node,
@@ -605,7 +605,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // self_loop_1 binds "dfb" as BOTH producer and consumer (self-loop). On the other WU,
     // an unrelated producer-only kernel is bound, while extra_consumer covers the consume side.
@@ -649,7 +649,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
 
 TEST_F(ProgramSpecTestQuasar, EmptyKernelsFails) {
     ProgramSpec spec;
-    spec.program_id = "empty_program";
+    spec.name = "empty_program";
     spec.work_units = std::vector<WorkUnitSpec>{};  // Empty work_units too
 
     EXPECT_THAT(
@@ -662,7 +662,7 @@ TEST_F(ProgramSpecTestQuasar, KernelWithZeroThreadsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel", 0);  // 0 threads!
     spec.kernels = {kernel};
@@ -677,7 +677,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelExceedingMaxThreadsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Quasar has 8 DM cores per node (we reserve 2 for internal use)
     auto kernel = MakeMinimalDMKernel("kernel", 9);  // Too many threads!
@@ -694,7 +694,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Quasar has 4 Tensix cores per node
     auto kernel = MakeMinimalComputeKernel("kernel", 5);  // Too many threads!
@@ -711,7 +711,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     // Remove the Gen2 config
@@ -738,7 +738,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     // Remove both Gen1 and Gen2 configs
@@ -761,7 +761,7 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
     NodeCoord consumer_node{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
@@ -797,7 +797,7 @@ inline ProgramSpec MakeBorrowedDFBProgramSpec(
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
@@ -1038,7 +1038,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");  // Compute!
@@ -1062,7 +1062,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnboundDFBF
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
@@ -1164,7 +1164,7 @@ TEST_F(ProgramSpecTestQuasar, FP32ProducerOnlyBindingDoesNotRequireEntry) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer_compute = MakeMinimalComputeKernel("producer_compute");
     auto& producer_config = std::get<ComputeConfiguration>(producer_compute.config_spec);
@@ -1191,7 +1191,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32OnProducerBindingFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer_compute = MakeMinimalComputeKernel("producer_compute");
     auto& producer_config = std::get<ComputeConfiguration>(producer_compute.config_spec);
@@ -1278,7 +1278,7 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
@@ -1306,7 +1306,7 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
@@ -1336,7 +1336,7 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
 
 TEST_F(ProgramSpecTestQuasar, EmptyWorkUnitSpecsFails) {
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
@@ -1352,13 +1352,13 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitSpecWithNoKernelsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
 
     WorkUnitSpec work_unit;
-    work_unit.unique_id = "work_unit";
+    work_unit.name = "work_unit";
     work_unit.target_nodes = node;
     work_unit.kernels = {};  // No kernels!
     spec.work_units = std::vector<WorkUnitSpec>{work_unit};
@@ -1373,7 +1373,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitSpecReferencesUnknownKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("real_kernel");
     spec.kernels = {kernel};
@@ -1392,7 +1392,7 @@ TEST_F(ProgramSpecTestQuasar, OverlappingWorkUnitSpecsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel1 = MakeMinimalDMKernel("kernel1");
     auto kernel2 = MakeMinimalDMKernel("kernel2");
@@ -1411,7 +1411,7 @@ TEST_F(ProgramSpecTestQuasar, KernelNotInAnyWorkUnitSpecFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel1 = MakeMinimalDMKernel("kernel1");
     auto kernel2 = MakeMinimalDMKernel("kernel2");  // Not in any work_unit!
@@ -1429,7 +1429,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsDMCoreBudgetFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Create enough DM kernels to exceed the 8 DM core budget
     auto kernel1 = MakeMinimalDMKernel("dm1", 3);
@@ -1449,7 +1449,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsComputeCoreBudgetFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Create enough compute kernels to exceed the 4 Tensix core budget (2+4=6).
     // (Legal thread counts on Quasar are 1, 2, 4; 3 is explicitly disallowed.)
@@ -1470,7 +1470,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitWithMultipleComputeKernelsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto compute1 = MakeMinimalComputeKernel("compute1");
     auto compute2 = MakeMinimalComputeKernel("compute2");
@@ -1491,7 +1491,7 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatch
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
@@ -1524,7 +1524,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelInterScopeFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "self_loop_inter";
+    spec.name = "self_loop_inter";
 
     auto compute = MakeMinimalComputeKernel("compute");
     compute.dfb_compute_self_loop_scopes.push_back(
@@ -1551,7 +1551,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnDMKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "self_loop_on_dm";
+    spec.name = "self_loop_on_dm";
 
     auto producer = MakeMinimalDMKernel("producer");
     // Misapplied: self-loop scope entries are valid only on compute kernels.
@@ -1576,7 +1576,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeReferencingUnknownDFBFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "self_loop_unknown_dfb";
+    spec.name = "self_loop_unknown_dfb";
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Misapplied: there is no DFB named "ghost" in the spec.
@@ -1603,7 +1603,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnNonSelfLoopedDFBFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "self_loop_not_self_looped";
+    spec.name = "self_loop_not_self_looped";
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Misapplied: the kernel only produces; it does not self-loop the DFB.
@@ -1630,7 +1630,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSelfLoopScopeEntriesFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "self_loop_duplicate";
+    spec.name = "self_loop_duplicate";
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Two entries for the same DFB on the same kernel.
@@ -1679,7 +1679,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelImplicitIntraSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "self_loop_implicit_intra";
+    spec.name = "self_loop_implicit_intra";
 
     auto compute = MakeMinimalComputeKernel("compute");
 
@@ -1705,7 +1705,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelExplicitIntraSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "self_loop_explicit_intra";
+    spec.name = "self_loop_explicit_intra";
 
     auto compute = MakeMinimalComputeKernel("compute");
     compute.dfb_compute_self_loop_scopes.push_back(
@@ -1730,7 +1730,7 @@ TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "dm_only_program";
+    spec.name = "dm_only_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
@@ -1752,7 +1752,7 @@ TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
     NodeRange nodes{{0, 0}, {1, 1}};  // 2x2 grid
 
     ProgramSpec spec;
-    spec.program_id = "multi_node_program";
+    spec.name = "multi_node_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
@@ -1775,7 +1775,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleWorkUnitsOnDifferentNodesSucceeds) {
     NodeRangeSet all_nodes(std::set<NodeRange>{NodeRange{node0, node0}, NodeRange{node1, node1}});
 
     ProgramSpec spec;
-    spec.program_id = "multi_work_unit_program";
+    spec.name = "multi_work_unit_program";
 
     // Kernels span both nodes
     auto kernel = MakeMinimalDMKernel("kernel");
@@ -1793,7 +1793,7 @@ TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "max_dm_threads";
+    spec.name = "max_dm_threads";
 
     auto producer = MakeMinimalDMKernel("producer", 3);
     auto consumer = MakeMinimalDMKernel("consumer", 3);  // Total: 6
@@ -1815,7 +1815,7 @@ TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "max_compute_threads";
+    spec.name = "max_compute_threads";
 
     auto dm = MakeMinimalDMKernel("dm");
     auto compute = MakeMinimalComputeKernel("compute", 4);  // Max threads
@@ -1838,7 +1838,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "multi_dfb_program";
+    spec.name = "multi_dfb_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
@@ -1897,7 +1897,7 @@ TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
     NodeRangeSet both{std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}}};
 
     ProgramSpec spec;
-    spec.program_id = "vararg_overlap_test";
+    spec.name = "vararg_overlap_test";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
         NumVarargsPerNode{{both, 3}, {node_a, 3}};  // node_a listed twice
@@ -1918,7 +1918,7 @@ TEST_F(ProgramSpecTestQuasar, NodeRangeSetTargetNodesSucceeds) {
     NodeRangeSet nodes(std::set<NodeRange>{NodeRange{{0, 0}, {0, 1}}, NodeRange{{2, 0}, {2, 1}}});
 
     ProgramSpec spec;
-    spec.program_id = "range_set_program";
+    spec.name = "range_set_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
@@ -1989,7 +1989,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
@@ -2103,7 +2103,7 @@ TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrde
     auto make_spec =
         [&](const std::string& id, std::vector<KernelSpec> kernels, const std::vector<WorkUnitSpec>& work_units) {
             ProgramSpec spec;
-            spec.program_id = id;
+            spec.name = id;
             spec.kernels = std::move(kernels);
             spec.work_units = work_units;
             return spec;
@@ -2192,7 +2192,7 @@ TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNod
     NodeRangeSet nodes_C(std::set<NodeRange>{NodeRange{node_01, node_01}, NodeRange{node_02, node_02}});
 
     ProgramSpec spec;
-    spec.program_id = "triangle_of_doom";
+    spec.name = "triangle_of_doom";
 
     auto kernel_a = MakeMinimalDMKernel("kernel_a", 3);
     auto kernel_b = MakeMinimalDMKernel("kernel_b", 3);
@@ -2337,12 +2337,12 @@ TEST(AggregateSpecTypes, DataflowBufferSpecDesignatedInitializers) {
 TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {
     // Demonstrates constructing WorkUnitSpec with designated initializers
     WorkUnitSpec work_unit{
-        .unique_id = "my_work_unit",
+        .name = "my_work_unit",
         .kernels = {"kernel1", "kernel2"},
         .target_nodes = NodeCoord{0, 0},
     };
 
-    EXPECT_EQ(work_unit.unique_id, "my_work_unit");
+    EXPECT_EQ(work_unit.name, "my_work_unit");
     EXPECT_EQ(work_unit.kernels.size(), 2u);
 }
 
@@ -2405,7 +2405,7 @@ TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {
 TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
     // Demonstrates constructing a complete ProgramSpec with designated initializers
     ProgramSpec spec{
-        .program_id = "my_program",
+        .name = "my_program",
         .kernels =
             {
                 KernelSpec{
@@ -2442,14 +2442,14 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
         .work_units =
             {
                 WorkUnitSpec{
-                    .unique_id = "work_unit",
+                    .name = "work_unit",
                     .kernels = {"producer", "consumer"},
                     .target_nodes = NodeCoord{0, 0},
                 },
             },
     };
 
-    EXPECT_EQ(spec.program_id, "my_program");
+    EXPECT_EQ(spec.name, "my_program");
     EXPECT_EQ(spec.kernels.size(), 2u);
     EXPECT_EQ(spec.dataflow_buffers.size(), 1u);
     EXPECT_EQ(spec.work_units.size(), 1u);
@@ -2532,7 +2532,7 @@ TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "dm_only_program";
+    spec.name = "dm_only_program";
 
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
@@ -2553,7 +2553,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "two_dm_program";
+    spec.name = "two_dm_program";
 
     auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
@@ -2568,7 +2568,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     kernel.num_threads = 2;
@@ -2585,7 +2585,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalComputeKernel("compute_kernel");
     kernel.num_threads = 2;
@@ -2603,7 +2603,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // MakeMinimalDMKernel produces a gen2 (Quasar) DM config
     auto kernel = MakeMinimalDMKernel("dm_kernel");
@@ -2621,7 +2621,7 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_0);  // conflict
@@ -2648,7 +2648,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
     const NodeCoord oob_node{0, 9};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     spec.kernels = {kernel};
@@ -2664,7 +2664,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
     const NodeCoord oob_node{8, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     spec.kernels = {kernel};
@@ -2730,7 +2730,7 @@ TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto k0 = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_0);
     auto k1 = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_1);  // duplicate name
@@ -2881,7 +2881,7 @@ TEST_F(ProgramSpecTestGen1, TensorAccessorBindingJITSmokeDMKernel) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "ta_smoke_dm";
+    spec.name = "ta_smoke_dm";
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
@@ -2955,7 +2955,7 @@ TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     const std::vector<std::filesystem::path> dm_paths = {"/tmp/dm_first", "/tmp/dm_second"};
     const std::vector<std::filesystem::path> compute_paths = {"/tmp/compute_only"};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -51,7 +51,6 @@ namespace tt::tt_metal::experimental {
 namespace {
 
 // Import shared test helpers
-using test_helpers::BindDFBToKernel;
 using test_helpers::BindTensorParameterToKernel;
 using test_helpers::MakeMinimalComputeKernel;
 using test_helpers::MakeMinimalDFB;
@@ -180,8 +179,8 @@ TEST_F(ProgramSpecTestQuasar, SharedLocalAccessorNameForDifferentDFBsFails) {
 
     // Bind two *different* DFBs with the same local_accessor_name — illegal
     // (self-loop sharing requires the same DFB on both bindings).
-    BindDFBToKernel(kernel, "dfb_0", "same_accessor", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(kernel, "dfb_1", "same_accessor", KernelSpec::DFBEndpointType::CONSUMER);
+    kernel.dfb_bindings.push_back(ProducerOf("dfb_0", "same_accessor"));
+    kernel.dfb_bindings.push_back(ConsumerOf("dfb_1", "same_accessor"));
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb0, dfb1};
@@ -205,9 +204,9 @@ TEST_F(ProgramSpecTestQuasar, DuplicateProducerBindingForSameLocalAccessorNameFa
 
     // Two PRODUCER bindings on the same kernel sharing a local_accessor_name —
     // illegal: the self-loop relaxation requires opposite endpoint types.
-    BindDFBToKernel(producer_kernel, "dfb", "shared", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(producer_kernel, "dfb", "shared", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer_kernel, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer_kernel.dfb_bindings.push_back(ProducerOf("dfb", "shared"));
+    producer_kernel.dfb_bindings.push_back(ProducerOf("dfb", "shared"));
+    consumer_kernel.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer_kernel, consumer_kernel};
     spec.dataflow_buffers = {dfb};
@@ -229,8 +228,8 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopWithSharedLocalAccessorNameSucceeds) {
     // local_accessor_name across the PRODUCER and CONSUMER bindings.
     auto kernel = MakeMinimalDMKernel("kernel");
     auto dfb = MakeMinimalDFB("dfb");
-    BindDFBToKernel(kernel, "dfb", "acc", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(kernel, "dfb", "acc", KernelSpec::DFBEndpointType::CONSUMER);
+    kernel.dfb_bindings.push_back(ProducerOf("dfb", "acc"));
+    kernel.dfb_bindings.push_back(ConsumerOf("dfb", "acc"));
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
@@ -263,7 +262,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
         auto kernel = MakeMinimalDMKernel("kernel");
         auto dfb = MakeMinimalDFB("dfb");
 
-        BindDFBToKernel(kernel, "dfb", bad_name, KernelSpec::DFBEndpointType::PRODUCER);
+        kernel.dfb_bindings.push_back(ProducerOf("dfb", bad_name));
 
         spec.kernels = {kernel};
         spec.dataflow_buffers = {dfb};
@@ -285,7 +284,7 @@ TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
 
     auto kernel = MakeMinimalDMKernel("kernel");
     // Bind to a DFB that doesn't exist
-    BindDFBToKernel(kernel, "nonexistent_dfb", "accessor", KernelSpec::DFBEndpointType::PRODUCER);
+    kernel.dfb_bindings.push_back(ProducerOf("nonexistent_dfb", "accessor"));
 
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
@@ -328,7 +327,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyProducerFails) {
     auto dfb = MakeMinimalDFB("dfb");
 
     // Only bind as producer, no consumer
-    BindDFBToKernel(kernel, "dfb", "accessor", KernelSpec::DFBEndpointType::PRODUCER);
+    kernel.dfb_bindings.push_back(ProducerOf("dfb", "accessor"));
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
@@ -349,7 +348,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
     auto dfb = MakeMinimalDFB("dfb");
 
     // Only bind as consumer, no producer
-    BindDFBToKernel(kernel, "dfb", "accessor", KernelSpec::DFBEndpointType::CONSUMER);
+    kernel.dfb_bindings.push_back(ConsumerOf("dfb", "accessor"));
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
@@ -375,9 +374,9 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInSameWorkUnitFails) {
 
     // Two PRODUCER bindings on the same DFB, both KernelSpecs in the same WorkUnitSpec.
     // Multi-binding requires non-overlapping WU membership per role; this should fail.
-    BindDFBToKernel(producer1, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(producer2, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer1.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    producer2.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer1, producer2, consumer};
     spec.dataflow_buffers = {dfb};
@@ -403,9 +402,9 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer1.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
+    consumer2.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer1, consumer2};
     spec.dataflow_buffers = {dfb};
@@ -432,9 +431,9 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInDifferentWorkUnitsSuccee
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer1.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
+    consumer2.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     // producer covers both WUs (placed in both); each consumer covers one WU.
     spec.kernels = {producer, consumer1, consumer2};
@@ -461,9 +460,9 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInDifferentWorkUnitsSuccee
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer1, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(producer2, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer1.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    producer2.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer1, producer2, consumer};
     spec.dataflow_buffers = {dfb};
@@ -488,8 +487,8 @@ TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     // Producer covers wu_p; consumer covers wu_c. Their coverages differ — invalid.
     spec.kernels = {producer, consumer};
@@ -518,9 +517,9 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingAccessPatternMismatchFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER, DFBAccessPattern::STRIDED);
-    BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER, DFBAccessPattern::ALL);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer1.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
+    consumer2.dfb_bindings.push_back(AllConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer1, consumer2};
     spec.dataflow_buffers = {dfb};
@@ -549,9 +548,9 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingNumThreadsMismatchFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer1, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(consumer2, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer1.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
+    consumer2.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer1, consumer2};
     spec.dataflow_buffers = {dfb};
@@ -586,10 +585,10 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) 
     // (e.g. ACC_DFB / INEG_DFB in the reduction op factory's negate path).
     dfb.disable_implicit_sync = true;
 
-    BindDFBToKernel(self_loop_1, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(self_loop_1, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(self_loop_2, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(self_loop_2, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
+    self_loop_1.dfb_bindings.push_back(ProducerOf("dfb", "p"));
+    self_loop_1.dfb_bindings.push_back(ConsumerOf("dfb", "c"));
+    self_loop_2.dfb_bindings.push_back(ProducerOf("dfb", "p"));
+    self_loop_2.dfb_bindings.push_back(ConsumerOf("dfb", "c"));
 
     spec.kernels = {self_loop_1, self_loop_2};
     spec.dataflow_buffers = {dfb};
@@ -619,10 +618,10 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(self_loop_1, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(self_loop_1, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(extra_producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(extra_consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    self_loop_1.dfb_bindings.push_back(ProducerOf("dfb", "p"));
+    self_loop_1.dfb_bindings.push_back(ConsumerOf("dfb", "c"));
+    extra_producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    extra_consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {self_loop_1, extra_producer, extra_consumer};
     spec.dataflow_buffers = {dfb};
@@ -767,8 +766,8 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalDMKernel("consumer");
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.remote_dataflow_buffers = {RemoteDataflowBufferSpec{
@@ -805,8 +804,8 @@ inline ProgramSpec MakeBorrowedDFBProgramSpec(
     auto dfb = MakeMinimalDFB("dfb", dfb_entry_size, dfb_num_entries);
     dfb.borrowed_from = tensor_param_name;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     auto tensor_param = MakeMinimalTensorParameter(tensor_param_name, tensor_buffer_type);
     // The TensorParameter must be bound to at least one kernel (referential-integrity check).
@@ -1049,8 +1048,8 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
     auto dfb = MakeMinimalDFB("dfb");
     // dfb.data_format_metadata is NOT set (nullopt)
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1079,8 +1078,8 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnboundDFBF
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1179,8 +1178,8 @@ TEST_F(ProgramSpecTestQuasar, FP32ProducerOnlyBindingDoesNotRequireEntry) {
     auto dfb = MakeMinimalDFB("dfb_0");
     dfb.data_format_metadata = tt::DataFormat::Float32;
 
-    BindDFBToKernel(producer_compute, "dfb_0", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer_dm, "dfb_0", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer_compute.dfb_bindings.push_back(ProducerOf("dfb_0", "out"));
+    consumer_dm.dfb_bindings.push_back(ConsumerOf("dfb_0", "in"));
 
     spec.kernels = {producer_compute, consumer_dm};
     spec.dataflow_buffers = {dfb};
@@ -1207,8 +1206,8 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32OnProducerBindingFails) {
     auto dfb = MakeMinimalDFB("dfb_0");
     dfb.data_format_metadata = tt::DataFormat::Float32;
 
-    BindDFBToKernel(producer_compute, "dfb_0", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer_dm, "dfb_0", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer_compute.dfb_bindings.push_back(ProducerOf("dfb_0", "out"));
+    consumer_dm.dfb_bindings.push_back(ConsumerOf("dfb_0", "in"));
 
     spec.kernels = {producer_compute, consumer_dm};
     spec.dataflow_buffers = {dfb};
@@ -1291,8 +1290,8 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
     // Legacy block-float format; not supported on Quasar.
     dfb.data_format_metadata = tt::DataFormat::Bfp8;
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1321,8 +1320,8 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
         auto dfb = MakeMinimalDFB(name);
         dfb.data_format_metadata = tt::DataFormat::Float16_b;
         spec.dataflow_buffers.push_back(dfb);
-        BindDFBToKernel(producer, name, "p_" + std::to_string(i), KernelSpec::DFBEndpointType::PRODUCER);
-        BindDFBToKernel(consumer, name, "c_" + std::to_string(i), KernelSpec::DFBEndpointType::CONSUMER);
+        producer.dfb_bindings.push_back(ProducerOf(name, "p_" + std::to_string(i)));
+        consumer.dfb_bindings.push_back(ConsumerOf(name, "c_" + std::to_string(i)));
     }
 
     spec.kernels = {producer, consumer};
@@ -1501,8 +1500,8 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatch
     auto consumer = MakeMinimalDMKernel("consumer");
     auto dfb = MakeMinimalDFB("dfb");
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1538,8 +1537,8 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelInterScopeFails) {
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     dfb.disable_implicit_sync = true;
 
-    BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    compute.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    compute.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {compute};
     spec.dataflow_buffers = {dfb};
@@ -1564,8 +1563,8 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnDMKernelFails) {
     auto consumer = MakeMinimalDMKernel("consumer");
 
     auto dfb = MakeMinimalDFB("dfb");
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1591,8 +1590,8 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeReferencingUnknownDFBFails) {
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     dfb.disable_implicit_sync = true;
 
-    BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    compute.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    compute.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {compute};
     spec.dataflow_buffers = {dfb};
@@ -1618,8 +1617,8 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnNonSelfLoopedDFBFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(dm_consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    compute.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    dm_consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {compute, dm_consumer};
     spec.dataflow_buffers = {dfb};
@@ -1647,8 +1646,8 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSelfLoopScopeEntriesFails) {
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     dfb.disable_implicit_sync = true;
 
-    BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    compute.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    compute.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {compute};
     spec.dataflow_buffers = {dfb};
@@ -1692,8 +1691,8 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelImplicitIntraSucceeds) {
     // INTRA requires implicit-sync OFF at the lower DFB layer.
     dfb.disable_implicit_sync = true;
 
-    BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    compute.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    compute.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {compute};
     spec.dataflow_buffers = {dfb};
@@ -1719,8 +1718,8 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelExplicitIntraSucceeds) {
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     dfb.disable_implicit_sync = true;
 
-    BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    compute.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    compute.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {compute};
     spec.dataflow_buffers = {dfb};
@@ -1741,8 +1740,8 @@ TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
     auto dfb = MakeMinimalDFB("dfb");
     // No data_format_metadata needed for DM-only DFBs
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1762,8 +1761,8 @@ TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
     auto consumer = MakeMinimalDMKernel("consumer");
     auto dfb = MakeMinimalDFB("dfb");
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1804,8 +1803,8 @@ TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.num_entries = 9;  // must be a multiple of the number of threads
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -1828,8 +1827,8 @@ TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     dfb.num_entries = 4;  // must be a multiple of the number of threads
 
-    BindDFBToKernel(dm, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    dm.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    compute.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {dm, compute};
     spec.dataflow_buffers = {dfb};
@@ -1852,10 +1851,10 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
     auto dfb2 = MakeMinimalDFB("dfb2");
     dfb2.data_format_metadata = tt::DataFormat::Int8;
 
-    BindDFBToKernel(producer, "dfb1", "out1", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(producer, "dfb2", "out2", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb1", "in1", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(consumer, "dfb2", "in2", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb1", "out1"));
+    producer.dfb_bindings.push_back(ProducerOf("dfb2", "out2"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb1", "in1"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb2", "in2"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb1, dfb2};
@@ -1928,8 +1927,8 @@ TEST_F(ProgramSpecTestQuasar, NodeRangeSetTargetNodesSucceeds) {
     auto consumer = MakeMinimalDMKernel("consumer");
     auto dfb = MakeMinimalDFB("dfb");
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -2004,10 +2003,10 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
     // dfb_1 is FP32 so the user can opt into UnpackToDestFp32 on it.
     dfb1.data_format_metadata = tt::DataFormat::Float32;
 
-    BindDFBToKernel(producer, "dfb_0", "out0", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(producer, "dfb_1", "out1", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb_0", "in0", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(consumer, "dfb_1", "in1", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb_0", "out0"));
+    producer.dfb_bindings.push_back(ProducerOf("dfb_1", "out1"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb_0", "in0"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb_1", "in1"));
 
     auto& compute_config = std::get<ComputeConfiguration>(consumer.config_spec);
     compute_config.fp32_dest_acc_en = true;
@@ -2417,12 +2416,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                     .source = KernelSpec::SourceCode{"void kernel_main() {}"},
                     .dfb_bindings =
                         {
-                            KernelSpec::DFBBinding{
-                                .dfb_spec_name = "dfb",
-                                .local_accessor_name = "out",
-                                .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-                                .access_pattern = DFBAccessPattern::STRIDED,
-                            },
+                            ProducerOf("dfb", "out"),
                         },
                     .config_spec =
                         DataMovementConfiguration{
@@ -2434,12 +2428,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                     .source = KernelSpec::SourceCode{"void kernel_main() {}"},
                     .dfb_bindings =
                         {
-                            KernelSpec::DFBBinding{
-                                .dfb_spec_name = "dfb",
-                                .local_accessor_name = "in",
-                                .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-                                .access_pattern = DFBAccessPattern::STRIDED,
-                            },
+                            ConsumerOf("dfb", "in"),
                         },
                     .config_spec = ComputeConfiguration{},
                 },
@@ -2475,7 +2464,6 @@ TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
         .dfb_spec_name = "my_dfb",
         .local_accessor_name = "accessor",
         .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-        .access_pattern = DFBAccessPattern::ALL,
     };
     EXPECT_EQ(binding.dfb_spec_name, "my_dfb");
 
@@ -2553,8 +2541,8 @@ TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     auto dfb = MakeMinimalDFB("dfb");
 
-    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -2987,8 +2975,8 @@ TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
 
     auto dfb = MakeMinimalDFB("dfb_0");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    BindDFBToKernel(dm_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+    dm_kernel.dfb_bindings.push_back(ProducerOf("dfb_0", "input_dfb"));
+    compute_kernel.dfb_bindings.push_back(ConsumerOf("dfb_0", "input_dfb"));
 
     spec.kernels = {dm_kernel, compute_kernel};
     spec.dataflow_buffers = {dfb};
@@ -3026,11 +3014,11 @@ ProgramSpec MakeAliasProgramSpec(
     KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
     KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
 
-    BindDFBToKernel(producer, dfb_a.unique_id, "out_a", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, dfb_a.unique_id, "in_a", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf(dfb_a.unique_id, "out_a"));
+    consumer.dfb_bindings.push_back(ConsumerOf(dfb_a.unique_id, "in_a"));
 
-    BindDFBToKernel(producer, dfb_b.unique_id, "out_b", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, dfb_b.unique_id, "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf(dfb_b.unique_id, "out_b"));
+    consumer.dfb_bindings.push_back(ConsumerOf(dfb_b.unique_id, "in_b"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb_a, dfb_b};
@@ -3092,10 +3080,10 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBMatmulStyleSucceeds) {
     KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
     KernelSpec other = MakeMinimalDMKernel("other_kernel");
 
-    BindDFBToKernel(producer, "dfb_a", "out_a", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb_a", "in_a", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(producer, "dfb_b", "out_b", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(other, "dfb_b", "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb_a", "out_a"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb_a", "in_a"));
+    producer.dfb_bindings.push_back(ProducerOf("dfb_b", "out_b"));
+    other.dfb_bindings.push_back(ConsumerOf("dfb_b", "in_b"));
 
     ProgramSpec spec;
     spec.kernels = {producer, consumer, other};
@@ -3122,10 +3110,10 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentNodeCoverage) {
     KernelSpec consumer_a = MakeMinimalDMKernel("consumer_a");
     KernelSpec producer_b = MakeMinimalDMKernel("producer_b");
     KernelSpec consumer_b = MakeMinimalDMKernel("consumer_b");
-    BindDFBToKernel(producer_a, "dfb_a", "out_a", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer_a, "dfb_a", "in_a", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(producer_b, "dfb_b", "out_b", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer_b, "dfb_b", "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+    producer_a.dfb_bindings.push_back(ProducerOf("dfb_a", "out_a"));
+    consumer_a.dfb_bindings.push_back(ConsumerOf("dfb_a", "in_a"));
+    producer_b.dfb_bindings.push_back(ProducerOf("dfb_b", "out_b"));
+    consumer_b.dfb_bindings.push_back(ConsumerOf("dfb_b", "in_b"));
 
     ProgramSpec spec;
     spec.kernels = {producer_a, consumer_a, producer_b, consumer_b};
@@ -3154,10 +3142,10 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
 
     KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
     KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
-    BindDFBToKernel(producer, "dfb_a", "out_a", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb_a", "in_a", KernelSpec::DFBEndpointType::CONSUMER);
-    BindDFBToKernel(producer, "dfb_b", "out_b", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb_b", "in_b", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("dfb_a", "out_a"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb_a", "in_a"));
+    producer.dfb_bindings.push_back(ProducerOf("dfb_b", "out_b"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb_b", "in_b"));
 
     auto tensor_param = MakeMinimalTensorParameter("borrowed_tensor", tt::tt_metal::BufferType::L1);
     BindTensorParameterToKernel(producer, "borrowed_tensor", "borrowed_t");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -104,7 +104,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateKernelNameFails) {
     // Add a kernel with duplicate name
     auto duplicate_kernel = MakeMinimalDMKernel("dm_kernel");
     DataMovementConfiguration dm_config;
-    dm_config.gen2 = DataMovementConfiguration::Gen2{};
+    dm_config.gen2 = DataMovementConfiguration::Gen2DM{};
     duplicate_kernel.config_spec = dm_config;
     spec.kernels.push_back(duplicate_kernel);
 
@@ -719,7 +719,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
     dm_config.gen2 = std::nullopt;
 
     // Add Gen1 config
-    dm_config.gen1 = DataMovementConfiguration::Gen1{
+    dm_config.gen1 = DataMovementConfiguration::Gen1DM{
         .processor = DataMovementProcessor::RISCV_0,
         .noc = NOC::RISCV_0_default,
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
@@ -2251,8 +2251,8 @@ static_assert(
 static_assert(
     std::is_aggregate_v<DataMovementConfiguration>,
     "DataMovementConfiguration must remain an aggregate to support designated initializers");
-static_assert(std::is_aggregate_v<DataMovementConfiguration::Gen1>, "Gen1 must remain an aggregate");
-static_assert(std::is_aggregate_v<DataMovementConfiguration::Gen2>, "Gen2 must remain an aggregate");
+static_assert(std::is_aggregate_v<DataMovementConfiguration::Gen1DM>, "Gen1 must remain an aggregate");
+static_assert(std::is_aggregate_v<DataMovementConfiguration::Gen2DM>, "Gen2 must remain an aggregate");
 static_assert(
     std::is_aggregate_v<KernelSpec::CompilerOptions>,
     "CompilerOptions must remain an aggregate to support designated initializers");
@@ -2280,7 +2280,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
         .num_threads = 2,
         .config_spec =
             DataMovementConfiguration{
-                .gen2 = DataMovementConfiguration::Gen2{},
+                .gen2 = DataMovementConfiguration::Gen2DM{},
             },
     };
 
@@ -2384,7 +2384,7 @@ TEST(AggregateSpecTypes, KernelSpecNamedRuntimeArgsDesignatedInitializers) {
             },
         .config_spec =
             DataMovementConfiguration{
-                .gen2 = DataMovementConfiguration::Gen2{},
+                .gen2 = DataMovementConfiguration::Gen2DM{},
             },
     };
     EXPECT_EQ(k.runtime_arguments_schema.runtime_args.size(), 1u);
@@ -2417,7 +2417,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                         },
                     .config_spec =
                         DataMovementConfiguration{
-                            .gen2 = DataMovementConfiguration::Gen2{},
+                            .gen2 = DataMovementConfiguration::Gen2DM{},
                         },
                 },
                 KernelSpec{
@@ -2477,7 +2477,7 @@ TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
     };
     EXPECT_EQ(opts.defines.size(), 2u);
 
-    DataMovementConfiguration::Gen1 gen1{
+    DataMovementConfiguration::Gen1DM gen1{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
         .noc = tt::tt_metal::NOC::RISCV_1_default,
         .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -978,16 +978,16 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
 
 TEST_F(ProgramSpecTestQuasar, NamedRuntimeArgsSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr", "output_ptr"};
-    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"tile_count"};
-    spec.kernels[0].compile_time_arg_bindings = {{"block_size", 64}};
+    spec.kernels[0].runtime_arguments_schema.runtime_args = {"input_ptr", "output_ptr"};
+    spec.kernels[0].runtime_arguments_schema.common_runtime_args = {"tile_count"};
+    spec.kernels[0].compile_time_args = {{"block_size", 64}};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, InvalidNamedRtaIdentifierFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"int"};  // C++ keyword
+    spec.kernels[0].runtime_arguments_schema.runtime_args = {"int"};  // C++ keyword
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -997,7 +997,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidNamedRtaIdentifierFails) {
 
 TEST_F(ProgramSpecTestQuasar, InvalidNamedCrtaIdentifierFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"has-dash"};
+    spec.kernels[0].runtime_arguments_schema.common_runtime_args = {"has-dash"};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -1008,8 +1008,8 @@ TEST_F(ProgramSpecTestQuasar, InvalidNamedCrtaIdentifierFails) {
 TEST_F(ProgramSpecTestQuasar, NamedRtaCrtaCollisionFails) {
     // A single name cannot be both a named RTA and a named CRTA (they share the user namespace).
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"count"};
-    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"count"};
+    spec.kernels[0].runtime_arguments_schema.runtime_args = {"count"};
+    spec.kernels[0].runtime_arguments_schema.common_runtime_args = {"count"};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -1019,8 +1019,8 @@ TEST_F(ProgramSpecTestQuasar, NamedRtaCrtaCollisionFails) {
 
 TEST_F(ProgramSpecTestQuasar, NamedRtaCtaCollisionFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"block_size"};
-    spec.kernels[0].compile_time_arg_bindings = {{"block_size", 64}};  // same name as CTA
+    spec.kernels[0].runtime_arguments_schema.runtime_args = {"block_size"};
+    spec.kernels[0].compile_time_args = {{"block_size", 64}};  // same name as CTA
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -1031,8 +1031,8 @@ TEST_F(ProgramSpecTestQuasar, NamedRtaCtaCollisionFails) {
 TEST_F(ProgramSpecTestQuasar, DifferentKernelsMayReuseArgNames) {
     // Collision rule is per-kernel. Two different kernels may have identically-named args.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"shared_name"};
-    spec.kernels[1].runtime_arguments_schema.named_runtime_args = {"shared_name"};
+    spec.kernels[0].runtime_arguments_schema.runtime_args = {"shared_name"};
+    spec.kernels[1].runtime_arguments_schema.runtime_args = {"shared_name"};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -1876,7 +1876,7 @@ TEST_F(ProgramSpecTestQuasar, CompileTimeArgBindingsSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add compile-time arg bindings
-    spec.kernels[0].compile_time_arg_bindings = {{"arg1", 100}, {"arg2", 200}};
+    spec.kernels[0].compile_time_args = {{"arg1", 100}, {"arg2", 200}};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -2352,14 +2352,14 @@ TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {
 TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
     // Named RTAs + CRTAs + scalar vararg counts, all via designated initializers.
     KernelSpec::RuntimeArgSchema schema{
-        .named_runtime_args = {"input_ptr", "output_ptr"},
-        .named_common_runtime_args = {"tile_count"},
+        .runtime_args = {"input_ptr", "output_ptr"},
+        .common_runtime_args = {"tile_count"},
         .num_runtime_varargs = 4,
         .num_common_runtime_varargs = 2,
     };
 
-    EXPECT_EQ(schema.named_runtime_args.size(), 2u);
-    EXPECT_EQ(schema.named_common_runtime_args.size(), 1u);
+    EXPECT_EQ(schema.runtime_args.size(), 2u);
+    EXPECT_EQ(schema.common_runtime_args.size(), 1u);
     EXPECT_EQ(schema.num_runtime_varargs, 4u);
     EXPECT_EQ(schema.num_common_runtime_varargs, 2u);
     EXPECT_FALSE(schema.num_runtime_varargs_per_node.has_value());
@@ -2383,14 +2383,14 @@ TEST(AggregateSpecTypes, KernelSpecNamedRuntimeArgsDesignatedInitializers) {
         .source = KernelSpec::SourceCode{"void kernel_main() {}"},
         .runtime_arguments_schema =
             KernelSpec::RuntimeArgSchema{
-                .named_runtime_args = {"input_ptr"},
+                .runtime_args = {"input_ptr"},
             },
         .config_spec =
             DataMovementConfiguration{
                 .gen2 = DataMovementConfiguration::Gen2{},
             },
     };
-    EXPECT_EQ(k.runtime_arguments_schema.named_runtime_args.size(), 1u);
+    EXPECT_EQ(k.runtime_arguments_schema.runtime_args.size(), 1u);
 }
 
 TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -895,7 +895,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
 
     // kernels[1] is the compute kernel in MakeMinimalValidProgramSpec
     ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
-    spec.kernels[1].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
+    spec.kernels[1].semaphore_bindings = {{"sem_0", "done_flag"}};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -949,7 +949,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
 
     spec.semaphores = {sem0, sem1};
 
-    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "same"), UseSemaphore("sem_1", "same")};
+    spec.kernels[0].semaphore_bindings = {{"sem_0", "same"}, {"sem_1", "same"}};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -2686,7 +2686,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
 
     // kernels[1] is the compute kernel in MakeMinimalGen1ValidProgramSpec
     ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
-    spec.kernels[1].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
+    spec.kernels[1].semaphore_bindings = {{"sem_0", "done_flag"}};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -2705,7 +2705,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {
 
     // kernels[0] is the DM kernel in MakeMinimalGen1ValidProgramSpec
     ASSERT_TRUE(spec.kernels[0].is_dm_kernel());
-    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
+    spec.kernels[0].semaphore_bindings = {{"sem_0", "done_flag"}};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -2720,7 +2720,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
     sem.initial_value = 3;
     spec.semaphores = {sem};
 
-    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
+    spec.kernels[0].semaphore_bindings = {{"sem_0", "done_flag"}};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -2840,7 +2840,7 @@ TEST_F(ProgramSpecTestGen1, AccessorNamesAcrossCategoriesAreSeparateNamespaces) 
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "input_dfb")};
+    spec.kernels[0].semaphore_bindings = {{"sem_0", "input_dfb"}};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_dfb");
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -105,7 +105,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateKernelNameFails) {
     // Add a kernel with duplicate name
     auto duplicate_kernel = MakeMinimalDMKernel("dm_kernel");
     DataMovementConfiguration dm_config;
-    dm_config.gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{};
+    dm_config.gen2 = DataMovementConfiguration::Gen2{};
     duplicate_kernel.config_spec = dm_config;
     spec.kernels.push_back(duplicate_kernel);
 
@@ -717,10 +717,10 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
     auto kernel = MakeMinimalDMKernel("kernel");
     // Remove the Gen2 config
     auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
-    dm_config.gen2_data_movement_config = std::nullopt;
+    dm_config.gen2 = std::nullopt;
 
     // Add Gen1 config
-    dm_config.gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
+    dm_config.gen1 = DataMovementConfiguration::Gen1{
         .processor = DataMovementProcessor::RISCV_0,
         .noc = NOC::RISCV_0_default,
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
@@ -744,8 +744,8 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
     auto kernel = MakeMinimalDMKernel("kernel");
     // Remove both Gen1 and Gen2 configs
     auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
-    dm_config.gen1_data_movement_config = std::nullopt;
-    dm_config.gen2_data_movement_config = std::nullopt;
+    dm_config.gen1 = std::nullopt;
+    dm_config.gen2 = std::nullopt;
 
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
@@ -2255,12 +2255,8 @@ static_assert(
 static_assert(
     std::is_aggregate_v<DataMovementConfiguration>,
     "DataMovementConfiguration must remain an aggregate to support designated initializers");
-static_assert(
-    std::is_aggregate_v<DataMovementConfiguration::Gen1DataMovementConfig>,
-    "Gen1DataMovementConfig must remain an aggregate");
-static_assert(
-    std::is_aggregate_v<DataMovementConfiguration::Gen2DataMovementConfig>,
-    "Gen2DataMovementConfig must remain an aggregate");
+static_assert(std::is_aggregate_v<DataMovementConfiguration::Gen1>, "Gen1 must remain an aggregate");
+static_assert(std::is_aggregate_v<DataMovementConfiguration::Gen2>, "Gen2 must remain an aggregate");
 static_assert(
     std::is_aggregate_v<KernelSpec::CompilerOptions>,
     "CompilerOptions must remain an aggregate to support designated initializers");
@@ -2288,7 +2284,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
         .num_threads = 2,
         .config_spec =
             DataMovementConfiguration{
-                .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+                .gen2 = DataMovementConfiguration::Gen2{},
             },
     };
 
@@ -2392,7 +2388,7 @@ TEST(AggregateSpecTypes, KernelSpecNamedRuntimeArgsDesignatedInitializers) {
             },
         .config_spec =
             DataMovementConfiguration{
-                .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+                .gen2 = DataMovementConfiguration::Gen2{},
             },
     };
     EXPECT_EQ(k.runtime_arguments_schema.named_runtime_args.size(), 1u);
@@ -2430,7 +2426,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                         },
                     .config_spec =
                         DataMovementConfiguration{
-                            .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+                            .gen2 = DataMovementConfiguration::Gen2{},
                         },
                 },
                 KernelSpec{
@@ -2496,7 +2492,7 @@ TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
     };
     EXPECT_EQ(opts.defines.size(), 2u);
 
-    DataMovementConfiguration::Gen1DataMovementConfig gen1{
+    DataMovementConfiguration::Gen1 gen1{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
         .noc = tt::tt_metal::NOC::RISCV_1_default,
         .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
@@ -2618,7 +2614,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
 }
 
 TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
-    // On gen1, a DM kernel that only has Gen2DataMovementConfig must be rejected
+    // On gen1, a DM kernel that only has Gen2 must be rejected
     NodeCoord node{0, 0};
 
     ProgramSpec spec;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -895,8 +895,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
 
     // kernels[1] is the compute kernel in MakeMinimalValidProgramSpec
     ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
-    spec.kernels[1].semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+    spec.kernels[1].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -950,9 +949,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
 
     spec.semaphores = {sem0, sem1};
 
-    spec.kernels[0].semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "same"},
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_1", .accessor_name = "same"}};
+    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "same"), UseSemaphore("sem_1", "same")};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -2689,8 +2686,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
 
     // kernels[1] is the compute kernel in MakeMinimalGen1ValidProgramSpec
     ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
-    spec.kernels[1].semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+    spec.kernels[1].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -2709,8 +2705,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {
 
     // kernels[0] is the DM kernel in MakeMinimalGen1ValidProgramSpec
     ASSERT_TRUE(spec.kernels[0].is_dm_kernel());
-    spec.kernels[0].semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -2725,8 +2720,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
     sem.initial_value = 3;
     spec.semaphores = {sem};
 
-    spec.kernels[0].semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "done_flag")};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -2846,8 +2840,7 @@ TEST_F(ProgramSpecTestGen1, AccessorNamesAcrossCategoriesAreSeparateNamespaces) 
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.kernels[0].semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "input_dfb"}};
+    spec.kernels[0].semaphore_bindings = {UseSemaphore("sem_0", "input_dfb")};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_dfb");
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -47,7 +47,7 @@
 
 #include "test_helpers.hpp"
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 namespace {
 
 // Import shared test helpers
@@ -3174,4 +3174,4 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -30,7 +30,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "test_helpers.hpp"
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 namespace {
 
 using test_helpers::BindDFBToKernel;
@@ -674,4 +674,4 @@ TEST_F(ProgramSpecHWTest, MultiBindingProducerMaskMismatchFails) {
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -599,9 +599,9 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
             .runtime_varargs = {{node, {num_pages}}},
         },
     };
-    params.tensor_args = {
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(input_tensor)},
-        ProgramRunParams::TensorArg{.tensor_parameter_name = "output_tensor", .tensor = std::cref(output_tensor)},
+    params.tensor_arguments = {
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "input_tensor", .tensor = std::cref(input_tensor)},
+        ProgramRunParams::TensorArgument{.tensor_parameter_name = "output_tensor", .tensor = std::cref(output_tensor)},
     };
     SetProgramRunParameters(program, params);
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -102,14 +102,12 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
 
     // Producer: BRISC reads from DRAM → DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp"};
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
     producer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     // Consumer: NCRISC reads DFB → DRAM
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     // DFB: both kernels bind it, with different local accessor names
@@ -233,8 +231,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     // Producer: BRISC reads DRAM → DFB. 1 named RTA, 1 named CRTA, 2 named CTAs, 3 RTA
     // varargs, 1 CRTA vararg.
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp"};
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp";
     producer.runtime_arguments_schema.named_runtime_args = {"src_addr"};
     producer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
     producer.runtime_arguments_schema.num_runtime_varargs = 3;
@@ -245,8 +242,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     // 1 named CRTA, 2 named CTAs, 2 RTA varargs (note: different count from producer —
     // this verifies the named_rta_words offset is baked per-kernel), 1 CRTA vararg.
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.named_runtime_args = {"dst_addr"};
     consumer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
     consumer.runtime_arguments_schema.num_runtime_varargs = 2;
@@ -357,8 +353,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     // Compute kernel: produces out_dfb. The kernel under test — exercises every
     // named-arg accessor (RTA / CRTA / two CTAs) plus RTA + CRTA varargs.
     auto compute = MakeMinimalComputeKernel("compute");
-    compute.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp"};
+    compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp";
     compute.runtime_arguments_schema.named_runtime_args = {"input_offset"};
     compute.runtime_arguments_schema.named_common_runtime_args = {"num_tiles"};
     compute.runtime_arguments_schema.num_runtime_varargs = 2;
@@ -368,8 +363,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     // Consumer: NCRISC reads out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp
     // verbatim (positional varargs only).
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
@@ -463,30 +457,26 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     // semaphore.
     KernelSpec producer{
         .unique_id = "producer",
-        .source =
-            KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}},
         .config_spec =
             DataMovementConfiguration{
-                .gen1_data_movement_config =
-                    DataMovementConfiguration::Gen1DataMovementConfig{
+                .gen1 =
+                    DataMovementConfiguration::Gen1{
                         .processor = DataMovementProcessor::RISCV_0,
                     },
             },
     };
     KernelSpec consumer{
         .unique_id = "consumer",
-        .source =
-            KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}},
         .config_spec =
             DataMovementConfiguration{
-                .gen1_data_movement_config =
-                    DataMovementConfiguration::Gen1DataMovementConfig{
+                .gen1 =
+                    DataMovementConfiguration::Gen1{
                         .processor = DataMovementProcessor::RISCV_1,
                     },
             },
@@ -565,14 +555,12 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
 
     // Producer (BRISC): reads input tensor via TA binding, pushes to DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer.source = KernelSpec::SourceFilePath{
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp"};
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp";
     producer.runtime_arguments_schema.num_runtime_varargs = 1;
 
     // Consumer (NCRISC): pops from DFB, writes output tensor via TA binding
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source = KernelSpec::SourceFilePath{
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.num_runtime_varargs = 1;
 
     // DFB connecting the two kernels

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -97,7 +97,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // Build ProgramSpec
     // -------------------------------------------------------
     ProgramSpec spec;
-    spec.program_id = "dfb_accessor_loopback";
+    spec.name = "dfb_accessor_loopback";
 
     // Producer: BRISC reads from DRAM → DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
@@ -225,7 +225,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     auto output_buffer = CreateBuffer(dram_config);
 
     ProgramSpec spec;
-    spec.program_id = "named_args_loopback";
+    spec.name = "named_args_loopback";
 
     // Producer: BRISC reads DRAM → DFB. 1 named RTA, 1 named CRTA, 2 named CTAs, 3 RTA
     // varargs, 1 CRTA vararg.
@@ -347,7 +347,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     auto output_buffer = CreateBuffer(dram_config);
 
     ProgramSpec spec;
-    spec.program_id = "named_args_loopback_compute";
+    spec.name = "named_args_loopback_compute";
 
     // Compute kernel: produces out_dfb. The kernel under test — exercises every
     // named-arg accessor (RTA / CRTA / two CTAs) plus RTA + CRTA varargs.
@@ -483,14 +483,14 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
 
     // A WorkUnitSpec describes the kernels that run on a shared set of nodes.
     WorkUnitSpec work_unit{
-        .unique_id = "work_unit_0",
+        .name = "work_unit_0",
         .kernels = {"producer", "consumer"},
         .target_nodes = node,
     };
 
     // The ProgramSpec aggregates everything and is consumed by `MakeProgramFromSpec`.
     ProgramSpec spec{
-        .program_id = "semaphore_accessor_loopback",
+        .name = "semaphore_accessor_loopback",
         .kernels = {producer, consumer},
         .semaphores = {sem},
         .work_units = std::vector<WorkUnitSpec>{work_unit},
@@ -550,7 +550,7 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     // Build ProgramSpec: 2 DM kernels + 1 DFB + 2 TensorParameters
     // -------------------------------------------------------
     ProgramSpec spec;
-    spec.program_id = "ta_binding_loopback";
+    spec.name = "ta_binding_loopback";
 
     // Producer (BRISC): reads input tensor via TA binding, pushes to DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
@@ -655,7 +655,7 @@ TEST_F(ProgramSpecHWTest, MultiBindingProducerMaskMismatchFails) {
     consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     ProgramSpec spec;
-    spec.program_id = "multi_binding_mask_mismatch";
+    spec.name = "multi_binding_mask_mismatch";
     spec.kernels = {producer_g1, producer_g2, consumer};
     spec.dataflow_buffers = {dfb};
     // consumer in both WUs (single-KernelSpec multi-WU membership) → consumer-side mask is fine.

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -462,7 +462,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .config_spec =
             DataMovementConfiguration{
                 .gen1 =
-                    DataMovementConfiguration::Gen1{
+                    DataMovementConfiguration::Gen1DM{
                         .processor = DataMovementProcessor::RISCV_0,
                     },
             },
@@ -475,7 +475,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .config_spec =
             DataMovementConfiguration{
                 .gen1 =
-                    DataMovementConfiguration::Gen1{
+                    DataMovementConfiguration::Gen1DM{
                         .processor = DataMovementProcessor::RISCV_1,
                     },
             },

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -33,7 +33,6 @@
 namespace tt::tt_metal::experimental {
 namespace {
 
-using test_helpers::BindDFBToKernel;
 using test_helpers::BindTensorParameterToKernel;
 using test_helpers::MakeMinimalComputeKernel;
 using test_helpers::MakeMinimalDFB;
@@ -113,8 +112,8 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // DFB: both kernels bind it, with different local accessor names
     auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    BindDFBToKernel(producer, "loopback_dfb", "my_local_dfb_name", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "loopback_dfb", "a_dfb_named_bob", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("loopback_dfb", "my_local_dfb_name"));
+    consumer.dfb_bindings.push_back(ConsumerOf("loopback_dfb", "a_dfb_named_bob"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -251,8 +250,8 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 
     auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries_in_dfb);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    BindDFBToKernel(producer, "loopback_dfb", "loopback_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "loopback_dfb", "loopback_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("loopback_dfb", "loopback_dfb"));
+    consumer.dfb_bindings.push_back(ConsumerOf("loopback_dfb", "loopback_dfb"));
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -369,8 +368,8 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
     out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(compute, "out_dfb", "out_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "out_dfb", "a_dfb_named_bob", KernelSpec::DFBEndpointType::CONSUMER);
+    compute.dfb_bindings.push_back(ProducerOf("out_dfb", "out_dfb"));
+    consumer.dfb_bindings.push_back(ConsumerOf("out_dfb", "a_dfb_named_bob"));
 
     spec.kernels = {compute, consumer};
     spec.dataflow_buffers = {out_dfb};
@@ -566,8 +565,8 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     // DFB connecting the two kernels
     auto dfb = MakeMinimalDFB("input_dfb", page_size, num_dfb_entries);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    BindDFBToKernel(producer, "input_dfb", "input_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "input_dfb", "input_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+    producer.dfb_bindings.push_back(ProducerOf("input_dfb", "input_dfb"));
+    consumer.dfb_bindings.push_back(ConsumerOf("input_dfb", "input_dfb"));
 
     // TensorAccessor bindings: each kernel sees its own tensor under its accessor name
     BindTensorParameterToKernel(producer, "input_tensor", "input_tensor");
@@ -651,9 +650,9 @@ TEST_F(ProgramSpecHWTest, MultiBindingProducerMaskMismatchFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer_g1, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(producer_g2, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer_g1.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    producer_g2.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     ProgramSpec spec;
     spec.program_id = "multi_binding_mask_mismatch";

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -231,22 +231,22 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     // varargs, 1 CRTA vararg.
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp";
-    producer.runtime_arguments_schema.named_runtime_args = {"src_addr"};
-    producer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
+    producer.runtime_arguments_schema.runtime_args = {"src_addr"};
+    producer.runtime_arguments_schema.common_runtime_args = {"num_entries"};
     producer.runtime_arguments_schema.num_runtime_varargs = 3;
     producer.runtime_arguments_schema.num_common_runtime_varargs = 1;
-    producer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
+    producer.compile_time_args = {{"bank_id", 0}, {"entry_size", entry_size}};
 
     // Consumer: NCRISC reads DFB → DRAM. Uses default `args` namespace, 1 named RTA,
     // 1 named CRTA, 2 named CTAs, 2 RTA varargs (note: different count from producer —
     // this verifies the named_rta_words offset is baked per-kernel), 1 CRTA vararg.
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp";
-    consumer.runtime_arguments_schema.named_runtime_args = {"dst_addr"};
-    consumer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
+    consumer.runtime_arguments_schema.runtime_args = {"dst_addr"};
+    consumer.runtime_arguments_schema.common_runtime_args = {"num_entries"};
     consumer.runtime_arguments_schema.num_runtime_varargs = 2;
     consumer.runtime_arguments_schema.num_common_runtime_varargs = 1;
-    consumer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
+    consumer.compile_time_args = {{"bank_id", 0}, {"entry_size", entry_size}};
 
     auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries_in_dfb);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -277,15 +277,15 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     params.kernel_run_params = {
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "producer",
-            .named_runtime_args = {{.node = node, .args = {{"src_addr", input_buffer->address()}}}},
-            .named_common_runtime_args = {{"num_entries", num_transfers}},
+            .runtime_args = {{.node = node, .args = {{"src_addr", input_buffer->address()}}}},
+            .common_runtime_args = {{"num_entries", num_transfers}},
             .runtime_varargs = {{node, {kProducerRta0, kProducerRta1, kProducerRta2}}},
             .common_runtime_varargs = {kProducerCrta0},
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer",
-            .named_runtime_args = {{.node = node, .args = {{"dst_addr", output_buffer->address()}}}},
-            .named_common_runtime_args = {{"num_entries", num_transfers}},
+            .runtime_args = {{.node = node, .args = {{"dst_addr", output_buffer->address()}}}},
+            .common_runtime_args = {{"num_entries", num_transfers}},
             .runtime_varargs = {{node, {kConsumerRta0, kConsumerRta1}}},
             .common_runtime_varargs = {kConsumerCrta0},
         },
@@ -353,11 +353,11 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     // named-arg accessor (RTA / CRTA / two CTAs) plus RTA + CRTA varargs.
     auto compute = MakeMinimalComputeKernel("compute");
     compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp";
-    compute.runtime_arguments_schema.named_runtime_args = {"input_offset"};
-    compute.runtime_arguments_schema.named_common_runtime_args = {"num_tiles"};
+    compute.runtime_arguments_schema.runtime_args = {"input_offset"};
+    compute.runtime_arguments_schema.common_runtime_args = {"num_tiles"};
     compute.runtime_arguments_schema.num_runtime_varargs = 2;
     compute.runtime_arguments_schema.num_common_runtime_varargs = 1;
-    compute.compile_time_arg_bindings = {{"magic", 0xCAFE0001u}, {"entry_size", entry_size}};
+    compute.compile_time_args = {{"magic", 0xCAFE0001u}, {"entry_size", entry_size}};
 
     // Consumer: NCRISC reads out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp
     // verbatim (positional varargs only).
@@ -393,8 +393,8 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     params.kernel_run_params = {
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "compute",
-            .named_runtime_args = {{.node = node, .args = {{"input_offset", kInputOffset}}}},
-            .named_common_runtime_args = {{"num_tiles", num_transfers}},
+            .runtime_args = {{.node = node, .args = {{"input_offset", kInputOffset}}}},
+            .common_runtime_args = {{"num_tiles", num_transfers}},
             .runtime_varargs = {{node, {kVararg0, kVararg1}}},
             .common_runtime_varargs = {kCommonVararg0},
         },

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -418,13 +418,13 @@ static bool reader_datacopy_writer_quasar(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "reader_datacopy_writer",
+        .name = "reader_datacopy_writer",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -392,12 +392,7 @@ static bool reader_datacopy_writer_quasar(
         .unique_id = READER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = num_threads,
-        .dfb_bindings = {{
-            .dfb_spec_name = INPUT_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
@@ -408,12 +403,7 @@ static bool reader_datacopy_writer_quasar(
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = num_threads,
-        .dfb_bindings = {{
-            .dfb_spec_name = OUTPUT_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
@@ -424,19 +414,7 @@ static bool reader_datacopy_writer_quasar(
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = num_threads,
-        .dfb_bindings =
-            {{
-                 .dfb_spec_name = INPUT_DFB,
-                 .local_accessor_name = "in",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = OUTPUT_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+        .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"per_core_tile_cnt", per_core_tile_cnt}, {"use_dfbs", 1u}},
         .config_spec = experimental::ComputeConfiguration{},
     };

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -393,9 +393,8 @@ static bool reader_datacopy_writer_quasar(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1u}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1u}},
+        .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -404,9 +403,8 @@ static bool reader_datacopy_writer_quasar(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1u}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1u}},
+        .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -415,7 +413,7 @@ static bool reader_datacopy_writer_quasar(
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"per_core_tile_cnt", per_core_tile_cnt}, {"use_dfbs", 1u}},
+        .compile_time_args = {{"per_core_tile_cnt", per_core_tile_cnt}, {"use_dfbs", 1u}},
         .config_spec = experimental::ComputeConfiguration{},
     };
 
@@ -440,7 +438,7 @@ static bool reader_datacopy_writer_quasar(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"src_addr", ctx.input_dram_byte_address},
@@ -450,7 +448,7 @@ static bool reader_datacopy_writer_quasar(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"dst_addr", ctx.output_dram_byte_address},

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -395,7 +395,8 @@ static bool reader_datacopy_writer_quasar(
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_args = {{"use_dfbs", 1u}},
         .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -405,7 +406,8 @@ static bool reader_datacopy_writer_quasar(
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_args = {{"use_dfbs", 1u}},
         .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -390,9 +390,7 @@ static bool reader_datacopy_writer_quasar(
 
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
@@ -405,15 +403,12 @@ static bool reader_datacopy_writer_quasar(
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
@@ -426,15 +421,12 @@ static bool reader_datacopy_writer_quasar(
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = num_threads,
         .dfb_bindings =
             {{

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -372,59 +372,55 @@ static bool reader_datacopy_writer_quasar(
     // Legacy DataflowBufferConfig used enable_implicit_sync = true on both DFBs;
     // keep DataflowBufferSpec::disable_implicit_sync at default (false) and set
     // the program-level reservation flag below.
-    experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
+    experimental::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,
         .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
         .num_entries = static_cast<uint32_t>(test_config.num_tiles),
         .data_format_metadata = test_config.l1_input_data_format,
     };
-    experimental::metal2_host_api::DataflowBufferSpec output_dfb_spec{
+    experimental::DataflowBufferSpec output_dfb_spec{
         .unique_id = OUTPUT_DFB,
         .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
         .num_entries = static_cast<uint32_t>(test_config.num_tiles),
         .data_format_metadata = test_config.l1_output_data_format,
     };
 
-    const experimental::metal2_host_api::NodeCoord node{
+    const experimental::NodeCoord node{
         static_cast<uint32_t>(test_config.core.x), static_cast<uint32_t>(test_config.core.y)};
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = num_threads,
@@ -432,39 +428,39 @@ static bool reader_datacopy_writer_quasar(
             {{
                  .dfb_spec_name = INPUT_DFB,
                  .local_accessor_name = "in",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = OUTPUT_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = {{"per_core_tile_cnt", per_core_tile_cnt}, {"use_dfbs", 1u}},
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "reader_datacopy_writer",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     log_info(tt::LogTest, "Num tiles per thread: {}", num_tiles_per_thread);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args =
                 {{.node = node,
@@ -474,7 +470,7 @@ static bool reader_datacopy_writer_quasar(
                        {"num_tiles", num_tiles_per_thread},
                        {"dram_page_stride", ctx.per_tile_stride}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args =
                 {{.node = node,
@@ -484,11 +480,11 @@ static bool reader_datacopy_writer_quasar(
                        {"num_tiles", num_tiles_per_thread},
                        {"dram_page_stride", ctx.per_tile_stride}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
         },
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
 

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -92,14 +92,14 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
 
     if (is_quasar) {
         auto spec = MakeMinimalDMKernel("dm_barrier_kernel", static_cast<uint8_t>(expected_num_threads));
-        spec.source = KernelSpec::SourceFilePath{kKernelPath};
+        spec.source = kKernelPath;
         spec.runtime_arguments_schema.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
         kernel_configs.push_back({"dm_barrier_kernel", spec, make_layout(l1_base, kRounds)});
         work_unit_kernel_names = {"dm_barrier_kernel"};
     } else {
         auto make_gen1 = [&](const std::string& name, tt::tt_metal::DataMovementProcessor proc, uint32_t layout_base) {
             auto spec = MakeMinimalGen1DMKernel(name, proc);
-            spec.source = KernelSpec::SourceFilePath{kKernelPath};
+            spec.source = kKernelPath;
             spec.runtime_arguments_schema.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
             return KernelConfig{name, spec, make_layout(layout_base, kRounds)};
         };

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -21,7 +21,7 @@
 #include "device_fixture.hpp"
 #include "metal2_host_api/test_helpers.hpp"
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 namespace {
 
 using test_helpers::MakeMinimalDMKernel;
@@ -150,4 +150,4 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -110,7 +110,7 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
     }
 
     ProgramSpec spec;
-    spec.program_id = "kernel_thread_barrier";
+    spec.name = "kernel_thread_barrier";
     for (const auto& cfg : kernel_configs) { spec.kernels.push_back(cfg.spec); }
     spec.work_units = {MakeMinimalWorkUnit("work_unit_0", node, work_unit_kernel_names)};
 

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -201,7 +201,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
                     .num_common_runtime_varargs = common_rtas ? num_runtime_args : 0,
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         });
         wu_kernel_names.push_back(kernel_names[k]);
     }

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -207,13 +207,13 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
     }
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = wu_kernel_names,
         .target_nodes = core_range_set,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "quasar_crta_test",
+        .name = "quasar_crta_test",
         .kernels = kernel_specs,
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -192,9 +192,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
         kernel_names[k] = "dm_kernel_" + std::to_string(k);
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = kernel_names[k],
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
             .num_threads = static_cast<uint8_t>(dm_processors_per_kernel),
             .compiler_options = {.defines = defines_vec},
             .runtime_arguments_schema =
@@ -204,8 +202,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
                 },
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
         });
         wu_kernel_names.push_back(kernel_names[k]);
     }

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -173,7 +173,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
 
     uint32_t max_dms = MetalContext::instance().hal().get_processor_types_count(
         HalProgrammableCoreType::TENSIX, ttsl::as_underlying_type(HalProcessorClassType::DM));
-    experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines defines_vec = {
+    experimental::KernelSpec::CompilerOptions::Defines defines_vec = {
         {"DATA_MOVEMENT", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(num_runtime_args)},
         {"RESULTS_ADDR", std::to_string(rta_base)},
@@ -183,14 +183,14 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
     }
 
     std::vector<std::string> kernel_names(num_kernels);
-    std::vector<experimental::metal2_host_api::KernelSpec> kernel_specs;
+    std::vector<experimental::KernelSpec> kernel_specs;
     std::vector<std::string> wu_kernel_names;
     kernel_specs.reserve(num_kernels);
     wu_kernel_names.reserve(num_kernels);
 
     for (uint32_t k = 0; k < num_kernels; k++) {
         kernel_names[k] = "dm_kernel_" + std::to_string(k);
-        kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
+        kernel_specs.push_back(experimental::KernelSpec{
             .unique_id = kernel_names[k],
             .source = "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
             .num_threads = static_cast<uint8_t>(dm_processors_per_kernel),
@@ -201,24 +201,23 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
                     .num_common_runtime_varargs = common_rtas ? num_runtime_args : 0,
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2 = experimental::metal2_host_api::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         });
         wu_kernel_names.push_back(kernel_names[k]);
     }
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = wu_kernel_names,
         .target_nodes = core_range_set,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "quasar_crta_test",
         .kernels = kernel_specs,
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     workload.add_program(device_range, std::move(program));
     return {std::move(workload), kernel_names};
@@ -977,13 +976,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCRTASharedL1Address) {
         unit_tests::runtime_args::kQuasarNumUserDms);
     auto& program = workload.get_programs().at(device_range);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = kernel_names[0],
         .runtime_varargs = {{core, std::vector<uint32_t>(common_rtas.size(), 0)}},
         .common_runtime_varargs = common_rtas,
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
     // Verify all 6 user DMs (DM2..DM7) share the same CRTA L1 address
@@ -1012,7 +1011,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCRTAUniqueL1Addresses) {
         mesh_device, core_range_set, base_crtas.size(), true, num_kernels, /*dm_processors_per_kernel*/ 1);
     auto& program = workload.get_programs().at(device_range);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     std::vector<std::vector<uint32_t>> all_crtas(num_kernels);
     for (uint32_t i = 0; i < num_kernels; i++) {
         std::vector<uint32_t> kernel_crtas = {base_crtas[0] + i, base_crtas[1] + i, base_crtas[2] + i};
@@ -1023,7 +1022,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCRTAUniqueL1Addresses) {
             .common_runtime_varargs = kernel_crtas,
         });
     }
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
     // Verify each user DM (DM2..DM7) has a unique CRTA L1 address

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -61,7 +61,8 @@ bool run_l2_flush_test(
                 .runtime_args = {"base_addr", "test_mode"},
                 .common_runtime_args = {"value", "num_words"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -147,7 +148,8 @@ bool run_l1_dcache_test(
                 .runtime_args = {"base_addr", "test_mode"},
                 .common_runtime_args = {"value", "num_words"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -42,7 +42,7 @@ bool run_l2_flush_test(
 
     IDevice* device = mesh_device->get_devices()[0];
     constexpr CoreCoord core = {0, 0};
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     // For invalidate tests, pre-populate with known "old" values
     // that should persist after invalidation (since invalidate doesn't write back)
@@ -52,44 +52,39 @@ bool run_l2_flush_test(
 
     constexpr const char* DM_KERNEL = "l2_flush";
 
-    experimental::metal2_host_api::KernelSpec dm_kernel_spec{
+    experimental::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp"},
+        .source = "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp",
         .num_threads = 1,
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"base_addr", "test_mode"},
                 .named_common_runtime_args = {"value", "num_words"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "l2_flush",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
         .named_runtime_args =
             {{.node = node, .args = {{"base_addr", config.base_addr}, {"test_mode", config.test_mode}}}},
         .named_common_runtime_args = {{"value", config.value}, {"num_words", config.num_words}},
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range(mesh_device->shape());
@@ -134,7 +129,7 @@ bool run_l1_dcache_test(
 
     IDevice* device = mesh_device->get_devices()[0];
     constexpr CoreCoord core = {0, 0};
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     // For invalidate tests, we need to pre-populate with known "old" values
     // that should persist after invalidation (since invalidate doesn't write back)
@@ -144,44 +139,39 @@ bool run_l1_dcache_test(
 
     constexpr const char* DM_KERNEL = "l1_dcache";
 
-    experimental::metal2_host_api::KernelSpec dm_kernel_spec{
+    experimental::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp"},
+        .source = "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp",
         .num_threads = 1,
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"base_addr", "test_mode"},
                 .named_common_runtime_args = {"value", "num_words"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "l1_dcache",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
         .named_runtime_args =
             {{.node = node, .args = {{"base_addr", config.base_addr}, {"test_mode", config.test_mode}}}},
         .named_common_runtime_args = {{"value", config.value}, {"num_words", config.num_words}},
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range(mesh_device->shape());

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -58,8 +58,8 @@ bool run_l2_flush_test(
         .num_threads = 1,
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"base_addr", "test_mode"},
-                .named_common_runtime_args = {"value", "num_words"},
+                .runtime_args = {"base_addr", "test_mode"},
+                .common_runtime_args = {"value", "num_words"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -80,9 +80,8 @@ bool run_l2_flush_test(
     experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
-        .named_runtime_args =
-            {{.node = node, .args = {{"base_addr", config.base_addr}, {"test_mode", config.test_mode}}}},
-        .named_common_runtime_args = {{"value", config.value}, {"num_words", config.num_words}},
+        .runtime_args = {{.node = node, .args = {{"base_addr", config.base_addr}, {"test_mode", config.test_mode}}}},
+        .common_runtime_args = {{"value", config.value}, {"num_words", config.num_words}},
     }};
     experimental::SetProgramRunParameters(program, params);
 
@@ -145,8 +144,8 @@ bool run_l1_dcache_test(
         .num_threads = 1,
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"base_addr", "test_mode"},
-                .named_common_runtime_args = {"value", "num_words"},
+                .runtime_args = {"base_addr", "test_mode"},
+                .common_runtime_args = {"value", "num_words"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -167,9 +166,8 @@ bool run_l1_dcache_test(
     experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
-        .named_runtime_args =
-            {{.node = node, .args = {{"base_addr", config.base_addr}, {"test_mode", config.test_mode}}}},
-        .named_common_runtime_args = {{"value", config.value}, {"num_words", config.num_words}},
+        .runtime_args = {{.node = node, .args = {{"base_addr", config.base_addr}, {"test_mode", config.test_mode}}}},
+        .common_runtime_args = {{"value", config.value}, {"num_words", config.num_words}},
     }};
     experimental::SetProgramRunParameters(program, params);
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -65,13 +65,13 @@ bool run_l2_flush_test(
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "l2_flush",
+        .name = "l2_flush",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
@@ -151,13 +151,13 @@ bool run_l1_dcache_test(
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "l1_dcache",
+        .name = "l1_dcache",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
@@ -43,7 +43,8 @@ bool run_addrgen_test(
             {{"src_stride_en", src_stride_en},
              {"dst_stride_en", dst_stride_en},
              {"num_of_addresses", num_of_addresses}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
@@ -33,40 +33,37 @@ bool run_addrgen_test(
     uint32_t dst_stride_en,
     uint32_t num_of_addresses) {
     constexpr const char* DM_KERNEL = "addrgen";
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
-    experimental::metal2_host_api::KernelSpec dm_kernel_spec{
+    experimental::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = 1,
         .compile_time_arg_bindings =
             {{"src_stride_en", src_stride_en},
              {"dst_stride_en", dst_stride_en},
              {"num_of_addresses", num_of_addresses}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "addrgen",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range(mesh_device->shape());

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
@@ -39,7 +39,7 @@ bool run_addrgen_test(
         .unique_id = DM_KERNEL,
         .source = kernel_path,
         .num_threads = 1,
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {{"src_stride_en", src_stride_en},
              {"dst_stride_en", dst_stride_en},
              {"num_of_addresses", num_of_addresses}},

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
@@ -47,13 +47,13 @@ bool run_addrgen_test(
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "addrgen",
+        .name = "addrgen",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -40,7 +40,8 @@ static void run_kernel(
         .source = kernel_path,
         .num_threads = 1,
         .compile_time_args = std::move(compile_time_args),
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -31,39 +31,36 @@ constexpr auto kIdma1DStrided =
 static void run_kernel(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const std::string& kernel_path,
-    experimental::metal2_host_api::KernelSpec::CompileTimeArgBindings compile_time_arg_bindings) {
+    experimental::KernelSpec::CompileTimeArgBindings compile_time_arg_bindings) {
     constexpr const char* DM_KERNEL = "idma";
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
-    experimental::metal2_host_api::KernelSpec dm_kernel_spec{
+    experimental::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = 1,
         .compile_time_arg_bindings = std::move(compile_time_arg_bindings),
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "idma",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range(mesh_device->shape());

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -31,7 +31,7 @@ constexpr auto kIdma1DStrided =
 static void run_kernel(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const std::string& kernel_path,
-    experimental::KernelSpec::CompileTimeArgBindings compile_time_arg_bindings) {
+    experimental::KernelSpec::CompileTimeArgs compile_time_args) {
     constexpr const char* DM_KERNEL = "idma";
     const experimental::NodeCoord node{0, 0};
 
@@ -39,7 +39,7 @@ static void run_kernel(
         .unique_id = DM_KERNEL,
         .source = kernel_path,
         .num_threads = 1,
-        .compile_time_arg_bindings = std::move(compile_time_arg_bindings),
+        .compile_time_args = std::move(compile_time_args),
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -44,13 +44,13 @@ static void run_kernel(
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "idma",
+        .name = "idma",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
@@ -29,37 +29,34 @@ bool run_im2col_test(
     const std::string& kernel_path,
     uint32_t num_of_addresses) {
     constexpr const char* DM_KERNEL = "addrgen";
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
-    experimental::metal2_host_api::KernelSpec dm_kernel_spec{
+    experimental::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = 1,
         .compile_time_arg_bindings = {{"num_of_addresses", num_of_addresses}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "im2col",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range(mesh_device->shape());

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
@@ -36,7 +36,8 @@ bool run_im2col_test(
         .source = kernel_path,
         .num_threads = 1,
         .compile_time_args = {{"num_of_addresses", num_of_addresses}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
@@ -40,13 +40,13 @@ bool run_im2col_test(
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "im2col",
+        .name = "im2col",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
@@ -35,7 +35,7 @@ bool run_im2col_test(
         .unique_id = DM_KERNEL,
         .source = kernel_path,
         .num_threads = 1,
-        .compile_time_arg_bindings = {{"num_of_addresses", num_of_addresses}},
+        .compile_time_args = {{"num_of_addresses", num_of_addresses}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -96,12 +96,12 @@ static void RunTest(
                                     .gen2 = experimental::DataMovementConfiguration::Gen2{}},
                         };
                         experimental::WorkUnitSpec wu{
-                            .unique_id = "main",
+                            .name = "main",
                             .kernels = {ASSERT_KERNEL_NAME},
                             .target_nodes = experimental::NodeCoord{logical_core},
                         };
                         experimental::ProgramSpec spec{
-                            .program_id = "watcher_assert_dm",
+                            .name = "watcher_assert_dm",
                             .kernels = {assert_kernel_spec},
                             .work_units = {wu},
                         };
@@ -129,12 +129,12 @@ static void RunTest(
                             .config_spec = experimental::ComputeConfiguration{},
                         };
                         experimental::WorkUnitSpec wu{
-                            .unique_id = "main",
+                            .name = "main",
                             .kernels = {ASSERT_KERNEL_NAME},
                             .target_nodes = experimental::NodeCoord{logical_core},
                         };
                         experimental::ProgramSpec spec{
-                            .program_id = "watcher_assert_compute",
+                            .name = "watcher_assert_compute",
                             .kernels = {assert_kernel_spec},
                             .work_units = {wu},
                         };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -85,29 +85,28 @@ static void RunTest(
                         // others exit early. DM0/DM1 are reserved for internal use and are skipped by the
                         // outer test fixture.
                         uint32_t dm_id = static_cast<uint32_t>(processor.processor_type);
-                        experimental::metal2_host_api::KernelSpec assert_kernel_spec{
+                        experimental::KernelSpec assert_kernel_spec{
                             .unique_id = ASSERT_KERNEL_NAME,
-                            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel},
+                            .source = kernel,
                             .num_threads = 6,
                             .compile_time_arg_bindings = {{"dm_id", dm_id}},
                             .runtime_arguments_schema =
                                 {.named_runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
                             .config_spec =
-                                experimental::metal2_host_api::DataMovementConfiguration{
-                                    .gen2_data_movement_config = experimental::metal2_host_api::
-                                        DataMovementConfiguration::Gen2DataMovementConfig{}},
+                                experimental::DataMovementConfiguration{
+                                    .gen2 = experimental::DataMovementConfiguration::Gen2{}},
                         };
-                        experimental::metal2_host_api::WorkUnitSpec wu{
+                        experimental::WorkUnitSpec wu{
                             .unique_id = "main",
                             .kernels = {ASSERT_KERNEL_NAME},
-                            .target_nodes = experimental::metal2_host_api::NodeCoord{logical_core},
+                            .target_nodes = experimental::NodeCoord{logical_core},
                         };
-                        experimental::metal2_host_api::ProgramSpec spec{
+                        experimental::ProgramSpec spec{
                             .program_id = "watcher_assert_dm",
                             .kernels = {assert_kernel_spec},
                             .work_units = {wu},
                         };
-                        program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+                        program = experimental::MakeProgramFromSpec(*mesh_device, spec);
                     } else {
                         DataMovementConfig dm_config{};
                         dm_config.processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type);
@@ -121,27 +120,27 @@ static void RunTest(
                 case HalProcessorClassType::COMPUTE:
                     if (is_quasar) {
                         uint32_t trisc_id = static_cast<uint32_t>(processor.processor_type);
-                        experimental::metal2_host_api::KernelSpec assert_kernel_spec{
+                        experimental::KernelSpec assert_kernel_spec{
                             .unique_id = ASSERT_KERNEL_NAME,
-                            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel},
+                            .source = kernel,
                             .num_threads = 1,
                             .compiler_options = {.defines = {{fmt::format("TRISC{}", trisc_id), "1"}}},
                             .compile_time_arg_bindings = {{"trisc_id", trisc_id}},
                             .runtime_arguments_schema =
                                 {.named_runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
-                            .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+                            .config_spec = experimental::ComputeConfiguration{},
                         };
-                        experimental::metal2_host_api::WorkUnitSpec wu{
+                        experimental::WorkUnitSpec wu{
                             .unique_id = "main",
                             .kernels = {ASSERT_KERNEL_NAME},
-                            .target_nodes = experimental::metal2_host_api::NodeCoord{logical_core},
+                            .target_nodes = experimental::NodeCoord{logical_core},
                         };
-                        experimental::metal2_host_api::ProgramSpec spec{
+                        experimental::ProgramSpec spec{
                             .program_id = "watcher_assert_compute",
                             .kernels = {assert_kernel_spec},
                             .work_units = {wu},
                         };
-                        program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+                        program = experimental::MakeProgramFromSpec(*mesh_device, spec);
                     } else {
                         assert_kernel = CreateKernel(
                             program,
@@ -192,15 +191,15 @@ static void RunTest(
     // Build runtime arg setter that targets either the Metal 2.0 named-name path or the legacy handle.
     auto set_args = [&](Program& prog, const std::vector<uint32_t>& args) {
         if (is_quasar) {
-            experimental::metal2_host_api::ProgramRunParams params;
+            experimental::ProgramRunParams params;
             params.kernel_run_params = {{
                 .kernel_spec_name = ASSERT_KERNEL_NAME,
                 .named_runtime_args =
-                    {{.node = experimental::metal2_host_api::NodeCoord{logical_core},
+                    {{.node = experimental::NodeCoord{logical_core},
                       .args =
                           {{"a", args[0]}, {"b", args[1]}, {"assert_type", args[2]}, {"hw_assert_cause", args[3]}}}},
             }};
-            experimental::metal2_host_api::SetProgramRunParameters(prog, params);
+            experimental::SetProgramRunParameters(prog, params);
         } else {
             SetRuntimeArgs(prog, assert_kernel, logical_core, args);
         }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -89,9 +89,8 @@ static void RunTest(
                             .unique_id = ASSERT_KERNEL_NAME,
                             .source = kernel,
                             .num_threads = 6,
-                            .compile_time_arg_bindings = {{"dm_id", dm_id}},
-                            .runtime_arguments_schema =
-                                {.named_runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
+                            .compile_time_args = {{"dm_id", dm_id}},
+                            .runtime_arguments_schema = {.runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
                             .config_spec =
                                 experimental::DataMovementConfiguration{
                                     .gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -125,9 +124,8 @@ static void RunTest(
                             .source = kernel,
                             .num_threads = 1,
                             .compiler_options = {.defines = {{fmt::format("TRISC{}", trisc_id), "1"}}},
-                            .compile_time_arg_bindings = {{"trisc_id", trisc_id}},
-                            .runtime_arguments_schema =
-                                {.named_runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
+                            .compile_time_args = {{"trisc_id", trisc_id}},
+                            .runtime_arguments_schema = {.runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
                             .config_spec = experimental::ComputeConfiguration{},
                         };
                         experimental::WorkUnitSpec wu{
@@ -194,7 +192,7 @@ static void RunTest(
             experimental::ProgramRunParams params;
             params.kernel_run_params = {{
                 .kernel_spec_name = ASSERT_KERNEL_NAME,
-                .named_runtime_args =
+                .runtime_args =
                     {{.node = experimental::NodeCoord{logical_core},
                       .args =
                           {{"a", args[0]}, {"b", args[1]}, {"assert_type", args[2]}, {"hw_assert_cause", args[3]}}}},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -93,7 +93,7 @@ static void RunTest(
                             .runtime_arguments_schema = {.runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
                             .config_spec =
                                 experimental::DataMovementConfiguration{
-                                    .gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                                    .gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
                         };
                         experimental::WorkUnitSpec wu{
                             .name = "main",

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -83,7 +83,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             .num_threads = static_cast<uint8_t>(kQuasarUserDmCores),
             .runtime_arguments_schema = {.common_runtime_args = {"wait_cycles"}},
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
         experimental::WorkUnitSpec wu{
             .name = "main",

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -77,33 +77,31 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
         // On Quasar, launch kernel on all user DMs (DM2..DM7). DM0/DM1 are reserved for internal use.
         // TODO: Watcher features for ERISCs and TRISCs are temporarily skipped on Quasar until basic runtime bring-up.
         constexpr uint32_t kQuasarUserDmCores = 6;
-        experimental::metal2_host_api::KernelSpec dm_spec{
+        experimental::KernelSpec dm_spec{
             .unique_id = DM_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path},
+            .source = path,
             .num_threads = static_cast<uint8_t>(kQuasarUserDmCores),
             .runtime_arguments_schema = {.named_common_runtime_args = {"wait_cycles"}},
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
-        experimental::metal2_host_api::WorkUnitSpec wu{
+        experimental::WorkUnitSpec wu{
             .unique_id = "main",
             .kernels = {DM_KERNEL_NAME},
-            .target_nodes = experimental::metal2_host_api::NodeRange{CoreRange(xy_start, xy_end)},
+            .target_nodes = experimental::NodeRange{CoreRange(xy_start, xy_end)},
         };
-        experimental::metal2_host_api::ProgramSpec spec{
+        experimental::ProgramSpec spec{
             .program_id = "watcher_pause",
             .kernels = {dm_spec},
             .work_units = {wu},
         };
-        program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+        program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-        experimental::metal2_host_api::ProgramRunParams params;
+        experimental::ProgramRunParams params;
         params.kernel_run_params = {
             {.kernel_spec_name = DM_KERNEL_NAME, .named_common_runtime_args = {{"wait_cycles", delay_cycles}}},
         };
-        experimental::metal2_host_api::SetProgramRunParameters(program, params);
+        experimental::SetProgramRunParameters(program, params);
         workload.add_program(device_range, std::move(program));
     } else {
         auto brisc_kid = CreateKernel(

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -86,12 +86,12 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
         experimental::WorkUnitSpec wu{
-            .unique_id = "main",
+            .name = "main",
             .kernels = {DM_KERNEL_NAME},
             .target_nodes = experimental::NodeRange{CoreRange(xy_start, xy_end)},
         };
         experimental::ProgramSpec spec{
-            .program_id = "watcher_pause",
+            .name = "watcher_pause",
             .kernels = {dm_spec},
             .work_units = {wu},
         };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -81,7 +81,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             .unique_id = DM_KERNEL_NAME,
             .source = path,
             .num_threads = static_cast<uint8_t>(kQuasarUserDmCores),
-            .runtime_arguments_schema = {.named_common_runtime_args = {"wait_cycles"}},
+            .runtime_arguments_schema = {.common_runtime_args = {"wait_cycles"}},
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
@@ -99,7 +99,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
 
         experimental::ProgramRunParams params;
         params.kernel_run_params = {
-            {.kernel_spec_name = DM_KERNEL_NAME, .named_common_runtime_args = {{"wait_cycles", delay_cycles}}},
+            {.kernel_spec_name = DM_KERNEL_NAME, .common_runtime_args = {{"wait_cycles", delay_cycles}}},
         };
         experimental::SetProgramRunParameters(program, params);
         workload.add_program(device_range, std::move(program));

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -242,7 +242,7 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
             .unique_id = DM_KERNEL_NAME,
             .source = rta_crta_kernel_path,
             .num_threads = static_cast<uint8_t>(num_dms_),
-            .compile_time_arg_bindings = {{"dm_id", 0}, {"l1_scratch_addr", l1_unreserved_base}},
+            .compile_time_args = {{"dm_id", 0}, {"l1_scratch_addr", l1_unreserved_base}},
             .runtime_arguments_schema =
                 {.num_runtime_varargs = default_rtas.size(), .num_common_runtime_varargs = default_crtas.size()},
             .config_spec =
@@ -391,7 +391,7 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
                 .source = rta_crta_kernel_path,
                 .num_threads = static_cast<uint8_t>(num_dms_),
                 .compiler_options = {.defines = m2_defines},
-                .compile_time_arg_bindings = {{"dm_id", 0}},
+                .compile_time_args = {{"dm_id", 0}},
                 .runtime_arguments_schema = schema,
                 .config_spec =
                     experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -490,7 +490,7 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
         .num_threads = static_cast<uint8_t>(num_dms_),
         .compiler_options =
             {.defines = {{"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}}},
-        .compile_time_arg_bindings = {{"num_dms", num_dms_}, {"l1_sync_addr", l1_unreserved_base}},
+        .compile_time_args = {{"num_dms", num_dms_}, {"l1_sync_addr", l1_unreserved_base}},
         .runtime_arguments_schema = {.num_runtime_varargs = default_rtas.size()},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -249,12 +249,12 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
         experimental::WorkUnitSpec wu{
-            .unique_id = "main",
+            .name = "main",
             .kernels = {DM_KERNEL_NAME},
             .target_nodes = experimental::NodeRangeSet{core_range_set},
         };
         experimental::ProgramSpec spec{
-            .program_id = "rta_validation",
+            .name = "rta_validation",
             .kernels = {dm_spec},
             .work_units = {wu},
         };
@@ -410,12 +410,12 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
         }
 
         experimental::WorkUnitSpec wu{
-            .unique_id = "main",
+            .name = "main",
             .kernels = {OOB_KERNEL_NAME},
             .target_nodes = experimental::NodeRangeSet{core_range_set},
         };
         experimental::ProgramSpec spec{
-            .program_id = "rta_oob",
+            .name = "rta_oob",
             .kernels = {kspec},
             .work_units = {wu},
         };
@@ -495,12 +495,12 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {MULTI_DM_KERNEL_NAME},
         .target_nodes = experimental::NodeRangeSet{core_range_set},
     };
     experimental::ProgramSpec spec{
-        .program_id = "multi_dm_oob",
+        .name = "multi_dm_oob",
         .kernels = {dm_spec},
         .work_units = {wu},
     };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -246,7 +246,7 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
             .runtime_arguments_schema =
                 {.num_runtime_varargs = default_rtas.size(), .num_common_runtime_varargs = default_crtas.size()},
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
         experimental::WorkUnitSpec wu{
             .name = "main",
@@ -394,7 +394,7 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
                 .compile_time_args = {{"dm_id", 0}},
                 .runtime_arguments_schema = schema,
                 .config_spec =
-                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
             };
         } else if (params.processor_class == HalProcessorClassType::COMPUTE) {
             kspec = experimental::KernelSpec{
@@ -492,7 +492,8 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
             {.defines = {{"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}}},
         .compile_time_args = {{"num_dms", num_dms_}, {"l1_sync_addr", l1_unreserved_base}},
         .runtime_arguments_schema = {.num_runtime_varargs = default_rtas.size()},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
     experimental::WorkUnitSpec wu{
         .name = "main",

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -238,43 +238,41 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     std::vector<uint32_t> rtas_range2 = {0x1000, 0x1001, 0x1002};
 
     auto build_metal2_program = [&]() {
-        experimental::metal2_host_api::KernelSpec dm_spec{
+        experimental::KernelSpec dm_spec{
             .unique_id = DM_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+            .source = rta_crta_kernel_path,
             .num_threads = static_cast<uint8_t>(num_dms_),
             .compile_time_arg_bindings = {{"dm_id", 0}, {"l1_scratch_addr", l1_unreserved_base}},
             .runtime_arguments_schema =
                 {.num_runtime_varargs = default_rtas.size(), .num_common_runtime_varargs = default_crtas.size()},
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
-        experimental::metal2_host_api::WorkUnitSpec wu{
+        experimental::WorkUnitSpec wu{
             .unique_id = "main",
             .kernels = {DM_KERNEL_NAME},
-            .target_nodes = experimental::metal2_host_api::NodeRangeSet{core_range_set},
+            .target_nodes = experimental::NodeRangeSet{core_range_set},
         };
-        experimental::metal2_host_api::ProgramSpec spec{
+        experimental::ProgramSpec spec{
             .program_id = "rta_validation",
             .kernels = {dm_spec},
             .work_units = {wu},
         };
-        program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+        program = experimental::MakeProgramFromSpec(*mesh_device, spec);
     };
 
     // Helper to set runtime arguments (per-node varargs + common varargs) on the active program
     auto set_metal2_runtime_args = [&](Program& prog) {
-        experimental::metal2_host_api::ProgramRunParams params;
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{
+        experimental::ProgramRunParams params;
+        experimental::ProgramRunParams::KernelRunParams krp{
             .kernel_spec_name = DM_KERNEL_NAME,
             .common_runtime_varargs = default_crtas,
         };
         for (const auto& c : core_range1) {
-            krp.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+            krp.runtime_varargs.push_back({experimental::NodeCoord{c}, default_rtas});
         }
         params.kernel_run_params = {krp};
-        experimental::metal2_host_api::SetProgramRunParameters(prog, params);
+        experimental::SetProgramRunParameters(prog, params);
     };
 
     if (is_quasar) {
@@ -370,7 +368,7 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     constexpr const char* OOB_KERNEL_NAME = "rta_oob";
 
     if (is_quasar) {
-        experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines m2_defines;
+        experimental::KernelSpec::CompilerOptions::Defines m2_defines;
         if (params.test_rta) {
             m2_defines.push_back({"MAX_RTA_IDX", std::to_string(default_rtas.size())});
         } else {
@@ -379,63 +377,61 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
 
         // RTA test reads index == default_rtas.size() (one past the end), so the kernel must declare
         // exactly default_rtas.size() varargs to make that access OOB.
-        experimental::metal2_host_api::KernelSpec::RuntimeArgSchema schema;
+        experimental::KernelSpec::RuntimeArgSchema schema;
         if (params.test_rta) {
             schema.num_runtime_varargs = default_rtas.size();
         } else {
             schema.num_common_runtime_varargs = default_crtas.size();
         }
 
-        experimental::metal2_host_api::KernelSpec kspec;
+        experimental::KernelSpec kspec;
         if (params.processor_class == HalProcessorClassType::DM) {
-            kspec = experimental::metal2_host_api::KernelSpec{
+            kspec = experimental::KernelSpec{
                 .unique_id = OOB_KERNEL_NAME,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+                .source = rta_crta_kernel_path,
                 .num_threads = static_cast<uint8_t>(num_dms_),
                 .compiler_options = {.defines = m2_defines},
                 .compile_time_arg_bindings = {{"dm_id", 0}},
                 .runtime_arguments_schema = schema,
                 .config_spec =
-                    experimental::metal2_host_api::DataMovementConfiguration{
-                        .gen2_data_movement_config =
-                            experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
             };
         } else if (params.processor_class == HalProcessorClassType::COMPUTE) {
-            kspec = experimental::metal2_host_api::KernelSpec{
+            kspec = experimental::KernelSpec{
                 .unique_id = OOB_KERNEL_NAME,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+                .source = rta_crta_kernel_path,
                 .num_threads = 1,  // Run only on 1 NEO Cluster
                 .compiler_options = {.defines = m2_defines},
                 .runtime_arguments_schema = schema,
-                .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+                .config_spec = experimental::ComputeConfiguration{},
             };
         } else {
             TT_THROW("Unsupported processor class");
         }
 
-        experimental::metal2_host_api::WorkUnitSpec wu{
+        experimental::WorkUnitSpec wu{
             .unique_id = "main",
             .kernels = {OOB_KERNEL_NAME},
-            .target_nodes = experimental::metal2_host_api::NodeRangeSet{core_range_set},
+            .target_nodes = experimental::NodeRangeSet{core_range_set},
         };
-        experimental::metal2_host_api::ProgramSpec spec{
+        experimental::ProgramSpec spec{
             .program_id = "rta_oob",
             .kernels = {kspec},
             .work_units = {wu},
         };
-        program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+        program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-        experimental::metal2_host_api::ProgramRunParams params_m2;
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = OOB_KERNEL_NAME};
+        experimental::ProgramRunParams params_m2;
+        experimental::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = OOB_KERNEL_NAME};
         if (params.test_rta) {
             for (const auto& c : core_range) {
-                krp.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+                krp.runtime_varargs.push_back({experimental::NodeCoord{c}, default_rtas});
             }
         } else {
             krp.common_runtime_varargs = default_crtas;
         }
         params_m2.kernel_run_params = {krp};
-        experimental::metal2_host_api::SetProgramRunParameters(program, params_m2);
+        experimental::SetProgramRunParameters(program, params_m2);
     } else {
         std::map<std::string, std::string> defines;
         if (params.test_rta) {
@@ -488,38 +484,35 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
     Program program;
 
     constexpr const char* MULTI_DM_KERNEL_NAME = "multi_dm_oob";
-    experimental::metal2_host_api::KernelSpec dm_spec{
+    experimental::KernelSpec dm_spec{
         .unique_id = MULTI_DM_KERNEL_NAME,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+        .source = rta_crta_kernel_path,
         .num_threads = static_cast<uint8_t>(num_dms_),
         .compiler_options =
             {.defines = {{"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}}},
         .compile_time_arg_bindings = {{"num_dms", num_dms_}, {"l1_sync_addr", l1_unreserved_base}},
         .runtime_arguments_schema = {.num_runtime_varargs = default_rtas.size()},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {MULTI_DM_KERNEL_NAME},
-        .target_nodes = experimental::metal2_host_api::NodeRangeSet{core_range_set},
+        .target_nodes = experimental::NodeRangeSet{core_range_set},
     };
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "multi_dm_oob",
         .kernels = {dm_spec},
         .work_units = {wu},
     };
-    program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
-    experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = MULTI_DM_KERNEL_NAME};
+    experimental::ProgramRunParams params;
+    experimental::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = MULTI_DM_KERNEL_NAME};
     for (const auto& c : core_range) {
-        krp.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+        krp.runtime_varargs.push_back({experimental::NodeCoord{c}, default_rtas});
     }
     params.kernel_run_params = {krp};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -245,7 +245,7 @@ void RunTestOnCore(
                           "mcast_dst_end_x",
                           "mcast_dst_end_y"}},
                 .config_spec =
-                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
             };
             experimental::WorkUnitSpec wu{
                 .name = "main",

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -197,7 +197,7 @@ void RunTestOnCore(
             // Quasar: user DMs (DM2..DM7) run the kernel; multi_dm_race syncs them to race, else only dm_id executes.
             // DM0/DM1 are reserved for internal use, so the test exercises 6 user DMs.
             constexpr uint32_t num_dms = 6;
-            experimental::KernelSpec::CompileTimeArgBindings cta_bindings;
+            experimental::KernelSpec::CompileTimeArgs cta_bindings;
             experimental::KernelSpec::CompilerOptions::Defines defines;
             if (multi_dm_race) {
                 constexpr uint32_t multi_dm_base_addr = 0xFFFF0000;
@@ -225,9 +225,9 @@ void RunTestOnCore(
                 .source = kernel,
                 .num_threads = static_cast<uint8_t>(num_dms),
                 .compiler_options = {.defines = defines},
-                .compile_time_arg_bindings = cta_bindings,
+                .compile_time_args = cta_bindings,
                 .runtime_arguments_schema =
-                    {.named_runtime_args =
+                    {.runtime_args =
                          {"local_buffer_addr",
                           "buffer_src_addr",
                           "src_noc_x",
@@ -369,7 +369,7 @@ void RunTestOnCore(
         experimental::ProgramRunParams params;
         params.kernel_run_params = {{
             .kernel_spec_name = DRAM_COPY_KERNEL_NAME,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = experimental::NodeCoord{core},
                   .args =
                       {{"local_buffer_addr", buffer_addr},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -197,8 +197,8 @@ void RunTestOnCore(
             // Quasar: user DMs (DM2..DM7) run the kernel; multi_dm_race syncs them to race, else only dm_id executes.
             // DM0/DM1 are reserved for internal use, so the test exercises 6 user DMs.
             constexpr uint32_t num_dms = 6;
-            experimental::metal2_host_api::KernelSpec::CompileTimeArgBindings cta_bindings;
-            experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines defines;
+            experimental::KernelSpec::CompileTimeArgBindings cta_bindings;
+            experimental::KernelSpec::CompilerOptions::Defines defines;
             if (multi_dm_race) {
                 constexpr uint32_t multi_dm_base_addr = 0xFFFF0000;
                 constexpr uint32_t multi_dm_base_size = 0x1000;
@@ -220,9 +220,9 @@ void RunTestOnCore(
             } else {
                 cta_bindings = {{"dm_id", dm_id}};
             }
-            experimental::metal2_host_api::KernelSpec dm_spec{
+            experimental::KernelSpec dm_spec{
                 .unique_id = DRAM_COPY_KERNEL_NAME,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel},
+                .source = kernel,
                 .num_threads = static_cast<uint8_t>(num_dms),
                 .compiler_options = {.defines = defines},
                 .compile_time_arg_bindings = cta_bindings,
@@ -245,21 +245,19 @@ void RunTestOnCore(
                           "mcast_dst_end_x",
                           "mcast_dst_end_y"}},
                 .config_spec =
-                    experimental::metal2_host_api::DataMovementConfiguration{
-                        .gen2_data_movement_config =
-                            experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
             };
-            experimental::metal2_host_api::WorkUnitSpec wu{
+            experimental::WorkUnitSpec wu{
                 .unique_id = "main",
                 .kernels = {DRAM_COPY_KERNEL_NAME},
-                .target_nodes = experimental::metal2_host_api::NodeCoord{core},
+                .target_nodes = experimental::NodeCoord{core},
             };
-            experimental::metal2_host_api::ProgramSpec spec{
+            experimental::ProgramSpec spec{
                 .program_id = "watcher_sanitize",
                 .kernels = {dm_spec},
                 .work_units = {wu},
             };
-            program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+            program = experimental::MakeProgramFromSpec(*mesh_device, spec);
             // Quasar SD does not yet expose a NOC index in the same way as legacy DMs; the watcher
             // log emits "noc0" for Metal 2.0 DM kernels. Match that so expected strings line up.
             noc = 0;
@@ -368,11 +366,11 @@ void RunTestOnCore(
         mcast_dst_end_y};
 
     if (is_quasar) {
-        experimental::metal2_host_api::ProgramRunParams params;
+        experimental::ProgramRunParams params;
         params.kernel_run_params = {{
             .kernel_spec_name = DRAM_COPY_KERNEL_NAME,
             .named_runtime_args =
-                {{.node = experimental::metal2_host_api::NodeCoord{core},
+                {{.node = experimental::NodeCoord{core},
                   .args =
                       {{"local_buffer_addr", buffer_addr},
                        {"buffer_src_addr", input_buffer_addr},
@@ -391,7 +389,7 @@ void RunTestOnCore(
                        {"mcast_dst_end_x", mcast_dst_end_x},
                        {"mcast_dst_end_y", mcast_dst_end_y}}}},
         }};
-        experimental::metal2_host_api::SetProgramRunParameters(program, params);
+        experimental::SetProgramRunParameters(program, params);
     } else {
         tt_metal::SetRuntimeArgs(program, dram_copy_kernel, core, rta_values);
     }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -248,12 +248,12 @@ void RunTestOnCore(
                     experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
             };
             experimental::WorkUnitSpec wu{
-                .unique_id = "main",
+                .name = "main",
                 .kernels = {DRAM_COPY_KERNEL_NAME},
                 .target_nodes = experimental::NodeCoord{core},
             };
             experimental::ProgramSpec spec{
-                .program_id = "watcher_sanitize",
+                .name = "watcher_sanitize",
                 .kernels = {dm_spec},
                 .work_units = {wu},
             };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -85,7 +85,7 @@ void RunOneTest(
                 .num_threads = static_cast<uint8_t>(dms_per_kernel),
                 .compile_time_args = {{"usage", free}},
                 .config_spec =
-                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
             });
             kernel_names.push_back(name);
         }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -72,48 +72,46 @@ void RunOneTest(
             num_user_dms);
         uint32_t num_kernels = num_user_dms / dms_per_kernel;
 
-        std::vector<experimental::metal2_host_api::KernelSpec> kernel_specs;
-        std::vector<experimental::metal2_host_api::KernelSpecName> kernel_names;
+        std::vector<experimental::KernelSpec> kernel_specs;
+        std::vector<experimental::KernelSpecName> kernel_names;
         kernel_specs.reserve(num_kernels + 1);
         kernel_names.reserve(num_kernels + 1);
 
         for (uint32_t i = 0; i < num_kernels; i++) {
             std::string name = fmt::format("dm_{}", i);
-            kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
+            kernel_specs.push_back(experimental::KernelSpec{
                 .unique_id = name,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path},
+                .source = path,
                 .num_threads = static_cast<uint8_t>(dms_per_kernel),
                 .compile_time_arg_bindings = {{"usage", free}},
                 .config_spec =
-                    experimental::metal2_host_api::DataMovementConfiguration{
-                        .gen2_data_movement_config =
-                            experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
             });
             kernel_names.push_back(name);
         }
         constexpr const char* COMPUTE_NAME = "compute";
-        kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
+        kernel_specs.push_back(experimental::KernelSpec{
             .unique_id = COMPUTE_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path},
+            .source = path,
             // One thread per Neo (Quasar Tensix has 4) so the compute kernel fans out across
             // all Neos; each Neo internally runs the kernel on its 4 TRISCs.
             .num_threads = 4,
             .compile_time_arg_bindings = {{"usage", free}},
-            .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+            .config_spec = experimental::ComputeConfiguration{},
         });
         kernel_names.push_back(COMPUTE_NAME);
 
-        experimental::metal2_host_api::WorkUnitSpec wu{
+        experimental::WorkUnitSpec wu{
             .unique_id = "main",
             .kernels = kernel_names,
-            .target_nodes = experimental::metal2_host_api::NodeCoord{coord},
+            .target_nodes = experimental::NodeCoord{coord},
         };
-        experimental::metal2_host_api::ProgramSpec spec{
+        experimental::ProgramSpec spec{
             .program_id = "watcher_stack",
             .kernels = kernel_specs,
             .work_units = {wu},
         };
-        Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+        Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
         workload.add_program(device_range, std::move(program));
     } else {
         // BH/WH legacy path

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -83,7 +83,7 @@ void RunOneTest(
                 .unique_id = name,
                 .source = path,
                 .num_threads = static_cast<uint8_t>(dms_per_kernel),
-                .compile_time_arg_bindings = {{"usage", free}},
+                .compile_time_args = {{"usage", free}},
                 .config_spec =
                     experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
             });
@@ -96,7 +96,7 @@ void RunOneTest(
             // One thread per Neo (Quasar Tensix has 4) so the compute kernel fans out across
             // all Neos; each Neo internally runs the kernel on its 4 TRISCs.
             .num_threads = 4,
-            .compile_time_arg_bindings = {{"usage", free}},
+            .compile_time_args = {{"usage", free}},
             .config_spec = experimental::ComputeConfiguration{},
         });
         kernel_names.push_back(COMPUTE_NAME);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -102,12 +102,12 @@ void RunOneTest(
         kernel_names.push_back(COMPUTE_NAME);
 
         experimental::WorkUnitSpec wu{
-            .unique_id = "main",
+            .name = "main",
             .kernels = kernel_names,
             .target_nodes = experimental::NodeCoord{coord},
         };
         experimental::ProgramSpec spec{
-            .program_id = "watcher_stack",
+            .name = "watcher_stack",
             .kernels = kernel_specs,
             .work_units = {wu},
         };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -46,8 +46,7 @@ void RunTest(
     auto* device = mesh_device->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-    const experimental::metal2_host_api::NodeCoord node{
-        static_cast<uint32_t>(logical_core.x), static_cast<uint32_t>(logical_core.y)};
+    const experimental::NodeCoord node{static_cast<uint32_t>(logical_core.x), static_cast<uint32_t>(logical_core.y)};
 
     // Allocate L1 buffer for sync flag
     tt_metal::InterleavedBufferConfig sync_buffer_config{
@@ -62,14 +61,13 @@ void RunTest(
 
     // DFB config: 1 DM producer -> 4 NEO unpacker consumers
     // use_remapper: true -> all (remapper enabled), false -> strided (bypass mode)
-    const auto cap = use_remapper ? experimental::metal2_host_api::DFBAccessPattern::ALL
-                                  : experimental::metal2_host_api::DFBAccessPattern::STRIDED;
+    const auto cap = use_remapper ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED;
 
     constexpr const char* TILE_COUNTER_DFB = "tile_counter_dfb";
     constexpr const char* PRODUCER = "producer";
     constexpr const char* CONSUMER = "consumer";
 
-    experimental::metal2_host_api::DataflowBufferSpec dfb_spec{
+    experimental::DataflowBufferSpec dfb_spec{
         .unique_id = TILE_COUNTER_DFB,
         .entry_size = TILE_SIZE,
         .num_entries = NUM_ENTRIES_PER_DFB,
@@ -80,58 +78,55 @@ void RunTest(
 
     const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_tile_counters.cpp";
 
-    experimental::metal2_host_api::KernelSpec producer_spec{
+    experimental::KernelSpec producer_spec{
         .unique_id = PRODUCER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = NUM_PRODUCERS,
         .compiler_options = {.defines = {{"DFB_PRODUCER", "1"}}},
         .dfb_bindings = {{
             .dfb_spec_name = TILE_COUNTER_DFB,
             .local_accessor_name = "tile_counter_dfb",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"num_entries", NUM_ENTRIES_PER_PRODUCER}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
     // NEO compute consumer kernel (4 threads = 4 Neo clusters)
     // blocked: each consumer sees all entries; strided: entries distributed among consumers
     uint32_t entries_per_consumer = use_remapper ? NUM_ENTRIES_PER_DFB : NUM_ENTRIES_PER_CONSUMER;
-    experimental::metal2_host_api::KernelSpec consumer_spec{
+    experimental::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = NUM_CONSUMERS,
         .dfb_bindings = {{
             .dfb_spec_name = TILE_COUNTER_DFB,
             .local_accessor_name = "tile_counter_dfb",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
             .access_pattern = cap,
         }},
         .compile_time_arg_bindings =
             {{"num_entries", entries_per_consumer},
              {"num_consumers_to_run", NUM_CONSUMERS_TO_RUN},
              {"sync_flag_addr", tensix_sync_addr}},
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {PRODUCER, CONSUMER},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "tile_counter_log",
         .kernels = {producer_spec, consumer_spec},
         .dataflow_buffers = {dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
     workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -85,7 +85,8 @@ void RunTest(
         .compiler_options = {.defines = {{"DFB_PRODUCER", "1"}}},
         .dfb_bindings = {experimental::ProducerOf(TILE_COUNTER_DFB, "tile_counter_dfb")},
         .compile_time_args = {{"num_entries", NUM_ENTRIES_PER_PRODUCER}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     // NEO compute consumer kernel (4 threads = 4 Neo clusters)

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -83,12 +83,7 @@ void RunTest(
         .source = kernel_path,
         .num_threads = NUM_PRODUCERS,
         .compiler_options = {.defines = {{"DFB_PRODUCER", "1"}}},
-        .dfb_bindings = {{
-            .dfb_spec_name = TILE_COUNTER_DFB,
-            .local_accessor_name = "tile_counter_dfb",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(TILE_COUNTER_DFB, "tile_counter_dfb")},
         .compile_time_arg_bindings = {{"num_entries", NUM_ENTRIES_PER_PRODUCER}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -109,13 +109,13 @@ void RunTest(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {PRODUCER, CONSUMER},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "tile_counter_log",
+        .name = "tile_counter_log",
         .kernels = {producer_spec, consumer_spec},
         .dataflow_buffers = {dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -84,7 +84,7 @@ void RunTest(
         .num_threads = NUM_PRODUCERS,
         .compiler_options = {.defines = {{"DFB_PRODUCER", "1"}}},
         .dfb_bindings = {experimental::ProducerOf(TILE_COUNTER_DFB, "tile_counter_dfb")},
-        .compile_time_arg_bindings = {{"num_entries", NUM_ENTRIES_PER_PRODUCER}},
+        .compile_time_args = {{"num_entries", NUM_ENTRIES_PER_PRODUCER}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -101,7 +101,7 @@ void RunTest(
             .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
             .access_pattern = cap,
         }},
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {{"num_entries", entries_per_consumer},
              {"num_consumers_to_run", NUM_CONSUMERS_TO_RUN},
              {"sync_flag_addr", tensix_sync_addr}},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -114,12 +114,12 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             .config_spec = experimental::ComputeConfiguration{},
         };
         experimental::WorkUnitSpec wu{
-            .unique_id = "main",
+            .name = "main",
             .kernels = {DM_KERNEL_NAME, COMPUTE_KERNEL_NAME},
             .target_nodes = experimental::NodeRange{core_range},
         };
         experimental::ProgramSpec spec{
-            .program_id = "watcher_waypoints",
+            .name = "watcher_waypoints",
             .kernels = {dm_spec, compute_spec},
             .work_units = {wu},
         };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -104,7 +104,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             .num_threads = kQuasarUserDmCores,
             .runtime_arguments_schema = {.common_runtime_args = {"sync_flag_addr"}},
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
         experimental::KernelSpec compute_spec{
             .unique_id = COMPUTE_KERNEL_NAME,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -98,42 +98,40 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
         // On Quasar, kernel runs on the 6 user DMs (DM2..DM7). DM0/DM1 are reserved for internal use.
         constexpr uint32_t kQuasarUserDmCores = 6;
         auto core_range = CoreRange(xy_start, xy_end);
-        experimental::metal2_host_api::KernelSpec dm_spec{
+        experimental::KernelSpec dm_spec{
             .unique_id = DM_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+            .source = kernel_path,
             .num_threads = kQuasarUserDmCores,
             .runtime_arguments_schema = {.named_common_runtime_args = {"sync_flag_addr"}},
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
-        experimental::metal2_host_api::KernelSpec compute_spec{
+        experimental::KernelSpec compute_spec{
             .unique_id = COMPUTE_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+            .source = kernel_path,
             .num_threads = 4,
             .runtime_arguments_schema = {.named_common_runtime_args = {"sync_flag_addr"}},
-            .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+            .config_spec = experimental::ComputeConfiguration{},
         };
-        experimental::metal2_host_api::WorkUnitSpec wu{
+        experimental::WorkUnitSpec wu{
             .unique_id = "main",
             .kernels = {DM_KERNEL_NAME, COMPUTE_KERNEL_NAME},
-            .target_nodes = experimental::metal2_host_api::NodeRange{core_range},
+            .target_nodes = experimental::NodeRange{core_range},
         };
-        experimental::metal2_host_api::ProgramSpec spec{
+        experimental::ProgramSpec spec{
             .program_id = "watcher_waypoints",
             .kernels = {dm_spec, compute_spec},
             .work_units = {wu},
         };
-        program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+        program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-        experimental::metal2_host_api::ProgramRunParams params;
+        experimental::ProgramRunParams params;
         params.kernel_run_params = {
             {.kernel_spec_name = DM_KERNEL_NAME, .named_common_runtime_args = {{"sync_flag_addr", tensix_sync_addr}}},
             {.kernel_spec_name = COMPUTE_KERNEL_NAME,
              .named_common_runtime_args = {{"sync_flag_addr", tensix_sync_addr}}},
         };
-        experimental::metal2_host_api::SetProgramRunParameters(program, params);
+        experimental::SetProgramRunParameters(program, params);
         workload.add_program(device_range, std::move(program));
     } else {
         auto brisc_kid = CreateKernel(

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -102,7 +102,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             .unique_id = DM_KERNEL_NAME,
             .source = kernel_path,
             .num_threads = kQuasarUserDmCores,
-            .runtime_arguments_schema = {.named_common_runtime_args = {"sync_flag_addr"}},
+            .runtime_arguments_schema = {.common_runtime_args = {"sync_flag_addr"}},
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
@@ -110,7 +110,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             .unique_id = COMPUTE_KERNEL_NAME,
             .source = kernel_path,
             .num_threads = 4,
-            .runtime_arguments_schema = {.named_common_runtime_args = {"sync_flag_addr"}},
+            .runtime_arguments_schema = {.common_runtime_args = {"sync_flag_addr"}},
             .config_spec = experimental::ComputeConfiguration{},
         };
         experimental::WorkUnitSpec wu{
@@ -127,9 +127,8 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
 
         experimental::ProgramRunParams params;
         params.kernel_run_params = {
-            {.kernel_spec_name = DM_KERNEL_NAME, .named_common_runtime_args = {{"sync_flag_addr", tensix_sync_addr}}},
-            {.kernel_spec_name = COMPUTE_KERNEL_NAME,
-             .named_common_runtime_args = {{"sync_flag_addr", tensix_sync_addr}}},
+            {.kernel_spec_name = DM_KERNEL_NAME, .common_runtime_args = {{"sync_flag_addr", tensix_sync_addr}}},
+            {.kernel_spec_name = COMPUTE_KERNEL_NAME, .common_runtime_args = {{"sync_flag_addr", tensix_sync_addr}}},
         };
         experimental::SetProgramRunParameters(program, params);
         workload.add_program(device_range, std::move(program));

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -273,7 +273,8 @@ static void matmul_tile_quasar(
                   "in0_block_size_bytes",
                   "in1_block_size_bytes",
                   "with_bias"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -282,7 +283,8 @@ static void matmul_tile_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .runtime_arguments_schema = {.runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     // The Quasar matmul_block.cpp kernel uses named CTAs. Map cfg.compute_kernel_args (positional)

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -262,7 +262,7 @@ static void matmul_tile_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(SRC0_DFB, "in0"), experimental::ProducerOf(SRC1_DFB, "in1")},
         .runtime_arguments_schema =
-            {.named_runtime_args =
+            {.runtime_args =
                  {"src0_addr",
                   "src0_dram_bank_id",
                   "src1_addr",
@@ -281,7 +281,7 @@ static void matmul_tile_quasar(
         .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
-        .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
+        .runtime_arguments_schema = {.runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -292,7 +292,7 @@ static void matmul_tile_quasar(
         cfg.compute_kernel_args.size() == 7,
         "Quasar matmul_block expects 7 compile-time args but got {}",
         cfg.compute_kernel_args.size());
-    experimental::KernelSpec::CompileTimeArgBindings compute_cta_bindings{
+    experimental::KernelSpec::CompileTimeArgs compute_cta_bindings{
         {"block_tile_dim", cfg.compute_kernel_args[0]},
         {"dst_tile_rows", cfg.compute_kernel_args[1]},
         {"dst_tile_cols", cfg.compute_kernel_args[2]},
@@ -319,7 +319,7 @@ static void matmul_tile_quasar(
             {experimental::ConsumerOf(SRC0_DFB, "in0"),
              experimental::ConsumerOf(SRC1_DFB, "in1"),
              experimental::ProducerOf(DST_DFB, "out")},
-        .compile_time_arg_bindings = compute_cta_bindings,
+        .compile_time_args = compute_cta_bindings,
         .config_spec =
             experimental::ComputeConfiguration{
                 .math_fidelity = cfg.math_fidelity,
@@ -361,7 +361,7 @@ static void matmul_tile_quasar(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"src0_addr", ctx.src0_dram_buffer->address()},
@@ -377,7 +377,7 @@ static void matmul_tile_quasar(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"dst_addr", ctx.dst_dram_buffer->address()}, {"bank_id", 0u}, {"num_tiles", ctx.num_tiles}}}},

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -329,13 +329,13 @@ static void matmul_tile_quasar(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "matmul_X_tile",
+        .name = "matmul_X_tile",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {src0_dfb_spec, src1_dfb_spec, dst_dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -260,19 +260,7 @@ static void matmul_tile_quasar(
         .unique_id = READER,
         .source = cfg.reader_kernel,
         .num_threads = 1,
-        .dfb_bindings =
-            {{
-                 .dfb_spec_name = SRC0_DFB,
-                 .local_accessor_name = "in0",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = SRC1_DFB,
-                 .local_accessor_name = "in1",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+        .dfb_bindings = {experimental::ProducerOf(SRC0_DFB, "in0"), experimental::ProducerOf(SRC1_DFB, "in1")},
         .runtime_arguments_schema =
             {.named_runtime_args =
                  {"src0_addr",
@@ -292,12 +280,7 @@ static void matmul_tile_quasar(
         .unique_id = WRITER,
         .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = DST_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -333,24 +316,9 @@ static void matmul_tile_quasar(
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =
-            {{
-                 .dfb_spec_name = SRC0_DFB,
-                 .local_accessor_name = "in0",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = SRC1_DFB,
-                 .local_accessor_name = "in1",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = DST_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+            {experimental::ConsumerOf(SRC0_DFB, "in0"),
+             experimental::ConsumerOf(SRC1_DFB, "in1"),
+             experimental::ProducerOf(DST_DFB, "out")},
         .compile_time_arg_bindings = compute_cta_bindings,
         .config_spec =
             experimental::ComputeConfiguration{

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -224,7 +224,7 @@ static void matmul_tile_quasar(
     vector<bfloat16> tensor_vals) {
     auto ctx = setup_matmul_tile_context(mesh_device, cfg);
 
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     constexpr const char* SRC0_DFB = "src0_dfb";
     constexpr const char* SRC1_DFB = "src1_dfb";
@@ -234,21 +234,21 @@ static void matmul_tile_quasar(
     constexpr const char* COMPUTE = "compute";
 
     // Legacy DataflowBufferConfig used enable_implicit_sync = false on all DFBs.
-    experimental::metal2_host_api::DataflowBufferSpec src0_dfb_spec{
+    experimental::DataflowBufferSpec src0_dfb_spec{
         .unique_id = SRC0_DFB,
         .entry_size = ctx.single_tile_size_bfp16b,
         .num_entries = ctx.num_input_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .disable_implicit_sync = true,
     };
-    experimental::metal2_host_api::DataflowBufferSpec src1_dfb_spec{
+    experimental::DataflowBufferSpec src1_dfb_spec{
         .unique_id = SRC1_DFB,
         .entry_size = ctx.single_tile_size_bfp16b,
         .num_entries = ctx.num_input_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .disable_implicit_sync = true,
     };
-    experimental::metal2_host_api::DataflowBufferSpec dst_dfb_spec{
+    experimental::DataflowBufferSpec dst_dfb_spec{
         .unique_id = DST_DFB,
         .entry_size = ctx.single_tile_size_out0,
         .num_entries = ctx.num_tiles,
@@ -256,22 +256,22 @@ static void matmul_tile_quasar(
         .disable_implicit_sync = true,
     };
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{cfg.reader_kernel},
+        .source = cfg.reader_kernel,
         .num_threads = 1,
         .dfb_bindings =
             {{
                  .dfb_spec_name = SRC0_DFB,
                  .local_accessor_name = "in0",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = SRC1_DFB,
                  .local_accessor_name = "in1",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .runtime_arguments_schema =
             {.named_runtime_args =
@@ -285,28 +285,21 @@ static void matmul_tile_quasar(
                   "in0_block_size_bytes",
                   "in1_block_size_bytes",
                   "with_bias"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{"tt_metal/kernels/dataflow/writer_unary.cpp"},
+        .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = DST_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
     // The Quasar matmul_block.cpp kernel uses named CTAs. Map cfg.compute_kernel_args (positional)
@@ -316,7 +309,7 @@ static void matmul_tile_quasar(
         cfg.compute_kernel_args.size() == 7,
         "Quasar matmul_block expects 7 compile-time args but got {}",
         cfg.compute_kernel_args.size());
-    experimental::metal2_host_api::KernelSpec::CompileTimeArgBindings compute_cta_bindings{
+    experimental::KernelSpec::CompileTimeArgBindings compute_cta_bindings{
         {"block_tile_dim", cfg.compute_kernel_args[0]},
         {"dst_tile_rows", cfg.compute_kernel_args[1]},
         {"dst_tile_cols", cfg.compute_kernel_args[2]},
@@ -326,7 +319,7 @@ static void matmul_tile_quasar(
         {"out_block_tile_cnt", cfg.compute_kernel_args[6]},
     };
 
-    experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines = {
+    experimental::KernelSpec::CompilerOptions::Defines compute_defines = {
         {"WITH_DT", cfg.with_dt ? "1" : "0"},
         {"TEST_INIT_SHORT", cfg.test_init_short ? "1" : "0"},
     };
@@ -334,53 +327,53 @@ static void matmul_tile_quasar(
         compute_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{cfg.compute_kernel},
+        .source = cfg.compute_kernel,
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =
             {{
                  .dfb_spec_name = SRC0_DFB,
                  .local_accessor_name = "in0",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = SRC1_DFB,
                  .local_accessor_name = "in1",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = DST_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = compute_cta_bindings,
         .config_spec =
-            experimental::metal2_host_api::ComputeConfiguration{
+            experimental::ComputeConfiguration{
                 .math_fidelity = cfg.math_fidelity,
                 .fp32_dest_acc_en = cfg.fp32_dest_acc_en,
                 .dst_full_sync_en = cfg.dst_full_sync_en,
             },
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "matmul_X_tile",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {src0_dfb_spec, src1_dfb_spec, dst_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     fixture->WriteBuffer(mesh_device, ctx.src0_dram_buffer, activations);
     fixture->WriteBuffer(mesh_device, ctx.src1_dram_buffer, weights);
@@ -396,9 +389,9 @@ static void matmul_tile_quasar(
         static_cast<uint32_t>((single_tile ? 1u : ctx.N) * ctx.single_tile_size_bfp16b);
     const uint32_t with_bias_arg = single_tile ? 0u : static_cast<uint32_t>(cfg.with_bias);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args =
                 {{.node = node,
@@ -414,18 +407,18 @@ static void matmul_tile_quasar(
                        {"in1_block_size_bytes", in1_block_size_bytes},
                        {"with_bias", with_bias_arg}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args =
                 {{.node = node,
                   .args =
                       {{"dst_addr", ctx.dst_dram_buffer->address()}, {"bank_id", 0u}, {"num_tiles", ctx.num_tiles}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
         },
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     auto* device = mesh_device->get_devices()[0];
     tt::tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -120,12 +120,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .unique_id = READER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = SRC0_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(SRC0_DFB, "out")},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_dram_bank_id", "num_tiles", "ublock_size_tiles", "reader_only"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -135,12 +130,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = DST_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_dram_bank_id", "num_tiles", "ublock_size_tiles", "writer_only"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -156,19 +146,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
-        .dfb_bindings =
-            {{
-                 .dfb_spec_name = SRC0_DFB,
-                 .local_accessor_name = "in",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = DST_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+        .dfb_bindings = {experimental::ConsumerOf(SRC0_DFB, "in"), experimental::ProducerOf(DST_DFB, "out")},
         .compile_time_arg_bindings = {{"num_tiles", num_tiles}, {"num_single_transfer", test_config.compute_ublock}},
         .config_spec =
             experimental::ComputeConfiguration{

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -76,7 +76,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const CopyBlockMatmulPartialsConfig& test_config) {
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     uint32_t single_tile_size = test_config.single_tile_size;
     uint32_t num_tiles = test_config.num_tiles;
@@ -99,7 +99,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
     constexpr const char* WRITER = "writer";
     constexpr const char* COMPUTE = "compute";
 
-    experimental::metal2_host_api::DataflowBufferSpec src0_dfb_spec{
+    experimental::DataflowBufferSpec src0_dfb_spec{
         .unique_id = SRC0_DFB,
         .entry_size = single_tile_size,
         .num_entries = num_input_tiles,
@@ -107,7 +107,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         // Match pre-migration behavior: legacy DataflowBufferConfig set enable_implicit_sync=false.
         .disable_implicit_sync = true,
     };
-    experimental::metal2_host_api::DataflowBufferSpec dst_dfb_spec{
+    experimental::DataflowBufferSpec dst_dfb_spec{
         .unique_id = DST_DFB,
         .entry_size = single_tile_size,
         .num_entries = num_output_tiles,
@@ -116,100 +116,88 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .disable_implicit_sync = true,
     };
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = SRC0_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_dram_bank_id", "num_tiles", "ublock_size_tiles", "reader_only"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = DST_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_dram_bank_id", "num_tiles", "ublock_size_tiles", "writer_only"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;
+    experimental::KernelSpec::CompilerOptions::Defines compute_defines;
     if (test_config.fp32_dest_acc_en) {
         compute_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =
             {{
                  .dfb_spec_name = SRC0_DFB,
                  .local_accessor_name = "in",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = DST_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = {{"num_tiles", num_tiles}, {"num_single_transfer", test_config.compute_ublock}},
         .config_spec =
-            experimental::metal2_host_api::ComputeConfiguration{
+            experimental::ComputeConfiguration{
                 .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
                 .dst_full_sync_en = test_config.dst_full_sync_en,
             },
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "single_core_copy_block_matmul_partials",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {src0_dfb_spec, dst_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     std::vector<uint32_t> src_vec = generate_copy_block_stimulus(dram_buffer_size, test_config);
     distributed::WriteShard(cq, src_dram_buffer, src_vec, zero_coord);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args =
                 {{.node = node,
@@ -220,7 +208,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
                        {"ublock_size_tiles", test_config.reader_ublock},
                        {"reader_only", 0u}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args =
                 {{.node = node,
@@ -231,11 +219,11 @@ void run_single_core_copy_block_matmul_partials_quasar(
                        {"ublock_size_tiles", test_config.writer_ublock},
                        {"writer_only", 0u}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
         },
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     auto* dev = mesh_device->get_devices()[0];
     tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -122,7 +122,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(SRC0_DFB, "out")},
         .runtime_arguments_schema =
-            {.named_runtime_args = {"src_addr", "src_dram_bank_id", "num_tiles", "ublock_size_tiles", "reader_only"}},
+            {.runtime_args = {"src_addr", "src_dram_bank_id", "num_tiles", "ublock_size_tiles", "reader_only"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -132,7 +132,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .runtime_arguments_schema =
-            {.named_runtime_args = {"dst_addr", "dst_dram_bank_id", "num_tiles", "ublock_size_tiles", "writer_only"}},
+            {.runtime_args = {"dst_addr", "dst_dram_bank_id", "num_tiles", "ublock_size_tiles", "writer_only"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -147,7 +147,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings = {experimental::ConsumerOf(SRC0_DFB, "in"), experimental::ProducerOf(DST_DFB, "out")},
-        .compile_time_arg_bindings = {{"num_tiles", num_tiles}, {"num_single_transfer", test_config.compute_ublock}},
+        .compile_time_args = {{"num_tiles", num_tiles}, {"num_single_transfer", test_config.compute_ublock}},
         .config_spec =
             experimental::ComputeConfiguration{
                 .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
@@ -177,7 +177,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"src_addr", src_dram_buffer->address()},
@@ -188,7 +188,7 @@ void run_single_core_copy_block_matmul_partials_quasar(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"dst_addr", dst_dram_buffer->address()},

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -123,7 +123,8 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .dfb_bindings = {experimental::ProducerOf(SRC0_DFB, "out")},
         .runtime_arguments_schema =
             {.runtime_args = {"src_addr", "src_dram_bank_id", "num_tiles", "ublock_size_tiles", "reader_only"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -133,7 +134,8 @@ void run_single_core_copy_block_matmul_partials_quasar(
         .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .runtime_arguments_schema =
             {.runtime_args = {"dst_addr", "dst_dram_bank_id", "num_tiles", "ublock_size_tiles", "writer_only"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -156,13 +156,13 @@ void run_single_core_copy_block_matmul_partials_quasar(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "single_core_copy_block_matmul_partials",
+        .name = "single_core_copy_block_matmul_partials",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {src0_dfb_spec, dst_dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -42,7 +42,7 @@ static vector<uint32_t> run_mxfp4_typecast(
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
     IDevice* dev = mesh_device->get_devices()[0];
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);
     uint32_t output_tile_size = tt::tile_size(output_fmt);
@@ -67,101 +67,89 @@ static vector<uint32_t> run_mxfp4_typecast(
     constexpr const char* WRITER = "writer";
     constexpr const char* COMPUTE = "compute";
 
-    experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
+    experimental::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,
         .entry_size = input_tile_size,
         .num_entries = 2,
         .data_format_metadata = input_fmt,
     };
-    experimental::metal2_host_api::DataflowBufferSpec output_dfb_spec{
+    experimental::DataflowBufferSpec output_dfb_spec{
         .unique_id = OUTPUT_DFB,
         .entry_size = output_tile_size,
         .num_entries = 2,
         .data_format_metadata = output_fmt,
     };
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = 1,
         .dfb_bindings =
             {{
                  .dfb_spec_name = INPUT_DFB,
                  .local_accessor_name = "in",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = OUTPUT_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1}},
         .config_spec =
-            experimental::metal2_host_api::ComputeConfiguration{
+            experimental::ComputeConfiguration{
                 .fp32_dest_acc_en = fp32_dest_acc_en,
             },
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "mxfp4_typecast",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     detail::WriteToBuffer(src_buffer, src_vec);
     // Pass aligned DRAM page stride so the reader/writer advance the DRAM
@@ -170,9 +158,9 @@ static vector<uint32_t> run_mxfp4_typecast(
     uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
     uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args =
                 {{.node = node,
@@ -182,7 +170,7 @@ static vector<uint32_t> run_mxfp4_typecast(
                        {"num_tiles", num_tiles},
                        {"dram_page_stride", src_dram_stride}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args =
                 {{.node = node,
@@ -192,11 +180,11 @@ static vector<uint32_t> run_mxfp4_typecast(
                        {"num_tiles", num_tiles},
                        {"dram_page_stride", dst_dram_stride}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
         },
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
 

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -87,7 +87,8 @@ static vector<uint32_t> run_mxfp4_typecast(
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_args = {{"use_dfbs", 1}},
         .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -97,7 +98,8 @@ static vector<uint32_t> run_mxfp4_typecast(
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_args = {{"use_dfbs", 1}},
         .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -113,13 +113,13 @@ static vector<uint32_t> run_mxfp4_typecast(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "mxfp4_typecast",
+        .name = "mxfp4_typecast",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -85,9 +85,8 @@ static vector<uint32_t> run_mxfp4_typecast(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1}},
+        .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -96,9 +95,8 @@ static vector<uint32_t> run_mxfp4_typecast(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1}},
+        .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -107,7 +105,7 @@ static vector<uint32_t> run_mxfp4_typecast(
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1}},
+        .compile_time_args = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1}},
         .config_spec =
             experimental::ComputeConfiguration{
                 .fp32_dest_acc_en = fp32_dest_acc_en,
@@ -140,7 +138,7 @@ static vector<uint32_t> run_mxfp4_typecast(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"src_addr", src_buffer->address()},
@@ -150,7 +148,7 @@ static vector<uint32_t> run_mxfp4_typecast(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"dst_addr", dst_buffer->address()},

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -84,12 +84,7 @@ static vector<uint32_t> run_mxfp4_typecast(
         .unique_id = READER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = INPUT_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"use_dfbs", 1}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
@@ -100,12 +95,7 @@ static vector<uint32_t> run_mxfp4_typecast(
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = OUTPUT_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_arg_bindings = {{"use_dfbs", 1}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
@@ -116,19 +106,7 @@ static vector<uint32_t> run_mxfp4_typecast(
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = 1,
-        .dfb_bindings =
-            {{
-                 .dfb_spec_name = INPUT_DFB,
-                 .local_accessor_name = "in",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = OUTPUT_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+        .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1}},
         .config_spec =
             experimental::ComputeConfiguration{

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -476,7 +476,7 @@ void run_single_core_reduce_program_quasar(
 
     // Build reader spec depending on reduce dim
     std::string reader_kernel_path;
-    experimental::KernelSpec::CompileTimeArgBindings reader_cta_bindings;
+    experimental::KernelSpec::CompileTimeArgs reader_cta_bindings;
     experimental::KernelSpec::CompilerOptions::Defines reader_defines;
     std::vector<std::string> reader_named_runtime_args;
     if (test_config.reduce_dim == ReduceDim::H) {
@@ -499,8 +499,8 @@ void run_single_core_reduce_program_quasar(
         .dfb_bindings =
             {experimental::ProducerOf(SRC0_DFB, "out_data"), experimental::ProducerOf(SRC1_DFB, "out_scaler")},
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
-        .compile_time_arg_bindings = reader_cta_bindings,
-        .runtime_arguments_schema = {.named_runtime_args = reader_named_runtime_args},
+        .compile_time_args = reader_cta_bindings,
+        .runtime_arguments_schema = {.runtime_args = reader_named_runtime_args},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -510,7 +510,7 @@ void run_single_core_reduce_program_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
-        .runtime_arguments_schema = {.named_runtime_args = {"num_tiles"}},
+        .runtime_arguments_schema = {.runtime_args = {"num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -523,7 +523,7 @@ void run_single_core_reduce_program_quasar(
             {experimental::ConsumerOf(SRC0_DFB, "in_data"),
              experimental::ConsumerOf(SRC1_DFB, "in_scaler"),
              experimental::ProducerOf(DST_DFB, "out")},
-        .compile_time_arg_bindings = {{"Ht", dims.Ht}, {"Wt", dims.Wt}, {"NC", dims.NC}},
+        .compile_time_args = {{"Ht", dims.Ht}, {"Wt", dims.Wt}, {"NC", dims.NC}},
         .config_spec =
             experimental::ComputeConfiguration{
                 .math_fidelity = test_config.math_fidelity,
@@ -568,11 +568,11 @@ void run_single_core_reduce_program_quasar(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args = {{.node = node, .args = reader_named_rtas}},
+            .runtime_args = {{.node = node, .args = reader_named_rtas}},
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args = {{.node = node, .args = {{"num_tiles", writer_num_tiles}}}},
+            .runtime_args = {{.node = node, .args = {{"num_tiles", writer_num_tiles}}}},
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -394,9 +394,8 @@ void validate_reduce_result(
     EXPECT_TRUE(pass);
 }
 
-static experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines build_reduce_defines(
-    const ReduceConfig& test_config) {
-    experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines reduce_defines;
+static experimental::KernelSpec::CompilerOptions::Defines build_reduce_defines(const ReduceConfig& test_config) {
+    experimental::KernelSpec::CompilerOptions::Defines reduce_defines;
     reduce_defines.emplace_back("REDUCE_DIM", get_reduce_dim_define_string(test_config.reduce_dim));
     switch (test_config.reduce_type) {
         case ReduceType::SUM: reduce_defines.emplace_back("REDUCE_OP", "PoolType::SUM"); break;
@@ -422,7 +421,7 @@ static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry
 
 void run_single_core_reduce_program_quasar(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ReduceConfig& test_config) {
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     const ReduceDims dims = compute_and_validate_reduce_dims(test_config);
 
@@ -450,7 +449,7 @@ void run_single_core_reduce_program_quasar(
     constexpr const char* OUT_TENSOR = "out_tensor";
 
     // Match pre-migration behavior: legacy DataflowBufferConfig set enable_implicit_sync=false on all 3 DFBs.
-    experimental::metal2_host_api::DataflowBufferSpec src0_dfb_spec{
+    experimental::DataflowBufferSpec src0_dfb_spec{
         .unique_id = SRC0_DFB,
         .entry_size = dims.single_tile_bytes,
         .num_entries = num_buffer_tiles,
@@ -458,7 +457,7 @@ void run_single_core_reduce_program_quasar(
         .tile_format_metadata = test_config.tile_shape,
         .disable_implicit_sync = true,
     };
-    experimental::metal2_host_api::DataflowBufferSpec src1_dfb_spec{
+    experimental::DataflowBufferSpec src1_dfb_spec{
         .unique_id = SRC1_DFB,
         .entry_size = 2 * TILE_WIDTH * TILE_HEIGHT,
         .num_entries = 2,
@@ -466,7 +465,7 @@ void run_single_core_reduce_program_quasar(
         .tile_format_metadata = tt_metal::Tile({32, 32}),
         .disable_implicit_sync = true,
     };
-    experimental::metal2_host_api::DataflowBufferSpec dst_dfb_spec{
+    experimental::DataflowBufferSpec dst_dfb_spec{
         .unique_id = DST_DFB,
         .entry_size = dims.single_tile_bytes,
         .num_entries = num_output_buffer_tiles,
@@ -477,8 +476,8 @@ void run_single_core_reduce_program_quasar(
 
     // Build reader spec depending on reduce dim
     std::string reader_kernel_path;
-    experimental::metal2_host_api::KernelSpec::CompileTimeArgBindings reader_cta_bindings;
-    experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines reader_defines;
+    experimental::KernelSpec::CompileTimeArgBindings reader_cta_bindings;
+    experimental::KernelSpec::CompilerOptions::Defines reader_defines;
     std::vector<std::string> reader_named_runtime_args;
     if (test_config.reduce_dim == ReduceDim::H) {
         reader_kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp";
@@ -492,94 +491,85 @@ void run_single_core_reduce_program_quasar(
         reader_named_runtime_args = {"num_tiles", "scaler"};
     }
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{reader_kernel_path},
+        .source = reader_kernel_path,
         .num_threads = 1,
         .compiler_options = {.defines = reader_defines},
         .dfb_bindings =
             {{
                  .dfb_spec_name = SRC0_DFB,
                  .local_accessor_name = "out_data",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = SRC1_DFB,
                  .local_accessor_name = "out_scaler",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
         .compile_time_arg_bindings = reader_cta_bindings,
         .runtime_arguments_schema = {.named_runtime_args = reader_named_runtime_args},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = DST_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
         .runtime_arguments_schema = {.named_runtime_args = {"num_tiles"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{get_compute_kernel_name(test_config.reduce_dim)},
+        .source = get_compute_kernel_name(test_config.reduce_dim),
         .num_threads = 1,
         .compiler_options = {.defines = build_reduce_defines(test_config)},
         .dfb_bindings =
             {{
                  .dfb_spec_name = SRC0_DFB,
                  .local_accessor_name = "in_data",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = SRC1_DFB,
                  .local_accessor_name = "in_scaler",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = DST_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = {{"Ht", dims.Ht}, {"Wt", dims.Wt}, {"NC", dims.NC}},
         .config_spec =
-            experimental::metal2_host_api::ComputeConfiguration{
+            experimental::ComputeConfiguration{
                 .math_fidelity = test_config.math_fidelity,
                 .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
                 .dst_full_sync_en = test_config.dst_full_sync_en,
             },
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "single_core_reduce",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {src0_dfb_spec, src1_dfb_spec, dst_dfb_spec},
@@ -591,7 +581,7 @@ void run_single_core_reduce_program_quasar(
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     // Reader/writer RTAs depend on reduce_dim
     std::unordered_map<std::string, uint32_t> reader_named_rtas;
@@ -605,17 +595,17 @@ void run_single_core_reduce_program_quasar(
                                                                   : (dims.num_tensor_tiles / (dims.Wt * dims.Ht));
     }
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args = {{.node = node, .args = reader_named_rtas}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args = {{.node = node, .args = {{"num_tiles", writer_num_tiles}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
         },
     };
@@ -623,7 +613,7 @@ void run_single_core_reduce_program_quasar(
         {.tensor_parameter_name = IN_TENSOR, .tensor = in_tensor},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = out_tensor},
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         dims.dram_buffer_size, test_config.data_gen_rand_max, test_config.data_gen_seed, test_config.data_gen_offset);

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -497,18 +497,7 @@ void run_single_core_reduce_program_quasar(
         .num_threads = 1,
         .compiler_options = {.defines = reader_defines},
         .dfb_bindings =
-            {{
-                 .dfb_spec_name = SRC0_DFB,
-                 .local_accessor_name = "out_data",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = SRC1_DFB,
-                 .local_accessor_name = "out_scaler",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+            {experimental::ProducerOf(SRC0_DFB, "out_data"), experimental::ProducerOf(SRC1_DFB, "out_scaler")},
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
         .compile_time_arg_bindings = reader_cta_bindings,
         .runtime_arguments_schema = {.named_runtime_args = reader_named_runtime_args},
@@ -519,12 +508,7 @@ void run_single_core_reduce_program_quasar(
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = DST_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
         .runtime_arguments_schema = {.named_runtime_args = {"num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -536,24 +520,9 @@ void run_single_core_reduce_program_quasar(
         .num_threads = 1,
         .compiler_options = {.defines = build_reduce_defines(test_config)},
         .dfb_bindings =
-            {{
-                 .dfb_spec_name = SRC0_DFB,
-                 .local_accessor_name = "in_data",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = SRC1_DFB,
-                 .local_accessor_name = "in_scaler",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = DST_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+            {experimental::ConsumerOf(SRC0_DFB, "in_data"),
+             experimental::ConsumerOf(SRC1_DFB, "in_scaler"),
+             experimental::ProducerOf(DST_DFB, "out")},
         .compile_time_arg_bindings = {{"Ht", dims.Ht}, {"Wt", dims.Wt}, {"NC", dims.NC}},
         .config_spec =
             experimental::ComputeConfiguration{

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -580,7 +580,7 @@ void run_single_core_reduce_program_quasar(
             .kernel_spec_name = COMPUTE,
         },
     };
-    params.tensor_args = {
+    params.tensor_arguments = {
         {.tensor_parameter_name = IN_TENSOR, .tensor = in_tensor},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = out_tensor},
     };

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -533,13 +533,13 @@ void run_single_core_reduce_program_quasar(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "single_core_reduce",
+        .name = "single_core_reduce",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {src0_dfb_spec, src1_dfb_spec, dst_dfb_spec},
         .tensor_parameters =

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -501,7 +501,8 @@ void run_single_core_reduce_program_quasar(
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
         .compile_time_args = reader_cta_bindings,
         .runtime_arguments_schema = {.runtime_args = reader_named_runtime_args},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -511,7 +512,8 @@ void run_single_core_reduce_program_quasar(
         .dfb_bindings = {experimental::ConsumerOf(DST_DFB, "in")},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
         .runtime_arguments_schema = {.runtime_args = {"num_tiles"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -236,7 +236,7 @@ bool run_sfpu_all_same_buffer(
             .source = "tt_metal/kernels/dataflow/reader_unary.cpp",
             .num_threads = 1,
             .dfb_bindings = {experimental::ProducerOf(IN_DFB, "out")},
-            .runtime_arguments_schema = {.named_runtime_args = {"src_addr", "bank_id", "num_tiles"}},
+            .runtime_arguments_schema = {.runtime_args = {"src_addr", "bank_id", "num_tiles"}},
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
@@ -246,7 +246,7 @@ bool run_sfpu_all_same_buffer(
             .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
             .num_threads = 1,
             .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
-            .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
+            .runtime_arguments_schema = {.runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
@@ -262,7 +262,7 @@ bool run_sfpu_all_same_buffer(
             .num_threads = 1,
             .compiler_options = {.defines = std::move(compute_defines)},
             .dfb_bindings = {experimental::ConsumerOf(IN_DFB, "in"), experimental::ProducerOf(OUT_DFB, "out")},
-            .compile_time_arg_bindings =
+            .compile_time_args =
                 {{"per_core_block_cnt", static_cast<uint32_t>(test_config.num_tiles)}, {"per_core_block_dim", 1u}},
             .config_spec =
                 experimental::ComputeConfiguration{
@@ -289,7 +289,7 @@ bool run_sfpu_all_same_buffer(
         params.kernel_run_params = {
             experimental::ProgramRunParams::KernelRunParams{
                 .kernel_spec_name = READER,
-                .named_runtime_args =
+                .runtime_args =
                     {{.node = node,
                       .args =
                           {{"src_addr", input_dram_buffer->address()},
@@ -298,7 +298,7 @@ bool run_sfpu_all_same_buffer(
             },
             experimental::ProgramRunParams::KernelRunParams{
                 .kernel_spec_name = WRITER,
-                .named_runtime_args =
+                .runtime_args =
                     {{.node = node,
                       .args =
                           {{"dst_addr", output_dram_buffer->address()},

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -235,12 +235,7 @@ bool run_sfpu_all_same_buffer(
             .unique_id = READER,
             .source = "tt_metal/kernels/dataflow/reader_unary.cpp",
             .num_threads = 1,
-            .dfb_bindings = {{
-                .dfb_spec_name = IN_DFB,
-                .local_accessor_name = "out",
-                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::DFBAccessPattern::STRIDED,
-            }},
+            .dfb_bindings = {experimental::ProducerOf(IN_DFB, "out")},
             .runtime_arguments_schema = {.named_runtime_args = {"src_addr", "bank_id", "num_tiles"}},
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -250,12 +245,7 @@ bool run_sfpu_all_same_buffer(
             .unique_id = WRITER,
             .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
             .num_threads = 1,
-            .dfb_bindings = {{
-                .dfb_spec_name = OUT_DFB,
-                .local_accessor_name = "in",
-                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                .access_pattern = experimental::DFBAccessPattern::STRIDED,
-            }},
+            .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
             .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -271,19 +261,7 @@ bool run_sfpu_all_same_buffer(
             .source = "tt_metal/kernels/compute/eltwise_sfpu.cpp",
             .num_threads = 1,
             .compiler_options = {.defines = std::move(compute_defines)},
-            .dfb_bindings =
-                {{
-                     .dfb_spec_name = IN_DFB,
-                     .local_accessor_name = "in",
-                     .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                     .access_pattern = experimental::DFBAccessPattern::STRIDED,
-                 },
-                 {
-                     .dfb_spec_name = OUT_DFB,
-                     .local_accessor_name = "out",
-                     .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                     .access_pattern = experimental::DFBAccessPattern::STRIDED,
-                 }},
+            .dfb_bindings = {experimental::ConsumerOf(IN_DFB, "in"), experimental::ProducerOf(OUT_DFB, "out")},
             .compile_time_arg_bindings =
                 {{"per_core_block_cnt", static_cast<uint32_t>(test_config.num_tiles)}, {"per_core_block_dim", 1u}},
             .config_spec =

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -238,7 +238,7 @@ bool run_sfpu_all_same_buffer(
             .dfb_bindings = {experimental::ProducerOf(IN_DFB, "out")},
             .runtime_arguments_schema = {.runtime_args = {"src_addr", "bank_id", "num_tiles"}},
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
 
         experimental::KernelSpec writer_spec{
@@ -248,7 +248,7 @@ bool run_sfpu_all_same_buffer(
             .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
             .runtime_arguments_schema = {.runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
 
         experimental::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -206,7 +206,7 @@ bool run_sfpu_all_same_buffer(
         const CoreRange& core_range = *test_config.cores.ranges().begin();
         TT_FATAL(core_range.start_coord == core_range.end_coord, "Metal 2.0 sfpu path expects a single-core CoreRange");
         const CoreCoord core = core_range.start_coord;
-        const experimental::metal2_host_api::NodeCoord node{core.x, core.y};
+        const experimental::NodeCoord node{core.x, core.y};
 
         constexpr const char* IN_DFB = "in_dfb";
         constexpr const char* OUT_DFB = "out_dfb";
@@ -216,14 +216,14 @@ bool run_sfpu_all_same_buffer(
 
         // Legacy DataflowBufferConfig set enable_implicit_sync = false on both DFBs;
         // mirror that with disable_implicit_sync = true.
-        experimental::metal2_host_api::DataflowBufferSpec in_dfb_spec{
+        experimental::DataflowBufferSpec in_dfb_spec{
             .unique_id = IN_DFB,
             .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
             .num_entries = static_cast<uint32_t>(test_config.num_tiles),
             .data_format_metadata = test_config.l1_input_data_format,
             .disable_implicit_sync = true,
         };
-        experimental::metal2_host_api::DataflowBufferSpec out_dfb_spec{
+        experimental::DataflowBufferSpec out_dfb_spec{
             .unique_id = OUT_DFB,
             .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
             .num_entries = static_cast<uint32_t>(test_config.num_tiles),
@@ -231,92 +231,85 @@ bool run_sfpu_all_same_buffer(
             .disable_implicit_sync = true,
         };
 
-        experimental::metal2_host_api::KernelSpec reader_spec{
+        experimental::KernelSpec reader_spec{
             .unique_id = READER,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{"tt_metal/kernels/dataflow/reader_unary.cpp"},
+            .source = "tt_metal/kernels/dataflow/reader_unary.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = IN_DFB,
                 .local_accessor_name = "out",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                .access_pattern = experimental::DFBAccessPattern::STRIDED,
             }},
             .runtime_arguments_schema = {.named_runtime_args = {"src_addr", "bank_id", "num_tiles"}},
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
 
-        experimental::metal2_host_api::KernelSpec writer_spec{
+        experimental::KernelSpec writer_spec{
             .unique_id = WRITER,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{"tt_metal/kernels/dataflow/writer_unary.cpp"},
+            .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = OUT_DFB,
                 .local_accessor_name = "in",
-                .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                .access_pattern = experimental::DFBAccessPattern::STRIDED,
             }},
             .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
 
-        experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;
+        experimental::KernelSpec::CompilerOptions::Defines compute_defines;
         for (const auto& [k, v] : sfpu_defines) {
             compute_defines.emplace_back(k, v);
         }
 
-        experimental::metal2_host_api::KernelSpec compute_spec{
+        experimental::KernelSpec compute_spec{
             .unique_id = COMPUTE,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{"tt_metal/kernels/compute/eltwise_sfpu.cpp"},
+            .source = "tt_metal/kernels/compute/eltwise_sfpu.cpp",
             .num_threads = 1,
             .compiler_options = {.defines = std::move(compute_defines)},
             .dfb_bindings =
                 {{
                      .dfb_spec_name = IN_DFB,
                      .local_accessor_name = "in",
-                     .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                     .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                     .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                     .access_pattern = experimental::DFBAccessPattern::STRIDED,
                  },
                  {
                      .dfb_spec_name = OUT_DFB,
                      .local_accessor_name = "out",
-                     .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                     .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                     .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                     .access_pattern = experimental::DFBAccessPattern::STRIDED,
                  }},
             .compile_time_arg_bindings =
                 {{"per_core_block_cnt", static_cast<uint32_t>(test_config.num_tiles)}, {"per_core_block_dim", 1u}},
             .config_spec =
-                experimental::metal2_host_api::ComputeConfiguration{
+                experimental::ComputeConfiguration{
                     .math_approx_mode = test_config.approx_mode,
                 },
         };
 
-        experimental::metal2_host_api::WorkUnitSpec wu{
+        experimental::WorkUnitSpec wu{
             .unique_id = "main",
             .kernels = {READER, WRITER, COMPUTE},
             .target_nodes = node,
         };
 
-        experimental::metal2_host_api::ProgramSpec spec{
+        experimental::ProgramSpec spec{
             .program_id = "sfpu_compute",
             .kernels = {reader_spec, writer_spec, compute_spec},
             .dataflow_buffers = {in_dfb_spec, out_dfb_spec},
             .work_units = {wu},
         };
 
-        Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+        Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-        experimental::metal2_host_api::ProgramRunParams params;
+        experimental::ProgramRunParams params;
         params.kernel_run_params = {
-            experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+            experimental::ProgramRunParams::KernelRunParams{
                 .kernel_spec_name = READER,
                 .named_runtime_args =
                     {{.node = node,
@@ -325,7 +318,7 @@ bool run_sfpu_all_same_buffer(
                            {"bank_id", 0u},
                            {"num_tiles", static_cast<uint32_t>(test_config.num_tiles)}}}},
             },
-            experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+            experimental::ProgramRunParams::KernelRunParams{
                 .kernel_spec_name = WRITER,
                 .named_runtime_args =
                     {{.node = node,
@@ -334,11 +327,11 @@ bool run_sfpu_all_same_buffer(
                            {"bank_id", 0u},
                            {"num_tiles", static_cast<uint32_t>(test_config.num_tiles)}}}},
             },
-            experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+            experimental::ProgramRunParams::KernelRunParams{
                 .kernel_spec_name = COMPUTE,
             },
         };
-        experimental::metal2_host_api::SetProgramRunParameters(program, params);
+        experimental::SetProgramRunParameters(program, params);
 
         tt_metal::detail::WriteToBuffer(input_dram_buffer, packed_input);
         tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -271,13 +271,13 @@ bool run_sfpu_all_same_buffer(
         };
 
         experimental::WorkUnitSpec wu{
-            .unique_id = "main",
+            .name = "main",
             .kernels = {READER, WRITER, COMPUTE},
             .target_nodes = node,
         };
 
         experimental::ProgramSpec spec{
-            .program_id = "sfpu_compute",
+            .name = "sfpu_compute",
             .kernels = {reader_spec, writer_spec, compute_spec},
             .dataflow_buffers = {in_dfb_spec, out_dfb_spec},
             .work_units = {wu},

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -310,24 +310,9 @@ static bool single_core_binary_quasar(
         .num_threads = 1,
         .compiler_options = {.defines = defines},
         .dfb_bindings =
-            {{
-                 .dfb_spec_name = INP0_DFB,
-                 .local_accessor_name = "in0",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = INP1_DFB,
-                 .local_accessor_name = "in1",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = INP2_DFB,
-                 .local_accessor_name = "in2",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+            {experimental::ProducerOf(INP0_DFB, "in0"),
+             experimental::ProducerOf(INP1_DFB, "in1"),
+             experimental::ProducerOf(INP2_DFB, "in2")},
         .runtime_arguments_schema =
             {.named_runtime_args =
                  {"src0_addr", "src0_bank_id", "src1_addr", "src1_bank_id", "num_tiles", "src2_addr", "src2_bank_id"}},
@@ -338,12 +323,7 @@ static bool single_core_binary_quasar(
         .unique_id = WRITER,
         .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = OUT_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
         .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -354,30 +334,10 @@ static bool single_core_binary_quasar(
         .num_threads = 1,
         .compiler_options = {.defines = defines},
         .dfb_bindings =
-            {{
-                 .dfb_spec_name = INP0_DFB,
-                 .local_accessor_name = "in0",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = INP1_DFB,
-                 .local_accessor_name = "in1",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = INP2_DFB,
-                 .local_accessor_name = "in2",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = OUT_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+            {experimental::ConsumerOf(INP0_DFB, "in0"),
+             experimental::ConsumerOf(INP1_DFB, "in1"),
+             experimental::ConsumerOf(INP2_DFB, "in2"),
+             experimental::ProducerOf(OUT_DFB, "out")},
         .runtime_arguments_schema = {.named_runtime_args = {"per_core_block_cnt", "per_core_block_size", "acc_to_dst"}},
         .config_spec =
             experimental::ComputeConfiguration{

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -346,13 +346,13 @@ static bool single_core_binary_quasar(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "single_core_binary",
+        .name = "single_core_binary",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {inp0_dfb_spec, inp1_dfb_spec, inp2_dfb_spec, out_dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -254,7 +254,7 @@ static bool single_core_binary_quasar(
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
-    const experimental::metal2_host_api::NodeCoord node{
+    const experimental::NodeCoord node{
         static_cast<uint32_t>(test_config.core.x), static_cast<uint32_t>(test_config.core.y)};
 
     auto stimulus = generate_binary_stimulus(test_config, /*is_quasar=*/true);
@@ -265,7 +265,7 @@ static bool single_core_binary_quasar(
     auto& output_dram_buffer = buffers.output;
 
     auto defines_map = build_binary_defines(test_config);
-    experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines defines;
+    experimental::KernelSpec::CompilerOptions::Defines defines;
     defines.reserve(defines_map.size());
     for (auto& kv : defines_map) {
         defines.emplace_back(kv.first, kv.second);
@@ -280,7 +280,7 @@ static bool single_core_binary_quasar(
     constexpr const char* COMPUTE = "compute";
 
     auto make_input_dfb = [&](const std::string& name) {
-        return experimental::metal2_host_api::DataflowBufferSpec{
+        return experimental::DataflowBufferSpec{
             .unique_id = name,
             .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
             .num_entries = static_cast<uint32_t>(test_config.num_tiles),
@@ -291,10 +291,10 @@ static bool single_core_binary_quasar(
         };
     };
 
-    experimental::metal2_host_api::DataflowBufferSpec inp0_dfb_spec = make_input_dfb(INP0_DFB);
-    experimental::metal2_host_api::DataflowBufferSpec inp1_dfb_spec = make_input_dfb(INP1_DFB);
-    experimental::metal2_host_api::DataflowBufferSpec inp2_dfb_spec = make_input_dfb(INP2_DFB);
-    experimental::metal2_host_api::DataflowBufferSpec out_dfb_spec{
+    experimental::DataflowBufferSpec inp0_dfb_spec = make_input_dfb(INP0_DFB);
+    experimental::DataflowBufferSpec inp1_dfb_spec = make_input_dfb(INP1_DFB);
+    experimental::DataflowBufferSpec inp2_dfb_spec = make_input_dfb(INP2_DFB);
+    experimental::DataflowBufferSpec out_dfb_spec{
         .unique_id = OUT_DFB,
         .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
         .num_entries = static_cast<uint32_t>(test_config.num_tiles),
@@ -304,116 +304,106 @@ static bool single_core_binary_quasar(
         .disable_implicit_sync = true,
     };
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = defines},
         .dfb_bindings =
             {{
                  .dfb_spec_name = INP0_DFB,
                  .local_accessor_name = "in0",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = INP1_DFB,
                  .local_accessor_name = "in1",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = INP2_DFB,
                  .local_accessor_name = "in2",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .runtime_arguments_schema =
             {.named_runtime_args =
                  {"src0_addr", "src0_bank_id", "src1_addr", "src1_bank_id", "num_tiles", "src2_addr", "src2_bank_id"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{"tt_metal/kernels/dataflow/writer_unary.cpp"},
+        .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{"tt_metal/kernels/compute/eltwise_binary.cpp"},
+        .source = "tt_metal/kernels/compute/eltwise_binary.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = defines},
         .dfb_bindings =
             {{
                  .dfb_spec_name = INP0_DFB,
                  .local_accessor_name = "in0",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = INP1_DFB,
                  .local_accessor_name = "in1",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = INP2_DFB,
                  .local_accessor_name = "in2",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = OUT_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .runtime_arguments_schema = {.named_runtime_args = {"per_core_block_cnt", "per_core_block_size", "acc_to_dst"}},
         .config_spec =
-            experimental::metal2_host_api::ComputeConfiguration{
+            experimental::ComputeConfiguration{
                 .math_fidelity = test_config.math_fidelity,
             },
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "single_core_binary",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {inp0_dfb_spec, inp1_dfb_spec, inp2_dfb_spec, out_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     const uint32_t num_tiles_u = static_cast<uint32_t>(test_config.num_tiles);
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args =
                 {{.node = node,
@@ -426,20 +416,20 @@ static bool single_core_binary_quasar(
                        {"src2_addr", input2_dram_buffer->address()},
                        {"src2_bank_id", 0u}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args =
                 {{.node = node,
                   .args = {{"dst_addr", output_dram_buffer->address()}, {"bank_id", 0u}, {"num_tiles", num_tiles_u}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
             .named_runtime_args =
                 {{.node = node,
                   .args = {{"per_core_block_cnt", num_tiles_u}, {"per_core_block_size", 1u}, {"acc_to_dst", 0u}}}},
         },
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     auto* dev = mesh_device->get_devices()[0];
     tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -314,7 +314,7 @@ static bool single_core_binary_quasar(
              experimental::ProducerOf(INP1_DFB, "in1"),
              experimental::ProducerOf(INP2_DFB, "in2")},
         .runtime_arguments_schema =
-            {.named_runtime_args =
+            {.runtime_args =
                  {"src0_addr", "src0_bank_id", "src1_addr", "src1_bank_id", "num_tiles", "src2_addr", "src2_bank_id"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -324,7 +324,7 @@ static bool single_core_binary_quasar(
         .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
-        .runtime_arguments_schema = {.named_runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
+        .runtime_arguments_schema = {.runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -338,7 +338,7 @@ static bool single_core_binary_quasar(
              experimental::ConsumerOf(INP1_DFB, "in1"),
              experimental::ConsumerOf(INP2_DFB, "in2"),
              experimental::ProducerOf(OUT_DFB, "out")},
-        .runtime_arguments_schema = {.named_runtime_args = {"per_core_block_cnt", "per_core_block_size", "acc_to_dst"}},
+        .runtime_arguments_schema = {.runtime_args = {"per_core_block_cnt", "per_core_block_size", "acc_to_dst"}},
         .config_spec =
             experimental::ComputeConfiguration{
                 .math_fidelity = test_config.math_fidelity,
@@ -365,7 +365,7 @@ static bool single_core_binary_quasar(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"src0_addr", input0_dram_buffer->address()},
@@ -378,13 +378,13 @@ static bool single_core_binary_quasar(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args = {{"dst_addr", output_dram_buffer->address()}, {"bank_id", 0u}, {"num_tiles", num_tiles_u}}}},
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args = {{"per_core_block_cnt", num_tiles_u}, {"per_core_block_size", 1u}, {"acc_to_dst", 0u}}}},
         },

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -316,7 +316,8 @@ static bool single_core_binary_quasar(
         .runtime_arguments_schema =
             {.runtime_args =
                  {"src0_addr", "src0_bank_id", "src1_addr", "src1_bank_id", "num_tiles", "src2_addr", "src2_bank_id"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -325,7 +326,8 @@ static bool single_core_binary_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
         .runtime_arguments_schema = {.runtime_args = {"dst_addr", "bank_id", "num_tiles"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -216,7 +216,7 @@ void run_single_core_transpose_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
-        .runtime_arguments_schema = {.named_runtime_args = {"N", "Ht", "Wt", "HtWt"}},
+        .runtime_arguments_schema = {.runtime_args = {"N", "Ht", "Wt", "HtWt"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -226,7 +226,7 @@ void run_single_core_transpose_quasar(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
-        .runtime_arguments_schema = {.named_runtime_args = {"num_tiles"}},
+        .runtime_arguments_schema = {.runtime_args = {"num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -241,7 +241,7 @@ void run_single_core_transpose_quasar(
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"NHtWt", Ht * Wt * NC}},
+        .compile_time_args = {{"NHtWt", Ht * Wt * NC}},
         .config_spec = experimental::ComputeConfiguration{},
     };
 
@@ -269,11 +269,11 @@ void run_single_core_transpose_quasar(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args = {{.node = node, .args = {{"N", NC}, {"Ht", Ht}, {"Wt", Wt}, {"HtWt", Ht * Wt}}}},
+            .runtime_args = {{.node = node, .args = {{"N", NC}, {"Ht", Ht}, {"Wt", Wt}, {"HtWt", Ht * Wt}}}},
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args = {{.node = node, .args = {{"num_tiles", num_tensor_tiles}}}},
+            .runtime_args = {{.node = node, .args = {{"num_tiles", num_tensor_tiles}}}},
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -214,12 +214,7 @@ void run_single_core_transpose_quasar(
         .unique_id = READER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = INPUT_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
         .runtime_arguments_schema = {.named_runtime_args = {"N", "Ht", "Wt", "HtWt"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -229,12 +224,7 @@ void run_single_core_transpose_quasar(
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = OUTPUT_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
         .runtime_arguments_schema = {.named_runtime_args = {"num_tiles"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -250,19 +240,7 @@ void run_single_core_transpose_quasar(
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
-        .dfb_bindings =
-            {{
-                 .dfb_spec_name = INPUT_DFB,
-                 .local_accessor_name = "in",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = OUTPUT_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+        .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"NHtWt", Ht * Wt * NC}},
         .config_spec = experimental::ComputeConfiguration{},
     };

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -217,7 +217,8 @@ void run_single_core_transpose_quasar(
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
         .runtime_arguments_schema = {.runtime_args = {"N", "Ht", "Wt", "HtWt"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -227,7 +228,8 @@ void run_single_core_transpose_quasar(
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
         .runtime_arguments_schema = {.runtime_args = {"num_tiles"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -246,13 +246,13 @@ void run_single_core_transpose_quasar(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "transpose_wh",
+        .name = "transpose_wh",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .tensor_parameters =

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -172,7 +172,7 @@ static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry
 void run_single_core_transpose_quasar(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TransposeConfig& test_config) {
     auto* device = mesh_device->get_devices()[0];
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     const TransposeDims dims = compute_and_validate_transpose_dims(test_config.shape);
     const uint32_t NC = dims.NC, Wt = dims.Wt, Ht = dims.Ht, num_tensor_tiles = dims.num_tensor_tiles;
@@ -195,14 +195,14 @@ void run_single_core_transpose_quasar(
     constexpr const char* IN_TENSOR = "in_tensor";
     constexpr const char* OUT_TENSOR = "out_tensor";
 
-    experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
+    experimental::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,
         .entry_size = test_config.single_tile_size,
         .num_entries = num_buffer_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .disable_implicit_sync = true,
     };
-    experimental::metal2_host_api::DataflowBufferSpec output_dfb_spec{
+    experimental::DataflowBufferSpec output_dfb_spec{
         .unique_id = OUTPUT_DFB,
         .entry_size = test_config.single_tile_size,
         .num_entries = num_output_buffer_tiles,
@@ -210,82 +210,70 @@ void run_single_core_transpose_quasar(
         .disable_implicit_sync = true,
     };
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
         .runtime_arguments_schema = {.named_runtime_args = {"N", "Ht", "Wt", "HtWt"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "dst_tensor"}},
         .runtime_arguments_schema = {.named_runtime_args = {"num_tiles"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;
+    experimental::KernelSpec::CompilerOptions::Defines compute_defines;
     if (test_config.short_init) {
         compute_defines.emplace_back("SHORT_INIT", "1");
     }
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =
             {{
                  .dfb_spec_name = INPUT_DFB,
                  .local_accessor_name = "in",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = OUTPUT_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = {{"NHtWt", Ht * Wt * NC}},
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "transpose_wh",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
@@ -297,19 +285,19 @@ void run_single_core_transpose_quasar(
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args = {{.node = node, .args = {{"N", NC}, {"Ht", Ht}, {"Wt", Wt}, {"HtWt", Ht * Wt}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args = {{.node = node, .args = {{"num_tiles", num_tensor_tiles}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
         },
     };
@@ -317,7 +305,7 @@ void run_single_core_transpose_quasar(
         {.tensor_parameter_name = IN_TENSOR, .tensor = in_tensor},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = out_tensor},
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     vector<uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 100.0f, 0x1234);
     tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), src_vec);

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -281,7 +281,7 @@ void run_single_core_transpose_quasar(
             .kernel_spec_name = COMPUTE,
         },
     };
-    params.tensor_args = {
+    params.tensor_arguments = {
         {.tensor_parameter_name = IN_TENSOR, .tensor = in_tensor},
         {.tensor_parameter_name = OUT_TENSOR, .tensor = out_tensor},
     };

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -600,9 +600,8 @@ static void run_quasar_tilize_untilize_test(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1u}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1u}},
+        .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -611,14 +610,13 @@ static void run_quasar_tilize_untilize_test(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1u}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1u}},
+        .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
     std::string compute_kernel;
-    experimental::KernelSpec::CompileTimeArgBindings compute_cta_bindings;
+    experimental::KernelSpec::CompileTimeArgs compute_cta_bindings;
     switch (mode) {
         case QuasarTestMode::TILIZE:
             compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/tilize.cpp";
@@ -653,7 +651,7 @@ static void run_quasar_tilize_untilize_test(
         .source = compute_kernel,
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
-        .compile_time_arg_bindings = compute_cta_bindings,
+        .compile_time_args = compute_cta_bindings,
         .config_spec =
             experimental::ComputeConfiguration{
                 .fp32_dest_acc_en = fp32_dest_acc_en,
@@ -706,7 +704,7 @@ static void run_quasar_tilize_untilize_test(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"src_addr", dram_buffer_src_addr},
@@ -716,7 +714,7 @@ static void run_quasar_tilize_untilize_test(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"dst_addr", dram_buffer_dst_addr},

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -602,7 +602,8 @@ static void run_quasar_tilize_untilize_test(
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_args = {{"use_dfbs", 1u}},
         .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -612,7 +613,8 @@ static void run_quasar_tilize_untilize_test(
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_args = {{"use_dfbs", 1u}},
         .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     std::string compute_kernel;

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -660,13 +660,13 @@ static void run_quasar_tilize_untilize_test(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "quasar_tilize_untilize",
+        .name = "quasar_tilize_untilize",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -537,7 +537,7 @@ static void run_quasar_tilize_untilize_test(
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
 
     IDevice* dev = mesh_device->get_devices()[0];
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     bool is_8bit_integer = (data_format == tt::DataFormat::Int8 || data_format == tt::DataFormat::UInt8);
     uint32_t num_tiles = num_tiles_r * num_tiles_c;
@@ -582,63 +582,53 @@ static void run_quasar_tilize_untilize_test(
     constexpr const char* WRITER = "writer";
     constexpr const char* COMPUTE = "compute";
 
-    experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
+    experimental::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,
         .entry_size = input_single_tile_size,
         .num_entries = dfb_num_entries,
         .data_format_metadata = data_format,
     };
-    experimental::metal2_host_api::DataflowBufferSpec output_dfb_spec{
+    experimental::DataflowBufferSpec output_dfb_spec{
         .unique_id = OUTPUT_DFB,
         .entry_size = output_single_tile_size,
         .num_entries = dfb_num_entries,
         .data_format_metadata = output_data_format,
     };
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
     std::string compute_kernel;
-    experimental::metal2_host_api::KernelSpec::CompileTimeArgBindings compute_cta_bindings;
+    experimental::KernelSpec::CompileTimeArgBindings compute_cta_bindings;
     switch (mode) {
         case QuasarTestMode::TILIZE:
             compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/tilize.cpp";
@@ -668,45 +658,45 @@ static void run_quasar_tilize_untilize_test(
         }
     }
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{compute_kernel},
+        .source = compute_kernel,
         .num_threads = 1,
         .dfb_bindings =
             {{
                  .dfb_spec_name = INPUT_DFB,
                  .local_accessor_name = "in",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = OUTPUT_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = compute_cta_bindings,
         .config_spec =
-            experimental::metal2_host_api::ComputeConfiguration{
+            experimental::ComputeConfiguration{
                 .fp32_dest_acc_en = fp32_dest_acc_en,
                 .dst_full_sync_en = dst_full_sync_en,
             },
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "quasar_tilize_untilize",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     std::vector<uint32_t> src_vec;
     if (data_format == tt::DataFormat::Int8) {
@@ -734,9 +724,9 @@ static void run_quasar_tilize_untilize_test(
     const uint32_t src_tile_stride_bytes = src_dram_buffer_size / num_tiles;
     const uint32_t dst_tile_stride_bytes = dst_dram_buffer_size / num_tiles;
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args =
                 {{.node = node,
@@ -746,7 +736,7 @@ static void run_quasar_tilize_untilize_test(
                        {"num_tiles", num_tiles},
                        {"dram_page_stride", src_tile_stride_bytes}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args =
                 {{.node = node,
@@ -756,11 +746,11 @@ static void run_quasar_tilize_untilize_test(
                        {"num_tiles", num_tiles},
                        {"dram_page_stride", dst_tile_stride_bytes}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
         },
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     detail::LaunchProgram(dev, program, true);
 

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -599,12 +599,7 @@ static void run_quasar_tilize_untilize_test(
         .unique_id = READER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = INPUT_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
@@ -615,12 +610,7 @@ static void run_quasar_tilize_untilize_test(
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = OUTPUT_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
@@ -662,19 +652,7 @@ static void run_quasar_tilize_untilize_test(
         .unique_id = COMPUTE,
         .source = compute_kernel,
         .num_threads = 1,
-        .dfb_bindings =
-            {{
-                 .dfb_spec_name = INPUT_DFB,
-                 .local_accessor_name = "in",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = OUTPUT_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+        .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
         .compile_time_arg_bindings = compute_cta_bindings,
         .config_spec =
             experimental::ComputeConfiguration{

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -36,7 +36,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
 
     IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     // These addresses have been randomly chosen
     uint32_t l1_address = 1000 * 1024;
@@ -62,11 +62,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
     constexpr const char* L1_TO_DRAM_2 = "l1_to_dram_2";
 
     auto make_dram_to_l1_spec = [](const char* id) {
-        return experimental::metal2_host_api::KernelSpec{
+        return experimental::KernelSpec{
             .unique_id = id,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp"},
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp",
             .num_threads = 1,
             .semaphore_bindings = {{.semaphore_spec_name = "sem", .accessor_name = "sem"}},
             .runtime_arguments_schema =
@@ -74,18 +72,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
                     .named_runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
     };
 
     auto make_l1_to_dram_spec = [](const char* id) {
-        return experimental::metal2_host_api::KernelSpec{
+        return experimental::KernelSpec{
             .unique_id = id,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp"},
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp",
             .num_threads = 1,
             .semaphore_bindings = {{.semaphore_spec_name = "sem", .accessor_name = "sem"}},
             .runtime_arguments_schema =
@@ -93,24 +87,22 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
                     .named_runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
     };
 
-    experimental::metal2_host_api::SemaphoreSpec sem{
+    experimental::SemaphoreSpec sem{
         .unique_id = "sem",
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DRAM_TO_L1_0, DRAM_TO_L1_1, DRAM_TO_L1_2, L1_TO_DRAM_0, L1_TO_DRAM_1, L1_TO_DRAM_2},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "dm_loopback",
         .kernels =
             {make_dram_to_l1_spec(DRAM_TO_L1_0),
@@ -122,12 +114,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
         .semaphores = {sem},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     const char* dram_to_l1_names[] = {DRAM_TO_L1_0, DRAM_TO_L1_1, DRAM_TO_L1_2};
     const char* l1_to_dram_names[] = {L1_TO_DRAM_0, L1_TO_DRAM_1, L1_TO_DRAM_2};
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     uint32_t signal_value = 0;
     for (uint32_t i = 0; i < num_loopback_stages; i++) {
         params.kernel_run_params.push_back(
@@ -156,7 +148,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
         l1_address += sizeof(uint32_t);
         signal_value++;
     }
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -97,13 +97,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DRAM_TO_L1_0, DRAM_TO_L1_1, DRAM_TO_L1_2, L1_TO_DRAM_0, L1_TO_DRAM_1, L1_TO_DRAM_2},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "dm_loopback",
+        .name = "dm_loopback",
         .kernels =
             {make_dram_to_l1_spec(DRAM_TO_L1_0),
              make_dram_to_l1_spec(DRAM_TO_L1_1),

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -72,7 +72,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
                     .runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
     };
 
@@ -87,7 +87,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
                     .runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
     };
 

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -69,7 +69,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
             .semaphore_bindings = {{.semaphore_spec_name = "sem", .accessor_name = "sem"}},
             .runtime_arguments_schema =
                 {
-                    .named_runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
+                    .runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -84,7 +84,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
             .semaphore_bindings = {{.semaphore_spec_name = "sem", .accessor_name = "sem"}},
             .runtime_arguments_schema =
                 {
-                    .named_runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
+                    .runtime_args = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -124,7 +124,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
     for (uint32_t i = 0; i < num_loopback_stages; i++) {
         params.kernel_run_params.push_back(
             {.kernel_spec_name = dram_to_l1_names[i],
-             .named_runtime_args = {
+             .runtime_args = {
                  {.node = node,
                   .args = {
                       {"dram_addr", dram_address},
@@ -137,7 +137,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
 
         params.kernel_run_params.push_back(
             {.kernel_spec_name = l1_to_dram_names[i],
-             .named_runtime_args = {
+             .runtime_args = {
                  {.node = node,
                   .args = {
                       {"dram_addr", dram_address},

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -67,11 +67,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     // Three kernels split 6 user DMs as 3 + 2 + 1 to mirror the original 4 + 3 + 1 split
     // (preserving the "shared kernel binary across multiple DMs" + "single-DM kernel" mix).
     auto make_dm_kernel_spec = [](const char* unique_id, uint32_t kernel_id, uint8_t num_threads) {
-        return experimental::metal2_host_api::KernelSpec{
+        return experimental::KernelSpec{
             .unique_id = unique_id,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_tls_check.cpp"},
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_tls_check.cpp",
             .num_threads = num_threads,
             .compile_time_arg_bindings = {{"kernel_id", kernel_id}},
             .runtime_arguments_schema =
@@ -79,9 +77,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
                     .named_runtime_args = {"signal_address", "dram_dst_address", "dram_dst_bank_id", "l1_result_addr"},
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
     };
 
@@ -89,24 +85,24 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     auto k2 = make_dm_kernel_spec(DM_KERNEL_2, /*kernel_id=*/2, /*num_threads=*/2);
     auto k3 = make_dm_kernel_spec(DM_KERNEL_3, /*kernel_id=*/3, /*num_threads=*/1);
 
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_KERNEL_1, DM_KERNEL_2, DM_KERNEL_3},
         .target_nodes = node,
     };
 
     // Total user-DM threads = 3 + 2 + 1 = 6, fitting within the default DM2..DM7 cap.
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "globals_and_tls",
         .kernels = {k1, k2, k3},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     auto make_kernel_run_params = [&](const char* name) {
-        return experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        return experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = name,
             .named_runtime_args =
                 {{.node = node,
@@ -118,13 +114,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
         };
     };
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
         make_kernel_run_params(DM_KERNEL_1),
         make_kernel_run_params(DM_KERNEL_2),
         make_kernel_run_params(DM_KERNEL_3),
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
@@ -303,40 +299,38 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
     constexpr const char* COMPUTE_KERNEL = "compute_tls";
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
-    experimental::metal2_host_api::KernelSpec compute_kernel_spec{
+    experimental::KernelSpec compute_kernel_spec{
         .unique_id = COMPUTE_KERNEL,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/simple_tls_check.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/simple_tls_check.cpp",
         .num_threads = QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER,
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"l1_result_addr"},
             },
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {COMPUTE_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "compute_kernel_tls",
         .kernels = {compute_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = COMPUTE_KERNEL,
         .named_runtime_args = {{.node = node, .args = {{"l1_result_addr", l1_result_addr}}}},
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -71,10 +71,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
             .unique_id = unique_id,
             .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_tls_check.cpp",
             .num_threads = num_threads,
-            .compile_time_arg_bindings = {{"kernel_id", kernel_id}},
+            .compile_time_args = {{"kernel_id", kernel_id}},
             .runtime_arguments_schema =
                 {
-                    .named_runtime_args = {"signal_address", "dram_dst_address", "dram_dst_bank_id", "l1_result_addr"},
+                    .runtime_args = {"signal_address", "dram_dst_address", "dram_dst_bank_id", "l1_result_addr"},
                 },
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -104,7 +104,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     auto make_kernel_run_params = [&](const char* name) {
         return experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = name,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"signal_address", signal_address},
@@ -307,7 +307,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
         .num_threads = QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER,
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"l1_result_addr"},
+                .runtime_args = {"l1_result_addr"},
             },
         .config_spec = experimental::ComputeConfiguration{},
     };
@@ -328,7 +328,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = COMPUTE_KERNEL,
-        .named_runtime_args = {{.node = node, .args = {{"l1_result_addr", l1_result_addr}}}},
+        .runtime_args = {{.node = node, .args = {{"l1_result_addr", l1_result_addr}}}},
     }};
     experimental::SetProgramRunParameters(program, params);
 

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -88,14 +88,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     const experimental::NodeCoord node{0, 0};
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_KERNEL_1, DM_KERNEL_2, DM_KERNEL_3},
         .target_nodes = node,
     };
 
     // Total user-DM threads = 3 + 2 + 1 = 6, fitting within the default DM2..DM7 cap.
     experimental::ProgramSpec spec{
-        .program_id = "globals_and_tls",
+        .name = "globals_and_tls",
         .kernels = {k1, k2, k3},
         .work_units = {main_wu},
     };
@@ -313,13 +313,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {COMPUTE_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "compute_kernel_tls",
+        .name = "compute_kernel_tls",
         .kernels = {compute_kernel_spec},
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -77,7 +77,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
                     .runtime_args = {"signal_address", "dram_dst_address", "dram_dst_bank_id", "l1_result_addr"},
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
     };
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp
@@ -5,7 +5,7 @@
 // Test kernel: TensorAccessor loopback consumer using a Metal 2.0 TensorBinding.
 // Pops entries from a DFB bound via dfb::input_dfb and writes them as pages to an output tensor
 // via TensorAccessor(ta::output_tensor). The base address comes from the binding's slot in the
-// kernel's TensorBinding address section, filled by SetProgramRunParameters from TensorArg.
+// kernel's TensorBinding address section, filled by SetProgramRunParameters from TensorArgument.
 //
 // Runtime args:
 //   arg 0: number of pages to transfer

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp
@@ -6,7 +6,7 @@
 // Reads pages from an input tensor via TensorAccessor(ta::input_tensor) and pushes them
 // entry by entry into a DFB bound via dfb::input_dfb. The base address comes from the binding's
 // slot in the kernel's TensorBinding address section, filled by SetProgramRunParameters from
-// TensorArg.
+// TensorArgument.
 //
 // Runtime args:
 //   arg 0: number of pages to transfer

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -48,11 +48,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     constexpr const char* KERNEL_3 = "kernel_3";
 
     auto make_dm_kernel_spec = [](const char* id, uint8_t num_threads, uint32_t l1_addr) {
-        return experimental::metal2_host_api::KernelSpec{
+        return experimental::KernelSpec{
             .unique_id = id,
-            .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp"},
+            .source = "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
             .num_threads = num_threads,
             .compile_time_arg_bindings = {{"l1_address", l1_addr}},
             .runtime_arguments_schema =
@@ -60,9 +58,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
                     .named_runtime_args = {"a", "b"},
                 },
             .config_spec =
-                experimental::metal2_host_api::DataMovementConfiguration{
-                    .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
         };
     };
 
@@ -71,42 +67,40 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     auto k2 = make_dm_kernel_spec(KERNEL_2, 2, MEM_L1_UNCACHED_BASE + (2 * sizeof(int)));
     auto k3 = make_dm_kernel_spec(KERNEL_3, 2, MEM_L1_UNCACHED_BASE + (2 * sizeof(int)));
 
-    experimental::metal2_host_api::WorkUnitSpec wu_core0{
+    experimental::WorkUnitSpec wu_core0{
         .unique_id = "wu_core0",
         .kernels = {KERNEL_0, KERNEL_1, KERNEL_2},
-        .target_nodes = experimental::metal2_host_api::NodeCoord{0, 0},
+        .target_nodes = experimental::NodeCoord{0, 0},
     };
-    experimental::metal2_host_api::WorkUnitSpec wu_core1{
+    experimental::WorkUnitSpec wu_core1{
         .unique_id = "wu_core1",
         .kernels = {KERNEL_0, KERNEL_1, KERNEL_3},
-        .target_nodes = experimental::metal2_host_api::NodeCoord{1, 0},
+        .target_nodes = experimental::NodeCoord{1, 0},
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "multi_dm_add_two_ints",
         .kernels = {k0, k1, k2, k3},
         .work_units = {wu_core0, wu_core1},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
         {.kernel_spec_name = KERNEL_0,
          .named_runtime_args =
-             {{.node = experimental::metal2_host_api::NodeCoord{0, 0}, .args = {{"a", 1}, {"b", 2}}},
-              {.node = experimental::metal2_host_api::NodeCoord{1, 0}, .args = {{"a", 1}, {"b", 2}}}}},
+             {{.node = experimental::NodeCoord{0, 0}, .args = {{"a", 1}, {"b", 2}}},
+              {.node = experimental::NodeCoord{1, 0}, .args = {{"a", 1}, {"b", 2}}}}},
         {.kernel_spec_name = KERNEL_1,
          .named_runtime_args =
-             {{.node = experimental::metal2_host_api::NodeCoord{0, 0}, .args = {{"a", 3}, {"b", 4}}},
-              {.node = experimental::metal2_host_api::NodeCoord{1, 0}, .args = {{"a", 3}, {"b", 4}}}}},
+             {{.node = experimental::NodeCoord{0, 0}, .args = {{"a", 3}, {"b", 4}}},
+              {.node = experimental::NodeCoord{1, 0}, .args = {{"a", 3}, {"b", 4}}}}},
         {.kernel_spec_name = KERNEL_2,
-         .named_runtime_args =
-             {{.node = experimental::metal2_host_api::NodeCoord{0, 0}, .args = {{"a", 5}, {"b", 6}}}}},
+         .named_runtime_args = {{.node = experimental::NodeCoord{0, 0}, .args = {{"a", 5}, {"b", 6}}}}},
         {.kernel_spec_name = KERNEL_3,
-         .named_runtime_args =
-             {{.node = experimental::metal2_host_api::NodeCoord{1, 0}, .args = {{"a", 7}, {"b", 8}}}}},
+         .named_runtime_args = {{.node = experimental::NodeCoord{1, 0}, .args = {{"a", 7}, {"b", 8}}}}},
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -58,7 +58,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
                     .runtime_args = {"a", "b"},
                 },
             .config_spec =
-                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
         };
     };
 

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -52,10 +52,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
             .unique_id = id,
             .source = "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
             .num_threads = num_threads,
-            .compile_time_arg_bindings = {{"l1_address", l1_addr}},
+            .compile_time_args = {{"l1_address", l1_addr}},
             .runtime_arguments_schema =
                 {
-                    .named_runtime_args = {"a", "b"},
+                    .runtime_args = {"a", "b"},
                 },
             .config_spec =
                 experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -88,17 +88,17 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     experimental::ProgramRunParams params;
     params.kernel_run_params = {
         {.kernel_spec_name = KERNEL_0,
-         .named_runtime_args =
+         .runtime_args =
              {{.node = experimental::NodeCoord{0, 0}, .args = {{"a", 1}, {"b", 2}}},
               {.node = experimental::NodeCoord{1, 0}, .args = {{"a", 1}, {"b", 2}}}}},
         {.kernel_spec_name = KERNEL_1,
-         .named_runtime_args =
+         .runtime_args =
              {{.node = experimental::NodeCoord{0, 0}, .args = {{"a", 3}, {"b", 4}}},
               {.node = experimental::NodeCoord{1, 0}, .args = {{"a", 3}, {"b", 4}}}}},
         {.kernel_spec_name = KERNEL_2,
-         .named_runtime_args = {{.node = experimental::NodeCoord{0, 0}, .args = {{"a", 5}, {"b", 6}}}}},
+         .runtime_args = {{.node = experimental::NodeCoord{0, 0}, .args = {{"a", 5}, {"b", 6}}}}},
         {.kernel_spec_name = KERNEL_3,
-         .named_runtime_args = {{.node = experimental::NodeCoord{1, 0}, .args = {{"a", 7}, {"b", 8}}}}},
+         .runtime_args = {{.node = experimental::NodeCoord{1, 0}, .args = {{"a", 7}, {"b", 8}}}}},
     };
     experimental::SetProgramRunParameters(program, params);
 

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -68,18 +68,18 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     auto k3 = make_dm_kernel_spec(KERNEL_3, 2, MEM_L1_UNCACHED_BASE + (2 * sizeof(int)));
 
     experimental::WorkUnitSpec wu_core0{
-        .unique_id = "wu_core0",
+        .name = "wu_core0",
         .kernels = {KERNEL_0, KERNEL_1, KERNEL_2},
         .target_nodes = experimental::NodeCoord{0, 0},
     };
     experimental::WorkUnitSpec wu_core1{
-        .unique_id = "wu_core1",
+        .name = "wu_core1",
         .kernels = {KERNEL_0, KERNEL_1, KERNEL_3},
         .target_nodes = experimental::NodeCoord{1, 0},
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "multi_dm_add_two_ints",
+        .name = "multi_dm_add_two_ints",
         .kernels = {k0, k1, k2, k3},
         .work_units = {wu_core0, wu_core1},
     };

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -86,7 +86,8 @@ static void run_pack_relu_test(
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_args = {{"use_dfbs", 1u}},
         .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -96,7 +97,8 @@ static void run_pack_relu_test(
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_args = {{"use_dfbs", 1u}},
         .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -83,12 +83,7 @@ static void run_pack_relu_test(
         .unique_id = READER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = INPUT_DFB,
-            .local_accessor_name = "out",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
@@ -99,12 +94,7 @@ static void run_pack_relu_test(
         .unique_id = WRITER,
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
-        .dfb_bindings = {{
-            .dfb_spec_name = OUTPUT_DFB,
-            .local_accessor_name = "in",
-            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::DFBAccessPattern::STRIDED,
-        }},
+        .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
@@ -116,19 +106,7 @@ static void run_pack_relu_test(
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"PACK_RELU", "1"}}},
-        .dfb_bindings =
-            {{
-                 .dfb_spec_name = INPUT_DFB,
-                 .local_accessor_name = "in",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             },
-             {
-                 .dfb_spec_name = OUTPUT_DFB,
-                 .local_accessor_name = "out",
-                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
-             }},
+        .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
         .compile_time_arg_bindings = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1u}},
         .runtime_arguments_schema = {.named_runtime_args = {"relu_config"}},
         .config_spec = experimental::ComputeConfiguration{},

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -84,9 +84,8 @@ static void run_pack_relu_test(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1u}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1u}},
+        .runtime_arguments_schema = {.runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -95,9 +94,8 @@ static void run_pack_relu_test(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
-        .compile_time_arg_bindings = {{"use_dfbs", 1u}},
-        .runtime_arguments_schema =
-            {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
+        .compile_time_args = {{"use_dfbs", 1u}},
+        .runtime_arguments_schema = {.runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
@@ -107,8 +105,8 @@ static void run_pack_relu_test(
         .num_threads = 1,
         .compiler_options = {.defines = {{"PACK_RELU", "1"}}},
         .dfb_bindings = {experimental::ConsumerOf(INPUT_DFB, "in"), experimental::ProducerOf(OUTPUT_DFB, "out")},
-        .compile_time_arg_bindings = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1u}},
-        .runtime_arguments_schema = {.named_runtime_args = {"relu_config"}},
+        .compile_time_args = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1u}},
+        .runtime_arguments_schema = {.runtime_args = {"relu_config"}},
         .config_spec = experimental::ComputeConfiguration{},
     };
 
@@ -138,7 +136,7 @@ static void run_pack_relu_test(
     params.kernel_run_params = {
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"src_addr", dram_buffer_src_addr},
@@ -148,7 +146,7 @@ static void run_pack_relu_test(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
-            .named_runtime_args =
+            .runtime_args =
                 {{.node = node,
                   .args =
                       {{"dst_addr", dram_buffer_dst_addr},
@@ -158,7 +156,7 @@ static void run_pack_relu_test(
         },
         experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
-            .named_runtime_args = {{.node = node, .args = {{"relu_config", relu_config}}}},
+            .runtime_args = {{.node = node, .args = {{"relu_config", relu_config}}}},
         },
     };
     experimental::SetProgramRunParameters(program, params);

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -41,7 +41,7 @@ static void run_pack_relu_test(
     uint32_t relu_config,
     const std::function<float(float)>& golden_fn) {
     IDevice* dev = mesh_device->get_devices()[0];
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
 
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 1;
@@ -66,100 +66,88 @@ static void run_pack_relu_test(
     // Legacy DataflowBufferConfig used enable_implicit_sync = true on both DFBs;
     // keep DataflowBufferSpec::disable_implicit_sync at its default (false) and
     // set the program-level reservation flag below.
-    experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
+    experimental::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,
         .entry_size = single_tile_size,
         .num_entries = 2,
         .data_format_metadata = tt::DataFormat::Float16_b,
     };
-    experimental::metal2_host_api::DataflowBufferSpec output_dfb_spec{
+    experimental::DataflowBufferSpec output_dfb_spec{
         .unique_id = OUTPUT_DFB,
         .entry_size = single_tile_size,
         .num_entries = 2,
         .data_format_metadata = tt::DataFormat::Float16_b,
     };
 
-    experimental::metal2_host_api::KernelSpec reader_spec{
+    experimental::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
             .local_accessor_name = "out",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec writer_spec{
+    experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
             .local_accessor_name = "in",
-            .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-            .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+            .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+            .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .compile_time_arg_bindings = {{"use_dfbs", 1u}},
         .runtime_arguments_schema =
             {.named_runtime_args = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec compute_spec{
+    experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"PACK_RELU", "1"}}},
         .dfb_bindings =
             {{
                  .dfb_spec_name = INPUT_DFB,
                  .local_accessor_name = "in",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::CONSUMER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              },
              {
                  .dfb_spec_name = OUTPUT_DFB,
                  .local_accessor_name = "out",
-                 .endpoint_type = experimental::metal2_host_api::KernelSpec::DFBEndpointType::PRODUCER,
-                 .access_pattern = experimental::metal2_host_api::DFBAccessPattern::STRIDED,
+                 .endpoint_type = experimental::KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_arg_bindings = {{"per_core_tile_cnt", num_tiles}, {"use_dfbs", 1u}},
         .runtime_arguments_schema = {.named_runtime_args = {"relu_config"}},
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu{
+    experimental::WorkUnitSpec wu{
         .unique_id = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "pack_relu",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},
     };
 
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     // Stimulus: random bfloat16 in [-1, 1]
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 1.0f, 0xCAFE);
@@ -168,9 +156,9 @@ static void run_pack_relu_test(
     const uint32_t src_aligned_page_size = static_cast<uint32_t>(src_dram_buffer->aligned_page_size());
     const uint32_t dst_aligned_page_size = static_cast<uint32_t>(dst_dram_buffer->aligned_page_size());
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = READER,
             .named_runtime_args =
                 {{.node = node,
@@ -180,7 +168,7 @@ static void run_pack_relu_test(
                        {"num_tiles", num_tiles},
                        {"dram_page_stride", src_aligned_page_size}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = WRITER,
             .named_runtime_args =
                 {{.node = node,
@@ -190,12 +178,12 @@ static void run_pack_relu_test(
                        {"num_tiles", num_tiles},
                        {"dram_page_stride", dst_aligned_page_size}}}},
         },
-        experimental::metal2_host_api::ProgramRunParams::KernelRunParams{
+        experimental::ProgramRunParams::KernelRunParams{
             .kernel_spec_name = COMPUTE,
             .named_runtime_args = {{.node = node, .args = {{"relu_config", relu_config}}}},
         },
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     detail::LaunchProgram(dev, program, true);
 

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -111,13 +111,13 @@ static void run_pack_relu_test(
     };
 
     experimental::WorkUnitSpec wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {READER, WRITER, COMPUTE},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "pack_relu",
+        .name = "pack_relu",
         .kernels = {reader_spec, writer_spec, compute_spec},
         .dataflow_buffers = {input_dfb_spec, output_dfb_spec},
         .work_units = {wu},

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -61,13 +61,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {COMPUTE_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "compute_kernel_multiple_threads",
+        .name = "compute_kernel_multiple_threads",
         .kernels = {compute_kernel_spec},
         .work_units = {main_wu},
     };
@@ -135,13 +135,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {COMPUTE_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "compute_kernel_single_thread",
+        .name = "compute_kernel_single_thread",
         .kernels = {compute_kernel_spec},
         .work_units = {main_wu},
     };
@@ -192,13 +192,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSing
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {COMPUTE_KERNEL_1, COMPUTE_KERNEL_2},
         .target_nodes = experimental::NodeCoord{0, 0},
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "multiple_compute_kernels",
+        .name = "multiple_compute_kernels",
         .kernels = {compute_kernel_spec_1, compute_kernel_spec_2},
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -55,7 +55,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
         .num_threads = 4,
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"l1_address"},
+                .runtime_args = {"l1_address"},
             },
         .config_spec = experimental::ComputeConfiguration{},
     };
@@ -76,7 +76,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = COMPUTE_KERNEL,
-        .named_runtime_args = {{.node = node, .args = {{"l1_address", l1_address}}}},
+        .runtime_args = {{.node = node, .args = {{"l1_address", l1_address}}}},
     }};
     experimental::SetProgramRunParameters(program, params);
 
@@ -129,7 +129,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
         .num_threads = 1,
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"l1_address"},
+                .runtime_args = {"l1_address"},
             },
         .config_spec = experimental::ComputeConfiguration{},
     };
@@ -150,7 +150,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = COMPUTE_KERNEL,
-        .named_runtime_args = {{.node = node, .args = {{"l1_address", l1_address}}}},
+        .runtime_args = {{.node = node, .args = {{"l1_address", l1_address}}}},
     }};
     experimental::SetProgramRunParameters(program, params);
 

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -36,7 +36,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     }
 
     // We are going to use the first device (0) and the first core (0, 0) on the device.
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
     // Command queue lets us submit work (execute programs and read/write buffers) to the device.
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     // Prepare a workload and a device coordinate range that spans the mesh.
@@ -49,38 +49,36 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
 
     constexpr const char* COMPUTE_KERNEL = "risc_math";
 
-    experimental::metal2_host_api::KernelSpec compute_kernel_spec{
+    experimental::KernelSpec compute_kernel_spec{
         .unique_id = COMPUTE_KERNEL,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 4,
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"l1_address"},
             },
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {COMPUTE_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "compute_kernel_multiple_threads",
         .kernels = {compute_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = COMPUTE_KERNEL,
         .named_runtime_args = {{.node = node, .args = {{"l1_address", l1_address}}}},
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
@@ -112,7 +110,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     }
 
     // We are going to use the first device (0) and the first core (0, 0) on the device.
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
     // Command queue lets us submit work (execute programs and read/write buffers) to the device.
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     // Prepare a workload and a device coordinate range that spans the mesh.
@@ -125,38 +123,36 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
 
     constexpr const char* COMPUTE_KERNEL = "risc_math";
 
-    experimental::metal2_host_api::KernelSpec compute_kernel_spec{
+    experimental::KernelSpec compute_kernel_spec{
         .unique_id = COMPUTE_KERNEL,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 1,
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"l1_address"},
             },
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {COMPUTE_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "compute_kernel_single_thread",
         .kernels = {compute_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = COMPUTE_KERNEL,
         .named_runtime_args = {{.node = node, .args = {{"l1_address", l1_address}}}},
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
@@ -181,35 +177,31 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSing
     constexpr const char* COMPUTE_KERNEL_1 = "risc_math_1";
     constexpr const char* COMPUTE_KERNEL_2 = "risc_math_2";
 
-    experimental::metal2_host_api::KernelSpec compute_kernel_spec_1{
+    experimental::KernelSpec compute_kernel_spec_1{
         .unique_id = COMPUTE_KERNEL_1,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 1,
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::KernelSpec compute_kernel_spec_2{
+    experimental::KernelSpec compute_kernel_spec_2{
         .unique_id = COMPUTE_KERNEL_2,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 2,
-        .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
+        .config_spec = experimental::ComputeConfiguration{},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {COMPUTE_KERNEL_1, COMPUTE_KERNEL_2},
-        .target_nodes = experimental::metal2_host_api::NodeCoord{0, 0},
+        .target_nodes = experimental::NodeCoord{0, 0},
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "multiple_compute_kernels",
         .kernels = {compute_kernel_spec_1, compute_kernel_spec_2},
         .work_units = {main_wu},
     };
 
-    ASSERT_THROW(experimental::metal2_host_api::MakeProgramFromSpec(*devices_[0], spec), std::runtime_error);
+    ASSERT_THROW(experimental::MakeProgramFromSpec(*devices_[0], spec), std::runtime_error);
 }

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -68,7 +68,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
         .semaphore_bindings = {{.semaphore_spec_name = "sem0", .accessor_name = "sem"}},
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
+                .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -83,7 +83,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
                 {.semaphore_spec_name = "sem0", .accessor_name = "sem_in"},
                 {.semaphore_spec_name = "sem1", .accessor_name = "sem_out"},
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_elements", num_elements},
                 {"buf_a", buf_a_addr},
@@ -99,7 +99,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
         .semaphore_bindings = {{.semaphore_spec_name = "sem1", .accessor_name = "sem"}},
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
+                .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -121,7 +121,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     experimental::ProgramRunParams params;
     params.kernel_run_params = {
         {.kernel_spec_name = DM_READER,
-         .named_runtime_args =
+         .runtime_args =
              {{.node = node,
                .args =
                    {{"dram_addr", dram_src_addr},
@@ -130,7 +130,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
                     {"dram_bank_id", 0u}}}}},
         {.kernel_spec_name = DM_TRANSFORM},
         {.kernel_spec_name = DM_WRITER,
-         .named_runtime_args =
+         .runtime_args =
              {{.node = node,
                .args =
                    {{"dram_addr", dram_dst_addr},
@@ -213,7 +213,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
         .num_threads = 1,
         .compiler_options = {.defines = {{"OUTGOING_SEM", "1"}}},
         .semaphore_bindings = {{.semaphore_spec_name = "sem_core_0", .accessor_name = "sem_out"}},
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_elements", num_elements},
                 {"buf_a", buf_a_addr},
@@ -234,7 +234,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
             },
         .runtime_arguments_schema =
             {
-                .named_runtime_args =
+                .runtime_args =
                     {"dram_addr", "l1_addr", "num_elements", "dram_bank_id", "remote_noc_x", "remote_noc_y"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -252,7 +252,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
             },
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
+                .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -267,7 +267,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 {.semaphore_spec_name = "sem0_core_1", .accessor_name = "sem_in"},
                 {.semaphore_spec_name = "sem1_core_1", .accessor_name = "sem_out"},
             },
-        .compile_time_arg_bindings =
+        .compile_time_args =
             {
                 {"num_elements", num_elements},
                 {"buf_a", buf_a_addr},
@@ -283,7 +283,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
         .semaphore_bindings = {{.semaphore_spec_name = "sem1_core_1", .accessor_name = "sem"}},
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
+                .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -312,7 +312,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
         {.kernel_spec_name = DM_TRANSFORM_0},
         {.kernel_spec_name = DM_TRANSFORM_1},
         {.kernel_spec_name = DM_WRITER_0,
-         .named_runtime_args =
+         .runtime_args =
              {{.node = node_0,
                .args =
                    {{"dram_addr", dram_mid_addr},
@@ -322,7 +322,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                     {"remote_noc_x", static_cast<uint32_t>(core_1_virtual.x)},
                     {"remote_noc_y", static_cast<uint32_t>(core_1_virtual.y)}}}}},
         {.kernel_spec_name = DM_READER_1,
-         .named_runtime_args =
+         .runtime_args =
              {{.node = node_1,
                .args =
                    {{"dram_addr", dram_mid_addr},
@@ -330,7 +330,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                     {"num_elements", num_elements},
                     {"dram_bank_id", 0u}}}}},
         {.kernel_spec_name = DM_WRITER_1,
-         .named_runtime_args =
+         .runtime_args =
              {{.node = node_1,
                .args =
                    {{"dram_addr", dram_dst_addr},

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -29,7 +29,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     auto mesh_device = devices_[0];
 
     // We are going to use the first device (0) and the first core (0, 0) on the device.
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
     // Command queue lets us submit work (execute programs and read/write buffers) to the device.
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     // Prepare a workload and a device coordinate range that spans the mesh.
@@ -52,37 +52,30 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     constexpr const char* DM_TRANSFORM = "dm_transform";
     constexpr const char* DM_WRITER = "dm_writer";
 
-    experimental::metal2_host_api::SemaphoreSpec sem0_spec{
+    experimental::SemaphoreSpec sem0_spec{
         .unique_id = "sem0",
         .target_nodes = node,
     };
-    experimental::metal2_host_api::SemaphoreSpec sem1_spec{
+    experimental::SemaphoreSpec sem1_spec{
         .unique_id = "sem1",
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::KernelSpec dm_reader_spec{
+    experimental::KernelSpec dm_reader_spec{
         .unique_id = DM_READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "sem0", .accessor_name = "sem"}},
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec dm_transform_spec{
+    experimental::KernelSpec dm_transform_spec{
         .unique_id = DM_TRANSFORM,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"OUTGOING_SEM", "1"}, {"INCOMING_SEM", "1"}}},
         .semaphore_bindings =
@@ -96,44 +89,36 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec dm_writer_spec{
+    experimental::KernelSpec dm_writer_spec{
         .unique_id = DM_WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "sem1", .accessor_name = "sem"}},
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_READER, DM_TRANSFORM, DM_WRITER},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "multi_semaphore_pipeline",
         .kernels = {dm_reader_spec, dm_transform_spec, dm_writer_spec},
         .semaphores = {sem0_spec, sem1_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
         {.kernel_spec_name = DM_READER,
          .named_runtime_args =
@@ -153,7 +138,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
                     {"num_elements", num_elements},
                     {"dram_bank_id", 0u}}}}},
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
@@ -177,8 +162,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
 
     auto mesh_device = devices_[0];
 
-    const experimental::metal2_host_api::NodeCoord node_0{0, 0};
-    const experimental::metal2_host_api::NodeCoord node_1{1, 0};
+    const experimental::NodeCoord node_0{0, 0};
+    const experimental::NodeCoord node_1{1, 0};
 
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
 
@@ -199,19 +184,19 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
 
     const CoreCoord core_1_virtual = mesh_device->worker_core_from_logical_core(node_1);
 
-    experimental::metal2_host_api::SemaphoreSpec sem_core_0_spec{
+    experimental::SemaphoreSpec sem_core_0_spec{
         .unique_id = "sem_core_0",
         .target_nodes = node_0,
     };
-    experimental::metal2_host_api::SemaphoreSpec sem_cross_spec{
+    experimental::SemaphoreSpec sem_cross_spec{
         .unique_id = "sem_cross",
-        .target_nodes = experimental::metal2_host_api::NodeRange{node_0, node_1},
+        .target_nodes = experimental::NodeRange{node_0, node_1},
     };
-    experimental::metal2_host_api::SemaphoreSpec sem0_core_1_spec{
+    experimental::SemaphoreSpec sem0_core_1_spec{
         .unique_id = "sem0_core_1",
         .target_nodes = node_1,
     };
-    experimental::metal2_host_api::SemaphoreSpec sem1_core_1_spec{
+    experimental::SemaphoreSpec sem1_core_1_spec{
         .unique_id = "sem1_core_1",
         .target_nodes = node_1,
     };
@@ -222,11 +207,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     constexpr const char* DM_TRANSFORM_1 = "dm_transform_1";
     constexpr const char* DM_WRITER_1 = "dm_writer_1";
 
-    experimental::metal2_host_api::KernelSpec dm_transform_0_spec{
+    experimental::KernelSpec dm_transform_0_spec{
         .unique_id = DM_TRANSFORM_0,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"OUTGOING_SEM", "1"}}},
         .semaphore_bindings = {{.semaphore_spec_name = "sem_core_0", .accessor_name = "sem_out"}},
@@ -236,17 +219,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec dm_writer_0_spec{
+    experimental::KernelSpec dm_writer_0_spec{
         .unique_id = DM_WRITER_0,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"INCREMENT_REMOTE_SEM", "1"}}},
         .semaphore_bindings =
@@ -259,17 +237,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 .named_runtime_args =
                     {"dram_addr", "l1_addr", "num_elements", "dram_bank_id", "remote_noc_x", "remote_noc_y"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec dm_reader_1_spec{
+    experimental::KernelSpec dm_reader_1_spec{
         .unique_id = DM_READER_1,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"WAIT_FOR_REMOTE_SEM", "1"}}},
         .semaphore_bindings =
@@ -281,17 +254,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
             {
                 .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec dm_transform_1_spec{
+    experimental::KernelSpec dm_transform_1_spec{
         .unique_id = DM_TRANSFORM_1,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"INCOMING_SEM", "1"}, {"OUTGOING_SEM", "1"}}},
         .semaphore_bindings =
@@ -305,49 +273,41 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::KernelSpec dm_writer_1_spec{
+    experimental::KernelSpec dm_writer_1_spec{
         .unique_id = DM_WRITER_1,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "sem1_core_1", .accessor_name = "sem"}},
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec wu_core_0{
+    experimental::WorkUnitSpec wu_core_0{
         .unique_id = "wu_core_0",
         .kernels = {DM_TRANSFORM_0, DM_WRITER_0},
         .target_nodes = node_0,
     };
-    experimental::metal2_host_api::WorkUnitSpec wu_core_1{
+    experimental::WorkUnitSpec wu_core_1{
         .unique_id = "wu_core_1",
         .kernels = {DM_READER_1, DM_TRANSFORM_1, DM_WRITER_1},
         .target_nodes = node_1,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "multi_cluster_multi_semaphore_pipeline",
         .kernels = {dm_transform_0_spec, dm_writer_0_spec, dm_reader_1_spec, dm_transform_1_spec, dm_writer_1_spec},
         .semaphores = {sem_core_0_spec, sem_cross_spec, sem0_core_1_spec, sem1_core_1_spec},
         .work_units = {wu_core_0, wu_core_1},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {
         {.kernel_spec_name = DM_TRANSFORM_0},
         {.kernel_spec_name = DM_TRANSFORM_1},
@@ -378,7 +338,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                     {"num_elements", num_elements},
                     {"dram_bank_id", 0u}}}}},
     };
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -105,13 +105,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_READER, DM_TRANSFORM, DM_WRITER},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "multi_semaphore_pipeline",
+        .name = "multi_semaphore_pipeline",
         .kernels = {dm_reader_spec, dm_transform_spec, dm_writer_spec},
         .semaphores = {sem0_spec, sem1_spec},
         .work_units = {main_wu},
@@ -289,18 +289,18 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     };
 
     experimental::WorkUnitSpec wu_core_0{
-        .unique_id = "wu_core_0",
+        .name = "wu_core_0",
         .kernels = {DM_TRANSFORM_0, DM_WRITER_0},
         .target_nodes = node_0,
     };
     experimental::WorkUnitSpec wu_core_1{
-        .unique_id = "wu_core_1",
+        .name = "wu_core_1",
         .kernels = {DM_READER_1, DM_TRANSFORM_1, DM_WRITER_1},
         .target_nodes = node_1,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "multi_cluster_multi_semaphore_pipeline",
+        .name = "multi_cluster_multi_semaphore_pipeline",
         .kernels = {dm_transform_0_spec, dm_writer_0_spec, dm_reader_1_spec, dm_transform_1_spec, dm_writer_1_spec},
         .semaphores = {sem_core_0_spec, sem_cross_spec, sem0_core_1_spec, sem1_core_1_spec},
         .work_units = {wu_core_0, wu_core_1},

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -70,7 +70,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
             {
                 .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec dm_transform_spec{
@@ -89,7 +90,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec dm_writer_spec{
@@ -101,7 +103,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
             {
                 .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -219,7 +222,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec dm_writer_0_spec{
@@ -237,7 +241,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 .runtime_args =
                     {"dram_addr", "l1_addr", "num_elements", "dram_bank_id", "remote_noc_x", "remote_noc_y"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec dm_reader_1_spec{
@@ -254,7 +259,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
             {
                 .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec dm_transform_1_spec{
@@ -273,7 +279,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::KernelSpec dm_writer_1_spec{
@@ -285,7 +292,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
             {
                 .runtime_args = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec wu_core_0{

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -30,7 +30,7 @@ namespace tt::tt_metal {
 
 class RISCVAtomicsFixture : public MeshDispatchFixture {
 protected:
-    static constexpr experimental::metal2_host_api::NodeCoord core = {0, 0};
+    static constexpr experimental::NodeCoord core = {0, 0};
     static constexpr uint32_t SENTINEL{0xABABABAB};
     static constexpr uint32_t iterations{2000};
     const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/riscv_atomics.cpp";
@@ -82,12 +82,11 @@ protected:
         if (arch_ == tt::ARCH::QUASAR) {
             constexpr const char* DM_KERNEL = "dm_kernel";
 
-            experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines defines_vec(
-                dm_defines.begin(), dm_defines.end());
+            experimental::KernelSpec::CompilerOptions::Defines defines_vec(dm_defines.begin(), dm_defines.end());
 
-            experimental::metal2_host_api::KernelSpec dm_kernel_spec{
+            experimental::KernelSpec dm_kernel_spec{
                 .unique_id = DM_KERNEL,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+                .source = kernel_path,
                 .num_threads = static_cast<uint8_t>(num_dms_),
                 .compiler_options = {.defines = defines_vec},
                 .runtime_arguments_schema =
@@ -95,32 +94,30 @@ protected:
                         .named_runtime_args = {"l1_counter_addr", "increment_times"},
                     },
                 .config_spec =
-                    experimental::metal2_host_api::DataMovementConfiguration{
-                        .gen2_data_movement_config =
-                            experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
             };
 
-            experimental::metal2_host_api::WorkUnitSpec main_wu{
+            experimental::WorkUnitSpec main_wu{
                 .unique_id = "main",
                 .kernels = {DM_KERNEL},
                 .target_nodes = core,
             };
 
-            experimental::metal2_host_api::ProgramSpec spec{
+            experimental::ProgramSpec spec{
                 .program_id = "riscv_atomics",
                 .kernels = {dm_kernel_spec},
                 .work_units = {main_wu},
             };
-            program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device_, spec);
+            program = experimental::MakeProgramFromSpec(*mesh_device_, spec);
 
-            experimental::metal2_host_api::ProgramRunParams params;
+            experimental::ProgramRunParams params;
             params.kernel_run_params = {{
                 .kernel_spec_name = DM_KERNEL,
                 .named_runtime_args =
                     {{.node = core,
                       .args = {{"l1_counter_addr", l1_unreserved_base}, {"increment_times", iterations}}}},
             }};
-            experimental::metal2_host_api::SetProgramRunParameters(program, params);
+            experimental::SetProgramRunParameters(program, params);
         } else {
             // BH:
             for (uint32_t dm_id = 0; dm_id < num_dms_; dm_id++) {

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -94,7 +94,7 @@ protected:
                         .runtime_args = {"l1_counter_addr", "increment_times"},
                     },
                 .config_spec =
-                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+                    experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
             };
 
             experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -98,13 +98,13 @@ protected:
             };
 
             experimental::WorkUnitSpec main_wu{
-                .unique_id = "main",
+                .name = "main",
                 .kernels = {DM_KERNEL},
                 .target_nodes = core,
             };
 
             experimental::ProgramSpec spec{
-                .program_id = "riscv_atomics",
+                .name = "riscv_atomics",
                 .kernels = {dm_kernel_spec},
                 .work_units = {main_wu},
             };

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -91,7 +91,7 @@ protected:
                 .compiler_options = {.defines = defines_vec},
                 .runtime_arguments_schema =
                     {
-                        .named_runtime_args = {"l1_counter_addr", "increment_times"},
+                        .runtime_args = {"l1_counter_addr", "increment_times"},
                     },
                 .config_spec =
                     experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
@@ -113,7 +113,7 @@ protected:
             experimental::ProgramRunParams params;
             params.kernel_run_params = {{
                 .kernel_spec_name = DM_KERNEL,
-                .named_runtime_args =
+                .runtime_args =
                     {{.node = core,
                       .args = {{"l1_counter_addr", l1_unreserved_base}, {"increment_times", iterations}}}},
             }};

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -56,8 +56,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
         .num_threads = 2,
         .runtime_arguments_schema =
             {
-                .named_runtime_args = {"address"},
-                .named_common_runtime_args = {"value"},
+                .runtime_args = {"address"},
+                .common_runtime_args = {"value"},
             },
         .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
@@ -78,8 +78,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
     experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
-        .named_runtime_args = {{.node = node, .args = {{"address", address}}}},
-        .named_common_runtime_args = {{"value", value}},
+        .runtime_args = {{.node = node, .args = {{"address", address}}}},
+        .common_runtime_args = {{"value", value}},
     }};
     experimental::SetProgramRunParameters(program, params);
     std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -59,7 +59,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
                 .runtime_args = {"address"},
                 .common_runtime_args = {"value"},
             },
-        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
+        .config_spec =
+            experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2DM{}},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -63,13 +63,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
     };
 
     experimental::WorkUnitSpec main_wu{
-        .unique_id = "main",
+        .name = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
     experimental::ProgramSpec spec{
-        .program_id = "single_dm_l1_write",
+        .name = "single_dm_l1_write",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -41,7 +41,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
     }
 
     // We are going to use the first device (0) and the first core (0, 0) on the device.
-    const experimental::metal2_host_api::NodeCoord node{0, 0};
+    const experimental::NodeCoord node{0, 0};
     tt_metal::detail::WriteToDeviceL1(dev, node, address, outputs);
     // Command queue lets us submit work (execute programs and read/write buffers) to the device.
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
@@ -50,43 +50,38 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     constexpr const char* DM_KERNEL = "dm_kernel";
 
-    experimental::metal2_host_api::KernelSpec dm_kernel_spec{
+    experimental::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = 2,
         .runtime_arguments_schema =
             {
                 .named_runtime_args = {"address"},
                 .named_common_runtime_args = {"value"},
             },
-        .config_spec =
-            experimental::metal2_host_api::DataMovementConfiguration{
-                .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .config_spec = experimental::DataMovementConfiguration{.gen2 = experimental::DataMovementConfiguration::Gen2{}},
     };
 
-    experimental::metal2_host_api::WorkUnitSpec main_wu{
+    experimental::WorkUnitSpec main_wu{
         .unique_id = "main",
         .kernels = {DM_KERNEL},
         .target_nodes = node,
     };
 
-    experimental::metal2_host_api::ProgramSpec spec{
+    experimental::ProgramSpec spec{
         .program_id = "single_dm_l1_write",
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = DM_KERNEL,
         .named_runtime_args = {{.node = node, .args = {{"address", address}}}},
         .named_common_runtime_args = {{"value", value}},
     }};
-    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+    experimental::SetProgramRunParameters(program, params);
     std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."
               << std::endl;
 

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -141,7 +141,7 @@ void run_strided_dfb_copy_test(
     const NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.program_id = "strided_pages_dfb_copy";
+    spec.name = "strided_pages_dfb_copy";
 
     const TensorAccessorArgs input_accessor_args(*input_buffer);
     const TensorAccessorArgs output_accessor_args(*output_buffer);

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -57,7 +57,7 @@ constexpr const char* kWriterKernelPath =
 // Returns the comma-separated CTA value string for the KERNEL_COMPILE_TIME_ARGS define.
 // This enables device kernels that use TensorAccessorArgs<0, 0>() (positional CTA access)
 // to compile correctly under the Metal 2.0 API, which does not pass positional CTAs through
-// compile_time_arg_bindings.
+// compile_time_args.
 std::string build_cta_define(const TensorAccessorArgs& accessor_args) {
     const auto ctas = accessor_args.get_compile_time_args();
     std::ostringstream ss;

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -229,8 +229,8 @@ TEST_P(TensorAccessorStridedDFBTest, Gen1StridedPagesCopy) {
         reader = MakeMinimalGen1DMKernel("reader", DataMovementProcessor::RISCV_0);
         writer = MakeMinimalGen1DMKernel("writer", DataMovementProcessor::RISCV_1);
         // STRIDED with 1 thread: stride=1, each thread accesses all DFB entries
-        BindDFBToKernel(reader, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-        BindDFBToKernel(writer, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+        reader.dfb_bindings.push_back(ProducerOf("staging_dfb", "my_dfb"));
+        writer.dfb_bindings.push_back(ConsumerOf("staging_dfb", "my_dfb"));
     };
 
     switch (params.dtype) {
@@ -301,8 +301,8 @@ TEST_P(TensorAccessorStridedDFBTest, QuasarStridedPagesCopy) {
         reader = MakeMinimalDMKernel("reader", kNumDMThreads);
         writer = MakeMinimalDMKernel("writer", kNumDMThreads);
         // STRIDED with 3 threads: each thread owns every 3rd DFB entry
-        BindDFBToKernel(reader, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::PRODUCER);
-        BindDFBToKernel(writer, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+        reader.dfb_bindings.push_back(ProducerOf("staging_dfb", "my_dfb"));
+        writer.dfb_bindings.push_back(ConsumerOf("staging_dfb", "my_dfb"));
     };
 
     // DFB depth: 2 entries per DM thread (double-buffer) × 3 threads = 6 entries

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -37,8 +37,8 @@ namespace {
 
 using namespace tt;
 using namespace tt::tt_metal;
-using namespace tt::tt_metal::experimental::metal2_host_api;
-using namespace tt::tt_metal::experimental::metal2_host_api::test_helpers;
+using namespace tt::tt_metal::experimental;
+using namespace tt::tt_metal::experimental::test_helpers;
 using namespace ttnn;
 
 // ============================================================================
@@ -156,8 +156,8 @@ void run_strided_dfb_copy_test(
     kernel_builder_fn(reader, writer);
 
     // Inject CTA define so TensorAccessorArgs<0, 0>() resolves at compile time
-    reader.source = KernelSpec::SourceFilePath{kReaderKernelPath};
-    writer.source = KernelSpec::SourceFilePath{kWriterKernelPath};
+    reader.source = kReaderKernelPath;
+    writer.source = kWriterKernelPath;
     reader.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", input_cta_str});
     writer.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", output_cta_str});
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_configuration.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/base_types.hpp>  // For MathFidelity, UnpackToDestMode (global scope)
+
+namespace tt::tt_metal::experimental {
+
+// Tensix hardware resource configuration for compute kernels
+struct ComputeConfiguration {
+    // The Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack).
+    // There are two math engines:
+    //  - FPU reads operands from the SrcA / SrcB register files (~19-bit),
+    //    writes to the Dest register file (16- or 32-bit, configurable).
+    //  - SFPU runs SIMD transcendentals. It can only access Dest.
+    // The fields below configure this pipeline.
+
+    // NOTE:
+    // The compute pipeline configuration fields are the SAME for Gen1 and Gen2.
+    // Unlike the DM configuration, there is no per-architecture subdivision.
+    // This is incidental; we may need to introduce arch-specific config in the
+    // future (i.e. Gen1, Gen2, etc. substructures).
+
+    // Number of multiply passes the FPU runs to use more mantissa bits
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+
+    // Configure Dest register to hold 32-bit elements (instead of the default 16-bit)
+    bool fp32_dest_acc_en = false;
+
+    // Dest register sync mode:
+    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered)
+    //   true  (Full) — Dest is one buffer; twice the capacity, no math/pack overlap
+    bool dst_full_sync_en = false;
+
+    // Pack-side precision tweak for the Bfp8 block-float format.
+    // (Affects how exponents are reconciled when converting Dest contents to Bfp8)
+    bool bfp8_pack_precise = false;
+
+    // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
+    bool math_approx_mode = false;
+
+    // Per-DFB choice of how the unpacker delivers data into the math stage:
+    //   Default          — unpack via SrcA/B regs (~19-bit elements; full FPU access)
+    //   UnpackToDestFp32 — unpack via Dest regs with full FP32 precision (SFPU only)
+    //
+    // This choice matters only when ALL of the following hold for the DFB binding:
+    //   1. The kernel is the consumer endpoint (unpacking data into the kernel)
+    //   2. The DFB's data format is Float32.
+    //   3. fp32_dest_acc_en is true (Dest must be 32-bit-wide to hold FP32).
+    //
+    // You MUST provide an unpack_to_dest_mode entry for the DFB if these conditions hold;
+    // failing to do so will trigger an error. Otherwise, supplying an entry is optional
+    // and only Default is accepted.
+    using UnpackToDestModeEntry = std::pair<DFBSpecName, tt::tt_metal::UnpackToDestMode>;
+    std::vector<UnpackToDestModeEntry> unpack_to_dest_mode;
+};
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include <tt-metalium/kernel_types.hpp>  // For DataMovementProcessor, NOC, etc.
+
+namespace tt::tt_metal::experimental {
+
+// Hardware generations referenced in this API:
+//   Gen1 — Wormhole (WH), Blackhole (BH)
+//   Gen2 — Quasar and derivative architectures
+
+// Data movement hardware resource configuration for DM kernels
+struct DataMovementConfiguration {
+    // The DM configuration differs between hardware generations.
+    //  - Gen1 (WH/BH) requires explicit processor/NOC selection.
+    //  - Gen2 (Quasar) has no user-facing configuration yet (placeholder only).
+    // For architecture-agnostic host code, provide both.
+
+    struct Gen1 {
+        tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
+        tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
+        tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
+    };
+    std::optional<Gen1> gen1 = std::nullopt;
+
+    struct Gen2 {
+        // Currently, no configuration is needed for Gen2!
+        // The empty struct is still used to express a Gen2 DM kernel.
+    };
+    std::optional<Gen2> gen2 = std::nullopt;
+};
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
@@ -17,9 +17,8 @@ namespace tt::tt_metal::experimental {
 // Data movement hardware resource configuration for DM kernels
 struct DataMovementConfiguration {
     // The DM configuration differs between hardware generations.
-    //  - Gen1 (WH/BH) requires explicit processor/NOC selection.
-    //  - Gen2 (Quasar) has no user-facing configuration yet (placeholder only).
-    // For architecture-agnostic host code, provide both.
+    //  - Gen1 requires explicit processor/NOC selection.
+    //  - Gen2 has no user-facing configuration yet (placeholder only).
 
     struct Gen1 {
         tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
@@ -20,19 +20,19 @@ struct DataMovementConfiguration {
     //  - Gen1 requires explicit processor/NOC selection.
     //  - Gen2 has no user-facing configuration yet (placeholder only).
 
-    struct Gen1 {
+    struct Gen1DM {
         tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
         tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
         tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
     };
-    std::optional<Gen1> gen1 = std::nullopt;
+    std::optional<Gen1DM> gen1 = std::nullopt;
 
-    struct Gen2 {
+    struct Gen2DM {
         // Currently, no configuration is needed for Gen2!
         // The empty struct is here as a placeholder.
-        // (It is NOT required to provide an empty Gen2 config for Gen2 architectures.)
+        // (It is NOT required to provide an empty Gen2DM config for Gen2 architectures.)
     };
-    std::optional<Gen2> gen2 = std::nullopt;
+    std::optional<Gen2DM> gen2 = std::nullopt;
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
@@ -30,7 +30,8 @@ struct DataMovementConfiguration {
 
     struct Gen2 {
         // Currently, no configuration is needed for Gen2!
-        // The empty struct is still used to express a Gen2 DM kernel.
+        // The empty struct is here as a placeholder.
+        // (It is NOT required to provide an empty Gen2 config for Gen2 architectures.)
     };
     std::optional<Gen2> gen2 = std::nullopt;
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>  // tt::DataFormat
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 // A name identifying a DataflowBufferSpec within a ProgramSpec.
 // String literals work directly; misnamed references fail at validation.
@@ -146,4 +146,4 @@ struct RemoteDataflowBufferSpec {
     ProducerConsumerMap producer_consumer_map;
 };
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -67,7 +67,8 @@ struct DataflowBufferSpec {
     // Required for DFBs bound to compute kernels; optional for DM-only DFBs
     std::optional<tt::DataFormat> data_format_metadata = std::nullopt;
 
-    // Optional; used to pass tile type info from host to kernel
+    // Required for DFBs bound to compute kernels, when the DFB holds data with
+    // non-default tile geometry (non-32x32); otherwise optional.
     std::optional<tt::tt_metal::Tile> tile_format_metadata = std::nullopt;
 
     //////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -103,8 +103,9 @@ struct DataflowBufferSpec {
     DFBIdentifiers alias_with;  // empty vector means no aliasing
 
     // Disable implicit sync
-    // Implicit sync is handled via ISR (available on Gen2 only)
+    // Implicit sync is handled via ISR (available on Gen2 DM kernels only)
     // Disabling may be useful in niche cases for fine tuning performance or performance debug.
+    // (TODO: move this option to Gen2 DataMovementConfiguration)
     bool disable_implicit_sync = false;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -18,11 +18,7 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a DataflowBufferSpec within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* INPUT_DFB = "input_dfb";
-//   DataflowBufferSpec{.unique_id = INPUT_DFB, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
+// String literals work directly; misnamed references fail at validation.
 using DFBSpecName = std::string;
 
 // DataflowBuffer endpoint access patterns:

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -4,12 +4,10 @@
 
 #pragma once
 
-#include <concepts>
 #include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -73,18 +71,18 @@ struct DataMovementConfiguration {
     // You can provide either a Gen1 config, a Gen2 config, or both.
     // If your host code is intended to be architecture-agnostic, provide both.
 
-    struct Gen1DataMovementConfig {
+    struct Gen1 {
         tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
         tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
         tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
     };
-    std::optional<Gen1DataMovementConfig> gen1_data_movement_config = std::nullopt;
+    std::optional<Gen1> gen1 = std::nullopt;
 
-    struct Gen2DataMovementConfig {
+    struct Gen2 {
         // Currently, no configuration is needed for Gen2!
         // The empty struct is still used to express a Gen2 DM kernel.
     };
-    std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
+    std::optional<Gen2> gen2 = std::nullopt;
 };
 
 // A name identifying a KernelSpec within a ProgramSpec.
@@ -132,7 +130,6 @@ struct KernelSpec {
     // NOTE: The kernel's target node set is a DERIVED property, based on the
     //       WorkUnitSpec(s) that include this kernel.
 
-    // Kernel threading:
     // Number of kernel threads
     int num_threads = 1;
 
@@ -171,11 +168,11 @@ struct KernelSpec {
     // DFB bindings
     // Declares that this kernel requires a DFB resource (declared at the ProgramSpec level)
     // The kernel constructs the accessor via DataflowBufferAccessor(dfb::<local_accessor_name>)
-    enum class DFBEndpointType { PRODUCER, CONSUMER, RELAY };
+    enum class DFBEndpointType { PRODUCER, CONSUMER };
     struct DFBBinding {
         DFBSpecName dfb_spec_name;        // identify the DFB within the ProgramSpec
         std::string local_accessor_name;  // DFB accessor name (used in the kernel source code)
-        DFBEndpointType endpoint_type;    // producer, consumer, or relay
+        DFBEndpointType endpoint_type;    // producer or consumer
         DFBAccessPattern access_pattern = DFBAccessPattern::STRIDED;  // strided, all, or blocked
     };
     std::vector<DFBBinding> dfb_bindings;
@@ -293,5 +290,31 @@ struct KernelSpec {
     };
     std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
 };
+
+// Convenience factories for DFBBinding. Equivalent to writing a designated-init
+// DFBBinding{...} with endpoint_type set; the access_pattern defaults to STRIDED.
+inline KernelSpec::DFBBinding ProducerOf(
+    DFBSpecName dfb_spec_name,
+    std::string local_accessor_name,
+    DFBAccessPattern access_pattern = DFBAccessPattern::STRIDED) {
+    return KernelSpec::DFBBinding{
+        .dfb_spec_name = std::move(dfb_spec_name),
+        .local_accessor_name = std::move(local_accessor_name),
+        .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+        .access_pattern = access_pattern,
+    };
+}
+
+inline KernelSpec::DFBBinding ConsumerOf(
+    DFBSpecName dfb_spec_name,
+    std::string local_accessor_name,
+    DFBAccessPattern access_pattern = DFBAccessPattern::STRIDED) {
+    return KernelSpec::DFBBinding{
+        .dfb_spec_name = std::move(dfb_spec_name),
+        .local_accessor_name = std::move(local_accessor_name),
+        .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+        .access_pattern = access_pattern,
+    };
+}
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -86,11 +88,7 @@ struct DataMovementConfiguration {
 };
 
 // A name identifying a KernelSpec within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* READER_KERNEL = "reader";
-//   KernelSpec{.unique_id = READER_KERNEL, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
+// String literals work directly; misnamed references fail at validation.
 using KernelSpecName = std::string;
 
 // A KernelSpec is a descriptor for a Tenstorrent kernel:
@@ -124,28 +122,26 @@ struct KernelSpec {
     KernelSpecName unique_id;
 
     // Kernel source: either a path to a source file, or the source code itself.
-    // (Force callers to choose explicitly between path and inline code.)
-    struct SourceFilePath {
-        std::filesystem::path path;
-    };
+    // String literals are accepted directly as a file path (the common case);
+    // wrap inline source code with SourceCode{...}.
     struct SourceCode {
         std::string code;
     };
-    std::variant<SourceFilePath, SourceCode> source;
+    std::variant<std::filesystem::path, SourceCode> source;
 
     // NOTE: The kernel's target node set is a DERIVED property, based on the
     //       WorkUnitSpec(s) that include this kernel.
 
     // Kernel threading:
     // Number of kernel threads
-    uint8_t num_threads = 1;
+    int num_threads = 1;
 
     // (Optional) Per-node thread count specification
     // The default threading is num_threads. However, you may override this on a per-node basis.
     // NOTE: This feature is currently unsupported. It's an open question if we EVER want to support it.
     //       Here as a placeholder; specifying it will trigger a runtime error.
     using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
-    using NodeSpecificThreadCount = std::pair<Nodes, uint8_t>;  // {node_set, num_threads}
+    using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -25,8 +25,6 @@ namespace tt::tt_metal::experimental {
 // String literals work directly; misnamed references fail at validation.
 using KernelSpecName = std::string;
 
-using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
-
 // A KernelSpec is a descriptor for a Tenstorrent kernel:
 // A single computational task compiled into one or more executable files that work
 // collaboratively on a single node.
@@ -34,9 +32,9 @@ using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
 // The KernelSpec describes the properties of a compute or data movement kernel:
 //  - Source code
 //  - Compiler options for generating the kernel binary/binaries
-//  - Resource bindings (access to DFBs, semaphores, etc.)
+//  - Resource bindings (access to DFBs, semaphores, tensors)
 //  - Kernel argument schema (for arguments specified when the Program is enqueued)
-//  - Kernel argument bindings (for compile-time constant arguments)
+//  - Compile-time kernel arguments (constexpr args specified at Program compile time)
 //  - The configuration of any hardware resources controlled by the kernel
 //
 // Specialization: A single kernel source may be represented by multiple KernelSpecs in
@@ -46,6 +44,7 @@ using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
 //
 // Instancing: A KernelSpec is a *per-node template*. At runtime, one independent
 // instance runs on each node where the kernel is placed, with its own runtime arguments.
+// (Compile-time arguments and common runtime arguments are across all instances.)
 //
 // Placement: The nodes the kernel runs on is derived from WorkUnitSpec membership.
 //

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -291,6 +291,14 @@ struct KernelSpec {
     std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
 };
 
+// Namespace-level aliases for commonly-used nested types. Both the qualified
+// (KernelSpec::Foo) and unqualified (Foo) forms refer to the same type.
+using DFBBinding = KernelSpec::DFBBinding;
+using DFBEndpointType = KernelSpec::DFBEndpointType;
+using SemaphoreBinding = KernelSpec::SemaphoreBinding;
+using TensorBinding = KernelSpec::TensorBinding;
+using SourceCode = KernelSpec::SourceCode;
+
 // Convenience factories for DFBBinding. Equivalent to writing a designated-init
 // DFBBinding{...} with endpoint_type set; the access_pattern defaults to STRIDED.
 inline KernelSpec::DFBBinding ProducerOf(

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -19,7 +19,7 @@
 #include <tt-metalium/base_types.hpp>    // For MathFidelity, UnpackToDestMode (global scope)
 #include <tt-metalium/kernel_types.hpp>  // For DataMovementProcessor, NOC, etc.
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 struct ComputeConfiguration {
     // Tensix hardware resource configuration for compute kernels.
@@ -325,4 +325,4 @@ inline KernelSpec::DFBBinding ConsumerOf(
     };
 }
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -141,8 +141,8 @@ struct KernelSpec {
     //----------------------------------------------------------------------------
     // Compile time argument bindings
     // (Bound argument values cannot be changed between Program executions)
-    using CompileTimeArgBindings = std::vector<std::pair<std::string, uint32_t>>;
-    CompileTimeArgBindings compile_time_arg_bindings;
+    using CompileTimeArgs = std::vector<std::pair<std::string, uint32_t>>;
+    CompileTimeArgs compile_time_args;
     // TODO -- extend to support arbitrary POD types, including user-defined structs.
 
     //----------------------------------------------------------------------------
@@ -159,10 +159,10 @@ struct KernelSpec {
     //     Vararg indices are stable across schema changes (e.g., moving a named arg from RTA→CRTA).
     struct RuntimeArgSchema {
         // Named RTAs: names in declaration order. Must be unique valid C++ identifiers.
-        std::vector<std::string> named_runtime_args;
+        std::vector<std::string> runtime_args;
 
         // Named CRTAs: names in declaration order. Must be unique valid C++ identifiers.
-        std::vector<std::string> named_common_runtime_args;
+        std::vector<std::string> common_runtime_args;
 
         //----------------------
         // Advanced options

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -303,24 +303,4 @@ inline DFBBinding BlockedConsumerOf(
 }
 */
 
-//////////////////////////////////////////////////////////////////////////////
-// Convenience factories for SemaphoreBinding and TensorBinding
-//////////////////////////////////////////////////////////////////////////////
-
-// Creates a SemaphoreBinding (kernel uses a Semaphore declared at ProgramSpec level)
-inline SemaphoreBinding UseSemaphore(SemaphoreSpecName semaphore_spec_name, std::string accessor_name) {
-    return SemaphoreBinding{
-        .semaphore_spec_name = std::move(semaphore_spec_name),
-        .accessor_name = std::move(accessor_name),
-    };
-}
-
-// Creates a TensorBinding (kernel accesses a TensorParameter declared at ProgramSpec level)
-inline TensorBinding UseTensor(TensorParameterName tensor_parameter_name, std::string accessor_name) {
-    return TensorBinding{
-        .tensor_parameter_name = std::move(tensor_parameter_name),
-        .accessor_name = std::move(accessor_name),
-    };
-}
-
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -12,78 +12,14 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/experimental/metal2_host_api/compute_configuration.hpp>
+#include <tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
-#include <tt-metalium/base_types.hpp>    // For MathFidelity, UnpackToDestMode (global scope)
-#include <tt-metalium/kernel_types.hpp>  // For DataMovementProcessor, NOC, etc.
 
 namespace tt::tt_metal::experimental {
-
-struct ComputeConfiguration {
-    // Tensix hardware resource configuration for compute kernels.
-    // Gen1 and Gen2 configurations are identical.
-    //
-    // The Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack).
-    // There are two math engines:
-    //  - FPU reads operands from the SrcA / SrcB register files (~19-bit),
-    //    writes to the Dest register file (16- or 32-bit, configurable).
-    //  - SFPU runs SIMD transcendentals. It can only access Dest.
-    // The fields below configure this pipeline.
-
-    // Number of multiply passes the FPU runs to use more mantissa bits
-    MathFidelity math_fidelity = MathFidelity::HiFi4;
-
-    // Configure Dest register to hold 32-bit elements (instead of the default 16-bit)
-    bool fp32_dest_acc_en = false;
-
-    // Dest register sync mode:
-    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered)
-    //   true  (Full) — Dest is one buffer; twice the capacity, no math/pack overlap
-    bool dst_full_sync_en = false;
-
-    // Pack-side precision tweak for the Bfp8 block-float format.
-    // (Affects how exponents are reconciled when converting Dest contents to Bfp8)
-    bool bfp8_pack_precise = false;
-
-    // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
-    bool math_approx_mode = false;
-
-    // Per-DFB choice of how the unpacker delivers data into the math stage:
-    //   Default          — unpack via SrcA/B regs (~19-bit elements; full FPU access)
-    //   UnpackToDestFp32 — unpack via Dest regs with full FP32 precision (SFPU only)
-    //
-    // This choice matters only when ALL of the following hold for the DFB binding:
-    //   1. The kernel is the consumer endpoint (unpacking data into the kernel)
-    //   2. The DFB's data format is Float32.
-    //   3. fp32_dest_acc_en is true (Dest must be 32-bit-wide to hold FP32).
-    //
-    // You MUST provide an unpack_to_dest_mode entry for the DFB if these conditions hold;
-    // failing to do so will trigger an error. Otherwise, supplying an entry is optional
-    // and only Default is accepted.
-    using UnpackToDestModeEntry = std::pair<DFBSpecName, tt::tt_metal::UnpackToDestMode>;
-    std::vector<UnpackToDestModeEntry> unpack_to_dest_mode;
-};
-
-struct DataMovementConfiguration {
-    // The DM configuration is different for Gen1 and Gen2.
-    // You can provide either a Gen1 config, a Gen2 config, or both.
-    // If your host code is intended to be architecture-agnostic, provide both.
-
-    struct Gen1 {
-        tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
-        tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
-        tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
-    };
-    std::optional<Gen1> gen1 = std::nullopt;
-
-    struct Gen2 {
-        // Currently, no configuration is needed for Gen2!
-        // The empty struct is still used to express a Gen2 DM kernel.
-    };
-    std::optional<Gen2> gen2 = std::nullopt;
-};
 
 // A name identifying a KernelSpec within a ProgramSpec.
 // String literals work directly; misnamed references fail at validation.
@@ -291,38 +227,80 @@ struct KernelSpec {
     std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
 };
 
-// Namespace-level aliases for commonly-used nested types. Both the qualified
-// (KernelSpec::Foo) and unqualified (Foo) forms refer to the same type.
+//////////////////////////////////////////////////////////////////////////////
+// Namespace-level aliases for commonly-used nested types
+//////////////////////////////////////////////////////////////////////////////
+
+// The qualified (KernelSpec::Foo) and unqualified (Foo) forms refer to the same type.
 using DFBBinding = KernelSpec::DFBBinding;
 using DFBEndpointType = KernelSpec::DFBEndpointType;
 using SemaphoreBinding = KernelSpec::SemaphoreBinding;
 using TensorBinding = KernelSpec::TensorBinding;
 using SourceCode = KernelSpec::SourceCode;
 
-// Convenience factories for DFBBinding. Equivalent to writing a designated-init
-// DFBBinding{...} with endpoint_type set; the access_pattern defaults to STRIDED.
-inline KernelSpec::DFBBinding ProducerOf(
-    DFBSpecName dfb_spec_name,
-    std::string local_accessor_name,
-    DFBAccessPattern access_pattern = DFBAccessPattern::STRIDED) {
-    return KernelSpec::DFBBinding{
+//////////////////////////////////////////////////////////////////////////////
+// Convenience factories for DFBBinding
+//////////////////////////////////////////////////////////////////////////////
+
+// Ergonomic alternatives to writing a designated-init DFBBinding{...}
+
+// Creates a DFB producer binding with a STRIDED access pattern
+// (All DFB producers are STRIDED)
+inline DFBBinding ProducerOf(DFBSpecName dfb_spec_name, std::string local_accessor_name) {
+    return DFBBinding{
         .dfb_spec_name = std::move(dfb_spec_name),
         .local_accessor_name = std::move(local_accessor_name),
-        .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-        .access_pattern = access_pattern,
+        .endpoint_type = DFBEndpointType::PRODUCER,
+        .access_pattern = DFBAccessPattern::STRIDED};
+}
+
+// Creates a DFB consumer binding (with a default-STRIDED access pattern)
+// Use this for single-threaded kernels, where the access pattern doesn't matter.
+// For multi-threaded kernels (Quasar), prefer the explicit access pattern
+// helper factories below.
+inline DFBBinding ConsumerOf(DFBSpecName dfb_spec_name, std::string local_accessor_name) {
+    return DFBBinding{
+        .dfb_spec_name = std::move(dfb_spec_name),
+        .local_accessor_name = std::move(local_accessor_name),
+        .endpoint_type = DFBEndpointType::CONSUMER,
+        // access pattern defaults to STRIDED
     };
 }
 
-inline KernelSpec::DFBBinding ConsumerOf(
-    DFBSpecName dfb_spec_name,
-    std::string local_accessor_name,
-    DFBAccessPattern access_pattern = DFBAccessPattern::STRIDED) {
-    return KernelSpec::DFBBinding{
+// Creates a DFB consumer binding with a STRIDED access pattern
+// (The common case for multi-threaded DFB consumers)
+inline DFBBinding StridedConsumerOf(DFBSpecName dfb_spec_name, std::string local_accessor_name) {
+    return DFBBinding{
         .dfb_spec_name = std::move(dfb_spec_name),
         .local_accessor_name = std::move(local_accessor_name),
-        .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-        .access_pattern = access_pattern,
+        .endpoint_type = DFBEndpointType::CONSUMER,
+        .access_pattern = DFBAccessPattern::STRIDED,
     };
 }
+
+// Creates a DFB consumer binding with a ALL access pattern
+inline DFBBinding AllConsumerOf(DFBSpecName dfb_spec_name, std::string local_accessor_name) {
+    return DFBBinding{
+        .dfb_spec_name = std::move(dfb_spec_name),
+        .local_accessor_name = std::move(local_accessor_name),
+        .endpoint_type = DFBEndpointType::CONSUMER,
+        .access_pattern = DFBAccessPattern::ALL,
+    };
+}
+
+// Creates a DFB consumer binding with a BLOCKED access pattern
+// Uncomment when BLOCKED support is added (currently TT_FATALs)
+/*
+inline DFBBinding BlockedConsumerOf(
+    DFBSpecName dfb_spec_name,
+    std::string local_accessor_name) {
+    return DFBBinding{
+        .dfb_spec_name = std::move(dfb_spec_name),
+        .local_accessor_name = std::move(local_accessor_name),
+        .endpoint_type = DFBEndpointType::CONSUMER,
+        .access_pattern = DFBAccessPattern::BLOCKED,
+    };
+}
+*/
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -25,6 +25,8 @@ namespace tt::tt_metal::experimental {
 // String literals work directly; misnamed references fail at validation.
 using KernelSpecName = std::string;
 
+using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
+
 // A KernelSpec is a descriptor for a Tenstorrent kernel:
 // A single computational task compiled into one or more executable files that work
 // collaboratively on a single node.
@@ -73,7 +75,6 @@ struct KernelSpec {
     // The default threading is num_threads. However, you may override this on a per-node basis.
     // NOTE: This feature is currently unsupported. It's an open question if we EVER want to support it.
     //       Here as a placeholder; specifying it will trigger a runtime error.
-    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
     using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
@@ -302,5 +303,25 @@ inline DFBBinding BlockedConsumerOf(
     };
 }
 */
+
+//////////////////////////////////////////////////////////////////////////////
+// Convenience factories for SemaphoreBinding and TensorBinding
+//////////////////////////////////////////////////////////////////////////////
+
+// Creates a SemaphoreBinding (kernel uses a Semaphore declared at ProgramSpec level)
+inline SemaphoreBinding UseSemaphore(SemaphoreSpecName semaphore_spec_name, std::string accessor_name) {
+    return SemaphoreBinding{
+        .semaphore_spec_name = std::move(semaphore_spec_name),
+        .accessor_name = std::move(accessor_name),
+    };
+}
+
+// Creates a TensorBinding (kernel accesses a TensorParameter declared at ProgramSpec level)
+inline TensorBinding UseTensor(TensorParameterName tensor_parameter_name, std::string accessor_name) {
+    return TensorBinding{
+        .tensor_parameter_name = std::move(tensor_parameter_name),
+        .accessor_name = std::move(accessor_name),
+    };
+}
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
@@ -19,6 +19,8 @@
 // A "node" is a NOC endpoint with an x,y address - a block in the accelerator grid.
 // This header provides type aliases for the new "Node" terminology.
 
+#include <variant>
+
 #include <tt-metalium/core_coord.hpp>
 
 namespace tt::tt_metal::experimental {
@@ -27,6 +29,9 @@ namespace tt::tt_metal::experimental {
 using NodeCoord = tt::tt_metal::CoreCoord;
 using NodeRange = tt::tt_metal::CoreRange;
 using NodeRangeSet = tt::tt_metal::CoreRangeSet;
+
+// A set of nodes specified as a single point, range, or range set.
+using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
 
 // Function aliases: Node terminology equivalents
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
@@ -21,7 +21,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 // Type aliases: Node terminology for NOC endpoint coordinates
 using NodeCoord = tt::tt_metal::CoreCoord;
@@ -64,4 +64,4 @@ inline std::optional<NodeRange> select_contiguous_range_from_noderangeset(
     return tt::tt_metal::select_contiguous_range_from_corerangeset(nrs, x, y);
 }
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -40,13 +40,13 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params);
 //
 // PRE-CONDITION: SetProgramRunParameters must have been called previously.
 //
-// COMPLETENESS: A TensorArg must be specified for every TensorParameter declared in the
+// COMPLETENESS: A TensorArgument must be specified for every TensorParameter declared in the
 // ProgramSpec, exactly once. The supplied MeshTensor's TensorSpec must match the
 // TensorParameter's declared spec.
 //
 // USE CASE: Program re-enqueue loops where the only per-enqueue ProgramRunParams variation
 // is in the tensor args (i.e. which specific MeshTensors are operated on by the Program).
-void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args);
+void UpdateTensorArguments(Program& program, std::span<const ProgramRunParams::TensorArgument> tensor_arguments);
 
 // Power-user API for updating the mutable parameters of a Program in-place.
 // ProgramRunParamsView is a non-owning view into the Program's command buffers,

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 //------------------------------------------------
 // Temporary Metal 2.0 APIs
@@ -57,7 +57,7 @@ ProgramRunParamsView& GetProgramRunParamsView(Program& program);
 // Useful? Might want to expose a const view for debug/test use?
 // ProgramRunParamsConstView GetProgramRunParamsConstView(const Program& program);
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental
 
 // The code below is not compiled!
 // This is a placeholder for the "post-experimental" desired Program object semantics.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -33,21 +33,21 @@ struct ProgramRunParams {
         KernelSpecName kernel_spec_name;
 
         // Named Runtime Argument settings
-        // Every argument in this kernel's RuntimeArgSchema::named_runtime_args must be set,
+        // Every argument in this kernel's RuntimeArgSchema::runtime_args must be set,
         // for every node the kernel runs on.
         // Missing arguments or superfluous arguments will trigger validation errors.
         //
         // NOTE: If a kernel runtime argument always has the same value for all nodes, passing
         // a common runtime argument would provide better dispatch efficiency.
-        struct NodeNamedRTAs {
+        struct NodeRuntimeArgs {
             NodeCoord node;
             std::unordered_map<std::string, uint32_t> args;
         };
-        std::vector<NodeNamedRTAs> named_runtime_args;
+        std::vector<NodeRuntimeArgs> runtime_args;
 
         // Named Common Runtime Argument settings
-        // Every arg in this kernel's RuntimeArgSchema::named_common_runtime_args must be set.
-        std::unordered_map<std::string, uint32_t> named_common_runtime_args;
+        // Every arg in this kernel's RuntimeArgSchema::common_runtime_args must be set.
+        std::unordered_map<std::string, uint32_t> common_runtime_args;
 
         // Unnamed runtime argument "varargs"
         // (these are specified per-node; length can vary per-node)
@@ -103,7 +103,7 @@ struct ProgramRunParams {
 // Namespace-level aliases for commonly-used nested types. Both the qualified
 // (ProgramRunParams::Foo) and unqualified (Foo) forms refer to the same type.
 using KernelRunParams = ProgramRunParams::KernelRunParams;
-using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+using NodeRuntimeArgs = ProgramRunParams::KernelRunParams::NodeRuntimeArgs;
 using NodeVarargs = ProgramRunParams::KernelRunParams::NodeVarargs;
 
 //------------------------------------------------

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -68,7 +68,7 @@ struct ProgramRunParams {
     ////////////////////////////////////////////////////////////////////////
     // Tensor arguments
     ////////////////////////////////////////////////////////////////////////
-    struct TensorArg {
+    struct TensorArgument {
         // Tensor identifier (matches a TensorParameter::unique_id in the ProgramSpec)
         TensorParameterName tensor_parameter_name;
 
@@ -76,9 +76,9 @@ struct ProgramRunParams {
         // (Non-owning reference. Will become MeshTensorView when available; existing callsites won't change.)
         std::reference_wrapper<const MeshTensor> tensor;
     };
-    // A TensorArg must be specified for EVERY TensorParameter declared in the ProgramSpec.
+    // A TensorArgument must be specified for EVERY TensorParameter declared in the ProgramSpec.
     // The argument's TensorSpec must match the TensorParameter's TensorSpec (shape, layout, data type).
-    std::vector<TensorArg> tensor_args;
+    std::vector<TensorArgument> tensor_arguments;
 
     ////////////////////////////////////////////////////////////////////////
     // DFB parameters (optional, advanced use cases)

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -100,6 +100,12 @@ struct ProgramRunParams {
     std::vector<DFBRunParams> dfb_run_params;
 };
 
+// Namespace-level aliases for commonly-used nested types. Both the qualified
+// (ProgramRunParams::Foo) and unqualified (Foo) forms refer to the same type.
+using KernelRunParams = ProgramRunParams::KernelRunParams;
+using NodeNamedRTAs = ProgramRunParams::KernelRunParams::NodeNamedRTAs;
+using NodeVarargs = ProgramRunParams::KernelRunParams::NodeVarargs;
+
 //------------------------------------------------
 // ProgramRunParamsView (for advanced users)
 //------------------------------------------------

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -17,7 +17,7 @@
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 //------------------------------------------------
 // ProgramRunParams
@@ -155,4 +155,4 @@ struct ProgramRunParamsView {
 
 // TODO: Consider a const version of the view object, for debug/test use?
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -28,15 +28,14 @@ namespace tt::tt_metal::experimental {
 // Placement: The WorkUnitSpec defines the node placement of its kernels.
 // (A kernel may be included in multiple WorkUnitSpecs.)
 struct WorkUnitSpec {
-    // Human-readable name surfaced in error messages, logs, and profiling output.
-    // Not a cross-reference — no uniqueness enforcement (though distinct values aid debuggability).
+    // WorkUnitSpec name (used for messaging, logs, etc)
     std::string name;
 
     // The kernels that run on this WorkUnitSpec's nodes.
     std::vector<KernelSpecName> kernels;
 
     // The set of nodes configured by this WorkUnitSpec.
-    std::variant<NodeCoord, NodeRange, NodeRangeSet> target_nodes;
+    Nodes target_nodes;
 };
 
 // A ProgramSpec describes the immutable properties of a Program:
@@ -44,19 +43,21 @@ struct WorkUnitSpec {
 // Analogous to a function's signature and body — declared once, executed many times.
 // (Each time with a new ProgramRunParams configuring the mutable execution parameters.)
 struct ProgramSpec {
-    // Human-readable name surfaced in error messages, logs, and profiling output.
-    // Not a cross-reference — no uniqueness enforcement (though distinct values aid debuggability).
+    // ProgramSpec name (used for messaging, logs, etc)
     std::string name;
 
-    // Kernels, DFBs (local + remote), and semaphores that make up the Program
+    // Kernels that make up the Program
     std::vector<KernelSpec> kernels;
+
+    // Program-scope resources with program-execution lifetime allocation
     std::vector<DataflowBufferSpec> dataflow_buffers;
     std::vector<RemoteDataflowBufferSpec> remote_dataflow_buffers;
     std::vector<SemaphoreSpec> semaphores;
 
     // Tensor parameter declarations
-    // Provides ids and layout specs for tensors the Program's kernels will operate on
-    // (The actual MeshTensors are supplied via ProgramRunParams.)
+    // Describes the tensor memory objects that the Program's kernels will use.
+    // (The actual MeshTensors are user-managed memory resources,
+    // supplied via ProgramRunParams.)
     std::vector<TensorParameter> tensor_parameters;
 
     // WorkUnit specifications:

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -19,15 +19,10 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a ProgramSpec within a MeshWorkload.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* MATMUL_PROGRAM = "matmul";
-//   ProgramSpec{.program_id = MATMUL_PROGRAM, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
+// String literals work directly; misnamed references fail at validation.
 using ProgramSpecName = std::string;
 
 // A name identifying a WorkUnitSpec within a ProgramSpec.
-// CONVENTION: define names as `constexpr const char*` constants (see above).
 using WorkUnitSpecName = std::string;
 
 //------------------------------------------------

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 // A name identifying a ProgramSpec within a MeshWorkload.
 // String literals work directly; misnamed references fail at validation.
@@ -69,4 +69,4 @@ struct ProgramSpec {
     std::vector<WorkUnitSpec> work_units;
 };
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -18,13 +18,6 @@
 
 namespace tt::tt_metal::experimental {
 
-// A name identifying a ProgramSpec within a MeshWorkload.
-// String literals work directly; misnamed references fail at validation.
-using ProgramSpecName = std::string;
-
-// A name identifying a WorkUnitSpec within a ProgramSpec.
-using WorkUnitSpecName = std::string;
-
 //------------------------------------------------
 // ProgramSpec & WorkUnitSpec
 //------------------------------------------------
@@ -35,7 +28,9 @@ using WorkUnitSpecName = std::string;
 // Placement: The WorkUnitSpec defines the node placement of its kernels.
 // (A kernel may be included in multiple WorkUnitSpecs.)
 struct WorkUnitSpec {
-    WorkUnitSpecName unique_id;
+    // Human-readable name surfaced in error messages, logs, and profiling output.
+    // Not a cross-reference — no uniqueness enforcement (though distinct values aid debuggability).
+    std::string name;
 
     // The kernels that run on this WorkUnitSpec's nodes.
     std::vector<KernelSpecName> kernels;
@@ -49,8 +44,9 @@ struct WorkUnitSpec {
 // Analogous to a function's signature and body — declared once, executed many times.
 // (Each time with a new ProgramRunParams configuring the mutable execution parameters.)
 struct ProgramSpec {
-    // Program identifier (identifies a Program within a MeshWorkload)
-    ProgramSpecName program_id;
+    // Human-readable name surfaced in error messages, logs, and profiling output.
+    // Not a cross-reference — no uniqueness enforcement (though distinct values aid debuggability).
+    std::string name;
 
     // Kernels, DFBs (local + remote), and semaphores that make up the Program
     std::vector<KernelSpec> kernels;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -15,11 +15,7 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a SemaphoreSpec within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* DONE_FLAG = "done_flag";
-//   SemaphoreSpec{.unique_id = DONE_FLAG, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
+// String literals work directly; misnamed references fail at validation.
 using SemaphoreSpecName = std::string;
 
 // A SemaphoreSpec is a descriptor for a Tenstorrent semaphore,

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -12,7 +12,7 @@
 
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 // A name identifying a SemaphoreSpec within a ProgramSpec.
 // String literals work directly; misnamed references fail at validation.
@@ -54,4 +54,4 @@ struct SemaphoreSpec {
     SemaphoreMemoryType memory_type = SemaphoreMemoryType::L1;
 };
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -34,7 +34,6 @@ struct SemaphoreSpec {
     SemaphoreSpecName unique_id;
 
     // Target nodes
-    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
     Nodes target_nodes;
 
     //////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -11,11 +11,8 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a TensorParameter within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* INPUT_TENSOR = "input_tensor";
-//   TensorParameter{.unique_id = INPUT_TENSOR, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
+// String literals work directly; misnamed references fail at validation
+// with a clear error message naming the missing identifier.
 using TensorParameterName = std::string;
 
 // A TensorParameter is used to declare that a Program operates on a MeshTensor

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -8,7 +8,7 @@
 
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 // A name identifying a TensorParameter within a ProgramSpec.
 // String literals work directly; misnamed references fail at validation
@@ -26,4 +26,4 @@ struct TensorParameter {
     tt::tt_metal::TensorSpec spec;
 };
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -23,7 +23,7 @@ struct TensorParameter {
     TensorParameterName unique_id;
 
     // Single-device tensor layout
-    tt::tt_metal::TensorSpec spec;
+    TensorSpec spec;
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -98,7 +98,7 @@ using SemaphoreLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t
 // Metal 2.0: per-kernel resolved TensorBinding.
 // Carries the offsets the kernel-side codegen needs to emit a token, plus the program-level
 // TensorParameter name so SetProgramRunParameters can fill the binding's base-address slot
-// from the corresponding TensorArg at enqueue time.
+// from the corresponding TensorArgument at enqueue time.
 struct TensorBindingHandle {
     std::string accessor_name;          // user-facing identifier (kernel symbol in `ta::`)
     std::string tensor_parameter_name;  // refers back to the program-level TensorParameter

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -15,7 +15,7 @@
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 // ============================================================================
 // Validation Helpers
@@ -557,4 +557,4 @@ ProgramRunParamsView& GetProgramRunParamsView(Program& program) {
     //   - Or, create the view object upon Program construction.
 }
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -151,16 +151,16 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
         const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
 
         std::unordered_set<NodeCoord> nodes_with_named_params;
-        for (const auto& node_params : kernel_params.named_runtime_args) {
+        for (const auto& node_params : kernel_params.runtime_args) {
             auto [it_node, inserted_node] = nodes_with_named_params.insert(node_params.node);
             TT_FATAL(
                 inserted_node,
-                "Duplicate node_coord {} in named_runtime_args for kernel '{}'.",
+                "Duplicate node_coord {} in runtime_args for kernel '{}'.",
                 node_params.node.str(),
                 kernel_name);
             TT_FATAL(
                 kernel_nodes.contains(node_params.node),
-                "Kernel '{}' is setting named_runtime_args for node {}, but the kernel does not run on that node.",
+                "Kernel '{}' is setting runtime_args for node {}, but the kernel does not run on that node.",
                 kernel_name,
                 node_params.node.str());
             TT_FATAL(
@@ -184,7 +184,7 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
             for (const auto& node : kernel_nodes) {
                 TT_FATAL(
                     nodes_with_named_params.contains(node),
-                    "Kernel '{}' has named RTAs declared but no named_runtime_args provided for node {}.",
+                    "Kernel '{}' has named RTAs declared but no runtime_args provided for node {}.",
                     kernel_name,
                     node.str());
             }
@@ -197,17 +197,17 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
         const auto& named_crta_names = schema->named_common_runtime_args;
         for (const auto& name : named_crta_names) {
             TT_FATAL(
-                kernel_params.named_common_runtime_args.contains(name),
+                kernel_params.common_runtime_args.contains(name),
                 "Kernel '{}' is missing named CRTA '{}'.",
                 kernel_name,
                 name);
         }
         TT_FATAL(
-            kernel_params.named_common_runtime_args.size() == named_crta_names.size(),
+            kernel_params.common_runtime_args.size() == named_crta_names.size(),
             "Kernel '{}' expects {} user-named CRTAs, but {} were provided",
             kernel_name,
             named_crta_names.size(),
-            kernel_params.named_common_runtime_args.size());
+            kernel_params.common_runtime_args.size());
     }
 
     // Validate that all registered kernels with a non-empty RTA/CRTA schema have parameters.
@@ -375,7 +375,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
         // Build a node -> named-RTA-values-map lookup for serialization.
         std::unordered_map<NodeCoord, const std::unordered_map<std::string, uint32_t>*> named_rtas_by_node;
-        for (const auto& node_params : kernel_params.named_runtime_args) {
+        for (const auto& node_params : kernel_params.runtime_args) {
             named_rtas_by_node[node_params.node] = &node_params.args;
         }
 
@@ -424,7 +424,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
         }
 
         // Assemble the kernel's per-enqueue CRTA buffer in three structurally-separate sections:
-        //   1. User-named CRTAs, in schema order, sourced from named_common_runtime_args.
+        //   1. User-named CRTAs, in schema order, sourced from common_runtime_args.
         //   2. TensorBinding addresses, in binding-handle order, sourced from TensorArg via the
         //      ta_binding_addresses map. Each handle's addr_crta_offset (computed at spec
         //      resolution as (num_user_crtas + binding_index) * 4) lines up with the slot
@@ -436,9 +436,9 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
             schema->named_common_runtime_args.size() + binding_handles.size() +
             kernel_params.common_runtime_varargs.size());
         for (const auto& name : schema->named_common_runtime_args) {
-            auto v_it = kernel_params.named_common_runtime_args.find(name);
+            auto v_it = kernel_params.common_runtime_args.find(name);
             TT_FATAL(
-                v_it != kernel_params.named_common_runtime_args.end(),
+                v_it != kernel_params.common_runtime_args.end(),
                 "Internal error: named CRTA '{}' missing for kernel '{}'.",
                 name,
                 kernel_params.kernel_spec_name);

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -24,33 +24,34 @@ namespace tt::tt_metal::experimental {
 // Type alias for readability
 using KernelRTASchema = detail::ProgramImpl::KernelRTASchema;
 
-// Internal validation function - validates a TensorArg list against the Program's TensorParameters.
-// Shared by SetProgramRunParameters (full path) and UpdateTensorArgs (partial path).
+// Internal validation function - validates a TensorArgument list against the Program's TensorParameters.
+// Shared by SetProgramRunParameters (full path) and UpdateTensorArguments (partial path).
 //   - No duplicate tensor_parameter_name entries
 //   - Every entry references a TensorParameter declared in the ProgramSpec
 //   - The supplied MeshTensor's TensorSpec equals the binding's expected TensorSpec
 //     (full equality is required, for now. This will be loosened to layout-compatible-modulo-shape
 //     in a follow-up PR that adds RuntimeTensorShape as a mutable parameter).
 //   - Every declared TensorParameter must be set
-void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args) {
+void ValidateTensorArguments(
+    const Program& program, std::span<const ProgramRunParams::TensorArgument> tensor_arguments) {
     const detail::ProgramImpl& program_impl = program.impl();
 
     std::unordered_set<std::string> tensor_parameters_with_params;
-    for (const auto& tensor_params : tensor_args) {
+    for (const auto& tensor_params : tensor_arguments) {
         auto [it, inserted] = tensor_parameters_with_params.insert(tensor_params.tensor_parameter_name);
         TT_FATAL(
             inserted,
-            "Duplicate tensor_parameter_name '{}' in tensor_args. Each TensorParameter must appear at most once.",
+            "Duplicate tensor_parameter_name '{}' in tensor_arguments. Each TensorParameter must appear at most once.",
             tensor_params.tensor_parameter_name);
         const TensorSpec* expected_spec = program_impl.get_tensor_parameter_layout(tensor_params.tensor_parameter_name);
         TT_FATAL(
             expected_spec != nullptr,
-            "TensorArg references unknown TensorParameter '{}'.",
+            "TensorArgument references unknown TensorParameter '{}'.",
             tensor_params.tensor_parameter_name);
         const TensorSpec& runtime_spec = tensor_params.tensor.get().tensor_spec();
         TT_FATAL(
             runtime_spec == *expected_spec,
-            "TensorArg for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
+            "TensorArgument for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
             "declared spec. The binding declaration in ProgramSpec is the single source of truth for layout; the "
             "supplied tensor must conform to it.",
             tensor_params.tensor_parameter_name);
@@ -58,7 +59,7 @@ void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams
     for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {
         TT_FATAL(
             tensor_parameters_with_params.contains(declared),
-            "TensorParameter '{}' is declared in the Program but has no TensorArg entry.",
+            "TensorParameter '{}' is declared in the Program but has no TensorArgument entry.",
             declared);
     }
 }
@@ -192,7 +193,7 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
 
         // Validate named CRTAs: every declared name supplied, no extras.
         // The TensorBinding address section lives in its own structurally-separate part of the
-        // kernel's CRTA buffer and is filled from TensorArg at enqueue.
+        // kernel's CRTA buffer and is filled from TensorArgument at enqueue.
         // (This is separate from the schema->named_common_runtime_args.)
         const auto& named_crta_names = schema->named_common_runtime_args;
         for (const auto& name : named_crta_names) {
@@ -248,14 +249,14 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
     // Unlike kernels, DFBs don't require DFBRunParams.
     // (Borrowed-memory DFBs don't need a DFBRunParams entry either — they identify their backing
     // MeshTensor by name via DataflowBufferSpec::borrowed_from, and the tensor flows through
-    // tensor_args.)
+    // tensor_arguments.)
 
     // Validate tensor runtime parameters (delegated to shared helper).
-    ValidateTensorArgs(program, params.tensor_args);
+    ValidateTensorArguments(program, params.tensor_arguments);
 }
 
 // Attach the actual L1 Buffer to every borrowed-memory DFB, by resolving each DFB's named
-// TensorParameter to the corresponding MeshTensor passed in tensor_args and extracting its
+// TensorParameter to the corresponding MeshTensor passed in tensor_arguments and extracting its
 // MeshBuffer's reference buffer. Under the lockstep mesh allocation invariant, any one of the
 // per-device buffers is a valid representative — same convention used by dynamic CB via
 // `MeshTensor::mesh_buffer().get_reference_buffer()`.
@@ -266,18 +267,18 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
 //     MeshTensor, validate it, and hand it to the device-side DFB.
 //   - Re-entry (a subsequent run-params call with a different MeshTensor) just re-attaches.
 //
-// Pre-condition: ValidateTensorArgs has enforced that every declared TensorParameter
-// has a corresponding TensorArg, so the lookup below cannot miss for any registered binding.
+// Pre-condition: ValidateTensorArguments has enforced that every declared TensorParameter
+// has a corresponding TensorArgument, so the lookup below cannot miss for any registered binding.
 void AttachBorrowedDFBBuffers(
-    detail::ProgramImpl& program_impl, std::span<const ProgramRunParams::TensorArg> tensor_args) {
+    detail::ProgramImpl& program_impl, std::span<const ProgramRunParams::TensorArgument> tensor_arguments) {
     const auto& borrowed_bindings = program_impl.get_dfb_borrowed_bindings();
     if (borrowed_bindings.empty()) {
         return;
     }
 
     std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
-    tensor_by_param.reserve(tensor_args.size());
-    for (const auto& tensor_params : tensor_args) {
+    tensor_by_param.reserve(tensor_arguments.size());
+    for (const auto& tensor_params : tensor_arguments) {
         tensor_by_param.emplace(tensor_params.tensor_parameter_name, &tensor_params.tensor.get());
     }
 
@@ -285,7 +286,7 @@ void AttachBorrowedDFBBuffers(
         auto it = tensor_by_param.find(tp_name);
         TT_FATAL(
             it != tensor_by_param.end(),
-            "Internal error: DFB id {} borrows from TensorParameter '{}' but no TensorArg supplied it (validation "
+            "Internal error: DFB id {} borrows from TensorParameter '{}' but no TensorArgument supplied it (validation "
             "should have caught this).",
             dfb_id,
             tp_name);
@@ -329,7 +330,7 @@ void AttachBorrowedDFBBuffers(
 }
 
 // ============================================================================
-// PUBLIC ENTRY POINTS: SetProgramRunParameters + UpdateTensorArgs + GetProgramRunParamsView
+// PUBLIC ENTRY POINTS: SetProgramRunParameters + UpdateTensorArguments + GetProgramRunParamsView
 // ============================================================================
 
 void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
@@ -340,12 +341,12 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
     detail::ProgramImpl& program_impl = program.impl();
 
-    // Build a tensor_parameter_name -> base address lookup from the user's TensorArg entries.
+    // Build a tensor_parameter_name -> base address lookup from the user's TensorArgument entries.
     // Used below to fill the kernel's TensorBinding address section from MeshTensor::address().
     // NOTE: We assume lockstep mesh allocation, so a device-independent, single uint32_t per binding.
     std::unordered_map<std::string, uint32_t> ta_binding_addresses;
-    ta_binding_addresses.reserve(params.tensor_args.size());
-    for (const auto& tensor_params : params.tensor_args) {
+    ta_binding_addresses.reserve(params.tensor_arguments.size());
+    for (const auto& tensor_params : params.tensor_arguments) {
         const auto address = tensor_params.tensor.get().address();
         TT_FATAL(
             address <= std::numeric_limits<uint32_t>::max(),
@@ -425,7 +426,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
         // Assemble the kernel's per-enqueue CRTA buffer in three structurally-separate sections:
         //   1. User-named CRTAs, in schema order, sourced from common_runtime_args.
-        //   2. TensorBinding addresses, in binding-handle order, sourced from TensorArg via the
+        //   2. TensorBinding addresses, in binding-handle order, sourced from TensorArgument via the
         //      ta_binding_addresses map. Each handle's addr_crta_offset (computed at spec
         //      resolution as (num_user_crtas + binding_index) * 4) lines up with the slot
         //      position chosen here.
@@ -482,14 +483,14 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
     // Process DFB runtime parameters:
     //   - Borrowed-memory DFB backing L1 Buffer*
     //   - Later, add DFB size overrides (not yet implemented)
-    AttachBorrowedDFBBuffers(program_impl, params.tensor_args);
+    AttachBorrowedDFBBuffers(program_impl, params.tensor_arguments);
 }
 
-void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args) {
+void UpdateTensorArguments(Program& program, std::span<const ProgramRunParams::TensorArgument> tensor_arguments) {
     log_debug(tt::LogMetal, "Updating tensor args (partial fast-path)");
 
-    // Validate the TensorArg list (shared with the full-path validator).
-    ValidateTensorArgs(program, tensor_args);
+    // Validate the TensorArgument list (shared with the full-path validator).
+    ValidateTensorArguments(program, tensor_arguments);
 
     detail::ProgramImpl& program_impl = program.impl();
 
@@ -497,8 +498,8 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::Tensor
     // As in SetProgramRunParameters, this assumes lockstep mesh allocation:
     // a single device-independent uint32_t address per binding.
     std::unordered_map<std::string, uint32_t> ta_binding_addresses;
-    ta_binding_addresses.reserve(tensor_args.size());
-    for (const auto& tensor_params : tensor_args) {
+    ta_binding_addresses.reserve(tensor_arguments.size());
+    for (const auto& tensor_params : tensor_arguments) {
         const auto address = tensor_params.tensor.get().address();
         TT_FATAL(
             address <= std::numeric_limits<uint32_t>::max(),
@@ -523,7 +524,7 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::Tensor
         // populate this kernel's CRTA buffer. Without it, there is no buffer to patch into.
         TT_FATAL(
             !kernel->common_runtime_args().empty(),
-            "UpdateTensorArgs called on Program before SetProgramRunParameters: kernel '{}' has tensor "
+            "UpdateTensorArguments called on Program before SetProgramRunParameters: kernel '{}' has tensor "
             "bindings but its CRTA buffer has not been allocated. Call SetProgramRunParameters at least "
             "once first.",
             kernel_name);
@@ -543,7 +544,7 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::Tensor
     }
 
     // Process DFB runtime parameters to update borrowed-memory DFB backing L1 Buffer*s.
-    AttachBorrowedDFBBuffers(program_impl, tensor_args);
+    AttachBorrowedDFBBuffers(program_impl, tensor_arguments);
 }
 
 ProgramRunParamsView& GetProgramRunParamsView(Program& program) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -325,10 +325,8 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 
             if (dfb_binding.endpoint_type == KernelSpec::DFBEndpointType::PRODUCER) {
                 endpoint_info.producers.push_back({&kernel, &dfb_binding});
-            } else if (dfb_binding.endpoint_type == KernelSpec::DFBEndpointType::CONSUMER) {
-                endpoint_info.consumers.push_back({&kernel, &dfb_binding});
             } else {
-                TT_FATAL(false, "RELAY endpoints are only used for remote DFB, which is not supported yet");
+                endpoint_info.consumers.push_back({&kernel, &dfb_binding});
             }
         }
     }
@@ -671,20 +669,19 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
             // Both Gen1 and Gen2 configs are optional. But at least one must be specified.
             TT_FATAL(
-                data_movement_config.gen1_data_movement_config.has_value() ||
-                    data_movement_config.gen2_data_movement_config.has_value(),
+                data_movement_config.gen1.has_value() || data_movement_config.gen2.has_value(),
                 "KernelSpec '{}' must specify a DM config for Gen1, Gen2, or both.",
                 kernel.unique_id);
 
             // The config for the current target architecture must be specified.
             if (is_gen2_arch()) {
                 TT_FATAL(
-                    data_movement_config.gen2_data_movement_config.has_value(),
+                    data_movement_config.gen2.has_value(),
                     "KernelSpec '{}' must specify a Gen2 DM config when targeting Quasar.",
                     kernel.unique_id);
             } else if (is_gen1_arch()) {
                 TT_FATAL(
-                    data_movement_config.gen1_data_movement_config.has_value(),
+                    data_movement_config.gen1.has_value(),
                     "KernelSpec '{}' must specify a Gen1 DM config when targeting WH or BH.",
                     kernel.unique_id);
             } else {
@@ -703,7 +700,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 continue;
             }
             const auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
-            const auto& gen1 = dm_config.gen1_data_movement_config.value();
+            const auto& gen1 = dm_config.gen1.value();
             const NodeRangeSet& nodes = collected.kernel_node_set.at(kernel.unique_id);
             for (const auto& range : nodes.ranges()) {
                 for (const auto& node : range) {
@@ -1662,7 +1659,7 @@ KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const Collec
     return result;
 }
 
-// Gen1 (WH/BH) processor assignment: just read the explicit processor from Gen1DataMovementConfig
+// Gen1 (WH/BH) processor assignment: just read the explicit processor from Gen1
 // and returns a KernelRiscMaskMap using the Gen1 bit encoding (RISCV_0: bit 0, RISCV_1: bit 1, compute: bit 2).
 KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
     static constexpr uint8_t GEN1_COMPUTE_RISC_BIT = 2;
@@ -1671,7 +1668,7 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
     for (const KernelSpec& kernel : spec.kernels) {
         if (kernel.is_dm_kernel()) {
             const auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
-            const auto& gen1 = dm_config.gen1_data_movement_config.value();
+            const auto& gen1 = dm_config.gen1.value();
             result[&kernel] = static_cast<uint16_t>(1u << static_cast<uint8_t>(gen1.processor));
         } else {
             result[&kernel] = static_cast<uint16_t>(1u << GEN1_COMPUTE_RISC_BIT);
@@ -1936,10 +1933,10 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         .entry_size = dfb_spec->entry_size,
         .num_entries = dfb_spec->num_entries,
         .producer_risc_mask = producer_risc_mask,
-        .num_producers = producer->num_threads,
+        .num_producers = static_cast<uint8_t>(producer->num_threads),
         .pap = producer_access_pattern,
         .consumer_risc_mask = consumer_risc_mask,
-        .num_consumers = consumer->num_threads,
+        .num_consumers = static_cast<uint8_t>(consumer->num_threads),
         .cap = consumer_access_pattern,
         .enable_implicit_sync = !dfb_spec->disable_implicit_sync,
         .data_format = dfb_spec->data_format_metadata.value_or(tt::DataFormat::Invalid),
@@ -1958,9 +1955,9 @@ KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
     return std::visit(
         [&](const auto& src) -> KernelSource {
             using T = std::decay_t<decltype(src)>;
-            if constexpr (std::is_same_v<T, KernelSpec::SourceFilePath>) {
-                TT_FATAL(!src.path.empty(), "KernelSpec '{}' has empty source file path", kernel_spec.unique_id);
-                return KernelSource(src.path.string(), KernelSource::SourceType::FILE_PATH);
+            if constexpr (std::is_same_v<T, std::filesystem::path>) {
+                TT_FATAL(!src.empty(), "KernelSpec '{}' has empty source file path", kernel_spec.unique_id);
+                return KernelSource(src.string(), KernelSource::SourceType::FILE_PATH);
             } else if constexpr (std::is_same_v<T, KernelSpec::SourceCode>) {
                 TT_FATAL(!src.code.empty(), "KernelSpec '{}' has empty inline source code", kernel_spec.unique_id);
                 return KernelSource(src.code, KernelSource::SourceType::SOURCE_CODE);
@@ -1991,7 +1988,7 @@ std::map<std::string, std::string> to_defines_map(const KernelSpec::CompilerOpti
 DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
     const auto& dm_config = std::get<DataMovementConfiguration>(kernel_spec.config_spec);
-    const auto& gen1 = dm_config.gen1_data_movement_config.value();
+    const auto& gen1 = dm_config.gen1.value();
 
     return DataMovementConfig{
         .processor = gen1.processor,
@@ -2079,7 +2076,7 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(cons
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
 
     return experimental::quasar::QuasarDataMovementConfig{
-        .num_threads_per_cluster = kernel_spec.num_threads,
+        .num_threads_per_cluster = static_cast<uint32_t>(kernel_spec.num_threads),
         .compile_args = {},  // only named_compile_args is used
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
@@ -2102,7 +2099,7 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         BuildUnpackToDestModeVector(compute_config.unpack_to_dest_mode, dfb_name_to_id);
 
     return experimental::quasar::QuasarComputeConfig{
-        .num_threads_per_cluster = kernel_spec.num_threads,
+        .num_threads_per_cluster = static_cast<uint32_t>(kernel_spec.num_threads),
         .math_fidelity = compute_config.math_fidelity,
         .fp32_dest_acc_en = compute_config.fp32_dest_acc_en,
         .dst_full_sync_en = compute_config.dst_full_sync_en,
@@ -2177,7 +2174,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
     // Step 2a: Build kernel risc masks (arch-specific)
     //  - Gen2: backtracking solver assigns DM cores automatically
-    //  - Gen1: processor is user-specified in Gen1DataMovementConfig
+    //  - Gen1: processor is user-specified in Gen1
     KernelRiscMaskMap kernel_to_risc_mask =
         is_gen2_arch() ? SolveGen2KernelRiscMasks(spec, collected) : BuildGen1KernelRiscMasks(spec);
 
@@ -2187,7 +2184,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     // time (deliberately not done here).
     //
     // Gen1: the mask is a deterministic function of the user's KernelSpec config_spec (compute
-    //   placement is fixed; DM processor is user-specified via Gen1DataMovementConfig). A
+    //   placement is fixed; DM processor is user-specified via Gen1). A
     //   mismatch is therefore a user error — the user supplied multi-binding KernelSpecs with
     //   incompatible processor placement.
     // Gen2 (Quasar): the mask is solver-assigned. The solver currently doesn't know about
@@ -2237,7 +2234,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                         "DFB '{}' has multiple {} KernelSpecs ('{}', '{}') with mismatched "
                         "processor placement (risc_mask 0x{:x} vs 0x{:x}). Multi-binding "
                         "requires all same-role kernels to share processor placement (for DM "
-                        "kernels, check Gen1DataMovementConfig::processor; for compute, the "
+                        "kernels, check Gen1::processor; for compute, the "
                         "placement is determined by the KernelSpec's config_spec type).",
                         dfb.unique_id,
                         role,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -606,13 +606,13 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 it->second,
                 kind);
         };
-        for (const auto& name : kernel.runtime_arguments_schema.named_runtime_args) {
+        for (const auto& name : kernel.runtime_arguments_schema.runtime_args) {
             check_name(name, "named RTA");
         }
-        for (const auto& name : kernel.runtime_arguments_schema.named_common_runtime_args) {
+        for (const auto& name : kernel.runtime_arguments_schema.common_runtime_args) {
             check_name(name, "named CRTA");
         }
-        for (const auto& [name, value] : kernel.compile_time_arg_bindings) {
+        for (const auto& [name, value] : kernel.compile_time_args) {
             (void)value;
             check_name(name, "named CTA");
         }
@@ -1977,8 +1977,7 @@ KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
 // This is deliberate, done so ProgramSpec stays hashable for TTNN's program caching.
 // For now, just convert to the map types that the core runtime expects.
 // TODO: Fix this inefficiency eventually.
-std::unordered_map<std::string, uint32_t> to_named_compile_args_map(
-    const KernelSpec::CompileTimeArgBindings& bindings) {
+std::unordered_map<std::string, uint32_t> to_named_compile_args_map(const KernelSpec::CompileTimeArgs& bindings) {
     return std::unordered_map<std::string, uint32_t>(bindings.begin(), bindings.end());
 }
 std::map<std::string, std::string> to_defines_map(const KernelSpec::CompilerOptions::Defines& defines) {
@@ -1996,7 +1995,7 @@ DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
         .noc_mode = gen1.noc_mode,
         .compile_args = {},  // only named_compile_args is used
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
-        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),
         .opt_level = kernel_spec.compiler_options.opt_level,
         .compiler_include_paths = kernel_spec.compiler_options.include_paths,
     };
@@ -2062,7 +2061,7 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         .math_approx_mode = compute_config.math_approx_mode,
         .compile_args = {},  // only named_compile_args is used
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
-        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),
         .opt_level = kernel_spec.compiler_options.opt_level,
         .compiler_include_paths = kernel_spec.compiler_options.include_paths,
     };
@@ -2079,7 +2078,7 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(cons
         .num_threads_per_cluster = static_cast<uint32_t>(kernel_spec.num_threads),
         .compile_args = {},  // only named_compile_args is used
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
-        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),
         .is_legacy_kernel = false,
         .opt_level = kernel_spec.compiler_options.opt_level,
         .compiler_include_paths = kernel_spec.compiler_options.include_paths,
@@ -2108,7 +2107,7 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         .math_approx_mode = compute_config.math_approx_mode,
         .compile_args = {},  // Compile args are passed via named_compile_args
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
-        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),
         .opt_level = kernel_spec.compiler_options.opt_level,
         .compiler_include_paths = kernel_spec.compiler_options.include_paths,
     };
@@ -2350,7 +2349,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // Resolve TensorBindings for this kernel:
         //  - pack each binding's pre-resolved CTA payload into the kernel's positional CTA buffer
         //  - assign each binding a slot in the kernel's CRTA buffer (TensorBinding address section)
-        const auto& user_named_crtas = kernel_spec.runtime_arguments_schema.named_common_runtime_args;
+        const auto& user_named_crtas = kernel_spec.runtime_arguments_schema.common_runtime_args;
         TensorBindingsForKernel ta_bindings = ResolveTensorBindingsForKernel(
             kernel_spec, resolved_binding_ctas, /*base_named_crta_count=*/user_named_crtas.size());
 
@@ -2361,7 +2360,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // emit kernel_args_generated.h and factor into the kernel cache key. The TensorBinding
         // address section is tracked separately (via tensor_binding_handles), so we pass the user
         // CRTA list through unchanged.
-        const auto& named_rtas = kernel_spec.runtime_arguments_schema.named_runtime_args;
+        const auto& named_rtas = kernel_spec.runtime_arguments_schema.runtime_args;
 
         // Create the kernel object
         std::shared_ptr<Kernel> kernel;
@@ -2451,7 +2450,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // Overlapping override entries (two entries covering the same node) are an error.
         const auto& user_schema = kernel_spec.runtime_arguments_schema;
         detail::ProgramImpl::KernelRTASchema runtime_schema;
-        runtime_schema.named_runtime_args = user_schema.named_runtime_args;
+        runtime_schema.named_runtime_args = user_schema.runtime_args;
 
         // Pass the user CRTA list through.
         // NOTE: The TensorBinding address section is tracked separately on the Kernel

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -30,7 +30,7 @@
 #include <core_descriptor.hpp>
 #include <llrt/tt_cluster.hpp>
 
-namespace tt::tt_metal::experimental::metal2_host_api {
+namespace tt::tt_metal::experimental {
 
 // ============================================================================
 // Constants
@@ -2496,4 +2496,4 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     return Program(std::move(program_impl));
 }
 
-}  // namespace tt::tt_metal::experimental::metal2_host_api
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -152,7 +152,7 @@ inline bool is_gen1_arch() {
     return arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE;
 }
 
-NodeRangeSet to_node_range_set(const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes) {
+NodeRangeSet to_node_range_set(const Nodes& nodes) {
     return std::visit(
         [](const auto& n) -> NodeRangeSet {
             using T = std::decay_t<decltype(n)>;
@@ -168,9 +168,7 @@ NodeRangeSet to_node_range_set(const std::variant<NodeCoord, NodeRange, NodeRang
         nodes);
 }
 
-bool nodes_intersect(
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& a,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& b) {
+bool nodes_intersect(const Nodes& a, const Nodes& b) {
     NodeRangeSet a_set = to_node_range_set(a);
     NodeRangeSet b_set = to_node_range_set(b);
     return a_set.intersects(b_set);
@@ -513,7 +511,7 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
     // No need for dispatch-specific checks (and dispatch-specific error messages confuse users)
     const CoreCoord compute_grid = tt::get_compute_grid_size(env_impl, chip_id, num_hw_cqs, dispatch_core_config);
 
-    auto check_target_nodes = [&](const std::variant<NodeCoord, NodeRange, NodeRangeSet>& target_nodes,
+    auto check_target_nodes = [&](const Nodes& target_nodes,
                                   std::string_view entity_type,
                                   std::string_view entity_name) {
         const NodeRangeSet range_set = to_node_range_set(target_nodes);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -424,15 +424,6 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
             tensor_parameter.unique_id);
     }
 
-    // Check for duplicate WorkUnitSpec unique_ids
-    {
-        std::unordered_set<WorkUnitSpecName> work_unit_names;
-        for (const auto& work_unit : spec.work_units) {
-            auto [it, inserted] = work_unit_names.insert(work_unit.unique_id);
-            TT_FATAL(inserted, "Duplicate WorkUnitSpec name '{}'", work_unit.unique_id);
-        }
-    }
-
     // Build WorkUnitSpec membership for each kernel, validating references along the way.
     // A kernel may belong to multiple WorkUnitSpecs; its effective target node set is the union.
     for (const auto& work_unit : spec.work_units) {
@@ -440,7 +431,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
             TT_FATAL(
                 collected.kernel_by_name.contains(kernel_name),
                 "WorkUnitSpec '{}' references unknown kernel '{}'",
-                work_unit.unique_id,
+                work_unit.name,
                 kernel_name);
             collected.kernel_work_units[kernel_name].push_back(&work_unit);
         }
@@ -543,7 +534,7 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
     };
 
     for (const auto& work_unit : spec.work_units) {
-        check_target_nodes(work_unit.target_nodes, "WorkUnitSpec", work_unit.unique_id);
+        check_target_nodes(work_unit.target_nodes, "WorkUnitSpec", work_unit.name);
     }
     for (const auto& sem : spec.semaphores) {
         check_target_nodes(sem.target_nodes, "SemaphoreSpec", sem.unique_id);
@@ -855,7 +846,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 TT_THROW(
                     "ProgramSpec '{}' has too many DataflowBufferSpecs ({}). The target "
                     "architecture supports up to {}.",
-                    spec.program_id,
+                    spec.name,
                     spec.dataflow_buffers.size(),
                     max_dfbs);
             } else if (is_gen2_arch()) {
@@ -863,7 +854,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     "ProgramSpec '{}' has too many DataflowBufferSpecs ({}). The permitted "
                     "number of DFBs for the target architecture is configuration-dependent, "
                     "but {} is a hard upper limit.",
-                    spec.program_id,
+                    spec.name,
                     spec.dataflow_buffers.size(),
                     max_dfbs);
             } else {
@@ -958,7 +949,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                         "prior {} binding). Same-role bindings must have pairwise-disjoint WorkUnitSpec membership.",
                         dfb.unique_id,
                         role,
-                        wu->unique_id,
+                        wu->name,
                         rec.kernel->unique_id,
                         role);
                 }
@@ -1051,7 +1042,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         spec.remote_dataflow_buffers.empty(),
         "RemoteDataflowBufferSpec is part of the Metal 2.0 API surface but is not yet supported "
         "by the runtime. (ProgramSpec '{}' has {} remote DFB(s).)",
-        spec.program_id,
+        spec.name,
         spec.remote_dataflow_buffers.size());
 
     // Validate borrowed-memory DFBs.
@@ -1304,22 +1295,19 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // WorkUnitSpecs may not overlap in their target nodes
     for (const auto& work_unit : work_units) {
         for (const auto& other_work_unit : work_units) {
-            if (work_unit.unique_id == other_work_unit.unique_id) {
+            if (work_unit.name == other_work_unit.name) {
                 continue;
             }
             if (nodes_intersect(work_unit.target_nodes, other_work_unit.target_nodes)) {
                 TT_FATAL(
-                    false,
-                    "WorkUnitSpecs '{}' and '{}' overlap in target nodes",
-                    work_unit.unique_id,
-                    other_work_unit.unique_id);
+                    false, "WorkUnitSpecs '{}' and '{}' overlap in target nodes", work_unit.name, other_work_unit.name);
             }
         }
     }
 
     // A WorkUnitSpec must have at least one kernel
     for (const auto& work_unit : work_units) {
-        TT_FATAL(!work_unit.kernels.empty(), "WorkUnitSpec '{}' has no kernels", work_unit.unique_id);
+        TT_FATAL(!work_unit.kernels.empty(), "WorkUnitSpec '{}' has no kernels", work_unit.name);
     }
 
     // Does the WorkUnit have enough cores to run all of its kernels?
@@ -1339,13 +1327,13 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             TT_FATAL(
                 compute_engines_needed <= QUASAR_TENSIX_ENGINES_PER_NODE,
                 "WorkUnitSpec '{}' needs {} Tensix engines, but only {} are available",
-                work_unit.unique_id,
+                work_unit.name,
                 compute_engines_needed,
                 QUASAR_TENSIX_ENGINES_PER_NODE);
             TT_FATAL(
                 dm_cores_needed <= QUASAR_USER_DM_CORES_PER_NODE,
                 "WorkUnitSpec '{}' requests {} data movement cores. This exceeds the permitted maximum of {}.",
-                work_unit.unique_id,
+                work_unit.name,
                 dm_cores_needed,
                 QUASAR_USER_DM_CORES_PER_NODE);
         }
@@ -1353,12 +1341,12 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             TT_FATAL(
                 compute_engines_needed <= 1,
                 "WorkUnitSpec '{}' has {} compute kernels. The target architecture supports at most one.",
-                work_unit.unique_id,
+                work_unit.name,
                 compute_engines_needed);
             TT_FATAL(
                 dm_cores_needed <= 2,
                 "WorkUnitSpec '{}' has {} data movement kernels. The target architecture supports at most two.",
-                work_unit.unique_id,
+                work_unit.name,
                 dm_cores_needed);
         }
     }
@@ -1372,7 +1360,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 num_compute_kernels++;
             }
         }
-        TT_FATAL(num_compute_kernels <= 1, "WorkUnitSpec '{}' has more than one compute kernel", work_unit.unique_id);
+        TT_FATAL(num_compute_kernels <= 1, "WorkUnitSpec '{}' has more than one compute kernel", work_unit.name);
     }
 
     // NOTE:
@@ -1420,7 +1408,7 @@ std::pair<DMProcessorMask, DMProcessorMask> ReserveDMProcessors(
     const KernelSpec* kernel_spec,
     std::optional<DMProcessorMask> existing_mask,
     DMProcessorMask cumulative_mask,
-    const WorkUnitSpecName& work_unit_id) {
+    const std::string& work_unit_name) {
     // Was this kernel already assigned a mask from a previous WorkUnitSpec?
     if (existing_mask.has_value()) {
         DMProcessorMask existing = existing_mask.value();
@@ -1434,7 +1422,7 @@ std::pair<DMProcessorMask, DMProcessorMask> ReserveDMProcessors(
             " - A solution exists, but the greedy algorithm failed to find it. \n"
             " - The runtime's \"common DM cores\" assumption has been violated!",
             kernel_spec->unique_id,
-            work_unit_id);
+            work_unit_name);
 
         // Return existing mask and updated cumulative
         return {existing, cumulative_mask | existing};
@@ -1447,7 +1435,7 @@ std::pair<DMProcessorMask, DMProcessorMask> ReserveDMProcessors(
         "Failed to reserve processors for DM kernel '{}' on WorkUnitSpec '{}'. "
         "The \"common DM cores\" assumption has been violated!",
         kernel_spec->unique_id,
-        work_unit_id);
+        work_unit_name);
 
     DMProcessorMask mask = reserved.value();
     return {mask, cumulative_mask | mask};
@@ -2154,7 +2142,7 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
 // ============================================================================
 
 Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
-    log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.program_id);
+    log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.name);
 
     // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)
     CollectedSpecData collected = CollectSpecData(spec);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1046,7 +1046,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate borrowed-memory DFBs.
     //
     // A borrowed-memory DFB names a TensorParameter via DataflowBufferSpec::borrowed_from. The
-    // backing MeshTensor flows through ProgramRunParams::tensor_args at execution time.
+    // backing MeshTensor flows through ProgramRunParams::tensor_arguments at execution time.
     // We enforce only the safety-relevant checks:
     //  - the named parameter exists
     //  - the TensorSpec places storage in L1,
@@ -1674,7 +1674,7 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
 //    (packed two-per-uint32)
 //
 // All the TensorAccessorArgs data are static (CTAs) for now.
-// The tensor base address is specified per-enqueue, via TensorArg on ProgramRunParams.
+// The tensor base address is specified per-enqueue, via TensorArgument on ProgramRunParams.
 // (See also ResolveTensorBindingsForKernel below).
 std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
     const TensorParameter& tensor_parameter, const distributed::MeshDevice& mesh_device) {
@@ -2234,7 +2234,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     //     CTA buffer. (Empty in Metal 2.0 today; the binding payload is its first user.)
     //   - Per-enqueue base address flows through a reserved-prefix named CRTA, appended to
     //     the kernel's user-named CRTAs and filled by SetProgramRunParameters from the
-    //     corresponding TensorArg entry.
+    //     corresponding TensorArgument entry.
     std::unordered_map<TensorParameterName, std::vector<uint32_t>> resolved_binding_ctas;
     resolved_binding_ctas.reserve(spec.tensor_parameters.size());
     for (const auto& tensor_parameter : spec.tensor_parameters) {
@@ -2269,7 +2269,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         dfb_name_to_id[dfb_name] = dfb_id;
 
         // Borrowed-memory DFB: record the dfb_id ↔ TensorParameterName binding so that
-        // SetProgramRunParameters / UpdateTensorArgs can resolve and attach the actual L1 Buffer
+        // SetProgramRunParameters / UpdateTensorArguments can resolve and attach the actual L1 Buffer
         // at runtime (analog of dynamic CB's UpdateDynamicCircularBufferAddress).
         if (dfb_spec.borrowed_from.has_value()) {
             program_impl->register_dfb_borrowed_binding(dfb_id, *dfb_spec.borrowed_from);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -667,24 +667,17 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (kernel.is_dm_kernel()) {
             const auto& data_movement_config = std::get<DataMovementConfiguration>(kernel.config_spec);
 
-            // Both Gen1 and Gen2 configs are optional. But at least one must be specified.
-            TT_FATAL(
-                data_movement_config.gen1.has_value() || data_movement_config.gen2.has_value(),
-                "KernelSpec '{}' must specify a DM config for Gen1, Gen2, or both.",
-                kernel.unique_id);
-
-            // The config for the current target architecture must be specified.
-            if (is_gen2_arch()) {
-                TT_FATAL(
-                    data_movement_config.gen2.has_value(),
-                    "KernelSpec '{}' must specify a Gen2 DM config when targeting Quasar.",
-                    kernel.unique_id);
-            } else if (is_gen1_arch()) {
+            // Both Gen1 and Gen2 configs are optional.
+            // - Gen1: required when targeting WH/BH (Gen1 needs explicit processor/NOC).
+            // - Gen2: not required (Gen2 has no required configuration). The Gen2 sub-struct
+            //   may still be set explicitly as documentation of intent, or to specify any
+            //   future Gen2-specific options.
+            if (is_gen1_arch()) {
                 TT_FATAL(
                     data_movement_config.gen1.has_value(),
                     "KernelSpec '{}' must specify a Gen1 DM config when targeting WH or BH.",
                     kernel.unique_id);
-            } else {
+            } else if (!is_gen2_arch()) {
                 TT_FATAL(false, "Unknown architecture");
             }
         }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -134,7 +134,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     //       Legacy kernels passed semaphores both ways, kernel folks think this was more random than intentional.
     //
     //       TensorBindings are the first accessor category to use implicit CRTAs (for the tensor base address).
-    //       Each binding's tensor base address is specified per-enqueue, from the corresponding TensorArg.
+    //       Each binding's tensor base address is specified per-enqueue, from the corresponding TensorArgument.
     //       The static layout tensor metadata (rank, shape, bank coords, etc.) comes in through positional CTAs,
     //       added automatically by the Metal 2.0 host API machinery.
     ostringstream content;

--- a/tt_metal/programming_examples/profiler/test_realtime_profiler_csv/test_realtime_profiler_csv.cpp
+++ b/tt_metal/programming_examples/profiler/test_realtime_profiler_csv/test_realtime_profiler_csv.cpp
@@ -38,7 +38,7 @@ static void WriteRealtimeRecordToCsv(const tt::tt_metal::experimental::ProgramRe
 
     fmt::print(
         "realtime record: id={} chip_id={} start={} end={} duration_cycles={} duration_ns={:.2f}\n",
-        record.program_id,
+        record.name,
         record.chip_id,
         record.start_timestamp,
         record.end_timestamp,
@@ -75,9 +75,8 @@ static void WriteRealtimeRecordToCsv(const tt::tt_metal::experimental::ProgramRe
                    << "kernel_sources\n";
         g_csv_header_written = true;
     }
-    g_csv_file << record.program_id << "," << record.chip_id << "," << record.start_timestamp << ","
-               << record.end_timestamp << "," << duration_cycles << "," << duration_ns << "," << record.frequency << ","
-               << escaped << "\n";
+    g_csv_file << record.name << "," << record.chip_id << "," << record.start_timestamp << "," << record.end_timestamp
+               << "," << duration_cycles << "," << duration_ns << "," << record.frequency << "," << escaped << "\n";
     g_csv_file.flush();
 }
 

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -58,6 +58,8 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/lightmetal/lightmetal_capture_utils.hpp
     api/tt-metalium/experimental/lightmetal/lightmetal_replay.hpp
     api/tt-metalium/experimental/mesh_program_descriptor.hpp
+    api/tt-metalium/experimental/metal2_host_api/compute_configuration.hpp
+    api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
     api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/node_coord.hpp

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -589,8 +589,8 @@ public:
     // -----------------------------------------------------------------------
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
-        using TensorParameterName = tt::tt_metal::experimental::metal2_host_api::TensorParameterName;
-        using TensorArg = tt::tt_metal::experimental::metal2_host_api::ProgramRunParams::TensorArg;
+        using TensorParameterName = tt::tt_metal::experimental::TensorParameterName;
+        using TensorArg = tt::tt_metal::experimental::ProgramRunParams::TensorArg;
 
         // Stored across cache entries: for each TensorArg in a program's
         // ProgramRunParams, which io_tensor (by index into the deterministic
@@ -683,9 +683,8 @@ public:
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
-                auto program =
-                    tt::tt_metal::experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                tt::tt_metal::experimental::metal2_host_api::SetProgramRunParameters(program, artifacts.run_params);
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunParameters(program, artifacts.run_params);
                 shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
                 mesh_workload.add_program(range, std::move(program));
             }
@@ -711,7 +710,7 @@ public:
                     fresh_tensor_args.push_back(TensorArg{
                         .tensor_parameter_name = b.tensor_parameter_name, .tensor = io_mesh_tensors[b.io_tensor_idx]});
                 }
-                tt::tt_metal::experimental::metal2_host_api::UpdateTensorArgs(program, fresh_tensor_args);
+                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
             }
         }
     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -168,18 +168,18 @@ private:
     struct DirectDescriptorFactory {
         static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& attrs,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value,
             const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt) {
             if constexpr (requires {
                               DeviceOperation::create_descriptor(
-                                  attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                                  attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
                           }) {
                 return DeviceOperation::create_descriptor(
-                    attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                    attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
             } else {
                 (void)mesh_dispatch_coordinate;
-                return DeviceOperation::create_descriptor(attrs, tensor_args, tensor_return_value);
+                return DeviceOperation::create_descriptor(attrs, tensor_arguments, tensor_return_value);
             }
         }
     };
@@ -202,11 +202,11 @@ public:
         "DeviceOperation must implement select_program_factory when program_factory_t has more than one type.");
 
     static program_factory_t select_program_factory(
-        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_arguments) {
         if constexpr (HasDirectDescriptor<DeviceOperation>) {
             return program_factory_t{DirectDescriptorFactory{}};
         } else if constexpr (HasSelectProgramFactory<DeviceOperation>) {
-            return DeviceOperation::select_program_factory(attrs, tensor_args);
+            return DeviceOperation::select_program_factory(attrs, tensor_arguments);
         } else {
             return program_factory_t{std::variant_alternative_t<0, program_factory_t>{}};
         }
@@ -223,35 +223,37 @@ public:
         return std::string(ttsl::get_type_name<device_operation_t>());
     }
 
-    static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_arguments) {
         if constexpr (HasValidateOnProgramCacheHit<DeviceOperation>) {
-            DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
+            DeviceOperation::validate_on_program_cache_hit(attrs, tensor_arguments);
         } else {
-            DeviceOperation::validate_on_program_cache_miss(attrs, tensor_args);
+            DeviceOperation::validate_on_program_cache_miss(attrs, tensor_arguments);
         }
     }
 
-    static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        DeviceOperation::validate_on_program_cache_miss(attrs, tensor_args);
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_arguments) {
+        DeviceOperation::validate_on_program_cache_miss(attrs, tensor_arguments);
     }
 
     static spec_return_value_t compute_output_specs(
-        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        return DeviceOperation::compute_output_specs(attrs, tensor_args);
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_arguments) {
+        return DeviceOperation::compute_output_specs(attrs, tensor_arguments);
     }
 
     static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        return DeviceOperation::create_output_tensors(attrs, tensor_args);
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_arguments) {
+        return DeviceOperation::create_output_tensors(attrs, tensor_arguments);
     }
 
     static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            return DeviceOperation::compute_program_hash(attrs, tensor_args);
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_arguments) {
+        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_arguments); }) {
+            return DeviceOperation::compute_program_hash(attrs, tensor_arguments);
         } else {
             return ttsl::hash::hash_objects_with_default_seed(
-                ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+                ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_arguments);
         }
     }
 
@@ -265,14 +267,14 @@ public:
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value) {
             ProgramFactory program_factory;
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
-                auto cached_program = program_factory.create(attrs, tensor_args, tensor_return_value);
+                auto cached_program = program_factory.create(attrs, tensor_arguments, tensor_return_value);
                 mesh_workload.add_program(range, std::move(cached_program.program));
                 shared_variables[range] = std::move(cached_program.shared_variables);
             }
@@ -283,7 +285,7 @@ public:
         static void override_runtime_arguments(
             cached_mesh_workload_t& cached_workload,
             const operation_attributes_t& attrs,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value) {
             ProgramFactory program_factory;
 
@@ -296,7 +298,7 @@ public:
                     shared_variables,
                     attrs,
                     *(coordinate_range.begin()),
-                    tensor_args,
+                    tensor_arguments,
                     tensor_return_value);
             }
         }
@@ -382,7 +384,7 @@ public:
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
-        // Enumerate every Buffer* reachable from `tensor_args`,
+        // Enumerate every Buffer* reachable from `tensor_arguments`,
         // `tensor_return_value`, and the workload descriptor's resource
         // buffers (workload-scoped MeshBuffers exposed via .buffers).  Order is
         // stable: input tensors, then outputs, then workload buffers in their
@@ -395,11 +397,11 @@ public:
         // Returns a stack-allocated SmallVector (16 inline slots) so the
         // cache-hit fast path avoids the heap allocation tax.
         static ttsl::SmallVector<tt::tt_metal::Buffer*, 16> collect_tensor_buffers(
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             const tensor_return_value_t& tensor_return_value,
             const tt::tt_metal::WorkloadDescriptor& workload_descriptor) {
             ttsl::SmallVector<tt::tt_metal::Buffer*, 16> buffers;
-            extract_tensor_buffers_into(tensor_args, buffers);
+            extract_tensor_buffers_into(tensor_arguments, buffers);
             extract_tensor_buffers_into(tensor_return_value, buffers);
             for (const auto& wb : workload_descriptor.buffers) {
                 buffers.push_back(wb.buffer);
@@ -414,20 +416,20 @@ public:
             if constexpr (std::is_same_v<DescriptorFactory, DirectDescriptorFactory>) {
                 return requires(
                     const operation_attributes_t& attrs,
-                    const tensor_args_t& tensor_args,
+                    const tensor_args_t& tensor_arguments,
                     tensor_return_value_t& tensor_return_value,
                     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
                     DeviceOperation::create_descriptor(
-                        attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                        attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
                 };
             } else {
                 return requires(
                     const operation_attributes_t& attrs,
-                    const tensor_args_t& tensor_args,
+                    const tensor_args_t& tensor_arguments,
                     tensor_return_value_t& tensor_return_value,
                     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
                     DescriptorFactory::create_descriptor(
-                        attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                        attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
                 };
             }
         }
@@ -437,25 +439,25 @@ public:
         // this — it iterates `workload_descriptor.programs` directly.
         static tt::tt_metal::ProgramDescriptor invoke_per_coord(
             const operation_attributes_t& attrs,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value,
             const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
             if constexpr (requires {
                               DescriptorFactory::create_descriptor(
-                                  attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                                  attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
                           }) {
                 return DescriptorFactory::create_descriptor(
-                    attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                    attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
             } else {
                 (void)mesh_dispatch_coordinate;
-                return DescriptorFactory::create_descriptor(attrs, tensor_args, tensor_return_value);
+                return DescriptorFactory::create_descriptor(attrs, tensor_arguments, tensor_return_value);
             }
         }
 
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value) {
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
@@ -473,11 +475,12 @@ public:
                 // (semaphores, buffers) and resolved bindings.  The per-coord
                 // ProgramDescriptors have already been consumed into Programs.
                 tt::tt_metal::WorkloadDescriptor workload_descriptor = DescriptorFactory::create_workload_descriptor(
-                    attrs, tensor_args, tensor_return_value, tensor_coords);
+                    attrs, tensor_arguments, tensor_return_value, tensor_coords);
                 auto programs = std::move(workload_descriptor.programs);
                 for (auto& [device_range, desc] : programs) {
                     tt::tt_metal::Program program{desc};
-                    auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value, workload_descriptor);
+                    auto tensor_buffers =
+                        collect_tensor_buffers(tensor_arguments, tensor_return_value, workload_descriptor);
                     auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
@@ -491,10 +494,11 @@ public:
                 const auto build_and_add_program =
                     [&](const ttnn::MeshCoordinateRange& device_range,
                         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-                        auto desc = invoke_per_coord(attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                        auto desc =
+                            invoke_per_coord(attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
                         tt::tt_metal::Program program{desc};
                         auto tensor_buffers =
-                            collect_tensor_buffers(tensor_args, tensor_return_value, empty_descriptor);
+                            collect_tensor_buffers(tensor_arguments, tensor_return_value, empty_descriptor);
                         auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
                         mesh_workload.add_program(device_range, std::move(program));
                         shared_variables[device_range] = shared_variables_t{.resolved_bindings = std::move(resolved)};
@@ -517,7 +521,7 @@ public:
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
             const operation_attributes_t& attrs,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value) {
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 auto& sv = cached_workload.shared_variables.at(coordinate_range);
@@ -531,7 +535,7 @@ public:
                     // `desc.cbs[i].buffer` and declares no rt-arg buffer bindings.
                     if (!sv.resolved_bindings.empty()) {
                         auto current_buffers =
-                            collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
+                            collect_tensor_buffers(tensor_arguments, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
                     }
                 } else {
@@ -544,12 +548,13 @@ public:
                     // through to the slow-path rebuild instead.
                     if (!sv.resolved_bindings.rt_args.empty()) {
                         auto current_buffers =
-                            collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
+                            collect_tensor_buffers(tensor_arguments, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
                     } else {
                         const ttnn::MeshCoordinate mesh_coord = coordinate_range.start_coord();
                         const std::optional<ttnn::MeshCoordinate> mesh_dispatch_coordinate(mesh_coord);
-                        auto desc = invoke_per_coord(attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                        auto desc =
+                            invoke_per_coord(attrs, tensor_arguments, tensor_return_value, mesh_dispatch_coordinate);
                         tt::tt_metal::apply_descriptor_runtime_args(program, desc);
                     }
                 }
@@ -570,16 +575,16 @@ public:
     // On cache miss: the adapter calls create_program_spec, builds one Program
     // per coordinate range via metal2_host_api::MakeProgramFromSpec, applies
     // the initial ProgramRunParams via SetProgramRunParameters, then resolves
-    // each TensorArg against the io_tensors enumerated from tensor_args /
+    // each TensorArgument against the io_tensors enumerated from tensor_arguments /
     // tensor_return_value (pointer-identity match within the call).
     //
     // On cache hit: the adapter enumerates fresh io_tensors, mutates the
-    // cached TensorArg storage in place using the stored index bindings, and
-    // applies via metal2_host_api::UpdateTensorArgs — no Program rebuild,
+    // cached TensorArgument storage in place using the stored index bindings, and
+    // applies via metal2_host_api::UpdateTensorArguments — no Program rebuild,
     // no heap allocation.
     //
-    // Limitation: every TensorArg returned by the factory must reference a
-    // MeshTensor reachable from tensor_args or tensor_return_value.
+    // Limitation: every TensorArgument returned by the factory must reference a
+    // MeshTensor reachable from tensor_arguments or tensor_return_value.
     //
     // TODO: support op-owned resource tensors (the prepare_resources analog
     // from the descriptor adapter) — will require extending shared_variables_t
@@ -590,9 +595,9 @@ public:
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
         using TensorParameterName = tt::tt_metal::experimental::TensorParameterName;
-        using TensorArg = tt::tt_metal::experimental::ProgramRunParams::TensorArg;
+        using TensorArgument = tt::tt_metal::experimental::ProgramRunParams::TensorArgument;
 
-        // Stored across cache entries: for each TensorArg in a program's
+        // Stored across cache entries: for each TensorArgument in a program's
         // ProgramRunParams, which io_tensor (by index into the deterministic
         // reflection-driven enumeration) it was bound to. Pointer identity is
         // only valid within a single call; the index is stable across calls.
@@ -606,36 +611,36 @@ public:
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
-        // Walk tensor_args and tensor_return_value via reflection, collecting
+        // Walk tensor_arguments and tensor_return_value via reflection, collecting
         // the MeshTensor of every Tensor leaf. The walk order is deterministic
         // (reflection-driven, stable across calls), so the resulting indices
         // are stable across calls. Metal 2.0 analog of the descriptor adapter's
         // collect_tensor_buffers, at the MeshTensor level instead of Buffer*.
         static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_mesh_tensors(
-            const tensor_args_t& tensor_args, const tensor_return_value_t& tensor_return_value) {
+            const tensor_args_t& tensor_arguments, const tensor_return_value_t& tensor_return_value) {
             std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> result;
             const auto visit = [&result](const tt::tt_metal::Tensor& t) {
                 result.push_back(std::cref(t.mesh_tensor()));
             };
-            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_args);
+            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_arguments);
             ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_return_value);
             return result;
         }
 
-        // Match each TensorArg's MeshTensor reference back to its index in the
+        // Match each TensorArgument's MeshTensor reference back to its index in the
         // io_tensor enumeration. Cache-miss path only.
-        // TT_FATALs on a TensorArg that doesn't reference an io_tensor (see
+        // TT_FATALs on a TensorArgument that doesn't reference an io_tensor (see
         // adapter-level TODO on op-owned resource tensor support).
         //
         // NOTE on host perf: the index-based binding scheme is what makes a
         // fast cache-hit path possible, but the current straightforward
         // implementation isn't there yet — collect_mesh_tensors returns a
-        // heap std::vector, and apply_descriptor builds a fresh TensorArg
+        // heap std::vector, and apply_descriptor builds a fresh TensorArgument
         // vector each dispatch. Both costs are fixable by mirroring the
         // descriptor adapter's compile-time-unrolled walker + SmallVector +
-        // cached TensorArg storage pattern. Deferred pending profiling.
+        // cached TensorArgument storage pattern. Deferred pending profiling.
         static std::vector<ResolvedTensorBinding> resolve_bindings(
-            const std::vector<TensorArg>& factory_tensor_args,
+            const std::vector<TensorArgument>& factory_tensor_args,
             const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& io_mesh_tensors) {
             std::vector<ResolvedTensorBinding> bindings;
             bindings.reserve(factory_tensor_args.size());
@@ -646,7 +651,7 @@ public:
                 });
                 TT_FATAL(
                     it != io_mesh_tensors.end(),
-                    "TensorArg '{}' must reference a MeshTensor reachable from tensor_args or "
+                    "TensorArgument '{}' must reference a MeshTensor reachable from tensor_arguments or "
                     "tensor_return_value (got non-io_tensor MeshTensor)",
                     tensor_arg.tensor_parameter_name);
                 bindings.push_back(
@@ -659,26 +664,27 @@ public:
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value) {
             // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull from the
-            // first device tensor reachable from tensor_args. Op factories
+            // first device tensor reachable from tensor_arguments. Op factories
             // satisfying this concept are tensor-driven, so first_tensor is
             // always populated for current callers.
-            auto first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_args);
+            auto first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_arguments);
             TT_FATAL(
                 first_tensor.has_value(),
-                "ProgramSpec factory adapter requires at least one Tensor in tensor_args to source the MeshDevice");
+                "ProgramSpec factory adapter requires at least one Tensor in tensor_arguments to source the "
+                "MeshDevice");
             auto* mesh_device = first_tensor.value().device();
-            TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
+            TT_FATAL(mesh_device != nullptr, "First tensor in tensor_arguments must be allocated on a MeshDevice");
 
             // The factory produces a single ProgramArtifacts; the adapter stamps it
             // across all coordinate ranges. Bindings derive from the (single) set of
-            // factory tensor_args and are identical for every stamped program; copy
+            // factory tensor_arguments and are identical for every stamped program; copy
             // per range into the cached shared state.
-            auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+            auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_arguments, tensor_return_value);
+            auto io_mesh_tensors = collect_mesh_tensors(tensor_arguments, tensor_return_value);
+            auto bindings = resolve_bindings(artifacts.run_params.tensor_arguments, io_mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
@@ -699,18 +705,18 @@ public:
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
             const operation_attributes_t& /*attrs*/,
-            const tensor_args_t& tensor_args,
+            const tensor_args_t& tensor_arguments,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            auto io_mesh_tensors = collect_mesh_tensors(tensor_arguments, tensor_return_value);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 const auto& sv = cached_workload.shared_variables.at(coordinate_range);
-                std::vector<TensorArg> fresh_tensor_args;
+                std::vector<TensorArgument> fresh_tensor_args;
                 fresh_tensor_args.reserve(sv.bindings.size());
                 for (const auto& b : sv.bindings) {
-                    fresh_tensor_args.push_back(TensorArg{
+                    fresh_tensor_args.push_back(TensorArgument{
                         .tensor_parameter_name = b.tensor_parameter_name, .tensor = io_mesh_tensors[b.io_tensor_idx]});
                 }
-                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+                tt::tt_metal::experimental::UpdateTensorArguments(program, fresh_tensor_args);
             }
         }
     };
@@ -718,18 +724,19 @@ public:
     static ttsl::hash::hash_t compute_mesh_workload_hash(
         tt::tt_metal::distributed::MeshDevice* mesh_device,
         const operation_attributes_t& attrs,
-        const tensor_args_t& tensor_args) {
+        const tensor_args_t& tensor_arguments) {
         ttsl::hash::hash_t hash;
 
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            hash = DeviceOperation::compute_program_hash(attrs, tensor_args);
+        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_arguments); }) {
+            hash = DeviceOperation::compute_program_hash(attrs, tensor_arguments);
         } else {
-            hash =
-                ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+            hash = ttsl::hash::hash_objects_with_default_seed(
+                ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_arguments);
         }
 
         // Combine with the mesh coordinates the workload is targeting.
-        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
+        for (const auto& coord :
+             mesh_device_operation_utils::extract_tensor_coordinates(tensor_arguments, mesh_device)) {
             hash = ttsl::hash::hash_objects(hash, coord);
         }
         return hash;
@@ -737,19 +744,20 @@ public:
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& attributes,
-        const tensor_args_t& tensor_args,
+        const tensor_args_t& tensor_arguments,
         tensor_return_value_t& tensor_return_value) {
         if constexpr (requires {
-                          device_operation_t::create_op_performance_model(attributes, tensor_args, tensor_return_value);
+                          device_operation_t::create_op_performance_model(
+                              attributes, tensor_arguments, tensor_return_value);
                       }) {
             // Custom Performance Model detected for this Op
-            return device_operation_t::create_op_performance_model(attributes, tensor_args, tensor_return_value);
+            return device_operation_t::create_op_performance_model(attributes, tensor_arguments, tensor_return_value);
         } else {
             // Use generic Op Performance Models
-            if constexpr (requires { tensor_args.input_tensors; }) {
+            if constexpr (requires { tensor_arguments.input_tensors; }) {
                 // tensor_args_t for Op contains input_tensors attribute
                 return tt::tt_metal::operation::OpPerformanceModelGeneral(
-                    tensor_args.input_tensors,
+                    tensor_arguments.input_tensors,
                     tensor_return_value,
                     1 /* ideal_compute_cycles: specify as 1, since op perf model is not provided*/);
             } else {

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -17,8 +17,8 @@ namespace ttnn::device_operation {
 // A future MeshWorkloadSpecFactoryConcept will return a different (multi-program)
 // artifact type for ops whose programs vary across the mesh.
 struct ProgramArtifacts {
-    tt::tt_metal::experimental::metal2_host_api::ProgramSpec spec;
-    tt::tt_metal::experimental::metal2_host_api::ProgramRunParams run_params;
+    tt::tt_metal::experimental::ProgramSpec spec;
+    tt::tt_metal::experimental::ProgramRunParams run_params;
 };
 
 }  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -25,10 +25,10 @@ template <typename T>
 concept ProgramFactoryConcept = requires {
     typename T::cached_program_t;
 
-    [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
-        auto cached_program = T::create(operation_attributes, tensor_args, tensor_return_value);
+    [](const auto& operation_attributes, const auto& tensor_arguments, auto& tensor_return_value) {
+        auto cached_program = T::create(operation_attributes, tensor_arguments, tensor_return_value);
 
-        T::override_runtime_arguments(cached_program, operation_attributes, tensor_args, tensor_return_value);
+        T::override_runtime_arguments(cached_program, operation_attributes, tensor_arguments, tensor_return_value);
     };
 };
 
@@ -75,10 +75,10 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // Metal 2.0 factory concept: factories that return ProgramArtifacts (a ProgramSpec +
 // ProgramRunParams) from create_program_spec. The framework adapter stamps a Program
 // from the spec onto each mesh coordinate range on cache miss, and patches TensorArgs
-// via metal2_host_api::UpdateTensorArgs on cache hit.
+// via metal2_host_api::UpdateTensorArguments on cache hit.
 //
-// NOTE: Each TensorArg.tensor in ProgramRunParams MUST reference a MeshTensor reachable
-// from the factory's `tensor_args` / `tensor_return_value` parameters — the adapter
+// NOTE: Each TensorArgument.tensor in ProgramRunParams MUST reference a MeshTensor reachable
+// from the factory's `tensor_arguments` / `tensor_return_value` parameters — the adapter
 // matches by pointer identity. Constructing or copying a MeshTensor and referencing the
 // copy will TT_FATAL at runtime.
 //
@@ -99,9 +99,9 @@ template <typename device_operation_t>
 concept HasComputeOutputSpecs = requires(
     device_operation_t op,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args) {
+    const typename device_operation_t::tensor_args_t& tensor_arguments) {
     {
-        op.compute_output_specs(operation_attributes, tensor_args)
+        op.compute_output_specs(operation_attributes, tensor_arguments)
     } -> std::same_as<typename device_operation_t::spec_return_value_t>;
 };
 
@@ -110,8 +110,8 @@ concept HasComputeOutputSpecs = requires(
 template <typename device_operation_t>
 concept HasValidateOnProgramCacheHit = requires(
     const typename device_operation_t::operation_attributes_t& attrs,
-    const typename device_operation_t::tensor_args_t& tensor_args) {
-    device_operation_t::validate_on_program_cache_hit(attrs, tensor_args);
+    const typename device_operation_t::tensor_args_t& tensor_arguments) {
+    device_operation_t::validate_on_program_cache_hit(attrs, tensor_arguments);
 };
 
 // Detect if operation provides a custom select_program_factory.
@@ -119,9 +119,9 @@ concept HasValidateOnProgramCacheHit = requires(
 template <typename device_operation_t>
 concept HasSelectProgramFactory = requires(
     const typename device_operation_t::operation_attributes_t& attrs,
-    const typename device_operation_t::tensor_args_t& tensor_args) {
+    const typename device_operation_t::tensor_args_t& tensor_arguments) {
     {
-        device_operation_t::select_program_factory(attrs, tensor_args)
+        device_operation_t::select_program_factory(attrs, tensor_arguments)
     } -> std::same_as<typename device_operation_t::program_factory_t>;
 };
 
@@ -151,12 +151,12 @@ template <typename device_operation_t>
 concept DeviceOperationConcept =
     requires {
         [](const typename device_operation_t::operation_attributes_t& operation_attributes,
-           const typename device_operation_t::tensor_args_t& tensor_args) {
-            device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+           const typename device_operation_t::tensor_args_t& tensor_arguments) {
+            device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_arguments);
 
             using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;
             static_assert(std::same_as<
-                          decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
+                          decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_arguments)),
                           tensor_return_value_t>);
         };
     } && HasComputeOutputSpecs<device_operation_t> &&
@@ -168,9 +168,9 @@ concept DeviceOperationWithCustomProgramCacheConcept =
     DeviceOperationConcept<device_operation_t> &&
     requires(
         const typename device_operation_t::operation_attributes_t& operation_attributes,
-        const typename device_operation_t::tensor_args_t& tensor_args) {
+        const typename device_operation_t::tensor_args_t& tensor_arguments) {
         {
-            device_operation_t::compute_program_hash(operation_attributes, tensor_args)
+            device_operation_t::compute_program_hash(operation_attributes, tensor_arguments)
         } -> std::convertible_to<std::uint64_t>;
     };
 
@@ -178,10 +178,10 @@ template <typename device_operation_t>
 concept HasSkipLaunch = requires(
     device_operation_t op,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args,
+    const typename device_operation_t::tensor_args_t& tensor_arguments,
     const typename device_operation_t::tensor_return_value_t& tensor_return_value) {
     {
-        device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)
+        device_operation_t::skip_launch(operation_attributes, tensor_arguments, tensor_return_value)
     } -> std::convertible_to<bool>;
 };
 

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -687,7 +687,7 @@ void device_module(nb::module_& m_device) {
 
             Example:
                 >>> def my_callback(record):
-                ...     print(f"Program {record.program_id} on chip {record.chip_id}")
+                ...     print(f"Program {record.name} on chip {record.chip_id}")
                 >>> handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(my_callback)
         )doc");
 


### PR DESCRIPTION
## PR Category
Feature. 
Well, ish. More accurate to call it an API cleanup.

## Summary
A "cleanup" of the experimental Metal 2.0 host APIs to improve ergonomics, improve AI author usability, and reduce verbosity. This is based on observations from the first real-world uses of Metal 2.0.

**There are no semantic changes in this PR**. 
But, there are numerous small syntax changes. 

### API Changes
- **Namespace**: Metal 2.0 APIs are now in the `tt_metal::experimental` (I dropped the `metal2_host_api`).
- **Type aliases**: Some of the nested types produce hairy-looking user code. I've aliased these into the top-level namespace (all safe in both `experimental` and `tt-metal`)
- **Factory helpers**: When you create a KernelSpec, now you can (optionally) write things like
```C++
   .dfb_bindings = {
       experimental::ProducerOf("out_cb", "out"),   // Implicitly documents producer/consumer asymmetry   
       experimental::StridedConsumerOf("data_cb", "data"),  // (unique_id, local_accessor_name)
   }
```
- **Header split**. `kernel_spec.hpp` was getting unwieldy, so I moved the compute and DM config objects into their own headers.
- **Type and field renames**. A handful of structs / fields renamed for clarity or brevity, e.g.:
    - `named_runtime_args` -> `runtime_args` (clarity + brevity)
    - `compile_time_arg_bindings` -> `compile_time_args` (brevity)
    -  `DataMovementConfiguration::...`-> `DataMovementConfiguration::Gen1DM`
    - `program_id` and WorkUnitSpec `unique_id` were renamed to just `name`. (These are just debug/messaging names. This disambiguates them from other Metal 2.0 `unique_id`, which are used for cross-referencing.)
    - `TensorArg` -> `TensorArgument` (AI ergonomics; better parallel to the Parameter/Binding/Argument trio)
- **Odds and ends**. Misc tiny tweaks, e.g.
    - Kernel `num_threads` is now an int (was a `uint8_t`... no clue what I was thinking there)
    - Remove the pointless `SourceFilePath` wrapper
    - Remove the `RELAY` member from `DFBEndpoint` enum. (It was confusing everyone, humans and Claudes alike. Painless to add back in if we need it.)
    - Moved the repeated `Nodes` declaration into node_coords.hpp
    - Relaxed validation rules to stop requiring the silly empty "Gen2" struct on Quasar DM kernels (but left it in, as it's about to get a member!)
- **Header comments**. Also got a light cleanup pass.
     - Note: I removed the comments insisting that an AI use a  `const char * BLAH` everywhere. Claude decided it wasn't useful after all.

Some small matching changes in the `impl`.

### Propagating the Changes

Mechanically propagate the non-optional changes through all the Metal 2.0 use sites in the codebase:
 - `tt_metal/tests`
 - New  TTNN `ProgramSpecFactory` infrastructure stub
 
## Notes for reviewers
This is a gross diff. Sorry.
The best way to review is to read the list in the PR description :)
If interested, _maybe_ skim what this looks like in the public API headers, and one of the tests. 
(Many improvements are optional, so not all are propagated to the tests. This is for the op porting to come.)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/verbosity-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/verbosity-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/verbosity-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/verbosity-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/verbosity-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/verbosity-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/verbosity-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/verbosity-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/verbosity-reduction)