### PR TITLE
fabric/ccl: add ProgramDescriptor variants of fabric_mux helpers

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1917,7 +1917,13 @@ void fabric_mux_connection_rt_args(
     // and parking a SemaphoreDescriptor on the ProgramDescriptor. Returns the new ID.
     auto alloc_sem = [&]() -> uint32_t {
         auto id_opt = desc.find_available_semaphore_id(worker_logical_core, tt::CoreType::WORKER);
-        TT_FATAL(id_opt.has_value(), "No available semaphore ID for fabric mux connection on worker core");
+        TT_FATAL(
+            id_opt.has_value(),
+            "No available semaphore ID for fabric mux connection on worker core (x={}, y={}, core_type=WORKER); "
+            "{} SemaphoreDescriptors already allocated on this ProgramDescriptor.",
+            worker_logical_core.x,
+            worker_logical_core.y,
+            desc.semaphores.size());
         const uint32_t id = id_opt.value();
         desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
             .id = id,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1896,6 +1896,62 @@ void fabric_mux_connection_rt_args(
     worker_rt_args.push_back(termination_master_virtual_core.y);                   // termination_master_noc_y 16
 }
 
+// ProgramDescriptor (Contract-2) variant — mirrors the legacy Program& helper above.
+// Allocates the same five mux-side semaphores by pushing SemaphoreDescriptors into
+// desc.semaphores and recording their IDs into worker_rt_args. The arg-vector
+// layout (positions 0..16) is identical to the legacy helper so worker kernels
+// are byte-compatible across the two variants.
+void fabric_mux_connection_rt_args(
+    const bool mux_connection_valid,
+    const bool is_termination_master,
+    const tt::tt_fabric::FabricMuxChannelType channel_type,
+    const CoreCoord& mux_virtual_core,
+    const uint32_t worker_id,
+    const CoreCoord& worker_logical_core,
+    const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
+    tt::tt_metal::ProgramDescriptor& desc,
+    CoreCoord termination_master_virtual_core,
+    std::vector<uint32_t>& worker_rt_args,
+    std::optional<uint32_t> termination_master_semaphore_id) {
+    // Allocate a worker-core-scoped semaphore by querying the next available ID
+    // and parking a SemaphoreDescriptor on the ProgramDescriptor. Returns the new ID.
+    auto alloc_sem = [&]() -> uint32_t {
+        auto id_opt = desc.find_available_semaphore_id(worker_logical_core, tt::CoreType::WORKER);
+        TT_FATAL(id_opt.has_value(), "No available semaphore ID for fabric mux connection on worker core");
+        const uint32_t id = id_opt.value();
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = CoreRangeSet(CoreRange(worker_logical_core, worker_logical_core)),
+            .initial_value = 0});
+        return id;
+    };
+
+    worker_rt_args.push_back(mux_connection_valid);   // mux_connection_valid 0
+    worker_rt_args.push_back(is_termination_master);  // is_termination_master 1
+    worker_rt_args.push_back(mux_virtual_core.x);     // fabric_mux_x 2
+    worker_rt_args.push_back(mux_virtual_core.y);     // fabric_mux_y 3
+    worker_rt_args.push_back(
+        mux_kernel_config.get_channel_base_address(channel_type, worker_id));  // fabric_mux_channel_base_address 4
+    worker_rt_args.push_back(mux_kernel_config.get_connection_info_address(
+        channel_type, worker_id));  // fabric_mux_connection_info_address 5
+    worker_rt_args.push_back(mux_kernel_config.get_connection_handshake_address(
+        channel_type, worker_id));  // fabric_mux_connection_handshake_address 6
+    worker_rt_args.push_back(
+        mux_kernel_config.get_flow_control_address(channel_type, worker_id));  // fabric_mux_flow_control_address 7
+    worker_rt_args.push_back(
+        mux_kernel_config.get_buffer_index_address(channel_type, worker_id));  // fabric_mux_buffer_index_address 8
+    worker_rt_args.push_back(
+        mux_kernel_config.get_channel_credits_stream_id(channel_type, worker_id));    // fabric_mux_channel_id 9
+    worker_rt_args.push_back(termination_master_semaphore_id.value_or(alloc_sem()));  // termination_sync_address 10
+    worker_rt_args.push_back(alloc_sem());                        // local_fabric_mux_status_address 11
+    worker_rt_args.push_back(alloc_sem());                        // local_flow_control_address 12
+    worker_rt_args.push_back(alloc_sem());                        // local_teardown_address 13
+    worker_rt_args.push_back(alloc_sem());                        // local_buffer_index_address 14
+    worker_rt_args.push_back(termination_master_virtual_core.x);  // termination_master_noc_x 15
+    worker_rt_args.push_back(termination_master_virtual_core.y);  // termination_master_noc_y 16
+}
+
 namespace {  // anonymous namespace for internal helpers
 
 // Fabric bandwidth is based on raw hardware capability

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -14,6 +14,7 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/types.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -781,6 +782,27 @@ void fabric_mux_connection_rt_args(
     CoreCoord termination_master_virtual_core,
     std::vector<uint32_t>& worker_rt_args,
     std::optional<uint32_t> = std::nullopt);
+
+// ProgramDescriptor (Contract-2) variant of fabric_mux_connection_rt_args.
+// Mirrors the legacy Program& helper but allocates the five mux-side semaphores by
+// pushing SemaphoreDescriptors into desc.semaphores and recording their IDs into
+// worker_rt_args at the same positions. Semaphore IDs are obtained from
+// ProgramDescriptor::find_available_semaphore_id so they don't collide with IDs
+// already allocated on the same worker_logical_core. An optional
+// termination_master_semaphore_id can be supplied if the caller already owns one
+// (e.g. the termination master worker on this core).
+void fabric_mux_connection_rt_args(
+    bool mux_connection_valid,
+    bool is_termination_master,
+    tt::tt_fabric::FabricMuxChannelType channel_type,
+    const CoreCoord& mux_virtual_core,
+    uint32_t worker_id,
+    const CoreCoord& worker_logical_core,
+    const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
+    tt::tt_metal::ProgramDescriptor& desc,
+    CoreCoord termination_master_virtual_core,
+    std::vector<uint32_t>& worker_rt_args,
+    std::optional<uint32_t> termination_master_semaphore_id = std::nullopt);
 
 // Estimate fabric transfer time (nanoseconds).
 //   arch:          Wormhole or Blackhole

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
@@ -234,7 +234,13 @@ void append_fabric_mux_connection_rt_args(
     // and parking a SemaphoreDescriptor on the ProgramDescriptor. Returns the new ID.
     auto alloc_sem = [&]() -> uint32_t {
         auto id_opt = desc.find_available_semaphore_id(worker_logical_core, tt::CoreType::WORKER);
-        TT_FATAL(id_opt.has_value(), "No available semaphore ID for fabric mux connection on worker core");
+        TT_FATAL(
+            id_opt.has_value(),
+            "No available semaphore ID for fabric mux connection on worker core (x={}, y={}, core_type=WORKER); "
+            "{} SemaphoreDescriptors already allocated on this ProgramDescriptor.",
+            worker_logical_core.x,
+            worker_logical_core.y,
+            desc.semaphores.size());
         const uint32_t id = id_opt.value();
         desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
             .id = id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
@@ -219,4 +219,57 @@ void append_fabric_mux_connection_rt_args(
     std::copy(rt_args.begin(), rt_args.end(), std::back_inserter(worker_rt_args));
 }
 
+void append_fabric_mux_connection_rt_args(
+    bool mux_connection_valid,
+    const tt::tt_metal::CoreCoord& mux_virtual_core,
+    tt::tt_fabric::FabricMuxChannelType channel_type,
+    const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
+    const tt::tt_metal::CoreCoord& worker_logical_core,
+    uint32_t worker_per_direction_id,
+    bool is_termination_master,
+    tt::tt_metal::CoreCoord termination_master_virtual_core,
+    tt::tt_metal::ProgramDescriptor& desc,
+    tt::tt_metal::KernelDescriptor::RTArgList& worker_rt_args) {
+    // Allocate a worker-core-scoped semaphore by querying the next available ID
+    // and parking a SemaphoreDescriptor on the ProgramDescriptor. Returns the new ID.
+    auto alloc_sem = [&]() -> uint32_t {
+        auto id_opt = desc.find_available_semaphore_id(worker_logical_core, tt::CoreType::WORKER);
+        TT_FATAL(id_opt.has_value(), "No available semaphore ID for fabric mux connection on worker core");
+        const uint32_t id = id_opt.value();
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges =
+                tt::tt_metal::CoreRangeSet(tt::tt_metal::CoreRange(worker_logical_core, worker_logical_core)),
+            .initial_value = 0});
+        return id;
+    };
+
+    constexpr auto num_rt_args = 17;
+    worker_rt_args.reserve(num_rt_args);
+    worker_rt_args.push_back(static_cast<uint32_t>(mux_connection_valid));
+    worker_rt_args.push_back(static_cast<uint32_t>(is_termination_master));
+    worker_rt_args.push_back(static_cast<uint32_t>(mux_virtual_core.x));
+    worker_rt_args.push_back(static_cast<uint32_t>(mux_virtual_core.y));
+    worker_rt_args.push_back(
+        static_cast<uint32_t>(mux_kernel_config.get_channel_base_address(channel_type, worker_per_direction_id)));
+    worker_rt_args.push_back(
+        static_cast<uint32_t>(mux_kernel_config.get_connection_info_address(channel_type, worker_per_direction_id)));
+    worker_rt_args.push_back(static_cast<uint32_t>(
+        mux_kernel_config.get_connection_handshake_address(channel_type, worker_per_direction_id)));
+    worker_rt_args.push_back(
+        static_cast<uint32_t>(mux_kernel_config.get_flow_control_address(channel_type, worker_per_direction_id)));
+    worker_rt_args.push_back(
+        static_cast<uint32_t>(mux_kernel_config.get_buffer_index_address(channel_type, worker_per_direction_id)));
+    worker_rt_args.push_back(
+        static_cast<uint32_t>(mux_kernel_config.get_channel_credits_stream_id(channel_type, worker_per_direction_id)));
+    worker_rt_args.push_back(alloc_sem());
+    worker_rt_args.push_back(alloc_sem());
+    worker_rt_args.push_back(alloc_sem());
+    worker_rt_args.push_back(alloc_sem());
+    worker_rt_args.push_back(alloc_sem());
+    worker_rt_args.push_back(static_cast<uint32_t>(termination_master_virtual_core.x));
+    worker_rt_args.push_back(static_cast<uint32_t>(termination_master_virtual_core.y));
+}
+
 }  // namespace ttnn::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 
 #include "ttnn/distributed/types.hpp"
@@ -76,5 +77,23 @@ void append_fabric_mux_connection_rt_args(
     tt::tt_metal::CoreCoord termination_master_virtual_core,
     tt::tt_metal::Program& program,
     std::vector<uint32_t>& worker_rt_args);
+
+// ProgramDescriptor (Contract-2) variant — same wire layout as the legacy helper
+// (17 args in the order listed above), but allocates the five worker-side
+// semaphores by pushing SemaphoreDescriptors onto desc.semaphores and writes
+// the resulting args into a KernelDescriptor::RTArgList so callers can feed
+// the list directly into KernelDescriptor::emplace_runtime_args. The legacy
+// Program& helper is preserved; consumers migrate one at a time.
+void append_fabric_mux_connection_rt_args(
+    bool mux_connection_valid,
+    const tt::tt_metal::CoreCoord& mux_virtual_core,
+    tt::tt_fabric::FabricMuxChannelType channel_type,
+    const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
+    const tt::tt_metal::CoreCoord& worker_logical_core,
+    uint32_t worker_per_direction_id,
+    bool is_termination_master,
+    tt::tt_metal::CoreCoord termination_master_virtual_core,
+    tt::tt_metal::ProgramDescriptor& desc,
+    tt::tt_metal::KernelDescriptor::RTArgList& worker_rt_args);
 
 }  // namespace ttnn::experimental::ccl


### PR DESCRIPTION
## Summary
Adds `ProgramDescriptor&` / `KernelDescriptor::RTArgList&` overloads to fabric_mux helpers used by CCL ops:
- `ttnn::ccl::fabric_mux_connection_rt_args`
- `ttnn::experimental::ccl::append_fabric_mux_connection_rt_args`

`tt_fabric::FabricMuxConfig::get_fabric_mux_run_time_args` is already templated and works with `ProgramDescriptor`; no change needed there.

Part of #42193. Prerequisite for CCL ops that use the fabric mux on the workload path.

## Dependencies
None.

## Test plan
- [ ] sanity-tests.yaml
- [ ] runtime-sanity-tests.yaml
- [ ] blackhole-post-commit.yaml
- [ ] tt-metal-l2-nightly.yaml

Additive — legacy \`Program&\` paths untouched.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-fabric-mux-helpers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-fabric-mux-helpers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-fabric-mux-helpers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-fabric-mux-helpers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-fabric-mux-helpers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-fabric-mux-helpers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-fabric-mux-helpers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-fabric-mux-helpers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-fabric-mux-helpers)