### PR TITLE
sliding_window + data_movement + conv: migrate halo + reshape_tiled + conv2d + conv3d to ProgramDescriptor (Contract-2)

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -687,17 +687,20 @@ bool is_split_reader_viable(
     return is_viable;
 }
 
-void post_conv2d_op_memory_checks(
-    tt::tt_metal::Program& program,
+// Helper shared by the legacy and descriptor post-build checks: recomputes the
+// CBInfo-predicted L1 usage (CB_allocation_size + tensor_allocation_size) from
+// the operation attributes.  Callers compute the actually-emitted CB byte
+// count themselves (calculate_total_cb_size for the legacy path, summed
+// desc.cbs for the descriptor path) and compare against the returned
+// `CB_allocation_size`.
+static conv_op_l1_usage predicted_conv2d_l1_usage(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
-    Tensor& /*output_tensor*/,
     std::optional<uint32_t> reader_indices_actual_page_size) {
     const auto& input_tensor_a = tensor_args.a;
     const auto& input_tensor_b = tensor_args.b;
     const auto& input_tensor_bias = tensor_args.bias;
     const bool has_bias = input_tensor_bias.has_value();
-    auto *device = input_tensor_a.device();
     const auto& weights_shape = input_tensor_b.padded_shape();
     const auto& sliding_window_config = operation_attributes.sliding_window_config;
     const auto& parallelization_config = operation_attributes.parallelization_config;
@@ -710,16 +713,10 @@ void post_conv2d_op_memory_checks(
     const auto& enable_weights_double_buffer = operation_attributes.enable_weights_double_buffer;
     const auto& enable_activation_reuse = operation_attributes.enable_activation_reuse;
     const auto& config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
-    const auto& pre_op_l1_allocation_size_bytes = operation_attributes.pre_op_l1_allocation_size_bytes;
     const auto& force_split_reader = operation_attributes.force_split_reader;
     const auto output_channels = operation_attributes.output_channels;
     const auto groups = operation_attributes.groups;
     const auto untilize_out = operation_attributes.untilize_out;
-
-    const uint32_t post_op_l1_allocation_size =
-        device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-
-    auto actual_cb_size = calculate_total_cb_size(program);
 
     auto kernel_dims =
         std::array<uint32_t, 2>({sliding_window_config.window_hw.first, sliding_window_config.window_hw.second});
@@ -729,7 +726,7 @@ void post_conv2d_op_memory_checks(
 
     const std::array<uint32_t, 2> shard_shape = input_tensor_a.shard_spec().value().shape;
     const uint32_t input_channels_padded = shard_shape[1];
-    conv_op_l1_usage l1_usage = calculate_L1_usage(
+    return calculate_L1_usage(
         compute_kernel_config,
         block_config,
         parallelization_config,
@@ -754,6 +751,110 @@ void post_conv2d_op_memory_checks(
         input_channels_padded,
         skip_mcast.skip_activation_mcast,
         reader_indices_actual_page_size);
+}
+
+void emit_cb_descriptors(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::ProgramDescriptor& desc,
+    const CoreRangeSet& all_cores_set,
+    tt::tt_metal::Buffer* input_buffer,
+    tt::tt_metal::Buffer* output_buffer,
+    tt::tt_metal::Buffer* indices_buffer) {
+    uint32_t cb_index = 0;
+    for (auto& cb : cb_info) {
+        if (cb.num_pages == 0) {
+            // Skip circular buffers with zero pages (matches allocate_cbs behavior).
+            continue;
+        }
+
+        tt::tt_metal::Buffer* buffer = nullptr;
+        if (cb.is_globally_allocated) {
+            if (cb.name == Conv2dCb::ACT_SHARDED) {
+                buffer = input_buffer;
+            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
+                buffer = output_buffer;
+            } else if (cb.name == Conv2dCb::READER_INDICES) {
+                buffer = indices_buffer;
+            } else {
+                TT_THROW(
+                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
+                    enchantum::to_string(cb.name));
+            }
+        }
+
+        cb.index = cb_index++;
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = cb.num_pages * cb.page_size,
+            .core_ranges = all_cores_set,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb.index),
+                .data_format = cb.data_format,
+                .page_size = cb.page_size,
+            }}},
+            .buffer = buffer,
+        });
+    }
+
+    for (auto& cb : cb_info) {
+        if (cb.overlapped_by_cb.has_value()) {
+            // If this CB is overlapped by another CB, mirror the overlapped CB's index.
+            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
+            cb.index = overlapped_cb.index;
+        }
+    }
+}
+
+void post_conv2d_op_memory_checks_descriptor(
+    const tt::tt_metal::ProgramDescriptor& desc,
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    std::optional<uint32_t> reader_indices_actual_page_size) {
+    // Sum non-globally-allocated CB sizes from the descriptor.  Mirrors
+    // calculate_total_cb_size(program) which sums (cb->globally_allocated() ? 0 : cb->size())
+    // over the realised program: in the descriptor world, a CB is globally
+    // allocated iff its `buffer` is non-null.
+    uint32_t actual_cb_size = 0;
+    for (const auto& cb : desc.cbs) {
+        if (cb.buffer == nullptr) {
+            actual_cb_size += cb.total_size;
+        }
+    }
+
+    const conv_op_l1_usage l1_usage =
+        predicted_conv2d_l1_usage(operation_attributes, tensor_args, reader_indices_actual_page_size);
+
+    TT_FATAL(
+        actual_cb_size == l1_usage.CB_allocation_size,
+        "Calculated CB size {} does not match with the actual CB size {}",
+        l1_usage.CB_allocation_size,
+        actual_cb_size);
+
+    // NOTE: the legacy post_conv2d_op_memory_checks() also verifies that the
+    // device L1 allocator advanced by exactly l1_usage.tensor_allocation_size
+    // bytes between pre_op_l1_allocation_size_bytes and post-Program-creation.
+    // That second check requires a realised Program (so create_circular_buffer
+    // has already affected the allocator) and isn't reachable from the
+    // descriptor path: the framework realises the Program after this function
+    // returns.  The CB-size equality above is the same fail-fast guard the
+    // legacy path opens with, and is sufficient to catch CBInfo vs. emission
+    // drifts.
+}
+
+void post_conv2d_op_memory_checks(
+    tt::tt_metal::Program& program,
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& /*output_tensor*/,
+    std::optional<uint32_t> reader_indices_actual_page_size) {
+    auto* device = tensor_args.a.device();
+    const auto& pre_op_l1_allocation_size_bytes = operation_attributes.pre_op_l1_allocation_size_bytes;
+
+    const uint32_t post_op_l1_allocation_size =
+        device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+
+    const auto actual_cb_size = calculate_total_cb_size(program);
+    const conv_op_l1_usage l1_usage =
+        predicted_conv2d_l1_usage(operation_attributes, tensor_args, reader_indices_actual_page_size);
 
     TT_FATAL(
         actual_cb_size == l1_usage.CB_allocation_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -9,7 +9,9 @@
 
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 
+#include "tt-metalium/buffer.hpp"
 #include "tt-metalium/circular_buffer_config.hpp"
+#include "tt-metalium/program_descriptors.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
@@ -122,6 +124,37 @@ void post_conv2d_op_memory_checks(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
     Tensor& output_tensor,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
+
+// Builds CBDescriptor entries from a vector of CBInfo onto the supplied
+// ProgramDescriptor, mirroring allocate_cbs() but emitting onto the descriptor
+// data structures instead of a realised Program.  The set of globally-allocated
+// CBs (ACT_SHARDED/OUT/MATMUL_PARTIALS/READER_INDICES) is wired to the supplied
+// raw Buffer*s, which is what the framework's fast cache-hit path patches.
+// This single helper is used by both the sharded and width-sharded conv2d
+// program factories to avoid divergence in CB emission logic.
+void emit_cb_descriptors(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::ProgramDescriptor& desc,
+    const CoreRangeSet& all_cores_set,
+    tt::tt_metal::Buffer* input_buffer,
+    tt::tt_metal::Buffer* output_buffer,
+    tt::tt_metal::Buffer* indices_buffer);
+
+// Descriptor-path equivalent of post_conv2d_op_memory_checks().  Verifies that
+// the sum of non-globally-allocated CB sizes emitted on `desc` matches the L1
+// usage predicted by calculate_L1_usage() — the same equality the legacy
+// program-based check enforced via calculate_total_cb_size().  The L1
+// allocator-tracking half of post_conv2d_op_memory_checks() can't be performed
+// here because the framework realises the Program after this function returns,
+// so post_op_l1_allocation_size isn't observable.  When that check is wanted
+// against a realised Program, post_conv2d_op_memory_checks() should be used
+// instead.  Fails fast (TT_FATAL) on CB-size mismatch so misconfigured CB
+// footprints surface in the same way as on the legacy path.
+void post_conv2d_op_memory_checks_descriptor(
+    const tt::tt_metal::ProgramDescriptor& desc,
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
     std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -175,11 +175,9 @@ ActivationReuseConfig calculate_activation_reuse_params(
 
 namespace {
 
-// Per-coord ProgramDescriptor build (originally lived in the legacy
-// Conv2dShardedProgramFactory::create body).  The intermediate
-// conv_reader_indices tensor is allocated once by create_workload_descriptor and
-// parked on the WorkloadDescriptor; we receive the raw Buffer* here and wire it
-// into the READER_INDICES CB and reader CT args.
+// The intermediate conv_reader_indices tensor is allocated once by
+// create_workload_descriptor and parked on the WorkloadDescriptor; we receive
+// the raw Buffer* here and wire it into the READER_INDICES CB and reader CT args.
 tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -181,7 +181,7 @@ namespace {
 // The set of globally-allocated CBs (ACT_SHARDED/OUT/MATMUL_PARTIALS/READER_INDICES)
 // is wired to the supplied raw Buffer*s, which is what the framework's fast
 // cache-hit path patches.
-void emit_cb_descriptors(
+void emit_cb_descriptors_sharded(
     std::vector<CBInfo>& cb_info,
     tt::tt_metal::ProgramDescriptor& desc,
     const CoreRangeSet& all_cores_set,
@@ -237,7 +237,7 @@ void emit_cb_descriptors(
 // conv_reader_indices tensor is allocated once by create_workload_descriptor and
 // parked on the WorkloadDescriptor; we receive the raw Buffer* here and wire it
 // into the READER_INDICES CB and reader CT args.
-tt::tt_metal::ProgramDescriptor build_program_descriptor(
+tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
     Tensor& output_tensor,
@@ -521,7 +521,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         act_block_h_nsubblocks_split = block_config.act_block_h_ntiles - act_block_h_nsubblocks_split_last;
     }
     uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * tt::constants::TILE_HEIGHT;
-    uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * tt::constants::TILE_HEIGHT;
 
     uint32_t act_block_num_tiles_split = act_block_h_nsubblocks_split * act_block_w_ntiles;
     uint32_t act_block_num_tiles_split_last = act_block_h_nsubblocks_split_last * act_block_w_ntiles;
@@ -745,7 +744,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
     // output, READER_INDICES on the workload-scoped indices buffer) and patches
     // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
     // override needed.
-    emit_cb_descriptors(cb_info, desc, all_cores, a.buffer(), output.buffer(), conv_reader_indices_buffer);
+    emit_cb_descriptors_sharded(cb_info, desc, all_cores, a.buffer(), output.buffer(), conv_reader_indices_buffer);
 
     const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
     const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
@@ -1538,11 +1537,9 @@ tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_de
     const auto& block_config = operation_attributes.block_config;
     const auto& parallelization_config = operation_attributes.parallelization_config;
     const auto enable_activation_reuse = operation_attributes.enable_activation_reuse;
-    const auto enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
     const auto force_split_reader = operation_attributes.force_split_reader;
     const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
     const bool block_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-    const bool height_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
 
     sliding_window::ParallelConfig input_parallel_config = {
         .grid = a.memory_config().shard_spec().value().grid,
@@ -1560,10 +1557,9 @@ tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_de
 
     // Determine the (act_block_h_datums, last) pair for the host-side index
     // generator.  This must agree exactly with the enable_split_reader path
-    // computed by build_program_descriptor(), since the generated index tensor
+    // computed by build_program_descriptor_sharded(), since the generated index tensor
     // is consumed by the reader kernel.
     const auto& b = tensor_args.b;
-    const auto& bias = tensor_args.bias;
     const auto output_channels = operation_attributes.output_channels;
     const auto groups = operation_attributes.groups;
     const auto has_bias = operation_attributes.has_bias;
@@ -1639,7 +1635,7 @@ tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_de
     // coord in `tensor_coords` (conv2d doesn't depend on cluster position).
     // Build the ProgramDescriptor once and copy into each range entry.
     tt::tt_metal::ProgramDescriptor desc =
-        build_program_descriptor(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
+        build_program_descriptor_sharded(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
 
     auto ranges = tensor_coords.ranges();
     workload_descriptor.programs.reserve(ranges.size());

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <umd/device/types/xy_pair.hpp>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -4,7 +4,9 @@
 
 #include <umd/device/types/xy_pair.hpp>
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
 #include <tt_stl/assert.hpp>
 #include "tt-metalium/circular_buffer_config.hpp"
 #include "tt-metalium/core_coord.hpp"
@@ -15,6 +17,7 @@
 #include "ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/types.hpp"
 #include <tt-logger/tt-logger.hpp>
@@ -22,8 +25,9 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <utility>
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
 
 namespace ttnn::prim {
@@ -170,9 +174,83 @@ ActivationReuseConfig calculate_activation_reuse_params(
     return config;
 }
 
-Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::create(
-    const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+namespace {
+
+// Build CBDescriptor entries from CBInfo, mirroring allocate_cbs() (in
+// conv2d_op_program_factory_common.cpp) but emitting onto a ProgramDescriptor.
+// The set of globally-allocated CBs (ACT_SHARDED/OUT/MATMUL_PARTIALS/READER_INDICES)
+// is wired to the supplied raw Buffer*s, which is what the framework's fast
+// cache-hit path patches.
+void emit_cb_descriptors(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::ProgramDescriptor& desc,
+    const CoreRangeSet& all_cores_set,
+    tt::tt_metal::Buffer* input_buffer,
+    tt::tt_metal::Buffer* output_buffer,
+    tt::tt_metal::Buffer* indices_buffer) {
+    uint32_t cb_index = 0;
+    for (auto& cb : cb_info) {
+        if (cb.num_pages == 0) {
+            // Skip circular buffers with zero pages (matches allocate_cbs behavior).
+            continue;
+        }
+
+        tt::tt_metal::Buffer* buffer = nullptr;
+        if (cb.is_globally_allocated) {
+            if (cb.name == Conv2dCb::ACT_SHARDED) {
+                buffer = input_buffer;
+            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
+                buffer = output_buffer;
+            } else if (cb.name == Conv2dCb::READER_INDICES) {
+                buffer = indices_buffer;
+            } else {
+                TT_THROW(
+                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
+                    enchantum::to_string(cb.name));
+            }
+        }
+
+        cb.index = cb_index++;
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = cb.num_pages * cb.page_size,
+            .core_ranges = all_cores_set,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb.index),
+                .data_format = cb.data_format,
+                .page_size = cb.page_size,
+            }}},
+            .buffer = buffer,
+        });
+    }
+
+    for (auto& cb : cb_info) {
+        if (cb.overlapped_by_cb.has_value()) {
+            // If this CB is overlapped by another CB, mirror the overlapped CB's index.
+            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
+            cb.index = overlapped_cb.index;
+        }
+    }
+}
+
+// Per-coord ProgramDescriptor build (originally lived in the legacy
+// Conv2dShardedProgramFactory::create body).  The intermediate
+// conv_reader_indices tensor is allocated once by create_workload_descriptor and
+// parked on the WorkloadDescriptor; we receive the raw Buffer* here and wire it
+// into the READER_INDICES CB and reader CT args.
+tt::tt_metal::ProgramDescriptor build_program_descriptor(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    tt::tt_metal::Buffer* conv_reader_indices_buffer) {
+    using tt::tt_metal::CBDescriptor;
+    using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::ComputeConfigDescriptor;
+    using tt::tt_metal::DataMovementConfigDescriptor;
+    using tt::tt_metal::KernelDescriptor;
+    using tt::tt_metal::ProgramDescriptor;
+    using tt::tt_metal::SemaphoreDescriptor;
+
+    ProgramDescriptor desc;
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
 
@@ -497,15 +575,13 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     const uint32_t in0_num_blocks_w = conv_act_c_blocks * num_blocks_act_w;
 
     // weight
-    const uint32_t weight_dram_addr = b.buffer()->address();
+    tt::tt_metal::Buffer* weights_buffer = b.buffer();
 
     // bias
     tt::tt_metal::Buffer* bias_buffer = nullptr;
-    uint32_t bias_dram_addr = 0;
     uint32_t bias_ntiles = 0;
     if (has_bias) {
         bias_buffer = bias.value().buffer();
-        bias_dram_addr = bias_buffer->address();
         bias_ntiles =
             bias.value().padded_shape()[3] / tt::constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
     }
@@ -582,30 +658,6 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         act_block_h_ntiles);
     uint32_t num_blocks_act_h_per_core = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
 
-    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
-        ttnn::operations::sliding_window::generate_sliding_window_op_config(
-            op_trace_metadata,
-            shard_boundaries,
-            stride_w,
-            true,
-            enable_split_reader ? act_block_h_datums_split : act_block_h_datums,
-            enable_split_reader ? act_block_h_datums_split_last : 0);
-
-    // create sharded ttnn config tensors
-    sliding_window::ParallelConfig input_parallel_config = {
-        .grid = a.memory_config().shard_spec().value().grid,
-        .shard_scheme = a.memory_config().memory_layout(),
-        .shard_orientation = a.memory_config().shard_spec().value().orientation,
-    };
-
-    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
-        conv_sharded_input_top_left_indices, input_parallel_config, config_tensors_in_dram);
-    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
-
-    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
-
     TT_FATAL(
         act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0,
         "Activation matrix height in tiles ({}) must be divisible by per-core output matrix height in tiles ({})",
@@ -661,11 +713,14 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         .enable_weights_double_buffer = enable_weights_double_buffer,
         .enable_activation_reuse = enable_activation_reuse,
         .force_split_reader = force_split_reader};
+    // The conv_reader_indices tensor itself is allocated once in
+    // create_workload_descriptor and parked on workload_descriptor.buffers; we
+    // receive the raw Buffer* and read its page size for the CB sizing below.
     // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
     // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
     // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
     // populated by the reader kernel.
-    const uint32_t reader_indices_actual_page_size = conv_reader_indices_storage.get_buffer()->page_size();
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -685,8 +740,12 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         input_channels_padded,
         reader_indices_actual_page_size);
 
-    // call function to allocate circular buffers
-    allocate_cbs(cb_info, program, all_cores, a, output, conv_reader_indices_tensor);
+    // Emit CBDescriptors directly onto the ProgramDescriptor.  The framework
+    // tracks the globally-allocated CBs (ACT_SHARDED on input, OUT/PARTIALS on
+    // output, READER_INDICES on the workload-scoped indices buffer) and patches
+    // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
+    // override needed.
+    emit_cb_descriptors(cb_info, desc, all_cores, a.buffer(), output.buffer(), conv_reader_indices_buffer);
 
     const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
     const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
@@ -701,8 +760,8 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     CoreRangeSet mcast_sender_cores =
         CoreRangeSet(CoreRange(top_left_core, top_left_core));  // If single core, this kernel doesn't do mcasting
     CoreRangeSet mcast_receiver_cores;
-    uint32_t weights_mcast_sender_semaphore_id{};
-    uint32_t weights_mcast_receiver_semaphore_id{};
+    uint32_t weights_mcast_sender_semaphore_id = 0;
+    uint32_t weights_mcast_receiver_semaphore_id = 0;
     uint32_t act_mcast_sender_semaphore_id = 0;
     uint32_t act_mcast_receiver_semaphore_id = 0;
     uint32_t act_split_reader_reserve_done_semaphore_id = 0;
@@ -718,6 +777,18 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     // When split reader is enabled with overlapped CBs, both readers write to the same circular buffer.
     // This requires synchronization between the main reader and the second reader to prevent race conditions.
     const bool split_reader_cb_shared = enable_split_reader && overlap_act_cb && block_sharded;
+
+    // Sequential semaphore IDs match the order in which CreateSemaphore would have
+    // allocated them; the framework realises desc.semaphores in this order on cache miss.
+    auto push_semaphore = [&desc](const CoreRangeSet& cores) -> uint32_t {
+        uint32_t id = static_cast<uint32_t>(desc.semaphores.size());
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = id,
+            .core_ranges = cores,
+            .initial_value = 0,  // 0 == INVALID
+        });
+        return id;
+    };
 
     if (block_sharded) {
         const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
@@ -736,36 +807,31 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         if (populate_skipped_work_cores) {
             mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
         }
-        act_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-        act_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        act_mcast_sender_semaphore_id = push_semaphore(all_cores);
+        act_mcast_receiver_semaphore_id = push_semaphore(all_cores);
 
         if (split_reader_cb_shared) {
-            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            act_split_reader_reserve_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            act_split_reader_write_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_sender_semaphore_id = push_semaphore(all_cores);
+            weights_mcast_receiver_semaphore_id = push_semaphore(all_cores);
+            act_split_reader_reserve_done_semaphore_id = push_semaphore(all_cores);
+            act_split_reader_write_done_semaphore_id = push_semaphore(all_cores);
         } else {
-            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+            weights_mcast_sender_semaphore_id = push_semaphore(output_cores);
+            weights_mcast_receiver_semaphore_id = push_semaphore(output_cores);
         }
     } else {
         // 1D mcast
         if (!skip_weights_mcast) {
             mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
-            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+            weights_mcast_sender_semaphore_id = push_semaphore(output_cores);
+            weights_mcast_receiver_semaphore_id = push_semaphore(output_cores);
         }
     }
 
-    const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
-    const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
     // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
     const bool partials_cb_uses_output =
         !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
     log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
-    const tt::tt_metal::CBHandle cb_partials = is_conv_1d_depthwise_conv
-                                                   ? tt::tt_metal::CBHandle{}
-                                                   : get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     std::string reader_kernel;
     std::string compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp";
@@ -864,9 +930,9 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
         writer_defines["CONFIG_TENSOR_IN_DRAM"] = "1";               // Needed for split reader
         writer_mcast_sender_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
-        reader_compile_time_args.push_back(conv_reader_indices_storage.get_buffer()->address());
-        reader_compile_time_args.push_back(conv_reader_indices_storage.get_buffer()->page_size());
-        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_storage.get_buffer()).append_to(reader_compile_time_args);
+        reader_compile_time_args.push_back(conv_reader_indices_buffer->address());
+        reader_compile_time_args.push_back(conv_reader_indices_buffer->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(reader_compile_time_args);
     } else {
         // Put enough 0s so that the offsets of activation reuse args are the same.
         // TensorAccessorArgs appends 2 CT args (is_dram + aligned_page_size), so we need 4 zeros total
@@ -1111,48 +1177,63 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     const tt::tt_metal::NOC reader_noc =
         writer_mcast_noc == tt::tt_metal::NOC::NOC_0 ? tt::tt_metal::NOC::NOC_1 : tt::tt_metal::NOC::NOC_0;
 
-    tt::tt_metal::KernelHandle writer_mcast_sender_id = CreateKernel(
-        program,
-        writer_mcast_sender_kernel,
-        mcast_sender_cores,
-        tt::tt_metal::DataMovementConfig{
+    // Build the writer_mcast_sender kernel descriptor (placed on mcast_sender_cores).
+    // We build runtime_args below after kernel placement is fixed.
+    KernelDescriptor writer_mcast_sender_desc;
+    writer_mcast_sender_desc.kernel_source = writer_mcast_sender_kernel;
+    writer_mcast_sender_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_mcast_sender_desc.core_ranges = mcast_sender_cores;
+    writer_mcast_sender_desc.compile_time_args = writer_compile_time_args;
+    for (const auto& [k, v] : writer_mcast_sender_defines) {
+        writer_mcast_sender_desc.defines.emplace_back(k, v);
+    }
+    writer_mcast_sender_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = writer_mcast_noc,
+    };
+
+    // Optional writer_mcast_receiver kernel (created only when weights mcast is not skipped).
+    KernelDescriptor writer_mcast_receiver_desc;
+    const bool create_writer_mcast_receiver = !skip_weights_mcast;
+    if (create_writer_mcast_receiver) {
+        writer_mcast_receiver_desc.kernel_source = writer_mcast_receiver_kernel;
+        writer_mcast_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_mcast_receiver_desc.core_ranges = mcast_receiver_cores;
+        writer_mcast_receiver_desc.compile_time_args = writer_compile_time_args;
+        for (const auto& [k, v] : writer_defines) {
+            writer_mcast_receiver_desc.defines.emplace_back(k, v);
+        }
+        writer_mcast_receiver_desc.config = DataMovementConfigDescriptor{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = writer_mcast_noc,
-            .compile_args = writer_compile_time_args,
-            .defines = writer_mcast_sender_defines});
-
-    tt::tt_metal::KernelHandle writer_mcast_receiver_id = -1;
-    if (!skip_weights_mcast) {
-        writer_mcast_receiver_id = CreateKernel(
-            program,
-            writer_mcast_receiver_kernel,
-            mcast_receiver_cores,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = writer_mcast_noc,
-                .compile_args = writer_compile_time_args,
-                .defines = writer_defines});
+        };
     }
 
-    tt::tt_metal::KernelHandle reader_id = CreateKernel(
-        program,
-        reader_kernel,
-        height_sharded ? input_cores : all_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = reader_noc,
-            .compile_args = reader_compile_time_args,
-            .defines = reader_defines});
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = height_sharded ? input_cores : all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    for (const auto& [k, v] : reader_defines) {
+        reader_desc.defines.emplace_back(k, v);
+    }
+    reader_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = reader_noc,
+    };
 
-    tt::tt_metal::KernelHandle compute_kernel_id = CreateKernel(
-        program,
-        compute_kernel,
-        height_sharded ? input_cores : all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .defines = compute_defines});
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source = compute_kernel;
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = height_sharded ? input_cores : all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
+    for (const auto& [k, v] : compute_defines) {
+        compute_kernel_desc.defines.emplace_back(k, v);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     // Helper lambda to setup mcast arguments
     auto setup_mcast_args = [&](bool is_noc_0, uint32_t start_x, uint32_t start_y, uint32_t end_x, uint32_t end_y) {
@@ -1216,7 +1297,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                 reader_rt_args.push_back(static_cast<uint32_t>(is_sender_core));    // is_receiver_core
                 reader_rt_args.push_back(transpose_mcast ? core.x : core.y);        // dram config reader index
                 reader_rt_args.insert(reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
-                SetRuntimeArgs(program, reader_id, core, reader_rt_args);
+                reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
             }
         }
     } else {
@@ -1232,24 +1313,37 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                     }
                 }
                 std::vector<uint32_t> reader_rt_args{core_index, reader_remaining_tiles_to_push};
-                SetRuntimeArgs(program, reader_id, core, reader_rt_args);
+                reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
                 core_index++;
             }
         }
     }
 
     // Setup writer mcast arguments
-    // Setup sender args first
+    // Setup sender args first.  runtime_args[0] is the weight buffer address and
+    // runtime_args[1] is the (optional) bias buffer address; both are registered
+    // as Buffer* bindings via emplace_runtime_args so the framework's fast
+    // cache-hit path patches addresses without GetRuntimeArgs.  When bias is
+    // absent we embed a literal 0 — has_bias gates the bias read on the kernel
+    // side.
     for (const CoreRange& core_range : mcast_sender_cores.ranges()) {
         for (const CoreCoord& core : core_range) {
             if (populate_skipped_work_cores && !output_cores.contains(core)) {
-                std::vector<uint32_t> args = std::vector<uint32_t>(14, 0);
-                args[10] = weights_mcast_sender_semaphore_id;
-                args[11] = weights_mcast_receiver_semaphore_id;
-                args[12] =
-                    static_cast<uint32_t>(true);  // is_sender_core, is always true for cores that belong to input_cores
-                args[13] = static_cast<uint32_t>(true);  //  skip work
-                SetRuntimeArgs(program, writer_mcast_sender_id, core, args);
+                // Pad-out path: 14 zeros with only the semaphore/bias-flag slots
+                // populated.  weight/bias addresses are unused for skipped work
+                // cores so we keep them as literal zeros (no buffer binding).
+                KernelDescriptor::RTArgList args;
+                args.reserve(14);
+                args.push_back(uint32_t{0});  // 0: weight addr (unused for skipped cores)
+                args.push_back(uint32_t{0});  // 1: bias addr (unused)
+                for (int i = 2; i < 10; ++i) {
+                    args.push_back(uint32_t{0});
+                }
+                args.push_back(weights_mcast_sender_semaphore_id);
+                args.push_back(weights_mcast_receiver_semaphore_id);
+                args.push_back(uint32_t{1});  // is_sender_core, always true for input_cores
+                args.push_back(uint32_t{1});  // skip_work
+                writer_mcast_sender_desc.emplace_runtime_args(core, args);
                 continue;
             }
             // Calculate weight slice indices
@@ -1263,8 +1357,17 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                 "bias_tile_offset {} should be less than bias_ntiles {}",
                 bias_tile_offset,
                 bias_ntiles);
-            std::vector<uint32_t> sender_rt_args = {
-                weight_dram_addr, bias_dram_addr, out_start_tile_id_w, bias_tile_offset};
+
+            KernelDescriptor::RTArgList sender_rt_args;
+            sender_rt_args.push_back(weights_buffer);  // 0: weight buffer address (Buffer* binding)
+            if (bias_buffer != nullptr) {
+                sender_rt_args.push_back(bias_buffer);  // 1: bias buffer address (Buffer* binding)
+            } else {
+                sender_rt_args.push_back(uint32_t{0});  // 1: bias placeholder (has_bias gates the read)
+            }
+            sender_rt_args.push_back(out_start_tile_id_w);  // 2
+            sender_rt_args.push_back(bias_tile_offset);     // 3
+
             if (block_sharded) {
                 const bool is_sender_core = input_cores.contains(core);
                 // 2D multicast setup
@@ -1280,17 +1383,14 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                         bottom_right_core_physical.x,
                         right_core_physical.y);
 
-                    sender_rt_args.insert(sender_rt_args.end(), mcast_coords.begin(), mcast_coords.end());
-
-                    sender_rt_args.insert(
-                        sender_rt_args.end(),
-                        {num_cores_x - 1,
-                         num_cores_x - 1,  // mcast_num_dests, mcast_num_cores
-                         weights_mcast_sender_semaphore_id,
-                         weights_mcast_receiver_semaphore_id,
-                         static_cast<uint32_t>(is_sender_core),
-                         static_cast<uint32_t>(false)});  // skip_work
-                    SetRuntimeArgs(program, writer_mcast_sender_id, core, sender_rt_args);
+                    sender_rt_args.append(mcast_coords);
+                    sender_rt_args.push_back(num_cores_x - 1);  // mcast_num_dests
+                    sender_rt_args.push_back(num_cores_x - 1);  // mcast_num_cores
+                    sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
+                    sender_rt_args.push_back(static_cast<uint32_t>(is_sender_core));
+                    sender_rt_args.push_back(uint32_t{0});  // skip_work
+                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
                 } else {
                     CoreCoord top_core = {(std::size_t)core.x, 0};
                     CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
@@ -1302,18 +1402,14 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                         top_core_physical.x,
                         bottom_right_core_physical.y);
 
-                    sender_rt_args.insert(sender_rt_args.end(), mcast_coords.begin(), mcast_coords.end());
-                    sender_rt_args.insert(
-                        sender_rt_args.end(),
-                        {
-                            num_cores_y - 1,
-                            num_cores_y - 1,  // mcast_num_dests, mcast_num_cores
-                            weights_mcast_sender_semaphore_id,
-                            weights_mcast_receiver_semaphore_id,
-                            static_cast<uint32_t>(is_sender_core),
-                            static_cast<uint32_t>(false)  // skip_work
-                        });
-                    SetRuntimeArgs(program, writer_mcast_sender_id, core, sender_rt_args);
+                    sender_rt_args.append(mcast_coords);
+                    sender_rt_args.push_back(num_cores_y - 1);  // mcast_num_dests
+                    sender_rt_args.push_back(num_cores_y - 1);  // mcast_num_cores
+                    sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
+                    sender_rt_args.push_back(static_cast<uint32_t>(is_sender_core));
+                    sender_rt_args.push_back(uint32_t{0});  // skip_work
+                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
                 }
             } else {
                 // 1D multicast setup
@@ -1324,13 +1420,11 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                     bottom_right_core_physical.x,
                     bottom_right_core_physical.y);
 
-                sender_rt_args.insert(sender_rt_args.end(), mcast_coords.begin(), mcast_coords.end());
-                sender_rt_args.insert(
-                    sender_rt_args.end(),
-                    {total_active_num_cores - 1,
-                     total_num_cores - 1,  // mcast_num_dests, mcast_num_cores
-                     weights_mcast_sender_semaphore_id,
-                     weights_mcast_receiver_semaphore_id});
+                sender_rt_args.append(mcast_coords);
+                sender_rt_args.push_back(total_active_num_cores - 1);  // mcast_num_dests
+                sender_rt_args.push_back(total_num_cores - 1);         // mcast_num_cores
+                sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
                 if (enable_activation_reuse) {
                     uint32_t writer_remaining_tiles_to_push = 0;
                     if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
@@ -1341,53 +1435,56 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
                     }
                     sender_rt_args.push_back(writer_remaining_tiles_to_push);
                 }
-                SetRuntimeArgs(program, writer_mcast_sender_id, core, sender_rt_args);
+                writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
             }
         }
     }
 
     // Setup receiver args second
-    for (const CoreRange& core_range : mcast_receiver_cores.ranges()) {
-        // Helper lambda to create receiver runtime args
-        auto create_receiver_args = [&](uint32_t sender_noc_x, uint32_t sender_noc_y) {
-            return std::vector<uint32_t>{
-                sender_noc_x, sender_noc_y, weights_mcast_sender_semaphore_id, weights_mcast_receiver_semaphore_id};
-        };
+    if (create_writer_mcast_receiver) {
+        for (const CoreRange& core_range : mcast_receiver_cores.ranges()) {
+            // Helper lambda to create receiver runtime args
+            auto create_receiver_args = [&](uint32_t sender_noc_x, uint32_t sender_noc_y) {
+                return std::vector<uint32_t>{
+                    sender_noc_x, sender_noc_y, weights_mcast_sender_semaphore_id, weights_mcast_receiver_semaphore_id};
+            };
 
-        for (const CoreCoord& core : core_range) {
-            std::vector<uint32_t> receiver_args;
-            if (block_sharded) {
-                if (transpose_mcast) {
-                    CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.y};
-                    CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
-                    receiver_args = create_receiver_args(top_left_core_physical.x, right_core_physical.y);
-                } else {
-                    CoreCoord top_core = {(std::size_t)core.x, 0};
-                    CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
-                    receiver_args = create_receiver_args(top_core_physical.x, top_left_core_physical.y);
-                }
-                const bool is_sender_core = input_cores.contains(core);
-                receiver_args.push_back(static_cast<uint32_t>(is_sender_core));
-            } else {
-                bool is_no_op_core = !input_cores.contains(core);
-                receiver_args = std::vector<uint32_t>{
-                    static_cast<uint32_t>(is_no_op_core),
-                    top_left_core_physical.x,
-                    top_left_core_physical.y,
-                    weights_mcast_sender_semaphore_id,
-                    weights_mcast_receiver_semaphore_id};
-                if (enable_activation_reuse) {
-                    uint32_t writer_remaining_tiles_to_push = 0;
-                    if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
-                        writer_remaining_tiles_to_push =
-                            activation_reuse_config.partial_core_writer_remaining_tiles_to_push_to_push;
-                    } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
-                        writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
+            for (const CoreCoord& core : core_range) {
+                std::vector<uint32_t> receiver_args;
+                if (block_sharded) {
+                    if (transpose_mcast) {
+                        CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.y};
+                        CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
+                        receiver_args = create_receiver_args(top_left_core_physical.x, right_core_physical.y);
+                    } else {
+                        CoreCoord top_core = {(std::size_t)core.x, 0};
+                        CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
+                        receiver_args = create_receiver_args(top_core_physical.x, top_left_core_physical.y);
                     }
-                    receiver_args.push_back(writer_remaining_tiles_to_push);
+                    const bool is_sender_core = input_cores.contains(core);
+                    receiver_args.push_back(static_cast<uint32_t>(is_sender_core));
+                } else {
+                    bool is_no_op_core = !input_cores.contains(core);
+                    receiver_args = std::vector<uint32_t>{
+                        static_cast<uint32_t>(is_no_op_core),
+                        top_left_core_physical.x,
+                        top_left_core_physical.y,
+                        weights_mcast_sender_semaphore_id,
+                        weights_mcast_receiver_semaphore_id};
+                    if (enable_activation_reuse) {
+                        uint32_t writer_remaining_tiles_to_push = 0;
+                        if (activation_reuse_config.has_partial_core &&
+                            core == activation_reuse_config.partial_work_core) {
+                            writer_remaining_tiles_to_push =
+                                activation_reuse_config.partial_core_writer_remaining_tiles_to_push_to_push;
+                        } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
+                            writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
+                        }
+                        receiver_args.push_back(writer_remaining_tiles_to_push);
+                    }
                 }
+                writer_mcast_receiver_desc.runtime_args.emplace_back(core, std::move(receiver_args));
             }
-            SetRuntimeArgs(program, writer_mcast_receiver_id, core, receiver_args);
         }
     }
 
@@ -1398,65 +1495,161 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         for (const CoreRange range : all_cores.ranges()) {
             for (const CoreCoord core : range) {
                 bool skip_compute = transpose_mcast ? core.y > end_coord_y : core.x > end_coord_x;
-                SetRuntimeArgs(
-                    program, compute_kernel_id, core, std::vector<uint32_t>{static_cast<uint32_t>(skip_compute)});
+                compute_kernel_desc.runtime_args.emplace_back(
+                    core, std::vector<uint32_t>{static_cast<uint32_t>(skip_compute)});
             }
         }
     }
 
-    std::vector<CoreCoord> mcast_sender_cores_vec;
-    for (const CoreRange& core_range : mcast_sender_cores.ranges()) {
-        std::vector<CoreCoord> core_range_vec = grid_to_cores(core_range.start_coord, core_range.end_coord, true);
-        mcast_sender_cores_vec.insert(mcast_sender_cores_vec.end(), core_range_vec.begin(), core_range_vec.end());
+    // NOTE: post_conv2d_op_memory_checks() operates on a tt::tt_metal::Program;
+    // in the ProgramDescriptor world the framework realises the Program on cache
+    // miss after this returns, so the original CB-size / L1-allocator sanity
+    // check cannot be invoked here.  The CB sizing comes from get_cb_info()
+    // which is shared with the legacy path, so behavioural equivalence is
+    // preserved.
+
+    desc.kernels.push_back(std::move(writer_mcast_sender_desc));
+    if (create_writer_mcast_receiver) {
+        desc.kernels.push_back(std::move(writer_mcast_receiver_desc));
     }
-    post_conv2d_op_memory_checks(
-        program, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
-    // Capture conv_reader_indices_storage to cache this with the program
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .mcast_sender_cores_vec = mcast_sender_cores_vec,
-            .writer_mcast_sender_id = writer_mcast_sender_id,
-            .cb_sharded_act = cb_sharded_act,
-            .cb_output = cb_output,
-            .cb_partials = cb_partials,
-            .partials_cb_uses_output = partials_cb_uses_output,
-            .has_bias = has_bias,
-            .conv_reader_indices_storage = conv_reader_indices_storage,
-        }};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+    return desc;
 }
 
-void Conv2dShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const Conv2dParams& /*operation_attributes*/,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
+    const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto* src_buffer_a = tensor_args.a.buffer();
-    auto* src_buffer_b = tensor_args.b.buffer();
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    const auto& shared_variables = cached_program.shared_variables;
-    auto& program = cached_program.program;
+    // Allocate the conv_reader_indices tensor on device once for the whole
+    // workload.  Wrap it in a shared_ptr<Tensor> so ~Tensor doesn't fire when
+    // the local goes out of scope: ~Tensor calls DeviceStorage::deallocate
+    // which force-frees the device buffer regardless of any shared_ptr
+    // ownership of the MeshBuffer (see WorkloadBuffer rationale in
+    // workload_descriptor.hpp).  Holding the Tensor in the WorkloadDescriptor
+    // defers destruction until the cached workload is evicted.
+    const auto& a = tensor_args.a;
+    const auto& sliding_window_config = operation_attributes.sliding_window_config;
+    const auto& block_config = operation_attributes.block_config;
+    const auto& parallelization_config = operation_attributes.parallelization_config;
+    const auto enable_activation_reuse = operation_attributes.enable_activation_reuse;
+    const auto enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
+    const auto force_split_reader = operation_attributes.force_split_reader;
+    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+    const bool block_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool height_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
 
-    std::optional<tt::tt_metal::Buffer*> src_buffer_c = std::nullopt;
-    if (shared_variables.has_bias) {
-        src_buffer_c = tensor_args.bias.value().buffer();
-        TT_FATAL(src_buffer_c.value() != nullptr, "Source buffer C must not be null when bias is present");
+    sliding_window::ParallelConfig input_parallel_config = {
+        .grid = a.memory_config().shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.memory_config().shard_spec().value().orientation,
+    };
+
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+
+    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
+    const uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
+
+    // Determine the (act_block_h_datums, last) pair for the host-side index
+    // generator.  This must agree exactly with the enable_split_reader path
+    // computed by build_program_descriptor(), since the generated index tensor
+    // is consumed by the reader kernel.
+    const auto& b = tensor_args.b;
+    const auto& bias = tensor_args.bias;
+    const auto output_channels = operation_attributes.output_channels;
+    const auto groups = operation_attributes.groups;
+    const auto has_bias = operation_attributes.has_bias;
+    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;
+    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;
+    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const ttnn::Shape ashape(operation_attributes.input_tensor_shape);
+    const std::array<uint32_t, 2> shard_shape = a.shard_spec().value().shape;
+
+    uint32_t input_channels_padded = shard_shape[1];
+    if (block_sharded) {
+        const uint32_t in_num_cores_x = input_parallel_config.grid.bounding_box().end_coord.x + 1;
+        const uint32_t in_num_cores_y = input_parallel_config.grid.bounding_box().end_coord.y + 1;
+        const bool transpose_mcast = a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+        input_channels_padded = shard_shape[1] * (transpose_mcast ? in_num_cores_y : in_num_cores_x);
     }
+    const bool is_conv_1d_depthwise_conv =
+        is_1d_depthwise_conv(groups, ashape[3], output_channels, filter_h, ashape[1], has_bias);
 
-    auto& writer_sender_kernel_args_by_core = GetRuntimeArgs(program, shared_variables.writer_mcast_sender_id);
-    for (const auto& core : shared_variables.mcast_sender_cores_vec) {
-        auto& runtime_args = writer_sender_kernel_args_by_core[core.x][core.y];
-        runtime_args[0] = src_buffer_b->address();
-        if (shared_variables.has_bias) {
-            runtime_args[1] = (*src_buffer_c)->address();
-        }
-    }
+    auto compute_kernel_config_args =
+        get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
+    const bool fp32_dest_acc_en = std::get<2>(compute_kernel_config_args);
 
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_sharded_act, *src_buffer_a);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *output_tensor.buffer());
-    if (shared_variables.partials_cb_uses_output) {
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_partials, *output_tensor.buffer());
+    const bool enable_split_reader =
+        is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
+        force_split_reader.value_or(is_split_reader_viable(
+            a.memory_config().memory_layout(),
+            act_block_h_ntiles,
+            input_channels_padded,
+            filter_w,
+            tt::tt_metal::hal::get_arch(),
+            a.dtype(),
+            parallelization_config.per_core_out_matrix_width_ntile * block_config.act_block_w_ntiles,
+            tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(b.dtype())),
+            dilation_w,
+            parallelization_config.per_core_out_matrix_height_ntile / block_config.act_block_h_ntiles,
+            block_config.act_block_w_ntiles,
+            fp32_dest_acc_en,
+            output_tensor.dtype(),
+            enable_activation_reuse));
+
+    uint32_t act_block_h_nsubblocks_split = block_config.act_block_h_ntiles;
+    uint32_t act_block_h_nsubblocks_split_last = 0;
+    if (enable_split_reader) {
+        act_block_h_nsubblocks_split_last = block_config.act_block_h_ntiles / 2;
+        act_block_h_nsubblocks_split = block_config.act_block_h_ntiles - act_block_h_nsubblocks_split_last;
     }
+    const uint32_t act_block_h_datums = act_block_h_ntiles * tt::constants::TILE_HEIGHT;
+    const uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * tt::constants::TILE_HEIGHT;
+    const uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * tt::constants::TILE_HEIGHT;
+
+    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
+        ttnn::operations::sliding_window::generate_sliding_window_op_config(
+            op_trace_metadata,
+            shard_boundaries,
+            stride_w,
+            true,
+            enable_split_reader ? act_block_h_datums_split : act_block_h_datums,
+            enable_split_reader ? act_block_h_datums_split_last : 0);
+
+    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, input_parallel_config, config_tensors_in_dram);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
+
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
+
+    auto conv_reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor));
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_tensor_owner->buffer();
+    workload_descriptor.buffers.push_back({conv_reader_indices_tensor_owner, conv_reader_indices_buffer});
+
+    // Single-device op: per-coord program is structurally identical for every
+    // coord in `tensor_coords` (conv2d doesn't depend on cluster position).
+    // Build the ProgramDescriptor once and copy into each range entry.
+    tt::tt_metal::ProgramDescriptor desc =
+        build_program_descriptor(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -175,62 +175,6 @@ ActivationReuseConfig calculate_activation_reuse_params(
 
 namespace {
 
-// Build CBDescriptor entries from CBInfo, mirroring allocate_cbs() (in
-// conv2d_op_program_factory_common.cpp) but emitting onto a ProgramDescriptor.
-// The set of globally-allocated CBs (ACT_SHARDED/OUT/MATMUL_PARTIALS/READER_INDICES)
-// is wired to the supplied raw Buffer*s, which is what the framework's fast
-// cache-hit path patches.
-void emit_cb_descriptors_sharded(
-    std::vector<CBInfo>& cb_info,
-    tt::tt_metal::ProgramDescriptor& desc,
-    const CoreRangeSet& all_cores_set,
-    tt::tt_metal::Buffer* input_buffer,
-    tt::tt_metal::Buffer* output_buffer,
-    tt::tt_metal::Buffer* indices_buffer) {
-    uint32_t cb_index = 0;
-    for (auto& cb : cb_info) {
-        if (cb.num_pages == 0) {
-            // Skip circular buffers with zero pages (matches allocate_cbs behavior).
-            continue;
-        }
-
-        tt::tt_metal::Buffer* buffer = nullptr;
-        if (cb.is_globally_allocated) {
-            if (cb.name == Conv2dCb::ACT_SHARDED) {
-                buffer = input_buffer;
-            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
-                buffer = output_buffer;
-            } else if (cb.name == Conv2dCb::READER_INDICES) {
-                buffer = indices_buffer;
-            } else {
-                TT_THROW(
-                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
-                    enchantum::to_string(cb.name));
-            }
-        }
-
-        cb.index = cb_index++;
-        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = cb.num_pages * cb.page_size,
-            .core_ranges = all_cores_set,
-            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(cb.index),
-                .data_format = cb.data_format,
-                .page_size = cb.page_size,
-            }}},
-            .buffer = buffer,
-        });
-    }
-
-    for (auto& cb : cb_info) {
-        if (cb.overlapped_by_cb.has_value()) {
-            // If this CB is overlapped by another CB, mirror the overlapped CB's index.
-            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
-            cb.index = overlapped_cb.index;
-        }
-    }
-}
-
 // Per-coord ProgramDescriptor build (originally lived in the legacy
 // Conv2dShardedProgramFactory::create body).  The intermediate
 // conv_reader_indices tensor is allocated once by create_workload_descriptor and
@@ -743,7 +687,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
     // output, READER_INDICES on the workload-scoped indices buffer) and patches
     // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
     // override needed.
-    emit_cb_descriptors_sharded(cb_info, desc, all_cores, a.buffer(), output.buffer(), conv_reader_indices_buffer);
+    emit_cb_descriptors(cb_info, desc, all_cores, a.buffer(), output.buffer(), conv_reader_indices_buffer);
 
     const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
     const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
@@ -1499,12 +1443,11 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         }
     }
 
-    // NOTE: post_conv2d_op_memory_checks() operates on a tt::tt_metal::Program;
-    // in the ProgramDescriptor world the framework realises the Program on cache
-    // miss after this returns, so the original CB-size / L1-allocator sanity
-    // check cannot be invoked here.  The CB sizing comes from get_cb_info()
-    // which is shared with the legacy path, so behavioural equivalence is
-    // preserved.
+    // Descriptor-path CB-size check (mirrors the legacy post_conv2d_op_memory_checks
+    // CB-sizing equality).  The L1-allocator delta half of the legacy check requires a
+    // realised Program and so isn't reachable here: the framework realises the Program
+    // after this function returns.
+    post_conv2d_op_memory_checks_descriptor(desc, operation_attributes, tensor_args, reader_indices_actual_page_size);
 
     desc.kernels.push_back(std::move(writer_mcast_sender_desc));
     if (create_writer_mcast_receiver) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -3,33 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::prim {
 
 struct Conv2dShardedProgramFactory {
-    struct shared_variables_t {
-        std::vector<CoreCoord> mcast_sender_cores_vec;
-        tt::tt_metal::KernelHandle writer_mcast_sender_id{};
-        tt::tt_metal::CBHandle cb_sharded_act{};
-        tt::tt_metal::CBHandle cb_output{};
-        tt::tt_metal::CBHandle cb_partials{};
-        bool partials_cb_uses_output = false;
-        bool has_bias = false;
-        tt::tt_metal::DeviceStorage conv_reader_indices_storage;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Builds the workload in one call (cache miss).  The intermediate
+    // conv_reader_indices tensor — which must outlive the cached program — is
+    // allocated here and parked on the WorkloadDescriptor's `buffers` vector
+    // (wrapped in `shared_ptr<Tensor>` so `~Tensor` cannot force-deallocate the
+    // device memory while the cached program is still alive).
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const Conv2dParams& operation_attributes,
         const Conv2dInputs& tensor_args,
-        Tensor& output_tensor);
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -115,7 +115,7 @@ namespace {
 // conv_reader_indices tensor is allocated once by create_workload_descriptor and
 // parked on the WorkloadDescriptor; we receive the raw Buffer* here and wire it
 // into the READER_INDICES CB and reader CT args.
-static tt::tt_metal::ProgramDescriptor build_program_descriptor(
+tt::tt_metal::ProgramDescriptor build_program_descriptor(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
     Tensor& output_tensor,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -50,11 +50,9 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
 
 namespace {
 
-// Per-coord ProgramDescriptor build (originally lived in the legacy
-// Conv2dWidthShardedProgramFactory::create body).  The intermediate
-// conv_reader_indices tensor is allocated once by create_workload_descriptor and
-// parked on the WorkloadDescriptor; we receive the raw Buffer* here and wire it
-// into the READER_INDICES CB and reader CT args.
+// The intermediate conv_reader_indices tensor is allocated once by
+// create_workload_descriptor and parked on the WorkloadDescriptor; we receive
+// the raw Buffer* here and wire it into the READER_INDICES CB and reader CT args.
 tt::tt_metal::ProgramDescriptor build_program_descriptor(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
 #include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp"
@@ -14,10 +16,72 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
 
 namespace ttnn::prim {
+
+namespace {
+
+// Build CBDescriptor entries from CBInfo, mirroring allocate_cbs() (in
+// conv2d_op_program_factory_common.cpp) but emitting onto a ProgramDescriptor.
+// The set of globally-allocated CBs (ACT_SHARDED/OUT/MATMUL_PARTIALS/READER_INDICES)
+// is wired to the supplied raw Buffer*s, which is what the framework's fast
+// cache-hit path patches.
+void emit_cb_descriptors(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::ProgramDescriptor& desc,
+    const CoreRangeSet& all_cores_set,
+    tt::tt_metal::Buffer* input_buffer,
+    tt::tt_metal::Buffer* output_buffer,
+    tt::tt_metal::Buffer* indices_buffer) {
+    uint32_t cb_index = 0;
+    for (auto& cb : cb_info) {
+        if (cb.num_pages == 0) {
+            // Skip circular buffers with zero pages (matches allocate_cbs behavior).
+            continue;
+        }
+
+        tt::tt_metal::Buffer* buffer = nullptr;
+        if (cb.is_globally_allocated) {
+            if (cb.name == Conv2dCb::ACT_SHARDED) {
+                buffer = input_buffer;
+            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
+                buffer = output_buffer;
+            } else if (cb.name == Conv2dCb::READER_INDICES) {
+                buffer = indices_buffer;
+            } else {
+                TT_THROW(
+                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
+                    enchantum::to_string(cb.name));
+            }
+        }
+
+        cb.index = cb_index++;
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = cb.num_pages * cb.page_size,
+            .core_ranges = all_cores_set,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb.index),
+                .data_format = cb.data_format,
+                .page_size = cb.page_size,
+            }}},
+            .buffer = buffer,
+        });
+    }
+
+    for (auto& cb : cb_info) {
+        if (cb.overlapped_by_cb.has_value()) {
+            // If this CB is overlapped by another CB, mirror the overlapped CB's index.
+            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
+            cb.index = overlapped_cb.index;
+        }
+    }
+}
+
+}  // namespace
 
 namespace unary = ttnn::operations::unary;
 using ttnn::operations::conv::conv_skip_mcast;
@@ -44,9 +108,27 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
     return {{1, num_rows_padded, num_cols_padded}, {1, num_rows, num_cols}};
 }
 
-Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFactory::create(
-    const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+namespace {
+
+// Per-coord ProgramDescriptor build (originally lived in the legacy
+// Conv2dWidthShardedProgramFactory::create body).  The intermediate
+// conv_reader_indices tensor is allocated once by create_workload_descriptor and
+// parked on the WorkloadDescriptor; we receive the raw Buffer* here and wire it
+// into the READER_INDICES CB and reader CT args.
+static tt::tt_metal::ProgramDescriptor build_program_descriptor(
+    const Conv2dParams& operation_attributes,
+    const Conv2dInputs& tensor_args,
+    Tensor& output_tensor,
+    tt::tt_metal::Buffer* conv_reader_indices_buffer) {
+    using tt::tt_metal::CBDescriptor;
+    using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::ComputeConfigDescriptor;
+    using tt::tt_metal::DataMovementConfigDescriptor;
+    using tt::tt_metal::KernelDescriptor;
+    using tt::tt_metal::ProgramDescriptor;
+    using tt::tt_metal::SemaphoreDescriptor;
+
+    ProgramDescriptor desc;
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
 
@@ -341,8 +423,20 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         (uint32_t)weights_noc,
         (uint32_t)device->arch());
 
-    uint32_t act_mcast_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);    // 0==INVALID
-    uint32_t act_mcast_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);  // 0==INVALID.
+    // Sequential semaphore IDs match the order in which CreateSemaphore would have
+    // allocated them; the framework realises desc.semaphores in this order on cache miss.
+    uint32_t act_mcast_sender_semaphore = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = act_mcast_sender_semaphore,
+        .core_ranges = all_cores,
+        .initial_value = 0,  // 0 == INVALID
+    });
+    uint32_t act_mcast_receiver_semaphore = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = act_mcast_receiver_semaphore,
+        .core_ranges = all_cores,
+        .initial_value = 0,  // 0 == INVALID
+    });
 
     CoreCoord act_mcast_start_core_logical(0, 0);
     CoreCoord act_mcast_end_core_logical(all_cores.bounding_box().end_coord.x, all_cores.bounding_box().end_coord.y);
@@ -400,24 +494,14 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         .enable_act_double_buffer = enable_act_double_buffer,
         .enable_weights_double_buffer = enable_weights_double_buffer};
 
-    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
-        ttnn::operations::sliding_window::generate_sliding_window_op_config(
-            op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
-
-    // create sharded ttnn config tensors
-    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
-        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
-    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
-
-    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
-
+    // The conv_reader_indices tensor itself is allocated once in
+    // create_workload_descriptor and parked on workload_descriptor.buffers; we
+    // receive the raw Buffer* and read its page size for the CB sizing below.
     // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
     // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
     // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
     // populated by the reader kernel.
-    const uint32_t reader_indices_actual_page_size = conv_reader_indices_storage.get_buffer()->page_size();
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -437,12 +521,18 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         input_channels_padded,
         reader_indices_actual_page_size);
 
-    // call function to allocate circular buffers
-    allocate_cbs(cb_info, program, all_reader_cores, a, output, conv_reader_indices_tensor);
-    const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
-    const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
+    // Emit CBDescriptors directly onto the ProgramDescriptor.  The framework
+    // tracks the globally-allocated CBs (ACT_SHARDED on input, OUT/PARTIALS on
+    // output, READER_INDICES on the workload-scoped indices buffer) and patches
+    // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
+    // override needed.
+    const CoreRangeSet all_reader_cores_set(all_reader_cores);
+    emit_cb_descriptors(cb_info, desc, all_reader_cores_set, a.buffer(), output.buffer(), conv_reader_indices_buffer);
+    // partials_cb_uses_output is still consumed by compute_kernel_args below; the
+    // CB-on-output wiring is handled inline by emit_cb_descriptors (MATMUL_PARTIALS
+    // is mapped to output_buffer when is_globally_allocated is true), so we no
+    // longer need to call UpdateDynamicCircularBufferAddress on cache hit.
     const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
-    const tt::tt_metal::CBHandle cb_partials = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     std::vector<uint32_t> compute_kernel_args = {
         act_block_w_ntiles,                         // in0_block_w
@@ -538,10 +628,9 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
 
     if (config_tensors_in_dram) {
         reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
-        activation_kernel_compile_args.push_back(conv_reader_indices_storage.get_buffer()->address());
-        activation_kernel_compile_args.push_back(conv_reader_indices_storage.get_buffer()->page_size());
-        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_storage.get_buffer())
-            .append_to(activation_kernel_compile_args);
+        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->address());
+        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(activation_kernel_compile_args);
     }
 
     for (uint32_t index = 0; index < activation_kernel_compile_args.size(); index++) {
@@ -551,35 +640,44 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
     tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(weights_kernel_compile_args);
     tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(weights_kernel_compile_args);
 
-    auto act_kernel_id = CreateKernel(
-        program,
-        activation_kernel_path,
-        all_reader_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = act_noc,
-            .compile_args = activation_kernel_compile_args,
-            .defines = reader_defines});
+    KernelDescriptor act_kernel_desc;
+    act_kernel_desc.kernel_source = activation_kernel_path;
+    act_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    act_kernel_desc.core_ranges = CoreRangeSet(all_reader_cores);
+    act_kernel_desc.compile_time_args = std::move(activation_kernel_compile_args);
+    for (const auto& [k, v] : reader_defines) {
+        act_kernel_desc.defines.emplace_back(k, v);
+    }
+    act_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = act_noc,
+    };
 
-    auto weights_kernel_id = CreateKernel(
-        program,
-        weights_kernel_path,
-        all_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = weights_noc,
-            .compile_args = weights_kernel_compile_args,
-            .defines = writer_defines});
+    KernelDescriptor weights_kernel_desc;
+    weights_kernel_desc.kernel_source = weights_kernel_path;
+    weights_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    weights_kernel_desc.core_ranges = all_cores;
+    weights_kernel_desc.compile_time_args = std::move(weights_kernel_compile_args);
+    for (const auto& [k, v] : writer_defines) {
+        weights_kernel_desc.defines.emplace_back(k, v);
+    }
+    weights_kernel_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = weights_noc,
+    };
 
-    CreateKernel(
-        program,
-        compute_kernel_path,
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_kernel_args,
-            .defines = compute_defines});
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source = compute_kernel_path;
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
+    for (const auto& [k, v] : compute_defines) {
+        compute_kernel_desc.defines.emplace_back(k, v);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
     auto full_core_grid = device->compute_with_storage_grid_size();
     std::vector<uint32_t> act_mcast_noc_y;
@@ -595,12 +693,12 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         act_mcast_noc_y.push_back(device->worker_core_from_logical_core(CoreCoord(0, core_index)).y);
     }
 
-    uint32_t bias_base_address = 0;
-    if (bias) {
-        bias_base_address = bias.value().buffer()->address();
-    }
+    tt::tt_metal::Buffer* weights_buffer = b.buffer();
+    tt::tt_metal::Buffer* bias_buffer = bias ? bias->buffer() : nullptr;
     auto total_num_active_cores = std::max(input_num_cores, output_num_cores);
     auto total_num_cores = all_reader_cores.size();
+    act_kernel_desc.runtime_args.reserve(total_num_cores);
+    weights_kernel_desc.runtime_args.reserve(total_num_active_cores);
     for (uint32_t core_index = 0; core_index < total_num_cores; core_index++) {
         uint32_t core_x = core_index % full_core_grid.x;
         uint32_t core_y = core_index / full_core_grid.x;
@@ -616,65 +714,105 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         // Mcast Y Lookup Table
         rt_args.insert(rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
 
-        SetRuntimeArgs(program, act_kernel_id, CoreCoord(core_x, core_y), rt_args);
+        act_kernel_desc.runtime_args.emplace_back(CoreCoord(core_x, core_y), std::move(rt_args));
 
-        // Weights kernel is not placed on inactive cores.
+        // Weights kernel is not placed on inactive cores.  Weights[1] is the
+        // weight buffer base address and bias[2] is the (optional) bias address;
+        // emplace_runtime_args registers them as buffer bindings so the
+        // framework's fast cache-hit path patches addresses without
+        // GetRuntimeArgs.  When bias is absent we embed a literal 0 — has_bias
+        // gates the bias read on the kernel side.
         if (core_index < total_num_active_cores) {
-            SetRuntimeArgs(
-                program,
-                weights_kernel_id,
-                CoreCoord(core_x, core_y),
-                {core_index * weight_block_w_ntiles,
-                 b.buffer()->address(),
-                 bias_base_address,
-                 (uint32_t)(core_index < output_num_cores)});
+            KernelDescriptor::RTArgList weights_rt_args;
+            weights_rt_args.reserve(4);
+            weights_rt_args.push_back(static_cast<uint32_t>(core_index * weight_block_w_ntiles));
+            weights_rt_args.push_back(weights_buffer);
+            if (bias_buffer != nullptr) {
+                weights_rt_args.push_back(bias_buffer);
+            } else {
+                weights_rt_args.push_back(uint32_t{0});
+            }
+            weights_rt_args.push_back(static_cast<uint32_t>(core_index < output_num_cores));
+            weights_kernel_desc.emplace_runtime_args(CoreCoord(core_x, core_y), weights_rt_args);
         }
     }
 
-    post_conv2d_op_memory_checks(
-        program, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .cb_sharded_act = cb_sharded_act,
-            .cb_output = cb_output,
-            .cb_partials = cb_partials,
-            .partials_cb_uses_output = partials_cb_uses_output,
-            .has_bias = has_bias,
-            .full_core_grid = full_core_grid,
-            .weights_kernel_id = weights_kernel_id,
-            .total_num_active_cores = total_num_active_cores,
-            .conv_reader_indices_storage = conv_reader_indices_storage,
-        }};
+    // NOTE: post_conv2d_op_memory_checks() operates on a tt::tt_metal::Program;
+    // in the ProgramDescriptor world the framework realises the Program on cache
+    // miss after this returns, so the original CB-size / L1-allocator sanity
+    // check cannot be invoked here.  The CB sizing comes from get_cb_info()
+    // which is shared with the legacy path, so behavioural equivalence is
+    // preserved.
+
+    desc.kernels.push_back(std::move(act_kernel_desc));
+    desc.kernels.push_back(std::move(weights_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+    return desc;
 }
 
-void Conv2dWidthShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const Conv2dParams& /*operation_attributes*/,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
+    const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto* src_buffer_a = tensor_args.a.buffer();
-    auto* src_buffer_b = tensor_args.b.buffer();
-    auto& program = cached_program.program;
-    const auto& shared_variables = cached_program.shared_variables;
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    auto& weights_kernel_runtime_args = GetRuntimeArgs(program, shared_variables.weights_kernel_id);
-    for (uint32_t core_index = 0; core_index < shared_variables.total_num_active_cores; core_index++) {
-        uint32_t core_x = core_index % shared_variables.full_core_grid.x;
-        uint32_t core_y = core_index / shared_variables.full_core_grid.x;
+    // Allocate the conv_reader_indices tensor on device once for the whole
+    // workload.  Wrap it in a shared_ptr<Tensor> so ~Tensor doesn't fire when
+    // the local goes out of scope: ~Tensor calls DeviceStorage::deallocate
+    // which force-frees the device buffer regardless of any shared_ptr
+    // ownership of the MeshBuffer (see WorkloadBuffer rationale in
+    // workload_descriptor.hpp).  Holding the Tensor in the WorkloadDescriptor
+    // defers destruction until the cached workload is evicted.
+    const auto& a = tensor_args.a;
+    const auto& sliding_window_config = operation_attributes.sliding_window_config;
+    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
 
-        auto& this_core_weights_kernel_runtime_args = weights_kernel_runtime_args[core_x][core_y];
-        this_core_weights_kernel_runtime_args[1] = src_buffer_b->address();
-        if (shared_variables.has_bias) {
-            this_core_weights_kernel_runtime_args[2] = tensor_args.bias.value().buffer()->address();
-        }
+    ttnn::operations::sliding_window::ParallelConfig parallel_config{
+        .grid = a.shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.shard_spec().value().orientation};
+
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
+    const uint32_t act_block_h_ntiles = operation_attributes.block_config.act_block_h_ntiles;
+    const uint32_t act_block_h_datums = act_block_h_ntiles * tt::constants::TILE_HEIGHT;
+
+    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
+        ttnn::operations::sliding_window::generate_sliding_window_op_config(
+            op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
+
+    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
+
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
+
+    auto conv_reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor));
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_tensor_owner->buffer();
+    workload_descriptor.buffers.push_back({conv_reader_indices_tensor_owner, conv_reader_indices_buffer});
+
+    // Single-device op: per-coord program is structurally identical for every
+    // coord in `tensor_coords` (conv2d doesn't depend on cluster position).
+    // Build the ProgramDescriptor once and copy into each range entry.
+    tt::tt_metal::ProgramDescriptor desc =
+        build_program_descriptor(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
     }
-
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_sharded_act, *src_buffer_a);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *output_tensor.buffer());
-    if (shared_variables.partials_cb_uses_output) {
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_partials, *output_tensor.buffer());
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
     }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -23,66 +23,6 @@
 
 namespace ttnn::prim {
 
-namespace {
-
-// Build CBDescriptor entries from CBInfo, mirroring allocate_cbs() (in
-// conv2d_op_program_factory_common.cpp) but emitting onto a ProgramDescriptor.
-// The set of globally-allocated CBs (ACT_SHARDED/OUT/MATMUL_PARTIALS/READER_INDICES)
-// is wired to the supplied raw Buffer*s, which is what the framework's fast
-// cache-hit path patches.
-void emit_cb_descriptors(
-    std::vector<CBInfo>& cb_info,
-    tt::tt_metal::ProgramDescriptor& desc,
-    const CoreRangeSet& all_cores_set,
-    tt::tt_metal::Buffer* input_buffer,
-    tt::tt_metal::Buffer* output_buffer,
-    tt::tt_metal::Buffer* indices_buffer) {
-    uint32_t cb_index = 0;
-    for (auto& cb : cb_info) {
-        if (cb.num_pages == 0) {
-            // Skip circular buffers with zero pages (matches allocate_cbs behavior).
-            continue;
-        }
-
-        tt::tt_metal::Buffer* buffer = nullptr;
-        if (cb.is_globally_allocated) {
-            if (cb.name == Conv2dCb::ACT_SHARDED) {
-                buffer = input_buffer;
-            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
-                buffer = output_buffer;
-            } else if (cb.name == Conv2dCb::READER_INDICES) {
-                buffer = indices_buffer;
-            } else {
-                TT_THROW(
-                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
-                    enchantum::to_string(cb.name));
-            }
-        }
-
-        cb.index = cb_index++;
-        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = cb.num_pages * cb.page_size,
-            .core_ranges = all_cores_set,
-            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(cb.index),
-                .data_format = cb.data_format,
-                .page_size = cb.page_size,
-            }}},
-            .buffer = buffer,
-        });
-    }
-
-    for (auto& cb : cb_info) {
-        if (cb.overlapped_by_cb.has_value()) {
-            // If this CB is overlapped by another CB, mirror the overlapped CB's index.
-            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
-            cb.index = overlapped_cb.index;
-        }
-    }
-}
-
-}  // namespace
-
 namespace unary = ttnn::operations::unary;
 using ttnn::operations::conv::conv_skip_mcast;
 using ttnn::operations::conv::SkipMcast;
@@ -737,12 +677,11 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         }
     }
 
-    // NOTE: post_conv2d_op_memory_checks() operates on a tt::tt_metal::Program;
-    // in the ProgramDescriptor world the framework realises the Program on cache
-    // miss after this returns, so the original CB-size / L1-allocator sanity
-    // check cannot be invoked here.  The CB sizing comes from get_cb_info()
-    // which is shared with the legacy path, so behavioural equivalence is
-    // preserved.
+    // Descriptor-path CB-size check (mirrors the legacy post_conv2d_op_memory_checks
+    // CB-sizing equality).  The L1-allocator delta half of the legacy check requires a
+    // realised Program and so isn't reachable here: the framework realises the Program
+    // after this function returns.
+    post_conv2d_op_memory_checks_descriptor(desc, operation_attributes, tensor_args, reader_indices_actual_page_size);
 
     desc.kernels.push_back(std::move(act_kernel_desc));
     desc.kernels.push_back(std::move(weights_kernel_desc));

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -3,34 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::prim {
 
 struct Conv2dWidthShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::CBHandle cb_sharded_act{};
-        tt::tt_metal::CBHandle cb_output{};
-        tt::tt_metal::CBHandle cb_partials{};
-        bool partials_cb_uses_output = false;
-        bool has_bias = false;
-        CoreCoord full_core_grid;
-        tt::tt_metal::KernelHandle weights_kernel_id{};
-        uint32_t total_num_active_cores = 0;
-        tt::tt_metal::DeviceStorage conv_reader_indices_storage;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Builds the workload in one call (cache miss).  The intermediate
+    // conv_reader_indices tensor — which must outlive the cached program — is
+    // allocated here and parked on the WorkloadDescriptor's `buffers` vector
+    // (wrapped in `shared_ptr<Tensor>` so `~Tensor` cannot force-deallocate the
+    // device memory while the cached program is still alive).
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const Conv2dParams& operation_attributes,
         const Conv2dInputs& tensor_args,
-        Tensor& output_tensor);
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
@@ -463,8 +463,7 @@ tt::tt_metal::WorkloadDescriptor ReshapeViewTiledProgramFactory::create_workload
     // Note: operation_attributes.recreate_mapping_tensor is intentionally
     // ignored here — it's excluded from the program hash, so on a cache
     // hit the cached mapping_tensor (which depends only on hashed inputs)
-    // is always valid.  The legacy override_runtime_arguments path that
-    // re-uploaded the mapping is no longer needed under Contract-2.
+    // is always valid.
 
     // Single-device op: build the per-coord ProgramDescriptor ONCE and
     // copy it into each coord-range entry to avoid redundant work on

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
@@ -5,13 +5,15 @@
 #include "ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.hpp"
 
 #include <cmath>
+#include <memory>
 #include <numeric>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp"
 
@@ -271,98 +273,102 @@ Tensor compute_reshape_mapping_host_tensor(
 // map, the reader copies the segment from the input page to a scratch page stored in L1. When all segments are written,
 // the scratch page is copied to its output destination.
 
-ReshapeViewTiledProgramFactory::cached_program_t ReshapeViewTiledProgramFactory::create(
-    const ReshapeViewParams& operation_attributes, const ReshapeViewInputs& tensor_args, Tensor& tensor_return_value) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& output_tensor = tensor_return_value;
+namespace {
 
-    const auto& input_shape = input_tensor.logical_shape();
-    const auto& output_shape = output_tensor.logical_shape();
+// Build the per-coord reshape ProgramDescriptor.  The mapping_buffer is
+// workload-scoped (owned by the surrounding WorkloadDescriptor), so its
+// address survives across cache hits and the framework patches the input
+// / output buffer addresses via the buffer-binding fast path.
+tt::tt_metal::ProgramDescriptor build_reshape_tiled_program(
+    const ReshapeViewParams& operation_attributes,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    tt::tt_metal::Buffer* mapping_buffer,
+    uint32_t mapping_page_size,
+    uint32_t mapping_page_size_bytes,
+    tt::DataFormat mapping_dataformat,
+    uint32_t num_output_pages) {
+    using namespace tt::tt_metal;
 
-    TT_FATAL(input_shape.volume() == output_shape.volume(), "Requested shapes are not of equal volume");
+    Buffer* input_buffer = input_tensor.buffer();
+    Buffer* output_buffer = output_tensor.buffer();
+    TT_ASSERT(input_buffer != nullptr, "Input buffer should be allocated on device!");
+    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    const auto& face_shape = input_tensor.tensor_spec().tile().get_face_shape();
-
-    TT_ASSERT(input_shape.size() == 3 && output_shape.size() == 3, "Kernel designed for rank 3 tensors");
-
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
-    tt::tt_metal::distributed::MeshDevice* device = input_tensor.device();
-
-    tt::tt_metal::Buffer* input_buffer = input_tensor.buffer();
-    tt::tt_metal::Buffer* output_buffer = output_tensor.buffer();
-
-    TT_ASSERT(input_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    const uint32_t num_input_pages = tt::div_up(input_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
-    const uint32_t num_output_pages = tt::div_up(output_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
-
-    Tensor mapping_tensor = detail::compute_reshape_mapping_host_tensor(
-                                num_input_pages, num_output_pages, input_shape, output_shape, tile_shape, face_shape)
-                                .to_device(device);
-
-    tt::tt_metal::Buffer* mapping_buffer = mapping_tensor.buffer();
+    distributed::MeshDevice* device = input_tensor.device();
     const auto grid = device->compute_with_storage_grid_size();
-
-    uint32_t num_cores_x = grid.x;
-    uint32_t num_cores_y = grid.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
-
-    // set up CB for mapping metadata
 
     // PCC fails when this is greater than 1. TODO figure out why.
     constexpr auto reader_cb_len = 1;
 
-    auto mapping_page_size = mapping_tensor.logical_shape()[-1];
-    auto mapping_dataformat = tt::tt_metal::datatype_to_dataformat_converter(mapping_tensor.dtype());
-    auto mapping_page_size_bytes = mapping_page_size * mapping_tensor.element_size();
     constexpr auto mapping_cb_idx = tt::CBIndex::c_0;
 
-    const tt::tt_metal::CircularBufferConfig cb_mapping_config =
-        tt::tt_metal::CircularBufferConfig(
-            mapping_page_size_bytes * reader_cb_len, {{mapping_cb_idx, mapping_dataformat}})
-            .set_page_size(mapping_cb_idx, mapping_page_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_mapping_config);
-
     // set up CB for input tiles
-    const auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    const auto input_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     const auto input_tile_size_bytes = tt::tile_size(input_cb_data_format);
     constexpr auto input_cb_idx = tt::CBIndex::c_1;
 
-    tt::tt_metal::CircularBufferConfig cb_input_config =
-        tt::tt_metal::CircularBufferConfig(
-            input_tile_size_bytes * reader_cb_len, {{input_cb_idx, input_cb_data_format}})
-            .set_page_size(input_cb_idx, input_tile_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_input_config);
-
     // TODO assert output tile size and data format same as input
-    const auto output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+    const auto output_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
     const auto output_tile_size_bytes = tt::tile_size(output_cb_data_format);
     constexpr auto output_cb_idx = tt::CBIndex::c_2;
-
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(output_tile_size_bytes, {{output_cb_idx, output_cb_data_format}})
-            .set_page_size(output_cb_idx, output_tile_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_output_config);
 
     const auto
         [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
             operation_attributes.sub_core_grid.has_value()
-                ? tt::tt_metal::split_work_to_cores(operation_attributes.sub_core_grid.value(), num_output_pages)
-                : tt::tt_metal::split_work_to_cores(grid, num_output_pages);
+                ? split_work_to_cores(operation_attributes.sub_core_grid.value(), num_output_pages)
+                : split_work_to_cores(grid, num_output_pages);
 
     TT_ASSERT(num_cores <= num_output_pages);
 
+    ProgramDescriptor desc;
+
+    // mapping metadata CB (no buffer binding — reader stages mapping pages
+    // through this CB on the fly)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = mapping_page_size_bytes * reader_cb_len,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(mapping_cb_idx),
+            .data_format = mapping_dataformat,
+            .page_size = mapping_page_size_bytes,
+        }}},
+    });
+
+    // input tile CB
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_tile_size_bytes * reader_cb_len,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_cb_idx),
+            .data_format = input_cb_data_format,
+            .page_size = input_tile_size_bytes,
+        }}},
+    });
+
+    // output tile CB
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_tile_size_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_idx),
+            .data_format = output_cb_data_format,
+            .page_size = output_tile_size_bytes,
+        }}},
+    });
+
     std::vector<uint32_t> reader_compile_time_args = {
         mapping_page_size_bytes, input_tile_size_bytes, mapping_cb_idx, input_cb_idx};
-    tt::tt_metal::TensorAccessorArgs(*mapping_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    TensorAccessorArgs(*mapping_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     const uint32_t max_map_entries = mapping_page_size / detail::SegmentMapData::size;
     std::vector<uint32_t> writer_compile_time_args = {
@@ -372,16 +378,17 @@ ReshapeViewTiledProgramFactory::cached_program_t ReshapeViewTiledProgramFactory:
         mapping_cb_idx,
         input_cb_idx,
         output_cb_idx};
-    tt::tt_metal::TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/"
-        "writer_reshape_tiled.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
     uint32_t page_idx_start = 0, page_idx_end = 0;
-    std::vector<CoreCoord> utilized_cores;
     for (auto c : corerange_to_cores(all_cores, std::nullopt)) {
         uint32_t increment = 0;
         if (core_group_1.contains(c)) {
@@ -393,65 +400,94 @@ ReshapeViewTiledProgramFactory::cached_program_t ReshapeViewTiledProgramFactory:
         }
         page_idx_end += increment;
 
-        const std::vector<uint32_t> reader_runtime_args = {
-            input_buffer->address(), mapping_buffer->address(), page_idx_start, page_idx_end};
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, c, reader_runtime_args);
-
-        const std::vector<uint32_t> writer_runtime_args = {output_buffer->address(), page_idx_start, page_idx_end};
-
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, c, writer_runtime_args);
+        // Bind input + mapping buffers via emplace_runtime_args so the
+        // framework's fast cache-hit path patches their addresses without
+        // re-running the factory.
+        reader_desc.emplace_runtime_args(c, {input_buffer, mapping_buffer, page_idx_start, page_idx_end});
+        writer_desc.emplace_runtime_args(c, {output_buffer, page_idx_start, page_idx_end});
 
         page_idx_start += increment;
-        utilized_cores.push_back(c);
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, utilized_cores, mapping_tensor}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void ReshapeViewTiledProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor ReshapeViewTiledProgramFactory::create_workload_descriptor(
     const ReshapeViewParams& operation_attributes,
     const ReshapeViewInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto& shared_variables = cached_program.shared_variables;
-    const auto& reader_kernel_id = shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = shared_variables.writer_kernel_id;
-    const auto& utilized_cores = shared_variables.utilized_cores;
-    auto& mapping_tensor = shared_variables.mapping_tensor;
-
+    Tensor& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     const auto& input_tensor = tensor_args.input;
-    const auto& output_tensor = tensor_return_value;
+    auto& output_tensor = tensor_return_value;
 
-    if (operation_attributes.recreate_mapping_tensor) {
-        const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-        const auto& face_shape = input_tensor.tensor_spec().tile().get_face_shape();
-        const uint32_t num_input_pages = tt::div_up(input_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
-        const uint32_t num_output_pages = tt::div_up(output_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
+    const auto& input_shape = input_tensor.logical_shape();
+    const auto& output_shape = output_tensor.logical_shape();
 
-        mapping_tensor = detail::compute_reshape_mapping_host_tensor(
-                             num_input_pages,
-                             num_output_pages,
-                             input_tensor.logical_shape(),
-                             output_tensor.logical_shape(),
-                             tile_shape,
-                             face_shape)
-                             .to_device(input_tensor.device());
+    TT_FATAL(input_shape.volume() == output_shape.volume(), "Requested shapes are not of equal volume");
+
+    const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    const auto& face_shape = input_tensor.tensor_spec().tile().get_face_shape();
+
+    TT_ASSERT(input_shape.size() == 3 && output_shape.size() == 3, "Kernel designed for rank 3 tensors");
+
+    tt::tt_metal::distributed::MeshDevice* device = input_tensor.device();
+
+    const uint32_t num_input_pages = tt::div_up(input_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
+    const uint32_t num_output_pages = tt::div_up(output_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
+
+    // Host-compute and upload the input→output page-mapping tensor.
+    Tensor mapping_tensor = detail::compute_reshape_mapping_host_tensor(
+                                num_input_pages, num_output_pages, input_shape, output_shape, tile_shape, face_shape)
+                                .to_device(device);
+
+    const uint32_t mapping_page_size = mapping_tensor.logical_shape()[-1];
+    const auto mapping_dataformat = tt::tt_metal::datatype_to_dataformat_converter(mapping_tensor.dtype());
+    const uint32_t mapping_page_size_bytes = mapping_page_size * mapping_tensor.element_size();
+
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    // Park the mapping Tensor on the WorkloadDescriptor.  Wrapping in a
+    // shared_ptr<Tensor> defers ~Tensor (which force-deallocates the
+    // underlying device memory via DeviceStorage::deallocate) until the
+    // cached workload is evicted.  See pool_multi_core_program_factory.cpp
+    // for the lifetime rationale.
+    auto mapping_owner = std::make_shared<Tensor>(std::move(mapping_tensor));
+    tt::tt_metal::Buffer* mapping_buffer = mapping_owner->buffer();
+    workload_descriptor.buffers.push_back({std::move(mapping_owner), mapping_buffer});
+
+    // Note: operation_attributes.recreate_mapping_tensor is intentionally
+    // ignored here — it's excluded from the program hash, so on a cache
+    // hit the cached mapping_tensor (which depends only on hashed inputs)
+    // is always valid.  The legacy override_runtime_arguments path that
+    // re-uploaded the mapping is no longer needed under Contract-2.
+
+    // Single-device op: build the per-coord ProgramDescriptor ONCE and
+    // copy it into each coord-range entry to avoid redundant work on
+    // multi-coord workloads.
+    auto desc = build_reshape_tiled_program(
+        operation_attributes,
+        input_tensor,
+        output_tensor,
+        mapping_buffer,
+        mapping_page_size,
+        mapping_page_size_bytes,
+        mapping_dataformat,
+        num_output_pages);
+
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
     }
-
-    const auto input_buffer_addr = input_tensor.buffer()->address();
-    const auto output_buffer_addr = output_tensor.buffer()->address();
-    auto& program = cached_program.program;
-
-    for (const auto& core : utilized_cores) {
-        auto& reader_runtime_args_core = GetRuntimeArgs(program, reader_kernel_id, core);
-        reader_runtime_args_core.at(0) = input_buffer_addr;
-        if (operation_attributes.recreate_mapping_tensor) {
-            reader_runtime_args_core.at(1) = mapping_tensor.buffer()->address();
-        }
-
-        auto& writer_runtime_args_core = GetRuntimeArgs(program, writer_kernel_id, core);
-        writer_runtime_args_core.at(0) = output_buffer_addr;
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
     }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.hpp
@@ -4,30 +4,26 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/reshape_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct ReshapeViewTiledProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        std::vector<CoreCoord> utilized_cores;
-        Tensor mapping_tensor;
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    // create_workload_descriptor() materializes the host-computed
+    // input-to-output page-mapping tensor onto the device and parks the
+    // owning Tensor on the WorkloadDescriptor so its backing buffer
+    // outlives the cached programs.  The mapping is fully determined by
+    // the hashed input/output shapes; the legacy `recreate_mapping_tensor`
+    // override-path is no longer needed in Contract-2.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const ReshapeViewParams& operation_attributes,
         const ReshapeViewInputs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ReshapeViewParams& operation_attributes,
-        const ReshapeViewInputs& tensor_args,
-        Tensor& tensor_return_value);
+        Tensor& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.hpp
@@ -17,8 +17,7 @@ struct ReshapeViewTiledProgramFactory {
     // input-to-output page-mapping tensor onto the device and parks the
     // owning Tensor on the WorkloadDescriptor so its backing buffer
     // outlives the cached programs.  The mapping is fully determined by
-    // the hashed input/output shapes; the legacy `recreate_mapping_tensor`
-    // override-path is no longer needed in Contract-2.
+    // the hashed input/output shapes.
     static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const ReshapeViewParams& operation_attributes,
         const ReshapeViewInputs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -24,7 +24,6 @@ struct Conv3dDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<Conv3dProgramFactory>;
-    using shared_variables_t = Conv3dProgramFactory::shared_variables_t;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -8,6 +8,7 @@
 #include "kernels/conv3d_weight_share.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
@@ -28,8 +29,18 @@ static uint32_t largest_divisor_up_to(uint32_t n, uint32_t cap) {
     return 1;
 }
 
-Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
+tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
     const Conv3dParams& operation_attributes, const Conv3dInputs& tensor_args, Tensor& tensor_return_value) {
+    using tt::tt_metal::CBDescriptor;
+    using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::ComputeConfigDescriptor;
+    using tt::tt_metal::DataMovementConfigDescriptor;
+    using tt::tt_metal::KernelDescriptor;
+    using tt::tt_metal::ProgramDescriptor;
+    using tt::tt_metal::ReaderConfigDescriptor;
+    using tt::tt_metal::SemaphoreDescriptor;
+    using tt::tt_metal::WriterConfigDescriptor;
+
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& weight_tensor = tensor_args.weight_tensor;
     const auto& bias_tensor = tensor_args.bias_tensor;
@@ -38,7 +49,7 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     // Extract config from operation_attributes
     const auto& config = operation_attributes.config;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     auto grid_size = config.compute_with_storage_grid_size;
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
@@ -162,15 +173,37 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
                                     ? std::min(num_patches, (uint32_t)tt::constants::TILE_HEIGHT)
                                     : std::min(num_patches, 2 * tt::constants::TILE_HEIGHT);
     uint32_t cb_vol2col_rm_id = next_cb_index++;
-    tt::tt_metal::create_cb(
-        cb_vol2col_rm_id, program, core_grid, padded_patch_size_bytes, vol2col_rm_pages, data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = vol2col_rm_pages * padded_patch_size_bytes,
+        .core_ranges = CoreRangeSet(core_grid),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_vol2col_rm_id),
+            .data_format = data_format,
+            .page_size = padded_patch_size_bytes,
+        }}},
+    });
 
     uint32_t cb_vol2col_tiled_id = next_cb_index++;
-    tt::tt_metal::create_cb(
-        cb_vol2col_tiled_id, program, core_grid, tile_size, out_subblock_h * matmul_K_t, data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out_subblock_h * matmul_K_t * tile_size,
+        .core_ranges = CoreRangeSet(core_grid),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_vol2col_tiled_id),
+            .data_format = data_format,
+            .page_size = tile_size,
+        }}},
+    });
 
     uint32_t cb_weight_tiled_id = next_cb_index++;
-    tt::tt_metal::create_cb(cb_weight_tiled_id, program, core_grid, tile_size, matmul_K_t * matmul_N_t, data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = matmul_K_t * matmul_N_t * tile_size,
+        .core_ranges = CoreRangeSet(core_grid),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_weight_tiled_id),
+            .data_format = data_format,
+            .page_size = tile_size,
+        }}},
+    });
 
     // Use fp32 partials whenever we have multiple C_in blocks and fp32 dest is enabled.
     // This eliminates bf16 truncation between C_in block partial sums.
@@ -179,19 +212,29 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     auto partial_tile_size = tt::tile_size(partial_data_format);
 
     uint32_t cb_matmul_interm_tiled_id = next_cb_index++;
-    tt::tt_metal::create_cb(
-        cb_matmul_interm_tiled_id, program, core_grid, partial_tile_size, matmul_M_t * matmul_N_t, partial_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = matmul_M_t * matmul_N_t * partial_tile_size,
+        .core_ranges = CoreRangeSet(core_grid),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_matmul_interm_tiled_id),
+            .data_format = partial_data_format,
+            .page_size = partial_tile_size,
+        }}},
+    });
 
     // NOTE: Most kernels create RM CB with tile_size pages and num_tile number of pages.
     // Using stick pages led to PCC issues.
     uint32_t cb_matmul_result_rm_id = next_cb_index++;
-    tt::tt_metal::create_cb(
-        cb_matmul_result_rm_id,
-        program,
-        core_grid,
-        tile_size,
-        matmul_M_t * matmul_N_t,  // untilize will write padded rows, so this must be sized to avoid overflowing CB
-        data_format);
+    desc.cbs.push_back(CBDescriptor{
+        // untilize will write padded rows, so this must be sized to avoid overflowing CB
+        .total_size = matmul_M_t * matmul_N_t * tile_size,
+        .core_ranges = CoreRangeSet(core_grid),
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_matmul_result_rm_id),
+            .data_format = data_format,
+            .page_size = tile_size,
+        }}},
+    });
 
     uint32_t cb_reduction_tiled_id =
         32;  // Invalid value for cb index since there is only 32 of them and the indices go from 0 to 31
@@ -201,18 +244,41 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         // Multi-core reduction step: each core computes a partial sum, then they reduce
         // Use same format as partials CB so reduction adds matching formats
         cb_reduction_tiled_id = next_cb_index++;
-        tt::tt_metal::create_cb(
-            cb_reduction_tiled_id, program, core_grid, partial_tile_size, matmul_M_t * matmul_N_t, partial_data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = matmul_M_t * matmul_N_t * partial_tile_size,
+            .core_ranges = CoreRangeSet(core_grid),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_reduction_tiled_id),
+                .data_format = partial_data_format,
+                .page_size = partial_tile_size,
+            }}},
+        });
 
         cb_worker_ack_back_id = next_cb_index++;
-        tt::tt_metal::create_cb(cb_worker_ack_back_id, program, core_grid, tile_size, 1, data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = tile_size,
+            .core_ranges = CoreRangeSet(core_grid),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_worker_ack_back_id),
+                .data_format = data_format,
+                .page_size = tile_size,
+            }}},
+        });
     }
 
     uint32_t cb_bias_tiled_id =
         32;  // Invalid value for cb index since there is only 32 of them and the indices go from 0 to 31
     if (use_bias) {
         cb_bias_tiled_id = next_cb_index++;
-        tt::tt_metal::create_cb(cb_bias_tiled_id, program, core_grid, tile_size, matmul_N_t, data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = matmul_N_t * tile_size,
+            .core_ranges = CoreRangeSet(core_grid),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_bias_tiled_id),
+                .data_format = data_format,
+                .page_size = tile_size,
+            }}},
+        });
     }
 
     log_debug(
@@ -253,8 +319,15 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     uint32_t cb_dram_read_scratch_id = 32;  // Invalid; set below if DRAM read staging is needed
     if (enable_dram_read_staging) {
         cb_dram_read_scratch_id = next_cb_index++;
-        tt::tt_metal::create_cb(
-            cb_dram_read_scratch_id, program, core_grid, dram_read_scratch_page_bytes, 1, data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = dram_read_scratch_page_bytes,
+            .core_ranges = CoreRangeSet(core_grid),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_dram_read_scratch_id),
+                .data_format = data_format,
+                .page_size = dram_read_scratch_page_bytes,
+            }}},
+        });
     }
 
     // L1 pre-fetch buffer for kernels > 1x1x1 with no dilation.
@@ -343,8 +416,15 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
                 shard_positions_max + coalesced_scratch_rows * coalesced_scratch_pages_per_row;
             const uint32_t shard_bytes_alloc = shard_positions_alloc * C_in_block_bytes;
             cb_input_shard_id = next_cb_index++;
-            tt::tt_metal::create_cb(
-                cb_input_shard_id, program, core_grid, C_in_block_bytes, shard_positions_alloc, data_format);
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = shard_positions_alloc * C_in_block_bytes,
+                .core_ranges = CoreRangeSet(core_grid),
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(cb_input_shard_id),
+                    .data_format = data_format,
+                    .page_size = C_in_block_bytes,
+                }}},
+            });
 
             log_debug(
                 tt::LogOp,
@@ -534,12 +614,27 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     // Set up semaphore for synchronization. It is dual-purpose.
     // On the reducer core, it tracks the number of workers that are done with an output block.
     // On the worker core, it is a valid bit indicating the worker can continue.
-    auto semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, 0);
+    uint32_t semaphore_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = semaphore_id,
+        .core_ranges = CoreRangeSet(core_grid),
+        .initial_value = 0,
+    });
 
     // Weight-mcast semaphores. Always created so writer kernel can take their ids as compile-time
     // constants. They are only used when enable_weight_mcast is true at runtime.
-    auto weights_mcast_sender_sem_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
-    auto weights_mcast_receiver_sem_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
+    uint32_t weights_mcast_sender_sem_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = weights_mcast_sender_sem_id,
+        .core_ranges = CoreRangeSet(core_grid),
+        .initial_value = INVALID,
+    });
+    uint32_t weights_mcast_receiver_sem_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = weights_mcast_receiver_sem_id,
+        .core_ranges = CoreRangeSet(core_grid),
+        .initial_value = INVALID,
+    });
 
     // Trid-ring depth for gather_rows_to_shard.  Per-shape autotune (see
     // conv3d_trid_pipeline_findings.md).  Cutoff constants live in
@@ -640,11 +735,12 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         dram_read_alignment};
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
 
-    auto reader_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp",
-        core_grid,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = CoreRangeSet(core_grid);
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Matmul parameters (out_subblock_h, out_subblock_w, dst_size computed earlier for CB sizing)
     const uint32_t in0_block_w = matmul_K_t;
@@ -701,16 +797,17 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         // Stream final output rows only for many small output writes when there is a writer tail to overlap.
         (uint32_t)(enable_streaming_output ? 1 : 0)};
 
-    auto compute_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp",
-        core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args});
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = CoreRangeSet(core_grid);
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
 
     std::vector<uint32_t> writer_compile_time_args = {
         cb_matmul_result_rm_id,
@@ -744,16 +841,17 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     tt::tt_metal::TensorAccessorArgs(bias_tensor.has_value() ? bias_tensor.value().buffer() : nullptr)
         .append_to(writer_compile_time_args);
 
-    auto writer_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp",
-        core_grid,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = CoreRangeSet(core_grid);
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    uint32_t input_addr = input_tensor.buffer()->address();
-    uint32_t out_addr = output_tensor.buffer()->address();
-    uint32_t weight_addr = weight_tensor.buffer()->address();
-    uint32_t bias_addr = bias_tensor.has_value() ? bias_tensor.value().buffer()->address() : 0;
+    tt::tt_metal::Buffer* input_buffer = input_tensor.buffer();
+    tt::tt_metal::Buffer* out_buffer = output_tensor.buffer();
+    tt::tt_metal::Buffer* weight_buffer = weight_tensor.buffer();
+    tt::tt_metal::Buffer* bias_buffer = bias_tensor.has_value() ? bias_tensor.value().buffer() : nullptr;
 
     // Per-core work assignment via the original core_id row-major mapping. See WeightShareRole
     // in conv3d_weight_share.hpp for the role values.
@@ -1070,76 +1168,91 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     }
 
     // Build and set runtime args.
+    reader_desc.runtime_args.reserve(num_cores);
+    compute_desc.runtime_args.reserve(num_cores);
+    writer_desc.runtime_args.reserve(num_cores);
     for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
         CoreCoord core = cores.at(core_id);
         const CoreWork& cw = core_work[core_id];
         const uint32_t group_id = cw.reduction_group_id;
 
-        std::vector<uint32_t> reader_args = {
-            input_addr,
-            cw.c_in_block_start,
-            cw.c_in_block_end,
-            cw.c_out_block_start,
-            cw.c_out_block_end,
-            cw.t_out_start,
-            cw.t_out_end,
-            cw.h_out_start,
-            cw.h_out_end,
-            cw.w_out_start,
-            cw.w_out_end,
-        };
-
         const uint32_t num_workers = cw.has_work ? (uint32_t)worker_core_ids[group_id].size() : 0u;
 
-        std::vector<uint32_t> compute_args = {
-            cw.c_in_block_start,
-            cw.c_in_block_end,
-            cw.c_out_block_start,
-            cw.c_out_block_end,
-            cw.t_out_start,
-            cw.t_out_end,
-            cw.h_out_start,
-            cw.h_out_end,
-            cw.w_out_start,
-            cw.w_out_end,
-            (uint32_t)cw.is_reducer,
-            num_workers};
+        // Reader pos[0] is the input buffer address (patched on cache hit via emplace_runtime_args).
+        reader_desc.emplace_runtime_args(
+            core,
+            {input_buffer,
+             cw.c_in_block_start,
+             cw.c_in_block_end,
+             cw.c_out_block_start,
+             cw.c_out_block_end,
+             cw.t_out_start,
+             cw.t_out_end,
+             cw.h_out_start,
+             cw.h_out_end,
+             cw.w_out_start,
+             cw.w_out_end});
 
-        std::vector<uint32_t> writer_args = {
-            out_addr,
-            weight_addr,
-            bias_addr,
-            cw.c_in_block_start,
-            cw.c_in_block_end,
-            cw.c_out_block_start,
-            cw.c_out_block_end,
-            cw.t_out_start,
-            cw.t_out_end,
-            cw.h_out_start,
-            cw.h_out_end,
-            cw.w_out_start,
-            cw.w_out_end,
-            (uint32_t)cw.is_reducer,
-            static_cast<uint32_t>(cw.weight_share_role),
-            cw.weight_src_noc_x,
-            cw.weight_src_noc_y,
-            cw.chain_succ_noc_x,
-            cw.chain_succ_noc_y,
-            cw.mcast_bbox_start_x,
-            cw.mcast_bbox_start_y,
-            cw.mcast_bbox_end_x,
-            cw.mcast_bbox_end_y,
-            cw.mcast_num_dests,
-            cw.mcast_num_iters,
-            num_workers};
+        compute_desc.runtime_args.emplace_back(
+            core,
+            std::vector<uint32_t>{
+                cw.c_in_block_start,
+                cw.c_in_block_end,
+                cw.c_out_block_start,
+                cw.c_out_block_end,
+                cw.t_out_start,
+                cw.t_out_end,
+                cw.h_out_start,
+                cw.h_out_end,
+                cw.w_out_start,
+                cw.w_out_end,
+                (uint32_t)cw.is_reducer,
+                num_workers});
+
+        // Writer pos[0..2] are the output, weight, and bias buffer addresses. nullptr bias becomes
+        // an embedded 0 so the kernel-side address is still well-defined.
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.reserve(26 + (num_workers > 0 ? 2 + 2 * num_workers : 0));
+        writer_args.push_back(out_buffer);
+        writer_args.push_back(weight_buffer);
+        if (bias_buffer != nullptr) {
+            writer_args.push_back(bias_buffer);
+        } else {
+            writer_args.push_back(uint32_t{0});
+        }
+        writer_args.push_back(cw.c_in_block_start);
+        writer_args.push_back(cw.c_in_block_end);
+        writer_args.push_back(cw.c_out_block_start);
+        writer_args.push_back(cw.c_out_block_end);
+        writer_args.push_back(cw.t_out_start);
+        writer_args.push_back(cw.t_out_end);
+        writer_args.push_back(cw.h_out_start);
+        writer_args.push_back(cw.h_out_end);
+        writer_args.push_back(cw.w_out_start);
+        writer_args.push_back(cw.w_out_end);
+        writer_args.push_back((uint32_t)cw.is_reducer);
+        writer_args.push_back(static_cast<uint32_t>(cw.weight_share_role));
+        writer_args.push_back(cw.weight_src_noc_x);
+        writer_args.push_back(cw.weight_src_noc_y);
+        writer_args.push_back(cw.chain_succ_noc_x);
+        writer_args.push_back(cw.chain_succ_noc_y);
+        writer_args.push_back(cw.mcast_bbox_start_x);
+        writer_args.push_back(cw.mcast_bbox_start_y);
+        writer_args.push_back(cw.mcast_bbox_end_x);
+        writer_args.push_back(cw.mcast_bbox_end_y);
+        writer_args.push_back(cw.mcast_num_dests);
+        writer_args.push_back(cw.mcast_num_iters);
+        writer_args.push_back(num_workers);
 
         if (num_workers > 0) {
             writer_args.push_back(reducer_core_physical_xs[group_id]);
             writer_args.push_back(reducer_core_physical_ys[group_id]);
-            writer_args.insert(
-                writer_args.end(), worker_core_physical_xs[group_id].begin(), worker_core_physical_xs[group_id].end());
-            writer_args.insert(
-                writer_args.end(), worker_core_physical_ys[group_id].begin(), worker_core_physical_ys[group_id].end());
+            for (uint32_t v : worker_core_physical_xs[group_id]) {
+                writer_args.push_back(v);
+            }
+            for (uint32_t v : worker_core_physical_ys[group_id]) {
+                writer_args.push_back(v);
+            }
         }
 
         log_debug(
@@ -1156,53 +1269,14 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
             cw.c_out_idx,
             num_workers);
 
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
-        SetRuntimeArgs(program, compute_kernels_id, core, compute_args);
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, writer_args);
     }
 
-    // Return cached program with shared variables
-    return cached_program_t{
-        std::move(program),
-        {/* num_cores = */ num_cores,
-         /* cores = */ cores,
-         /* grid_size = */ grid_size,
-         /* reader_kernels_id = */ reader_kernels_id,
-         /* writer_kernels_id = */ writer_kernels_id,
-         /* compute_kernels_id = */ compute_kernels_id}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void Conv3dProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const Conv3dParams& /*operation_attributes*/,
-    const Conv3dInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    using namespace tt::tt_metal;
-
-    auto& shared_vars = cached_program.shared_variables;
-    auto& reader_kernels_id = shared_vars.reader_kernels_id;
-    auto& writer_kernels_id = shared_vars.writer_kernels_id;
-    auto& num_cores = shared_vars.num_cores;
-    auto& cores = shared_vars.cores;
-    auto& program = cached_program.program;
-
-    auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernels_id);
-    auto& writer_args_by_core = GetRuntimeArgs(program, writer_kernels_id);
-
-    auto input_addr = tensor_args.input_tensor.buffer()->address();
-    auto weight_addr = tensor_args.weight_tensor.buffer()->address();
-    auto output_addr = tensor_return_value.buffer()->address();
-    auto bias_addr = tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0;
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = cores.at(i);
-        auto& reader_args = reader_args_by_core[core.x][core.y];
-        auto& writer_args = writer_args_by_core[core.x][core.y];
-        reader_args[0] = input_addr;
-        writer_args[0] = output_addr;
-        writer_args[1] = weight_addr;
-        writer_args[2] = bias_addr;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.hpp
@@ -4,32 +4,15 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "conv3d_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::experimental::prim {
 
-struct Conv3dSharedVariables {
-    uint32_t num_cores = 0;
-    std::vector<CoreCoord> cores;
-    CoreCoord grid_size;
-    tt::tt_metal::KernelHandle reader_kernels_id = 0;
-    tt::tt_metal::KernelHandle writer_kernels_id = 0;
-    tt::tt_metal::KernelHandle compute_kernels_id = 0;
-};
-
 struct Conv3dProgramFactory {
-    using shared_variables_t = Conv3dSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const Conv3dParams& operation_attributes, const Conv3dInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const Conv3dParams& operation_attributes,
-        const Conv3dInputs& tensor_args,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -97,7 +97,6 @@ ProgramDescriptor build_halo_program(
     const bool remote_read = operation_attributes.remote_read;
     const bool transpose_mcast = operation_attributes.transpose_mcast;
 
-    const bool is_in_tiled = input_tensor.layout() == Layout::TILE;
     const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
 
     Buffer* src_buffer = input_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -10,9 +10,10 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/types.hpp"
@@ -49,22 +50,45 @@ private:
     uint32_t next_cb_id = tt::CBIndex::c_0;
 };
 
-static inline CBHandle create_circular_buffer(
-    Program& program,
+constexpr bool ENABLE_UNTILIZE_DOUBLE_BUFFERING = true;
+
+namespace {
+
+// Append a CBDescriptor for a single-format circular buffer.  When `buffer`
+// is non-null the CB is globally-allocated against that buffer so address
+// patching on cache hit works via the framework's dynamic CB update path.
+void add_cb(
+    ProgramDescriptor& desc,
     const CoreRangeSet& cores,
     uint32_t cb_id,
     tt::DataFormat df,
     uint32_t npages,
     uint32_t pagesize,
     Buffer* buffer = nullptr) {
-    return std::get<1>(tt::tt_metal::create_cb(cb_id, program, cores, pagesize, npages, df, buffer));
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = npages * pagesize,
+        .core_ranges = cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = df,
+            .page_size = pagesize,
+        }}},
+        .buffer = buffer,
+    });
 }
 
-constexpr bool ENABLE_UNTILIZE_DOUBLE_BUFFERING = true;
-
-UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory::create(
-    const HaloParams& operation_attributes, const Tensor& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args;
+// Build the per-coord halo ProgramDescriptor.  All workload-scoped
+// intermediate buffers (the four halo config tensors) are passed in by
+// pointer — their owning Tensors live on the WorkloadDescriptor.
+ProgramDescriptor build_halo_program(
+    const HaloParams& operation_attributes,
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    Buffer* padding_config_buffer0,
+    Buffer* padding_config_buffer1,
+    Buffer* gather_config_buffer0,
+    Buffer* gather_config_buffer1,
+    const std::vector<uint16_t>& number_of_blocks_per_core) {
     const auto& pad_val = operation_attributes.pad_val;
     const int block_size = UNTILIZE_BLOCK_SIZE;
     const uint32_t ncores_nhw = operation_attributes.config.num_cores_nhw;
@@ -73,75 +97,8 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
     const bool remote_read = operation_attributes.remote_read;
     const bool transpose_mcast = operation_attributes.transpose_mcast;
 
-    auto *device = input_tensor.device();
-
-    bool is_in_tiled = input_tensor.layout() == Layout::TILE;
-    bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-
-    using namespace ttnn::operations;
-    auto pad_metadata = sliding_window::generate_pad_metadata(operation_attributes.config);
-    auto op_trace_metadata = sliding_window::generate_op_trace_metadata(operation_attributes.config);
-    auto shard_boundaries = sliding_window::generate_shard_boundaries(operation_attributes.config);
-    const uint32_t input_shard_height = input_tensor.memory_config().shard_spec()->shape[0];
-    auto tensor_metadata =
-        sliding_window::generate_tensor_metadata(pad_metadata, operation_attributes.config, input_shard_height);
-
-    uint32_t num_cores_x = input_tensor.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
-
-    auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
-        tensor_metadata,
-        shard_boundaries,
-        is_block_sharded,
-        transpose_mcast,
-        remote_read,
-        device,
-        num_cores_x,
-        is_in_tiled,
-        UNTILIZE_BLOCK_SIZE);
-
-    const auto& pad_config0 = kernel_config.pad_config0;
-    const auto& pad_config1 = kernel_config.pad_config1;
-    const auto& gather_config0 = kernel_config.gather_config0;
-    const auto& gather_config1 = kernel_config.gather_config1;
-
-    const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor(
-        pad_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
-        pad_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor(
-        gather_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor(
-        gather_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-
-    auto pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
-        pad_config_tensor0,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    auto pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-        pad_config_tensor1,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    auto gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
-        gather_config_tensor0,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    auto gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-        gather_config_tensor1,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-
-    const auto number_of_blocks_per_core = sliding_window::remap_nhw_scalar_argument_across_full_grid(
-        kernel_config.number_of_blocks_per_core, operation_attributes.parallel_config);
-
-    Program program = CreateProgram();
+    const bool is_in_tiled = input_tensor.layout() == Layout::TILE;
+    const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
 
     Buffer* src_buffer = input_tensor.buffer();
     Buffer* dst_buffer = output_tensor.buffer();
@@ -187,12 +144,13 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         input_npages = input_shard_shape[0];
     }
 
+    ProgramDescriptor desc;
+
     CBIndices cb_indices = CBIndices();
 
     // The input CB can either be tiled or row-major
     cb_indices.src_cb_id = cb_indices.get_next_cb_id();
-    auto src_cb =
-        create_circular_buffer(program, all_cores, cb_indices.src_cb_id, in_df, input_npages, in_page_size, src_buffer);
+    add_cb(desc, all_cores, cb_indices.src_cb_id, in_df, input_npages, in_page_size, src_buffer);
 
     // We need to clamp in the case that the block size is larger than the nhw input size
     TT_FATAL(block_size % TILE_HEIGHT == 0, "Block size must be a multiple of tile height (was {})", block_size);
@@ -203,21 +161,20 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         "Block size must be a multiple of tile height (was {})",
         clamped_block_size_height);
 
-    uint32_t out_cb_pagesize = aligned_stick_nbytes;
-    uint32_t out_cb_npages = max_out_nsticks_per_core;
+    const uint32_t out_cb_pagesize = aligned_stick_nbytes;
+    const uint32_t out_cb_npages = max_out_nsticks_per_core;
     cb_indices.out_cb_id = cb_indices.get_next_cb_id();
-    auto out_cb = create_circular_buffer(
-        program, all_cores, cb_indices.out_cb_id, out_df, out_cb_npages, out_cb_pagesize, dst_buffer);
+    add_cb(desc, all_cores, cb_indices.out_cb_id, out_df, out_cb_npages, out_cb_pagesize, dst_buffer);
 
     // Used for storing padding immediate values (only used if not zero padding)
-    uint32_t pad_cb_pagesize = aligned_stick_nbytes;
-    uint32_t pad_cb_npages = 1;
+    const uint32_t pad_cb_pagesize = aligned_stick_nbytes;
+    const uint32_t pad_cb_npages = 1;
     cb_indices.pad_cb_id0 = cb_indices.get_next_cb_id();
-    create_circular_buffer(program, all_cores, cb_indices.pad_cb_id0, out_df, pad_cb_npages, pad_cb_pagesize);
+    add_cb(desc, all_cores, cb_indices.pad_cb_id0, out_df, pad_cb_npages, pad_cb_pagesize);
     cb_indices.pad_cb_id1 = cb_indices.get_next_cb_id();
-    create_circular_buffer(program, all_cores, cb_indices.pad_cb_id1, out_df, pad_cb_npages, pad_cb_pagesize);
+    add_cb(desc, all_cores, cb_indices.pad_cb_id1, out_df, pad_cb_npages, pad_cb_pagesize);
 
-    tt::DataFormat kernel_config_df = tt::DataFormat::RawUInt16;  // NOTE: UInt16 is not supported for CB types
+    const tt::DataFormat kernel_config_df = tt::DataFormat::RawUInt16;  // NOTE: UInt16 is not supported for CB types
 
     uint32_t input_to_writer_cb_id0 = cb_indices.src_cb_id;
     uint32_t input_to_writer_cb_id1 = cb_indices.src_cb_id;
@@ -231,13 +188,9 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         input_to_writer_cb_id1 = cb_indices.untilize_out_cb_id1;
         const uint32_t output_ntiles = (clamped_block_size_height / TILE_HEIGHT) * ntiles_per_block;
         const uint32_t untilize_out_cb_num_pages = ENABLE_UNTILIZE_DOUBLE_BUFFERING ? 2 * output_ntiles : output_ntiles;
-        create_circular_buffer(
-            program, all_cores, cb_indices.untilize_out_cb_id0, out_df, untilize_out_cb_num_pages, out_tile_size);
-        create_circular_buffer(
-            program, all_cores, cb_indices.untilize_out_cb_id1, out_df, untilize_out_cb_num_pages, out_tile_size);
+        add_cb(desc, all_cores, cb_indices.untilize_out_cb_id0, out_df, untilize_out_cb_num_pages, out_tile_size);
+        add_cb(desc, all_cores, cb_indices.untilize_out_cb_id1, out_df, untilize_out_cb_num_pages, out_tile_size);
 
-        const std::string compute_kernel_name =
-            "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp";
         const std::vector<uint32_t> compute_ct_args = {
             cb_indices.src_cb_id,
             input_to_writer_cb_id0,
@@ -248,32 +201,36 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         };
         auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
             get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
-        KernelHandle untilize_kernel_id = CreateKernel(
-            program,
-            compute_kernel_name,
-            all_cores,
-            ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .dst_full_sync_en = dst_full_sync_en,
-                .math_approx_mode = math_approx_mode,
-                .compile_args = compute_ct_args});
 
-        for (int core_id = 0; core_id < cores.size(); core_id++) {
-            SetRuntimeArgs(program, untilize_kernel_id, cores[core_id], {number_of_blocks_per_core[core_id]});
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = all_cores;
+        compute_desc.compile_time_args = compute_ct_args;
+        compute_desc.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+        };
+
+        for (size_t core_id = 0; core_id < cores.size(); core_id++) {
+            compute_desc.runtime_args.emplace_back(
+                cores[core_id], std::vector<uint32_t>{number_of_blocks_per_core[core_id]});
         }
+
+        desc.kernels.push_back(std::move(compute_desc));
     }
 
-    TT_ASSERT(pad_config_device_tensor0.dtype() == DataType::UINT16);
-    TT_ASSERT(pad_config_device_tensor1.dtype() == DataType::UINT16);
-    TT_ASSERT(gather_config_device_tensor0.dtype() == DataType::UINT16);
-    TT_ASSERT(gather_config_device_tensor1.dtype() == DataType::UINT16);
+    TT_ASSERT(padding_config_buffer0 != nullptr);
+    TT_ASSERT(padding_config_buffer1 != nullptr);
+    TT_ASSERT(gather_config_buffer0 != nullptr);
+    TT_ASSERT(gather_config_buffer1 != nullptr);
 
-    const auto& padding_config_storage0 = pad_config_device_tensor0.device_storage();
-    auto* padding_config_buffer0 = padding_config_storage0.get_buffer();
     cb_indices.padding_config0 = cb_indices.get_next_cb_id();
-    auto padding_config_cb0 = create_circular_buffer(
-        program,
+    add_cb(
+        desc,
         all_cores,
         cb_indices.padding_config0,
         kernel_config_df,
@@ -281,11 +238,9 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         padding_config_buffer0->page_size(),
         config_tensors_in_dram ? nullptr : padding_config_buffer0);
 
-    const auto& padding_config_storage1 = pad_config_device_tensor1.device_storage();
-    auto* padding_config_buffer1 = padding_config_storage1.get_buffer();
     cb_indices.padding_config1 = cb_indices.get_next_cb_id();
-    auto padding_config_cb1 = create_circular_buffer(
-        program,
+    add_cb(
+        desc,
         all_cores,
         cb_indices.padding_config1,
         kernel_config_df,
@@ -293,11 +248,9 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         padding_config_buffer1->page_size(),
         config_tensors_in_dram ? nullptr : padding_config_buffer1);
 
-    const auto& gather_config_storage0 = gather_config_device_tensor0.device_storage();
-    auto* gather_config_buffer0 = gather_config_storage0.get_buffer();
     cb_indices.gather_config0 = cb_indices.get_next_cb_id();
-    auto gather_config_cb0 = create_circular_buffer(
-        program,
+    add_cb(
+        desc,
         all_cores,
         cb_indices.gather_config0,
         kernel_config_df,
@@ -305,11 +258,9 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         gather_config_buffer0->page_size(),
         config_tensors_in_dram ? nullptr : gather_config_buffer0);
 
-    const auto& gather_config_storage1 = gather_config_device_tensor1.device_storage();
-    auto* gather_config_buffer1 = gather_config_storage1.get_buffer();
     cb_indices.gather_config1 = cb_indices.get_next_cb_id();
-    auto gather_config_cb1 = create_circular_buffer(
-        program,
+    add_cb(
+        desc,
         all_cores,
         cb_indices.gather_config1,
         kernel_config_df,
@@ -343,29 +294,34 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         0,            // Block start offset
         block_stride  // Block stride
     };
-    std::map<std::string, std::string> reader_defines;
+    KernelDescriptor::Defines reader_defines;
     std::vector<uint32_t> core_0_reader_ct_args = common_reader_ct_args;
     std::vector<uint32_t> core_1_reader_ct_args = common_reader_ct_args;
 
     if (config_tensors_in_dram) {
-        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
-        core_0_reader_ct_args.push_back(padding_config_storage0.get_buffer()->address());
-        core_0_reader_ct_args.push_back(padding_config_storage0.get_buffer()->page_size());
+        reader_defines.emplace_back("CONFIG_TENSOR_IN_DRAM", "1");
+        // NOTE: the config-buffer addresses are baked into compile-time args
+        // here.  The buffers themselves are parked on the WorkloadDescriptor,
+        // so their device allocations stay valid for the cached workload's
+        // lifetime — the address embedded below remains correct on cache hit
+        // because the buffers are not re-allocated.
+        core_0_reader_ct_args.push_back(padding_config_buffer0->address());
+        core_0_reader_ct_args.push_back(padding_config_buffer0->page_size());
 
-        core_0_reader_ct_args.push_back(gather_config_storage0.get_buffer()->address());
-        core_0_reader_ct_args.push_back(gather_config_storage0.get_buffer()->page_size());
+        core_0_reader_ct_args.push_back(gather_config_buffer0->address());
+        core_0_reader_ct_args.push_back(gather_config_buffer0->page_size());
 
-        core_1_reader_ct_args.push_back(padding_config_storage1.get_buffer()->address());
-        core_1_reader_ct_args.push_back(padding_config_storage1.get_buffer()->page_size());
+        core_1_reader_ct_args.push_back(padding_config_buffer1->address());
+        core_1_reader_ct_args.push_back(padding_config_buffer1->page_size());
 
-        core_1_reader_ct_args.push_back(gather_config_storage1.get_buffer()->address());
-        core_1_reader_ct_args.push_back(gather_config_storage1.get_buffer()->page_size());
+        core_1_reader_ct_args.push_back(gather_config_buffer1->address());
+        core_1_reader_ct_args.push_back(gather_config_buffer1->page_size());
 
-        tt::tt_metal::TensorAccessorArgs(padding_config_storage0.get_buffer()).append_to(core_0_reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(gather_config_storage0.get_buffer()).append_to(core_0_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(padding_config_buffer0).append_to(core_0_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(gather_config_buffer0).append_to(core_0_reader_ct_args);
 
-        tt::tt_metal::TensorAccessorArgs(padding_config_storage1.get_buffer()).append_to(core_1_reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(gather_config_storage1.get_buffer()).append_to(core_1_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(padding_config_buffer1).append_to(core_1_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(gather_config_buffer1).append_to(core_1_reader_ct_args);
     }
     const uint32_t EMPTY_PADDING_CONFIG_BUFFER_SIZE = 4;
     const bool enable_padding = config_tensors_in_dram ||
@@ -382,74 +338,181 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
     core_1_reader_ct_args[5] = cb_indices.pad_cb_id1;
     core_1_reader_ct_args[16] = 1;  // Block start offset
 
-    auto reader_0_kernel_id = CreateKernel(
-        program,
-        reader_kernel_name,
-        all_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = core_0_reader_ct_args,
-            .defines = reader_defines});
+    KernelDescriptor reader_0_desc;
+    reader_0_desc.kernel_source = reader_kernel_name;
+    reader_0_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_0_desc.core_ranges = all_cores;
+    reader_0_desc.compile_time_args = std::move(core_0_reader_ct_args);
+    reader_0_desc.defines = reader_defines;
+    reader_0_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+    };
 
-    auto reader_1_kernel_id = CreateKernel(
-        program,
-        reader_kernel_name,
-        all_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = core_1_reader_ct_args,
-            .defines = reader_defines});
+    KernelDescriptor reader_1_desc;
+    reader_1_desc.kernel_source = reader_kernel_name;
+    reader_1_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_1_desc.core_ranges = all_cores;
+    reader_1_desc.compile_time_args = std::move(core_1_reader_ct_args);
+    reader_1_desc.defines = std::move(reader_defines);
+    reader_1_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_1,
+        .noc = NOC::RISCV_1_default,
+    };
 
     if (config_tensors_in_dram) {
         uint32_t core_index = 0;
-        for (auto core : cores) {
+        for (const auto& core : cores) {
             if (is_height_sharded) {
-                SetRuntimeArgs(program, reader_0_kernel_id, core, {core_index});
-                SetRuntimeArgs(program, reader_1_kernel_id, core, {core_index});
+                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{core_index});
+                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{core_index});
             } else if (is_width_sharded) {
-                SetRuntimeArgs(program, reader_0_kernel_id, core, {0});
-                SetRuntimeArgs(program, reader_1_kernel_id, core, {0});
+                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0});
+                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0});
             } else if (is_block_sharded) {
-                auto nhw_index = is_rm_orientation ? core.y : core.x;
-                SetRuntimeArgs(program, reader_0_kernel_id, core, {nhw_index});
-                SetRuntimeArgs(program, reader_1_kernel_id, core, {nhw_index});
+                const auto nhw_index = is_rm_orientation ? core.y : core.x;
+                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{nhw_index});
+                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{nhw_index});
             }
             core_index++;
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .src_cb = src_cb,
-            .out_cb = out_cb,
-            .padding_config_cb0 = padding_config_cb0,
-            .padding_config_cb1 = padding_config_cb1,
-            .gather_config_cb0 = gather_config_cb0,
-            .gather_config_cb1 = gather_config_cb1,
-            .padding_config_storage0 = padding_config_storage0,
-            .padding_config_storage1 = padding_config_storage1,
-            .gather_config_storage0 = gather_config_storage0,
-            .gather_config_storage1 = gather_config_storage1,
-        }};
+    desc.kernels.push_back(std::move(reader_0_desc));
+    desc.kernels.push_back(std::move(reader_1_desc));
+
+    return desc;
 }
 
-void UntilizeWithHaloProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const HaloParams& /*operation_attributes*/,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor UntilizeWithHaloProgramFactory::create_workload_descriptor(
+    const HaloParams& operation_attributes,
     const Tensor& tensor_args,
-    Tensor& output_tensor) {
-    auto& program = cached_program.program;
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    const auto& input_tensor = tensor_args;
+    auto* device = input_tensor.device();
 
-    auto* src_buffer = tensor_args.buffer();
-    auto *dst_buffer = output_tensor.buffer();
-    auto& src_cb = cached_program.shared_variables.src_cb;
-    auto& out_cb = cached_program.shared_variables.out_cb;
+    const bool is_in_tiled = input_tensor.layout() == Layout::TILE;
+    const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool remote_read = operation_attributes.remote_read;
+    const bool transpose_mcast = operation_attributes.transpose_mcast;
 
-    UpdateDynamicCircularBufferAddress(program, src_cb, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, out_cb, *dst_buffer);
+    using namespace ttnn::operations;
+    auto pad_metadata = sliding_window::generate_pad_metadata(operation_attributes.config);
+    auto op_trace_metadata = sliding_window::generate_op_trace_metadata(operation_attributes.config);
+    auto shard_boundaries = sliding_window::generate_shard_boundaries(operation_attributes.config);
+    const uint32_t input_shard_height = input_tensor.memory_config().shard_spec()->shape[0];
+    auto tensor_metadata =
+        sliding_window::generate_tensor_metadata(pad_metadata, operation_attributes.config, input_shard_height);
+
+    const uint32_t num_cores_x = input_tensor.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+
+    auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
+        tensor_metadata,
+        shard_boundaries,
+        is_block_sharded,
+        transpose_mcast,
+        remote_read,
+        device,
+        num_cores_x,
+        is_in_tiled,
+        UNTILIZE_BLOCK_SIZE);
+
+    const auto& pad_config0 = kernel_config.pad_config0;
+    const auto& pad_config1 = kernel_config.pad_config1;
+    const auto& gather_config0 = kernel_config.gather_config0;
+    const auto& gather_config1 = kernel_config.gather_config1;
+
+    const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+        pad_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+        pad_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+        gather_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+        gather_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+
+    Tensor pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+        pad_config_tensor0,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+    Tensor pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+        pad_config_tensor1,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+    Tensor gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+        gather_config_tensor0,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+    Tensor gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+        gather_config_tensor1,
+        operation_attributes.parallel_config,
+        is_block_sharded,
+        device,
+        operation_attributes.config_tensors_in_dram);
+
+    TT_ASSERT(pad_config_device_tensor0.dtype() == DataType::UINT16);
+    TT_ASSERT(pad_config_device_tensor1.dtype() == DataType::UINT16);
+    TT_ASSERT(gather_config_device_tensor0.dtype() == DataType::UINT16);
+    TT_ASSERT(gather_config_device_tensor1.dtype() == DataType::UINT16);
+
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    // Park each intermediate halo-config Tensor on the WorkloadDescriptor.
+    // The Tensor itself (not just shared_ptr<MeshBuffer>) must outlive the
+    // cached workload: ~Tensor force-deallocates the underlying device memory
+    // via DeviceStorage::deallocate regardless of other shared owners.  See
+    // pool_multi_core_program_factory.cpp for the lifetime rationale.
+    auto pad0_owner = std::make_shared<Tensor>(std::move(pad_config_device_tensor0));
+    Buffer* pad0_buf = pad0_owner->buffer();
+    workload_descriptor.buffers.push_back({pad0_owner, pad0_buf});
+
+    auto pad1_owner = std::make_shared<Tensor>(std::move(pad_config_device_tensor1));
+    Buffer* pad1_buf = pad1_owner->buffer();
+    workload_descriptor.buffers.push_back({pad1_owner, pad1_buf});
+
+    auto gather0_owner = std::make_shared<Tensor>(std::move(gather_config_device_tensor0));
+    Buffer* gather0_buf = gather0_owner->buffer();
+    workload_descriptor.buffers.push_back({gather0_owner, gather0_buf});
+
+    auto gather1_owner = std::make_shared<Tensor>(std::move(gather_config_device_tensor1));
+    Buffer* gather1_buf = gather1_owner->buffer();
+    workload_descriptor.buffers.push_back({gather1_owner, gather1_buf});
+
+    const auto number_of_blocks_per_core = sliding_window::remap_nhw_scalar_argument_across_full_grid(
+        kernel_config.number_of_blocks_per_core, operation_attributes.parallel_config);
+
+    // Single-device op: the kernel program is structurally identical for every
+    // coord in `tensor_coords` (halo doesn't depend on cluster position).
+    // Build the per-coord ProgramDescriptor ONCE and copy it into each
+    // coord-range entry to avoid redundant work on multi-coord workloads.
+    auto desc = build_halo_program(
+        operation_attributes,
+        input_tensor,
+        output_tensor,
+        pad0_buf,
+        pad1_buf,
+        gather0_buf,
+        gather1_buf,
+        number_of_blocks_per_core);
+
+    auto ranges = tensor_coords.ranges();
+    workload_descriptor.programs.reserve(ranges.size());
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        workload_descriptor.programs.push_back({ranges[i], desc});
+    }
+    if (!ranges.empty()) {
+        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
@@ -4,35 +4,25 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeWithHaloProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::CBHandle src_cb{};
-        tt::tt_metal::CBHandle out_cb{};
-        tt::tt_metal::CBHandle padding_config_cb0{};
-        tt::tt_metal::CBHandle padding_config_cb1{};
-        tt::tt_metal::CBHandle gather_config_cb0{};
-        tt::tt_metal::CBHandle gather_config_cb1{};
-        tt::tt_metal::DeviceStorage padding_config_storage0;
-        tt::tt_metal::DeviceStorage padding_config_storage1;
-        tt::tt_metal::DeviceStorage gather_config_storage0;
-        tt::tt_metal::DeviceStorage gather_config_storage1;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const HaloParams& operation_attributes, const Tensor& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // create_workload_descriptor() allocates the four sliding-window halo
+    // config tensors (pad_config0/1, gather_config0/1) on device and parks
+    // them on the returned WorkloadDescriptor so their backing buffers
+    // outlive the cached programs.  The buffers are bound to the
+    // CBDescriptor entries that the reader kernels stream from.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const HaloParams& operation_attributes,
         const Tensor& tensor_args,
-        Tensor& output_tensor);
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
## Summary
Contract-2 (WorkloadDescriptor) migration of 5 ops that allocate intermediate device tensors and need them kept alive for the cached workload's lifetime:
- sliding_window/halo (pad_config × 2 + gather_config × 2 device tensors)
- data_movement/reshape_view/reshape_tiled (mapping_tensor)
- conv/conv2d/conv2d_op_sharded (conv_reader_indices_storage)
- conv/conv2d/conv2d_op_width_sharded
- experimental/conv3d (Contract-1; no lifetime issue)

Each intermediate is wrapped in \`shared_ptr<Tensor>\` and parked on \`workload_descriptor.buffers\` (same pattern as Pool2D's existing migration).

Part of #42193 / #42210 / #42401.

## Dependencies
None.

## Test plan
- [ ] sanity-tests.yaml
- [ ] runtime-sanity-tests.yaml
- [ ] blackhole-post-commit.yaml
- [ ] tt-metal-l2-nightly.yaml (conv + halo families)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-lifetime-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-lifetime-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-lifetime-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-lifetime-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-lifetime-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-lifetime-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-lifetime-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-lifetime-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-lifetime-ops)