### PR TITLE
data_movement: migrate transpose + permute + untilize + untilize_with_unpadding to ProgramDescriptor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -216,7 +216,7 @@ tt::tt_metal::ProgramDescriptor FillPadProgramFactory::create_descriptor(
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_ct);
     reader_desc.defines = kernel_defines;
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
@@ -225,7 +225,7 @@ tt::tt_metal::ProgramDescriptor FillPadProgramFactory::create_descriptor(
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_ct);
     writer_desc.defines = kernel_defines;
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
@@ -547,7 +547,7 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
         reader_desc.compile_time_args = {
             W_tiles, rp_idx, input_element_size_bytes, static_cast<uint32_t>(cb_data_in_idx)};
         reader_desc.defines = kernel_defines;
-        reader_desc.config = ReaderDataMovementConfig{};
+        reader_desc.config = ReaderConfigDescriptor{};
         reader_kernel_idx[rp_idx] = static_cast<int>(desc.kernels.size());
         desc.kernels.push_back(std::move(reader_desc));
     }
@@ -574,7 +574,7 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
             static_cast<uint32_t>(cb_bot_mask_idx),
             static_cast<uint32_t>(cb_data_out_idx)};
         writer_desc.defines = kernel_defines;
-        writer_desc.config = WriterDataMovementConfig{};
+        writer_desc.config = WriterConfigDescriptor{};
         writer_kernel_idx[rp_idx] = static_cast<int>(desc.kernels.size());
         desc.kernels.push_back(std::move(writer_desc));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "fill_pad_program_factory.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -14,7 +15,9 @@
 
 namespace ttnn::prim {
 
-FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
+using namespace tt::tt_metal;
+
+tt::tt_metal::ProgramDescriptor FillPadProgramFactory::create_descriptor(
     const FillPadParams& operation_attributes, const FillPadInputs& tensor_args, Tensor& /*tensor_return_value*/) {
     const Tensor& input_tensor = tensor_args.input;
     TT_FATAL(
@@ -27,7 +30,7 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
 
     const float fill_value = operation_attributes.fill_value;
     tt::tt_metal::IDevice* device = input_tensor.device();
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     const tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     tt::tt_metal::Buffer* tens_buffer = input_tensor.buffer();
@@ -92,47 +95,64 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     constexpr uint32_t cb_data_out_idx = tt::CBIndex::c_16;
 
     // CB[0]: data in, double-buffered (reader → compute)
-    {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_in_idx, cb_data_format}})
-                .set_page_size(cb_data_in_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
-    }
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_bytes * 2,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cb_data_in_idx,
+            .data_format = cb_data_format,
+            .page_size = tile_bytes,
+        }}},
+    });
 
     // CB[1]: right mask, capacity=1 (writer → compute, persistent; only when has_right_pad)
     if (has_right_pad) {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_right_mask_idx, cb_data_format}})
-                .set_page_size(cb_right_mask_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = tile_bytes,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cb_right_mask_idx,
+                .data_format = cb_data_format,
+                .page_size = tile_bytes,
+            }}},
+        });
     }
 
     // CB[2]: bottom mask, capacity=1 (writer → compute, persistent; only when has_bottom_pad)
     if (has_bottom_pad) {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_bot_mask_idx, cb_data_format}})
-                .set_page_size(cb_bot_mask_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = tile_bytes,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cb_bot_mask_idx,
+                .data_format = cb_data_format,
+                .page_size = tile_bytes,
+            }}},
+        });
     }
 
     // CB[16]: data out, double-buffered (compute → writer)
-    {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_out_idx, cb_data_format}})
-                .set_page_size(cb_data_out_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
-    }
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_bytes * 2,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cb_data_out_idx,
+            .data_format = cb_data_format,
+            .page_size = tile_bytes,
+        }}},
+    });
 
     // ---- Kernel defines ----
-    std::map<std::string, std::string> kernel_defines;
-    kernel_defines["MASK_ELEM_UINT"] = (input_element_size_bytes == 2) ? "uint16_t" : "uint32_t";
-    kernel_defines["MASK_VALUE"] = is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u";
-    kernel_defines["FILL_PAD_DATA_FMT"] = detail::get_where_data_fmt(input_tensor.dtype());
+    KernelDescriptor::Defines kernel_defines;
+    kernel_defines.emplace_back("MASK_ELEM_UINT", (input_element_size_bytes == 2) ? "uint16_t" : "uint32_t");
+    kernel_defines.emplace_back("MASK_VALUE", is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u");
+    kernel_defines.emplace_back("FILL_PAD_DATA_FMT", detail::get_where_data_fmt(input_tensor.dtype()));
     if (!is_float_type) {
-        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = fmt::format("DataFormat::{}", cb_data_format);
+        kernel_defines.emplace_back("FILL_PAD_FILL_DATA_FMT", fmt::format("DataFormat::{}", cb_data_format));
     }
-    kernel_defines["FILL_PAD_FILL_FN"] = is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>";
-    kernel_defines["FILL_PAD_FILL_ARG"] = "fill_bits";
+    kernel_defines.emplace_back(
+        "FILL_PAD_FILL_FN", is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>");
+    kernel_defines.emplace_back("FILL_PAD_FILL_ARG", "fill_bits");
 
     // ---- Reader CT args ----
     // [0] W_tiles, [1] H_tiles, [2] N_slices, [3] has_right_pad, [4] has_bottom_pad,
@@ -175,7 +195,7 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     // [0] W_tiles, [1] H_tiles, [2] has_right_pad, [3] has_bottom_pad,
     // [4] elem_size, [5] fill_bits, [6] cb_data_in=0, [7] cb_right_mask=1,
     // [8] cb_bot_mask=2, [9] cb_data_out=16
-    const std::vector<uint32_t> compute_ct = {
+    std::vector<uint32_t> compute_ct = {
         W_tiles,
         H_tiles,
         has_right_pad,
@@ -189,17 +209,23 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     };
 
     // ---- Kernel creation ----
-    const tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct, kernel_defines));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct);
+    reader_desc.defines = kernel_defines;
+    reader_desc.config = ReaderDataMovementConfig{};
 
-    const tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct, kernel_defines));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct);
+    writer_desc.defines = kernel_defines;
+    writer_desc.config = WriterDataMovementConfig{};
 
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
@@ -209,22 +235,26 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
         unpack_to_dest_mode[cb_bot_mask_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
 
-    const tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = need_fp32_dest_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_ct,
-            .defines = kernel_defines,
-        });
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_ct);
+    compute_desc.defines = std::move(kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = need_fp32_dest_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     // ---- Per-core runtime args ----
     // Each core's global range [work_start, work_start + num_work) is intersected with the three
     // global blocks to produce per-phase (start, num) pairs. Phases with num==0 are skipped in the
     // kernels.
     const std::vector<CoreCoord> cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    compute_desc.runtime_args.reserve(cores.size());
     uint32_t work_start = 0;
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores[i];
@@ -259,7 +289,7 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
         clip_to_phase_block(T_right, T_bottom, start_bottom, num_bottom);
         clip_to_phase_block(T_right + T_bottom, T_corner, start_corner, num_corner);
 
-        const std::vector<uint32_t> rt_args = {
+        std::vector<uint32_t> rt_args = {
             static_cast<uint32_t>(tens_buffer->address()),
             start_right,
             num_right,
@@ -268,48 +298,23 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
             start_corner,
             num_corner,
         };
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, rt_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, rt_args);
+        reader_desc.runtime_args.emplace_back(core, rt_args);
+        writer_desc.runtime_args.emplace_back(core, std::move(rt_args));
 
         // Compute RT: per-phase counts; starts are not needed (CBs are FIFO).
-        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, {num_right, num_bottom, num_corner});
+        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_right, num_bottom, num_corner});
 
         work_start = work_end;
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = reader_kernel_id,
-            .writer_kernel_id = writer_kernel_id,
-            .compute_kernel_id = compute_kernel_id,
-            .cores = cores,
-        }};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void FillPadProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const FillPadParams& /*operation_attributes*/,
-    const FillPadInputs& tensor_args,
-    Tensor& /*tensor_return_value*/) {
-    const Tensor& input_tensor = tensor_args.input;
-    tt::tt_metal::Buffer* tens_buffer = input_tensor.buffer();
-
-    tt::tt_metal::Program& program = cached_program.program;
-    const tt::tt_metal::KernelHandle reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const tt::tt_metal::KernelHandle writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& cores = cached_program.shared_variables.cores;
-
-    auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
-    auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
-
-    for (const auto& core : cores) {
-        reader_runtime_args[core.x][core.y][0] = tens_buffer->address();
-        writer_runtime_args[core.x][core.y][0] = tens_buffer->address();
-    }
-}
-
-FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descriptor(
     const FillPadParams& operation_attributes, const FillPadInputs& tensor_args, Tensor& /*tensor_return_value*/) {
     const Tensor& input_tensor = tensor_args.input;
     TT_FATAL(
@@ -322,7 +327,7 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
 
     const float fill_value = operation_attributes.fill_value;
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     const tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     tt::tt_metal::Buffer* tens_buffer = input_tensor.buffer();
@@ -473,67 +478,94 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     constexpr uint32_t cb_data_out_idx = tt::CBIndex::c_16;
 
     // ---- Circular buffers (all active cores) ----
-    {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_in_idx, cb_data_format}})
-                .set_page_size(cb_data_in_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
-    }
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_bytes * 2,
+        .core_ranges = all_active_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cb_data_in_idx,
+            .data_format = cb_data_format,
+            .page_size = tile_bytes,
+        }}},
+    });
     if (has_right_pad) {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_right_mask_idx, cb_data_format}})
-                .set_page_size(cb_right_mask_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = tile_bytes,
+            .core_ranges = all_active_set,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cb_right_mask_idx,
+                .data_format = cb_data_format,
+                .page_size = tile_bytes,
+            }}},
+        });
     }
     if (has_bottom_pad) {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_bot_mask_idx, cb_data_format}})
-                .set_page_size(cb_bot_mask_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = tile_bytes,
+            .core_ranges = all_active_set,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cb_bot_mask_idx,
+                .data_format = cb_data_format,
+                .page_size = tile_bytes,
+            }}},
+        });
     }
-    {
-        const tt::tt_metal::CircularBufferConfig cb_config =
-            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_out_idx, cb_data_format}})
-                .set_page_size(cb_data_out_idx, tile_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
-    }
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_bytes * 2,
+        .core_ranges = all_active_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = cb_data_out_idx,
+            .data_format = cb_data_format,
+            .page_size = tile_bytes,
+        }}},
+    });
 
     // ---- Kernel defines ----
-    std::map<std::string, std::string> kernel_defines;
-    kernel_defines["MASK_ELEM_UINT"] = (input_element_size_bytes == 2) ? "uint16_t" : "uint32_t";
-    kernel_defines["MASK_VALUE"] = is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u";
-    kernel_defines["FILL_PAD_DATA_FMT"] = detail::get_where_data_fmt(input_tensor.dtype());
+    KernelDescriptor::Defines kernel_defines;
+    kernel_defines.emplace_back("MASK_ELEM_UINT", (input_element_size_bytes == 2) ? "uint16_t" : "uint32_t");
+    kernel_defines.emplace_back("MASK_VALUE", is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u");
+    kernel_defines.emplace_back("FILL_PAD_DATA_FMT", detail::get_where_data_fmt(input_tensor.dtype()));
     if (!is_float_type) {
-        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = fmt::format("DataFormat::{}", cb_data_format);
+        kernel_defines.emplace_back("FILL_PAD_FILL_DATA_FMT", fmt::format("DataFormat::{}", cb_data_format));
     }
-    kernel_defines["FILL_PAD_FILL_FN"] = is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>";
-    kernel_defines["FILL_PAD_FILL_ARG"] = "fill_bits";
+    kernel_defines.emplace_back(
+        "FILL_PAD_FILL_FN", is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>");
+    kernel_defines.emplace_back("FILL_PAD_FILL_ARG", "fill_bits");
 
     // ---- Reader kernels (one per has_right_pad value) ----
     // CT: [0] W_tiles, [1] has_right_pad, [2] elem_size, [3] cb_data_in
-    std::array<tt::tt_metal::KernelHandle, 2> reader_kernel_ids = {0, 0};
+    // Track descriptor indices so per-core runtime args can target the right kernel below.
+    std::array<int, 2> reader_kernel_idx = {-1, -1};
     for (uint32_t rp_idx = 0; rp_idx <= 1; ++rp_idx) {
         if (rw_ranges[rp_idx].empty()) {
             continue;
         }
-        const std::vector<uint32_t> reader_ct = {
+        KernelDescriptor reader_desc;
+        reader_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp";
+        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader_desc.core_ranges = CoreRangeSet(rw_ranges[rp_idx]);
+        reader_desc.compile_time_args = {
             W_tiles, rp_idx, input_element_size_bytes, static_cast<uint32_t>(cb_data_in_idx)};
-        reader_kernel_ids[rp_idx] = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp",
-            CoreRangeSet(rw_ranges[rp_idx]),
-            tt::tt_metal::ReaderDataMovementConfig(reader_ct, kernel_defines));
+        reader_desc.defines = kernel_defines;
+        reader_desc.config = ReaderDataMovementConfig{};
+        reader_kernel_idx[rp_idx] = static_cast<int>(desc.kernels.size());
+        desc.kernels.push_back(std::move(reader_desc));
     }
 
     // ---- Writer kernels (one per has_right_pad value) ----
     // CT: [0] W_tiles, [1] has_right_pad, [2] W_mod32, [3] H_mod32,
     //     [4] cb_right_mask, [5] cb_bot_mask, [6] cb_data_out
-    std::array<tt::tt_metal::KernelHandle, 2> writer_kernel_ids = {0, 0};
+    std::array<int, 2> writer_kernel_idx = {-1, -1};
     for (uint32_t rp_idx = 0; rp_idx <= 1; ++rp_idx) {
         if (rw_ranges[rp_idx].empty()) {
             continue;
         }
-        const std::vector<uint32_t> writer_ct = {
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = CoreRangeSet(rw_ranges[rp_idx]);
+        writer_desc.compile_time_args = {
             W_tiles,
             rp_idx,
             W_mod32,
@@ -541,11 +573,10 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
             static_cast<uint32_t>(cb_right_mask_idx),
             static_cast<uint32_t>(cb_bot_mask_idx),
             static_cast<uint32_t>(cb_data_out_idx)};
-        writer_kernel_ids[rp_idx] = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp",
-            CoreRangeSet(rw_ranges[rp_idx]),
-            tt::tt_metal::WriterDataMovementConfig(writer_ct, kernel_defines));
+        writer_desc.defines = kernel_defines;
+        writer_desc.config = WriterDataMovementConfig{};
+        writer_kernel_idx[rp_idx] = static_cast<int>(desc.kernels.size());
+        desc.kernels.push_back(std::move(writer_desc));
     }
 
     // ---- Compute kernel unpack-to-dest mode ----
@@ -561,10 +592,14 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     // CT: [0] W_tiles (= effective_W for this group), [1] H_tiles, [2] has_right_pad, [3] has_bottom_pad,
     //     [4] elem_size, [5] fill_bits, [6] cb_data_in, [7] cb_right_mask,
     //     [8] cb_bot_mask, [9] cb_data_out
-    std::map<ComputeKey, tt::tt_metal::KernelHandle> compute_kernel_map;
-    std::vector<tt::tt_metal::KernelHandle> compute_kernel_ids_vec;
+    std::map<ComputeKey, int> compute_kernel_idx_map;
     for (auto& [key, ranges] : compute_ranges) {
-        const std::vector<uint32_t> compute_ct = {
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = CoreRangeSet(ranges);
+        compute_desc.compile_time_args = {
             key.effective_W,
             key.H,
             key.has_right_pad,
@@ -575,31 +610,24 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
             static_cast<uint32_t>(cb_right_mask_idx),
             static_cast<uint32_t>(cb_bot_mask_idx),
             static_cast<uint32_t>(cb_data_out_idx)};
-        const tt::tt_metal::KernelHandle h = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp",
-            CoreRangeSet(ranges),
-            tt::tt_metal::ComputeConfig{
-                .fp32_dest_acc_en = need_fp32_dest_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_ct,
-                .defines = kernel_defines});
-        compute_kernel_map[key] = h;
-        compute_kernel_ids_vec.push_back(h);
+        compute_desc.defines = kernel_defines;
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = need_fp32_dest_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        compute_kernel_idx_map[key] = static_cast<int>(desc.kernels.size());
+        desc.kernels.push_back(std::move(compute_desc));
     }
 
     // ---- Per-core runtime args ----
     // RT layout: [0] buf_addr, [1] shard_H_tiles, [2] has_bottom_pad_core, [3] num_work,
     //            [4] local_right_col
     const uint32_t buf_addr = static_cast<uint32_t>(tens_buffer->address());
-    std::vector<CoreCoord> active_coords;
-    std::vector<uint32_t> active_has_right_pad;
 
     for (const auto& ci : active) {
-        const std::vector<uint32_t> rt = {
-            buf_addr, ci.shard_H_tiles, ci.has_bottom_pad, ci.num_work, ci.local_right_col};
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[ci.has_right_pad], ci.coord, rt);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_ids[ci.has_right_pad], ci.coord, rt);
+        std::vector<uint32_t> rt = {buf_addr, ci.shard_H_tiles, ci.has_bottom_pad, ci.num_work, ci.local_right_col};
+        desc.kernels[reader_kernel_idx[ci.has_right_pad]].runtime_args.emplace_back(ci.coord, rt);
+        desc.kernels[writer_kernel_idx[ci.has_right_pad]].runtime_args.emplace_back(ci.coord, std::move(rt));
 
         // Compute RT: (num_right, num_bottom, num_corner) per the unified phase layout.
         // The sharded reader/writer push tiles in the same order (right, bottom, corner),
@@ -618,51 +646,12 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
             num_bottom = ci.local_valid_w;
         }
         const uint32_t key_H = ci.has_bottom_pad ? ci.shard_H_tiles : pages_per_shard_y;
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            compute_kernel_map.at({ci.has_right_pad, ci.has_bottom_pad, key_H, ci.local_valid_w}),
-            ci.coord,
-            {num_right, num_bottom, num_corner});
-        active_coords.push_back(ci.coord);
-        active_has_right_pad.push_back(ci.has_right_pad);
+        const int ck_idx = compute_kernel_idx_map.at({ci.has_right_pad, ci.has_bottom_pad, key_H, ci.local_valid_w});
+        desc.kernels[ck_idx].runtime_args.emplace_back(
+            ci.coord, std::vector<uint32_t>{num_right, num_bottom, num_corner});
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_ids = reader_kernel_ids,
-            .writer_kernel_ids = writer_kernel_ids,
-            .compute_kernel_ids = std::move(compute_kernel_ids_vec),
-            .active_cores = std::move(active_coords),
-            .active_core_has_right_pad = std::move(active_has_right_pad),
-        }};
-}
-
-void FillPadL1ShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const FillPadParams& /*operation_attributes*/,
-    const FillPadInputs& tensor_args,
-    Tensor& /*tensor_return_value*/) {
-    const uint32_t buf_addr = static_cast<uint32_t>(tensor_args.input.buffer()->address());
-
-    tt::tt_metal::Program& program = cached_program.program;
-    const auto& sv = cached_program.shared_variables;
-
-    for (uint32_t rp_idx = 0; rp_idx <= 1; ++rp_idx) {
-        if (sv.reader_kernel_ids[rp_idx] == 0) {
-            continue;
-        }
-        auto& rrt = GetRuntimeArgs(program, sv.reader_kernel_ids[rp_idx]);
-        auto& wrt = GetRuntimeArgs(program, sv.writer_kernel_ids[rp_idx]);
-        for (uint32_t i = 0; i < sv.active_cores.size(); ++i) {
-            if (sv.active_core_has_right_pad[i] != rp_idx) {
-                continue;
-            }
-            const CoreCoord& core = sv.active_cores[i];
-            rrt[core.x][core.y][0] = buf_addr;
-            wrt[core.x][core.y][0] = buf_addr;
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -289,20 +289,13 @@ tt::tt_metal::ProgramDescriptor FillPadProgramFactory::create_descriptor(
         clip_to_phase_block(T_right, T_bottom, start_bottom, num_bottom);
         clip_to_phase_block(T_right + T_bottom, T_corner, start_corner, num_corner);
 
-        std::vector<uint32_t> rt_args = {
-            static_cast<uint32_t>(tens_buffer->address()),
-            start_right,
-            num_right,
-            start_bottom,
-            num_bottom,
-            start_corner,
-            num_corner,
-        };
-        reader_desc.runtime_args.emplace_back(core, rt_args);
-        writer_desc.runtime_args.emplace_back(core, std::move(rt_args));
+        reader_desc.emplace_runtime_args(
+            core, {tens_buffer, start_right, num_right, start_bottom, num_bottom, start_corner, num_corner});
+        writer_desc.emplace_runtime_args(
+            core, {tens_buffer, start_right, num_right, start_bottom, num_bottom, start_corner, num_corner});
 
         // Compute RT: per-phase counts; starts are not needed (CBs are FIFO).
-        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_right, num_bottom, num_corner});
+        compute_desc.emplace_runtime_args(core, {num_right, num_bottom, num_corner});
 
         work_start = work_end;
     }
@@ -622,12 +615,11 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
     // ---- Per-core runtime args ----
     // RT layout: [0] buf_addr, [1] shard_H_tiles, [2] has_bottom_pad_core, [3] num_work,
     //            [4] local_right_col
-    const uint32_t buf_addr = static_cast<uint32_t>(tens_buffer->address());
-
     for (const auto& ci : active) {
-        std::vector<uint32_t> rt = {buf_addr, ci.shard_H_tiles, ci.has_bottom_pad, ci.num_work, ci.local_right_col};
-        desc.kernels[reader_kernel_idx[ci.has_right_pad]].runtime_args.emplace_back(ci.coord, rt);
-        desc.kernels[writer_kernel_idx[ci.has_right_pad]].runtime_args.emplace_back(ci.coord, std::move(rt));
+        desc.kernels[reader_kernel_idx[ci.has_right_pad]].emplace_runtime_args(
+            ci.coord, {tens_buffer, ci.shard_H_tiles, ci.has_bottom_pad, ci.num_work, ci.local_right_col});
+        desc.kernels[writer_kernel_idx[ci.has_right_pad]].emplace_runtime_args(
+            ci.coord, {tens_buffer, ci.shard_H_tiles, ci.has_bottom_pad, ci.num_work, ci.local_right_col});
 
         // Compute RT: (num_right, num_bottom, num_corner) per the unified phase layout.
         // The sharded reader/writer push tiles in the same order (right, bottom, corner),
@@ -647,8 +639,7 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
         }
         const uint32_t key_H = ci.has_bottom_pad ? ci.shard_H_tiles : pages_per_shard_y;
         const int ck_idx = compute_kernel_idx_map.at({ci.has_right_pad, ci.has_bottom_pad, key_H, ci.local_valid_w});
-        desc.kernels[ck_idx].runtime_args.emplace_back(
-            ci.coord, std::vector<uint32_t>{num_right, num_bottom, num_corner});
+        desc.kernels[ck_idx].emplace_runtime_args(ci.coord, {num_right, num_bottom, num_corner});
     }
 
     return desc;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -6,6 +6,8 @@
 
 #include "fill_pad_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <array>
 #include <bit>
 
@@ -66,13 +68,6 @@ inline std::string get_where_data_fmt(ttnn::DataType dtype) {
 
 namespace ttnn::prim {
 
-struct FillPadSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    tt::tt_metal::KernelHandle compute_kernel_id = 0;
-    std::vector<CoreCoord> cores;
-};
-
 // Handles DRAM tensors (Interleaved + DRAM sharded).
 //
 // Work splitting is unified across three border-tile phases (right / bottom /
@@ -83,44 +78,16 @@ struct FillPadSharedVariables {
 // with num == 0 are skipped. A single compute kernel binary covers all cores
 // (CT has_right_pad / has_bottom_pad gate the phase branches at compile time).
 struct FillPadProgramFactory {
-    using shared_variables_t = FillPadSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const FillPadParams& operation_attributes, const FillPadInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const FillPadParams& operation_attributes,
-        const FillPadInputs& tensor_args,
-        Tensor& tensor_return_value);
-};
-
-struct FillPadL1ShardedSharedVariables {
-    // Indexed by has_right_pad (0/1); 0 means that group is unused.
-    std::array<tt::tt_metal::KernelHandle, 2> reader_kernel_ids = {0, 0};
-    std::array<tt::tt_metal::KernelHandle, 2> writer_kernel_ids = {0, 0};
-    std::vector<tt::tt_metal::KernelHandle> compute_kernel_ids;
-    std::vector<CoreCoord> active_cores;
-    // has_right_pad per active core (for override_runtime_arguments)
-    std::vector<uint32_t> active_core_has_right_pad;
 };
 
 // Handles all L1-sharded tensors (HEIGHT_SHARDED, WIDTH_SHARDED, BLOCK_SHARDED).
 // Unlike `FillPadProgramFactory` which gives each core a comparable number of borders,
 // with FillPadL1ShardedProgramFactory, each core only processes its own local L1 data (no balancing).
 struct FillPadL1ShardedProgramFactory {
-    using shared_variables_t = FillPadL1ShardedSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const FillPadParams& operation_attributes, const FillPadInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const FillPadParams& operation_attributes,
-        const FillPadInputs& tensor_args,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -13,6 +13,7 @@
 #include "ttnn/types.hpp"
 #include <tt_stl/span.hpp>
 #include "ttnn/operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::data_movement {
 
@@ -33,20 +34,7 @@ struct PermuteDeviceOperation {
 
     // Implementation for a row major tensor where the row dimension is not moved in the permutation
     struct MultiCoreRowInvariant {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            tt::tt_metal::CoreRangeSet core_range;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
@@ -54,21 +42,7 @@ struct PermuteDeviceOperation {
 
     // Implementation for a row major tensor where the row dimension is moved in the permutation
     struct MultiCoreBlockedGeneric {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            CoreRangeSet core_range;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
@@ -77,22 +51,7 @@ struct PermuteDeviceOperation {
     // Implementation for when the tile is not broken apart (either dims = {..., rank - 2, rank - 1} or {..., rank - 1,
     // rank - 2})
     struct MultiCoreTileInvariant {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            CoreRangeSet core_range;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
@@ -102,22 +61,7 @@ struct PermuteDeviceOperation {
     // another dimension (dims = {..., rank - 2,
     // ..., i, rank - 1})
     struct MultiCoreTileRowInvariant {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            CoreRangeSet core_range;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
@@ -125,22 +69,7 @@ struct PermuteDeviceOperation {
 
     // Implementation for when both the height and width dimension is swapped around in the permutation
     struct MultiCoreTiledGeneric {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            CoreRangeSet core_range;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -35,7 +37,7 @@ std::vector<uint32_t> get_row_strides(const ttnn::Shape& shape) {
 
 }  // namespace detail
 
-PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOperation::MultiCoreRowInvariant::create(
+tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreRowInvariant::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -48,14 +50,14 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
     auto* src_buffer = input_tensor.buffer();
     auto* dst_buffer = output_tensor.buffer();
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_rm_page_size = detail::page_size(input_tensor);
 
     uint32_t output_rm_page_size = detail::page_size(tensor_return_value);
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_pages_to_read = 2;
 
     uint32_t num_rows = detail::num_pages(input_tensor);
@@ -64,36 +66,47 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows);
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_pages_to_read * input_rm_page_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, input_rm_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * input_rm_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = input_rm_page_size,
+        }}},
+    });
 
     uint32_t N = operation_attributes.dims.size();
 
     std::vector<uint32_t> reader_compile_time_args = {};
-    std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
         {"N", N}, {"page_size", input_rm_page_size}, {"num_rows", num_rows}};
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "reader_permute_interleaved_rm_row_invariant.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
+        "reader_permute_interleaved_rm_row_invariant.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     std::vector<uint32_t> writer_compile_time_args = {};
-    std::unordered_map<std::string, uint32_t> writer_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs writer_named_compile_time_args = {
         {"N", N}, {"page_size", output_rm_page_size}, {"num_rows", num_rows}};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "writer_permute_interleaved_rm_row_invariant.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
+        "writer_permute_interleaved_rm_row_invariant.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
 
@@ -109,6 +122,8 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
     auto cores = corerange_to_cores(all_cores, std::nullopt);
     uint32_t start_row = 0;
     uint32_t num_rows_per_core = 0;
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
     for (const auto& core : cores) {
         if (core_group_1.contains(core)) {
             num_rows_per_core = num_tiles_per_core_group_1;
@@ -123,46 +138,18 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
         reader_runtime_args[2] = end_row;
         writer_runtime_args[1] = start_row;
         writer_runtime_args[2] = end_row;
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
+        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
         start_row = end_row;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = unary_reader_kernel_id,
-         .unary_writer_kernel_id = unary_writer_kernel_id,
-         .core_range = all_cores},
-    };
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void PermuteDeviceOperation::MultiCoreRowInvariant::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto& output_tensor = tensor_return_value;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    auto& all_cores = cached_program.shared_variables.core_range;
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    for (const auto& core : cores) {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-        auto& runtime_args_writer = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, core);
-        runtime_args_writer[0] = dst_buffer->address();
-    }
-}
-
-PermuteDeviceOperation::MultiCoreBlockedGeneric::cached_program_t
-PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
+tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreBlockedGeneric::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -175,7 +162,7 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
     auto* src_buffer = input_tensor.buffer();
     auto* dst_buffer = output_tensor.buffer();
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t w_block_size = constants::TILE_WIDTH;
@@ -185,9 +172,9 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
     uint32_t x_block_size = constants::TILE_HEIGHT;
     uint32_t output_cb_page_size = x_block_size * input_tensor.element_size();
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t src1_cb_index = tt::CBIndex::c_2;
-    uint32_t src2_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t src1_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t src2_cb_index = tt::CBIndex::c_1;
     uint32_t num_input_pages_to_read = 2;
 
     // we are focused on reading one row at a time, in a pattern that allows us to write an entire output row at a time
@@ -218,28 +205,39 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks_total);
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_pages_to_read * input_cb_page_size * x_block_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, input_cb_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * input_cb_page_size * x_block_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = input_cb_page_size,
+        }}},
+    });
 
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_pages_to_read * output_cb_page_size * w_block_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, output_cb_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * output_cb_page_size * w_block_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src1_cb_index,
+            .data_format = cb_data_format,
+            .page_size = output_cb_page_size,
+        }}},
+    });
 
-    tt::tt_metal::CircularBufferConfig cb_src2_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_pages_to_read * x_block_size * w_block_size * input_tensor.element_size(),
-            {{src2_cb_index, cb_data_format}})
-            .set_page_size(src2_cb_index, x_block_size * w_block_size * input_tensor.element_size());
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * x_block_size * w_block_size * input_tensor.element_size(),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src2_cb_index,
+            .data_format = cb_data_format,
+            .page_size = x_block_size * w_block_size * input_tensor.element_size(),
+        }}},
+    });
 
     std::vector<uint32_t> reader_compile_time_args = {};
 
-    std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
         {"N", N},
         {"page_size", input_cb_page_size},
         {"num_rows", num_rows},
@@ -254,16 +252,19 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
 
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "reader_permute_interleaved_rm_blocked_generic.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
+        "reader_permute_interleaved_rm_blocked_generic.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     std::vector<uint32_t> writer_compile_time_args = {};
 
-    std::unordered_map<std::string, uint32_t> writer_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs writer_named_compile_time_args = {
         {"N", N},
         {"output_page_size", output_cb_page_size},
         {"num_rows", num_rows},
@@ -282,28 +283,33 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
         {"output_tensor_page_size", static_cast<uint32_t>(dst_buffer->aligned_page_size())}};
 
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "writer_permute_interleaved_rm_blocked_generic.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
+        "writer_permute_interleaved_rm_blocked_generic.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     std::vector<uint32_t> compute_kernel_args = {x_block_size, w_block_size};
-    std::unordered_map<std::string, uint32_t> compute_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs compute_named_compile_time_args = {
         {"x_block_size", x_block_size}, {"w_block_size", w_block_size}};
     bool fp32_dest_acc_en = cb_data_format_output == tt::DataFormat::Float32 ||
                             cb_data_format_output == tt::DataFormat::Int32 ||
                             cb_data_format_output == tt::DataFormat::UInt32;
-    auto compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .named_compile_args = compute_named_compile_time_args,
-        });
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.named_compile_time_args = std::move(compute_named_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     auto input_shape_view = input_tensor.logical_shape().view();
 
@@ -323,6 +329,9 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
 
     uint32_t start_block = 0;
     uint32_t num_blocks_per_core = 0;
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    compute_desc.runtime_args.reserve(cores.size());
     for (const auto& core : cores) {
         if (core_group_1.contains(core)) {
             num_blocks_per_core = num_tiles_per_core_group_1;
@@ -338,43 +347,17 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
         reader_runtime_args[2] = end_block;
         writer_runtime_args[1] = start_block;
         writer_runtime_args[2] = end_block;
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
+        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
         start_block = end_block;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = unary_reader_kernel_id,
-         .unary_writer_kernel_id = unary_writer_kernel_id,
-         .compute_kernel_id = compute_kernel_id,
-         .core_range = all_cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void PermuteDeviceOperation::MultiCoreBlockedGeneric::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto& output_tensor = tensor_return_value;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    auto& all_cores = cached_program.shared_variables.core_range;
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    for (const auto& core : cores) {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-        auto& runtime_args_writer = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, core);
-        runtime_args_writer[0] = dst_buffer->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -91,7 +91,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreRowInvariant::c
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_compile_time_args = {};
     KernelDescriptor::NamedCompileTimeArgs writer_named_compile_time_args = {
@@ -106,7 +106,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreRowInvariant::c
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
 
@@ -260,7 +260,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreBlockedGeneric:
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_compile_time_args = {};
 
@@ -291,7 +291,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreBlockedGeneric:
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<uint32_t> compute_kernel_args = {x_block_size, w_block_size};
     KernelDescriptor::NamedCompileTimeArgs compute_named_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -108,16 +108,16 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreRowInvariant::c
     writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
     writer_desc.config = WriterConfigDescriptor{};
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
-
     auto input_shape_view = input_tensor.logical_shape().view();
     auto output_strides = detail::get_row_strides(output_tensor.logical_shape());  // in anticipation of RM padding
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0};
-    writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
-    writer_runtime_args.insert(
-        writer_runtime_args.end(), operation_attributes.dims.begin(), operation_attributes.dims.end());
-    writer_runtime_args.insert(writer_runtime_args.end(), output_strides.begin(), output_strides.end());
+    // Trailing writer args (everything after dst_addr/start/end) are the same for every core; build once.
+    std::vector<uint32_t> writer_trailing_args;
+    writer_trailing_args.reserve(input_shape_view.size() + operation_attributes.dims.size() + output_strides.size());
+    writer_trailing_args.insert(writer_trailing_args.end(), input_shape_view.begin(), input_shape_view.end());
+    writer_trailing_args.insert(
+        writer_trailing_args.end(), operation_attributes.dims.begin(), operation_attributes.dims.end());
+    writer_trailing_args.insert(writer_trailing_args.end(), output_strides.begin(), output_strides.end());
 
     auto cores = corerange_to_cores(all_cores, std::nullopt);
     uint32_t start_row = 0;
@@ -134,12 +134,14 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreRowInvariant::c
             num_rows_per_core = 0;
         }
         uint32_t end_row = start_row + num_rows_per_core;
-        reader_runtime_args[1] = start_row;
-        reader_runtime_args[2] = end_row;
-        writer_runtime_args[1] = start_row;
-        writer_runtime_args[2] = end_row;
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        reader_desc.emplace_runtime_args(core, {src_buffer, start_row, end_row});
+
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.push_back(dst_buffer);
+        writer_args.push_back(start_row);
+        writer_args.push_back(end_row);
+        writer_args.append(writer_trailing_args);
+        writer_desc.emplace_runtime_args(core, writer_args);
         start_row = end_row;
     }
 
@@ -313,19 +315,19 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreBlockedGeneric:
 
     auto input_shape_view = input_tensor.logical_shape().view();
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
-    reader_runtime_args.insert(reader_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
-    reader_runtime_args.insert(reader_runtime_args.end(), input_strides.begin(), input_strides.end());
+    // Trailing args (everything after src_addr/start/end) are core-invariant; build once.
+    std::vector<uint32_t> reader_trailing_args;
+    reader_trailing_args.reserve(input_shape_view.size() + input_strides.size());
+    reader_trailing_args.insert(reader_trailing_args.end(), input_shape_view.begin(), input_shape_view.end());
+    reader_trailing_args.insert(reader_trailing_args.end(), input_strides.begin(), input_strides.end());
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0};
-
-    writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
-    writer_runtime_args.insert(
-        writer_runtime_args.end(), operation_attributes.dims.begin(), operation_attributes.dims.end());
-    writer_runtime_args.insert(writer_runtime_args.end(), output_strides.begin(), output_strides.end());
+    std::vector<uint32_t> writer_trailing_args;
+    writer_trailing_args.reserve(input_shape_view.size() + operation_attributes.dims.size() + output_strides.size());
+    writer_trailing_args.insert(writer_trailing_args.end(), input_shape_view.begin(), input_shape_view.end());
+    writer_trailing_args.insert(
+        writer_trailing_args.end(), operation_attributes.dims.begin(), operation_attributes.dims.end());
+    writer_trailing_args.insert(writer_trailing_args.end(), output_strides.begin(), output_strides.end());
     auto cores = corerange_to_cores(all_cores, std::nullopt);
-
-    std::vector<uint32_t> compute_runtime_args = {dst_buffer->address(), 0, 0};
 
     uint32_t start_block = 0;
     uint32_t num_blocks_per_core = 0;
@@ -341,15 +343,25 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreBlockedGeneric:
             // no-op
             num_blocks_per_core = 0;
         }
-        compute_runtime_args[0] = num_blocks_per_core;
         uint32_t end_block = start_block + num_blocks_per_core;
-        reader_runtime_args[1] = start_block;
-        reader_runtime_args[2] = end_block;
-        writer_runtime_args[1] = start_block;
-        writer_runtime_args[2] = end_block;
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
-        compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
+
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(src_buffer);
+        reader_args.push_back(start_block);
+        reader_args.push_back(end_block);
+        reader_args.append(reader_trailing_args);
+        reader_desc.emplace_runtime_args(core, reader_args);
+
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.push_back(dst_buffer);
+        writer_args.push_back(start_block);
+        writer_args.push_back(end_block);
+        writer_args.append(writer_trailing_args);
+        writer_desc.emplace_runtime_args(core, writer_args);
+
+        // Compute only consumes num_blocks_per_core in slot 0; the remaining two
+        // slots are unused/padding (preserve historical layout).
+        compute_desc.emplace_runtime_args(core, {num_blocks_per_core, 0u, 0u});
         start_block = end_block;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <vector>
 #include <tt-metalium/hal.hpp>
@@ -86,7 +88,7 @@ uint32_t get_buffer_alignment(const ttnn::Tensor& tensor) {
 
 }  // namespace detail
 
-PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOperation::MultiCoreTileInvariant::create(
+tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -99,14 +101,14 @@ PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOp
     auto* src_buffer = input_tensor.buffer();
     auto* dst_buffer = output_tensor.buffer();
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_page_size = detail::tile_size(input_tensor);
 
     uint32_t num_tiles = detail::num_tiles(tensor_return_value);
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_pages_to_read = 2;
 
     uint32_t rank = operation_attributes.dims.size();
@@ -116,64 +118,80 @@ PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOp
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_pages_to_read * input_page_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = input_page_size,
+        }}},
+    });
 
     uint32_t output_cb_index = src0_cb_index;
     if (swap_hw) {
-        uint32_t src1_cb_index = tt::CBIndex::c_16;
-        tt::tt_metal::CircularBufferConfig cb_src1_config =
-            tt::tt_metal::CircularBufferConfig(
-                num_input_pages_to_read * input_page_size, {{src1_cb_index, cb_data_format}})
-                .set_page_size(src1_cb_index, input_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+        constexpr uint8_t src1_cb_index = tt::CBIndex::c_16;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_input_pages_to_read * input_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = src1_cb_index,
+                .data_format = cb_data_format,
+                .page_size = input_page_size,
+            }}},
+        });
         output_cb_index = src1_cb_index;
     }
 
     std::vector<uint32_t> reader_compile_time_args = {};
-    std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
         {"rank", rank},
         {"page_size", input_page_size},
         {"num_tiles", num_tiles},
     };
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "reader_permute_interleaved_tiled_invariant.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
+        "reader_permute_interleaved_tiled_invariant.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
-    uint32_t compute_kernel_id = 0;
+    bool has_compute = swap_hw;
+    KernelDescriptor compute_desc;
     if (swap_hw) {
         std::vector<uint32_t> compute_kernel_args = {};
         bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                                 cb_data_format == tt::DataFormat::UInt32;
-        std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+        std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+            NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
         if (cb_data_format == tt::DataFormat::Float32) {
             unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         }
-        compute_kernel_id = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp",
-            all_cores,
-            tt::tt_metal::ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_kernel_args,
-            });
+        compute_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = all_cores;
+        compute_desc.compile_time_args = std::move(compute_kernel_args);
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
     }
 
     // think of tensor as its tiled shape rather than its logical shape
@@ -201,6 +219,11 @@ PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOp
     auto cores = corerange_to_cores(all_cores, std::nullopt);
     uint32_t start_tile = 0;
     uint32_t num_tiles_per_core = 0;
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    if (has_compute) {
+        compute_desc.runtime_args.reserve(cores.size());
+    }
     for (const auto& core : cores) {
         if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
@@ -214,54 +237,28 @@ PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOp
         reader_runtime_args[1] = start_tile;
         reader_runtime_args[2] = end_tile;
 
-        writer_runtime_args[1] = num_tiles_per_core;     // for some reason num_tiles comes first in writer unary
-        writer_runtime_args[2] = start_tile;             // start tile is second in writer unary
+        writer_runtime_args[1] = num_tiles_per_core;  // for some reason num_tiles comes first in writer unary
+        writer_runtime_args[2] = start_tile;          // start tile is second in writer unary
 
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
+        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
         if (swap_hw) {
             compute_runtime_args[0] = num_tiles_per_core;  // number of tiles transposed
-            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+            compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
         }
         start_tile = end_tile;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = unary_reader_kernel_id,
-         .unary_writer_kernel_id = unary_writer_kernel_id,
-         .compute_kernel_id = compute_kernel_id,
-         .core_range = all_cores}};
-}
-
-void PermuteDeviceOperation::MultiCoreTileInvariant::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto& output_tensor = tensor_return_value;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    auto& all_cores = cached_program.shared_variables.core_range;
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    for (const auto& core : cores) {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-
-        auto& runtime_args_writer = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, core);
-        runtime_args_writer[0] = dst_buffer->address();
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (has_compute) {
+        desc.kernels.push_back(std::move(compute_desc));
     }
+
+    return desc;
 }
 
-PermuteDeviceOperation::MultiCoreTileRowInvariant::cached_program_t
-PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
+tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvariant::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -299,7 +296,7 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
     auto* src_buffer = input_tensor.buffer();
     auto* dst_buffer = output_tensor.buffer();
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_page_size = detail::tile_size(input_tensor);
@@ -307,8 +304,8 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
     uint32_t num_tiles = detail::num_tiles(input_tensor);
     uint32_t num_output_tiles = detail::num_tiles(tensor_return_value);
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t padding_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t padding_cb_index = tt::CBIndex::c_1;
     uint32_t output_cb_index = src0_cb_index;
 
     uint32_t num_input_pages_to_read = 2;
@@ -330,28 +327,42 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
 
     all_cores = num_cores > padded_num_cores ? all_cores : padded_all_cores;
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_pages_to_read * input_page_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = input_page_size,
+        }}},
+    });
 
     uint32_t output_H = input_shape[dims[rank - 2]];
     uint32_t element_size = input_tensor.element_size();
 
     bool needs_padding = (output_H % tile_shape[1] != 0);
     if (needs_padding) {
-        tt::tt_metal::CircularBufferConfig cb_src1_config =
-            tt::tt_metal::CircularBufferConfig(face_shape[1] * element_size, {{padding_cb_index, cb_data_format}})
-                .set_page_size(padding_cb_index, face_shape[1] * element_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = face_shape[1] * element_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = padding_cb_index,
+                .data_format = cb_data_format,
+                .page_size = face_shape[1] * element_size,
+            }}},
+        });
     }
     if (swap_hw) {
-        uint32_t src2_cb_index = tt::CBIndex::c_16;
-        tt::tt_metal::CircularBufferConfig cb_src2_config =
-            tt::tt_metal::CircularBufferConfig(
-                num_input_pages_to_read * input_page_size, {{src2_cb_index, cb_data_format}})
-                .set_page_size(src2_cb_index, input_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
+        constexpr uint8_t src2_cb_index = tt::CBIndex::c_16;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_input_pages_to_read * input_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = src2_cb_index,
+                .data_format = cb_data_format,
+                .page_size = input_page_size,
+            }}},
+        });
         output_cb_index = src2_cb_index;
     }
     uint32_t padding_val_packed = 0;
@@ -394,7 +405,7 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
 
     std::vector<uint32_t> reader_compile_time_args = {};
 
-    std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
         {"num_writes", num_writes},
         {"padding_val_packed", padding_val_packed},
         {"needs_padding", needs_padding},
@@ -408,36 +419,41 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
 
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
+        "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
-    uint32_t compute_kernel_id = 0;
+    bool has_compute = swap_hw;
+    KernelDescriptor compute_desc;
     if (swap_hw) {
         std::vector<uint32_t> compute_kernel_args = {};
         bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                                 cb_data_format == tt::DataFormat::UInt32;
-        std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+        std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+            NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
         if (cb_data_format == tt::DataFormat::Float32) {
             unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         }
-        compute_kernel_id = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp",
-            all_cores,
-            tt::tt_metal::ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_kernel_args,
-            });
+        compute_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = all_cores;
+        compute_desc.compile_time_args = std::move(compute_kernel_args);
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
     }
 
     std::vector<uint32_t> writer_compile_time_args = {};
 
-    std::unordered_map<std::string, uint32_t> writer_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs writer_named_compile_time_args = {
         {"element_size", element_size},
         {"output_cb_index", output_cb_index},
         {"output_H", output_H},
@@ -454,12 +470,15 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
 
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "writer_permute_interleaved_tiled_row_invariant.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
+        "writer_permute_interleaved_tiled_row_invariant.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     auto input_shape_view = input_shape.view();
 
@@ -477,6 +496,11 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
     uint32_t start_tile_padding = 0;
     uint32_t num_tiles_per_core_padding = 0;
     uint32_t end_tile_padding = 0;
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    if (has_compute) {
+        compute_desc.runtime_args.reserve(cores.size());
+    }
     for (const auto& core : cores) {
         if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
@@ -509,50 +533,26 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
         }
         if (swap_hw) {
             compute_runtime_args[0] = num_tiles_per_core;  // number of tiles transposed
-            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+            compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
+        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
 
         start_tile = end_tile;
         start_tile_padding = end_tile_padding;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = unary_reader_kernel_id,
-         .unary_writer_kernel_id = unary_writer_kernel_id,
-         .compute_kernel_id = compute_kernel_id,
-         .core_range = all_cores}};
-}
-
-void PermuteDeviceOperation::MultiCoreTileRowInvariant::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto& output_tensor = tensor_return_value;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    auto& all_cores = cached_program.shared_variables.core_range;
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    for (const auto& core : cores) {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-        auto& runtime_args_writer = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, core);
-        runtime_args_writer[0] = dst_buffer->address();
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (has_compute) {
+        desc.kernels.push_back(std::move(compute_desc));
     }
+
+    return desc;
 }
 
-PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOperation::MultiCoreTiledGeneric::create(
+tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -591,7 +591,7 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
     auto* src_buffer = input_tensor.buffer();
     auto* dst_buffer = output_tensor.buffer();
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
     uint32_t logical_volume = input_shape.volume();
     uint32_t num_rows = logical_volume / input_shape[rank - 1];
     uint32_t y_dim_index_in_input = dims[rank - 2];
@@ -648,7 +648,7 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
     uint32_t padding_val_packed = 0;
     uint32_t num_writes = 0;
 
-    uint32_t padding_cb_index = tt::CBIndex::c_3;
+    constexpr uint8_t padding_cb_index = tt::CBIndex::c_3;
 
     if (needs_padding) {
         uint32_t num_packed_values = sizeof(uint32_t) / element_size;
@@ -687,9 +687,9 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
 
     uint32_t num_output_tiles = detail::num_tiles(tensor_return_value);
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t src1_cb_index = tt::CBIndex::c_1;
-    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    constexpr uint8_t src1_cb_index = tt::CBIndex::c_1;
+    constexpr uint8_t src2_cb_index = tt::CBIndex::c_2;
 
     uint32_t num_input_pages_to_read = 2;
 
@@ -714,33 +714,53 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_page_size = detail::tile_size(tensor_return_value) + misalignment;
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_pages_to_read * input_page_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = input_page_size,
+        }}},
+    });
 
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(num_input_pages_to_read * input_page_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src1_cb_index,
+            .data_format = cb_data_format,
+            .page_size = input_page_size,
+        }}},
+    });
 
-    tt::tt_metal::CircularBufferConfig cb_src2_config =
-        tt::tt_metal::CircularBufferConfig(num_input_pages_to_read * input_page_size, {{src2_cb_index, cb_data_format}})
-            .set_page_size(src2_cb_index, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages_to_read * input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src2_cb_index,
+            .data_format = cb_data_format,
+            .page_size = input_page_size,
+        }}},
+    });
 
     if (needs_y_padding) {
-        tt::tt_metal::CircularBufferConfig cb_padding_cfg =
-            tt::tt_metal::CircularBufferConfig(face_shape[1] * element_size, {{padding_cb_index, cb_data_format}})
-                .set_page_size(padding_cb_index, face_shape[1] * element_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_padding_cfg);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = face_shape[1] * element_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = padding_cb_index,
+                .data_format = cb_data_format,
+                .page_size = face_shape[1] * element_size,
+            }}},
+        });
     }
 
     uint32_t non_x_rows = num_rows / x;
 
     std::vector<uint32_t> reader_compile_time_args = {};
 
-    std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
         {"rank", rank},
         {"page_size", input_page_size},
         {"element_size", element_size},
@@ -773,28 +793,33 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
 
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "reader_permute_interleaved_tiled_generic.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
+        "reader_permute_interleaved_tiled_generic.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     std::vector<uint32_t> compute_kernel_args = {};
 
     bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                             cb_data_format == tt::DataFormat::UInt32;
-    auto compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-        });
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     std::vector<uint32_t> writer_compile_time_args = {};
-    std::unordered_map<std::string, uint32_t> writer_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs writer_named_compile_time_args = {
         {"rank", rank},
         {"page_size", input_page_size},
         {"element_size", element_size},
@@ -821,12 +846,15 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
     };
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
-        "writer_permute_interleaved_tiled_generic.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
+        "writer_permute_interleaved_tiled_generic.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     auto input_shape_view = input_shape.view();
 
@@ -845,6 +873,9 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
     uint32_t num_blocks_per_core = 0;
     uint32_t num_tiles_per_core_padding = 0;
     uint32_t start_tile_padding = 0;
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    compute_desc.runtime_args.reserve(cores.size());
     for (const auto& core : cores) {
         if (core_group_1.contains(core)) {
             num_blocks_per_core = num_blocks_per_core_group_1;
@@ -882,44 +913,18 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
             start_tile_padding = end_tile_padding;
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
+        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
 
         start_block = end_block;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = unary_reader_kernel_id,
-         .unary_writer_kernel_id = unary_writer_kernel_id,
-         .compute_kernel_id = compute_kernel_id,
-         .core_range = all_cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void PermuteDeviceOperation::MultiCoreTiledGeneric::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto& output_tensor = tensor_return_value;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    auto& all_cores = cached_program.shared_variables.core_range;
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    for (const auto& core : cores) {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-        auto& runtime_args_writer = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, core);
-        runtime_args_writer[0] = dst_buffer->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -159,7 +159,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
@@ -170,7 +170,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     bool has_compute = swap_hw;
     KernelDescriptor compute_desc;
@@ -427,7 +427,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     bool has_compute = swap_hw;
     KernelDescriptor compute_desc;
@@ -478,7 +478,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     auto input_shape_view = input_shape.view();
 
@@ -801,7 +801,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> compute_kernel_args = {};
 
@@ -854,7 +854,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.named_compile_time_args = std::move(writer_named_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     auto input_shape_view = input_shape.view();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -91,7 +91,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     reader_desc.core_ranges = total_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.defines = std::move(reader_defines);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
     KernelDescriptor writer_desc;
@@ -102,7 +102,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     writer_desc.core_ranges = total_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.defines = std::move(writer_defines);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
     writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
     // Set runtime arguments for each core

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -131,12 +131,9 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
         uint32_t n = curr_c % N;
         uint32_t start_tile = num_pages_read + (curr_c * batch_step) - (curr_c / N * channel_step);
 
-        reader_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                src0_buffer->address(), N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_pages_per_core, num_pages_read});
+        reader_desc.emplace_runtime_args(
+            core, {src0_buffer, N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_pages_per_core, num_pages_read});
 
         num_pages_read += num_pages_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
@@ -15,7 +16,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
     auto input_shape = input_tensor.padded_shape();
@@ -24,7 +25,7 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_cn needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_cn needs to be allocated in a buffer on device!");
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t page_shape[2] = {TILE_WIDTH, TILE_HEIGHT};
@@ -54,18 +55,23 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_pages = 2;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(num_input_pages * stick_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, stick_size);
-    CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_pages * stick_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size,
+        }}},
+    });
 
-    std::map<std::string, std::string> reader_defines;
+    KernelDescriptor::Defines reader_defines;
     std::vector<uint32_t> reader_compile_time_args = {
         static_cast<uint32_t>(src0_cb_index), src0_buffer->aligned_page_size(), stick_size};
     std::vector<uint32_t> reader_common_runtime_args;
     TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines writer_defines;
     std::vector<uint32_t> writer_compile_time_args = {
         static_cast<uint32_t>(src0_cb_index), dst_buffer->aligned_page_size(), stick_size};
     std::vector<uint32_t> writer_common_runtime_args;
@@ -73,25 +79,31 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     if (row_major) {
-        reader_defines["CN_RM"] = "1";
-        writer_defines["CN_RM"] = "1";
+        reader_defines.emplace_back("CN_RM", "1");
+        writer_defines.emplace_back("CN_RM", "1");
     }
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_cn_interleaved_start_id.cpp",
-        total_cores,
-        ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
-    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
+        "reader_unary_transpose_cn_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_cn_interleaved_start_id.cpp",
-        total_cores,
-        WriterDataMovementConfig(writer_compile_time_args, writer_defines));
-    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
+        "writer_unary_transpose_cn_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
     // Set runtime arguments for each core
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
@@ -103,6 +115,8 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
     uint32_t batch_step = CHtWt - HtWt;
     uint32_t channel_step = NCHtWt - HtWt;
 
+    reader_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
     for (uint32_t i = 0, num_pages_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_pages_per_core = 0;
@@ -117,104 +131,20 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
         uint32_t n = curr_c % N;
         uint32_t start_tile = num_pages_read + (curr_c * batch_step) - (curr_c / N * channel_step);
 
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.runtime_args.emplace_back(
             core,
-            {src0_buffer->address(), N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
-
-        SetRuntimeArgs(program, writer_kernel_id, core, {dst_buffer->address(), num_pages_per_core, num_pages_read});
-
-        num_pages_read += num_pages_per_core;
-    }
-
-    return {
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
-         .writer_kernel_id = writer_kernel_id,
-         .core_group_1 = core_group_1,
-         .core_group_2 = core_group_2,
-         .num_cores_total = num_cores_total,
-         .num_cores_y = num_cores_y,
-         .num_pages_per_core_group_1 = num_pages_per_core_group_1,
-         .num_pages_per_core_group_2 = num_pages_per_core_group_2}};
-}
-
-void TransposeCNProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    const auto& input_tensor = tensor_args.input;
-
-    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
-        program,
-        shared_variables.reader_kernel_id,
-        shared_variables.writer_kernel_id,
-        *input_tensor.buffer(),
-        *output_tensor.buffer());
-
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
-
-    uint32_t page_shape[2] = {TILE_WIDTH, TILE_HEIGHT};
-    if (input_tensor.layout() == Layout::ROW_MAJOR) {
-        page_shape[0] = 1;
-        page_shape[1] = input_shape[-1];
-    }
-    uint32_t page_size = page_shape[0] * page_shape[1];
-
-    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
-    uint32_t Wt = W / page_shape[1];
-    uint32_t Ht = H / page_shape[0];
-    uint32_t num_tensor_pages = N * C * H * W / page_size;
-    uint32_t HtWt = Ht * Wt;
-    uint32_t CHtWt = C * HtWt;
-    uint32_t NCHtWt = num_tensor_pages;
-    uint32_t batch_step = CHtWt - HtWt;
-    uint32_t channel_step = NCHtWt - HtWt;
-
-    auto& cached_reader_args = GetRuntimeArgs(program, shared_variables.reader_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, shared_variables.writer_kernel_id);
-
-    for (uint32_t i = 0, num_pages_read = 0; i < shared_variables.num_cores_total; i++) {
-        CoreCoord core = {i / shared_variables.num_cores_y, i % shared_variables.num_cores_y};
-        uint32_t num_pages_per_core = 0;
-        if (shared_variables.core_group_1.contains(core)) {
-            num_pages_per_core = shared_variables.num_pages_per_core_group_1;
-        } else if (shared_variables.core_group_2.contains(core)) {
-            num_pages_per_core = shared_variables.num_pages_per_core_group_2;
-        }
-
-        uint32_t hw = num_pages_read % HtWt;
-        uint32_t curr_c = num_pages_read / HtWt;
-        uint32_t n = curr_c % N;
-        uint32_t start_tile = num_pages_read + (curr_c * batch_step) - (curr_c / N * channel_step);
-
-        auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-        auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-
-        reader_args[0] = input_buffer->address();
-        reader_args[1] = N;
-        reader_args[2] = C;
-        reader_args[3] = HtWt;
-        reader_args[4] = batch_step;
-        reader_args[5] = channel_step;
-        reader_args[6] = num_pages_per_core;
-        reader_args[7] = start_tile;
-        reader_args[8] = hw;
-        reader_args[9] = n;
-
-        writer_args[0] = output_buffer->address();
-        writer_args[1] = num_pages_per_core;
-        writer_args[2] = num_pages_read;
+            std::vector<uint32_t>{
+                src0_buffer->address(), N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_pages_per_core, num_pages_read});
 
         num_pages_read += num_pages_per_core;
     }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.hpp
@@ -8,32 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeCNSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    CoreRangeSet core_group_1;
-    CoreRangeSet core_group_2;
-    uint32_t num_cores_total{};
-    uint32_t num_cores_y{};
-    uint32_t num_pages_per_core_group_1{};
-    uint32_t num_pages_per_core_group_2{};
-};
-
 struct TransposeCNProgramFactory {
-    using shared_variables_t = TransposeCNSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -177,7 +177,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = total_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
     KernelDescriptor writer_desc;
@@ -187,7 +187,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = total_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
     writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
     emit_runtime_args_hc_rm(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -64,21 +64,12 @@ void emit_runtime_args_hc_rm(
             num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
         }
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                input_buffer->address(),
-                num_sticks_per_core_read,
-                num_read_per_barrier,
-                curr_sticks_read,
-                curr_c,
-                curr_h,
-                curr_n});
+            {input_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
 
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                output_buffer->address(), num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
+        writer_desc.emplace_runtime_args(
+            core, {output_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
 
         curr_sticks_write += num_sticks_per_core;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -18,10 +19,12 @@ namespace ttnn::prim {
 
 namespace {
 
-void set_runtime_args_hc_rm(
-    Program& program,
-    KernelHandle reader_kernel_id,
-    KernelHandle writer_kernel_id,
+// Compute per-core runtime args (reader+writer) for HC RM transpose and append them to the
+// supplied KernelDescriptors. The traversal logic that advances (curr_c, curr_h, curr_n) was
+// previously shared between `create` and `override_runtime_arguments`; now it has a single home.
+void emit_runtime_args_hc_rm(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
     const Tensor& input_tensor,
     Tensor& output_tensor,
     uint32_t num_cores_total,
@@ -29,8 +32,7 @@ void set_runtime_args_hc_rm(
     const CoreRangeSet& core_group_1,
     uint32_t num_sticks_per_core_group_1,
     const CoreRangeSet& core_group_2,
-    uint32_t num_sticks_per_core_group_2,
-    bool is_create) {
+    uint32_t num_sticks_per_core_group_2) {
     auto* input_buffer = input_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
@@ -41,8 +43,8 @@ void set_runtime_args_hc_rm(
     uint32_t max_read_size = 2048;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
 
-    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
+    reader_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
 
     for (uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -62,41 +64,21 @@ void set_runtime_args_hc_rm(
             num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
         }
 
-        if (is_create) {
-            SetRuntimeArgs(
-                program,
-                reader_kernel_id,
-                core,
-                {input_buffer->address(),
-                 num_sticks_per_core_read,
-                 num_read_per_barrier,
-                 curr_sticks_read,
-                 curr_c,
-                 curr_h,
-                 curr_n});
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                input_buffer->address(),
+                num_sticks_per_core_read,
+                num_read_per_barrier,
+                curr_sticks_read,
+                curr_c,
+                curr_h,
+                curr_n});
 
-            SetRuntimeArgs(
-                program,
-                writer_kernel_id,
-                core,
-                {output_buffer->address(), num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
-        } else {
-            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-
-            reader_args[0] = input_buffer->address();
-            reader_args[1] = num_sticks_per_core_read;
-            reader_args[2] = num_read_per_barrier;
-            reader_args[3] = curr_sticks_read;
-            reader_args[4] = curr_c;
-            reader_args[5] = curr_h;
-            reader_args[6] = curr_n;
-
-            writer_args[0] = output_buffer->address();
-            writer_args[1] = num_sticks_per_core_read;
-            writer_args[2] = num_read_per_barrier;
-            writer_args[3] = curr_sticks_write;
-        }
+        writer_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                output_buffer->address(), num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -121,7 +103,7 @@ void set_runtime_args_hc_rm(
 
 }  // namespace
 
-TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
@@ -132,7 +114,7 @@ TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::creat
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
     uint32_t NCH = N * C * H;
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
@@ -161,10 +143,15 @@ TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::creat
     uint32_t aligned_page = std::max(src0_buffer->aligned_page_size(), dst_buffer->aligned_page_size());
     auto stick_size = std::max(W * input_tensor.element_size(), aligned_page);
 
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(num_sticks * stick_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, stick_size);
-    CreateCircularBuffer(program, total_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_sticks * stick_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size,
+        }}},
+    });
 
     std::vector<uint32_t> reader_compile_time_args;
     std::vector<uint32_t> reader_common_runtime_args;
@@ -183,26 +170,29 @@ TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::creat
     TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp",
-        total_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
-    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
+        "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_hc_interleaved_start_id_rm.cpp",
-        total_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
-    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
+        "writer_unary_transpose_hc_interleaved_start_id_rm.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
-    set_runtime_args_hc_rm(
-        program,
-        reader_kernel_id,
-        writer_kernel_id,
+    emit_runtime_args_hc_rm(
+        reader_desc,
+        writer_desc,
         input_tensor,
         output_tensor,
         num_cores_total,
@@ -210,49 +200,12 @@ TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::creat
         core_group_1,
         num_sticks_per_core_group_1,
         core_group_2,
-        num_sticks_per_core_group_2,
-        true);
+        num_sticks_per_core_group_2);
 
-    return {
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
-         .writer_kernel_id = writer_kernel_id,
-         .core_group_1 = core_group_1,
-         .core_group_2 = core_group_2,
-         .num_cores_total = num_cores_total,
-         .num_cores_y = num_cores_y,
-         .num_sticks_per_core_group_1 = num_sticks_per_core_group_1,
-         .num_sticks_per_core_group_2 = num_sticks_per_core_group_2}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void TransposeHCRMProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
-        program,
-        shared_variables.reader_kernel_id,
-        shared_variables.writer_kernel_id,
-        *tensor_args.input.buffer(),
-        *output_tensor.buffer());
-
-    set_runtime_args_hc_rm(
-        program,
-        shared_variables.reader_kernel_id,
-        shared_variables.writer_kernel_id,
-        tensor_args.input,
-        output_tensor,
-        shared_variables.num_cores_total,
-        shared_variables.num_cores_y,
-        shared_variables.core_group_1,
-        shared_variables.num_sticks_per_core_group_1,
-        shared_variables.core_group_2,
-        shared_variables.num_sticks_per_core_group_2,
-        false);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.hpp
@@ -8,32 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeHCRMSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    CoreRangeSet core_group_1;
-    CoreRangeSet core_group_2;
-    uint32_t num_cores_total{};
-    uint32_t num_cores_y{};
-    uint32_t num_sticks_per_core_group_1{};
-    uint32_t num_sticks_per_core_group_2{};
-};
-
 struct TransposeHCRMProgramFactory {
-    using shared_variables_t = TransposeHCRMSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -375,7 +375,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.defines = std::move(reader_defines);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer kernel only exists in the special case path; the generic path puts
     // everything through the reader (writer args returned by the generic helper
@@ -409,7 +409,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
         writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
         writer_desc.core_ranges = all_cores;
         writer_desc.compile_time_args = {src0_cb_index, output_cb_index, stick_size_bytes};
-        writer_desc.config = WriterDataMovementConfig{};
+        writer_desc.config = WriterConfigDescriptor{};
         writer_desc.runtime_args.reserve(num_cores);
         for (uint32_t i = 0; i < num_cores; i++) {
             CoreCoord core;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -6,6 +6,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-logger/tt-logger.hpp>
 
 #include <map>
@@ -281,14 +282,14 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
 }  // namespace
 
-TransposeHCShardedProgramFactory::cached_program_t TransposeHCShardedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
@@ -320,18 +321,30 @@ TransposeHCShardedProgramFactory::cached_program_t TransposeHCShardedProgramFact
     uint32_t num_cores_y = grid_size.y;
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(shard_height * stick_size_bytes, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, stick_size_bytes)
-            .set_globally_allocated_address(*input_tensor.buffer());
-    auto cb_src0 = CreateCircularBuffer(program, all_cores, cb_src0_config);
+    // Sharded CBs bound to the input/output buffers: the framework re-applies
+    // UpdateDynamicCircularBufferAddress on cache hit via the .buffer member.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height * stick_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = stick_size_bytes,
+        }}},
+        .buffer = input_tensor.buffer(),
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(shard_height * stick_size_bytes, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, stick_size_bytes)
-            .set_globally_allocated_address(*output_tensor.buffer());
-    auto cb_output = CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height * stick_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = stick_size_bytes,
+        }}},
+        .buffer = output_tensor.buffer(),
+    });
 
     std::vector<uint32_t> reader_compile_time_args;
     if (is_special_case) {
@@ -349,30 +362,24 @@ TransposeHCShardedProgramFactory::cached_program_t TransposeHCShardedProgramFact
             num_cores_y};
     }
 
-    std::map<std::string, std::string> reader_defines;
+    KernelDescriptor::Defines reader_defines;
     if (is_special_case) {
-        reader_defines["USE_SPECIAL_CASE"] = "1";
+        reader_defines.emplace_back("USE_SPECIAL_CASE", "1");
     }
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_sharded_rm.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+        "reader_unary_transpose_hc_sharded_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderDataMovementConfig{};
 
-    KernelHandle writer_kernel_id{};
-    if (is_special_case) {
-        std::vector<uint32_t> writer_compile_time_args = {src0_cb_index, output_cb_index, stick_size_bytes};
-
-        writer_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-            "writer_unary_transpose_hc_sharded_rm.cpp",
-            all_cores,
-            WriterDataMovementConfig(writer_compile_time_args));
-    }
-
+    // Writer kernel only exists in the special case path; the generic path puts
+    // everything through the reader (writer args returned by the generic helper
+    // are empty, matching the legacy `KernelHandle writer_kernel_id{}` behavior).
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> all_runtime_args;
     if (is_special_case) {
         all_runtime_args =
@@ -381,6 +388,7 @@ TransposeHCShardedProgramFactory::cached_program_t TransposeHCShardedProgramFact
         all_runtime_args = get_runtime_args_hc_rm_sharded(input_tensor, num_cores, num_cores_x, num_cores_y);
     }
 
+    reader_desc.runtime_args.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core;
         if (row_major_orientation) {
@@ -388,34 +396,34 @@ TransposeHCShardedProgramFactory::cached_program_t TransposeHCShardedProgramFact
         } else {
             core = {i / num_cores_y, i % num_cores_y};
         }
-
-        SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
-        SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
+        reader_desc.runtime_args.emplace_back(core, all_runtime_args[i].first);
     }
 
-    return {
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
-         .writer_kernel_id = writer_kernel_id,
-         .cb_src0 = cb_src0,
-         .cb_output = cb_output,
-         .num_cores_x = num_cores_x,
-         .num_cores_y = num_cores_y}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
 
-void TransposeHCShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
+    if (is_special_case) {
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+            "writer_unary_transpose_hc_sharded_rm.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = all_cores;
+        writer_desc.compile_time_args = {src0_cb_index, output_cb_index, stick_size_bytes};
+        writer_desc.config = WriterDataMovementConfig{};
+        writer_desc.runtime_args.reserve(num_cores);
+        for (uint32_t i = 0; i < num_cores; i++) {
+            CoreCoord core;
+            if (row_major_orientation) {
+                core = {i % num_cores_x, i / num_cores_x};
+            } else {
+                core = {i / num_cores_y, i % num_cores_y};
+            }
+            writer_desc.runtime_args.emplace_back(core, all_runtime_args[i].second);
+        }
+        desc.kernels.push_back(std::move(writer_desc));
+    }
 
-    auto* const src_buffer = tensor_args.input.buffer();
-    auto* const dst_buffer = output_tensor.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src0, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.hpp
@@ -8,30 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeHCShardedSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    tt::tt_metal::CBHandle cb_src0{};
-    tt::tt_metal::CBHandle cb_output{};
-    uint32_t num_cores_x{};
-    uint32_t num_cores_y{};
-};
-
 struct TransposeHCShardedProgramFactory {
-    using shared_variables_t = TransposeHCShardedSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -22,13 +23,15 @@ namespace ttnn::prim {
 
 namespace {
 
-void set_runtime_args_hc_tiled_interleaved(
-    Program& program,
-    KernelHandle reader_kernel_id,
-    KernelHandle writer_kernel_id,
+// Per-core runtime args for the reader + writer kernels. The work split uses
+// two parallel partitions (unpadded vs padded tile counts) so each core needs a
+// (start, end) pair from both. Writer also tracks the padded range; reader only
+// the unpadded count.
+void emit_runtime_args_hc_tiled_interleaved(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    bool is_create,
     const CoreRange& total_cores) {
     auto* input_buffer = input_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();
@@ -39,9 +42,6 @@ void set_runtime_args_hc_tiled_interleaved(
     uint32_t num_output_tiles = output_tensor.physical_volume() / tile_hw;
     uint32_t padded_num_tensor_tiles = num_output_tiles / (output_tensor.padded_shape()[2] /
                                                            tile_shape[0]);  // only last row of Ct should have padding
-
-    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
 
     auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
@@ -83,21 +83,13 @@ void set_runtime_args_hc_tiled_interleaved(
 
         uint32_t end_idx = start_idx + num_tiles_per_core;
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
-        if (is_create) {
-            SetRuntimeArgs(program, reader_kernel_id, core, {input_buffer->address(), num_tiles_per_core, start_idx});
 
-            SetRuntimeArgs(
-                program,
-                writer_kernel_id,
-                core,
-                {output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
-        } else {
-            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
+        reader_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{input_buffer->address(), num_tiles_per_core, start_idx});
+        writer_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
 
-            reader_args[0] = input_buffer->address();
-            writer_args[0] = output_buffer->address();
-        }
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;
     }
@@ -105,7 +97,7 @@ void set_runtime_args_hc_tiled_interleaved(
 
 }  // namespace
 
-TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInterleavedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::create_descriptor(
     const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
     // pad_value is always defined at API level; padding is decided purely by shape
@@ -114,7 +106,7 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
-    Program program = Program();
+    ProgramDescriptor desc;
     auto tile = input_tensor.tensor_spec().tile();
     auto tile_shape = tile.get_tile_shape();
     auto face_shape = tile.get_face_shape();
@@ -132,15 +124,27 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t padding_cb_index = tt::CBIndex::c_1;
 
-    CircularBufferConfig cb_src0_config = CircularBufferConfig(2 * single_tile_size, {{src0_cb_index, cb_data_format}})
-                                              .set_page_size(src0_cb_index, single_tile_size);
-    CreateCircularBuffer(program, total_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
     auto max_padding_write = face_shape[0] * face_shape[1];
     if (needs_padding) {
-        CircularBufferConfig cb_src1_config =
-            CircularBufferConfig(max_padding_write * input_tensor.element_size(), {{padding_cb_index, cb_data_format}})
-                .set_page_size(padding_cb_index, max_padding_write * input_tensor.element_size());
-        CreateCircularBuffer(program, total_cores, cb_src1_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = max_padding_write * input_tensor.element_size(),
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(padding_cb_index),
+                .data_format = cb_data_format,
+                .page_size = max_padding_write * input_tensor.element_size(),
+            }}},
+        });
     }
 
     Buffer* src_buffer = input_tensor.buffer();
@@ -174,7 +178,7 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
 
     std::vector<uint32_t> reader_compile_time_args = {};
     std::vector<uint32_t> reader_common_runtime_args;
-    std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
+    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
         {"num_writes", num_writes},
         {"padding_val_packed", padding_val_packed},
         {"needs_padding", needs_padding},
@@ -188,13 +192,16 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
     TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
-        total_cores,
-        ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
-    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
+        "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
     Buffer* dst_buffer = output_tensor.buffer();
     std::vector<uint32_t> writer_compile_time_args = {
@@ -212,48 +219,22 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
     TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
-        total_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
-    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
+        "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
-    set_runtime_args_hc_tiled_interleaved(
-        program, reader_kernel_id, writer_kernel_id, input_tensor, output_tensor, true, total_cores);
+    emit_runtime_args_hc_tiled_interleaved(reader_desc, writer_desc, input_tensor, output_tensor, total_cores);
 
-    return {std::move(program), {.reader_kernel_id = reader_kernel_id, .writer_kernel_id = writer_kernel_id}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void TransposeHCTiledInterleavedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
-        program,
-        shared_variables.reader_kernel_id,
-        shared_variables.writer_kernel_id,
-        *tensor_args.input.buffer(),
-        *output_tensor.buffer());
-
-    auto compute_with_storage_grid_size = tensor_args.input.device()->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
-
-    set_runtime_args_hc_tiled_interleaved(
-        program,
-        shared_variables.reader_kernel_id,
-        shared_variables.writer_kernel_id,
-        tensor_args.input,
-        output_tensor,
-        false,
-        total_cores);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -200,7 +200,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     reader_desc.core_ranges = total_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
     Buffer* dst_buffer = output_tensor.buffer();
@@ -226,7 +226,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = total_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
     writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
     emit_runtime_args_hc_tiled_interleaved(reader_desc, writer_desc, input_tensor, output_tensor, total_cores);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
@@ -8,26 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeHCTiledInterleavedSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-};
-
 struct TransposeHCTiledInterleavedProgramFactory {
-    using shared_variables_t = TransposeHCTiledInterleavedSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -18,10 +19,9 @@ namespace ttnn::prim {
 
 namespace {
 
-void set_runtime_args_hc_tiled(
-    Program& program,
-    KernelHandle reader_kernel_id,
-    KernelHandle writer_kernel_id,
+void emit_runtime_args_hc_tiled(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
     const Tensor& input_tensor,
     Tensor& output_tensor,
     uint32_t num_cores_total,
@@ -29,8 +29,7 @@ void set_runtime_args_hc_tiled(
     const CoreRangeSet& core_group_1,
     uint32_t num_tiles_per_core_group_1,
     const CoreRangeSet& core_group_2,
-    uint32_t num_tiles_per_core_group_2,
-    bool is_create) {
+    uint32_t num_tiles_per_core_group_2) {
     auto* input_buffer = input_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
@@ -45,8 +44,8 @@ void set_runtime_args_hc_tiled(
     uint32_t CtHWt = Ct * H * Wt;
     uint32_t CtWt = Ct * Wt;
 
-    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
+    reader_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
 
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -63,51 +62,26 @@ void set_runtime_args_hc_tiled(
         uint32_t h = num_tiles_read / CtWt % H;
         uint32_t ct = num_tiles_read / Wt % Ct;
 
-        if (is_create) {
-            SetRuntimeArgs(
-                program,
-                reader_kernel_id,
-                core,
-                {input_buffer->address(),
-                 Wt,
-                 H,
-                 Ct,
-                 HW_bytes,
-                 CHW_bytes,
-                 num_tiles_read,
-                 num_tiles_per_core,
-                 num_tiles_read / CtHWt * CHW_bytes,
-                 h,
-                 h / TILE_HEIGHT * Wt,
-                 ct,
-                 ct * TILE_HEIGHT * HW_bytes,
-                 num_tiles_read % Wt});
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                input_buffer->address(),
+                Wt,
+                H,
+                Ct,
+                HW_bytes,
+                CHW_bytes,
+                num_tiles_read,
+                num_tiles_per_core,
+                num_tiles_read / CtHWt * CHW_bytes,
+                h,
+                h / TILE_HEIGHT * Wt,
+                ct,
+                ct * TILE_HEIGHT * HW_bytes,
+                num_tiles_read % Wt});
 
-            SetRuntimeArgs(
-                program, writer_kernel_id, core, {output_buffer->address(), num_tiles_per_core, num_tiles_read});
-        } else {
-            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-
-            reader_args[0] = input_buffer->address();
-            reader_args[1] = Wt;
-            reader_args[2] = H;
-            reader_args[3] = Ct;
-            reader_args[4] = HW_bytes;
-            reader_args[5] = CHW_bytes;
-            reader_args[6] = num_tiles_read;
-            reader_args[7] = num_tiles_per_core;
-            reader_args[8] = num_tiles_read / CtHWt * CHW_bytes;
-            reader_args[9] = h;
-            reader_args[10] = h / TILE_HEIGHT * Wt;
-            reader_args[11] = ct;
-            reader_args[12] = ct * TILE_HEIGHT * HW_bytes;
-            reader_args[13] = num_tiles_read % Wt;
-
-            writer_args[0] = output_buffer->address();
-            writer_args[1] = num_tiles_per_core;
-            writer_args[2] = num_tiles_read;
-        }
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{output_buffer->address(), num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -115,7 +89,7 @@ void set_runtime_args_hc_tiled(
 
 }  // namespace
 
-TransposeHCTiledProgramFactory::cached_program_t TransposeHCTiledProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
@@ -125,7 +99,7 @@ TransposeHCTiledProgramFactory::cached_program_t TransposeHCTiledProgramFactory:
     uint32_t sub_tile_line_bytes = 16 * input_tensor.element_size();
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
@@ -161,18 +135,29 @@ TransposeHCTiledProgramFactory::cached_program_t TransposeHCTiledProgramFactory:
     bool misaligned = alignment > sub_tile_line_bytes;
 
     uint32_t num_input_tiles = 2;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    CreateCircularBuffer(program, total_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
 
     // need some scratch memory here - if we need data from a misaligned address then we need to read from the
     // nearest aligned address and then copy the data to the correct location
     if (misaligned) {
         uint32_t src1_cb_index = 1;
-        CircularBufferConfig cb_src1_config =
-            CircularBufferConfig(alignment, {{src1_cb_index, cb_data_format}}).set_page_size(src1_cb_index, alignment);
-        CreateCircularBuffer(program, total_cores, cb_src1_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = alignment,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                .data_format = cb_data_format,
+                .page_size = alignment,
+            }}},
+        });
     }
 
     Buffer* src0_buffer = input_tensor.buffer();
@@ -185,23 +170,26 @@ TransposeHCTiledProgramFactory::cached_program_t TransposeHCTiledProgramFactory:
     std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_partitioned.cpp",
-        total_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_transpose_hc_interleaved_partitioned.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        total_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
-    set_runtime_args_hc_tiled(
-        program,
-        reader_kernel_id,
-        writer_kernel_id,
+    emit_runtime_args_hc_tiled(
+        reader_desc,
+        writer_desc,
         input_tensor,
         output_tensor,
         num_cores_total,
@@ -209,42 +197,12 @@ TransposeHCTiledProgramFactory::cached_program_t TransposeHCTiledProgramFactory:
         core_group_1,
         num_tiles_per_core_group_1,
         core_group_2,
-        num_tiles_per_core_group_2,
-        true);
+        num_tiles_per_core_group_2);
 
-    return {
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
-         .writer_kernel_id = writer_kernel_id,
-         .core_group_1 = core_group_1,
-         .core_group_2 = core_group_2,
-         .num_cores_total = num_cores_total,
-         .num_cores_y = num_cores_y,
-         .num_tiles_per_core_group_1 = num_tiles_per_core_group_1,
-         .num_tiles_per_core_group_2 = num_tiles_per_core_group_2}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void TransposeHCTiledProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    set_runtime_args_hc_tiled(
-        program,
-        shared_variables.reader_kernel_id,
-        shared_variables.writer_kernel_id,
-        tensor_args.input,
-        output_tensor,
-        shared_variables.num_cores_total,
-        shared_variables.num_cores_y,
-        shared_variables.core_group_1,
-        shared_variables.num_tiles_per_core_group_1,
-        shared_variables.core_group_2,
-        shared_variables.num_tiles_per_core_group_2,
-        false);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -177,7 +177,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = total_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
@@ -185,7 +185,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = total_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     emit_runtime_args_hc_tiled(
         reader_desc,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.hpp
@@ -8,32 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeHCTiledSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    CoreRangeSet core_group_1;
-    CoreRangeSet core_group_2;
-    uint32_t num_cores_total{};
-    uint32_t num_cores_y{};
-    uint32_t num_tiles_per_core_group_1{};
-    uint32_t num_tiles_per_core_group_2{};
-};
-
 struct TransposeHCTiledProgramFactory {
-    using shared_variables_t = TransposeHCTiledSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -257,7 +257,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = total_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
     KernelDescriptor writer_desc;
@@ -269,7 +269,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = total_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
     writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
     std::vector<uint32_t> compute_kernel_args = {};

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
@@ -17,11 +18,10 @@ namespace ttnn::prim {
 
 namespace {
 
-void set_runtime_args_wh_tiled(
-    Program& program,
-    KernelHandle reader_kernel_id,
-    KernelHandle compute_kernel_id,
-    KernelHandle writer_kernel_id,
+void emit_runtime_args_wh_tiled(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& compute_desc,
+    KernelDescriptor& writer_desc,
     const Tensor& input_tensor,
     Tensor& output_tensor,
     uint32_t num_cores_total,
@@ -29,8 +29,7 @@ void set_runtime_args_wh_tiled(
     const CoreRangeSet& core_group_1,
     uint32_t num_tiles_per_core_group_1,
     const CoreRangeSet& core_group_2,
-    uint32_t num_tiles_per_core_group_2,
-    bool is_create) {
+    uint32_t num_tiles_per_core_group_2) {
     auto input_shape = input_tensor.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2];
@@ -40,9 +39,9 @@ void set_runtime_args_wh_tiled(
 
     auto HtWt = Ht * Wt;
 
-    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
-    auto& cached_compute_args = GetRuntimeArgs(program, compute_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
+    reader_desc.runtime_args.reserve(num_cores_total);
+    compute_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
 
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -54,73 +53,36 @@ void set_runtime_args_wh_tiled(
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             num_tiles_per_core = 0;
-
-            if (!is_create) {
-                auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-                auto& compute_args = cached_compute_args.at(core.x).at(core.y);
-                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-
-                reader_args[1] = 0;
-                compute_args[0] = 0;
-                writer_args[1] = 0;
-                continue;
-            }
         }
 
         uint32_t h = num_tiles_read % Ht;
         uint32_t w = num_tiles_read / Ht % Wt;
 
-        if (is_create) {
-            SetRuntimeArgs(
-                program,
-                reader_kernel_id,
-                core,
-                {input_tensor.buffer()->address(),
-                 num_tiles_per_core,
-                 tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
-                 h,
-                 w,
-                 Ht,
-                 Wt,
-                 HtWt});
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                input_tensor.buffer()->address(),
+                num_tiles_per_core,
+                tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
+                h,
+                w,
+                Ht,
+                Wt,
+                HtWt});
 
-            SetRuntimeArgs(program, compute_kernel_id, core, {num_tiles_per_core});
+        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_tiles_per_core});
 
-            SetRuntimeArgs(
-                program,
-                writer_kernel_id,
-                core,
-                {output_tensor.buffer()->address(), num_tiles_per_core, num_tiles_read});
-        } else {
-            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-            auto& compute_args = cached_compute_args.at(core.x).at(core.y);
-            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-
-            reader_args[0] = input_tensor.buffer()->address();
-            reader_args[1] = num_tiles_per_core;
-            reader_args[2] = tt::round_down(num_tiles_read, HtWt) + h * Wt + w;
-            reader_args[3] = h;
-            reader_args[4] = w;
-            reader_args[5] = Ht;
-            reader_args[6] = Wt;
-            reader_args[7] = HtWt;
-
-            compute_args[0] = num_tiles_per_core;
-
-            writer_args[0] = output_tensor.buffer()->address();
-            writer_args[1] = num_tiles_per_core;
-            writer_args[2] = num_tiles_read;
-        }
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{output_tensor.buffer()->address(), num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
 }
 
-void set_runtime_args_wh_rm(
-    Program& program,
-    KernelHandle reader_kernel_id,
-    KernelHandle compute_kernel_id,
-    KernelHandle writer_kernel_id,
+void emit_runtime_args_wh_rm(
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& compute_desc,
+    KernelDescriptor& writer_desc,
     const Tensor& input_tensor,
     Tensor& output_tensor,
     uint32_t num_cores_total,
@@ -128,15 +90,14 @@ void set_runtime_args_wh_rm(
     const CoreRangeSet& core_group_1,
     uint32_t num_hw_blocks_per_core_group_1,
     const CoreRangeSet& core_group_2,
-    uint32_t num_hw_blocks_per_core_group_2,
-    bool is_create) {
+    uint32_t num_hw_blocks_per_core_group_2) {
     auto input_shape = input_tensor.logical_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2];
 
-    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
-    auto& cached_compute_args = GetRuntimeArgs(program, compute_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
+    reader_desc.runtime_args.reserve(num_cores_total);
+    compute_desc.runtime_args.reserve(num_cores_total);
+    writer_desc.runtime_args.reserve(num_cores_total);
 
     for (uint32_t i = 0, num_sticks_read = 0, num_sticks_write = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -150,35 +111,13 @@ void set_runtime_args_wh_rm(
             num_hw_blocks_per_core = 0;
         }
 
-        if (is_create) {
-            SetRuntimeArgs(
-                program,
-                reader_kernel_id,
-                core,
-                {input_tensor.buffer()->address(), num_sticks_read, num_hw_blocks_per_core});
+        reader_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{input_tensor.buffer()->address(), num_sticks_read, num_hw_blocks_per_core});
 
-            SetRuntimeArgs(program, compute_kernel_id, core, {num_hw_blocks_per_core});
+        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_hw_blocks_per_core});
 
-            SetRuntimeArgs(
-                program,
-                writer_kernel_id,
-                core,
-                {output_tensor.buffer()->address(), num_sticks_write, num_hw_blocks_per_core});
-        } else {
-            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-            auto& compute_args = cached_compute_args.at(core.x).at(core.y);
-            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-
-            reader_args[0] = input_tensor.buffer()->address();
-            reader_args[1] = num_sticks_read;
-            reader_args[2] = num_hw_blocks_per_core;
-
-            compute_args[0] = num_hw_blocks_per_core;
-
-            writer_args[0] = output_tensor.buffer()->address();
-            writer_args[1] = num_sticks_write;
-            writer_args[2] = num_hw_blocks_per_core;
-        }
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{output_tensor.buffer()->address(), num_sticks_write, num_hw_blocks_per_core});
 
         num_sticks_read += num_hw_blocks_per_core * H;
         num_sticks_write += num_hw_blocks_per_core * W;
@@ -187,7 +126,7 @@ void set_runtime_args_wh_rm(
 
 }  // namespace
 
-TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
@@ -202,7 +141,7 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
     uint32_t ht = (H + TILE_HEIGHT - 1) / TILE_HEIGHT;
     uint32_t wt = (W + TILE_WIDTH - 1) / TILE_WIDTH;
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -230,32 +169,52 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = row_major ? wt * 2 : 2;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, src0_single_tile_size);
-    CreateCircularBuffer(program, total_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * src0_single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = row_major ? ht * 2 : 2;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, dst_single_tile_size);
-    CreateCircularBuffer(program, total_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * dst_single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = dst_single_tile_size,
+        }}},
+    });
 
     if (row_major) {
         uint32_t im_cb_index = 24;
         uint32_t num_im_tiles = ht * wt;
-        CircularBufferConfig cb_im_config =
-            CircularBufferConfig(num_im_tiles * src0_single_tile_size, {{im_cb_index, src0_cb_data_format}})
-                .set_page_size(im_cb_index, src0_single_tile_size);
-        CreateCircularBuffer(program, total_cores, cb_im_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_im_tiles * src0_single_tile_size,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(im_cb_index),
+                .data_format = src0_cb_data_format,
+                .page_size = src0_single_tile_size,
+            }}},
+        });
         // TODO REMOVE
         uint32_t im2_cb_index = 25;
         uint32_t num_im2_tiles = ht;
-        CircularBufferConfig cb_im2_config =
-            CircularBufferConfig(num_im2_tiles * dst_single_tile_size, {{im2_cb_index, dst_cb_data_format}})
-                .set_page_size(im2_cb_index, dst_single_tile_size);
-        CreateCircularBuffer(program, total_cores, cb_im2_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_im2_tiles * dst_single_tile_size,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(im2_cb_index),
+                .data_format = dst_cb_data_format,
+                .page_size = dst_single_tile_size,
+            }}},
+        });
     }
 
     std::vector<uint32_t> reader_compile_time_args;
@@ -290,25 +249,28 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
     TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                    "reader_unary_transpose_wh_interleaved_start_id_rm.cpp"
-                  : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                    "reader_unary_transpose_wh_interleaved_start_id.cpp",
-        total_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
-    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                            "reader_unary_transpose_wh_interleaved_start_id_rm.cpp"
+                                          : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                            "reader_unary_transpose_wh_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         row_major
             ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
               "writer_unary_transpose_wh_interleaved_start_id_rm.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        total_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
-    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
+            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
     std::vector<uint32_t> compute_kernel_args = {};
     if (row_major) {
@@ -317,34 +279,38 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
         compute_kernel_args.push_back(ht * wt);
     }
 
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor::Defines compute_defines;
     if (row_major && (input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::INT32)) {
-        compute_defines["DST_ACCUM_MODE"] = "1";
+        compute_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (src0_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         if (row_major) {
-            unpack_to_dest_mode[static_cast<std::size_t>(tt::CBIndex::c_24)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[static_cast<std::size_t>(tt::CBIndex::c_24)] =
+                tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         }
     }
-    auto compute_kernel_id = CreateKernel(
-        program,
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
         row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp"
-                  : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp",
-        total_cores,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_kernel_args,
-            .defines = compute_defines});
+                  : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = total_cores;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.defines = std::move(compute_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     if (row_major) {
-        set_runtime_args_wh_rm(
-            program,
-            reader_kernel_id,
-            compute_kernel_id,
-            writer_kernel_id,
+        emit_runtime_args_wh_rm(
+            reader_desc,
+            compute_desc,
+            writer_desc,
             input_tensor,
             output_tensor,
             num_cores_total,
@@ -352,14 +318,12 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
             core_group_1,
             num_tiles_per_core_group_1,
             core_group_2,
-            num_tiles_per_core_group_2,
-            true);
+            num_tiles_per_core_group_2);
     } else {
-        set_runtime_args_wh_tiled(
-            program,
-            reader_kernel_id,
-            compute_kernel_id,
-            writer_kernel_id,
+        emit_runtime_args_wh_tiled(
+            reader_desc,
+            compute_desc,
+            writer_desc,
             input_tensor,
             output_tensor,
             num_cores_total,
@@ -367,70 +331,14 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
             core_group_1,
             num_tiles_per_core_group_1,
             core_group_2,
-            num_tiles_per_core_group_2,
-            true);
+            num_tiles_per_core_group_2);
     }
 
-    return {
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
-         .compute_kernel_id = compute_kernel_id,
-         .writer_kernel_id = writer_kernel_id,
-         .core_group_1 = core_group_1,
-         .core_group_2 = core_group_2,
-         .num_cores_total = num_cores_total,
-         .num_cores_y = num_cores_y,
-         .num_tiles_per_core_group_1 = num_tiles_per_core_group_1,
-         .num_tiles_per_core_group_2 = num_tiles_per_core_group_2,
-         .is_row_major = row_major}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void TransposeWHProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
-        program,
-        shared_variables.reader_kernel_id,
-        shared_variables.writer_kernel_id,
-        *tensor_args.input.buffer(),
-        *output_tensor.buffer());
-
-    if (shared_variables.is_row_major) {
-        set_runtime_args_wh_rm(
-            program,
-            shared_variables.reader_kernel_id,
-            shared_variables.compute_kernel_id,
-            shared_variables.writer_kernel_id,
-            tensor_args.input,
-            output_tensor,
-            shared_variables.num_cores_total,
-            shared_variables.num_cores_y,
-            shared_variables.core_group_1,
-            shared_variables.num_tiles_per_core_group_1,
-            shared_variables.core_group_2,
-            shared_variables.num_tiles_per_core_group_2,
-            false);
-    } else {
-        set_runtime_args_wh_tiled(
-            program,
-            shared_variables.reader_kernel_id,
-            shared_variables.compute_kernel_id,
-            shared_variables.writer_kernel_id,
-            tensor_args.input,
-            output_tensor,
-            shared_variables.num_cores_total,
-            shared_variables.num_cores_y,
-            shared_variables.core_group_1,
-            shared_variables.num_tiles_per_core_group_1,
-            shared_variables.core_group_2,
-            shared_variables.num_tiles_per_core_group_2,
-            false);
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -58,22 +58,20 @@ void emit_runtime_args_wh_tiled(
         uint32_t h = num_tiles_read % Ht;
         uint32_t w = num_tiles_read / Ht % Wt;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                input_tensor.buffer()->address(),
-                num_tiles_per_core,
-                tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
-                h,
-                w,
-                Ht,
-                Wt,
-                HtWt});
+            {input_tensor.buffer(),
+             num_tiles_per_core,
+             tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
+             h,
+             w,
+             Ht,
+             Wt,
+             HtWt});
 
-        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_tiles_per_core});
+        compute_desc.emplace_runtime_args(core, {num_tiles_per_core});
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_tensor.buffer()->address(), num_tiles_per_core, num_tiles_read});
+        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -111,13 +109,11 @@ void emit_runtime_args_wh_rm(
             num_hw_blocks_per_core = 0;
         }
 
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{input_tensor.buffer()->address(), num_sticks_read, num_hw_blocks_per_core});
+        reader_desc.emplace_runtime_args(core, {input_tensor.buffer(), num_sticks_read, num_hw_blocks_per_core});
 
-        compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_hw_blocks_per_core});
+        compute_desc.emplace_runtime_args(core, {num_hw_blocks_per_core});
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_tensor.buffer()->address(), num_sticks_write, num_hw_blocks_per_core});
+        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_sticks_write, num_hw_blocks_per_core});
 
         num_sticks_read += num_hw_blocks_per_core * H;
         num_sticks_write += num_hw_blocks_per_core * W;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.hpp
@@ -8,34 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeWHSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle compute_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    CoreRangeSet core_group_1;
-    CoreRangeSet core_group_2;
-    uint32_t num_cores_total{};
-    uint32_t num_cores_y{};
-    uint32_t num_tiles_per_core_group_1{};
-    uint32_t num_tiles_per_core_group_2{};
-    bool is_row_major{};
-};
-
 struct TransposeWHProgramFactory {
-    using shared_variables_t = TransposeWHSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -86,7 +86,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = total_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
@@ -94,7 +94,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = total_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -6,6 +6,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include <algorithm>
 
@@ -14,14 +15,14 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TransposeWHShardedProgramFactory::cached_program_t TransposeWHShardedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -45,50 +46,72 @@ TransposeWHShardedProgramFactory::cached_program_t TransposeWHShardedProgramFact
     auto& all_cores = shard_spec.grid;
     uint32_t num_tiles_per_shard = shard_spec.numel() / tile_hw;
 
+    // Sharded CBs: total_size depends on num_tiles_per_shard which can vary across
+    // cache hits; .buffer triggers UpdateDynamicCircularBufferAddress. total_size
+    // is not in the program hash so the framework re-applies the combined update
+    // via apply_descriptor_runtime_args.
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = num_tiles_per_shard;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, src0_single_tile_size)
-            .set_globally_allocated_address(*input_tensor.buffer());
-    auto cb_src0 = CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+        .buffer = input_tensor.buffer(),
+    });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = num_tiles_per_shard;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, dst_single_tile_size)
-            .set_globally_allocated_address(*output_tensor.buffer());
-    auto cb_output = CreateCircularBuffer(program, total_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * dst_single_tile_size,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = dst_single_tile_size,
+        }}},
+        .buffer = output_tensor.buffer(),
+    });
 
     std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
     std::vector<uint32_t> compute_compile_time_args = {src0_cb_index, output_cb_index};
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        total_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp",
-        total_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (src0_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    auto compute_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp",
-        total_cores,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_compile_time_args});
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = total_cores;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     auto padded_shape = input_tensor.padded_shape();
     auto shard_shape = shard_spec.shape;
@@ -111,121 +134,34 @@ TransposeWHShardedProgramFactory::cached_program_t TransposeWHShardedProgramFact
     std::vector<CoreCoord> cores =
         grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
 
-    std::vector<std::vector<uint32_t>> unary_reader_args = {cores.size(), std::vector<uint32_t>(1)};
-    std::vector<std::vector<uint32_t>> unary_compute_args = {cores.size(), std::vector<uint32_t>(5)};
-    std::vector<std::vector<uint32_t>> unary_writer_args = {cores.size(), std::vector<uint32_t>(1)};
-    std::fill(
-        unary_reader_args.begin(),
-        unary_reader_args.begin() + all_cores.num_cores(),
-        std::vector<uint32_t>{num_blocks});
-    std::fill(
-        unary_compute_args.begin(),
-        unary_compute_args.begin() + all_cores.num_cores(),
-        std::vector<uint32_t>{num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts});
-    std::fill(
-        unary_writer_args.begin(),
-        unary_writer_args.begin() + all_cores.num_cores(),
-        std::vector<uint32_t>{num_blocks});
+    // Active shard cores get the real arg values; the trailing no-op cores keep the
+    // default-constructed slots (matching legacy std::fill behavior on cores.size()).
+    const std::vector<uint32_t> reader_rt = {num_blocks};
+    const std::vector<uint32_t> compute_rt = {num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts};
+    const std::vector<uint32_t> writer_rt = {num_blocks};
 
-    SetRuntimeArgs(program, reader_kernel_id, cores, unary_reader_args);
-    SetRuntimeArgs(program, compute_kernel_id, cores, unary_compute_args);
-    SetRuntimeArgs(program, writer_kernel_id, cores, unary_writer_args);
-
-    return {
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
-         .compute_kernel_id = compute_kernel_id,
-         .writer_kernel_id = writer_kernel_id,
-         .cb_src0 = cb_src0,
-         .cb_output = cb_output,
-         .src0_single_tile_size = src0_single_tile_size,
-         .dst_single_tile_size = dst_single_tile_size,
-         .num_cores_x = num_cores_x,
-         .num_cores_y = num_cores_y}};
-}
-
-void TransposeWHShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    const auto& src_tensor = tensor_args.input;
-
-    auto* const src_buffer = src_tensor.buffer();
-    auto* const dst_buffer = output_tensor.buffer();
-
-    bool src0_sharded = src_tensor.is_sharded();
-    bool out_sharded = output_tensor.is_sharded();
-
-    auto shard_spec = src_tensor.shard_spec().value();
-
-    const auto tile = src_tensor.tensor_spec().tile();
-    const uint32_t tile_hw = tile.get_tile_hw();
-
-    uint32_t num_tiles_per_shard = shard_spec.numel() / tile_hw;
-
-    if (src0_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program,
-            shared_variables.cb_src0,
-            *src_buffer,
-            num_tiles_per_shard * shared_variables.src0_single_tile_size);
+    const uint32_t num_active = all_cores.num_cores();
+    reader_desc.runtime_args.reserve(cores.size());
+    compute_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+    for (uint32_t i = 0; i < cores.size(); ++i) {
+        if (i < num_active) {
+            reader_desc.runtime_args.emplace_back(cores[i], reader_rt);
+            compute_desc.runtime_args.emplace_back(cores[i], compute_rt);
+            writer_desc.runtime_args.emplace_back(cores[i], writer_rt);
+        } else {
+            // No-op core: matches legacy std::vector<uint32_t>(1)/(5) zero-initialized rows.
+            reader_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
+            compute_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(5));
+            writer_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
+        }
     }
 
-    if (out_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program,
-            shared_variables.cb_output,
-            *dst_buffer,
-            num_tiles_per_shard * shared_variables.dst_single_tile_size);
-    }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    auto padded_shape = src_tensor.padded_shape();
-    auto shard_shape = shard_spec.shape;
-
-    uint32_t H = padded_shape[2];
-    uint32_t Hs = shard_shape[0], Ws = shard_shape[1];
-
-    uint32_t Hts = Hs / tile.get_height();
-    uint32_t Wts = Ws / tile.get_width();
-
-    uint32_t Ht = H / tile.get_height();
-    uint32_t Ht_per_shard = std::min(Ht, Hts);
-
-    uint32_t num_hw_blocks_per_shard = Hts > Ht ? Hts / Ht : 1;
-
-    uint32_t HtWt_tile_size = Ht_per_shard * Wts;
-    uint32_t num_blocks = num_hw_blocks_per_shard * HtWt_tile_size;
-
-    const auto& all_cores = shard_spec.grid;
-    bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-
-    auto bbox = all_cores.bounding_box();
-    std::vector<CoreCoord> cores = grid_to_cores_with_noop(
-        bbox.end_coord.x, bbox.end_coord.y, shared_variables.num_cores_x, shared_variables.num_cores_y, row_major);
-
-    std::vector<std::vector<uint32_t>> unary_reader_args = {cores.size(), std::vector<uint32_t>(1)};
-    std::vector<std::vector<uint32_t>> unary_compute_args = {cores.size(), std::vector<uint32_t>(5)};
-    std::vector<std::vector<uint32_t>> unary_writer_args = {cores.size(), std::vector<uint32_t>(1)};
-    std::fill(
-        unary_reader_args.begin(),
-        unary_reader_args.begin() + all_cores.num_cores(),
-        std::vector<uint32_t>{num_blocks});
-    std::fill(
-        unary_compute_args.begin(),
-        unary_compute_args.begin() + all_cores.num_cores(),
-        std::vector<uint32_t>{num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts});
-    std::fill(
-        unary_writer_args.begin(),
-        unary_writer_args.begin() + all_cores.num_cores(),
-        std::vector<uint32_t>{num_blocks});
-
-    SetRuntimeArgs(program, shared_variables.reader_kernel_id, cores, unary_reader_args);
-    SetRuntimeArgs(program, shared_variables.compute_kernel_id, cores, unary_compute_args);
-    SetRuntimeArgs(program, shared_variables.writer_kernel_id, cores, unary_writer_args);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.hpp
@@ -8,33 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeWHShardedSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle compute_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    tt::tt_metal::CBHandle cb_src0{};
-    tt::tt_metal::CBHandle cb_output{};
-    uint32_t src0_single_tile_size{};
-    uint32_t dst_single_tile_size{};
-    uint32_t num_cores_x{};
-    uint32_t num_cores_y{};
-};
-
 struct TransposeWHShardedProgramFactory {
-    using shared_variables_t = TransposeWHShardedSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -6,6 +6,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-logger/tt-logger.hpp>
 
 #include <algorithm>
@@ -15,14 +16,14 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TransposeWHShardedRMProgramFactory::cached_program_t TransposeWHShardedRMProgramFactory::create(
+tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
-    Program program = CreateProgram();
+    ProgramDescriptor desc;
 
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -81,62 +82,88 @@ TransposeWHShardedRMProgramFactory::cached_program_t TransposeWHShardedRMProgram
 
     auto& all_cores = shard_spec.grid;
     [[maybe_unused]] uint32_t num_cores = shard_spec.num_cores();
-    auto bbox = shard_spec.grid.bounding_box();
-    CoreCoord grid_size = {bbox.end_coord.x + 1, bbox.end_coord.y + 1};
-    uint32_t num_cores_x = grid_size.x;
-    uint32_t num_cores_y = grid_size.y;
 
     log_debug(tt::LogOp, "all_cores: {}", all_cores);
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
 
-    // sharded cb
+    // sharded cb (input): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
     uint32_t src0_cb_index = tt::CBIndex::c_0;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(shard_height * stick_size_bytes, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, stick_size_bytes)
-            .set_globally_allocated_address(*input_tensor.buffer());
-    auto cb_src0 = CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height * stick_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = stick_size_bytes,
+        }}},
+        .buffer = input_tensor.buffer(),
+    });
 
-    // sharded cb
+    // sharded cb (output): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
     uint32_t output_cb_index = tt::CBIndex::c_16;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(stick_size_bytes * shard_height, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, output_page_size)
-            .set_globally_allocated_address(*output_tensor.buffer());
-    auto cb_output = CreateCircularBuffer(program, all_cores, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = stick_size_bytes * shard_height,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = output_page_size,
+        }}},
+        .buffer = output_tensor.buffer(),
+    });
 
-    // cb_in
+    // cb_in (double-buffered intermediate)
     uint32_t in_cb_index = tt::CBIndex::c_24;
     uint32_t num_in_tiles = wt * 2;  // double buffer
-    CircularBufferConfig cb_in_config =
-        CircularBufferConfig(num_in_tiles * src0_single_tile_size, {{in_cb_index, src0_cb_data_format}})
-            .set_page_size(in_cb_index, src0_single_tile_size);
-    CreateCircularBuffer(program, all_cores, cb_in_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_in_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(in_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
 
     // tilize cb
     uint32_t im_cb_index = tt::CBIndex::c_25;
     uint32_t num_im_tiles = ht * wt;
-    CircularBufferConfig cb_im_config =
-        CircularBufferConfig(num_im_tiles * src0_single_tile_size, {{im_cb_index, src0_cb_data_format}})
-            .set_page_size(im_cb_index, src0_single_tile_size);
-    CreateCircularBuffer(program, all_cores, cb_im_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_im_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(im_cb_index),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
 
-    // untilize cb
+    // untilize cb (only when ht > 8) + matching output staging CB
     if (ht > 8) {
         uint32_t im2_cb_index = tt::CBIndex::c_26;
         uint32_t num_im2_tiles = ht;
-        CircularBufferConfig cb_im2_config =
-            CircularBufferConfig(num_im2_tiles * dst_single_tile_size, {{im2_cb_index, dst_cb_data_format}})
-                .set_page_size(im2_cb_index, dst_single_tile_size);
-        CreateCircularBuffer(program, all_cores, cb_im2_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_im2_tiles * dst_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(im2_cb_index),
+                .data_format = dst_cb_data_format,
+                .page_size = dst_single_tile_size,
+            }}},
+        });
 
         // compute_output_cb
         uint32_t out_cb_index = tt::CBIndex::c_27;
         uint32_t num_out_tiles = ht * 2;  // double buffer
-        CircularBufferConfig cb_out_config =
-            CircularBufferConfig(num_out_tiles * dst_single_tile_size, {{out_cb_index, dst_cb_data_format}})
-                .set_page_size(out_cb_index, dst_single_tile_size);
-        CreateCircularBuffer(program, all_cores, cb_out_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_out_tiles * dst_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(out_cb_index),
+                .data_format = dst_cb_data_format,
+                .page_size = dst_single_tile_size,
+            }}},
+        });
     }
 
     std::vector<uint32_t> reader_compile_time_args = {
@@ -151,12 +178,14 @@ TransposeWHShardedRMProgramFactory::cached_program_t TransposeWHShardedRMProgram
     reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
     reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_wh_sharded_rm.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_transpose_wh_sharded_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)num_hw_blocks_per_core,
@@ -168,12 +197,14 @@ TransposeWHShardedRMProgramFactory::cached_program_t TransposeWHShardedRMProgram
         (std::uint32_t)ht * output_tensor.element_size() * TILE_HEIGHT,
     };
 
-    CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_wh_sharded_rm.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
+        "writer_unary_transpose_wh_sharded_rm.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     std::vector<uint32_t> compute_compile_time_args = {
         (std::uint32_t)ht,
@@ -187,47 +218,32 @@ TransposeWHShardedRMProgramFactory::cached_program_t TransposeWHShardedRMProgram
         (std::uint32_t)pack_num_pages_last_row_col,
     };
 
-    std::map<std::string, std::string> compute_defines;
-    compute_defines["SHARDED"] = "1";
+    KernelDescriptor::Defines compute_defines;
+    compute_defines.emplace_back("SHARDED", "1");
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (src0_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode[im_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp",
-        all_cores,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = compute_defines});
 
-    return {
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
-         .cb_src0 = cb_src0,
-         .cb_output = cb_output,
-         .num_cores_x = num_cores_x,
-         .num_cores_y = num_cores_y}};
-}
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.defines = std::move(compute_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
-void TransposeWHShardedRMProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const TransposeParams& /*operation_attributes*/,
-    const TransposeInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    const auto& src_tensor = tensor_args.input;
-
-    auto* const src_buffer = src_tensor.buffer();
-    auto* const dst_buffer = output_tensor.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src0, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -185,7 +185,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)num_hw_blocks_per_core,
@@ -204,7 +204,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<uint32_t> compute_compile_time_args = {
         (std::uint32_t)ht,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
@@ -8,29 +8,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
-struct TransposeWHShardedRMSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::CBHandle cb_src0{};
-    tt::tt_metal::CBHandle cb_output{};
-    uint32_t num_cores_x{};
-    uint32_t num_cores_y{};
-};
-
 struct TransposeWHShardedRMProgramFactory {
-    using shared_variables_t = TransposeWHShardedRMSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const TransposeParams& operation_attributes,
-        const TransposeInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
@@ -22,11 +23,11 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
     const UntilizeTensorReturnValue& output) {
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     const auto& a = tensor_args.input;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
@@ -113,14 +114,17 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
             (num_input_blocks_per_full_core == 1) ? num_tiles_per_input_block : num_tiles_per_input_block * 2;
     }
     Buffer* cb_backing_buffer = (input_is_sharded && !use_block_reader) ? src0_buffer : nullptr;
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        compute_core_range,
-        input_single_tile_size,
-        input_cb_num_tiles,
-        input_cb_data_format,
-        cb_backing_buffer);
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_cb_num_tiles * input_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = cb_backing_buffer,
+    });
 
     // Output CB
     uint32_t output_cb_num_tiles;
@@ -131,46 +135,46 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
         // Double buffer if the core is processing 2+ blocks
         output_cb_num_tiles = num_tiles_per_input_block * 2;
     }
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        compute_core_range,
-        output_single_tile_size,
-        output_cb_num_tiles,
-        output_cb_data_format);
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_num_tiles * output_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     // Reader compile-time args and kernel
-    KernelHandle unary_reader_kernel_id;
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = compute_core_range;
     if (use_block_reader) {
         // Block reader: copies from L1 shard into double-buffered CB one block at a time
-        std::vector<uint32_t> reader_compile_time_args = {
+        reader_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
+            "reader_unary_sharded_blocks.cpp";
+        reader_desc.compile_time_args = {
             (uint32_t)src0_cb_index,
             (uint32_t)num_tiles_per_input_block,
         };
-        unary_reader_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
-            "reader_unary_sharded_blocks.cpp",
-            compute_core_range,
-            ReaderDataMovementConfig(reader_compile_time_args));
+        reader_desc.config = ReaderDataMovementConfig{};
     } else if (input_is_sharded) {
         // Even sharding with pack_untilize: CB is backed by the sharded buffer, reader just pushes
-        std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
-        unary_reader_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-            compute_core_range,
-            ReaderDataMovementConfig(reader_compile_time_args));
+        reader_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+        reader_desc.compile_time_args = {(uint32_t)src0_cb_index};
+        reader_desc.config = ReaderDataMovementConfig{};
     } else {
         // Interleaved input
+        reader_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
+            "reader_unary_start_id.cpp";
         std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
         TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-        unary_reader_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
-            "reader_unary_start_id.cpp",
-            compute_core_range,
-            ReaderDataMovementConfig(reader_compile_time_args));
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
+        reader_desc.config = ReaderDataMovementConfig{};
     }
 
     // Writer compile-time args
@@ -204,60 +208,80 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
     };
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    // Writer kernel
-    KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
-        "writer_unary_stick_layout_split_rows_multi_core.cpp",
-        compute_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "writer_unary_stick_layout_split_rows_multi_core.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = compute_core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
 
     // Compute kernel file
-    std::string compute_kernel(
+    const std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
+
+    KernelDescriptor::Defines compute_kernel_defines;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+    }
+
+    // Push reader and writer first; track indices for the compute kernel(s) which may be
+    // absent depending on whether the corresponding core range is empty (sharded input never
+    // has a cliff core, for example).
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    constexpr size_t reader_idx = 0;
+    constexpr size_t writer_idx = 1;
+    int full_compute_idx = -1;
+    int cliff_compute_idx = -1;
 
     // Compute compile-time args and kernel
     // Note: This condition is always true for sharded input
-    KernelHandle untilize_kernel_id = 0;
-    std::map<std::string, std::string> compute_kernel_defines;
-    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
-    }
     if (!full_compute_core_range.ranges().empty()) {
         std::vector<uint32_t> compute_compile_time_args = {
             (uint32_t)num_tiles_per_input_block, (uint32_t)src0_cb_index, (uint32_t)output_cb_index};
-        untilize_kernel_id = CreateKernel(
-            program,
-            compute_kernel,
-            full_compute_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_compile_time_args,
-                .defines = compute_kernel_defines});
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = compute_kernel;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = full_compute_core_range;
+        compute_desc.compile_time_args = std::move(compute_compile_time_args);
+        compute_desc.defines = compute_kernel_defines;
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        full_compute_idx = static_cast<int>(desc.kernels.size());
+        desc.kernels.push_back(std::move(compute_desc));
     }
 
     // Compute Cliff compile_time args and kernel
     // Note: This condition is always false for sharded input (sharded input will never have a cliff core)
-    KernelHandle untilize_cliff_kernel_id = 0;
     if (!cliff_compute_core_range.ranges().empty()) {
         std::vector<uint32_t> compute_compile_time_args_cliff = {
             (uint32_t)num_tiles_per_input_block, (uint32_t)src0_cb_index, (uint32_t)output_cb_index};
-        untilize_cliff_kernel_id = CreateKernel(
-            program,
-            compute_kernel,
-            cliff_compute_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_compile_time_args_cliff,
-                .defines = compute_kernel_defines});
+        KernelDescriptor cliff_desc;
+        cliff_desc.kernel_source = compute_kernel;
+        cliff_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cliff_desc.core_ranges = cliff_compute_core_range;
+        cliff_desc.compile_time_args = std::move(compute_compile_time_args_cliff);
+        cliff_desc.defines = std::move(compute_kernel_defines);
+        cliff_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        cliff_compute_idx = static_cast<int>(desc.kernels.size());
+        desc.kernels.push_back(std::move(cliff_desc));
     }
+
+    KernelDescriptor& reader_ref = desc.kernels[reader_idx];
+    KernelDescriptor& writer_ref = desc.kernels[writer_idx];
 
     // Run-time arg assignment
     // Note: This variable is only applicable to interleaved input
@@ -336,9 +360,11 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
         std::vector<uint32_t> compute_run_time_args = {num_input_blocks_to_process};
 
         // Set run-time arg
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, untilize_kernel_id, core, compute_run_time_args);
+        reader_ref.runtime_args.emplace_back(core, std::move(reader_run_time_args));
+        writer_ref.runtime_args.emplace_back(core, std::move(writer_run_time_args));
+        if (full_compute_idx >= 0) {
+            desc.kernels[full_compute_idx].runtime_args.emplace_back(core, std::move(compute_run_time_args));
+        }
 
         // Update index of first tile to read
         tile_start_index += num_tiles_per_input_block * num_input_blocks_per_full_core;
@@ -388,61 +414,13 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
         std::vector<uint32_t> compute_run_time_args = {num_input_blocks_to_process};
 
         // Set run-time args
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, cliff_core, reader_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, cliff_core, writer_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, untilize_cliff_kernel_id, cliff_core, compute_run_time_args);
-    }
-
-    std::vector<CoreCoord> cores_with_run_time_args;
-    cores_with_run_time_args.reserve(full_cores.size() + cliff_cores.size());
-    cores_with_run_time_args.insert(cores_with_run_time_args.end(), full_cores.begin(), full_cores.end());
-    cores_with_run_time_args.insert(cores_with_run_time_args.end(), cliff_cores.begin(), cliff_cores.end());
-
-    return cached_program_t{
-        std::move(program),
-        {unary_reader_kernel_id,
-         unary_writer_kernel_id,
-         cb_src0,
-         cb_output,
-         cores_with_run_time_args,
-         use_block_reader}};
-}
-
-void UntilizeMultiCoreProgramFactory::override_runtime_arguments(
-    UntilizeMultiCoreProgramFactory::cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& cb_src0 = cached_program.shared_variables.cb_src0;
-    auto& cores_with_runtime_args = cached_program.shared_variables.cores_with_runtime_args;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    bool input_is_sharded = tensor_args.input.is_sharded();
-    bool block_reader = cached_program.shared_variables.has_uneven_sharding;
-
-    // Reader
-    if (input_is_sharded && !block_reader) {
-        // Even sharding with pack_untilize: CB is backed by the sharded buffer
-        UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
-    } else {
-        // Block reader (sharded) or interleaved: update src_addr in reader runtime args
-        auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-        for (const CoreCoord& core : cores_with_runtime_args) {
-            auto& runtime_args = reader_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
+        reader_ref.runtime_args.emplace_back(cliff_core, std::move(reader_run_time_args));
+        writer_ref.runtime_args.emplace_back(cliff_core, std::move(writer_run_time_args));
+        if (cliff_compute_idx >= 0) {
+            desc.kernels[cliff_compute_idx].runtime_args.emplace_back(cliff_core, std::move(compute_run_time_args));
         }
     }
 
-    // Writer
-    auto& runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
-    for (const CoreCoord& core : cores_with_runtime_args) {
-        auto& runtime_args = runtime_args_by_core[core.x][core.y];
-        runtime_args[0] = dst_buffer->address();
-    }
+    return desc;
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -326,21 +326,13 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
 
         // Reader run-time args
         uint32_t num_tiles_to_read = num_tiles_per_input_block * num_input_blocks_to_process;
-        std::vector<uint32_t> reader_run_time_args;
         if (use_block_reader) {
-            reader_run_time_args = {
-                src0_buffer->address(),
-                num_input_blocks_to_process,
-            };
+            reader_ref.emplace_runtime_args(core, {src0_buffer, num_input_blocks_to_process});
         } else if (input_is_sharded) {
-            reader_run_time_args = {num_tiles_to_read};
+            reader_ref.emplace_runtime_args(core, {num_tiles_to_read});
         } else {
             // Interleaved input
-            reader_run_time_args = {
-                src0_buffer->address(),
-                num_tiles_to_read,
-                tile_start_index,
-            };
+            reader_ref.emplace_runtime_args(core, {src0_buffer, num_tiles_to_read, tile_start_index});
         }
 
         // Writer run-time args
@@ -348,22 +340,18 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         uint32_t width_wise_output_block_start_index = input_block_global_col_index / num_cols_per_output_block;
         uint32_t num_cols_already_processed_in_first_output_block =
             input_block_global_col_index % num_cols_per_output_block;
-        std::vector<uint32_t> writer_run_time_args = {
-            dst_buffer->address(),
-            num_input_blocks_to_process,
-            height_wise_input_block_start_index,
-            num_unpadded_cols_per_input_block,
-            width_wise_output_block_start_index,
-            num_cols_already_processed_in_first_output_block};
+        writer_ref.emplace_runtime_args(
+            core,
+            {dst_buffer,
+             num_input_blocks_to_process,
+             height_wise_input_block_start_index,
+             num_unpadded_cols_per_input_block,
+             width_wise_output_block_start_index,
+             num_cols_already_processed_in_first_output_block});
 
         // Compute run-time args
-        std::vector<uint32_t> compute_run_time_args = {num_input_blocks_to_process};
-
-        // Set run-time arg
-        reader_ref.runtime_args.emplace_back(core, std::move(reader_run_time_args));
-        writer_ref.runtime_args.emplace_back(core, std::move(writer_run_time_args));
         if (full_compute_idx >= 0) {
-            desc.kernels[full_compute_idx].runtime_args.emplace_back(core, std::move(compute_run_time_args));
+            desc.kernels[full_compute_idx].emplace_runtime_args(core, {num_input_blocks_to_process});
         }
 
         // Update index of first tile to read
@@ -394,30 +382,22 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         uint32_t width_wise_output_block_start_index = input_block_global_col_index / num_cols_per_output_block;
         uint32_t num_cols_already_processed_in_first_output_block =
             input_block_global_col_index % num_cols_per_output_block;
-        std::vector<uint32_t> writer_run_time_args = {
-            dst_buffer->address(),
-            num_input_blocks_to_process,
-            height_wise_input_block_start_index,
-            num_unpadded_cols_per_input_block,
-            width_wise_output_block_start_index,
-            num_cols_already_processed_in_first_output_block};
+        writer_ref.emplace_runtime_args(
+            cliff_core,
+            {dst_buffer,
+             num_input_blocks_to_process,
+             height_wise_input_block_start_index,
+             num_unpadded_cols_per_input_block,
+             width_wise_output_block_start_index,
+             num_cols_already_processed_in_first_output_block});
 
         // Reader run-time args (always reading interleaved input as cliff core does not exist for sharded input)
         uint32_t num_tiles_to_read = num_tiles_per_input_block * num_input_blocks_to_process;
-        std::vector<uint32_t> reader_run_time_args = {
-            src0_buffer->address(),
-            num_tiles_to_read,
-            tile_start_index,
-        };
+        reader_ref.emplace_runtime_args(cliff_core, {src0_buffer, num_tiles_to_read, tile_start_index});
 
         // Compute run-time args
-        std::vector<uint32_t> compute_run_time_args = {num_input_blocks_to_process};
-
-        // Set run-time args
-        reader_ref.runtime_args.emplace_back(cliff_core, std::move(reader_run_time_args));
-        writer_ref.runtime_args.emplace_back(cliff_core, std::move(writer_run_time_args));
         if (cliff_compute_idx >= 0) {
-            desc.kernels[cliff_compute_idx].runtime_args.emplace_back(cliff_core, std::move(compute_run_time_args));
+            desc.kernels[cliff_compute_idx].emplace_runtime_args(cliff_core, {num_input_blocks_to_process});
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -159,13 +159,13 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
             (uint32_t)src0_cb_index,
             (uint32_t)num_tiles_per_input_block,
         };
-        reader_desc.config = ReaderDataMovementConfig{};
+        reader_desc.config = ReaderConfigDescriptor{};
     } else if (input_is_sharded) {
         // Even sharding with pack_untilize: CB is backed by the sharded buffer, reader just pushes
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
         reader_desc.compile_time_args = {(uint32_t)src0_cb_index};
-        reader_desc.config = ReaderDataMovementConfig{};
+        reader_desc.config = ReaderConfigDescriptor{};
     } else {
         // Interleaved input
         reader_desc.kernel_source =
@@ -174,7 +174,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
         TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
         reader_desc.compile_time_args = std::move(reader_compile_time_args);
-        reader_desc.config = ReaderDataMovementConfig{};
+        reader_desc.config = ReaderConfigDescriptor{};
     }
 
     // Writer compile-time args
@@ -215,7 +215,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = compute_core_range;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.hpp
@@ -7,22 +7,14 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "../untilize_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreProgramFactory {
-    using shared_variables_t = UntilizeSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
         const UntilizeTensorReturnValue& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -156,23 +156,24 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreSubCoreGridsProgramFactory::cre
     for (auto core : cores) {
         // reader runtime args
         auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                src0_buffer->address(),  // src_addr
-                ntiles_per_core,         // ntiles
-                tile_start_id            // start_id
+            {
+                src0_buffer,      // src_addr
+                ntiles_per_core,  // ntiles
+                tile_start_id     // start_id
             });
 
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                dst_buffer->address(),               // dst_addr
+            {
+                dst_buffer,                          // dst_addr
                 nsticks_per_core,                    // nsticks
                 ntiles_per_core,                     // ntiles_per_core
                 TILE_WIDTH * output.element_size(),  // tile_width_size
                 std::uint32_t{0},                    // start stick id = 0, since parallelizing on height
-                offset_within_stick});
+                offset_within_stick                  //
+            });
 
         tile_start_id += ntiles_per_core;
         offset_within_stick += ntiles_per_core * TILE_WIDTH * output.element_size();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -104,7 +104,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreSubCoreGridsProgramFactory::cre
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_ct_args = {stick_size};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
@@ -116,7 +116,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreSubCoreGridsProgramFactory::cre
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     /** compute
      */

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "untilize_multi_core_sub_core_grids_program_factory.hpp"
@@ -20,11 +21,11 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeMultiCoreSubCoreGridsProgramFactory::cached_program_t UntilizeMultiCoreSubCoreGridsProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeMultiCoreSubCoreGridsProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
     const UntilizeTensorReturnValue& tensor_return_value) {
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     const auto& a = tensor_args.input;
     const auto& output = tensor_return_value;
@@ -68,42 +69,54 @@ UntilizeMultiCoreSubCoreGridsProgramFactory::cached_program_t UntilizeMultiCoreS
     auto all_cores = num_cores_to_corerangeset_in_subcoregrids(cores[0], ncores, sub_core_grids, true);
     uint32_t nblocks_per_core = nblocks / ncores;
 
-    std::vector<CoreCoord> cores_with_rtargs;
-
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = ntiles_per_block * 2;
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_input_tiles, input_cb_data_format, nullptr);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = ntiles_per_block * 2;
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        all_cores,
-        output_single_tile_size,
-        num_output_tiles,
-        output_cb_data_format,
-        nullptr);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     std::vector<uint32_t> reader_ct_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
 
-    auto reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     std::vector<uint32_t> writer_ct_args = {stick_size};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
 
-    auto writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
-        "writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+        "writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     /** compute
      */
@@ -112,85 +125,63 @@ UntilizeMultiCoreSubCoreGridsProgramFactory::cached_program_t UntilizeMultiCoreS
         (uint32_t)ntiles_per_block,  // per_block_ntiles
         (uint32_t)src0_cb_index,
         (uint32_t)output_cb_index};
-    std::map<std::string, std::string> compute_kernel_defines;
+    KernelDescriptor::Defines compute_kernel_defines;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
 
-    CreateKernel(
-        program,
-        compute_kernel,
-        all_cores,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_args,
-            .defines = compute_kernel_defines});
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     uint32_t tile_start_id = 0;
     uint32_t offset_within_stick = 0;
 
     auto nsticks_per_core = ntiles_per_column * TILE_HEIGHT;
 
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
     for (auto core : cores) {
         // reader runtime args
         auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
-        const std::array reader_rt_args = {
-            src0_buffer->address(),  // src_addr
-            ntiles_per_core,         // ntiles
-            tile_start_id            // start_id
-        };
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                src0_buffer->address(),  // src_addr
+                ntiles_per_core,         // ntiles
+                tile_start_id            // start_id
+            });
 
-        const std::array writer_rt_args = {
-            dst_buffer->address(),               // dst_addr
-            nsticks_per_core,                    // nsticks
-            ntiles_per_core,                     // ntiles_per_core
-            TILE_WIDTH * output.element_size(),  // tile_width_size
-            std::uint32_t{0},                    // start stick id = 0, since parallelizing on height
-            offset_within_stick};
+        writer_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                dst_buffer->address(),               // dst_addr
+                nsticks_per_core,                    // nsticks
+                ntiles_per_core,                     // ntiles_per_core
+                TILE_WIDTH * output.element_size(),  // tile_width_size
+                std::uint32_t{0},                    // start stick id = 0, since parallelizing on height
+                offset_within_stick});
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_rt_args);
-        cores_with_rtargs.push_back(core);
         tile_start_id += ntiles_per_core;
         offset_within_stick += ntiles_per_core * TILE_WIDTH * output.element_size();
     }
 
-    return UntilizeMultiCoreSubCoreGridsProgramFactory::cached_program_t{
-        std::move(program), {reader_kernel_id, writer_kernel_id, cb_src0, cb_output, cores_with_rtargs}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void UntilizeMultiCoreSubCoreGridsProgramFactory::override_runtime_arguments(
-    UntilizeMultiCoreSubCoreGridsProgramFactory::cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& cores_with_rtargs = cached_program.shared_variables.cores_with_rtargs;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-    {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-        for (const CoreCoord& core : cores_with_rtargs) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-    }
-
-    {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
-        for (const CoreCoord& core : cores_with_rtargs) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.hpp
@@ -7,27 +7,12 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreSubCoreGridsProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_src0{};
-        tt::tt_metal::CBHandle cb_output{};
-        std::vector<CoreCoord> cores_with_rtargs;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
         const UntilizeTensorReturnValue& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -182,16 +182,10 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
 
     // Reader run-time args
     uint32_t start_page_id = 0;
-    reader_desc.runtime_args.emplace_back(
-        CoreCoord{0, 0},
-        std::vector<uint32_t>{
-            src0_buffer->address(),
-            num_tiles,
-            start_page_id,
-        });
+    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, {src0_buffer, num_tiles, start_page_id});
 
     // Writer run-time args
-    writer_desc.runtime_args.emplace_back(CoreCoord{0, 0}, std::vector<uint32_t>{dst_buffer->address()});
+    writer_desc.emplace_runtime_args(CoreCoord{0, 0}, {dst_buffer});
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -128,7 +128,7 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = core;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer compile-time args
     std::vector<uint32_t> writer_compile_time_args = {
@@ -151,7 +151,7 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = core;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     // Compute defines
     KernelDescriptor::Defines compute_kernel_defines;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "untilize_single_core_program_factory.hpp"
@@ -20,7 +21,7 @@ using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
-UntilizeSingleCoreProgramFactory::cached_program_t UntilizeSingleCoreProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
     const UntilizeTensorReturnValue& tensor_return_value) {
@@ -28,7 +29,7 @@ UntilizeSingleCoreProgramFactory::cached_program_t UntilizeSingleCoreProgramFact
     const auto& output = tensor_return_value;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     CoreRange core({0, 0}, {0, 0});
 
@@ -89,20 +90,30 @@ UntilizeSingleCoreProgramFactory::cached_program_t UntilizeSingleCoreProgramFact
     uint32_t output_stick_size = a.physical_volume() * output.element_size() / num_total_sticks;
 
     // Input CB
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t input_cb_num_tiles = num_tiles_per_block;
-    auto [src0_cb_index, cb_src0] =
-        create_cb(tt::CBIndex::c_0, program, core, input_single_tile_size, input_cb_num_tiles, input_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_cb_num_tiles * input_single_tile_size,
+        .core_ranges = core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     // Output CB
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
     uint32_t output_cb_num_tiles = num_tiles_per_block;
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16, program, core, output_single_tile_size, output_cb_num_tiles, output_cb_data_format);
-
-    // Reader compute defines
-    std::map<std::string, std::string> reader_compute_defines;
-
-    // Writer compute defines
-    std::map<std::string, std::string> writer_compute_defines;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_num_tiles * output_single_tile_size,
+        .core_ranges = core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     // Reader compile-time args
     std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
@@ -110,12 +121,14 @@ UntilizeSingleCoreProgramFactory::cached_program_t UntilizeSingleCoreProgramFact
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     // Tilized reader
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
-        "reader_unary_start_id.cpp",
-        core,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_compute_defines));
+        "reader_unary_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     // Writer compile-time args
     std::vector<uint32_t> writer_compile_time_args = {
@@ -131,81 +144,59 @@ UntilizeSingleCoreProgramFactory::cached_program_t UntilizeSingleCoreProgramFact
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // Untilized writer
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
-        "writer_unary_stick_layout_split_rows_single_core.cpp",
-        core,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_compute_defines));
+        "writer_unary_stick_layout_split_rows_single_core.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
-    // Compute file path
-    std::map<std::string, std::string> compute_kernel_defines;
+    // Compute defines
+    KernelDescriptor::Defines compute_kernel_defines;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
 
     // Compute compile-time args
     uint32_t num_blocks = num_columns_of_blocks * num_blocks_per_column_row * num_blocks_across_height;
     std::vector<uint32_t> compute_compile_time_args = {
         (uint32_t)num_blocks, (uint32_t)num_tiles_per_block, (uint32_t)src0_cb_index, (uint32_t)output_cb_index};
 
-    // Compute kernel
-    tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel,
-        core,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = compute_kernel_defines});
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     // Reader run-time args
     uint32_t start_page_id = 0;
-    std::vector<uint32_t> reader_run_time_args = {
-        src0_buffer->address(),
-        num_tiles,
-        start_page_id,
-    };
+    reader_desc.runtime_args.emplace_back(
+        CoreCoord{0, 0},
+        std::vector<uint32_t>{
+            src0_buffer->address(),
+            num_tiles,
+            start_page_id,
+        });
 
     // Writer run-time args
-    std::vector<uint32_t> writer_run_time_args = {dst_buffer->address()};
+    writer_desc.runtime_args.emplace_back(CoreCoord{0, 0}, std::vector<uint32_t>{dst_buffer->address()});
 
-    // Set run-time args
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    return UntilizeSingleCoreProgramFactory::cached_program_t{
-        std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id}};
-}
-
-void UntilizeSingleCoreProgramFactory::override_runtime_arguments(
-    UntilizeSingleCoreProgramFactory::cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    CoreCoord core = {0, 0};
-
-    {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-    }
-
-    {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
-        runtime_args[0] = dst_buffer->address();
-    }
+    return desc;
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.hpp
@@ -7,19 +7,11 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 namespace ttnn::prim {
 
 struct UntilizeSingleCoreProgramFactory {
-    using shared_variables_t = UntilizeSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
         const UntilizeTensorReturnValue& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -189,7 +189,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // writer
     uint32_t total_num_rows = output.logical_shape()[-2];
@@ -202,7 +202,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     // compute
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/common/constants.hpp"
@@ -20,13 +21,44 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::cached_program_t
-UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create(
+namespace {
+
+inline void push_cb_pair(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint32_t num_tiles,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format) {
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_descriptor(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
 
-    Program program{};
+    ProgramDescriptor desc;
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -89,70 +121,47 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create(
         el_size = a.element_size();
     }
 
+    // CBs: emit a pair (input + output) per non-empty core sub-region. The legacy code
+    // created two CreateCircularBuffer calls on different core ranges — descriptors mirror
+    // this layout exactly.
     if (!core_range.empty()) {
-        create_cb(
-            tt::CBIndex::c_0, program, core_range, input_single_tile_size, single_sub_block_size, input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
+        push_cb_pair(
+            desc,
             core_range,
-            output_single_tile_size,
             single_sub_block_size,
+            input_single_tile_size,
+            output_single_tile_size,
+            input_cb_data_format,
             output_cb_data_format);
     }
-
     if (has_cliff_col && has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
+        push_cb_pair(
+            desc,
             cliff_col_row_core_range,
+            single_block_size_cliff_row,
             input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_row_core_range,
             output_single_tile_size,
-            single_block_size_cliff_row,
+            input_cb_data_format,
             output_cb_data_format);
     }
-
     if (has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
+        push_cb_pair(
+            desc,
             cliff_row_core_range,
+            single_block_size_cliff_row,
             input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_row_core_range,
             output_single_tile_size,
-            single_block_size_cliff_row,
+            input_cb_data_format,
             output_cb_data_format);
     }
-
     if (has_cliff_col) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
+        push_cb_pair(
+            desc,
             cliff_col_core_range,
+            single_sub_block_size,
             input_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_core_range,
             output_single_tile_size,
-            single_sub_block_size,
+            input_cb_data_format,
             output_cb_data_format);
     }
 
@@ -174,80 +183,70 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create(
 
     std::vector<uint32_t> reader_compile_time_args = {num_tiles_2d, third_dim, total_tiles_per_row};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     // writer
     uint32_t total_num_rows = output.logical_shape()[-2];
     std::vector<uint32_t> writer_ct_args = {total_num_rows, third_dim, TILE_HEIGHT, unpadded_row_size_bytes};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_wh_multicore.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+        "writer_unary_stick_layout_wh_multicore.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     // compute
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_size_cliff_col_wh =
         single_block_size_cliff_col * single_block_size / single_sub_block_size;
-    std::map<std::string, std::string> compute_kernel_defines;
+    KernelDescriptor::Defines compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
+
+    const std::string compute_kernel_path(
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp");
+
+    auto push_compute = [&](const CoreRangeSet& cr, std::initializer_list<uint32_t> compile_args) {
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = compute_kernel_path;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = cr;
+        compute_desc.compile_time_args = std::vector<uint32_t>(compile_args.begin(), compile_args.end());
+        compute_desc.defines = compute_kernel_defines;
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        desc.kernels.push_back(std::move(compute_desc));
+    };
+
     if (!core_range.empty()) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_size_wh, single_sub_block_size, third_dim},
-                .defines = compute_kernel_defines});
+        push_compute(core_range, {single_sub_block_size_wh, single_sub_block_size, third_dim});
     }
     if (has_cliff_col && has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            cliff_col_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size_cliff_col, single_block_size_cliff_row, third_dim},
-                .defines = compute_kernel_defines});
+        push_compute(cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim});
     }
     if (has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            cliff_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size, single_block_size_cliff_row, third_dim},
-                .defines = compute_kernel_defines});
+        push_compute(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim});
     }
-
     if (has_cliff_col) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            cliff_col_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_size_cliff_col_wh, single_sub_block_size, third_dim},
-                .defines = compute_kernel_defines});
+        push_compute(cliff_col_core_range, {single_sub_block_size_cliff_col_wh, single_sub_block_size, third_dim});
     }
 
     // RUNTIME ARGS
@@ -265,6 +264,8 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create(
     }
     uint32_t cores_col_count = 1;
 
+    reader_desc.runtime_args.reserve(ncores);
+    writer_desc.runtime_args.reserve(ncores);
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
 
@@ -301,10 +302,11 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create(
             single_sub_block_size_row_arg};
 
         // reader runtime args
-        const std::array reader_rt_args = {
-            src0_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg};
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        reader_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                src0_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
+        writer_desc.runtime_args.emplace_back(core, std::move(writer_rt_args));
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * el_size);
         start_column_id = end_column_id % padded_row_size_bytes;
@@ -320,41 +322,12 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create(
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id,
-            .writer_kernel_id = unary_writer_kernel_id,
-            .cores = cores,
-            .ncores = ncores}};
-}
+    // Insert reader+writer at the beginning so they occupy descriptor positions 0 and 1
+    // (compute kernels follow).
+    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
+    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
 
-void UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const UntilizeWithUnpaddingParams& /*operation_attributes*/,
-    const Tensor& input,
-    const Tensor& output) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    const auto& ncores = shared_vars.ncores;
-    const auto& cores = shared_vars.cores;
-    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernel_id);
-    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernel_id);
-
-    for (uint32_t i = 0; i < ncores; ++i) {
-        const auto& core = cores[i];
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp
@@ -5,24 +5,14 @@
 #pragma once
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
-#include "untilize_with_unpadding_multi_core_shared_variables.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory {
-    using shared_variables_t = UntilizeWithUnpaddingMultiCoreSharedVariables;
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeWithUnpaddingParams& operation_attributes,
-        const Tensor& input,
-        const Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -107,7 +107,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // writer
     uint32_t total_num_rows = output.logical_shape()[-2];
@@ -122,7 +122,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     // compute
     const std::string compute_kernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/common/constants.hpp"
@@ -19,14 +20,13 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::cached_program_t
-UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_descriptor(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -62,15 +62,32 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create(
         el_size = a.element_size();
     }
 
-    create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_col, input_cb_data_format);
-    create_cb(tt::CBIndex::c_16, program, all_cores, output_single_tile_size, num_tiles_per_col, output_cb_data_format);
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_col * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_col * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     // reader
-
     uint32_t num_tiles_2d = a.padded_shape()[-1] * a.padded_shape()[-2] / TILE_HW;
 
     auto log_shape = output.logical_shape();
@@ -83,49 +100,57 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create(
 
     std::vector<uint32_t> reader_compile_time_args = {num_tiles_2d, third_dim, nblocks_per_core};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     // writer
     uint32_t total_num_rows = output.logical_shape()[-2];
 
     std::vector<uint32_t> writer_ct_args = {total_num_rows, ncores, third_dim, TILE_WIDTH, unpadded_row_size_bytes};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_col_multicore.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+        "writer_unary_stick_layout_col_multicore.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     // compute
-
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp");
+    const std::string compute_kernel(
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp");
 
     if (!core_range.empty()) {
-        CreateKernel(
-            program,
-            compute_kernel,
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .compile_args = {nblocks_per_core, num_tiles_per_col, third_dim}});
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = compute_kernel;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = core_range;
+        compute_desc.compile_time_args = {nblocks_per_core, num_tiles_per_col, third_dim};
+        compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+        desc.kernels.push_back(std::move(compute_desc));
     }
     if (has_cliff) {
-        CreateKernel(
-            program,
-            compute_kernel,
-            core_range_cliff,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .compile_args = {nblocks_per_core_cliff, num_tiles_per_col, third_dim}});
+        KernelDescriptor cliff_desc;
+        cliff_desc.kernel_source = compute_kernel;
+        cliff_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cliff_desc.core_ranges = core_range_cliff;
+        cliff_desc.compile_time_args = {nblocks_per_core_cliff, num_tiles_per_col, third_dim};
+        cliff_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
+        desc.kernels.push_back(std::move(cliff_desc));
     }
 
     // RUNTIME ARGS
     const auto& cores = corerange_to_cores(available_grid);
+    reader_desc.runtime_args.reserve(ncores);
+    writer_desc.runtime_args.reserve(ncores);
     uint32_t number_blocks_per_core;
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
@@ -138,55 +163,27 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create(
         uint32_t size_per_row_per_block = nblocks_per_core * TILE_WIDTH * el_size;
 
         //  writer runtime args
-        std::vector<uint32_t> writer_rt_args = {
-            dst_buffer->address(),
-            i,
-            size_per_row_per_block,
-            number_blocks_per_core,
-            TILE_WIDTH * el_size,
-        };
+        writer_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                dst_buffer->address(),
+                i,
+                size_per_row_per_block,
+                number_blocks_per_core,
+                TILE_WIDTH * el_size,
+            });
 
         // reader runtime args
-        const std::array reader_rt_args = {src0_buffer->address(), i, num_tiles_per_row, number_blocks_per_core};
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        reader_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{src0_buffer->address(), i, num_tiles_per_row, number_blocks_per_core});
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id,
-            .writer_kernel_id = unary_writer_kernel_id,
-            .cores = cores,
-            .ncores = ncores}};
-}
+    // Insert reader+writer at the start so kernel ordering matches the legacy program: reader is
+    // descriptor 0, writer is descriptor 1, compute kernels follow.
+    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
+    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
 
-void UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const UntilizeWithUnpaddingParams& /*operation_attributes*/,
-    const Tensor& input,
-    const Tensor& output) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
-    const auto& ncores = shared_vars.ncores;
-    const auto& cores = shared_vars.cores;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernel_id);
-    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernel_id);
-
-    for (uint32_t i = 0; i < ncores; ++i) {
-        const CoreCoord& core = cores[i];
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp
@@ -5,24 +5,14 @@
 #pragma once
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
-#include "untilize_with_unpadding_multi_core_shared_variables.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory {
-    using shared_variables_t = UntilizeWithUnpaddingMultiCoreSharedVariables;
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeWithUnpaddingParams& operation_attributes,
-        const Tensor& input,
-        const Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -97,7 +97,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     /** writer
      */
@@ -113,7 +113,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     /** compute
      */

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "untilize_with_unpadding_multi_core_interleaved_program_factory.hpp"
-#include "untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp"
 
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/common/constants.hpp"
@@ -20,13 +20,12 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::cached_program_t
-UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_descriptor(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -62,8 +61,26 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
         unpadded_row_size_bytes = output_shape[-1] * a.element_size();
     }
 
-    create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_row, input_cb_data_format);
-    create_cb(tt::CBIndex::c_16, program, all_cores, output_single_tile_size, num_tiles_per_row, output_cb_data_format);
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_row * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_row * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
@@ -74,11 +91,13 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
 
     std::vector<uint32_t> reader_compile_time_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     /** writer
      */
@@ -87,47 +106,64 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
          input_cb_data_format == tt::DataFormat::Int32),
         unpadded_row_size_bytes};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_split_rows_multicore.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+        "writer_unary_stick_layout_split_rows_multicore.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     /** compute
      */
-    std::map<std::string, std::string> compute_kernel_defines;
+    KernelDescriptor::Defines compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+    const std::string compute_kernel(
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+
+    // Track compute kernel indices in case both full and cliff exist; we push them after the
+    // dataflow kernels so reader stays at index 0 and writer at index 1.
+    int full_compute_idx = -1;
+    int cliff_compute_idx = -1;
 
     if (!core_range.empty()) {
-        CreateKernel(
-            program,
-            compute_kernel,
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {nblocks_per_core, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16},
-                .defines = compute_kernel_defines});
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = compute_kernel;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = core_range;
+        compute_desc.compile_time_args = {nblocks_per_core, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16};
+        compute_desc.defines = compute_kernel_defines;
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        full_compute_idx = 2 + static_cast<int>(desc.kernels.size());  // reader at 0, writer at 1 once pushed
+        (void)full_compute_idx;
+        desc.kernels.push_back(std::move(compute_desc));
     }
     if (has_cliff) {
-        CreateKernel(
-            program,
-            compute_kernel,
-            core_range_cliff,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {nblocks_per_core_cliff, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16},
-                .defines = compute_kernel_defines});
+        KernelDescriptor cliff_desc;
+        cliff_desc.kernel_source = compute_kernel;
+        cliff_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cliff_desc.core_ranges = core_range_cliff;
+        cliff_desc.compile_time_args = {nblocks_per_core_cliff, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16};
+        cliff_desc.defines = std::move(compute_kernel_defines);
+        cliff_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        cliff_compute_idx = 2 + static_cast<int>(desc.kernels.size());
+        (void)cliff_compute_idx;
+        desc.kernels.push_back(std::move(cliff_desc));
     }
 
     uint32_t tile_height = output.tensor_spec().tile().get_height();
@@ -138,6 +174,8 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
     uint32_t row_start_id = 0;
 
     const auto& cores = corerange_to_cores(available_grid);
+    reader_desc.runtime_args.reserve(ncores);
+    writer_desc.runtime_args.reserve(ncores);
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
         const std::vector<BlockRep>& assignment = core_assignments.at(i);
@@ -150,12 +188,12 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
             static_cast<unsigned int>(assignment.size()),
         };
 
-        uint32_t nblocks_per_core = 0;
+        uint32_t nblocks_per_core_core = 0;
 
         BlockRep ref_el = assignment[0];
         uint32_t count_repeated = 0;  // will be incremented in first iteration of the loop
         for (const auto& el : assignment) {
-            nblocks_per_core += el.block_count();
+            nblocks_per_core_core += el.block_count();
             row_start_id += el.data_row_count();
             if (compare_assignments(ref_el, el)) {
                 count_repeated++;
@@ -177,51 +215,21 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
         writer_rt_args.push_back(ref_el.times);
         writer_rt_args.push_back(count_repeated);
 
-        uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core;
+        uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core_core;
 
         // reader runtime args
-        const std::array reader_rt_args = {src0_buffer->address(), num_tiles_per_core, tile_start_id};
-
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        reader_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{src0_buffer->address(), num_tiles_per_core, tile_start_id});
+        writer_desc.runtime_args.emplace_back(core, std::move(writer_rt_args));
 
         tile_start_id += num_tiles_per_core;
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id,
-            .writer_kernel_id = unary_writer_kernel_id,
-            .cores = cores,
-            .ncores = ncores}};
-}
+    // Insert reader+writer at the beginning so they occupy descriptor positions 0 and 1.
+    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
+    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
 
-void UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const UntilizeWithUnpaddingParams& /*operation_attributes*/,
-    const Tensor& input,
-    const Tensor& output) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
-    const auto& ncores = shared_vars.ncores;
-    const auto& cores = shared_vars.cores;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernel_id);
-    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernel_id);
-
-    for (uint32_t i = 0; i < ncores; ++i) {
-        const CoreCoord& core = cores[i];
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -181,12 +181,11 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
         const std::vector<BlockRep>& assignment = core_assignments.at(i);
 
         // writer runtime args
-        std::vector<uint32_t> writer_rt_args = {
-            dst_buffer->address(),
-            padded_row_size_bytes,
-            row_start_id,
-            static_cast<unsigned int>(assignment.size()),
-        };
+        KernelDescriptor::RTArgList writer_rt_args;
+        writer_rt_args.push_back(dst_buffer);
+        writer_rt_args.push_back(padded_row_size_bytes);
+        writer_rt_args.push_back(row_start_id);
+        writer_rt_args.push_back(static_cast<uint32_t>(assignment.size()));
 
         uint32_t nblocks_per_core_core = 0;
 
@@ -218,9 +217,8 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
         uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core_core;
 
         // reader runtime args
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{src0_buffer->address(), num_tiles_per_core, tile_start_id});
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_rt_args));
+        reader_desc.emplace_runtime_args(core, {src0_buffer, num_tiles_per_core, tile_start_id});
+        writer_desc.emplace_runtime_args(core, writer_rt_args);
 
         tile_start_id += num_tiles_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.hpp
@@ -5,24 +5,14 @@
 #pragma once
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
-#include "untilize_with_unpadding_multi_core_shared_variables.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory {
-    using shared_variables_t = UntilizeWithUnpaddingMultiCoreSharedVariables;
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeWithUnpaddingParams& operation_attributes,
-        const Tensor& input,
-        const Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
@@ -22,10 +23,9 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::cached_program_t
-UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_descriptor(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     // const auto& a = input;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
@@ -86,13 +86,16 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
         // Double buffer if the core is processing 2+ blocks
         input_cb_num_tiles = num_tiles_per_input_block * 2;
     }
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        compute_core_range,
-        input_single_tile_size,
-        input_cb_num_tiles,
-        input_cb_data_format);
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_cb_num_tiles * input_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     // Output CB
     uint32_t output_cb_num_tiles;
@@ -103,28 +106,32 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
         // Double buffer if the core is processing 2+ blocks
         output_cb_num_tiles = num_tiles_per_input_block * 2;
     }
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        compute_core_range,
-        output_single_tile_size,
-        output_cb_num_tiles,
-        output_cb_data_format);
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_num_tiles * output_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
-    // Reader compile-time args and kernel
-    KernelHandle unary_reader_kernel_id;
-    // Sharded input
+    // Reader compile-time args and kernel (sharded input)
     std::vector<uint32_t> reader_compile_time_args = {
         (uint32_t)src0_cb_index,
         (uint32_t)num_tiles_per_input_block,
         (uint32_t)num_shards,
         (uint32_t)num_compute_cores};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp",
-        compute_core_range,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = compute_core_range;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     // Writer compile-time args
     uint32_t output_element_size = output.element_size();
@@ -181,45 +188,46 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
         .append_to(writer_compile_time_args);  // For ND sharded input, we need info on the input buffer distribution
 
     // Writer kernel
-    std::string writer_kernel_file =
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
         "writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = compute_core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
-    KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        writer_kernel_file,
-        compute_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-    tt::tt_metal::SetCommonRuntimeArgs(program, unary_writer_kernel_id, writer_common_runtime_args);
-
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
 
     // Compute kernel file
-    std::string compute_kernel(
+    const std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
 
     // Compute compile-time args and kernel
     // Note: This condition is always true for sharded input
-    KernelHandle untilize_kernel_id = 0;
-    std::map<std::string, std::string> compute_kernel_defines;
+    KernelDescriptor::Defines compute_kernel_defines;
     if (input.dtype() == DataType::INT32 || input.dtype() == DataType::UINT32 || input.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    if (!compute_core_range.ranges().empty()) {
+    KernelDescriptor compute_desc;
+    bool has_compute = !compute_core_range.ranges().empty();
+    if (has_compute) {
         std::vector<uint32_t> compute_compile_time_args = {
             (uint32_t)num_tiles_per_input_block, (uint32_t)src0_cb_index, (uint32_t)output_cb_index};
-        untilize_kernel_id = CreateKernel(
-            program,
-            compute_kernel,
-            compute_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_compile_time_args,
-                .defines = compute_kernel_defines});
+        compute_desc.kernel_source = compute_kernel;
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = compute_core_range;
+        compute_desc.compile_time_args = std::move(compute_compile_time_args);
+        compute_desc.defines = std::move(compute_kernel_defines);
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
     }
 
     // Run-time args
@@ -231,6 +239,11 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
     // page_mapping.core_host_page_indices[core_id] contains host page indices for all device pages on that core,
     // with UncompressedBufferPageMapping::PADDING indicating padding pages
     uint32_t start_shard_id = 0;
+    reader_desc.runtime_args.reserve(ordered_cores_with_data.size());
+    writer_desc.runtime_args.reserve(ordered_cores_with_data.size());
+    if (has_compute) {
+        compute_desc.runtime_args.reserve(ordered_cores_with_data.size());
+    }
     for (auto core : ordered_cores_with_data) {
         auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
         uint32_t num_input_blocks_to_process = 0;
@@ -256,47 +269,25 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
             }
         }
         // Reader run-time args
-        std::vector<uint32_t> reader_run_time_args = {src0_buffer->address(), start_shard_id};
+        reader_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{src0_buffer->address(), start_shard_id});
 
         // Writer run-time args
-        std::vector<uint32_t> writer_run_time_args = {dst_buffer->address(), src0_buffer->address(), start_shard_id};
+        writer_desc.runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), src0_buffer->address(), start_shard_id});
         start_shard_id++;
 
         // Compute run-time args
-        std::vector<uint32_t> compute_run_time_args = {num_input_blocks_to_process};
-        // Set run-time arg
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, untilize_kernel_id, core, compute_run_time_args);
+        if (has_compute) {
+            compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_input_blocks_to_process});
+        }
     }
 
-    return cached_program_t{
-        std::move(program),
-        {unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output, ordered_cores_with_data}};
-}
-
-void UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::override_runtime_arguments(
-    UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::cached_program_t& cached_program,
-    const UntilizeWithUnpaddingParams& /*operation_attributes*/,
-    const Tensor& input,
-    const Tensor& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& cores_with_runtime_args = cached_program.shared_variables.cores_with_runtime_args;
-
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    // Reader and Writer update buffer addresses
-    auto& runtime_args_by_core_reader = GetRuntimeArgs(program, reader_kernel_id);
-    auto& runtime_args_by_core_writer = GetRuntimeArgs(program, writer_kernel_id);
-    for (const CoreCoord& core : cores_with_runtime_args) {
-        auto& runtime_args_reader = runtime_args_by_core_reader[core.x][core.y];
-        runtime_args_reader[0] = src_buffer->address();
-        auto& runtime_args_writer = runtime_args_by_core_writer[core.x][core.y];
-        runtime_args_writer[0] = dst_buffer->address();
-        runtime_args_writer[1] = src_buffer->address();
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (has_compute) {
+        desc.kernels.push_back(std::move(compute_desc));
     }
+
+    return desc;
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -269,16 +269,15 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
             }
         }
         // Reader run-time args
-        reader_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{src0_buffer->address(), start_shard_id});
+        reader_desc.emplace_runtime_args(core, {src0_buffer, start_shard_id});
 
         // Writer run-time args
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), src0_buffer->address(), start_shard_id});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, src0_buffer, start_shard_id});
         start_shard_id++;
 
         // Compute run-time args
         if (has_compute) {
-            compute_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{num_input_blocks_to_process});
+            compute_desc.emplace_runtime_args(core, {num_input_blocks_to_process});
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -131,7 +131,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = compute_core_range;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer compile-time args
     uint32_t output_element_size = output.element_size();
@@ -195,7 +195,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = compute_core_range;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
     writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp
@@ -5,30 +5,14 @@
 #pragma once
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
-#include "untilize_with_unpadding_multi_core_shared_variables.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_src0{};
-        tt::tt_metal::CBHandle cb_output{};
-        std::vector<CoreCoord> cores_with_runtime_args;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeWithUnpaddingParams& operation_attributes,
-        const Tensor& input,
-        const Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -293,19 +293,18 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
                 }
             }
 
-            writer_desc.runtime_args.emplace_back(
+            writer_desc.emplace_runtime_args(
                 core,
-                std::vector<uint32_t>{
-                    dst_buffer->address(),  // dst_addr
-                    num_rows_block,
-                    block_row_size,
-                    std::uint32_t{1},
-                    std::uint32_t{1},
-                    std::uint32_t{1},
-                    row_size_unpadded,
-                    num_rows_unpadded,
-                    block_start_row_id_offset,
-                    block_start_row_offset});
+                {dst_buffer,  // dst_addr
+                 num_rows_block,
+                 block_row_size,
+                 std::uint32_t{1},
+                 std::uint32_t{1},
+                 std::uint32_t{1},
+                 row_size_unpadded,
+                 num_rows_unpadded,
+                 block_start_row_id_offset,
+                 block_start_row_offset});
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/common/constants.hpp"
@@ -21,13 +22,12 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeWithUnpaddingMultiCoreShardedProgramFactory::cached_program_t
-UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create_descriptor(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     bool src_sharded = a.memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();
@@ -82,42 +82,49 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
         std::swap(end_core.x, end_core.y);
     }
 
+    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = ntiles_per_block * nblocks_per_core;
-    uint32_t src0_cb_index;
-    CBHandle cb_src0;
-    std::tie(src0_cb_index, cb_src0) = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        all_cores,
-        input_single_tile_size,
-        num_input_tiles,
-        input_cb_data_format,
-        src_sharded ? a.buffer() : nullptr);
+    // Input CB: sharded → bind .buffer to the input buffer; framework re-applies
+    // UpdateDynamicCircularBufferAddress on cache hit.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+        .buffer = src_sharded ? a.buffer() : nullptr,
+    });
 
     uint32_t num_output_tiles = out_sharded ? (unpad_tensor_w_16 ? 16 : ntiles_per_batch * 2) : ntiles_per_block * 2;
     uint32_t aligned_page_size = static_cast<uint32_t>(output.buffer()->aligned_page_size());
-    uint32_t output_cb_index;
-    CBHandle cb_output;
-    std::tie(output_cb_index, cb_output) = create_cb(
-        tt::CBIndex::c_16, program, all_cores, output_single_tile_size, num_output_tiles, output_cb_data_format);
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
-    uint32_t sharded_output_cb_index;
-    CBHandle cb_sharded_output;
+    constexpr uint8_t sharded_output_cb_index = tt::CBIndex::c_17;
     if (out_sharded) {
         // The kernel advances the write pointer by aligned_page_size (which may be
         // larger than block_row_size due to buffer alignment padding), so the CB
         // page size must match to avoid overflow.
-        std::tie(sharded_output_cb_index, cb_sharded_output) = create_cb(
-            tt::CBIndex::c_17,
-            program,
-            all_cores,
-            aligned_page_size,
-            num_output_rows_unpadded,
-            output_cb_data_format,
-            output.buffer());
-    } else {
-        sharded_output_cb_index = static_cast<uint32_t>(tt::CBIndex::c_17);
-        cb_sharded_output = CBHandle{};
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_output_rows_unpadded * aligned_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = sharded_output_cb_index,
+                .data_format = output_cb_data_format,
+                .page_size = aligned_page_size,
+            }}},
+            .buffer = output.buffer(),
+        });
     }
 
     Buffer* dst_buffer = output.buffer();
@@ -125,42 +132,41 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
 
     /** reader
      */
-    KernelHandle unary_reader_kernel_id;
     std::vector<uint32_t> reader_ct_args;
     reader_ct_args.push_back(src0_cb_index);
 
-    unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     /** writer
      */
-    KernelHandle unary_writer_kernel_id;
+    KernelDescriptor writer_desc;
     if (out_sharded) {
         std::vector<uint32_t> writer_ct_args{output_cb_index, sharded_output_cb_index, aligned_page_size};
-        unary_writer_kernel_id = CreateKernel(
-            program,
+        writer_desc.kernel_source =
             unpad_tensor_w_16
                 ? "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
                   "writer_unary_unpad_width_16_sharded.cpp"
                 : "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-                  "writer_unary_unpad_batch_rows_sharded.cpp",
-            all_cores,
-            WriterDataMovementConfig(writer_ct_args));
+                  "writer_unary_unpad_batch_rows_sharded.cpp";
+        writer_desc.compile_time_args = std::move(writer_ct_args);
     } else {
         std::vector<uint32_t> writer_ct_args = {
             (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
              input_cb_data_format == tt::DataFormat::Int32),
             output_row_size};
         TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-        unary_writer_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp",
-            all_cores,
-            WriterDataMovementConfig(writer_ct_args));
+        writer_desc.kernel_source = "ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp";
+        writer_desc.compile_time_args = std::move(writer_ct_args);
     }
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterDataMovementConfig{};
 
     /** compute
      */
@@ -171,12 +177,13 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
         (uint32_t)output_cb_index,
     };
 
-    std::map<std::string, std::string> compute_kernel_defines;
+    KernelDescriptor::Defines compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
@@ -187,22 +194,27 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
         compute_args[0] = (uint32_t)num_input_tiles;  // per_core_tile_cnt
     }
 
-    CreateKernel(
-        program,
-        compute_kernel,
-        all_cores,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_args,
-            .defines = compute_kernel_defines});
-
-    // reader runtime args
-    const std::array reader_rt_args = {
-        ntiles_per_block * nblocks_per_core  // ntiles
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = compute_kernel;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
     };
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, reader_rt_args);
-    std::vector<CoreCoord> cores;
+
+    // Runtime args: legacy code uses SetRuntimeArgs(program, kernel, all_cores, args) which broadcasts
+    // the same args to every core. The descriptor API needs per-core entries; enumerate cores and
+    // emit one runtime_args entry per core.
+    const std::vector<CoreCoord> all_core_coords = corerange_to_cores(all_cores, std::nullopt, row_major);
+
+    const std::vector<uint32_t> reader_rt_args = {ntiles_per_block * nblocks_per_core};
+    reader_desc.runtime_args.reserve(all_core_coords.size());
+    for (const auto& core : all_core_coords) {
+        reader_desc.runtime_args.emplace_back(core, reader_rt_args);
+    }
 
     if (out_sharded) {
         std::vector<uint32_t> writer_rt_args;
@@ -217,11 +229,14 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
                 block_row_size,
                 batch};
         }
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, writer_rt_args);
+        writer_desc.runtime_args.reserve(all_core_coords.size());
+        for (const auto& core : all_core_coords) {
+            writer_desc.runtime_args.emplace_back(core, writer_rt_args);
+        }
     } else {
-        cores = corerange_to_cores(all_cores, std::nullopt, row_major);
-        for (uint32_t i = 0; i < cores.size(); ++i) {
-            CoreCoord& core = cores[i];
+        writer_desc.runtime_args.reserve(all_core_coords.size());
+        for (uint32_t i = 0; i < all_core_coords.size(); ++i) {
+            CoreCoord core = all_core_coords[i];
 
             // writer runtime args
             uint32_t block_start_row_offset;
@@ -278,55 +293,27 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
                 }
             }
 
-            const std::array writer_rt_args = {
-                dst_buffer->address(),  // dst_addr
-                num_rows_block,
-                block_row_size,
-                std::uint32_t{1},
-                std::uint32_t{1},
-                std::uint32_t{1},
-                row_size_unpadded,
-                num_rows_unpadded,
-                block_start_row_id_offset,
-                block_start_row_offset};
-
-            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+            writer_desc.runtime_args.emplace_back(
+                core,
+                std::vector<uint32_t>{
+                    dst_buffer->address(),  // dst_addr
+                    num_rows_block,
+                    block_row_size,
+                    std::uint32_t{1},
+                    std::uint32_t{1},
+                    std::uint32_t{1},
+                    row_size_unpadded,
+                    num_rows_unpadded,
+                    block_start_row_id_offset,
+                    block_start_row_offset});
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id,
-            .writer_kernel_id = unary_writer_kernel_id,
-            .cb_src0 = cb_src0,
-            .cb_sharded_output = cb_sharded_output,
-            .cores = cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void UntilizeWithUnpaddingMultiCoreShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const UntilizeWithUnpaddingParams& /*operation_attributes*/,
-    const Tensor& input,
-    const Tensor& output) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    bool out_sharded = output.memory_config().is_sharded();
-
-    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_src0, *src_buffer);
-
-    if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_sharded_output, *dst_buffer);
-    } else {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernel_id);
-        for (const CoreCoord& core : shared_vars.cores) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -141,7 +141,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     /** writer
      */
@@ -166,7 +166,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
     }
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     /** compute
      */

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.hpp
@@ -6,28 +6,13 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_src0{};
-        tt::tt_metal::CBHandle cb_sharded_output{};
-        std::vector<tt::tt_metal::CoreCoord> cores;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeWithUnpaddingParams& operation_attributes,
-        const Tensor& input,
-        const Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -160,7 +160,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = core;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderDataMovementConfig{};
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Untilized writer
     KernelDescriptor writer_desc;
@@ -170,7 +170,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = core;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterDataMovementConfig{};
+    writer_desc.config = WriterConfigDescriptor{};
 
     std::vector<uint32_t> compute_args = {
         uint32_t(num_tiles / num_tiles_per_block),

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -126,23 +126,6 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
         }}},
     });
 
-    const std::vector<uint32_t> writer_kernel_args = {
-        dst_buffer->address(),
-        output_w,
-        padded_W_diff_blocks,
-        output_z,
-        padded_Z_diff_blocks,
-        output_y,
-        padded_Y_diff_blocks,
-        num_leftover_Y,
-        output_x,
-        padded_stick_size,
-        num_blocks_w_input,
-        num_blocks_w_output,
-        num_blocks_w_diff,
-        block_row_size,
-        block_row_leftover_size};
-
     std::vector<uint32_t> reader_compile_time_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
@@ -201,9 +184,24 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     };
 
     CoreCoord core_0 = corerange_to_cores(core).at(0);
-    reader_desc.runtime_args.emplace_back(
-        core_0, std::vector<uint32_t>{src0_buffer->address(), uint32_t(num_tiles), 0});
-    writer_desc.runtime_args.emplace_back(core_0, writer_kernel_args);
+    reader_desc.emplace_runtime_args(core_0, {src0_buffer, uint32_t(num_tiles), 0u});
+    writer_desc.emplace_runtime_args(
+        core_0,
+        {dst_buffer,
+         output_w,
+         padded_W_diff_blocks,
+         output_z,
+         padded_Z_diff_blocks,
+         output_y,
+         padded_Y_diff_blocks,
+         num_leftover_Y,
+         output_x,
+         padded_stick_size,
+         num_blocks_w_input,
+         num_blocks_w_output,
+         num_blocks_w_diff,
+         block_row_size,
+         block_row_leftover_size});
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/common/constants.hpp"
@@ -21,7 +22,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeWithUnpaddingSingleCoreProgramFactory::cached_program_t UntilizeWithUnpaddingSingleCoreProgramFactory::create(
+tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::create_descriptor(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
@@ -29,7 +30,7 @@ UntilizeWithUnpaddingSingleCoreProgramFactory::cached_program_t UntilizeWithUnpa
     const auto& input_shape = a.padded_shape();
     const auto& output_shape = output.padded_shape();
 
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     CoreRange default_core({0, 0}, {0, 0});
     CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
@@ -101,21 +102,31 @@ UntilizeWithUnpaddingSingleCoreProgramFactory::cached_program_t UntilizeWithUnpa
     const uint32_t padded_W_diff_blocks = (input_w - output_w) * input_z * input_y / TILE_HEIGHT * num_blocks_w_input;
     const uint32_t num_leftover_Y = output_y - (output_y / TILE_HEIGHT * TILE_HEIGHT);
 
-    uint32_t src0_cb_index = 0;
+    constexpr uint8_t src0_cb_index = 0;
     uint32_t num_input_tiles = num_tiles_per_block;
-    auto cb_src0_config = tt::tt_metal::CircularBufferConfig(
-                              num_input_tiles * input_single_tile_size, {{src0_cb_index, input_cb_data_format}})
-                              .set_page_size(src0_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = num_tiles_per_block;
-    auto cb_output_config = tt::tt_metal::CircularBufferConfig(
-                                num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-                                .set_page_size(output_cb_index, output_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
-    const std::array writer_kernel_args = {
+    const std::vector<uint32_t> writer_kernel_args = {
         dst_buffer->address(),
         output_w,
         padded_W_diff_blocks,
@@ -143,19 +154,23 @@ UntilizeWithUnpaddingSingleCoreProgramFactory::cached_program_t UntilizeWithUnpa
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // Tilized reader
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        core,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderDataMovementConfig{};
 
     // Untilized writer
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_unpad_dims_split_rows.cpp",
-        core,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        "writer_unary_unpad_dims_split_rows.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterDataMovementConfig{};
 
     std::vector<uint32_t> compute_args = {
         uint32_t(num_tiles / num_tiles_per_block),
@@ -163,58 +178,38 @@ UntilizeWithUnpaddingSingleCoreProgramFactory::cached_program_t UntilizeWithUnpa
         uint32_t(src0_cb_index),
         uint32_t(output_cb_index)};
 
-    std::map<std::string, std::string> compute_kernel_defines;
+    KernelDescriptor::Defines compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
         unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
 
-    tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel,
-        core,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_args,
-            .defines = compute_kernel_defines});
-
-    tt::tt_metal::SetRuntimeArgs(
-        program, unary_reader_kernel_id, core, {src0_buffer->address(), uint32_t(num_tiles), 0});
-
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
-
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id, .writer_kernel_id = unary_writer_kernel_id, .core = core}};
-}
-
-void UntilizeWithUnpaddingSingleCoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const UntilizeWithUnpaddingParams& /*operation_attributes*/,
-    const Tensor& input,
-    const Tensor& output) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-    auto& core = shared_vars.core;
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     CoreCoord core_0 = corerange_to_cores(core).at(0);
-    {
-        auto& runtime_args = GetRuntimeArgs(program, shared_vars.reader_kernel_id, core_0);
-        runtime_args[0] = src_buffer->address();
-    }
-    {
-        auto& runtime_args = GetRuntimeArgs(program, shared_vars.writer_kernel_id, core_0);
-        runtime_args[0] = dst_buffer->address();
-    }
+    reader_desc.runtime_args.emplace_back(
+        core_0, std::vector<uint32_t>{src0_buffer->address(), uint32_t(num_tiles), 0});
+    writer_desc.runtime_args.emplace_back(core_0, writer_kernel_args);
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.hpp
@@ -6,26 +6,13 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingSingleCoreProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id {};
-        tt::tt_metal::KernelHandle writer_kernel_id {};
-        CoreRange core{{0, 0}, {0, 0}};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeWithUnpaddingParams& operation_attributes,
-        const Tensor& input,
-        const Tensor& output);
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
## Summary
Contract-1 migration of ~19 data_movement factories:
- transpose (cn, hc_rm, hc_sharded, hc_tiled, hc_tiled_interleaved, wh, wh_sharded, wh_sharded_rm)
- permute (5 nested factories)
- untilize (multi_core, multi_core_sub_core_grids, single_core)
- untilize_with_unpadding (6 variants: multi_core/single_core × interleaved/sharded/nd/block/col)
- fill_pad
- reshape_view/reshape_tiled

Big perf win on tiled transposes (–30% vs main). All use \`emplace_runtime_args\` for buffer bindings.

Part of #42193 / #42199.

## Dependencies
None.

## Test plan
- [ ] sanity-tests.yaml
- [ ] runtime-sanity-tests.yaml
- [ ] blackhole-post-commit.yaml
- [ ] tt-metal-l2-nightly.yaml (data_movement family)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-data-movement-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-data-movement-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-data-movement-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-data-movement-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-data-movement-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-data-movement-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-data-movement-leftovers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-data-movement-leftovers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-data-movement-leftovers)