### PR TITLE
Migrate deepseek_moe_fast_reduce_nc_fused + all_gather_via_broadcast to ProgramDescriptor (Contract-2)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
@@ -4,6 +4,8 @@
 
 #include "all_gather_via_broadcast_factory.hpp"
 
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 
@@ -301,6 +303,7 @@ tt::tt_metal::WorkloadDescriptor AllGatherViaBroadcastFactory::create_workload_d
     workload_descriptor.semaphores.push_back(init_barrier_semaphore);
     workload_descriptor.semaphores.push_back(final_barrier_semaphore);
 
+    workload_descriptor.programs.reserve(tensor_coords.coords().size());
     for (const auto& coord : tensor_coords.coords()) {
         auto desc = build_descriptor_at(
             operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
@@ -5,9 +5,11 @@
 #include "all_gather_via_broadcast_factory.hpp"
 
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
 
 #include <bit>
 #include <numeric>
+#include <variant>
 
 namespace ttnn {
 
@@ -15,40 +17,11 @@ using namespace ccl;
 
 namespace experimental::prim {
 
-AllGatherViaBroadcastFactory::cached_mesh_workload_t AllGatherViaBroadcastFactory::create_mesh_workload(
-    const AllGatherAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const AllGatherAsyncInputs& tensor_args,
-    Tensor& output_tensor) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+namespace {
 
-    auto* mesh_device = tensor_args.input_tensor.device();
-    auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
-
-    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
-    auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
-    log_debug(tt::LogOp, "Semaphores allocated and waiting for all devices to be ready");
-    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
-    log_debug(tt::LogOp, "All devices are ready, starting program execution");
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(
-            operation_attributes,
-            coord,
-            tensor_args.input_tensor,
-            output_tensor,
-            final_barrier_semaphore,
-            init_barrier_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-
-    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
-}
-
+// Worker-core selection close to the ethernet routers.  Preserves the
+// hand-tuned core layout from the legacy factory (ethernet locality matters
+// for the broadcast all-gather's fabric throughput).
 CoreRangeSet get_cores_close_to_erisc(uint32_t num_workers, bool row_wise) {
     CoreRangeSet worker_cores;
     std::vector<CoreRange> desired_core_range = {CoreRange({5, 3}, {6, 3}), CoreRange({2, 8}, {3, 8})};
@@ -67,7 +40,14 @@ CoreRangeSet get_cores_close_to_erisc(uint32_t num_workers, bool row_wise) {
     return worker_cores;
 }
 
-AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::create_at(
+// Build a ProgramDescriptor for one mesh coord.  The per-coord layout is
+// otherwise identical to the legacy factory's create_at(); the only changes
+// are:
+//   - kernels/CBs are pushed onto a ProgramDescriptor rather than created
+//     directly on a Program,
+//   - the writer kernel index (used as KernelHandle for the templated fabric
+//     helper) is the descriptor index of the writer KernelDescriptor.
+tt::tt_metal::ProgramDescriptor build_descriptor_at(
     const AllGatherAsyncParams& operation_attributes,
     const ttnn::MeshCoordinate& sender_device_coord,
     const Tensor& input,
@@ -75,7 +55,7 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
     const tt::tt_metal::GlobalSemaphore& semaphore,
     const tt::tt_metal::GlobalSemaphore& barrier_semaphore) {
     const auto& input_tensor = input;
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     uint32_t ring_size = operation_attributes.ring_size;
     uint32_t ring_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
@@ -132,11 +112,15 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
     // L1 Scratch CB Creation
     uint32_t src0_cb_index = tt::CB::c_in0;
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(3 * cb_page_size, {{src0_cb_index, df}})
-            .set_page_size(src0_cb_index, cb_page_size);
-
-    CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = 3 * cb_page_size,
+        .core_ranges = sender_worker_core_range,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = df,
+            .page_size = cb_page_size,
+        }}},
+    });
 
     // KERNEL CREATION
     // Reader
@@ -170,18 +154,29 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
     writer_compile_args.insert(writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
     tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_args);
-    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp",
-        sender_worker_core_range,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
 
-    // Writer
-    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp",
-        sender_worker_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_args));
+    // Kernels are pushed in a fixed order — reader first, then writer.  The
+    // writer's descriptor index becomes its KernelHandle, which the templated
+    // fabric helper uses to add defines.
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = sender_worker_core_range;
+    reader_kernel_desc.compile_time_args = std::move(reader_compile_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+    const tt::tt_metal::KernelHandle reader_kernel_index = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(reader_kernel_desc));
+
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = sender_worker_core_range;
+    writer_kernel_desc.compile_time_args = std::move(writer_compile_args);
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+    tt::tt_metal::KernelHandle writer_kernel_index = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(writer_kernel_desc));
 
     // Kernel Runtime Args
     CoreCoord drain_sync_core;  // the first worker of each chip is the drain sync core, which contains the output ready
@@ -202,13 +197,16 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
         uint32_t remainder = num_input_pages % operation_attributes.num_links;
         uint32_t input_tile_id_start = (link * input_pages_per_link) + std::min(link, remainder);
         uint32_t input_tile_id_end = ((link + 1) * input_pages_per_link) + std::min(link + 1, remainder);
-        std::vector<uint32_t> reader_rt_args = {
-            input_tensor.buffer()->address(),  // tensor_address0
-            input_tile_id_start,               // tile_id_start
-            input_tile_id_end,                 // tile_id_end
-        };
 
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+        // tensor_address0 is bound as a Buffer*; the framework patches it on
+        // cache hits via the buffer_bindings fast path.
+        desc.kernels[reader_kernel_index].emplace_runtime_args(
+            core,
+            {
+                input_tensor.buffer(),  // tensor_address0
+                input_tile_id_start,    // tile_id_start
+                input_tile_id_end,      // tile_id_end
+            });
 
         // Set writer runtime args
         bool wait_output_semaphore = (link == 0);
@@ -220,8 +218,15 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
         // page id in gathered tensor with the write page offset
         output_tile_id_start += write_page_offset;
         output_tile_id_end += write_page_offset;
+
+        // The fabric helper appends to a plain std::vector<uint32_t>; we mirror
+        // that here, then convert to the variant arg list at emplace time and
+        // splice the output_tensor Buffer* binding back at index 0.  The
+        // GlobalSemaphore addresses are stable for the workload lifetime
+        // (semaphores live on workload_descriptor.semaphores), so they may
+        // remain embedded plain uint32 values.
         std::vector<uint32_t> writer_rt_args = {
-            output_tensor.buffer()->address(),  // tensor_address0  //HERE
+            output_tensor.buffer()->address(),  // tensor_address0  (replaced with Buffer* below)
             semaphore.address(),                // out_ready_sem_bank_addr (absolute address)
             barrier_semaphore.address(),        // barrier_sem
             output_tile_id_start,
@@ -249,51 +254,65 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
             dst_nodes.push_back(backward_coord_fabric_node_id);
         }
 
-        append_routing_plane_connection_manager_rt_args(
-            sender_fabric_node_id, dst_nodes, {link}, program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+        // Templated fabric helper supports both Program and ProgramDescriptor;
+        // here it appends fabric routing args and adds kernel defines to the
+        // writer descriptor at writer_kernel_index.
+        tt::tt_fabric::append_routing_plane_connection_manager_rt_args<tt::tt_metal::ProgramDescriptor>(
+            sender_fabric_node_id, dst_nodes, {link}, desc, writer_kernel_index, core, writer_rt_args);
+
+        // Convert to the variant arg list and substitute the output Buffer*
+        // at the first position so the fast cache-hit path patches it.
+        std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> writer_rt_args_variant;
+        writer_rt_args_variant.reserve(writer_rt_args.size());
+        writer_rt_args_variant.emplace_back(output_tensor.buffer());
+        for (size_t i = 1; i < writer_rt_args.size(); ++i) {
+            writer_rt_args_variant.emplace_back(writer_rt_args[i]);
+        }
+        desc.kernels[writer_kernel_index].emplace_runtime_args(core, writer_rt_args_variant);
     }
 
-    shared_variables_t shared_variables{
-        .sender_worker_cores = sender_worker_cores,
-        .worker_sender_reader_kernel_id = worker_sender_reader_kernel_id,
-        .worker_sender_writer_kernel_id = worker_sender_writer_kernel_id,
-        .semaphore = semaphore,
-        .barrier_semaphore = barrier_semaphore,
-        .ring_index = ring_index,
-    };
-
-    return {std::move(program), std::move(shared_variables)};
+    return desc;
 }
 
-void AllGatherViaBroadcastFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const AllGatherAsyncParams& /*operation_attributes*/,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor AllGatherViaBroadcastFactory::create_workload_descriptor(
+    const AllGatherAsyncParams& operation_attributes,
     const AllGatherAsyncInputs& tensor_args,
-    Tensor& output_tensor) {
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        // const auto& coord = coordinate_range.start_coord();
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-        log_trace(tt::LogOp, "DEBUG: semaphore: {}", shared_vars.semaphore.address());
-        log_trace(tt::LogOp, "DEBUG: barrier_semaphore: {}", shared_vars.barrier_semaphore.address());
-        // update senders
-        auto& worker_reader_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_reader_kernel_id);
-        auto& worker_writer_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_writer_kernel_id);
+    auto* mesh_device = tensor_args.input_tensor.device();
+    auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
+    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
 
-        for (const auto& core : shared_vars.sender_worker_cores) {
-            // reader
-            auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
-            worker_reader_sender_runtime_args[0] = tensor_args.input_tensor.buffer()->address();
-            // writer
-            auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
-            worker_writer_sender_runtime_args[0] = output_tensor.buffer()->address();
-            worker_writer_sender_runtime_args[1] = shared_vars.semaphore.address();
-            worker_writer_sender_runtime_args[2] = shared_vars.barrier_semaphore.address();
-        }
+    // Workload-scoped semaphores: allocated once on cache miss and parked on
+    // workload_descriptor.semaphores so they outlive the cached workload (the
+    // program cache keeps the WorkloadDescriptor alive).  Both semaphores must
+    // be ready before any device starts executing, hence the synchronize.
+    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
+    auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
+    log_debug(tt::LogOp, "Semaphores allocated and waiting for all devices to be ready");
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
+    log_debug(tt::LogOp, "All devices are ready, starting program execution");
+
+    workload_descriptor.semaphores.push_back(init_barrier_semaphore);
+    workload_descriptor.semaphores.push_back(final_barrier_semaphore);
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = build_descriptor_at(
+            operation_attributes,
+            coord,
+            tensor_args.input_tensor,
+            output_tensor,
+            final_barrier_semaphore,
+            init_barrier_semaphore);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 }  // namespace experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.hpp
@@ -6,8 +6,6 @@
 
 #include "all_gather_async_device_operation_types.hpp"
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.hpp
@@ -6,76 +6,20 @@
 
 #include "all_gather_async_device_operation_types.hpp"
 
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::experimental::prim {
 
-struct AllGatherViaBroadcastFactoryProgramArtifacts {
-    std::vector<tt::tt_metal::CoreCoord> sender_worker_cores;
-    tt::tt_metal::KernelHandle worker_sender_reader_kernel_id{};
-    tt::tt_metal::KernelHandle worker_sender_writer_kernel_id{};
-    tt::tt_metal::GlobalSemaphore semaphore;
-    tt::tt_metal::GlobalSemaphore barrier_semaphore;
-    uint32_t ring_index = 0;
-};
-
 struct AllGatherViaBroadcastFactory {
-    // using shared_variables_t = AllBroadcastProgramFactory::shared_variables_t;
-    using shared_variables_t = AllGatherViaBroadcastFactoryProgramArtifacts;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const AllGatherAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const AllGatherAsyncInputs& tensor_args,
-        Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const AllGatherAsyncParams& operation_attributes,
         const AllGatherAsyncInputs& tensor_args,
-        Tensor& output_tensor);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const AllGatherAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinate& sender_device_coord,
-        const Tensor& input,
-        const Tensor& output_tensor,
-        const tt::tt_metal::GlobalSemaphore& semaphore,
-        const tt::tt_metal::GlobalSemaphore& barrier_semaphore);
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim
-
-namespace ttnn {
-using AllGatherViaBroadcastFactoryProgramArtifacts = experimental::prim::AllGatherViaBroadcastFactoryProgramArtifacts;
-
-// Builder function that creates kernels and returns artifacts
-AllGatherViaBroadcastFactoryProgramArtifacts build_all_gather_via_broadcast_program_artifacts(
-    tt::tt_metal::Program& program,
-    const Tensor& input_tensor,
-    const MeshCoordinate& sender_device_coord,
-    const std::optional<MeshCoordinate>& forward_coord,
-    const std::optional<MeshCoordinate>& backward_coord,
-    Tensor& output_tensor,
-    int32_t dim,
-    uint32_t num_links,
-    uint32_t ring_size,
-    uint32_t ring_index,
-    ccl::Topology topology,
-    const std::vector<GlobalSemaphore>& semaphore,
-    const std::optional<GlobalSemaphore>& barrier_semaphore,
-    bool using_persistent_buffers,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
-    std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
-    std::optional<uint32_t> chunks_per_sync,
-    std::optional<uint32_t> num_workers_per_direction_opt,
-    std::optional<uint32_t> num_buffers_per_channel,
-    CoreCoord core_grid_offset,
-    bool reverse_order,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
-
-}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
@@ -336,8 +336,13 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+    // NOTE: packer_l1_acc and dst_full_sync_en from get_compute_kernel_config_args are intentionally
+    // not destructured here; the legacy factory did not propagate them either. dst_full_sync_en is
+    // also available on ComputeConfigDescriptor but is left at its default to match prior behavior.
+    const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, _packer_l1_acc, _dst_full_sync_en] =
         get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
+    (void)_packer_l1_acc;
+    (void)_dst_full_sync_en;
 
     tt::tt_metal::KernelDescriptor::Defines compute_defines;
     if (fp32_dest_acc_en) {

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
@@ -84,22 +84,19 @@ std::vector<uint32_t> to_reader_ct_arg_vector(const DeepseekMoeFastReduceNcFused
     };
 }
 
-}  // namespace
-
-namespace ttnn::experimental::prim {
-
-ttnn::device_operation::CachedProgram<DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::shared_variables_t>
-DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
-    const DeepseekMoEFastReduceNCFusedParams& operation_attributes,
+// Builds the per-mesh-coord ProgramDescriptor.  The mesh coordinate enters via
+// reader runtime args at positions [4]/[5] (row/col), so each coord needs its
+// own descriptor.
+tt::tt_metal::ProgramDescriptor build_program_descriptor(
+    const ttnn::experimental::prim::DeepseekMoEFastReduceNCFusedParams& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
-    const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
+    const ttnn::experimental::prim::DeepseekMoEFastReduceNCFusedInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& output_tensors) {
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto* device = tensor_args.input_tensor.device();
     const uint32_t mesh_cols = device->get_view().num_cols();
-    auto program = Program();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -110,8 +107,6 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
     const ttnn::Tensor& expert_mapping_tensor = tensor_args.expert_mapping_tensor;
     const auto& input_shape = input_tensor.padded_shape();
     const uint32_t input_rank = input_shape.rank();
-
-    const std::vector<ttnn::Tensor>& output_tensors = tensor_return_value;
 
     const uint32_t reduction_dim = operation_attributes.reduce_dim;
 
@@ -181,55 +176,80 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
     const uint32_t input_tensor_buffer_factor = input_granularity * 2;
     const uint32_t output_tensor_buffer_factor = 2;
 
+    tt::tt_metal::ProgramDescriptor desc;
+
     // CB c_0: activation tiles (double-buffered)
-    uint32_t cb_in_act_id = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_in_act_config =
-        tt::tt_metal::CircularBufferConfig(
-            input_tensor_buffer_factor * input_page_size, {{cb_in_act_id, input_data_format}})
-            .set_page_size(cb_in_act_id, input_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_in_act_config);
+    const uint32_t cb_in_act_id = tt::CBIndex::c_0;
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = input_tensor_buffer_factor * input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_in_act_id),
+            .data_format = input_data_format,
+            .page_size = input_page_size,
+        }}},
+    });
 
     // CB c_1: pre-processed score tiles (one per expert), held resident during compute
-    uint32_t cb_scores_id = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_scores_config =
-        tt::tt_metal::CircularBufferConfig(reduction_dim_size * scores_tile_size, {{cb_scores_id, scores_data_format}})
-            .set_page_size(cb_scores_id, scores_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scores_config);
+    const uint32_t cb_scores_id = tt::CBIndex::c_1;
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = reduction_dim_size * scores_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_scores_id),
+            .data_format = scores_data_format,
+            .page_size = scores_tile_size,
+        }}},
+    });
 
     // CB c_2: scratch for reading raw RM scores from DRAM (one page = one token row)
-    uint32_t cb_scores_rm_id = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_scores_rm_config =
-        tt::tt_metal::CircularBufferConfig(
-            scores_rm_cb_num_pages * scores_cb_rm_page_size, {{cb_scores_rm_id, scores_data_format}})
-            .set_page_size(cb_scores_rm_id, scores_cb_rm_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scores_rm_config);
+    const uint32_t cb_scores_rm_id = tt::CBIndex::c_2;
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = scores_rm_cb_num_pages * scores_cb_rm_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_scores_rm_id),
+            .data_format = scores_data_format,
+            .page_size = scores_cb_rm_page_size,
+        }}},
+    });
 
     // CB c_3: full expert_indices_tensor mirrored in L1. Sized to hold every page once;
     // the reader loads all pages up front before the score-tilization prologue.
-    uint32_t cb_expert_indices_id = tt::CBIndex::c_3;
-    tt::tt_metal::CircularBufferConfig cb_expert_indices_config =
-        tt::tt_metal::CircularBufferConfig(
-            expert_indices_num_pages * expert_indices_cb_page_size,
-            {{cb_expert_indices_id, expert_indices_data_format}})
-            .set_page_size(cb_expert_indices_id, expert_indices_cb_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_expert_indices_config);
+    const uint32_t cb_expert_indices_id = tt::CBIndex::c_3;
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = expert_indices_num_pages * expert_indices_cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_expert_indices_id),
+            .data_format = expert_indices_data_format,
+            .page_size = expert_indices_cb_page_size,
+        }}},
+    });
 
     // CB c_4: full expert_mapping_tensor mirrored in L1, same loading pattern as c_3.
-    uint32_t cb_expert_mapping_id = tt::CBIndex::c_4;
-    tt::tt_metal::CircularBufferConfig cb_expert_mapping_config =
-        tt::tt_metal::CircularBufferConfig(
-            expert_mapping_num_pages * expert_mapping_cb_page_size,
-            {{cb_expert_mapping_id, expert_mapping_data_format}})
-            .set_page_size(cb_expert_mapping_id, expert_mapping_cb_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_expert_mapping_config);
+    const uint32_t cb_expert_mapping_id = tt::CBIndex::c_4;
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = expert_mapping_num_pages * expert_mapping_cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_expert_mapping_id),
+            .data_format = expert_mapping_data_format,
+            .page_size = expert_mapping_cb_page_size,
+        }}},
+    });
 
     // CB c_16: output tiles (double-buffered)
-    uint32_t cb_out_id = tt::CBIndex::c_16;
-    tt::tt_metal::CircularBufferConfig cb_out_config =
-        tt::tt_metal::CircularBufferConfig(
-            output_tensor_buffer_factor * output_page_size, {{cb_out_id, output_data_format}})
-            .set_page_size(cb_out_id, output_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+    const uint32_t cb_out_id = tt::CBIndex::c_16;
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = output_tensor_buffer_factor * output_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_out_id),
+            .data_format = output_data_format,
+            .page_size = output_page_size,
+        }}},
+    });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
@@ -292,18 +312,26 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
         TensorAccessorArgs(output_tensor.buffer()).append_to(writer_ct_args);
     }
 
-    const auto* const reader_kernel_file =
+    constexpr const char* reader_kernel_file =
         "ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/"
         "deepseek_moe_fast_reduce_nc_fused_reader.cpp";
-    const auto* const writer_kernel_file =
+    constexpr const char* writer_kernel_file =
         "ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/"
         "deepseek_moe_fast_reduce_nc_writer.cpp";
 
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program, reader_kernel_file, all_cores, tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    tt::tt_metal::KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel_file, all_cores, tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    tt::tt_metal::KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
@@ -311,15 +339,19 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
     const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
 
-    std::map<std::string, std::string> compute_defines;
+    tt::tt_metal::KernelDescriptor::Defines compute_defines;
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
-    const auto* const compute_kernel_file =
+    constexpr const char* compute_kernel_file =
         "ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/"
         "deepseek_moe_fast_reduce_nc_fused_compute.cpp";
 
-    std::vector<uint32_t> compute_ct_args_group_1 = {
+    tt::tt_metal::KernelDescriptor compute_desc_group_1;
+    compute_desc_group_1.kernel_source = compute_kernel_file;
+    compute_desc_group_1.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_group_1.core_ranges = core_group_1;
+    compute_desc_group_1.compile_time_args = {
         num_cols_per_core_group_1,
         reduction_dim_size,
         input_granularity,
@@ -327,19 +359,20 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
         cb_scores_id,
         cb_out_id,
     };
-    tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_file,
-        core_group_1,
-        tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_ct_args_group_1,
-            .defines = compute_defines});
+    compute_desc_group_1.defines = compute_defines;
+    compute_desc_group_1.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .math_approx_mode = math_approx_mode,
+    };
 
+    std::optional<tt::tt_metal::KernelDescriptor> compute_desc_group_2;
     if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_ct_args_group_2 = {
+        compute_desc_group_2.emplace();
+        compute_desc_group_2->kernel_source = compute_kernel_file;
+        compute_desc_group_2->source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_group_2->core_ranges = core_group_2;
+        compute_desc_group_2->compile_time_args = {
             num_cols_per_core_group_2,
             reduction_dim_size,
             input_granularity,
@@ -347,16 +380,12 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
             cb_scores_id,
             cb_out_id,
         };
-        tt::tt_metal::CreateKernel(
-            program,
-            compute_kernel_file,
-            core_group_2,
-            tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .math_approx_mode = math_approx_mode,
-                .compile_args = compute_ct_args_group_2,
-                .defines = compute_defines});
+        compute_desc_group_2->defines = compute_defines;
+        compute_desc_group_2->config = tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -383,6 +412,13 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
     TT_FATAL(
         core_group_2.ranges().empty() || num_cols_per_core_group_1 >= num_cols_per_core_group_2,
         "num_cols_per_core_group_1 must be greater than or equal to num_cols_per_core_group_2");
+
+    TT_FATAL(
+        mesh_coordinate.dims() == 2,
+        "deepseek_moe_fast_reduce_nc_fused expects a 2D mesh coordinate, got {}D",
+        mesh_coordinate.dims());
+    const uint32_t mesh_coord_row = mesh_coordinate[0];
+    const uint32_t mesh_coord_col = mesh_coordinate[1];
 
     const auto core_groups = {core_group_1, core_group_2};
 
@@ -411,76 +447,64 @@ DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_at(
             //   [5] mesh_coord_col
             //   [6] expert_indices addr
             //   [7] expert_mapping addr
-            TT_FATAL(
-                mesh_coordinate.dims() == 2,
-                "deepseek_moe_fast_reduce_nc_fused expects a 2D mesh coordinate, got {}D",
-                mesh_coordinate.dims());
-            const uint32_t mesh_coord_row = mesh_coordinate[0];
-            const uint32_t mesh_coord_col = mesh_coordinate[1];
-            std::vector<uint32_t> reader_rt_args = {
-                input_tensor.buffer()->address(),
-                scores_tensor.buffer()->address(),
-                start_tiles_read,
-                start_tiles_to_read,
-                mesh_coord_row,
-                mesh_coord_col,
-                expert_indices_tensor.buffer()->address(),
-                expert_mapping_tensor.buffer()->address()};
-            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
+            // Buffer* entries register as buffer bindings so the framework's
+            // cache-hit fast path can patch their addresses without re-running
+            // create_workload_descriptor.
+            reader_desc.emplace_runtime_args(
+                core,
+                {input_tensor.buffer(),
+                 scores_tensor.buffer(),
+                 start_tiles_read,
+                 start_tiles_to_read,
+                 mesh_coord_row,
+                 mesh_coord_col,
+                 expert_indices_tensor.buffer(),
+                 expert_mapping_tensor.buffer()});
 
-            std::vector<uint32_t> writer_rt_args = {
-                start_tiles_read, start_tiles_to_read, start_slice_row_offset, start_pages_read_in_row};
+            tt::tt_metal::KernelDescriptor::RTArgList writer_rt_args;
+            writer_rt_args.push_back(start_tiles_read);
+            writer_rt_args.push_back(start_tiles_to_read);
+            writer_rt_args.push_back(start_slice_row_offset);
+            writer_rt_args.push_back(start_pages_read_in_row);
             for (const ttnn::Tensor& output_tensor : output_tensors) {
-                writer_rt_args.push_back(output_tensor.buffer()->address());
+                writer_rt_args.push_back(output_tensor.buffer());
             }
-            tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_rt_args);
+            writer_desc.emplace_runtime_args(core, writer_rt_args);
 
             start_tiles_read++;
         }
     }
 
-    return ttnn::device_operation::CachedProgram<DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::shared_variables_t>{
-        std::move(program), {reader_kernel_id, writer_kernel_id, corerange_to_cores(all_cores), num_cores}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_group_1));
+    if (compute_desc_group_2.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc_group_2));
+    }
+
+    return desc;
 }
 
-void DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const DeepseekMoEFastReduceNCFusedParams&,
+}  // namespace
+
+namespace ttnn::experimental::prim {
+
+tt::tt_metal::WorkloadDescriptor DeepseekMoEFastReduceNCFusedMeshWorkloadFactory::create_workload_descriptor(
+    const DeepseekMoEFastReduceNCFusedParams& operation_attributes,
     const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
-    const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
-    const ttnn::Tensor& scores_tensor = tensor_args.scores_tensor;
-    const ttnn::Tensor& expert_indices_tensor = tensor_args.expert_indices_tensor;
-    const ttnn::Tensor& expert_mapping_tensor = tensor_args.expert_mapping_tensor;
-    const std::vector<ttnn::Tensor>& output_tensors = tensor_return_value;
-
-    // Mesh coords and cluster_axis are tied to the device/launch and don't change between
-    // launches with the same cache key, so we only refresh tensor addresses here.
-    // Reader RT arg layout (set in create_at):
-    //   [0] input addr, [1] scores addr, [2..3] work range,
-    //   [4..5] mesh (row, col), [6] expert_indices addr, [7] expert_mapping addr.
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-        const tt::tt_metal::KernelHandle& reader_kernel_id = shared_variables.reader_kernel_id;
-        const tt::tt_metal::KernelHandle& writer_kernel_id = shared_variables.writer_kernel_id;
-        const auto& all_cores = shared_variables.all_cores;
-        const uint32_t ncores = shared_variables.ncores;
-
-        for (uint32_t i = 0; i < ncores; ++i) {
-            const auto& core = all_cores[i];
-            auto& reader_rt_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            reader_rt_args[0] = input_tensor.buffer()->address();
-            reader_rt_args[1] = scores_tensor.buffer()->address();
-            reader_rt_args[6] = expert_indices_tensor.buffer()->address();
-            reader_rt_args[7] = expert_mapping_tensor.buffer()->address();
-
-            auto& writer_rt_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            const uint32_t output_tensor_start_idx = 4;
-            for (unsigned j = 0; j < output_tensors.size(); ++j) {
-                writer_rt_args[output_tensor_start_idx + j] = output_tensors.at(j).buffer()->address();
-            }
-        }
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+    // Per-coord programs: each coord encodes its own (row, col) in reader RT
+    // args [4]/[5], so a single shared descriptor would not be correct.  Build
+    // one descriptor per individual coordinate.
+    const auto coords = tensor_coords.coords();
+    workload_descriptor.programs.reserve(coords.size());
+    for (const auto& coord : coords) {
+        auto desc = build_program_descriptor(operation_attributes, coord, tensor_args, tensor_return_value);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.hpp
@@ -6,35 +6,23 @@
 
 #include <cstdint>
 
+#include <tt-metalium/workload_descriptor.hpp>
+
 #include "deepseek_moe_fast_reduce_nc_fused_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::experimental::prim {
 
+// Contract-2 mesh-workload factory: builds one ProgramDescriptor per mesh
+// coordinate (the per-coord reader RT args embed the (row, col) mesh
+// coordinate, so a single replicated descriptor would not be correct).
 struct DeepseekMoEFastReduceNCFusedMeshWorkloadFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id;
-        tt::tt_metal::KernelHandle writer_kernel_id;
-        std::vector<tt::tt_metal::CoreCoord> all_cores;
-        uint32_t ncores;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    // Per-device program construction. The framework iterates the mesh's coordinate range set and
-    // assembles the MeshWorkload by calling this for each coordinate.
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const DeepseekMoEFastReduceNCFusedParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const DeepseekMoEFastReduceNCFusedParams& operation_attributes,
         const DeepseekMoEFastReduceNCFusedInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value);
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
## Summary
Contract-2 migration of 2 standalone ops that already use the mesh workload pattern:
- experimental/reduction/deepseek_moe_fast_reduce_nc_fused
- experimental/ccl/all_gather_via_broadcast

Part of #42193 / #42209 / #42210.

**Note:** generic_op was originally part of this PR but the C2 migration was reverted because generic_op's descriptor is user-supplied per call (e.g. dynamic `CBDescriptor::address_offset`), which breaks C2's cache-hit assumption that the cached descriptor is the source of truth for non-address fields. Specifically, `test_cb_address_offset_preserved_on_cache_hit` regressed because `apply_resolved_bindings` uses the stored offset, not the current call's. generic_op stays on the legacy/Contract-1 path (with PR #42073's address_offset fix); a proper C2 migration needs a per-call descriptor refresh hook in the framework and is out of scope here.

## Dependencies
None.

## Test plan
- [ ] sanity-tests.yaml
- [ ] runtime-sanity-tests.yaml
- [ ] blackhole-post-commit.yaml
- [ ] tt-metal-l2-nightly.yaml

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-standalone-c2-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-standalone-c2-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-standalone-c2-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-standalone-c2-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-standalone-c2-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-standalone-c2-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-standalone-c2-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-standalone-c2-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-standalone-c2-ops)