### PR TITLE
experimental/transformer: migrate rotary embedding family to ProgramDescriptor

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
@@ -16,7 +16,6 @@ struct RotaryEmbeddingDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<RotaryEmbeddingProgramFactory>;
-    using shared_variables_t = RotaryEmbeddingProgramFactory::shared_variables_t;
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -99,7 +99,7 @@ ProgramDescriptor create_single_tile_descriptor(
         num_output_tiles = num_input_tiles;
     }
 
-    uint32_t input_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -112,7 +112,7 @@ ProgramDescriptor create_single_tile_descriptor(
     });
 
     // trans_mat CB at the slot the Wt>=2 path uses for "rotated input".
-    uint32_t trans_mat_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t trans_mat_cb_index = tt::CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = trans_mat_single_tile_size,
         .core_ranges = all_cores,
@@ -124,7 +124,7 @@ ProgramDescriptor create_single_tile_descriptor(
     });
 
     uint32_t num_cos_sin_tiles = token_idx.has_value() ? Wt : 2 * Wt;
-    uint32_t cos_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t cos_cb_index = tt::CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = all_cores,
@@ -135,7 +135,7 @@ ProgramDescriptor create_single_tile_descriptor(
         }}},
     });
 
-    uint32_t sin_cb_index = tt::CBIndex::c_3;
+    constexpr uint8_t sin_cb_index = tt::CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = all_cores,
@@ -147,7 +147,7 @@ ProgramDescriptor create_single_tile_descriptor(
     });
 
     uint32_t num_interm_tiles = 1;
-    uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -161,7 +161,7 @@ ProgramDescriptor create_single_tile_descriptor(
     // Keep sin/cos intermediates at input format regardless of sincos format.
     // The packer format stays stable across matmul / mul / add, avoiding
     // fragile pack_reconfig sequences after mm_init for mixed precision.
-    uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = tt::CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -172,7 +172,7 @@ ProgramDescriptor create_single_tile_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = tt::CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -183,7 +183,7 @@ ProgramDescriptor create_single_tile_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = all_cores,
@@ -197,12 +197,12 @@ ProgramDescriptor create_single_tile_descriptor(
 
     tt::DataFormat scalar_cb_data_format = tt::DataFormat::Float16_b;
     uint32_t scalar_single_tile_size = tt::tile_size(scalar_cb_data_format);
-    uint32_t untilized_cos_interm_cb_index = tt::CBIndex::c_27;
-    uint32_t untilized_cos_sync_cb_index = tt::CBIndex::c_5;
-    uint32_t untilized_sin_interm_cb_index = tt::CBIndex::c_28;
-    uint32_t untilized_sin_sync_cb_index = tt::CBIndex::c_6;
-    uint32_t retilized_cos_cb_index = tt::CBIndex::c_29;
-    uint32_t retilized_sin_cb_index = tt::CBIndex::c_30;
+    constexpr uint8_t untilized_cos_interm_cb_index = tt::CBIndex::c_27;
+    constexpr uint8_t untilized_cos_sync_cb_index = tt::CBIndex::c_5;
+    constexpr uint8_t untilized_sin_interm_cb_index = tt::CBIndex::c_28;
+    constexpr uint8_t untilized_sin_sync_cb_index = tt::CBIndex::c_6;
+    constexpr uint8_t retilized_cos_cb_index = tt::CBIndex::c_29;
+    constexpr uint8_t retilized_sin_cb_index = tt::CBIndex::c_30;
     KernelDescriptor::Defines reader_kernel_defines, writer_kernel_defines, compute_kernel_defines;
     if (token_idx.has_value()) {
         desc.cbs.push_back(CBDescriptor{
@@ -401,30 +401,23 @@ ProgramDescriptor create_single_tile_descriptor(
         if (!token_idx.has_value()) {
             cos_sin_start_id = num_tiles_written % HtWt;
         }
-        std::vector<uint32_t> reader_rt_args;
         if (in_sharded) {
-            reader_rt_args = {
-                cos_buffer->address(),
-                sin_buffer->address(),
-                num_rows_per_core,
-                num_tiles_written / Wt % Ht,
-                cos_sin_start_id};
+            reader_desc.emplace_runtime_args(
+                core, {cos_buffer, sin_buffer, num_rows_per_core, num_tiles_written / Wt % Ht, cos_sin_start_id});
         } else {
-            reader_rt_args = {
-                src_buffer->address(),
-                cos_buffer->address(),
-                sin_buffer->address(),
-                num_rows_per_core,
-                num_tiles_written,
-                num_tiles_written / Wt % Ht,
-                cos_sin_start_id};
+            reader_desc.emplace_runtime_args(
+                core,
+                {src_buffer,
+                 cos_buffer,
+                 sin_buffer,
+                 num_rows_per_core,
+                 num_tiles_written,
+                 num_tiles_written / Wt % Ht,
+                 cos_sin_start_id});
         }
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
 
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
         num_tiles_written += num_rows_per_core * Wt;
     }
 
@@ -514,7 +507,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         num_output_tiles = num_input_tiles;
     }
 
-    uint32_t input_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -526,7 +519,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         .buffer = in_sharded ? input.buffer() : nullptr,
     });
 
-    uint32_t rotated_input_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t rotated_input_cb_index = tt::CBIndex::c_1;
     uint32_t num_rotated_input_tiles = 2 * Wt;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_rotated_input_tiles * input_single_tile_size,
@@ -539,7 +532,7 @@ ProgramDescriptor create_multi_tile_descriptor(
     });
 
     uint32_t num_cos_sin_tiles = token_idx.has_value() ? Wt : 2 * Wt;
-    uint32_t cos_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t cos_cb_index = tt::CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = all_cores,
@@ -550,7 +543,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t sin_cb_index = tt::CBIndex::c_3;
+    constexpr uint8_t sin_cb_index = tt::CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = all_cores,
@@ -562,7 +555,7 @@ ProgramDescriptor create_multi_tile_descriptor(
     });
 
     // Used for bcast scalar
-    uint32_t src_scalar_cb_index = tt::CBIndex::c_4;
+    constexpr uint8_t src_scalar_cb_index = tt::CBIndex::c_4;
     uint32_t num_scalar_tiles = 1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_scalar_tiles * scalar_single_tile_size,
@@ -575,7 +568,7 @@ ProgramDescriptor create_multi_tile_descriptor(
     });
 
     uint32_t num_interm_tiles = 1;
-    uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -586,7 +579,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = tt::CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * cos_single_tile_size,
         .core_ranges = all_cores,
@@ -597,7 +590,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = tt::CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * sin_single_tile_size,
         .core_ranges = all_cores,
@@ -608,7 +601,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = all_cores,
@@ -620,12 +613,12 @@ ProgramDescriptor create_multi_tile_descriptor(
         .buffer = out_sharded ? output.buffer() : nullptr,
     });
 
-    uint32_t untilized_cos_interm_cb_index = tt::CBIndex::c_27;
-    uint32_t untilized_cos_sync_cb_index = tt::CBIndex::c_5;
-    uint32_t untilized_sin_interm_cb_index = tt::CBIndex::c_28;
-    uint32_t untilized_sin_sync_cb_index = tt::CBIndex::c_6;
-    uint32_t retilized_cos_cb_index = tt::CBIndex::c_29;
-    uint32_t retilized_sin_cb_index = tt::CBIndex::c_30;
+    constexpr uint8_t untilized_cos_interm_cb_index = tt::CBIndex::c_27;
+    constexpr uint8_t untilized_cos_sync_cb_index = tt::CBIndex::c_5;
+    constexpr uint8_t untilized_sin_interm_cb_index = tt::CBIndex::c_28;
+    constexpr uint8_t untilized_sin_sync_cb_index = tt::CBIndex::c_6;
+    constexpr uint8_t retilized_cos_cb_index = tt::CBIndex::c_29;
+    constexpr uint8_t retilized_sin_cb_index = tt::CBIndex::c_30;
     KernelDescriptor::Defines reader_kernel_defines, writer_kernel_defines, compute_kernel_defines;
     if (token_idx.has_value()) {
         desc.cbs.push_back(CBDescriptor{
@@ -845,30 +838,23 @@ ProgramDescriptor create_multi_tile_descriptor(
         if (!token_idx.has_value()) {
             cos_sin_start_id = num_tiles_written % HtWt;
         }
-        std::vector<uint32_t> reader_rt_args;
         if (in_sharded) {
-            reader_rt_args = {
-                cos_buffer->address(),
-                sin_buffer->address(),
-                num_rows_per_core,
-                num_tiles_written / Wt % Ht,
-                cos_sin_start_id};
+            reader_desc.emplace_runtime_args(
+                core, {cos_buffer, sin_buffer, num_rows_per_core, num_tiles_written / Wt % Ht, cos_sin_start_id});
         } else {
-            reader_rt_args = {
-                src_buffer->address(),
-                cos_buffer->address(),
-                sin_buffer->address(),
-                num_rows_per_core,
-                num_tiles_written,
-                num_tiles_written / Wt % Ht,
-                cos_sin_start_id};
+            reader_desc.emplace_runtime_args(
+                core,
+                {src_buffer,
+                 cos_buffer,
+                 sin_buffer,
+                 num_rows_per_core,
+                 num_tiles_written,
+                 num_tiles_written / Wt % Ht,
+                 cos_sin_start_id});
         }
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
 
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
         num_tiles_written += num_rows_per_core * Wt;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -8,10 +8,14 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::experimental::prim {
 
+using namespace tt;
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
 namespace {
 
@@ -19,19 +23,17 @@ namespace {
 // inter-tile half-swap + scalar negation, which collapses when Wt == 1 (half_Wt
 // == 0). Here we instead use matmul_tiles(input, trans_mat) with an in-L1
 // transformation matrix that encodes [[0, I], [-I, 0]].
-RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
+ProgramDescriptor create_single_tile_descriptor(
     const RotaryEmbeddingParams& operation_attributes,
     const RotaryEmbeddingInputs& tensor_args,
     Tensor& tensor_return_value) {
-    using namespace tt::tt_metal;
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input;
     const auto& cos = tensor_args.cos;
     const auto& sin = tensor_args.sin;
     auto& output = tensor_return_value;
     const auto& token_idx = operation_attributes.token_idx;
-
-    Program program{};
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -98,71 +100,100 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
     }
 
     uint32_t input_cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size);
-    if (in_sharded) {
-        cb_input_config = cb_input_config.set_globally_allocated_address(*input.buffer());
-    }
-    auto cb_input = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in_sharded ? input.buffer() : nullptr,
+    });
 
     // trans_mat CB at the slot the Wt>=2 path uses for "rotated input".
     uint32_t trans_mat_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_trans_mat_config =
-        tt::tt_metal::CircularBufferConfig(trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = trans_mat_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = trans_mat_cb_index,
+            .data_format = trans_mat_cb_data_format,
+            .page_size = trans_mat_single_tile_size,
+        }}},
+    });
 
     uint32_t num_cos_sin_tiles = token_idx.has_value() ? Wt : 2 * Wt;
     uint32_t cos_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_cos_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_cb_index = tt::CBIndex::c_3;
-    tt::tt_metal::CircularBufferConfig cb_sin_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t num_interm_tiles = 1;
     uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
-    tt::tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     // Keep sin/cos intermediates at input format regardless of sincos format.
     // The packer format stays stable across matmul / mul / add, avoiding
     // fragile pack_reconfig sequences after mm_init for mixed precision.
     uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
-    tt::tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{cos_interm_cb_index, input_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
-    tt::tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{sin_interm_cb_index, input_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    if (out_sharded) {
-        cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-    }
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = out_sharded ? output.buffer() : nullptr,
+    });
 
     tt::DataFormat scalar_cb_data_format = tt::DataFormat::Float16_b;
     uint32_t scalar_single_tile_size = tt::tile_size(scalar_cb_data_format);
@@ -172,40 +203,64 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
     uint32_t untilized_sin_sync_cb_index = tt::CBIndex::c_6;
     uint32_t retilized_cos_cb_index = tt::CBIndex::c_29;
     uint32_t retilized_sin_cb_index = tt::CBIndex::c_30;
-    std::map<std::string, std::string> reader_kernel_defines, writer_kernel_defines, compute_kernel_defines;
+    KernelDescriptor::Defines reader_kernel_defines, writer_kernel_defines, compute_kernel_defines;
     if (token_idx.has_value()) {
-        tt::tt_metal::CircularBufferConfig cb_cos2_config =
-            tt::tt_metal::CircularBufferConfig(
-                Wt * cos_single_tile_size, {{retilized_cos_cb_index, cos_cb_data_format}})
-                .set_page_size(retilized_cos_cb_index, cos_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos2_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * cos_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = retilized_cos_cb_index,
+                .data_format = cos_cb_data_format,
+                .page_size = cos_single_tile_size,
+            }}},
+        });
 
-        tt::tt_metal::CircularBufferConfig cb_sin2_config =
-            tt::tt_metal::CircularBufferConfig(
-                Wt * sin_single_tile_size, {{retilized_sin_cb_index, sin_cb_data_format}})
-                .set_page_size(retilized_sin_cb_index, sin_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin2_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * sin_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = retilized_sin_cb_index,
+                .data_format = sin_cb_data_format,
+                .page_size = sin_single_tile_size,
+            }}},
+        });
 
-        std::map<uint8_t, tt::DataFormat> cos_interim_data_format_spec = {
-            {untilized_cos_interm_cb_index, scalar_cb_data_format},
-            {untilized_cos_sync_cb_index, scalar_cb_data_format}};
-        tt::tt_metal::CircularBufferConfig cb_untilized_cos_interm_config =
-            tt::tt_metal::CircularBufferConfig(Wt * scalar_single_tile_size, cos_interim_data_format_spec)
-                .set_page_size(untilized_cos_interm_cb_index, scalar_single_tile_size)
-                .set_page_size(untilized_cos_sync_cb_index, scalar_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_untilized_cos_interm_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * scalar_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{
+                CBFormatDescriptor{
+                    .buffer_index = untilized_cos_interm_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+                CBFormatDescriptor{
+                    .buffer_index = untilized_cos_sync_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+            }},
+        });
 
-        std::map<uint8_t, tt::DataFormat> sin_interim_data_format_spec = {
-            {untilized_sin_interm_cb_index, scalar_cb_data_format},
-            {untilized_sin_sync_cb_index, scalar_cb_data_format}};
-        tt::tt_metal::CircularBufferConfig cb_untilized_sin_interm_config =
-            tt::tt_metal::CircularBufferConfig(Wt * scalar_single_tile_size, sin_interim_data_format_spec)
-                .set_page_size(untilized_sin_interm_cb_index, scalar_single_tile_size)
-                .set_page_size(untilized_sin_sync_cb_index, scalar_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_untilized_sin_interm_config);
-        reader_kernel_defines["DECODE_MODE"] = "1";
-        writer_kernel_defines["DECODE_MODE"] = "1";
-        compute_kernel_defines["DECODE_MODE"] = "1";
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * scalar_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{
+                CBFormatDescriptor{
+                    .buffer_index = untilized_sin_interm_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+                CBFormatDescriptor{
+                    .buffer_index = untilized_sin_sync_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+            }},
+        });
+        reader_kernel_defines.emplace_back("DECODE_MODE", "1");
+        writer_kernel_defines.emplace_back("DECODE_MODE", "1");
+        compute_kernel_defines.emplace_back("DECODE_MODE", "1");
     }
 
     auto* src_buffer = input.buffer();
@@ -223,8 +278,8 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
             (std::uint32_t)Ht,
             (std::uint32_t)HtWt,
         };
-        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
     } else {
         reader_compile_time_args = {
             (std::uint32_t)input_cb_index,
@@ -234,12 +289,12 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
             (std::uint32_t)Ht,
             (std::uint32_t)HtWt,
         };
-        tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
     }
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
     if (token_idx.has_value()) {
         writer_compile_time_args.insert(
             writer_compile_time_args.end(),
@@ -249,26 +304,32 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
              untilized_sin_sync_cb_index});
     }
     if (out_sharded) {
-        writer_kernel_defines["OUT_SHARDED"] = "1";
+        writer_kernel_defines.emplace_back("OUT_SHARDED", "1");
     }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         in_sharded ? "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/"
                      "reader_rotary_embedding_single_tile_interleaved_start_id_sharded.cpp"
                    : "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/"
-                     "reader_rotary_embedding_single_tile_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_kernel_defines));
+                     "reader_rotary_embedding_single_tile_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_kernel_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/"
-        "writer_rotary_embedding_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_kernel_defines));
+        "writer_rotary_embedding_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_kernel_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    std::vector<uint32_t> compute_kernel_args = {
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
         (std::uint32_t)input_cb_index,
         (std::uint32_t)cos_cb_index,
         (std::uint32_t)sin_cb_index,
@@ -279,8 +340,8 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
         (std::uint32_t)output_cb_index,
         (std::uint32_t)num_rows_per_core_group_1};
     if (token_idx.has_value()) {
-        compute_kernel_args.insert(
-            compute_kernel_args.end(),
+        compute_kernel_args_group_1.insert(
+            compute_kernel_args_group_1.end(),
             {(std::uint32_t)untilized_cos_interm_cb_index,
              (std::uint32_t)untilized_cos_sync_cb_index,
              (std::uint32_t)untilized_sin_interm_cb_index,
@@ -289,28 +350,36 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
              (std::uint32_t)retilized_sin_cb_index});
     }
 
-    tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc_g1;
+    compute_desc_g1.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
-        "rotary_embedding_single_tile.cpp",
-        core_group_1,
-        tt::tt_metal::ComputeConfig{
+        "rotary_embedding_single_tile.cpp";
+    compute_desc_g1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_g1.core_ranges = core_group_1;
+    compute_desc_g1.compile_time_args = compute_kernel_args_group_1;
+    compute_desc_g1.defines = compute_kernel_defines;
+    compute_desc_g1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
+
+    std::optional<KernelDescriptor> compute_desc_g2;
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = compute_kernel_args_group_1;
+        compute_kernel_args_group_2[8] = num_rows_per_core_group_2;
+        KernelDescriptor g2;
+        g2.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
+            "rotary_embedding_single_tile.cpp";
+        g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        g2.core_ranges = core_group_2;
+        g2.compile_time_args = std::move(compute_kernel_args_group_2);
+        g2.defines = compute_kernel_defines;
+        g2.config = ComputeConfigDescriptor{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .defines = compute_kernel_defines});
-    if (!core_group_2.ranges().empty()) {
-        compute_kernel_args[8] = num_rows_per_core_group_2;
-        tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
-            "rotary_embedding_single_tile.cpp",
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .compile_args = compute_kernel_args,
-                .defines = compute_kernel_defines});
+        };
+        compute_desc_g2 = std::move(g2);
     }
 
     uint32_t cos_sin_offset = 0;
@@ -322,6 +391,9 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
 
     uint32_t g1_numcores = core_group_1.num_cores();
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    reader_desc.runtime_args.reserve(num_cores);
+    writer_desc.runtime_args.reserve(num_cores);
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
         const CoreCoord& core = cores.at(i);
@@ -347,51 +419,36 @@ RotaryEmbeddingProgramFactory::cached_program_t create_single_tile(
                 num_tiles_written / Wt % Ht,
                 cos_sin_start_id};
         }
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
+        writer_desc.runtime_args.emplace_back(
             core,
-            {dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
+            std::vector<uint32_t>{
+                dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
         num_tiles_written += num_rows_per_core * Wt;
     }
 
-    RotaryEmbeddingSharedVariables shared_variables{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cb_input = cb_input,
-        .cb_output = cb_output,
-        .cores = cores,
-        .g1_numcores = g1_numcores,
-        .num_rows_per_core_group_1 = num_rows_per_core_group_1,
-        .num_rows_per_core_group_2 = num_rows_per_core_group_2,
-        .Wbytes = Wbytes,
-        .Wt = Wt,
-        .HtWt = HtWt};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_g1));
+    if (compute_desc_g2.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_g2));
+    }
 
-    return RotaryEmbeddingProgramFactory::cached_program_t{std::move(program), std::move(shared_variables)};
+    return desc;
 }
 
-}  // namespace
-
-RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::create(
+ProgramDescriptor create_multi_tile_descriptor(
     const RotaryEmbeddingParams& operation_attributes,
     const RotaryEmbeddingInputs& tensor_args,
     Tensor& tensor_return_value) {
-    using namespace tt::tt_metal;
-
-    if (tensor_args.input.padded_shape()[-1] / TILE_WIDTH == 1) {
-        return create_single_tile(operation_attributes, tensor_args, tensor_return_value);
-    }
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input;
     const auto& cos = tensor_args.cos;
     const auto& sin = tensor_args.sin;
     auto& output = tensor_return_value;
     const auto& token_idx = operation_attributes.token_idx;
-
-    Program program{};
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -458,78 +515,110 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
     }
 
     uint32_t input_cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size);
-    if (in_sharded) {
-        cb_input_config = cb_input_config.set_globally_allocated_address(*input.buffer());
-    }
-    auto cb_input = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in_sharded ? input.buffer() : nullptr,
+    });
 
     uint32_t rotated_input_cb_index = tt::CBIndex::c_1;
     uint32_t num_rotated_input_tiles = 2 * Wt;
-    tt::tt_metal::CircularBufferConfig cb_rotated_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_rotated_input_tiles * input_single_tile_size, {{rotated_input_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_rotated_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t num_cos_sin_tiles = token_idx.has_value() ? Wt : 2 * Wt;
     uint32_t cos_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_cos_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_cb_index = tt::CBIndex::c_3;
-    tt::tt_metal::CircularBufferConfig cb_sin_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     // Used for bcast scalar
     uint32_t src_scalar_cb_index = tt::CBIndex::c_4;
     uint32_t num_scalar_tiles = 1;
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_scalar_tiles * scalar_single_tile_size, {{src_scalar_cb_index, scalar_cb_data_format}})
-            .set_page_size(src_scalar_cb_index, scalar_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_scalar_tiles * scalar_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src_scalar_cb_index,
+            .data_format = scalar_cb_data_format,
+            .page_size = scalar_single_tile_size,
+        }}},
+    });
 
     uint32_t num_interm_tiles = 1;
     uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
-    tt::tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
-    tt::tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * cos_single_tile_size, {{cos_interm_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, cos_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * cos_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
-    tt::tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * sin_single_tile_size, {{sin_interm_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, sin_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * sin_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    if (out_sharded) {
-        cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-    }
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = out_sharded ? output.buffer() : nullptr,
+    });
 
     uint32_t untilized_cos_interm_cb_index = tt::CBIndex::c_27;
     uint32_t untilized_cos_sync_cb_index = tt::CBIndex::c_5;
@@ -537,40 +626,64 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
     uint32_t untilized_sin_sync_cb_index = tt::CBIndex::c_6;
     uint32_t retilized_cos_cb_index = tt::CBIndex::c_29;
     uint32_t retilized_sin_cb_index = tt::CBIndex::c_30;
-    std::map<std::string, std::string> reader_kernel_defines, writer_kernel_defines, compute_kernel_defines;
+    KernelDescriptor::Defines reader_kernel_defines, writer_kernel_defines, compute_kernel_defines;
     if (token_idx.has_value()) {
-        tt::tt_metal::CircularBufferConfig cb_cos2_config =
-            tt::tt_metal::CircularBufferConfig(
-                Wt * cos_single_tile_size, {{retilized_cos_cb_index, cos_cb_data_format}})
-                .set_page_size(retilized_cos_cb_index, cos_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos2_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * cos_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = retilized_cos_cb_index,
+                .data_format = cos_cb_data_format,
+                .page_size = cos_single_tile_size,
+            }}},
+        });
 
-        tt::tt_metal::CircularBufferConfig cb_sin2_config =
-            tt::tt_metal::CircularBufferConfig(
-                Wt * sin_single_tile_size, {{retilized_sin_cb_index, sin_cb_data_format}})
-                .set_page_size(retilized_sin_cb_index, sin_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin2_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * sin_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = retilized_sin_cb_index,
+                .data_format = sin_cb_data_format,
+                .page_size = sin_single_tile_size,
+            }}},
+        });
 
-        std::map<uint8_t, tt::DataFormat> cos_interim_data_format_spec = {
-            {untilized_cos_interm_cb_index, scalar_cb_data_format},
-            {untilized_cos_sync_cb_index, scalar_cb_data_format}};
-        tt::tt_metal::CircularBufferConfig cb_untilized_cos_interm_config =
-            tt::tt_metal::CircularBufferConfig(Wt * scalar_single_tile_size, cos_interim_data_format_spec)
-                .set_page_size(untilized_cos_interm_cb_index, scalar_single_tile_size)
-                .set_page_size(untilized_cos_sync_cb_index, scalar_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_untilized_cos_interm_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * scalar_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{
+                CBFormatDescriptor{
+                    .buffer_index = untilized_cos_interm_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+                CBFormatDescriptor{
+                    .buffer_index = untilized_cos_sync_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+            }},
+        });
 
-        std::map<uint8_t, tt::DataFormat> sin_interim_data_format_spec = {
-            {untilized_sin_interm_cb_index, scalar_cb_data_format},
-            {untilized_sin_sync_cb_index, scalar_cb_data_format}};
-        tt::tt_metal::CircularBufferConfig cb_untilized_sin_interm_config =
-            tt::tt_metal::CircularBufferConfig(Wt * scalar_single_tile_size, sin_interim_data_format_spec)
-                .set_page_size(untilized_sin_interm_cb_index, scalar_single_tile_size)
-                .set_page_size(untilized_sin_sync_cb_index, scalar_single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_untilized_sin_interm_config);
-        reader_kernel_defines["DECODE_MODE"] = "1";
-        writer_kernel_defines["DECODE_MODE"] = "1";
-        compute_kernel_defines["DECODE_MODE"] = "1";
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = Wt * scalar_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{
+                CBFormatDescriptor{
+                    .buffer_index = untilized_sin_interm_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+                CBFormatDescriptor{
+                    .buffer_index = untilized_sin_sync_cb_index,
+                    .data_format = scalar_cb_data_format,
+                    .page_size = scalar_single_tile_size,
+                },
+            }},
+        });
+        reader_kernel_defines.emplace_back("DECODE_MODE", "1");
+        writer_kernel_defines.emplace_back("DECODE_MODE", "1");
+        compute_kernel_defines.emplace_back("DECODE_MODE", "1");
     }
 
     const uint16_t bfloat16_scalar = std::bit_cast<uint16_t>(bfloat16(-1.0f));
@@ -594,8 +707,8 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
             (std::uint32_t)HtWt,
             (std::uint32_t)half_Wt * input_single_tile_size,
         };
-        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
     } else {
         reader_compile_time_args = {
             (std::uint32_t)input_cb_index,
@@ -609,12 +722,12 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
             (std::uint32_t)HtWt,
             (std::uint32_t)half_Wt,
         };
-        tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
     }
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     if (token_idx.has_value()) {
         writer_compile_time_args.insert(
@@ -626,26 +739,32 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
     }
 
     if (out_sharded) {
-        writer_kernel_defines["OUT_SHARDED"] = "1";
+        writer_kernel_defines.emplace_back("OUT_SHARDED", "1");
     }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         in_sharded ? "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/"
                      "reader_rotary_embedding_interleaved_start_id_sharded.cpp"
                    : "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/"
-                     "reader_rotary_embedding_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_kernel_defines));
+                     "reader_rotary_embedding_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_kernel_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/"
-        "writer_rotary_embedding_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_kernel_defines));
+        "writer_rotary_embedding_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_kernel_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    std::vector<uint32_t> compute_kernel_args = {
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
         (std::uint32_t)input_cb_index,
         (std::uint32_t)rotated_input_cb_index,
         (std::uint32_t)cos_cb_index,
@@ -659,8 +778,8 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
         (std::uint32_t)Wt,
         (std::uint32_t)half_Wt};
     if (token_idx.has_value()) {
-        compute_kernel_args.insert(
-            compute_kernel_args.end(),
+        compute_kernel_args_group_1.insert(
+            compute_kernel_args_group_1.end(),
             {(std::uint32_t)untilized_cos_interm_cb_index,
              (std::uint32_t)untilized_cos_sync_cb_index,
              (std::uint32_t)untilized_sin_interm_cb_index,
@@ -669,26 +788,37 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
              (std::uint32_t)retilized_sin_cb_index});
     }
 
-    tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc_g1;
+    compute_desc_g1.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
-        "rotary_embedding.cpp",
-        core_group_1,
-        tt::tt_metal::ComputeConfig{.compile_args = compute_kernel_args, .defines = compute_kernel_defines});
-    if (!core_group_2.ranges().empty()) {
-        compute_kernel_args[9] = num_rows_per_core_group_2;
+        "rotary_embedding.cpp";
+    compute_desc_g1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_g1.core_ranges = core_group_1;
+    compute_desc_g1.compile_time_args = compute_kernel_args_group_1;
+    compute_desc_g1.defines = compute_kernel_defines;
+    // NOTE: legacy create() left math_fidelity/fp32_dest_acc_en unset for the g1
+    // ComputeConfig in the multi-tile path; preserve those defaults here.
+    compute_desc_g1.config = ComputeConfigDescriptor{};
 
-        tt::tt_metal::CreateKernel(
-            program,
+    std::optional<KernelDescriptor> compute_desc_g2;
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = compute_kernel_args_group_1;
+        compute_kernel_args_group_2[9] = num_rows_per_core_group_2;
+        KernelDescriptor g2;
+        g2.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
-            "rotary_embedding.cpp",
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .compile_args = compute_kernel_args,
-                .defines = compute_kernel_defines});
+            "rotary_embedding.cpp";
+        g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        g2.core_ranges = core_group_2;
+        g2.compile_time_args = std::move(compute_kernel_args_group_2);
+        g2.defines = compute_kernel_defines;
+        g2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+        };
+        compute_desc_g2 = std::move(g2);
     }
+
     uint32_t cos_sin_offset = 0;
     uint32_t cos_sin_start_id = 0;
     if (token_idx.has_value()) {
@@ -699,6 +829,9 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
     uint32_t g1_numcores = core_group_1.num_cores();
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    reader_desc.runtime_args.reserve(num_cores);
+    writer_desc.runtime_args.reserve(num_cores);
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
         const CoreCoord& core = cores.at(i);
@@ -730,110 +863,35 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
                 num_tiles_written / Wt % Ht,
                 cos_sin_start_id};
         }
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
+        writer_desc.runtime_args.emplace_back(
             core,
-            {dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
+            std::vector<uint32_t>{
+                dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
         num_tiles_written += num_rows_per_core * Wt;
     }
 
-    RotaryEmbeddingSharedVariables shared_variables{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cb_input = cb_input,
-        .cb_output = cb_output,
-        .cores = cores,
-        .g1_numcores = g1_numcores,
-        .num_rows_per_core_group_1 = num_rows_per_core_group_1,
-        .num_rows_per_core_group_2 = num_rows_per_core_group_2,
-        .Wbytes = Wbytes,
-        .Wt = Wt,
-        .HtWt = HtWt};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_g1));
+    if (compute_desc_g2.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_g2));
+    }
 
-    return cached_program_t{std::move(program), std::move(shared_variables)};
+    return desc;
 }
 
-void RotaryEmbeddingProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
+}  // namespace
+
+ProgramDescriptor RotaryEmbeddingProgramFactory::create_descriptor(
     const RotaryEmbeddingParams& operation_attributes,
     const RotaryEmbeddingInputs& tensor_args,
     Tensor& tensor_return_value) {
-    using namespace tt::constants;
-
-    const auto& token_idx = operation_attributes.token_idx;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* cos_buffer = tensor_args.cos.buffer();
-    auto* sin_buffer = tensor_args.sin.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    bool in_sharded = tensor_args.input.is_sharded();
-    bool out_sharded = tensor_return_value.is_sharded();
-
-    auto& program = cached_program.program;
-    const auto& cores = cached_program.shared_variables.cores;
-    const auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    const auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    const auto& cb_input = cached_program.shared_variables.cb_input;
-    const auto& cb_output = cached_program.shared_variables.cb_output;
-    const auto& g1_numcores = cached_program.shared_variables.g1_numcores;
-    const auto& num_rows_per_core_group_1 = cached_program.shared_variables.num_rows_per_core_group_1;
-    const auto& num_rows_per_core_group_2 = cached_program.shared_variables.num_rows_per_core_group_2;
-    const auto& Wbytes = cached_program.shared_variables.Wbytes;
-    const auto& Wt = cached_program.shared_variables.Wt;
-    const auto& HtWt = cached_program.shared_variables.HtWt;
-
-    if (in_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_input, *src_buffer);
+    if (tensor_args.input.padded_shape()[-1] / TILE_WIDTH == 1) {
+        return create_single_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
     }
-
-    if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-    }
-
-    uint32_t cos_sin_offset = 0;
-    uint32_t cos_sin_start_id = 0;
-    if (token_idx.has_value()) {
-        cos_sin_offset = token_idx.value() % TILE_HEIGHT * Wbytes;
-        cos_sin_start_id = token_idx.value() / TILE_HEIGHT * Wt;
-    }
-
-    for (uint32_t i = 0, num_tiles_written = 0; i < cores.size(); ++i) {
-        const CoreCoord& core = cores.at(i);
-        uint32_t num_rows_per_core = 0;
-        if (i < g1_numcores) {
-            num_rows_per_core = num_rows_per_core_group_1;
-        } else {
-            num_rows_per_core = num_rows_per_core_group_2;
-        }
-        if (!token_idx.has_value()) {
-            cos_sin_start_id = num_tiles_written % HtWt;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            if (in_sharded) {
-                runtime_args[0] = cos_buffer->address();
-                runtime_args[1] = sin_buffer->address();
-                runtime_args[4] = cos_sin_start_id;
-            } else {
-                runtime_args[0] = src_buffer->address();
-                runtime_args[1] = cos_buffer->address();
-                runtime_args[2] = sin_buffer->address();
-                runtime_args[6] = cos_sin_start_id;
-            }
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-            runtime_args[3] = cos_sin_offset;
-        }
-        num_tiles_written += num_rows_per_core * Wt;
-    }
+    return create_multi_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
@@ -6,34 +6,16 @@
 
 #include "ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct RotaryEmbeddingSharedVariables {
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = 0;
-    tt::tt_metal::CBHandle cb_input{};
-    tt::tt_metal::CBHandle cb_output{};
-    std::vector<CoreCoord> cores;
-    uint32_t g1_numcores = 0;
-    uint32_t num_rows_per_core_group_1 = 0;
-    uint32_t num_rows_per_core_group_2 = 0;
-    uint32_t Wbytes = 0;
-    uint32_t Wt = 0;
-    uint32_t HtWt = 0;
-};
-
 struct RotaryEmbeddingProgramFactory {
-    using shared_variables_t = RotaryEmbeddingSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const RotaryEmbeddingParams& operation_attributes,
-        const RotaryEmbeddingInputs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Contract (1): single ProgramDescriptor.  Sharded variants set CBDescriptor::buffer
+    // so the framework patches dynamic CB addresses on cache hit; per-core runtime args
+    // and CB total_sizes (which depend on input shape) are re-applied via
+    // apply_descriptor_runtime_args.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingParams& operation_attributes,
         const RotaryEmbeddingInputs& tensor_args,
         Tensor& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.cpp
@@ -90,7 +90,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         num_output_tiles = num_input_tiles;
     }
 
-    uint32_t input_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -102,7 +102,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         .buffer = in_sharded ? input.buffer() : nullptr,
     });
 
-    uint32_t trans_mat_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t trans_mat_cb_index = tt::CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = trans_mat_single_tile_size,
         .core_ranges = all_cores,
@@ -113,7 +113,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         }}},
     });
 
-    uint32_t cos_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t cos_cb_index = tt::CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = cos_single_tile_size,
         .core_ranges = all_cores,
@@ -124,7 +124,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         }}},
     });
 
-    uint32_t sin_cb_index = tt::CBIndex::c_3;
+    constexpr uint8_t sin_cb_index = tt::CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
         .total_size = sin_single_tile_size,
         .core_ranges = all_cores,
@@ -136,7 +136,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
     });
 
     uint32_t num_interm_tiles = 1;
-    uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -147,7 +147,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = tt::CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -158,7 +158,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = tt::CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -169,7 +169,7 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = all_cores,
@@ -294,30 +294,22 @@ ProgramDescriptor create_single_tile_prefill_descriptor(
         uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
         uint32_t cos_sin_start_id = num_tiles_written % HtWt;
 
-        std::vector<uint32_t> reader_rt_args;
         if (in_sharded) {
-            reader_rt_args = {
-                cos_buffer->address(),
-                sin_buffer->address(),
-                num_rows_per_core,
-                num_tiles_written / Wt % Ht,
-                cos_sin_start_id,
-            };
+            reader_desc.emplace_runtime_args(
+                core, {cos_buffer, sin_buffer, num_rows_per_core, num_tiles_written / Wt % Ht, cos_sin_start_id});
         } else {
-            reader_rt_args = {
-                src_buffer->address(),
-                cos_buffer->address(),
-                sin_buffer->address(),
-                num_rows_per_core,
-                num_tiles_written,
-                num_tiles_written / Wt % Ht,
-                cos_sin_start_id,
-            };
+            reader_desc.emplace_runtime_args(
+                core,
+                {src_buffer,
+                 cos_buffer,
+                 sin_buffer,
+                 num_rows_per_core,
+                 num_tiles_written,
+                 num_tiles_written / Wt % Ht,
+                 cos_sin_start_id});
         }
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_rows_per_core * Wt, num_tiles_written});
         num_tiles_written += num_rows_per_core * Wt;
     }
 
@@ -402,7 +394,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         num_output_tiles = num_input_tiles;
     }
 
-    uint32_t input_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -414,7 +406,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         .buffer = in_sharded ? input.buffer() : nullptr,
     });
 
-    uint32_t rotated_input_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t rotated_input_cb_index = tt::CBIndex::c_1;
     uint32_t num_rotated_input_tiles = 2 * Wt;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_rotated_input_tiles * input_single_tile_size,
@@ -427,7 +419,7 @@ ProgramDescriptor create_multi_tile_descriptor(
     });
 
     uint32_t num_cos_sin_tiles = 2 * Wt;
-    uint32_t cos_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t cos_cb_index = tt::CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = all_cores,
@@ -438,7 +430,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t sin_cb_index = tt::CBIndex::c_3;
+    constexpr uint8_t sin_cb_index = tt::CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = all_cores,
@@ -449,7 +441,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t src_scalar_cb_index = tt::CBIndex::c_4;
+    constexpr uint8_t src_scalar_cb_index = tt::CBIndex::c_4;
     uint32_t num_scalar_tiles = 1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_scalar_tiles * scalar_single_tile_size,
@@ -462,7 +454,7 @@ ProgramDescriptor create_multi_tile_descriptor(
     });
 
     uint32_t num_interm_tiles = 1;
-    uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores,
@@ -473,7 +465,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = tt::CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * cos_single_tile_size,
         .core_ranges = all_cores,
@@ -484,7 +476,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = tt::CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * sin_single_tile_size,
         .core_ranges = all_cores,
@@ -495,7 +487,7 @@ ProgramDescriptor create_multi_tile_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = all_cores,
@@ -613,19 +605,17 @@ ProgramDescriptor create_multi_tile_descriptor(
         uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
         uint32_t cos_sin_start_id = num_tiles_written % HtWt;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                src_buffer->address(),
-                cos_buffer->address(),
-                sin_buffer->address(),
-                num_rows_per_core,
-                num_tiles_written,
-                num_tiles_written / Wt % Ht,
-                cos_sin_start_id});
+            {src_buffer,
+             cos_buffer,
+             sin_buffer,
+             num_rows_per_core,
+             num_tiles_written,
+             num_tiles_written / Wt % Ht,
+             cos_sin_start_id});
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_rows_per_core * Wt, num_tiles_written});
         num_tiles_written += num_rows_per_core * Wt;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.cpp
@@ -8,22 +8,22 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
 namespace {
 
-RotaryEmbeddingHfMultiCore::cached_program_t create_single_tile_prefill(
+ProgramDescriptor create_single_tile_prefill_descriptor(
     const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
-    using namespace tt::tt_metal;
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
-
-    Program program{};
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -91,64 +91,95 @@ RotaryEmbeddingHfMultiCore::cached_program_t create_single_tile_prefill(
     }
 
     uint32_t input_cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size);
-    if (in_sharded) {
-        cb_input_config = cb_input_config.set_globally_allocated_address(*input.buffer());
-    }
-    auto cb_input = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in_sharded ? input.buffer() : nullptr,
+    });
 
     uint32_t trans_mat_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_trans_mat_config =
-        tt::tt_metal::CircularBufferConfig(trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = trans_mat_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = trans_mat_cb_index,
+            .data_format = trans_mat_cb_data_format,
+            .page_size = trans_mat_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_cos_config =
-        tt::tt_metal::CircularBufferConfig(cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cos_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_cb_index = tt::CBIndex::c_3;
-    tt::tt_metal::CircularBufferConfig cb_sin_config =
-        tt::tt_metal::CircularBufferConfig(sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = sin_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t num_interm_tiles = 1;
     uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
-    tt::tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
-    tt::tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{cos_interm_cb_index, input_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
-    tt::tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{sin_interm_cb_index, input_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    if (out_sharded) {
-        cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-    }
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = out_sharded ? output.buffer() : nullptr,
+    });
 
     auto* src_buffer = input.buffer();
     auto* cos_buffer = cos.buffer();
@@ -165,8 +196,8 @@ RotaryEmbeddingHfMultiCore::cached_program_t create_single_tile_prefill(
             (std::uint32_t)Ht,
             (std::uint32_t)HtWt,
         };
-        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
     } else {
         reader_compile_time_args = {
             (std::uint32_t)input_cb_index,
@@ -176,36 +207,41 @@ RotaryEmbeddingHfMultiCore::cached_program_t create_single_tile_prefill(
             (std::uint32_t)Ht,
             (std::uint32_t)HtWt,
         };
-        tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
     }
 
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> writer_kernel_defines;
+    KernelDescriptor::Defines writer_kernel_defines;
     if (out_sharded) {
-        writer_kernel_defines["OUT_SHARDED"] = "1";
+        writer_kernel_defines.emplace_back("OUT_SHARDED", "1");
     }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         in_sharded ? "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/"
                      "dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp"
                    : "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/"
-                     "dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+                     "dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/"
-        "writer_rotary_embedding_hf_interleaved.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_kernel_defines));
+        "writer_rotary_embedding_hf_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_kernel_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    std::vector<uint32_t> compute_kernel_args = {
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
         (std::uint32_t)input_cb_index,
         (std::uint32_t)cos_cb_index,
         (std::uint32_t)sin_cb_index,
@@ -217,30 +253,41 @@ RotaryEmbeddingHfMultiCore::cached_program_t create_single_tile_prefill(
         (std::uint32_t)num_rows_per_core_group_1,
     };
 
-    tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc_g1;
+    compute_desc_g1.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
-        "rotary_embedding_single_tile.cpp",
-        core_group_1,
-        tt::tt_metal::ComputeConfig{
+        "rotary_embedding_single_tile.cpp";
+    compute_desc_g1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_g1.core_ranges = core_group_1;
+    compute_desc_g1.compile_time_args = compute_kernel_args_group_1;
+    compute_desc_g1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
+
+    std::optional<KernelDescriptor> compute_desc_g2;
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = compute_kernel_args_group_1;
+        compute_kernel_args_group_2[8] = num_rows_per_core_group_2;
+        KernelDescriptor g2;
+        g2.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
+            "rotary_embedding_single_tile.cpp";
+        g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        g2.core_ranges = core_group_2;
+        g2.compile_time_args = std::move(compute_kernel_args_group_2);
+        g2.config = ComputeConfigDescriptor{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args});
-    if (!core_group_2.ranges().empty()) {
-        compute_kernel_args[8] = num_rows_per_core_group_2;
-        tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
-            "rotary_embedding_single_tile.cpp",
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .compile_args = compute_kernel_args});
+        };
+        compute_desc_g2 = std::move(g2);
     }
 
     uint32_t g1_numcores = core_group_1.num_cores();
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    reader_desc.runtime_args.reserve(num_cores);
+    writer_desc.runtime_args.reserve(num_cores);
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
         const CoreCoord& core = cores.at(i);
@@ -267,47 +314,30 @@ RotaryEmbeddingHfMultiCore::cached_program_t create_single_tile_prefill(
                 cos_sin_start_id,
             };
         }
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
 
-        tt::tt_metal::SetRuntimeArgs(
-            program, unary_writer_kernel_id, core, {dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written});
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written});
         num_tiles_written += num_rows_per_core * Wt;
     }
 
-    RotaryEmbeddingHfMultiCore::shared_variables_t shared_variables{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cb_input = cb_input,
-        .cb_output = cb_output,
-        .cores = cores,
-        .g1_numcores = g1_numcores,
-        .num_rows_per_core_group_1 = num_rows_per_core_group_1,
-        .num_rows_per_core_group_2 = num_rows_per_core_group_2,
-        .Wt = Wt,
-        .Ht = Ht,
-        .HtWt = HtWt,
-        .single_tile = true,
-        .single_tile_reader_uses_sharded_args = in_sharded,
-    };
-
-    return RotaryEmbeddingHfMultiCore::cached_program_t{std::move(program), std::move(shared_variables)};
-}
-
-}  // namespace
-
-RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
-    const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
-    using namespace tt::tt_metal;
-
-    const auto& input = tensor_args.input_tensor;
-    if (input.padded_shape()[-1] / TILE_WIDTH == 1) {
-        return create_single_tile_prefill(operation_attributes, tensor_args, output);
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_g1));
+    if (compute_desc_g2.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_g2));
     }
 
+    return desc;
+}
+
+ProgramDescriptor create_multi_tile_descriptor(
+    const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
+    ProgramDescriptor desc;
+
+    const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
-
-    Program program{};
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -373,77 +403,109 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
     }
 
     uint32_t input_cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size);
-    if (in_sharded) {
-        cb_input_config = cb_input_config.set_globally_allocated_address(*input.buffer());
-    }
-    auto cb_input = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = in_sharded ? input.buffer() : nullptr,
+    });
 
     uint32_t rotated_input_cb_index = tt::CBIndex::c_1;
     uint32_t num_rotated_input_tiles = 2 * Wt;
-    tt::tt_metal::CircularBufferConfig cb_rotated_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_rotated_input_tiles * input_single_tile_size, {{rotated_input_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_rotated_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t num_cos_sin_tiles = 2 * Wt;
     uint32_t cos_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_cos_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_cb_index = tt::CBIndex::c_3;
-    tt::tt_metal::CircularBufferConfig cb_sin_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t src_scalar_cb_index = tt::CBIndex::c_4;
     uint32_t num_scalar_tiles = 1;
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_scalar_tiles * scalar_single_tile_size, {{src_scalar_cb_index, scalar_cb_data_format}})
-            .set_page_size(src_scalar_cb_index, scalar_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_scalar_tiles * scalar_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src_scalar_cb_index,
+            .data_format = scalar_cb_data_format,
+            .page_size = scalar_single_tile_size,
+        }}},
+    });
 
     uint32_t num_interm_tiles = 1;
     uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
-    tt::tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
-    tt::tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * cos_single_tile_size, {{cos_interm_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, cos_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * cos_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
-    tt::tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * sin_single_tile_size, {{sin_interm_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, sin_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * sin_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    if (out_sharded) {
-        cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-    }
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = out_sharded ? output.buffer() : nullptr,
+    });
 
     const uint16_t bfloat16_scalar = std::bit_cast<uint16_t>(bfloat16(-1.0f));
 
@@ -464,33 +526,38 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
         (std::uint32_t)HtWt,
         (std::uint32_t)half_Wt,
     };
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> writer_kernel_defines;
+    KernelDescriptor::Defines writer_kernel_defines;
     if (out_sharded) {
-        writer_kernel_defines["OUT_SHARDED"] = "1";
+        writer_kernel_defines.emplace_back("OUT_SHARDED", "1");
     }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/"
-        "reader_rotary_embedding_hf_interleaved.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_rotary_embedding_hf_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/"
-        "writer_rotary_embedding_hf_interleaved.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_kernel_defines));
+        "writer_rotary_embedding_hf_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_kernel_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    std::vector<uint32_t> compute_kernel_args = {
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
         (std::uint32_t)input_cb_index,
         (std::uint32_t)rotated_input_cb_index,
         (std::uint32_t)cos_cb_index,
@@ -504,135 +571,83 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
         (std::uint32_t)Wt,
         (std::uint32_t)half_Wt};
 
-    tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc_g1;
+    compute_desc_g1.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/"
-        "rotary_embedding_hf.cpp",
-        core_group_1,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+        "rotary_embedding_hf.cpp";
+    compute_desc_g1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_g1.core_ranges = core_group_1;
+    compute_desc_g1.compile_time_args = compute_kernel_args_group_1;
+    compute_desc_g1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
+    std::optional<KernelDescriptor> compute_desc_g2;
     if (!core_group_2.ranges().empty()) {
-        compute_kernel_args[9] = num_rows_per_core_group_2;
+        std::vector<uint32_t> compute_kernel_args_group_2 = compute_kernel_args_group_1;
+        compute_kernel_args_group_2[9] = num_rows_per_core_group_2;
 
-        tt::tt_metal::CreateKernel(
-            program,
+        KernelDescriptor g2;
+        g2.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/"
-            "rotary_embedding_hf.cpp",
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .compile_args = compute_kernel_args});
+            "rotary_embedding_hf.cpp";
+        g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        g2.core_ranges = core_group_2;
+        g2.compile_time_args = std::move(compute_kernel_args_group_2);
+        g2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+        };
+        compute_desc_g2 = std::move(g2);
     }
 
     uint32_t g1_numcores = core_group_1.num_cores();
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    reader_desc.runtime_args.reserve(num_cores);
+    writer_desc.runtime_args.reserve(num_cores);
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
         const CoreCoord& core = cores.at(i);
         uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
         uint32_t cos_sin_start_id = num_tiles_written % HtWt;
 
-        std::vector<uint32_t> reader_rt_args = {
-            src_buffer->address(),
-            cos_buffer->address(),
-            sin_buffer->address(),
-            num_rows_per_core,
-            num_tiles_written,
-            num_tiles_written / Wt % Ht,
-            cos_sin_start_id};
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                src_buffer->address(),
+                cos_buffer->address(),
+                sin_buffer->address(),
+                num_rows_per_core,
+                num_tiles_written,
+                num_tiles_written / Wt % Ht,
+                cos_sin_start_id});
 
-        tt::tt_metal::SetRuntimeArgs(
-            program, unary_writer_kernel_id, core, {dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written});
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written});
         num_tiles_written += num_rows_per_core * Wt;
     }
 
-    RotaryEmbeddingHfMultiCore::shared_variables_t shared_variables{
-        .unary_reader_kernel_id = unary_reader_kernel_id,
-        .unary_writer_kernel_id = unary_writer_kernel_id,
-        .cb_input = cb_input,
-        .cb_output = cb_output,
-        .cores = cores,
-        .g1_numcores = g1_numcores,
-        .num_rows_per_core_group_1 = num_rows_per_core_group_1,
-        .num_rows_per_core_group_2 = num_rows_per_core_group_2,
-        .Wt = Wt,
-        .Ht = Ht,
-        .HtWt = HtWt,
-        .single_tile = false,
-        .single_tile_reader_uses_sharded_args = false,
-    };
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_g1));
+    if (compute_desc_g2.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_g2));
+    }
 
-    return cached_program_t{std::move(program), std::move(shared_variables)};
+    return desc;
 }
 
-void RotaryEmbeddingHfMultiCore::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RotaryEmbeddingHfParams& operation_attributes,
-    const RotaryEmbeddingHfInputs& tensor_args,
-    Tensor& output) {
-    using namespace tt::constants;
+}  // namespace
 
-    (void)operation_attributes;
-
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* cos_buffer = tensor_args.cos_cache.buffer();
-    auto* sin_buffer = tensor_args.sin_cache.buffer();
-    auto* dst_buffer = output.buffer();
-
-    bool in_sharded = tensor_args.input_tensor.is_sharded();
-    bool out_sharded = output.is_sharded();
-
-    auto& program = cached_program.program;
-    const auto& cores = cached_program.shared_variables.cores;
-    const auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    const auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    const auto& cb_input = cached_program.shared_variables.cb_input;
-    const auto& cb_output = cached_program.shared_variables.cb_output;
-    const auto& g1_numcores = cached_program.shared_variables.g1_numcores;
-    const auto& num_rows_per_core_group_1 = cached_program.shared_variables.num_rows_per_core_group_1;
-    const auto& num_rows_per_core_group_2 = cached_program.shared_variables.num_rows_per_core_group_2;
-    const auto& Wt = cached_program.shared_variables.Wt;
-    const auto& HtWt = cached_program.shared_variables.HtWt;
-    const auto& single_tile = cached_program.shared_variables.single_tile;
-    const auto& single_tile_reader_uses_sharded_args =
-        cached_program.shared_variables.single_tile_reader_uses_sharded_args;
-
-    if (in_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_input, *src_buffer);
+ProgramDescriptor RotaryEmbeddingHfMultiCore::create_descriptor(
+    const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input_tensor;
+    if (input.padded_shape()[-1] / TILE_WIDTH == 1) {
+        return create_single_tile_prefill_descriptor(operation_attributes, tensor_args, output);
     }
-
-    if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-    }
-
-    for (uint32_t i = 0, num_tiles_written = 0; i < cores.size(); ++i) {
-        const CoreCoord& core = cores.at(i);
-        uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
-        uint32_t cos_sin_start_id = num_tiles_written % HtWt;
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            if (single_tile && single_tile_reader_uses_sharded_args) {
-                runtime_args[0] = cos_buffer->address();
-                runtime_args[1] = sin_buffer->address();
-                runtime_args[4] = cos_sin_start_id;
-            } else {
-                runtime_args[0] = src_buffer->address();
-                runtime_args[1] = cos_buffer->address();
-                runtime_args[2] = sin_buffer->address();
-                runtime_args[6] = cos_sin_start_id;
-            }
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-        num_tiles_written += num_rows_per_core * Wt;
-    }
+    return create_multi_tile_descriptor(operation_attributes, tensor_args, output);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.hpp
@@ -7,37 +7,15 @@
 #include "ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-using namespace tt::tt_metal;
-
 struct RotaryEmbeddingHfMultiCore {
-    struct shared_variables_t {
-        KernelHandle unary_reader_kernel_id;
-        KernelHandle unary_writer_kernel_id;
-        CBHandle cb_input;
-        CBHandle cb_output;
-        std::vector<CoreCoord> cores;
-        uint32_t g1_numcores;
-        uint32_t num_rows_per_core_group_1;
-        uint32_t num_rows_per_core_group_2;
-        uint32_t Wt;
-        uint32_t Ht;
-        uint32_t HtWt;
-        bool single_tile;
-        bool single_tile_reader_uses_sharded_args;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const RotaryEmbeddingHfParams& operation_attributes,
-        const RotaryEmbeddingHfInputs& tensor_args,
-        Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Contract (1): single ProgramDescriptor.  Sharded variants set CBDescriptor::buffer
+    // so the framework patches the dynamic address on cache hit.  Per-core reader/writer
+    // runtime args are re-applied by the framework via apply_descriptor_runtime_args.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingHfParams& operation_attributes,
         const RotaryEmbeddingHfInputs& tensor_args,
         Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.cpp
@@ -75,7 +75,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
     auto* sin_buffer = sin.buffer();
     auto* dst_buffer = output.buffer();
 
-    uint32_t input_cb_index = CBIndex::c_0;
+    constexpr uint8_t input_cb_index = CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -87,7 +87,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
         .buffer = src_buffer,
     });
 
-    uint32_t cos_cb_index = CBIndex::c_1;
+    constexpr uint8_t cos_cb_index = CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -99,7 +99,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
         .buffer = cos_buffer,
     });
 
-    uint32_t sin_cb_index = CBIndex::c_2;
+    constexpr uint8_t sin_cb_index = CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -111,7 +111,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
         .buffer = sin_buffer,
     });
 
-    uint32_t trans_mat_cb_index = CBIndex::c_3;
+    constexpr uint8_t trans_mat_cb_index = CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
         .total_size = trans_mat_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -123,7 +123,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
     });
 
     uint32_t num_interm_tiles = head_dim_t;
-    uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -134,7 +134,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -145,7 +145,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -156,7 +156,7 @@ ProgramDescriptor create_single_tile_decode_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = CBIndex::c_16;
+    constexpr uint8_t output_cb_index = CBIndex::c_16;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -266,7 +266,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
     auto* sin_buffer = sin.buffer();
     auto* dst_buffer = output.buffer();
 
-    uint32_t input_cb_index = CBIndex::c_0;
+    constexpr uint8_t input_cb_index = CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -278,7 +278,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
         .buffer = src_buffer,
     });
 
-    uint32_t cos_cb_index = CBIndex::c_1;
+    constexpr uint8_t cos_cb_index = CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -290,7 +290,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
         .buffer = cos_buffer,
     });
 
-    uint32_t sin_cb_index = CBIndex::c_2;
+    constexpr uint8_t sin_cb_index = CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -302,7 +302,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
         .buffer = sin_buffer,
     });
 
-    uint32_t src_scalar_cb_index = CBIndex::c_3;
+    constexpr uint8_t src_scalar_cb_index = CBIndex::c_3;
     uint32_t num_scalar_tiles = 1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_scalar_tiles * scalar_single_tile_size,
@@ -315,7 +315,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
     });
 
     uint32_t num_interm_tiles = head_dim_t;
-    uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -326,7 +326,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * cos_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -337,7 +337,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * sin_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -348,7 +348,7 @@ ProgramDescriptor create_multi_tile_decode_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = CBIndex::c_16;
+    constexpr uint8_t output_cb_index = CBIndex::c_16;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.cpp
@@ -8,22 +8,23 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
+using namespace tt;
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
 namespace {
 
-RotaryEmbeddingHfMultiCoreSharded::cached_program_t create_single_tile_decode(
+ProgramDescriptor create_single_tile_decode_descriptor(
     const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt;
-    using namespace tt::tt_metal;
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
-
-    Program program{};
 
     const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -75,62 +76,97 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t create_single_tile_decode(
     auto* dst_buffer = output.buffer();
 
     uint32_t input_cb_index = CBIndex::c_0;
-    tt_metal::CircularBufferConfig cb_input_config =
-        tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size)
-            .set_globally_allocated_address(*src_buffer);
-    auto cb_input = tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = src_buffer,
+    });
 
     uint32_t cos_cb_index = CBIndex::c_1;
-    tt_metal::CircularBufferConfig cb_cos_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size)
-            .set_globally_allocated_address(*cos_buffer);
-    auto cb_cos = tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+        .buffer = cos_buffer,
+    });
 
     uint32_t sin_cb_index = CBIndex::c_2;
-    tt_metal::CircularBufferConfig cb_sin_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size)
-            .set_globally_allocated_address(*sin_buffer);
-    auto cb_sin = tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+        .buffer = sin_buffer,
+    });
 
     uint32_t trans_mat_cb_index = CBIndex::c_3;
-    tt_metal::CircularBufferConfig cb_trans_mat_config =
-        tt_metal::CircularBufferConfig(trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = trans_mat_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = trans_mat_cb_index,
+            .data_format = trans_mat_cb_data_format,
+            .page_size = trans_mat_single_tile_size,
+        }}},
+    });
 
     uint32_t num_interm_tiles = head_dim_t;
     uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
-    tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = CBIndex::c_25;
-    tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{cos_interm_cb_index, input_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = CBIndex::c_26;
-    tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{sin_interm_cb_index, input_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = CBIndex::c_16;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size)
-            .set_globally_allocated_address(*dst_buffer);
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = dst_buffer,
+    });
 
     std::vector<uint32_t> compute_kernel_args = {
         (std::uint32_t)input_cb_index,
@@ -145,51 +181,43 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t create_single_tile_decode(
         (std::uint32_t)batch_per_core,
     };
 
-    tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/"
-        "rotary_embedding_hf_single_tile_sharded.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+        "rotary_embedding_hf_single_tile_sharded.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = CoreRangeSet(all_cores);
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)trans_mat_cb_index,
     };
-    tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/"
-        "reader_rotary_embedding_hf_single_tile_sharded.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_rotary_embedding_hf_single_tile_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = CoreRangeSet(all_cores);
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    return RotaryEmbeddingHfMultiCoreSharded::cached_program_t{
-        std::move(program),
-        RotaryEmbeddingHfMultiCoreSharded::shared_variables_t{
-            cb_input,
-            cb_cos,
-            cb_sin,
-            cb_output,
-        }};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-}  // namespace
-
-RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSharded::create(
+ProgramDescriptor create_multi_tile_decode_descriptor(
     const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt;
-    using namespace tt::tt_metal;
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input_tensor;
-    if (input.padded_shape()[-1] / TILE_WIDTH == 1) {
-        return create_single_tile_decode(operation_attributes, tensor_args, output);
-    }
-
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
-
-    Program program{};
 
     const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -239,64 +267,98 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
     auto* dst_buffer = output.buffer();
 
     uint32_t input_cb_index = CBIndex::c_0;
-    tt_metal::CircularBufferConfig cb_input_config =
-        tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size)
-            .set_globally_allocated_address(*src_buffer);
-    auto cb_input = tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = src_buffer,
+    });
 
     uint32_t cos_cb_index = CBIndex::c_1;
-    tt_metal::CircularBufferConfig cb_cos_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size)
-            .set_globally_allocated_address(*cos_buffer);
-    auto cb_cos = tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+        .buffer = cos_buffer,
+    });
 
     uint32_t sin_cb_index = CBIndex::c_2;
-    tt_metal::CircularBufferConfig cb_sin_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size)
-            .set_globally_allocated_address(*sin_buffer);
-    auto cb_sin = tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+        .buffer = sin_buffer,
+    });
 
     uint32_t src_scalar_cb_index = CBIndex::c_3;
     uint32_t num_scalar_tiles = 1;
-    tt_metal::CircularBufferConfig cb_src_scalar_config =
-        tt_metal::CircularBufferConfig(
-            num_scalar_tiles * scalar_single_tile_size, {{src_scalar_cb_index, scalar_cb_data_format}})
-            .set_page_size(src_scalar_cb_index, scalar_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src_scalar_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_scalar_tiles * scalar_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src_scalar_cb_index,
+            .data_format = scalar_cb_data_format,
+            .page_size = scalar_single_tile_size,
+        }}},
+    });
 
     uint32_t num_interm_tiles = head_dim_t;
     uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
-    tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = CBIndex::c_25;
-    tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * cos_single_tile_size, {{cos_interm_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, cos_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * cos_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = CBIndex::c_26;
-    tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * sin_single_tile_size, {{sin_interm_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, sin_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * sin_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = CBIndex::c_16;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size)
-            .set_globally_allocated_address(*dst_buffer);
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = dst_buffer,
+    });
 
     std::vector<uint32_t> compute_kernel_args = {
         (std::uint32_t)input_cb_index,
@@ -313,53 +375,47 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
         (std::uint32_t)batch_per_core,
     };
 
-    tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/"
-        "rotary_embedding_hf_sharded.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+        "rotary_embedding_hf_sharded.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = CoreRangeSet(all_cores);
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     const uint16_t bfloat16_neg_one = std::bit_cast<uint16_t>(bfloat16(-1.0f));
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)src_scalar_cb_index,
         (std::uint32_t)bfloat16_neg_one,
     };
-    tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/"
-        "reader_rotary_embedding_hf_sharded.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_rotary_embedding_hf_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = CoreRangeSet(all_cores);
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    return cached_program_t{
-        std::move(program),
-        RotaryEmbeddingHfMultiCoreSharded::shared_variables_t{
-            cb_input,
-            cb_cos,
-            cb_sin,
-            cb_output,
-        }};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void RotaryEmbeddingHfMultiCoreSharded::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RotaryEmbeddingHfParams& /*operation_attributes*/,
-    const RotaryEmbeddingHfInputs& tensor_args,
-    Tensor& output) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
+}  // namespace
 
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* cos_buffer = tensor_args.cos_cache.buffer();
-    auto* sin_buffer = tensor_args.sin_cache.buffer();
-    auto* dst_buffer = output.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_input, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_cos, *cos_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_sin, *sin_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *dst_buffer);
+ProgramDescriptor RotaryEmbeddingHfMultiCoreSharded::create_descriptor(
+    const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input_tensor;
+    if (input.padded_shape()[-1] / TILE_WIDTH == 1) {
+        return create_single_tile_decode_descriptor(operation_attributes, tensor_args, output);
+    }
+    return create_multi_tile_decode_descriptor(operation_attributes, tensor_args, output);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.hpp
@@ -7,28 +7,15 @@
 #include "ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-using namespace tt::tt_metal;
-
 struct RotaryEmbeddingHfMultiCoreSharded {
-    struct shared_variables_t {
-        CBHandle cb_input;
-        CBHandle cb_cos;
-        CBHandle cb_sin;
-        CBHandle cb_output;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const RotaryEmbeddingHfParams& operation_attributes,
-        const RotaryEmbeddingHfInputs& tensor_args,
-        Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Contract (1): single ProgramDescriptor.  All four working CBs (input/cos/sin/output)
+    // are sharded — they use CBDescriptor::buffer so the framework patches dynamic
+    // addresses on cache hit, mirroring the legacy UpdateDynamicCircularBufferAddress chain.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingHfParams& operation_attributes,
         const RotaryEmbeddingHfInputs& tensor_args,
         Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
@@ -6,23 +6,24 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLlamaMultiCorePrefillSharded::create(
+using namespace tt;
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
     tt::tt_metal::Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt::tt_metal;
-    using namespace tt;
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
     const auto& trans_mat = tensor_args.trans_mat;
-
-    Program program{};
 
     const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -76,9 +77,6 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
 
     CoreRange all_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    bool in_sharded = input.shard_spec().has_value();
-    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
-
     const uint32_t num_input_tiles = 2 * head_dim_t;
     const uint32_t num_output_tiles = num_input_tiles;
 
@@ -125,79 +123,115 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
     auto* dst_buffer = output.buffer();
 
     uint32_t input_cb_index = CBIndex::c_0;
-    tt_metal::CircularBufferConfig cb_input_config =
-        tt_metal::CircularBufferConfig(
-            input_cb_num_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_cb_num_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     // ------------------------------------------------------------------
     // Cos / Sin CBs — sharded path with optional reload fallback
     // ------------------------------------------------------------------
     uint32_t cos_cb_index = CBIndex::c_1;
     uint32_t sin_cb_index = CBIndex::c_2;
-    std::optional<CBHandle> cb_cos_handle;
-    std::optional<CBHandle> cb_sin_handle;
     if (cos_sin_sharded) {
         if (cos_sin_sharded_reload) {
-            tt_metal::CircularBufferConfig cos_cb_cfg =
-                tt_metal::CircularBufferConfig(
-                    num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-                    .set_page_size(cos_cb_index, cos_single_tile_size);
-            tt_metal::CreateCircularBuffer(program, all_cores, cos_cb_cfg);
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = num_cos_sin_tiles * cos_single_tile_size,
+                .core_ranges = CoreRangeSet(all_cores),
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = cos_cb_index,
+                    .data_format = cos_cb_data_format,
+                    .page_size = cos_single_tile_size,
+                }}},
+            });
 
-            tt_metal::CircularBufferConfig sin_cb_cfg =
-                tt_metal::CircularBufferConfig(
-                    num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-                    .set_page_size(sin_cb_index, sin_single_tile_size);
-            tt_metal::CreateCircularBuffer(program, all_cores, sin_cb_cfg);
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = num_cos_sin_tiles * sin_single_tile_size,
+                .core_ranges = CoreRangeSet(all_cores),
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = sin_cb_index,
+                    .data_format = sin_cb_data_format,
+                    .page_size = sin_single_tile_size,
+                }}},
+            });
         } else {
             const CoreRangeSet& cos_sin_shard_grid = cos.shard_spec()->grid;
             const bool partial_cos_sin = cos_sin_shard_grid.num_cores() < num_cores;
-            const auto& cos_sin_cb_cores = partial_cos_sin ? cos_sin_shard_grid : CoreRangeSet(all_cores);
+            const auto cos_sin_cb_cores = partial_cos_sin ? cos_sin_shard_grid : CoreRangeSet(all_cores);
 
-            auto cos_cb_cfg = tt_metal::CircularBufferConfig(
-                                  num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-                                  .set_page_size(cos_cb_index, cos_single_tile_size)
-                                  .set_globally_allocated_address(*cos_buffer);
-            cb_cos_handle = tt_metal::CreateCircularBuffer(program, cos_sin_cb_cores, cos_cb_cfg);
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = num_cos_sin_tiles * cos_single_tile_size,
+                .core_ranges = cos_sin_cb_cores,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = cos_cb_index,
+                    .data_format = cos_cb_data_format,
+                    .page_size = cos_single_tile_size,
+                }}},
+                .buffer = cos_buffer,
+            });
 
-            auto sin_cb_cfg = tt_metal::CircularBufferConfig(
-                                  num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-                                  .set_page_size(sin_cb_index, sin_single_tile_size)
-                                  .set_globally_allocated_address(*sin_buffer);
-            cb_sin_handle = tt_metal::CreateCircularBuffer(program, cos_sin_cb_cores, sin_cb_cfg);
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = num_cos_sin_tiles * sin_single_tile_size,
+                .core_ranges = cos_sin_cb_cores,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = sin_cb_index,
+                    .data_format = sin_cb_data_format,
+                    .page_size = sin_single_tile_size,
+                }}},
+                .buffer = sin_buffer,
+            });
 
             // Cores outside the shard grid still need a CB defined (they won't run work).
             if (partial_cos_sin) {
                 CoreRangeSet remaining_cores = CoreRangeSet(all_cores).subtract(cos_sin_shard_grid);
                 if (remaining_cores.num_cores() > 0) {
-                    tt_metal::CreateCircularBuffer(
-                        program,
-                        remaining_cores,
-                        tt_metal::CircularBufferConfig(cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-                            .set_page_size(cos_cb_index, cos_single_tile_size));
-                    tt_metal::CreateCircularBuffer(
-                        program,
-                        remaining_cores,
-                        tt_metal::CircularBufferConfig(sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-                            .set_page_size(sin_cb_index, sin_single_tile_size));
+                    desc.cbs.push_back(CBDescriptor{
+                        .total_size = cos_single_tile_size,
+                        .core_ranges = remaining_cores,
+                        .format_descriptors = {{CBFormatDescriptor{
+                            .buffer_index = cos_cb_index,
+                            .data_format = cos_cb_data_format,
+                            .page_size = cos_single_tile_size,
+                        }}},
+                    });
+                    desc.cbs.push_back(CBDescriptor{
+                        .total_size = sin_single_tile_size,
+                        .core_ranges = remaining_cores,
+                        .format_descriptors = {{CBFormatDescriptor{
+                            .buffer_index = sin_cb_index,
+                            .data_format = sin_cb_data_format,
+                            .page_size = sin_single_tile_size,
+                        }}},
+                    });
                 }
             }
         }
     } else {
         // Interleaved cos/sin (trans_mat may still be sharded).
-        tt_metal::CircularBufferConfig cb_cos_config =
-            tt_metal::CircularBufferConfig(
-                num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-                .set_page_size(cos_cb_index, cos_single_tile_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_cos_sin_tiles * cos_single_tile_size,
+            .core_ranges = CoreRangeSet(all_cores),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cos_cb_index,
+                .data_format = cos_cb_data_format,
+                .page_size = cos_single_tile_size,
+            }}},
+        });
 
-        tt_metal::CircularBufferConfig cb_sin_config =
-            tt_metal::CircularBufferConfig(
-                num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-                .set_page_size(sin_cb_index, sin_single_tile_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_cos_sin_tiles * sin_single_tile_size,
+            .core_ranges = CoreRangeSet(all_cores),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = sin_cb_index,
+                .data_format = sin_cb_data_format,
+                .page_size = sin_single_tile_size,
+            }}},
+        });
     }
 
     // ------------------------------------------------------------------
@@ -210,77 +244,108 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
     // When shard count < active cores, fall back to TensorAccessor reads (the non-sharded kernel path).
     const bool trans_mat_use_global_cb =
         trans_mat_sharded && num_active_cores_upper_bound <= trans_mat.shard_spec()->grid.num_cores();
-    std::optional<CBHandle> cb_trans_mat_handle;
     if (trans_mat_use_global_cb) {
         const CoreRangeSet& tm_shard_grid = trans_mat.shard_spec()->grid;
         const bool partial_tm = tm_shard_grid.num_cores() < num_cores;
-        const auto& tm_cb_cores = partial_tm ? tm_shard_grid : CoreRangeSet(all_cores);
+        const auto tm_cb_cores = partial_tm ? tm_shard_grid : CoreRangeSet(all_cores);
 
-        auto tm_cb_cfg =
-            tt_metal::CircularBufferConfig(
-                num_trans_mat_tiles * trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-                .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size)
-                .set_globally_allocated_address(*trans_mat_buffer);
-        cb_trans_mat_handle = tt_metal::CreateCircularBuffer(program, tm_cb_cores, tm_cb_cfg);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_trans_mat_tiles * trans_mat_single_tile_size,
+            .core_ranges = tm_cb_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = trans_mat_cb_index,
+                .data_format = trans_mat_cb_data_format,
+                .page_size = trans_mat_single_tile_size,
+            }}},
+            .buffer = trans_mat_buffer,
+        });
 
         // Cores outside the shard grid still need a CB defined (they won't run work).
         if (partial_tm) {
             CoreRangeSet tm_remaining = CoreRangeSet(all_cores).subtract(tm_shard_grid);
             if (tm_remaining.num_cores() > 0) {
-                tt_metal::CreateCircularBuffer(
-                    program,
-                    tm_remaining,
-                    tt_metal::CircularBufferConfig(
-                        trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-                        .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size));
+                desc.cbs.push_back(CBDescriptor{
+                    .total_size = trans_mat_single_tile_size,
+                    .core_ranges = tm_remaining,
+                    .format_descriptors = {{CBFormatDescriptor{
+                        .buffer_index = trans_mat_cb_index,
+                        .data_format = trans_mat_cb_data_format,
+                        .page_size = trans_mat_single_tile_size,
+                    }}},
+                });
             }
         }
     } else {
-        tt_metal::CircularBufferConfig cb_trans_mat_config =
-            tt_metal::CircularBufferConfig(
-                num_trans_mat_tiles * trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-                .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_trans_mat_tiles * trans_mat_single_tile_size,
+            .core_ranges = CoreRangeSet(all_cores),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = trans_mat_cb_index,
+                .data_format = trans_mat_cb_data_format,
+                .page_size = trans_mat_single_tile_size,
+            }}},
+        });
     }
 
     uint32_t num_interm_tiles = head_dim_t;
     uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
-    tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = CBIndex::c_25;
-    tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * cos_single_tile_size, {{cos_interm_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, cos_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * cos_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = CBIndex::c_26;
-    tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * sin_single_tile_size, {{sin_interm_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, sin_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * sin_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     uint32_t zero_cb_index = CBIndex::c_27;
-    tt_metal::CircularBufferConfig cb_zero_config =
-        tt_metal::CircularBufferConfig(head_dim_t * output_single_tile_size, {{zero_cb_index, output_cb_data_format}})
-            .set_page_size(zero_cb_index, output_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_zero_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = head_dim_t * output_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = zero_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
-    std::map<std::string, std::string> kernel_defines;
-    kernel_defines["RELOAD_IMPL"] = use_reload_impl ? "1" : "0";
-    kernel_defines["COS_SIN_SHARDED_RELOAD"] = cos_sin_sharded_reload ? "1" : "0";
+    KernelDescriptor::Defines kernel_defines;
+    kernel_defines.emplace_back("RELOAD_IMPL", use_reload_impl ? "1" : "0");
+    kernel_defines.emplace_back("COS_SIN_SHARDED_RELOAD", cos_sin_sharded_reload ? "1" : "0");
 
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)input_cb_index,
@@ -297,10 +362,10 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
         (std::uint32_t)sin_seq_len_t,
         (std::uint32_t)rotary_seq_len_t,
     };
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(trans_mat_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*trans_mat_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)output_cb_index,
         (std::uint32_t)zero_cb_index,
@@ -309,21 +374,27 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
         (std::uint32_t)seq_len_t,
         (std::uint32_t)rotary_seq_len_t,
     };
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
-        "reader_rotary_embedding_llama_prefill_sharded.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
+        "reader_rotary_embedding_llama_prefill_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = CoreRangeSet(all_cores);
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = kernel_defines;
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
-        "writer_rotary_embedding_llama_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args, kernel_defines));
+        "writer_rotary_embedding_llama_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = CoreRangeSet(all_cores);
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = kernel_defines;
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<uint32_t> compute_kernel_args = {
         (std::uint32_t)input_cb_index,
@@ -339,16 +410,18 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
         (std::uint32_t)rotary_seq_len_t,
     };
 
-    auto rotary_embedding_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/"
-        "rotary_embedding_llama.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .defines = kernel_defines});
+        "rotary_embedding_llama.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = CoreRangeSet(all_cores);
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.defines = std::move(kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
 
@@ -363,11 +436,9 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
 
     std::vector<uint32_t> default_compute_args = {0, 0, 0, 0};
 
-    std::vector<std::vector<uint32_t>> unary_reader_args = {cores.size(), default_reader_args};
-    std::vector<std::vector<uint32_t>> unary_writer_args = {cores.size(), default_writer_args};
-    std::vector<std::vector<uint32_t>> unary_compute_args = {cores.size(), default_compute_args};
-
-    uint32_t num_active_cores = 0;
+    std::vector<std::vector<uint32_t>> unary_reader_args(cores.size(), default_reader_args);
+    std::vector<std::vector<uint32_t>> unary_writer_args(cores.size(), default_writer_args);
+    std::vector<std::vector<uint32_t>> unary_compute_args(cores.size(), default_compute_args);
 
     for (uint32_t batch_parallel = 0; batch_parallel < batch_parallel_factor; batch_parallel++) {
         for (uint32_t seq_parallel = 0; seq_parallel < seq_parallel_factor; seq_parallel++) {
@@ -411,76 +482,23 @@ RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLla
             compute_rt_args[1] = end_batch;
             compute_rt_args[2] = start_seq;
             compute_rt_args[3] = end_seq;
-
-            num_active_cores = core_idx + 1;
         }
     }
 
-    tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, cores, unary_reader_args);
-    tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, cores, unary_writer_args);
-    tt_metal::SetRuntimeArgs(program, rotary_embedding_kernel_id, cores, unary_compute_args);
-
-    RotaryEmbeddingLlamaMultiCorePrefillSharded::shared_variables_t shared_variables;
-    shared_variables.unary_reader_kernel_id = unary_reader_kernel_id;
-    shared_variables.unary_writer_kernel_id = unary_writer_kernel_id;
-    shared_variables.rotary_embedding_kernel_id = rotary_embedding_kernel_id;
-    shared_variables.cores = cores;
-    shared_variables.num_active_cores = num_active_cores;
-    shared_variables.cb_cos = cb_cos_handle;
-    shared_variables.cb_sin = cb_sin_handle;
-    shared_variables.cb_trans_mat = cb_trans_mat_handle;
-
-    return {std::move(program), std::move(shared_variables)};
-}
-
-void RotaryEmbeddingLlamaMultiCorePrefillSharded::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RotaryEmbeddingLlamaParams& /*operation_attributes*/,
-    const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt::tt_metal;
-
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* cos_buffer = tensor_args.cos_cache.buffer();
-    auto* sin_buffer = tensor_args.sin_cache.buffer();
-    auto* trans_mat_buffer = tensor_args.trans_mat.buffer();
-    auto* dst_buffer = output.buffer();
-
-    auto& cached_reader_args = GetRuntimeArgs(program, shared_variables.unary_reader_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, shared_variables.unary_writer_kernel_id);
-
-    const auto& cores = shared_variables.cores;
-    uint32_t num_active_cores = shared_variables.num_active_cores;
-
-    for (uint32_t i = 0; i < num_active_cores; ++i) {
-        const CoreCoord& core = cores.at(i);
-        {
-            auto& runtime_args = cached_reader_args.at(core.x).at(core.y);
-            runtime_args[0] = src_buffer->address();
-            runtime_args[1] = cos_buffer->address();
-            runtime_args[2] = sin_buffer->address();
-            runtime_args[3] = trans_mat_buffer->address();
-        }
-
-        {
-            auto& runtime_args = cached_writer_args.at(core.x).at(core.y);
-            runtime_args[0] = dst_buffer->address();
-        }
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    compute_desc.runtime_args.reserve(cores.size());
+    for (uint32_t i = 0; i < cores.size(); ++i) {
+        reader_desc.runtime_args.emplace_back(cores[i], std::move(unary_reader_args[i]));
+        writer_desc.runtime_args.emplace_back(cores[i], std::move(unary_writer_args[i]));
+        compute_desc.runtime_args.emplace_back(cores[i], std::move(unary_compute_args[i]));
     }
 
-    if (shared_variables.cb_cos.has_value()) {
-        UpdateDynamicCircularBufferAddress(program, *shared_variables.cb_cos, *cos_buffer);
-    }
-    if (shared_variables.cb_sin.has_value()) {
-        UpdateDynamicCircularBufferAddress(program, *shared_variables.cb_sin, *sin_buffer);
-    }
-    if (shared_variables.cb_trans_mat.has_value()) {
-        UpdateDynamicCircularBufferAddress(program, *shared_variables.cb_trans_mat, *trans_mat_buffer);
-    }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
@@ -122,7 +122,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
     auto* trans_mat_buffer = trans_mat.buffer();
     auto* dst_buffer = output.buffer();
 
-    uint32_t input_cb_index = CBIndex::c_0;
+    constexpr uint8_t input_cb_index = CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = input_cb_num_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -136,8 +136,8 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
     // ------------------------------------------------------------------
     // Cos / Sin CBs — sharded path with optional reload fallback
     // ------------------------------------------------------------------
-    uint32_t cos_cb_index = CBIndex::c_1;
-    uint32_t sin_cb_index = CBIndex::c_2;
+    constexpr uint8_t cos_cb_index = CBIndex::c_1;
+    constexpr uint8_t sin_cb_index = CBIndex::c_2;
     if (cos_sin_sharded) {
         if (cos_sin_sharded_reload) {
             desc.cbs.push_back(CBDescriptor{
@@ -237,7 +237,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
     // ------------------------------------------------------------------
     // Trans_mat CB — sharded (global CB) or interleaved fallback
     // ------------------------------------------------------------------
-    uint32_t trans_mat_cb_index = CBIndex::c_3;
+    constexpr uint8_t trans_mat_cb_index = CBIndex::c_3;
     // We only take one tile of trans_mat
     uint32_t num_trans_mat_tiles = 1;
     // Globally-allocated CB for trans_mat requires shard grid to cover all active cores.
@@ -288,7 +288,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
     }
 
     uint32_t num_interm_tiles = head_dim_t;
-    uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -299,7 +299,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
         }}},
     });
 
-    uint32_t cos_interm_cb_index = CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * cos_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -310,7 +310,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
         }}},
     });
 
-    uint32_t sin_interm_cb_index = CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * sin_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -321,7 +321,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
         }}},
     });
 
-    uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
+    constexpr uint8_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -332,7 +332,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
         }}},
     });
 
-    uint32_t zero_cb_index = CBIndex::c_27;
+    constexpr uint8_t zero_cb_index = CBIndex::c_27;
     desc.cbs.push_back(CBDescriptor{
         .total_size = head_dim_t * output_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -429,16 +429,14 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
         Overall loop iterations: # total cores
     */
 
-    std::vector<uint32_t> default_reader_args = {
-        src_buffer->address(), cos_buffer->address(), sin_buffer->address(), trans_mat_buffer->address(), 0, 0, 0, 0};
-
-    std::vector<uint32_t> default_writer_args = {dst_buffer->address(), 0, 0, 0, 0};
-
-    std::vector<uint32_t> default_compute_args = {0, 0, 0, 0};
-
-    std::vector<std::vector<uint32_t>> unary_reader_args(cores.size(), default_reader_args);
-    std::vector<std::vector<uint32_t>> unary_writer_args(cores.size(), default_writer_args);
-    std::vector<std::vector<uint32_t>> unary_compute_args(cores.size(), default_compute_args);
+    // Per-core args tracked as {start_batch, end_batch, start_seq, end_seq}.
+    struct CoreArgs {
+        uint32_t start_batch = 0;
+        uint32_t end_batch = 0;
+        uint32_t start_seq = 0;
+        uint32_t end_seq = 0;
+    };
+    std::vector<CoreArgs> per_core_args(cores.size());
 
     for (uint32_t batch_parallel = 0; batch_parallel < batch_parallel_factor; batch_parallel++) {
         for (uint32_t seq_parallel = 0; seq_parallel < seq_parallel_factor; seq_parallel++) {
@@ -462,26 +460,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
                 start_seq,
                 end_seq);
 
-            // Reader runtime args
-            auto& reader_rt_args = unary_reader_args[core_idx];
-            reader_rt_args[4] = start_batch;
-            reader_rt_args[5] = end_batch;
-            reader_rt_args[6] = start_seq;
-            reader_rt_args[7] = end_seq;
-
-            // Writer runtime args
-            auto& writer_rt_args = unary_writer_args[core_idx];
-            writer_rt_args[1] = start_batch;
-            writer_rt_args[2] = end_batch;
-            writer_rt_args[3] = start_seq;
-            writer_rt_args[4] = end_seq;
-
-            // Compute runtime args
-            auto& compute_rt_args = unary_compute_args[core_idx];
-            compute_rt_args[0] = start_batch;
-            compute_rt_args[1] = end_batch;
-            compute_rt_args[2] = start_seq;
-            compute_rt_args[3] = end_seq;
+            per_core_args[core_idx] = CoreArgs{start_batch, end_batch, start_seq, end_seq};
         }
     }
 
@@ -489,9 +468,13 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCorePrefillSharded::create_descriptor
     writer_desc.runtime_args.reserve(cores.size());
     compute_desc.runtime_args.reserve(cores.size());
     for (uint32_t i = 0; i < cores.size(); ++i) {
-        reader_desc.runtime_args.emplace_back(cores[i], std::move(unary_reader_args[i]));
-        writer_desc.runtime_args.emplace_back(cores[i], std::move(unary_writer_args[i]));
-        compute_desc.runtime_args.emplace_back(cores[i], std::move(unary_compute_args[i]));
+        const auto& a = per_core_args[i];
+        reader_desc.emplace_runtime_args(
+            cores[i],
+            {src_buffer, cos_buffer, sin_buffer, trans_mat_buffer, a.start_batch, a.end_batch, a.start_seq, a.end_seq});
+        writer_desc.emplace_runtime_args(cores[i], {dst_buffer, a.start_batch, a.end_batch, a.start_seq, a.end_seq});
+        compute_desc.runtime_args.emplace_back(
+            cores[i], std::vector<uint32_t>{a.start_batch, a.end_batch, a.start_seq, a.end_seq});
     }
 
     desc.kernels.push_back(std::move(reader_desc));

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.hpp
@@ -7,34 +7,19 @@
 #include <optional>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
 #include "rotary_embedding_llama_device_operation_types.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct RotaryEmbeddingLlamaMultiCorePrefillSharded {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::KernelHandle rotary_embedding_kernel_id{};
-        std::vector<CoreCoord> cores;
-        uint32_t num_active_cores{};
-
-        // CB handles for globally-allocated (sharded) buffers; used by
-        // override_runtime_arguments to update addresses without re-creating CBs.
-        std::optional<tt::tt_metal::CBHandle> cb_cos;        // set iff cos is sharded and not reloading
-        std::optional<tt::tt_metal::CBHandle> cb_sin;        // set iff sin is sharded and not reloading
-        std::optional<tt::tt_metal::CBHandle> cb_trans_mat;  // set iff trans_mat uses global CB
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const RotaryEmbeddingLlamaParams& operation_attributes,
-        const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Contract (1): single ProgramDescriptor.  Globally-allocated cos/sin/trans_mat
+    // CBs (when sharded and grid-covering) bind through CBDescriptor::buffer so the
+    // framework patches dynamic addresses on cache hit; partial-grid shard cases
+    // get a second non-buffered CB on the remaining cores (CBs are merged at
+    // runtime since they share buffer indices).
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
         tt::tt_metal::Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
@@ -6,23 +6,24 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::create(
+using namespace tt;
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
     tt::tt_metal::Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt::tt_metal;
-    using namespace tt;
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
     const auto& trans_mat = tensor_args.trans_mat;
-
-    Program program{};
 
     const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -72,9 +73,6 @@ RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::c
 
     CoreRange all_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    bool in_sharded = input.shard_spec().has_value();
-    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
-
     const uint32_t num_input_tiles = 2 * head_dim_t;
     const uint32_t num_output_tiles = num_input_tiles;
 
@@ -104,70 +102,109 @@ RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::c
     }
 
     uint32_t input_cb_index = CBIndex::c_0;
-    tt_metal::CircularBufferConfig cb_input_config =
-        tt_metal::CircularBufferConfig(
-            input_cb_num_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_cb_num_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_cb_index = CBIndex::c_1;
-    tt_metal::CircularBufferConfig cb_cos_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_cb_index = CBIndex::c_2;
-    tt_metal::CircularBufferConfig cb_sin_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t trans_mat_cb_index = CBIndex::c_3;
     // We only take one tile of trans_mat
     uint32_t num_trans_mat_tiles = 1;
-    tt_metal::CircularBufferConfig cb_trans_mat_config =
-        tt_metal::CircularBufferConfig(
-            num_trans_mat_tiles * trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_trans_mat_tiles * trans_mat_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = trans_mat_cb_index,
+            .data_format = trans_mat_cb_data_format,
+            .page_size = trans_mat_single_tile_size,
+        }}},
+    });
 
     uint32_t num_interm_tiles = head_dim_t;
     uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
-    tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = CBIndex::c_25;
-    tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * cos_single_tile_size, {{cos_interm_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, cos_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * cos_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = CBIndex::c_26;
-    tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * sin_single_tile_size, {{sin_interm_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, sin_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * sin_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     uint32_t zero_cb_index = CBIndex::c_27;
-    tt_metal::CircularBufferConfig cb_zero_config =
-        tt_metal::CircularBufferConfig(head_dim_t * output_single_tile_size, {{zero_cb_index, output_cb_data_format}})
-            .set_page_size(zero_cb_index, output_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_zero_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = head_dim_t * output_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = zero_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
-    std::map<std::string, std::string> kernel_defines;
-    kernel_defines["RELOAD_IMPL"] = use_reload_impl ? "1" : "0";
+    KernelDescriptor::Defines kernel_defines;
+    kernel_defines.emplace_back("RELOAD_IMPL", use_reload_impl ? "1" : "0");
 
     auto* src_buffer = input.buffer();
     auto* cos_buffer = cos.buffer();
@@ -188,10 +225,10 @@ RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::c
         (std::uint32_t)sin_seq_len_t,
         (std::uint32_t)rotary_seq_len_t,
     };
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(trans_mat_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*trans_mat_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)output_cb_index,
         (std::uint32_t)zero_cb_index,
@@ -200,21 +237,27 @@ RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::c
         (std::uint32_t)seq_len_t,
         (std::uint32_t)rotary_seq_len_t,
     };
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
-        "reader_rotary_embedding_llama_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
+        "reader_rotary_embedding_llama_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = CoreRangeSet(all_cores);
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = kernel_defines;
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/"
-        "writer_rotary_embedding_llama_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args, kernel_defines));
+        "writer_rotary_embedding_llama_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = CoreRangeSet(all_cores);
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = kernel_defines;
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<uint32_t> compute_kernel_args = {
         (std::uint32_t)input_cb_index,
@@ -230,16 +273,18 @@ RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::c
         (std::uint32_t)rotary_seq_len_t,
     };
 
-    auto rotary_embedding_kernel_id = tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/"
-        "rotary_embedding_llama.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .defines = kernel_defines});
+        "rotary_embedding_llama.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = CoreRangeSet(all_cores);
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.defines = std::move(kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
 
@@ -254,11 +299,9 @@ RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::c
 
     std::vector<uint32_t> default_compute_args = {0, 0, 0, 0};
 
-    std::vector<std::vector<uint32_t>> unary_reader_args = {cores.size(), default_reader_args};
-    std::vector<std::vector<uint32_t>> unary_writer_args = {cores.size(), default_writer_args};
-    std::vector<std::vector<uint32_t>> unary_compute_args = {cores.size(), default_compute_args};
-
-    uint32_t num_active_cores = 0;
+    std::vector<std::vector<uint32_t>> unary_reader_args(cores.size(), default_reader_args);
+    std::vector<std::vector<uint32_t>> unary_writer_args(cores.size(), default_writer_args);
+    std::vector<std::vector<uint32_t>> unary_compute_args(cores.size(), default_compute_args);
 
     for (uint32_t batch_parallel = 0; batch_parallel < batch_parallel_factor; batch_parallel++) {
         for (uint32_t seq_parallel = 0; seq_parallel < seq_parallel_factor; seq_parallel++) {
@@ -302,63 +345,23 @@ RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::c
             compute_rt_args[1] = end_batch;
             compute_rt_args[2] = start_seq;
             compute_rt_args[3] = end_seq;
-
-            num_active_cores = core_idx + 1;
         }
     }
 
-    tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, cores, unary_reader_args);
-    tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, cores, unary_writer_args);
-    tt_metal::SetRuntimeArgs(program, rotary_embedding_kernel_id, cores, unary_compute_args);
-
-    RotaryEmbeddingLlamaMultiCore::shared_variables_t shared_variables;
-    shared_variables.unary_reader_kernel_id = unary_reader_kernel_id;
-    shared_variables.unary_writer_kernel_id = unary_writer_kernel_id;
-    shared_variables.rotary_embedding_kernel_id = rotary_embedding_kernel_id;
-    shared_variables.cores = cores;
-    shared_variables.num_active_cores = num_active_cores;
-
-    return {std::move(program), std::move(shared_variables)};
-}
-
-void RotaryEmbeddingLlamaMultiCore::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RotaryEmbeddingLlamaParams& /*operation_attributes*/,
-    const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt::tt_metal;
-
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* cos_buffer = tensor_args.cos_cache.buffer();
-    auto* sin_buffer = tensor_args.sin_cache.buffer();
-    auto* trans_mat_buffer = tensor_args.trans_mat.buffer();
-    auto* dst_buffer = output.buffer();
-
-    auto& cached_reader_args = GetRuntimeArgs(program, shared_variables.unary_reader_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, shared_variables.unary_writer_kernel_id);
-
-    const auto& cores = shared_variables.cores;
-    uint32_t num_active_cores = shared_variables.num_active_cores;
-
-    for (uint32_t i = 0; i < num_active_cores; ++i) {
-        const CoreCoord& core = cores.at(i);
-        {
-            auto& runtime_args = cached_reader_args.at(core.x).at(core.y);
-            runtime_args[0] = src_buffer->address();
-            runtime_args[1] = cos_buffer->address();
-            runtime_args[2] = sin_buffer->address();
-            runtime_args[3] = trans_mat_buffer->address();
-        }
-
-        {
-            auto& runtime_args = cached_writer_args.at(core.x).at(core.y);
-            runtime_args[0] = dst_buffer->address();
-        }
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    compute_desc.runtime_args.reserve(cores.size());
+    for (uint32_t i = 0; i < cores.size(); ++i) {
+        reader_desc.runtime_args.emplace_back(cores[i], std::move(unary_reader_args[i]));
+        writer_desc.runtime_args.emplace_back(cores[i], std::move(unary_writer_args[i]));
+        compute_desc.runtime_args.emplace_back(cores[i], std::move(unary_compute_args[i]));
     }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
@@ -101,7 +101,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         num_cos_sin_tiles = num_input_tiles;
     }
 
-    uint32_t input_cb_index = CBIndex::c_0;
+    constexpr uint8_t input_cb_index = CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = input_cb_num_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -112,7 +112,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         }}},
     });
 
-    uint32_t cos_cb_index = CBIndex::c_1;
+    constexpr uint8_t cos_cb_index = CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -123,7 +123,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         }}},
     });
 
-    uint32_t sin_cb_index = CBIndex::c_2;
+    constexpr uint8_t sin_cb_index = CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -134,7 +134,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         }}},
     });
 
-    uint32_t trans_mat_cb_index = CBIndex::c_3;
+    constexpr uint8_t trans_mat_cb_index = CBIndex::c_3;
     // We only take one tile of trans_mat
     uint32_t num_trans_mat_tiles = 1;
     desc.cbs.push_back(CBDescriptor{
@@ -148,7 +148,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
     });
 
     uint32_t num_interm_tiles = head_dim_t;
-    uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -159,7 +159,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * cos_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -170,7 +170,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * sin_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -181,7 +181,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
+    constexpr uint8_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -192,7 +192,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         }}},
     });
 
-    uint32_t zero_cb_index = CBIndex::c_27;
+    constexpr uint8_t zero_cb_index = CBIndex::c_27;
     desc.cbs.push_back(CBDescriptor{
         .total_size = head_dim_t * output_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -292,16 +292,14 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
         Overall loop iterations: # total cores
     */
 
-    std::vector<uint32_t> default_reader_args = {
-        src_buffer->address(), cos_buffer->address(), sin_buffer->address(), trans_mat_buffer->address(), 0, 0, 0, 0};
-
-    std::vector<uint32_t> default_writer_args = {dst_buffer->address(), 0, 0, 0, 0};
-
-    std::vector<uint32_t> default_compute_args = {0, 0, 0, 0};
-
-    std::vector<std::vector<uint32_t>> unary_reader_args(cores.size(), default_reader_args);
-    std::vector<std::vector<uint32_t>> unary_writer_args(cores.size(), default_writer_args);
-    std::vector<std::vector<uint32_t>> unary_compute_args(cores.size(), default_compute_args);
+    // Per-core args tracked as {start_batch, end_batch, start_seq, end_seq, active}.
+    struct CoreArgs {
+        uint32_t start_batch = 0;
+        uint32_t end_batch = 0;
+        uint32_t start_seq = 0;
+        uint32_t end_seq = 0;
+    };
+    std::vector<CoreArgs> per_core_args(cores.size());
 
     for (uint32_t batch_parallel = 0; batch_parallel < batch_parallel_factor; batch_parallel++) {
         for (uint32_t seq_parallel = 0; seq_parallel < seq_parallel_factor; seq_parallel++) {
@@ -325,26 +323,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
                 start_seq,
                 end_seq);
 
-            // Reader runtime args
-            auto& reader_rt_args = unary_reader_args[core_idx];
-            reader_rt_args[4] = start_batch;
-            reader_rt_args[5] = end_batch;
-            reader_rt_args[6] = start_seq;
-            reader_rt_args[7] = end_seq;
-
-            // Writer runtime args
-            auto& writer_rt_args = unary_writer_args[core_idx];
-            writer_rt_args[1] = start_batch;
-            writer_rt_args[2] = end_batch;
-            writer_rt_args[3] = start_seq;
-            writer_rt_args[4] = end_seq;
-
-            // Compute runtime args
-            auto& compute_rt_args = unary_compute_args[core_idx];
-            compute_rt_args[0] = start_batch;
-            compute_rt_args[1] = end_batch;
-            compute_rt_args[2] = start_seq;
-            compute_rt_args[3] = end_seq;
+            per_core_args[core_idx] = CoreArgs{start_batch, end_batch, start_seq, end_seq};
         }
     }
 
@@ -352,9 +331,13 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCore::create_descriptor(
     writer_desc.runtime_args.reserve(cores.size());
     compute_desc.runtime_args.reserve(cores.size());
     for (uint32_t i = 0; i < cores.size(); ++i) {
-        reader_desc.runtime_args.emplace_back(cores[i], std::move(unary_reader_args[i]));
-        writer_desc.runtime_args.emplace_back(cores[i], std::move(unary_writer_args[i]));
-        compute_desc.runtime_args.emplace_back(cores[i], std::move(unary_compute_args[i]));
+        const auto& a = per_core_args[i];
+        reader_desc.emplace_runtime_args(
+            cores[i],
+            {src_buffer, cos_buffer, sin_buffer, trans_mat_buffer, a.start_batch, a.end_batch, a.start_seq, a.end_seq});
+        writer_desc.emplace_runtime_args(cores[i], {dst_buffer, a.start_batch, a.end_batch, a.start_seq, a.end_seq});
+        compute_desc.runtime_args.emplace_back(
+            cores[i], std::vector<uint32_t>{a.start_batch, a.end_batch, a.start_seq, a.end_seq});
     }
 
     desc.kernels.push_back(std::move(reader_desc));

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.hpp
@@ -5,34 +5,18 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
 #include "rotary_embedding_llama_device_operation_types.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct RotaryEmbeddingLlamaMultiCore {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::KernelHandle rotary_embedding_kernel_id{};
-        std::vector<CoreCoord> cores;
-        uint32_t num_active_cores{};
-
-        tt::tt_metal::CBHandle cb_input{};
-        tt::tt_metal::CBHandle cb_cos{};
-        tt::tt_metal::CBHandle cb_sin{};
-        tt::tt_metal::CBHandle cb_trans_mat{};
-        tt::tt_metal::CBHandle cb_output{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const RotaryEmbeddingLlamaParams& operation_attributes,
-        const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Contract (1): single ProgramDescriptor for the interleaved (non-sharded) case.
+    // Per-core reader/writer/compute runtime args are re-applied by the framework via
+    // apply_descriptor_runtime_args; idle cores get zero-filled args so they don't wait
+    // on cos/sin data that never arrives.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
         tt::tt_metal::Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
@@ -75,7 +75,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
     auto* trans_mat_buffer = trans_mat.buffer();
     auto* dst_buffer = output.buffer();
 
-    uint32_t input_cb_index = CBIndex::c_0;
+    constexpr uint8_t input_cb_index = CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -87,7 +87,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
         .buffer = src_buffer,
     });
 
-    uint32_t cos_cb_index = CBIndex::c_1;
+    constexpr uint8_t cos_cb_index = CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -99,7 +99,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
         .buffer = cos_buffer,
     });
 
-    uint32_t sin_cb_index = CBIndex::c_2;
+    constexpr uint8_t sin_cb_index = CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -111,7 +111,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
         .buffer = sin_buffer,
     });
 
-    uint32_t trans_mat_cb_index = CBIndex::c_3;
+    constexpr uint8_t trans_mat_cb_index = CBIndex::c_3;
     // We only take one tile of trans_mat
     uint32_t num_trans_mat_tiles = 1;
     desc.cbs.push_back(CBDescriptor{
@@ -126,7 +126,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
     });
 
     uint32_t num_interm_tiles = head_dim_t;
-    uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -137,7 +137,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -148,7 +148,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),
@@ -159,7 +159,7 @@ ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
         }}},
     });
 
-    uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
+    constexpr uint8_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
         .core_ranges = CoreRangeSet(all_cores),

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
@@ -6,23 +6,24 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-RotaryEmbeddingLlamaMultiCoreSharded::cached_program_t RotaryEmbeddingLlamaMultiCoreSharded::create(
+using namespace tt;
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+ProgramDescriptor RotaryEmbeddingLlamaMultiCoreSharded::create_descriptor(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
     tt::tt_metal::Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt;
-    using namespace tt::tt_metal;
+    ProgramDescriptor desc;
 
     const auto& input = tensor_args.input_tensor;
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
     const auto& trans_mat = tensor_args.trans_mat;
-
-    Program program{};
 
     const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -75,66 +76,100 @@ RotaryEmbeddingLlamaMultiCoreSharded::cached_program_t RotaryEmbeddingLlamaMulti
     auto* dst_buffer = output.buffer();
 
     uint32_t input_cb_index = CBIndex::c_0;
-    tt_metal::CircularBufferConfig cb_input_config =
-        tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, input_single_tile_size)
-            .set_globally_allocated_address(*src_buffer);
-    auto cb_input = tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = src_buffer,
+    });
 
     uint32_t cos_cb_index = CBIndex::c_1;
-    tt_metal::CircularBufferConfig cb_cos_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size)
-            .set_globally_allocated_address(*cos_buffer);
-    auto cb_cos = tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+        .buffer = cos_buffer,
+    });
 
     uint32_t sin_cb_index = CBIndex::c_2;
-    tt_metal::CircularBufferConfig cb_sin_config =
-        tt_metal::CircularBufferConfig(num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size)
-            .set_globally_allocated_address(*sin_buffer);
-    auto cb_sin = tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+        .buffer = sin_buffer,
+    });
 
     uint32_t trans_mat_cb_index = CBIndex::c_3;
     // We only take one tile of trans_mat
     uint32_t num_trans_mat_tiles = 1;
-    tt_metal::CircularBufferConfig cb_trans_mat_config =
-        tt_metal::CircularBufferConfig(
-            num_trans_mat_tiles * trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size)
-            .set_globally_allocated_address(*trans_mat_buffer);
-    auto cb_trans_mat = tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_trans_mat_tiles * trans_mat_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = trans_mat_cb_index,
+            .data_format = trans_mat_cb_data_format,
+            .page_size = trans_mat_single_tile_size,
+        }}},
+        .buffer = trans_mat_buffer,
+    });
 
     uint32_t num_interm_tiles = head_dim_t;
     uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
-    tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = CBIndex::c_25;
-    tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{cos_interm_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, cos_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = CBIndex::c_26;
-    tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{sin_interm_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, sin_single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size)
-            .set_globally_allocated_address(*dst_buffer);
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = CoreRangeSet(all_cores),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = dst_buffer,
+    });
 
     // Set up the kernel
     std::vector<uint32_t> compute_kernel_args = {
@@ -150,46 +185,21 @@ RotaryEmbeddingLlamaMultiCoreSharded::cached_program_t RotaryEmbeddingLlamaMulti
         (std::uint32_t)n_heads_t,
     };
 
-    tt_metal::CreateKernel(
-        program,
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/"
-        "rotary_embedding_llama_sharded.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+        "rotary_embedding_llama_sharded.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = CoreRangeSet(all_cores);
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
-    RotaryEmbeddingLlamaMultiCoreSharded::shared_variables_t shared_variables;
-    shared_variables.cb_input = cb_input;
-    shared_variables.cb_cos = cb_cos;
-    shared_variables.cb_sin = cb_sin;
-    shared_variables.cb_trans_mat = cb_trans_mat;
-    shared_variables.cb_output = cb_output;
+    desc.kernels.push_back(std::move(compute_desc));
 
-    return {std::move(program), std::move(shared_variables)};
-}
-
-void RotaryEmbeddingLlamaMultiCoreSharded::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RotaryEmbeddingLlamaParams& /*operation_attributes*/,
-    const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt::tt_metal;
-
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* cos_buffer = tensor_args.cos_cache.buffer();
-    auto* sin_buffer = tensor_args.sin_cache.buffer();
-    auto* trans_mat_buffer = tensor_args.trans_mat.buffer();
-    auto* dst_buffer = output.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_input, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_cos, *cos_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_sin, *sin_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_trans_mat, *trans_mat_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.hpp
@@ -5,34 +5,18 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
 #include "rotary_embedding_llama_device_operation_types.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct RotaryEmbeddingLlamaMultiCoreSharded {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::KernelHandle rotary_embedding_kernel_id{};
-        std::vector<CoreCoord> cores;
-        uint32_t num_active_cores{};
-
-        tt::tt_metal::CBHandle cb_input{};
-        tt::tt_metal::CBHandle cb_cos{};
-        tt::tt_metal::CBHandle cb_sin{};
-        tt::tt_metal::CBHandle cb_trans_mat{};
-        tt::tt_metal::CBHandle cb_output{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const RotaryEmbeddingLlamaParams& operation_attributes,
-        const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Contract (1): single ProgramDescriptor for the fully-sharded decode case.
+    // All five working CBs (input/cos/sin/trans_mat/output) bind through
+    // CBDescriptor::buffer so the framework patches dynamic addresses on cache hit,
+    // matching the legacy UpdateDynamicCircularBufferAddress chain.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
         tt::tt_metal::Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_device_operation.hpp
@@ -18,7 +18,6 @@ struct RotaryEmbeddingLlamaFusedQKDeviceOperation {
     using spec_return_value_t = RotaryEmbeddingLlamaFusedQkResultSpec;
     using tensor_return_value_t = RotaryEmbeddingLlamaFusedQkResult;
     using program_factory_t = std::variant<RotaryEmbeddingLlamaFusedQKProgramFactory>;
-    using shared_variables_t = RotaryEmbeddingLlamaFusedQKProgramFactory::shared_variables_t;
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.cpp
@@ -8,16 +8,18 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
-RotaryEmbeddingLlamaFusedQKProgramFactory::cached_program_t RotaryEmbeddingLlamaFusedQKProgramFactory::create(
+ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
     const RotaryEmbeddingLlamaFusedQkParams& operation_attributes,
     const RotaryEmbeddingLlamaFusedQkInputs& tensor_args,
     RotaryEmbeddingLlamaFusedQkResult& tensor_return_value) {
-    Program program{};
+    ProgramDescriptor desc;
 
     const auto& q_input = tensor_args.q_input;
     const auto& k_input = tensor_args.k_input;
@@ -90,83 +92,123 @@ RotaryEmbeddingLlamaFusedQKProgramFactory::cached_program_t RotaryEmbeddingLlama
     auto* k_dst_buffer = k_output.buffer();
 
     uint32_t q_input_cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_q_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_q_input_tiles * input_single_tile_size, {{q_input_cb_index, input_cb_data_format}})
-            .set_page_size(q_input_cb_index, input_single_tile_size)
-            .set_globally_allocated_address(*q_src_buffer);
-    auto cb_q_input = tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_q_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_q_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = q_input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = q_src_buffer,
+    });
 
     uint32_t k_input_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_k_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_k_input_tiles * input_single_tile_size, {{k_input_cb_index, input_cb_data_format}})
-            .set_page_size(k_input_cb_index, input_single_tile_size)
-            .set_globally_allocated_address(*k_src_buffer);
-    auto cb_k_input = tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_k_input_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_k_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = k_input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = k_src_buffer,
+    });
 
     uint32_t cos_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_cos_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_cb_index, cos_single_tile_size)
-            .set_globally_allocated_address(*cos_buffer);
-    auto cb_cos = tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_cos_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * cos_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+        .buffer = cos_buffer,
+    });
 
     uint32_t sin_cb_index = tt::CBIndex::c_3;
-    tt::tt_metal::CircularBufferConfig cb_sin_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_cb_index, sin_single_tile_size)
-            .set_globally_allocated_address(*sin_buffer);
-    auto cb_sin = tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_sin_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cos_sin_tiles * sin_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+        .buffer = sin_buffer,
+    });
 
     uint32_t trans_mat_cb_index = tt::CBIndex::c_4;
     // We only take one tile of trans_mat
     uint32_t num_trans_mat_tiles = 1;
-    tt::tt_metal::CircularBufferConfig cb_trans_mat_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_trans_mat_tiles * trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
-            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size)
-            .set_globally_allocated_address(*trans_mat_buffer);
-    auto cb_trans_mat = tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_trans_mat_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_trans_mat_tiles * trans_mat_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = trans_mat_cb_index,
+            .data_format = trans_mat_cb_data_format,
+            .page_size = trans_mat_single_tile_size,
+        }}},
+        .buffer = trans_mat_buffer,
+    });
 
     uint32_t num_interm_tiles = head_dim_t;
     uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
-    tt::tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
-            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_rotated_input_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = rotated_input_interm_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
-    tt::tt_metal::CircularBufferConfig cb_cos_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{cos_interm_cb_index, cos_cb_data_format}})
-            .set_page_size(cos_interm_cb_index, cos_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_cos_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cos_interm_cb_index,
+            .data_format = cos_cb_data_format,
+            .page_size = cos_single_tile_size,
+        }}},
+    });
 
     uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
-    tt::tt_metal::CircularBufferConfig cb_sin_interm_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_interm_tiles * input_single_tile_size, {{sin_interm_cb_index, sin_cb_data_format}})
-            .set_page_size(sin_interm_cb_index, sin_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_sin_interm_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_interm_tiles * input_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = sin_interm_cb_index,
+            .data_format = sin_cb_data_format,
+            .page_size = sin_single_tile_size,
+        }}},
+    });
 
     uint32_t q_output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
-    tt::tt_metal::CircularBufferConfig cb_q_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_q_output_tiles * output_single_tile_size, {{q_output_cb_index, output_cb_data_format}})
-            .set_page_size(q_output_cb_index, output_single_tile_size)
-            .set_globally_allocated_address(*q_dst_buffer);
-    auto cb_q_output = tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_q_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = q_output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = q_dst_buffer,
+    });
     uint32_t k_output_cb_index = tt::CBIndex::c_17;  // output operands start at index 17
-    tt::tt_metal::CircularBufferConfig cb_k_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_k_output_tiles * output_single_tile_size, {{k_output_cb_index, output_cb_data_format}})
-            .set_page_size(k_output_cb_index, output_single_tile_size)
-            .set_globally_allocated_address(*k_dst_buffer);
-    auto cb_k_output = tt::tt_metal::CreateCircularBuffer(program, all_cores_bb, cb_k_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_k_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores_bb,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = k_output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+        .buffer = k_dst_buffer,
+    });
 
     // Set up the kernel
     std::vector<uint32_t> compute_kernel_args = {
@@ -192,59 +234,36 @@ RotaryEmbeddingLlamaFusedQKProgramFactory::cached_program_t RotaryEmbeddingLlama
               "compute/rotary_embedding_llama_sharded_row_major.cpp"
             : "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/"
               "compute/rotary_embedding_llama_sharded.cpp";
-    auto rotary_embedding_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_path,
-        all_cores_bb,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = compute_kernel_path;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores_bb;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     // Runtime args to differentiate between q, k or no work groups
     // TODO: Turn off unused compute cores? (technically, it doesn't matter since only compute kernel)
     // Running into code size issues on TRISC2 with profiler turned on; need to reduce stack size by 4B
     // constexpr bool has_work = true;
-    constexpr bool is_q = true;  // If not q, must be k
-    tt::tt_metal::SetRuntimeArgs(program, rotary_embedding_kernel_id, q_cores, {is_q});
-    tt::tt_metal::SetRuntimeArgs(program, rotary_embedding_kernel_id, k_cores, {!is_q});
-    // tt::tt_metal::SetRuntimeArgs(program, rotary_embedding_kernel_id, unused_cores, {!has_work});
+    constexpr uint32_t is_q_arg = 1;  // If not q, must be k
+    constexpr uint32_t is_k_arg = 0;
+    const auto q_cores_vec = corerange_to_cores(q_cores, std::nullopt, /*row_wise=*/true);
+    const auto k_cores_vec = corerange_to_cores(k_cores, std::nullopt, /*row_wise=*/true);
+    compute_desc.runtime_args.reserve(q_cores_vec.size() + k_cores_vec.size());
+    for (const auto& core : q_cores_vec) {
+        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{is_q_arg});
+    }
+    for (const auto& core : k_cores_vec) {
+        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{is_k_arg});
+    }
 
-    RotaryEmbeddingLlamaFusedQKSharedVariables shared_variables{
-        .cb_q_input = cb_q_input,
-        .cb_k_input = cb_k_input,
-        .cb_cos = cb_cos,
-        .cb_sin = cb_sin,
-        .cb_trans_mat = cb_trans_mat,
-        .cb_q_output = cb_q_output,
-        .cb_k_output = cb_k_output};
+    desc.kernels.push_back(std::move(compute_desc));
 
-    // NOLINTNEXTLINE(performance-move-const-arg): CachedProgram ctor requires rvalue reference
-    return cached_program_t{std::move(program), std::move(shared_variables)};
-}
-
-void RotaryEmbeddingLlamaFusedQKProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RotaryEmbeddingLlamaFusedQkParams& /*operation_attributes*/,
-    const RotaryEmbeddingLlamaFusedQkInputs& tensor_args,
-    RotaryEmbeddingLlamaFusedQkResult& tensor_return_value) {
-    auto& program = cached_program.program;
-    const auto& shared_variables = cached_program.shared_variables;
-
-    auto* q_src_buffer = tensor_args.q_input.buffer();
-    auto* k_src_buffer = tensor_args.k_input.buffer();
-    auto* cos_buffer = tensor_args.cos.buffer();
-    auto* sin_buffer = tensor_args.sin.buffer();
-    auto* trans_mat_buffer = tensor_args.trans_mat.buffer();
-    auto* q_dst_buffer = std::get<0>(tensor_return_value).buffer();
-    auto* k_dst_buffer = std::get<1>(tensor_return_value).buffer();
-
-    // Update the CB globally allocated addresses here
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_q_input, *q_src_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_k_input, *k_src_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_cos, *cos_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_sin, *sin_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_trans_mat, *trans_mat_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_q_output, *q_dst_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_k_output, *k_dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.cpp
@@ -91,7 +91,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
     auto* q_dst_buffer = q_output.buffer();
     auto* k_dst_buffer = k_output.buffer();
 
-    uint32_t q_input_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t q_input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_q_input_tiles * input_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -103,7 +103,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         .buffer = q_src_buffer,
     });
 
-    uint32_t k_input_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t k_input_cb_index = tt::CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_k_input_tiles * input_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -115,7 +115,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         .buffer = k_src_buffer,
     });
 
-    uint32_t cos_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t cos_cb_index = tt::CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * cos_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -127,7 +127,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         .buffer = cos_buffer,
     });
 
-    uint32_t sin_cb_index = tt::CBIndex::c_3;
+    constexpr uint8_t sin_cb_index = tt::CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_cos_sin_tiles * sin_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -139,7 +139,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         .buffer = sin_buffer,
     });
 
-    uint32_t trans_mat_cb_index = tt::CBIndex::c_4;
+    constexpr uint8_t trans_mat_cb_index = tt::CBIndex::c_4;
     // We only take one tile of trans_mat
     uint32_t num_trans_mat_tiles = 1;
     desc.cbs.push_back(CBDescriptor{
@@ -154,7 +154,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
     });
 
     uint32_t num_interm_tiles = head_dim_t;
-    uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
+    constexpr uint8_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -165,7 +165,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         }}},
     });
 
-    uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
+    constexpr uint8_t cos_interm_cb_index = tt::CBIndex::c_25;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -176,7 +176,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         }}},
     });
 
-    uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
+    constexpr uint8_t sin_interm_cb_index = tt::CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_interm_tiles * input_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -187,7 +187,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         }}},
     });
 
-    uint32_t q_output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
+    constexpr uint8_t q_output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_q_output_tiles * output_single_tile_size,
         .core_ranges = all_cores_bb,
@@ -198,7 +198,7 @@ ProgramDescriptor RotaryEmbeddingLlamaFusedQKProgramFactory::create_descriptor(
         }}},
         .buffer = q_dst_buffer,
     });
-    uint32_t k_output_cb_index = tt::CBIndex::c_17;  // output operands start at index 17
+    constexpr uint8_t k_output_cb_index = tt::CBIndex::c_17;  // output operands start at index 17
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_k_output_tiles * output_single_tile_size,
         .core_ranges = all_cores_bb,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.hpp
@@ -6,30 +6,16 @@
 
 #include "ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct RotaryEmbeddingLlamaFusedQKSharedVariables {
-    tt::tt_metal::CBHandle cb_q_input{};
-    tt::tt_metal::CBHandle cb_k_input{};
-    tt::tt_metal::CBHandle cb_cos{};
-    tt::tt_metal::CBHandle cb_sin{};
-    tt::tt_metal::CBHandle cb_trans_mat{};
-    tt::tt_metal::CBHandle cb_q_output{};
-    tt::tt_metal::CBHandle cb_k_output{};
-};
-
 struct RotaryEmbeddingLlamaFusedQKProgramFactory {
-    using shared_variables_t = RotaryEmbeddingLlamaFusedQKSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const RotaryEmbeddingLlamaFusedQkParams& operation_attributes,
-        const RotaryEmbeddingLlamaFusedQkInputs& tensor_args,
-        RotaryEmbeddingLlamaFusedQkResult& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Contract (1): single ProgramDescriptor.  All seven working CBs
+    // (q/k inputs, cos/sin/trans_mat, q/k outputs) are sharded and bind through
+    // CBDescriptor::buffer so the framework patches dynamic addresses on cache hit.
+    // The single compute kernel takes one per-core runtime arg to select q vs k work.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingLlamaFusedQkParams& operation_attributes,
         const RotaryEmbeddingLlamaFusedQkInputs& tensor_args,
         RotaryEmbeddingLlamaFusedQkResult& tensor_return_value);


### PR DESCRIPTION
## Summary
Contract-1 migration of 7 rotary embedding factories:
- rotary_embedding (Wt==1 + multi-tile paths)
- rotary_embedding_hf (multi_core + sharded)
- rotary_embedding_llama (multi_core + multi_core_prefill_sharded + sharded)
- rotary_embedding_llama_fused_qk

All use \`emplace_runtime_args\` for buffer bindings. Sharded CBs use \`.buffer = …\`.

Part of #42193.

## Dependencies
None.

## Test plan
- [ ] sanity-tests.yaml
- [ ] runtime-sanity-tests.yaml
- [ ] blackhole-post-commit.yaml
- [ ] tt-metal-l2-nightly.yaml (transformer family)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-transformer-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-transformer-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-transformer-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-transformer-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-transformer-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-transformer-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-transformer-rotary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-transformer-rotary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-transformer-rotary)