### PR TITLE
experimental/ccl: migrate non-matmul-fused CCL consumer ops to ProgramDescriptor (Contract-2)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1896,11 +1896,10 @@ void fabric_mux_connection_rt_args(
     worker_rt_args.push_back(termination_master_virtual_core.y);                   // termination_master_noc_y 16
 }
 
-// ProgramDescriptor (Contract-2) variant — mirrors the legacy Program& helper above.
-// Allocates the same five mux-side semaphores by pushing SemaphoreDescriptors into
-// desc.semaphores and recording their IDs into worker_rt_args. The arg-vector
-// layout (positions 0..16) is identical to the legacy helper so worker kernels
-// are byte-compatible across the two variants.
+// ProgramDescriptor overload — allocates the same five mux-side semaphores by
+// pushing SemaphoreDescriptors into desc.semaphores and recording their IDs
+// into worker_rt_args. The arg-vector layout (positions 0..16) matches the
+// Program& overload so worker kernels are byte-compatible across both.
 void fabric_mux_connection_rt_args(
     const bool mux_connection_valid,
     const bool is_termination_master,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -783,10 +783,10 @@ void fabric_mux_connection_rt_args(
     std::vector<uint32_t>& worker_rt_args,
     std::optional<uint32_t> = std::nullopt);
 
-// ProgramDescriptor (Contract-2) variant of fabric_mux_connection_rt_args.
-// Mirrors the legacy Program& helper but allocates the five mux-side semaphores by
-// pushing SemaphoreDescriptors into desc.semaphores and recording their IDs into
-// worker_rt_args at the same positions. Semaphore IDs are obtained from
+// ProgramDescriptor variant of fabric_mux_connection_rt_args.
+// Allocates the five mux-side semaphores by pushing SemaphoreDescriptors into
+// desc.semaphores and recording their IDs into worker_rt_args at the same
+// positions. Semaphore IDs are obtained from
 // ProgramDescriptor::find_available_semaphore_id so they don't collide with IDs
 // already allocated on the same worker_logical_core. An optional
 // termination_master_semaphore_id can be supplied if the caller already owns one

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -784,11 +784,10 @@ void all_gather_async_minimal_default_helper_override_runtime_arguments(
     }
 }
 
-// ProgramDescriptor (Contract-2) variant of build_all_gather_async_minimal_default_program_artifacts.
-// Mirrors the legacy builder body but appends descriptors instead of creating
-// kernels/CBs/semaphores directly on a Program.  Runtime args are emplaced
-// with Buffer* entries for the input/output tensors so the framework's fast
-// cache-hit path patches their base addresses.
+// ProgramDescriptor variant of build_all_gather_async_minimal_default_program_artifacts.
+// Appends descriptors instead of creating kernels/CBs/semaphores directly on a
+// Program.  Runtime args are emplaced with Buffer* entries for the input/output
+// tensors so the framework's fast cache-hit path patches their base addresses.
 //
 // Sub-helpers used (all have descriptor overloads on this branch):
 //   - AllGatherFusedOpSignaler::init_all_gather(ProgramDescriptor&, ...)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -14,131 +14,62 @@ using namespace ccl;
 
 namespace experimental::prim {
 
-DefaultMeshWorkloadFactory::cached_mesh_workload_t DefaultMeshWorkloadFactory::create_mesh_workload(
+tt::tt_metal::WorkloadDescriptor DefaultMeshWorkloadFactory::create_workload_descriptor(
     const AllGatherAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const AllGatherAsyncInputs& tensor_args,
-    Tensor& output_tensor) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, output_tensor);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
-}
-
-DefaultMeshWorkloadFactory::cached_program_t DefaultMeshWorkloadFactory::create_at(
-    const AllGatherAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const AllGatherAsyncInputs& tensor_args,
-    Tensor& output_tensor) {
+    Tensor& output_tensor,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     const auto& input_tensor = tensor_args.input_tensor;
-
-    const auto& sender_device_coord = mesh_coordinate;  // coord
-    const auto& forward_coord = get_physical_neighbor_from_physical_coord(
-        input_tensor, sender_device_coord, 1, operation_attributes.topology, operation_attributes.cluster_axis);
-    const auto& backward_coord = get_physical_neighbor_from_physical_coord(
-        input_tensor, sender_device_coord, -1, operation_attributes.topology, operation_attributes.cluster_axis);
-    TT_FATAL(forward_coord.has_value() || backward_coord.has_value(), "DEBUG: forward_coord or backward_coord is null");
-
-    const auto& dim = operation_attributes.dim;
-    const auto& num_links = operation_attributes.num_links;
-    const auto& ring_size = operation_attributes.ring_size;
-    const auto& ring_index = get_linearized_index_from_physical_coord(
-        input_tensor, sender_device_coord, operation_attributes.cluster_axis);  // device_index
-    const auto& topology = operation_attributes.topology;
-    const auto& semaphore = operation_attributes.semaphore;
-    const auto& barrier_semaphore = operation_attributes.barrier_semaphore;
-    bool using_persistent_buffers = operation_attributes.using_persistent_buffers;
-    const auto& sub_device_id = operation_attributes.sub_device_id;
-    std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler> fused_op_signaler;
-    const auto& chunks_per_sync = operation_attributes.chunks_per_sync;
-    const auto& num_workers_per_direction_opt = operation_attributes.num_workers_per_link;
-    const auto& num_buffers_per_channel = operation_attributes.num_buffers_per_channel;
-    const auto& core_grid_offset = CoreCoord(0, 0);
-    const auto& reverse_order = operation_attributes.reverse_order;
-    const auto& sub_core_grid = operation_attributes.sub_core_grid;
 
     log_trace(tt::LogOp, "Detected all gather specialized shape. all_gather_async_minimal_default is called");
 
-    tt::tt_metal::Program program{};
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    auto
-        [reader_kernel_id,
-         writer_kernel_id,
-         all_cores,
-         num_directions_per_link,
-         num_workers_per_direction,
-         num_mux_cores_per_direction_per_link,
-         num_cores_per_link] =
-            build_all_gather_async_minimal_default_program_artifacts(
-                program,
-                input_tensor,
-                sender_device_coord,
-                forward_coord,
-                backward_coord,
-                output_tensor,
-                dim,
-                num_links,
-                ring_size,
-                ring_index,
-                topology,
-                semaphore,
-                barrier_semaphore,
-                using_persistent_buffers,
-                sub_device_id,
-                fused_op_signaler,
-                chunks_per_sync,
-                num_workers_per_direction_opt,
-                num_buffers_per_channel,
-                core_grid_offset,
-                reverse_order,
-                sub_core_grid);
+    // Build a ProgramDescriptor per mesh coord — fabric topology (forward/
+    // backward neighbors, ring_index) is per-coord, so the descriptor body
+    // varies by coord and cannot be replicated.
+    for (const auto& coord : tensor_coords.coords()) {
+        const auto& sender_device_coord = coord;
+        const auto& forward_coord = get_physical_neighbor_from_physical_coord(
+            input_tensor, sender_device_coord, 1, operation_attributes.topology, operation_attributes.cluster_axis);
+        const auto& backward_coord = get_physical_neighbor_from_physical_coord(
+            input_tensor, sender_device_coord, -1, operation_attributes.topology, operation_attributes.cluster_axis);
+        TT_FATAL(
+            forward_coord.has_value() || backward_coord.has_value(), "DEBUG: forward_coord or backward_coord is null");
 
-    return {
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = reader_kernel_id,
-            .writer_kernel_id = writer_kernel_id,
-            .all_cores = all_cores,
-            .num_directions_per_link = num_directions_per_link,
-            .num_workers_per_direction = num_workers_per_direction,
-            .num_mux_cores_per_direction_per_link = num_mux_cores_per_direction_per_link,
-            .num_cores_per_link = num_cores_per_link}};
-}
+        const auto& ring_index = get_linearized_index_from_physical_coord(
+            input_tensor, sender_device_coord, operation_attributes.cluster_axis);  // device_index
+        std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler> fused_op_signaler;
 
-void DefaultMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const AllGatherAsyncParams& operation_attributes,
-    const AllGatherAsyncInputs& tensor_args,
-    Tensor& output_tensor) {
-    // Update runtime arguments for each program in the mesh workload
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
-
-        const auto& input = tensor_args.input_tensor;
-        const auto& output = output_tensor;
-
-        auto semaphore = operation_attributes.semaphore;
-        auto barrier_semaphore = operation_attributes.barrier_semaphore;
-
-        all_gather_async_minimal_default_helper_override_runtime_arguments(
-            program,
-            shared_vars.reader_kernel_id,
-            shared_vars.writer_kernel_id,
-            shared_vars.all_cores,
+        tt::tt_metal::ProgramDescriptor desc;
+        build_all_gather_async_minimal_default_program_artifacts_descriptor(
+            desc,
+            input_tensor,
+            sender_device_coord,
+            forward_coord,
+            backward_coord,
+            output_tensor,
+            operation_attributes.dim,
             operation_attributes.num_links,
-            shared_vars.num_directions_per_link,
-            shared_vars.num_workers_per_direction,
-            shared_vars.num_mux_cores_per_direction_per_link,
-            shared_vars.num_cores_per_link,
-            barrier_semaphore,
-            semaphore,
-            input,
-            output);
+            operation_attributes.ring_size,
+            ring_index,
+            operation_attributes.topology,
+            operation_attributes.semaphore,
+            operation_attributes.barrier_semaphore,
+            operation_attributes.using_persistent_buffers,
+            operation_attributes.sub_device_id,
+            fused_op_signaler,
+            operation_attributes.chunks_per_sync,
+            operation_attributes.num_workers_per_link,
+            operation_attributes.num_buffers_per_channel,
+            CoreCoord(0, 0),
+            operation_attributes.reverse_order,
+            operation_attributes.sub_core_grid);
+
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 }  // namespace experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
@@ -59,13 +59,13 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
 
-// ProgramDescriptor (Contract-2) variant of build_all_gather_async_minimal_default_program_artifacts.
+// ProgramDescriptor variant of build_all_gather_async_minimal_default_program_artifacts.
 //
-// Mirrors the legacy builder but appends KernelDescriptors / CBDescriptors /
-// SemaphoreDescriptors to `desc` instead of creating them directly on a
-// Program.  Runtime args are emplaced via KernelDescriptor::emplace_runtime_args
-// with Buffer* entries for the input/output tensors, so the framework's fast
-// cache-hit path patches their base addresses automatically.
+// Appends KernelDescriptors / CBDescriptors / SemaphoreDescriptors to `desc`
+// instead of creating them directly on a Program.  Runtime args are emplaced
+// via KernelDescriptor::emplace_runtime_args with Buffer* entries for the
+// input/output tensors, so the framework's fast cache-hit path patches their
+// base addresses automatically.
 //
 // The fused-op signaler and fabric-mux helpers used here all have
 // ProgramDescriptor overloads (init_all_gather, fabric_mux_connection_rt_args,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
@@ -7,6 +7,7 @@
 #include "all_gather_async_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -21,29 +22,11 @@ struct AllGatherProgramArtifacts {
 };
 
 struct DefaultMeshWorkloadFactory {
-    using shared_variables_t = AllGatherProgramArtifacts;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const AllGatherAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const AllGatherAsyncInputs& tensor_args,
-        Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const AllGatherAsyncParams& operation_attributes,
         const AllGatherAsyncInputs& tensor_args,
-        Tensor& output_tensor);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const AllGatherAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const AllGatherAsyncInputs& tensor_args,
-        Tensor& output_tensor);
+        Tensor& output_tensor,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_device_operation.hpp
@@ -15,6 +15,8 @@
 #include "ttnn/global_semaphore.hpp"
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include <vector>
 #include "ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata.hpp"
 
@@ -76,39 +78,19 @@ struct AllToAllDispatchMetadataDeviceOperation {
     using tensor_return_value_t = std::array<Tensor, 3>;
 
     struct AllToAllDispatchMetadataSparse {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle ternary_reader_kernel_id;
-            tt::tt_metal::KernelHandle binary_writer_kernel_id;
-            std::vector<CoreCoord> cores;
-            const std::optional<GlobalSemaphore> init_semaphore;  // Optional - not used in persistent mode
-            const GlobalSemaphore cross_device_semaphore;
-            const bool
-                skip_init_semaphore;  // True when using persistent mode (all outputs persistent + external semaphore)
-        };
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
+        // Contract-2: declarative WorkloadDescriptor.  Per coord, builds a
+        // ProgramDescriptor containing the mux (when worker_mode != DIRECT),
+        // reader, and writer kernels plus their CBs.  Workload-scoped init /
+        // cross-device GlobalSemaphores (cache miss only -- in persistent
+        // mode the caller-provided semaphore on operation_attributes is used
+        // instead) are parked on workload_descriptor.semaphores.  Tensor base
+        // addresses are bound via emplace_runtime_args(Buffer*) so the
+        // framework patches them on every dispatch.
+        static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
             const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const std::optional<GlobalSemaphore>& init_semaphore,
-            const GlobalSemaphore& cross_device_semaphore,
-            bool skip_init_semaphore);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
+            const ttnn::MeshCoordinateRangeSet& tensor_coords);
     };
 
     using program_factory_t = std::variant<AllToAllDispatchMetadataSparse>;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
@@ -27,13 +27,12 @@ namespace ttnn::operations::experimental::ccl {
 
 namespace detail {
 
-// ProgramDescriptor (Contract-2) variant of the legacy launch_mux_workers.
+// ProgramDescriptor variant of launch_mux_workers.
 // Appends a mux KernelDescriptor onto `desc` (with its runtime args baked in
 // per logical core via emplace_runtime_args) instead of issuing imperative
-// CreateKernel / SetRuntimeArgs calls.  Returns the same triple as the legacy
-// helper -- (mux_kernel_index, mux_kernel_config, per-link
-// mesh-coord->virtual-core maps) -- with the kernel handle being the index of
-// the appended KernelDescriptor in desc.kernels.
+// CreateKernel / SetRuntimeArgs calls.  Returns (mux_kernel_index,
+// mux_kernel_config, per-link mesh-coord->virtual-core maps); the kernel
+// handle is the index of the appended KernelDescriptor in desc.kernels.
 auto launch_mux_workers_descriptor(
     const MeshDevice& mesh_device,
     const CoreRangeSet& mux_core_range_set,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <ranges>
 #include <algorithm>
+#include <variant>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -18,6 +19,7 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <limits>
 
@@ -25,16 +27,21 @@ namespace ttnn::operations::experimental::ccl {
 
 namespace detail {
 
-// Launch mux worker kernels for fabric communication
-// Returns: tuple of (mux_kernel_id, mux_kernel_config, mux_neighbor_core_maps)
-auto launch_mux_workers(
+// ProgramDescriptor (Contract-2) variant of the legacy launch_mux_workers.
+// Appends a mux KernelDescriptor onto `desc` (with its runtime args baked in
+// per logical core via emplace_runtime_args) instead of issuing imperative
+// CreateKernel / SetRuntimeArgs calls.  Returns the same triple as the legacy
+// helper -- (mux_kernel_index, mux_kernel_config, per-link
+// mesh-coord->virtual-core maps) -- with the kernel handle being the index of
+// the appended KernelDescriptor in desc.kernels.
+auto launch_mux_workers_descriptor(
     const MeshDevice& mesh_device,
     const CoreRangeSet& mux_core_range_set,
     const tt::tt_fabric::FabricNodeId src_node_id,
     const std::vector<ttnn::MeshCoordinate>& neighbors,
     const uint32_t num_links,
     const uint32_t num_workers,
-    tt::tt_metal::Program& program) {
+    tt::tt_metal::ProgramDescriptor& desc) {
     auto num_full_size_channels = num_workers;
     constexpr auto num_header_only_channels = 0;
     constexpr auto num_buffers_full_size_channels = 2;
@@ -60,15 +67,19 @@ auto launch_mux_workers(
         corerange_to_cores(mux_core_range_set).size());
     const auto needed_mux_core_range_set =
         tt::tt_metal::select_from_corerangeset(mux_core_range_set, 0, num_mux_cores_needed - 1);
-    auto mux_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
-        needed_mux_core_range_set,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::NOC::RISCV_0_default,
-            .compile_args = mux_kernel_config.get_fabric_mux_compile_time_args(),
-            .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
+
+    tt::tt_metal::KernelDescriptor mux_kernel_desc;
+    mux_kernel_desc.kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp";
+    mux_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    mux_kernel_desc.core_ranges = needed_mux_core_range_set;
+    mux_kernel_desc.compile_time_args = mux_kernel_config.get_fabric_mux_compile_time_args();
+    mux_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::NOC::RISCV_0_default,
+    };
+    mux_kernel_desc.opt_level = tt::tt_metal::KernelBuildOptLevel::O3;
+    const auto mux_kernel_index = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(mux_kernel_desc));
 
     std::vector<std::map<ttnn::MeshCoordinate, CoreCoord>> mux_neigbor_core_maps;
     mux_neigbor_core_maps.reserve(num_links);
@@ -81,18 +92,24 @@ auto launch_mux_workers(
             auto mux_logical_core = *(mux_core_iter++);
             const auto mux_virtual_core = mesh_device.worker_core_from_logical_core(mux_logical_core);
 
-            std::vector<uint32_t> mux_rt_args = {};
             const auto dst_node_id = mesh_device.get_fabric_node_id(neighbor_coord);
-            mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
-                src_node_id, dst_node_id, link, program, {mux_logical_core});
+            // Templated FabricMuxConfig helper appends fabric routing args onto the
+            // ProgramDescriptor and returns the resulting per-core rt-arg vector.
+            std::vector<uint32_t> mux_rt_args =
+                mux_kernel_config.get_fabric_mux_run_time_args(src_node_id, dst_node_id, link, desc, mux_logical_core);
 
-            tt::tt_metal::SetRuntimeArgs(program, mux_kernel_id, {mux_logical_core}, mux_rt_args);
+            std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> mux_rt_args_variant;
+            mux_rt_args_variant.reserve(mux_rt_args.size());
+            for (uint32_t a : mux_rt_args) {
+                mux_rt_args_variant.emplace_back(a);
+            }
+            desc.kernels[mux_kernel_index].emplace_runtime_args(mux_logical_core, mux_rt_args_variant);
             mux_neigbor_core_map[neighbor_coord] = mux_virtual_core;
         }
         mux_neigbor_core_maps.push_back(mux_neigbor_core_map);
     }
 
-    return std::make_tuple(mux_kernel_id, mux_kernel_config, mux_neigbor_core_maps);
+    return std::make_tuple(mux_kernel_index, mux_kernel_config, mux_neigbor_core_maps);
 }
 
 uint32_t get_num_pages(const ttnn::Tensor& tensor) { return (uint32_t)tensor.buffer()->num_pages(); }
@@ -158,75 +175,24 @@ std::pair<std::array<uint32_t, 7>, std::array<uint32_t, 7>> get_cb_sizes(
     return {cb_sizes, cb_page_sizes};
 }
 
-}  // namespace detail
-
-AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::cached_mesh_workload_t
-AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_mesh_workload(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    auto* mesh_device = tensor_args.input_tensor.device();
-
-    // Determine if we're in persistent mode:
-    // - cross_device_semaphore is provided externally
-    // - all 3 output tensors are provided (persistent buffers)
-    // In this mode, we skip the init_semaphore to avoid the barrier overhead
-    bool skip_init_semaphore =
-        operation_attributes.cross_device_semaphore.has_value() && tensor_args.optional_output_tensors.has_value();
-
-    log_debug(
-        tt::LogOp,
-        "Persistent mode: {} (cross_device_semaphore={}, optional_output_tensors={})",
-        skip_init_semaphore,
-        operation_attributes.cross_device_semaphore.has_value(),
-        tensor_args.optional_output_tensors.has_value());
-
-    std::optional<GlobalSemaphore> init_barrier_semaphore = std::nullopt;
-    GlobalSemaphore final_barrier_semaphore = skip_init_semaphore
-                                                  ? operation_attributes.cross_device_semaphore.value()
-                                                  : ttnn::global_semaphore::create_global_semaphore(
-                                                        mesh_device, operation_attributes.worker_core_range_set, 0);
-
-    if (!skip_init_semaphore) {
-        init_barrier_semaphore =
-            ttnn::global_semaphore::create_global_semaphore(mesh_device, operation_attributes.worker_core_range_set, 0);
-    }
-
-    tt::tt_metal::distributed::Synchronize(
-        mesh_device, std::nullopt, {});  // interaction with subdevice needs to be investigated
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(
-            operation_attributes,
-            coord,
-            tensor_args,
-            tensor_return_value,
-            tensor_coords,
-            init_barrier_semaphore,
-            final_barrier_semaphore,
-            skip_init_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
-
-ttnn::device_operation::CachedProgram<
-    AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::shared_variables_t>
-AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_at(
-    const operation_attributes_t& operation_attributes,
+// Build the per-coord ProgramDescriptor.  Identical in structure to the legacy
+// create_at body; CB / kernel / runtime arg emission goes through
+// desc.{cbs,kernels,semaphores}.push_back / emplace_runtime_args instead of the
+// imperative Program-side APIs.  Tensor base addresses are bound via
+// emplace_runtime_args(Buffer*) so the framework's fast cache-hit path patches
+// them every dispatch; the cross-device + init GlobalSemaphores ride on
+// WorkloadDescriptor.semaphores and their addresses are embedded as uint32_t
+// (a different GlobalSemaphore triggers a recompile, same behavior as legacy).
+tt::tt_metal::ProgramDescriptor build_descriptor_at(
+    const AllToAllDispatchMetadataDeviceOperation::operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
+    const AllToAllDispatchMetadataDeviceOperation::tensor_args_t& tensor_args,
+    AllToAllDispatchMetadataDeviceOperation::tensor_return_value_t& tensor_return_value,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const std::optional<GlobalSemaphore>& init_semaphore,
     const GlobalSemaphore& cross_device_semaphore,
     bool skip_init_semaphore) {
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
 
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& indices_tensor = tensor_args.expert_indices_tensor;
@@ -238,7 +204,6 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
     auto num_links = operation_attributes.num_links;
     auto topology = operation_attributes.topology;
 
-    // Debug: print metadata tensor allocation details
     log_debug(
         tt::LogOp,
         "Metadata tensor buffer address: {} size: {}",
@@ -328,90 +293,15 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
     uint32_t scores_tensor_cb_id = tt::CBIndex::c_6;
 
     uint32_t aligned_input_page_size = detail::get_aligned_page_size(input_tensor);
-    log_debug(
-        tt::LogOp,
-        "input shape: {}, input_pages: {}, input_page_size: {}, aligned_input_page_size: {}",
-        input_tensor.logical_shape(),
-        input_pages,
-        input_page_size,
-        aligned_input_page_size);
-
     uint32_t aligned_indices_page_size = detail::get_aligned_page_size(indices_tensor);
-    log_debug(
-        tt::LogOp,
-        "indices shape: {}, indices_pages: {}, indices_page_size: {}, aligned_indices_page_size: {}",
-        indices_tensor.logical_shape(),
-        indices_pages,
-        indices_page_size,
-        aligned_indices_page_size);
-
     uint32_t aligned_scores_page_size = detail::get_aligned_page_size(scores_tensor);
-    log_debug(
-        tt::LogOp,
-        "scores shape: {}, scores_pages: {}, scores_page_size: {}, aligned_scores_page_size: {}",
-        scores_tensor.logical_shape(),
-        scores_pages,
-        scores_page_size,
-        aligned_scores_page_size);
     const auto aligned_output_scores_page_size = detail::get_aligned_page_size(scores_out_tensor);
-
     uint32_t aligned_mapping_page_size = detail::get_aligned_page_size(mapping_tensor);
-    log_debug(
-        tt::LogOp,
-        "mapping shape: {}, mapping_pages: {}, mapping_page_size: {}, aligned_mapping_page_size: {}",
-        mapping_tensor.logical_shape(),
-        mapping_pages,
-        mapping_page_size,
-        aligned_mapping_page_size);
-
     uint32_t aligned_output_page_size = detail::get_aligned_page_size(output_tensor);
-    log_debug(
-        tt::LogOp,
-        "output shape: {}, output_pages: {}, output_page_size: {}, aligned_output_page_size: {}",
-        output_tensor.logical_shape(),
-        output_pages,
-        output_page_size,
-        aligned_output_page_size);
-
     uint32_t aligned_metadata_page_size = detail::get_aligned_page_size(metadata_tensor);
-    log_debug(
-        tt::LogOp,
-        "metadata shape: {}, metadata_pages: {}, metadata_page_size: {}, aligned_metadata_page_size: {}",
-        metadata_tensor.logical_shape(),
-        metadata_pages,
-        metadata_page_size,
-        aligned_metadata_page_size);
 
     auto [cb_sizes, cb_page_sizes] = detail::get_cb_sizes(
         input_tensor, metadata_tensor, scores_out_tensor, mapping_tensor, num_links, operation_attributes.axis);
-
-    tt::tt_metal::CircularBufferConfig cb_input_tensor_config =
-        tt::tt_metal::CircularBufferConfig(cb_sizes[0], {{input_tensor_cb_id, input_data_format}})
-            .set_page_size(input_tensor_cb_id, cb_page_sizes[0]);
-
-    tt::tt_metal::CircularBufferConfig cb_indices_tensor_config =
-        tt::tt_metal::CircularBufferConfig(cb_sizes[1], {{indices_tensor_cb_id, indices_data_format}})
-            .set_page_size(indices_tensor_cb_id, cb_page_sizes[1]);
-
-    tt::tt_metal::CircularBufferConfig cb_mapping_tensor_config =
-        tt::tt_metal::CircularBufferConfig(cb_sizes[2], {{mapping_tensor_cb_id, mapping_data_format}})
-            .set_page_size(mapping_tensor_cb_id, cb_page_sizes[2]);
-
-    tt::tt_metal::CircularBufferConfig cb_send_preparation_buffer_config =
-        tt::tt_metal::CircularBufferConfig(cb_sizes[3], {{send_preparation_buffer_id, tt::DataFormat::UInt8}})
-            .set_page_size(send_preparation_buffer_id, cb_page_sizes[3]);
-
-    tt::tt_metal::CircularBufferConfig cb_metadata_buffer_config =
-        tt::tt_metal::CircularBufferConfig(cb_sizes[4], {{metadata_buffer_id, mapping_data_format}})
-            .set_page_size(metadata_buffer_id, cb_page_sizes[4]);
-
-    tt::tt_metal::CircularBufferConfig packet_header_cb_config =
-        tt::tt_metal::CircularBufferConfig(cb_sizes[5], {{packet_header_cb_id, tt::DataFormat::RawUInt32}})
-            .set_page_size(packet_header_cb_id, cb_page_sizes[5]);
-
-    tt::tt_metal::CircularBufferConfig cb_scores_tensor_config =
-        tt::tt_metal::CircularBufferConfig(cb_sizes[6], {{scores_tensor_cb_id, scores_data_format}})
-            .set_page_size(scores_tensor_cb_id, cb_page_sizes[6]);
 
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
 
@@ -474,14 +364,27 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
         subdevice_cores.at(0), num_cores, worker_core_range_set, true);
     std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
 
-    // create circular buffers
-    tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, cb_input_tensor_config);
-    tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, cb_indices_tensor_config);
-    tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, cb_scores_tensor_config);
-    tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, cb_mapping_tensor_config);
-    tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, packet_header_cb_config);
-    tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, cb_send_preparation_buffer_config);
-    tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, cb_metadata_buffer_config);
+    // Helper to push a CB onto desc with one buffer-index and matching format/page size.
+    auto push_cb = [&](uint32_t cb_id, uint32_t total_size, uint32_t page_size, tt::DataFormat data_format) {
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = total_size,
+            .core_ranges = sender_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_id),
+                .data_format = data_format,
+                .page_size = page_size,
+            }}},
+        });
+    };
+
+    // create circular buffers (same set / sizes / formats as legacy path)
+    push_cb(input_tensor_cb_id, cb_sizes[0], cb_page_sizes[0], input_data_format);
+    push_cb(indices_tensor_cb_id, cb_sizes[1], cb_page_sizes[1], indices_data_format);
+    push_cb(scores_tensor_cb_id, cb_sizes[6], cb_page_sizes[6], scores_data_format);
+    push_cb(mapping_tensor_cb_id, cb_sizes[2], cb_page_sizes[2], mapping_data_format);
+    push_cb(packet_header_cb_id, cb_sizes[5], cb_page_sizes[5], tt::DataFormat::RawUInt32);
+    push_cb(send_preparation_buffer_id, cb_sizes[3], cb_page_sizes[3], tt::DataFormat::UInt8);
+    push_cb(metadata_buffer_id, cb_sizes[4], cb_page_sizes[4], mapping_data_format);
 
     std::vector<uint32_t> dest_mesh_id, dest_chip_id;
     for (const auto& coord : tensor_coords.coords()) {
@@ -569,39 +472,27 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
     tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(scores_out_tensor.buffer()).append_to(reader_compile_time_args);
 
-    const auto& writer_compile_time_args = reader_compile_time_args;
-
-    tt::tt_metal::KernelHandle ternary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/"
-        "reader_all_to_all_dispatch_metadata.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::NOC::NOC_1,
-            .compile_args = reader_compile_time_args});
-
     // Code-gen a mesh-position to fabric chip ID array for the writer kernel
     // Code-gen a mesh-position to mesh-id array for the writer kernel
     // Code-gen a direction array that is set to true when a direction has a valid connection (when a neighbor exists or
     // if it's along a valid cluster axis)
-    std::map<std::string, std::string> writer_defines = {
+    std::vector<std::pair<std::string, std::string>> writer_defines = {
         {"DEST_CHIP_ID", ttnn::operations::ccl::common::stringify(dest_chip_id)},
         {"DEST_MESH_ID", ttnn::operations::ccl::common::stringify(dest_mesh_id)},
         {"DIRECTIONS", ttnn::operations::ccl::common::stringify(directions)},
         {"DISPATCH_ALGORITHM", std::to_string(static_cast<uint8_t>(operation_attributes.dispatch_algorithm))}};
 
     if (operation_attributes.axis.has_value()) {
-        writer_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
+        writer_defines.emplace_back("AXIS", std::to_string(operation_attributes.axis.value()));
     }
 
     // Conditionally set up mux infrastructure (use_mux already defined above)
     std::optional<tt::tt_fabric::FabricMuxConfig> mux_kernel_config;
     std::vector<std::map<ttnn::MeshCoordinate, CoreCoord>> mux_neigbor_core_maps;
-    [[maybe_unused]] tt::tt_metal::KernelHandle mux_kernel_id = 0;
+    [[maybe_unused]] tt::tt_metal::KernelHandle mux_kernel_index = 0;
 
     if (use_mux) {
-        writer_defines["USE_MUX"] = "1";
+        writer_defines.emplace_back("USE_MUX", "1");
         log_debug(tt::LogOp, "Using fabric mux for dispatch");
 
         // Validate mux core range has enough cores (need 1 mux per link)
@@ -612,34 +503,35 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
             mux_cores.size(),
             num_links);
 
-        // Launch mux workers
+        // Launch mux workers via the ProgramDescriptor helper.
         // Note: num_workers passed to launch_mux_workers should be workers_per_link (clients per mux channel)
-        auto [launched_mux_kernel_id, launched_mux_config, launched_mux_neigbor_core_maps] = detail::launch_mux_workers(
-            *mesh_device,
-            operation_attributes.mux_core_range_set,
-            src_fabric_node_id,
-            neighbors,
-            num_links,
-            workers_per_link,  // workers per link = clients per mux channel
-            program);
-        mux_kernel_id = launched_mux_kernel_id;
+        auto [launched_mux_kernel_index, launched_mux_config, launched_mux_neigbor_core_maps] =
+            detail::launch_mux_workers_descriptor(
+                *mesh_device,
+                operation_attributes.mux_core_range_set,
+                src_fabric_node_id,
+                neighbors,
+                num_links,
+                workers_per_link,  // workers per link = clients per mux channel
+                desc);
+        mux_kernel_index = launched_mux_kernel_index;
         mux_kernel_config = launched_mux_config;
         mux_neigbor_core_maps = std::move(launched_mux_neigbor_core_maps);
     }
 
     if (payload_split_mode) {
-        writer_defines["PAYLOAD_SPLIT_MODE"] = "1";
-        writer_defines["WORKERS_PER_LINK"] = std::to_string(workers_per_link);
+        writer_defines.emplace_back("PAYLOAD_SPLIT_MODE", "1");
+        writer_defines.emplace_back("WORKERS_PER_LINK", std::to_string(workers_per_link));
         log_debug(tt::LogOp, "Using payload split mode with {} workers per link", workers_per_link);
     }
 
     if (skip_init_semaphore) {
-        writer_defines["SKIP_INIT_SEMAPHORE"] = "1";
+        writer_defines.emplace_back("SKIP_INIT_SEMAPHORE", "1");
         log_debug(tt::LogOp, "Skipping init semaphore (persistent mode enabled)");
     }
 
     // Build writer compile-time args - add mux args if enabled
-    std::vector<uint32_t> writer_compile_time_args_final = writer_compile_time_args;
+    std::vector<uint32_t> writer_compile_time_args_final = reader_compile_time_args;
     if (use_mux) {
         ttnn::ccl::fabric_mux_connection_ct_args(
             workers_per_link,  // num_mux_clients = workers per link sharing each mux channel
@@ -648,53 +540,43 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
             writer_compile_time_args_final);
     }
 
-    tt::tt_metal::KernelHandle binary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    // Reader kernel
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/"
-        "writer_all_to_all_dispatch_metadata.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::NOC::NOC_0,
-            .compile_args = writer_compile_time_args_final,
-            .defines = writer_defines});
-
-    std::vector<uint32_t> reader_runtime_args = {
-        input_tensor.buffer()->address(),
-        indices_tensor.buffer()->address(),
-        scores_tensor.buffer()->address(),
-        mapping_tensor.buffer()->address(),
-        output_tensor.buffer()->address(),
-        metadata_tensor.buffer()->address(),
-        scores_out_tensor.buffer()->address(),
-        (uint32_t)cross_device_semaphore.address(),
+        "reader_all_to_all_dispatch_metadata.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = sender_core_grid;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = tt::tt_metal::NOC::NOC_1,
     };
+    const tt::tt_metal::KernelHandle ternary_reader_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(reader_kernel_desc));
 
-    uint32_t reader_token_start_idx = reader_runtime_args.size();
-    reader_runtime_args.push_back(0);
-    uint32_t reader_token_end_idx = reader_runtime_args.size();
-    reader_runtime_args.push_back(0);
-
-    // Pre-allocate slots for payload split args (only used in payload_split_mode)
-    uint32_t reader_payload_offset_idx = reader_runtime_args.size();
-    reader_runtime_args.push_back(0);
-    uint32_t reader_payload_size_idx = reader_runtime_args.size();
-    reader_runtime_args.push_back(0);
-    uint32_t reader_is_primary_idx = reader_runtime_args.size();
-    reader_runtime_args.push_back(0);
+    // Writer kernel
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/"
+        "writer_all_to_all_dispatch_metadata.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = sender_core_grid;
+    writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args_final);
+    writer_kernel_desc.defines = std::move(writer_defines);
+    writer_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::NOC::NOC_0,
+    };
+    const tt::tt_metal::KernelHandle binary_writer_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(writer_kernel_desc));
 
     // Get drain sync tilizer core NOC coordinates for direct metadata output
-    // drain_sync_tilizer_core was already resolved at the start of create_at
+    // drain_sync_tilizer_core was already resolved at the start of build_descriptor_at
     auto drain_sync_tilizer_noc_core = mesh_device->worker_core_from_logical_core(drain_sync_tilizer_core);
 
-    // Debug: print address comparison for overlap detection
-    log_debug(
-        tt::LogOp,
-        "Address comparison - metadata_tensor: {} (size: {}), cross_device_semaphore: {}, init_semaphore: {}",
-        metadata_tensor.buffer()->address(),
-        metadata_tensor.buffer()->size(),
-        cross_device_semaphore.address(),
-        init_semaphore.has_value() ? init_semaphore->address() : 0);
     log_debug(
         tt::LogOp,
         "drain_sync_tilizer_core logical: ({}, {}), NOC: ({}, {})",
@@ -705,7 +587,8 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
 
     // For mux: set up termination masters (one per link)
     // Each link has workers_per_link workers sharing the same mux cores
-    // The first worker on each link (worker_idx % workers_per_link == 0) is the termination master
+    // The first worker on each link (worker_idx % workers_per_link == 0) is the termination master.
+    // Each termination master needs its own per-core semaphore for the mux terminate handshake.
     std::vector<CoreCoord> termination_master_cores;
     std::vector<CoreCoord> termination_master_virtual_cores;
     std::vector<uint32_t> termination_master_semaphore_ids;
@@ -715,7 +598,20 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
             const auto& master_core = sender_cores[master_worker_idx];
             termination_master_cores.push_back(master_core);
             termination_master_virtual_cores.push_back(mesh_device->worker_core_from_logical_core(master_core));
-            termination_master_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, {master_core}, 0));
+            // Allocate a fresh per-core semaphore for this termination master.
+            auto sem_id_opt = desc.find_available_semaphore_id(master_core, tt::CoreType::WORKER);
+            TT_FATAL(
+                sem_id_opt.has_value(),
+                "Failed to find available semaphore id for termination master core {}",
+                master_core);
+            const uint32_t sem_id = sem_id_opt.value();
+            desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+                .id = sem_id,
+                .core_type = tt::CoreType::WORKER,
+                .core_ranges = CoreRangeSet({CoreRange(master_core, master_core)}),
+                .initial_value = 0,
+            });
+            termination_master_semaphore_ids.push_back(sem_id);
             log_debug(
                 tt::LogOp,
                 "Link {} termination master: worker {} at core ({}, {}), semaphore_id {}",
@@ -723,10 +619,13 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
                 master_worker_idx,
                 master_core.x,
                 master_core.y,
-                termination_master_semaphore_ids.back());
+                sem_id);
         }
     }
 
+    // Reader runtime args (per core) -- the first 7 positions are tensor buffer
+    // bindings; cross_device_semaphore is embedded as a uint32_t (recompile if
+    // the GlobalSemaphore changes, same as legacy).
     uint32_t tokens_per_core_start = 0;
     auto mux_core_map_iter = mux_neigbor_core_maps.cbegin();
     uint32_t current_link_id = 0;
@@ -736,6 +635,33 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
         uint32_t link_id = worker_idx / workers_per_link;
         uint32_t worker_idx_within_link = worker_idx % workers_per_link;
         bool is_termination_master = (worker_idx_within_link == 0);
+
+        // Build reader rt args as a uint32_t vector first (so existing arithmetic on
+        // index slots works unchanged), then convert to the variant arg list and
+        // substitute the tensor Buffer* bindings at positions 0..6.
+        std::vector<uint32_t> reader_runtime_args = {
+            input_tensor.buffer()->address(),
+            indices_tensor.buffer()->address(),
+            scores_tensor.buffer()->address(),
+            mapping_tensor.buffer()->address(),
+            output_tensor.buffer()->address(),
+            metadata_tensor.buffer()->address(),
+            scores_out_tensor.buffer()->address(),
+            (uint32_t)cross_device_semaphore.address(),
+        };
+
+        uint32_t reader_token_start_idx = reader_runtime_args.size();
+        reader_runtime_args.push_back(0);
+        uint32_t reader_token_end_idx = reader_runtime_args.size();
+        reader_runtime_args.push_back(0);
+
+        // Pre-allocate slots for payload split args (only used in payload_split_mode)
+        uint32_t reader_payload_offset_idx = reader_runtime_args.size();
+        reader_runtime_args.push_back(0);
+        uint32_t reader_payload_size_idx = reader_runtime_args.size();
+        reader_runtime_args.push_back(0);
+        uint32_t reader_is_primary_idx = reader_runtime_args.size();
+        reader_runtime_args.push_back(0);
 
         std::vector<uint32_t> writer_runtime_args = {
             input_tensor.buffer()->address(),
@@ -788,17 +714,6 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
             writer_runtime_args.push_back(payload_offset);
             writer_runtime_args.push_back(payload_size);
             writer_runtime_args.push_back(is_primary_payload_worker ? 1 : 0);
-
-            log_debug(
-                tt::LogOp,
-                "Worker {} payload split: link={}, tokens=[{},{}), offset={}, size={}, is_primary={}",
-                worker_idx,
-                link_id,
-                link_token_start,
-                link_token_end,
-                payload_offset,
-                payload_size,
-                is_primary_payload_worker);
         } else {
             // Token split mode or direct mode: distribute tokens across workers
             reader_runtime_args[reader_token_start_idx] = tokens_per_core_start;
@@ -855,6 +770,9 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
 
             for (const auto& neighbor_coordinate : neighbors) {
                 const auto& mux_virtual_core = mux_core_map_iter->at(neighbor_coordinate);
+                // ProgramDescriptor overload of fabric_mux_connection_rt_args allocates
+                // the five mux-side semaphores into desc.semaphores and bakes their IDs
+                // into writer_runtime_args.
                 ttnn::ccl::fabric_mux_connection_rt_args(
                     true,  // mux_connection_valid
                     is_termination_master,
@@ -863,7 +781,7 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
                     worker_idx_within_link,  // worker_index within the mux channel (0 to workers_per_link-1)
                     sender_core,
                     mux_kernel_config.value(),
-                    program,
+                    desc,
                     link_termination_master_virtual_core,
                     writer_runtime_args,
                     link_termination_master_semaphore_id);
@@ -879,7 +797,7 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
                 worker_idx_within_link,
                 is_termination_master);
         } else {
-            // Use direct fabric connection runtime args
+            // Use direct fabric connection runtime args (templated; supports ProgramDescriptor).
             for (const auto& neighbor_coordinate : neighbors) {
                 log_debug(
                     tt::LogOp,
@@ -894,77 +812,123 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
                     link_id,
                     reader_runtime_args[8],
                     reader_runtime_args[9]);
-                tt::tt_fabric::append_fabric_connection_rt_args(
+                tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
                     src_fabric_node_id,
                     mesh_device->get_fabric_node_id(neighbor_coordinate),
                     link_id,
-                    program,
+                    desc,
                     sender_core,
                     writer_runtime_args);
             }
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, ternary_reader_kernel_id, sender_core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, binary_writer_kernel_id, sender_core, writer_runtime_args);
-    }
-
-    return {
-        std::move(program),
-        {.ternary_reader_kernel_id = ternary_reader_kernel_id,
-         .binary_writer_kernel_id = binary_writer_kernel_id,
-         .cores = sender_cores,
-         .init_semaphore = init_semaphore,
-         .cross_device_semaphore = cross_device_semaphore,
-         .skip_init_semaphore = skip_init_semaphore}};
-}
-
-void AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-        const auto& ternary_reader_kernel_id = shared_variables.ternary_reader_kernel_id;
-        const auto& binary_writer_kernel_id = shared_variables.binary_writer_kernel_id;
-        const auto& cores = shared_variables.cores;
-
-        const auto& output_tensor = tensor_return_value.at(0);
-        const auto& metadata_tensor = tensor_return_value.at(1);
-        const auto& scores_out_tensor = tensor_return_value.at(2);
-
-        // Use the cross_device_semaphore from operation_attributes if provided (for double-buffering),
-        // otherwise fall back to the cached one from shared_variables
-        const auto& cross_device_semaphore = operation_attributes.cross_device_semaphore.has_value()
-                                                 ? operation_attributes.cross_device_semaphore.value()
-                                                 : shared_variables.cross_device_semaphore;
-
-        for (const auto& core : cores) {
-            auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, ternary_reader_kernel_id, core);
-            auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, binary_writer_kernel_id, core);
-            reader_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
-            reader_runtime_args.at(1) = tensor_args.expert_indices_tensor.buffer()->address();
-            reader_runtime_args.at(2) = tensor_args.expert_scores_tensor.buffer()->address();
-            reader_runtime_args.at(3) = tensor_args.expert_mapping_tensor.buffer()->address();
-            reader_runtime_args.at(4) = output_tensor.buffer()->address();
-            reader_runtime_args.at(5) = metadata_tensor.buffer()->address();
-            reader_runtime_args.at(6) = scores_out_tensor.buffer()->address();
-            reader_runtime_args.at(7) = (uint32_t)cross_device_semaphore.address();
-
-            writer_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
-            writer_runtime_args.at(1) = tensor_args.expert_indices_tensor.buffer()->address();
-            writer_runtime_args.at(2) = tensor_args.expert_scores_tensor.buffer()->address();
-            writer_runtime_args.at(3) = tensor_args.expert_mapping_tensor.buffer()->address();
-            writer_runtime_args.at(4) = output_tensor.buffer()->address();
-            writer_runtime_args.at(5) = metadata_tensor.buffer()->address();
-            writer_runtime_args.at(6) = scores_out_tensor.buffer()->address();
-            writer_runtime_args.at(7) = (uint32_t)cross_device_semaphore.address();
-            // init_semaphore is optional - only update if it exists (not in persistent mode)
-            if (shared_variables.init_semaphore.has_value()) {
-                writer_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore->address();
+        // Convert reader rt args to the variant arg list and substitute Buffer*
+        // bindings at the seven tensor positions so the framework patches them on
+        // every dispatch (matching the legacy override_runtime_arguments behavior
+        // -- the cross-device + init semaphore addresses remain embedded uint32s,
+        // recompile on different semaphores).
+        {
+            std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> rt_args_variant;
+            rt_args_variant.reserve(reader_runtime_args.size());
+            rt_args_variant.emplace_back(input_tensor.buffer());
+            rt_args_variant.emplace_back(indices_tensor.buffer());
+            rt_args_variant.emplace_back(scores_tensor.buffer());
+            rt_args_variant.emplace_back(mapping_tensor.buffer());
+            rt_args_variant.emplace_back(output_tensor.buffer());
+            rt_args_variant.emplace_back(metadata_tensor.buffer());
+            rt_args_variant.emplace_back(scores_out_tensor.buffer());
+            for (size_t i = 7; i < reader_runtime_args.size(); ++i) {
+                rt_args_variant.emplace_back(reader_runtime_args[i]);
             }
+            desc.kernels[ternary_reader_kernel_index].emplace_runtime_args(sender_core, rt_args_variant);
+        }
+        {
+            std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> rt_args_variant;
+            rt_args_variant.reserve(writer_runtime_args.size());
+            rt_args_variant.emplace_back(input_tensor.buffer());
+            rt_args_variant.emplace_back(indices_tensor.buffer());
+            rt_args_variant.emplace_back(scores_tensor.buffer());
+            rt_args_variant.emplace_back(mapping_tensor.buffer());
+            rt_args_variant.emplace_back(output_tensor.buffer());
+            rt_args_variant.emplace_back(metadata_tensor.buffer());
+            rt_args_variant.emplace_back(scores_out_tensor.buffer());
+            for (size_t i = 7; i < writer_runtime_args.size(); ++i) {
+                rt_args_variant.emplace_back(writer_runtime_args[i]);
+            }
+            desc.kernels[binary_writer_kernel_index].emplace_runtime_args(sender_core, rt_args_variant);
         }
     }
+
+    return desc;
+}
+
+}  // namespace detail
+
+tt::tt_metal::WorkloadDescriptor
+AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_workload_descriptor(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    auto* mesh_device = tensor_args.input_tensor.device();
+
+    // Determine if we're in persistent mode:
+    // - cross_device_semaphore is provided externally
+    // - all 3 output tensors are provided (persistent buffers)
+    // In this mode, we skip the init_semaphore to avoid the barrier overhead
+    bool skip_init_semaphore =
+        operation_attributes.cross_device_semaphore.has_value() && tensor_args.optional_output_tensors.has_value();
+
+    log_debug(
+        tt::LogOp,
+        "Persistent mode: {} (cross_device_semaphore={}, optional_output_tensors={})",
+        skip_init_semaphore,
+        operation_attributes.cross_device_semaphore.has_value(),
+        tensor_args.optional_output_tensors.has_value());
+
+    // Workload-scoped semaphores.  In persistent mode the caller-supplied
+    // cross_device_semaphore on operation_attributes is reused (no new
+    // allocation, no init barrier); otherwise we allocate fresh init + final
+    // GlobalSemaphores and park them on workload_descriptor.semaphores so they
+    // outlive the cached workload.
+    std::optional<GlobalSemaphore> init_barrier_semaphore = std::nullopt;
+    GlobalSemaphore final_barrier_semaphore = skip_init_semaphore
+                                                  ? operation_attributes.cross_device_semaphore.value()
+                                                  : ttnn::global_semaphore::create_global_semaphore(
+                                                        mesh_device, operation_attributes.worker_core_range_set, 0);
+
+    if (!skip_init_semaphore) {
+        init_barrier_semaphore =
+            ttnn::global_semaphore::create_global_semaphore(mesh_device, operation_attributes.worker_core_range_set, 0);
+    }
+
+    tt::tt_metal::distributed::Synchronize(
+        mesh_device, std::nullopt, {});  // interaction with subdevice needs to be investigated
+
+    if (!skip_init_semaphore) {
+        workload_descriptor.semaphores.push_back(init_barrier_semaphore.value());
+    }
+    // Always retain the final / cross-device semaphore on the workload.  When
+    // persistent mode reuses the caller-supplied semaphore the framework will
+    // simply see it twice, which is harmless (caller still owns it).
+    workload_descriptor.semaphores.push_back(final_barrier_semaphore);
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = detail::build_descriptor_at(
+            operation_attributes,
+            coord,
+            tensor_args,
+            tensor_return_value,
+            tensor_coords,
+            init_barrier_semaphore,
+            final_barrier_semaphore,
+            skip_init_semaphore);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
@@ -268,7 +268,6 @@ tt::tt_metal::ProgramDescriptor build_descriptor_at(
     auto input_pages = detail::get_num_pages(input_tensor);
     auto indices_pages = detail::get_num_pages(indices_tensor);
     auto scores_pages = detail::get_num_pages(scores_tensor);
-    auto mapping_pages = detail::get_num_pages(mapping_tensor);
     auto output_pages = detail::get_num_pages(output_tensor);
     auto metadata_pages = detail::get_num_pages(metadata_tensor);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
@@ -655,8 +655,7 @@ process_agmm_fusion_program_and_create_override_variables(
 
 // ProgramDescriptor variant of process_agmm_fusion_program_and_create_override_variables.
 //
-// Mirrors the legacy helper's parameter list but drops the Program& output param —
-// kernels / CBs / semaphores are appended onto the caller-supplied ProgramDescriptor
+// Kernels / CBs / semaphores are appended onto the caller-supplied ProgramDescriptor
 // (same shape as create_program_gather_in0_descriptor in the matmul 1D builder).
 // This is the llama-specific multicast variant: in0 is multicast in 4 K-chunks rather
 // than streamed through a worker ring, and the worker grid is the in1 (weight) shard
@@ -826,9 +825,9 @@ static tt::tt_metal::ProgramDescriptor process_agmm_fusion_descriptor(
     TileDescriptor output_tile_desc{output_tile};
 
     /* semaphores — the caller pre-allocates a free id on `all_cores` and passes it in as
-       base_semaphore_id.  Mirrors the legacy CreateSemaphore first-free-id behaviour while
-       avoiding aliasing when this descriptor is appended onto a caller's ProgramDescriptor
-       that already has semaphores on the same cores (CCL+matmul fused path). */
+       base_semaphore_id.  This avoids aliasing when this descriptor is appended onto a
+       caller's ProgramDescriptor that already has semaphores on the same cores
+       (CCL+matmul fused path). */
     uint32_t in0_signal_semaphore_id = base_semaphore_id;
     desc.semaphores.push_back(
         SemaphoreDescriptor{.id = in0_signal_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
@@ -1679,9 +1678,9 @@ ttnn::prim::matmul_mcast_1d_common_override_variables_t matmul_multi_core_agmm_f
         std::move(restricted_cores));
 }
 
-// ProgramDescriptor counterpart of matmul_multi_core_agmm_fusion_. Mirrors the legacy
-// inner helper's arg list but appends kernels / CBs / semaphores onto the caller-supplied
-// ProgramDescriptor instead of constructing a Program in place.
+// ProgramDescriptor counterpart of matmul_multi_core_agmm_fusion_. Appends kernels /
+// CBs / semaphores onto the caller-supplied ProgramDescriptor instead of constructing
+// a Program in place.
 static tt::tt_metal::ProgramDescriptor matmul_multi_core_agmm_fusion_descriptor_(
     const Tensor& a,
     const std::vector<Tensor>& b_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.hpp
@@ -32,12 +32,10 @@ ttnn::prim::matmul_mcast_1d_common_override_variables_t matmul_multi_core_agmm_f
 
 // ProgramDescriptor-flavored variant of matmul_multi_core_agmm_fusion_helper.
 //
-// Mirrors the legacy helper's argument list but drops the Program& output param —
-// kernels / CBs / semaphores are appended onto the caller-supplied
+// Kernels / CBs / semaphores are appended onto the caller-supplied
 // ProgramDescriptor (same shape as matmul_multi_core_reuse_mcast_1d_optimized_helper_descriptor).
 // Only the gather_in0 path of MatmulMultiCoreReuseMultiCast1DProgramConfig is supported:
-// the legacy helper TT_FATALs if mcast_in0 is set or gather_in0 is false, and the descriptor
-// variant preserves that constraint.
+// TT_FATAL fires if mcast_in0 is set or gather_in0 is false.
 //
 // This is a llama-specific fork of the gather_in0 builder: the in0 reader does a 4-step
 // multicast (chunks indexed via the CCL fused-op ring) instead of the ring-hop topology used

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
@@ -82,6 +82,17 @@ struct LlamaReduceScatterDeviceOperation {
             tensor_return_value_t& tensor_return_value,
             const std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& signaler);
 
+        // Append-style overload: writes builder output onto an existing ProgramDescriptor
+        // supplied by the caller, so a single descriptor can hold this reduce-scatter
+        // alongside other builders (e.g. the matmul gather_in0 helper in rs_matmul_op).
+        static void create_at_program_processing_descriptor(
+            tt::tt_metal::ProgramDescriptor& desc,
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinate& mesh_coordinate,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value,
+            const std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& signaler);
+
         // Contract-2 (WorkloadDescriptor) factory.  Builds one ProgramDescriptor
         // per mesh coord via create_at_program_processing_descriptor.  No
         // workload-scoped semaphores or intermediate Tensors are required

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
@@ -82,27 +82,6 @@ struct LlamaReduceScatterDeviceOperation {
             tensor_return_value_t& tensor_return_value,
             const std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& signaler);
 
-        // Append-style overload of create_at_program_processing_descriptor.
-        // Instead of returning a fresh ProgramDescriptor, this variant appends
-        // CBs/kernels/semaphores/runtime args onto an existing `desc` that the
-        // caller is composing.  Used by rs_matmul_op (Contract-2), which
-        // builds a single ProgramDescriptor holding both the reduce-scatter
-        // half (this builder) and the matmul half (gather_in0 descriptor
-        // helper) so they can share kernels on overlapping cores.
-        //
-        // Semaphore IDs are allocated via desc.find_available_semaphore_id()
-        // (rather than desc.semaphores.size()) so a local_semaphore allocated
-        // here cannot collide with semaphores the caller already registered on
-        // the same cores (e.g. the signaler's rs_semaphore from
-        // MatmulFusedOpSignaler::init_llama_rs_cores_rs).
-        static void create_at_program_processing_descriptor(
-            tt::tt_metal::ProgramDescriptor& desc,
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value,
-            const std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& signaler);
-
         // Contract-2 (WorkloadDescriptor) factory.  Builds one ProgramDescriptor
         // per mesh coord via create_at_program_processing_descriptor.  No
         // workload-scoped semaphores or intermediate Tensors are required

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -245,8 +245,8 @@ CoreRangeSet get_worker_cores(const CoreRangeSet& available_cores, const uint32_
 
 }  // namespace detail
 
-// Contract-2 workload builder.  Builds one ProgramDescriptor per mesh coord
-// via create_at_program_processing_descriptor (no fused-op signaler needed).
+// Workload builder.  Builds one ProgramDescriptor per mesh coord via
+// create_at_program_processing_descriptor (no fused-op signaler needed).
 // No workload-scoped resources beyond what the caller supplied; the
 // cross_device_semaphore in operation_attributes is the only external
 // semaphore and remains owned by the caller.
@@ -834,7 +834,7 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_proc
 }
 
 // Returns-fresh-ProgramDescriptor variant.  Builds an empty descriptor and
-// forwards to the append-style overload below.  Used by Contract-2 callers
+// forwards to the append-style overload below.  Used by callers
 // (LlamaReduceScatterAdd::create_workload_descriptor) that build one isolated
 // ProgramDescriptor per mesh coord.
 tt::tt_metal::ProgramDescriptor

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -139,12 +139,10 @@ void add_termination_master_rt_args(
     }
 }
 
-// ProgramDescriptor (Contract-2) variant of launch_mux_workers above.
-// Mirrors the legacy helper but appends the mux kernel onto the caller's
-// ProgramDescriptor (with its runtime args baked in per logical core) instead
-// of issuing imperative CreateKernel / SetRuntimeArgs calls.  The returned
-// per-link mesh-coord->virtual-core maps and the FabricMuxConfig are identical
-// to the legacy helper; the kernel index is the position of the appended
+// ProgramDescriptor variant of launch_mux_workers above.
+// Appends the mux kernel onto the caller's ProgramDescriptor (with its runtime
+// args baked in per logical core) instead of issuing imperative CreateKernel /
+// SetRuntimeArgs calls.  The kernel index is the position of the appended
 // KernelDescriptor in desc.kernels.
 auto launch_mux_workers_descriptor(
     const MeshDevice& mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -244,93 +244,95 @@ auto launch_mux_workers_descriptor(
 }
 
 }  // namespace detail
-UnifiedSelectReduce::cached_mesh_workload_t UnifiedSelectReduce::create_mesh_workload(
+
+tt::tt_metal::WorkloadDescriptor UnifiedSelectReduce::create_workload_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
     auto* mesh_device = tensor_args.dense_input_tensor.device();
     const ttnn::CoreRangeSet worker_core_range_set(operation_attributes.worker_cores);
+
+    // Workload-scoped GlobalSemaphores: allocated once on cache miss and parked
+    // on workload_descriptor.semaphores so they outlive the cached workload.
+    // The init/final barrier semaphores synchronize handoffs between devices,
+    // hence the Synchronize call before kicking off any per-coord program.
     auto init_barrier_semaphore =
         ttnn::global_semaphore::create_global_semaphore(mesh_device, worker_core_range_set, 0);
 
-    auto final_barrier_semaphore = operation_attributes.optional_cross_device_semaphore.value_or(
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, worker_core_range_set, 0));
+    GlobalSemaphore final_barrier_semaphore =
+        operation_attributes.optional_cross_device_semaphore.has_value()
+            ? operation_attributes.optional_cross_device_semaphore.value()
+            : ttnn::global_semaphore::create_global_semaphore(mesh_device, worker_core_range_set, 0);
 
     tt::tt_metal::distributed::Synchronize(
         mesh_device, std::nullopt, {});  // interaction with subdevice needs to be investigated
 
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(
+    workload_descriptor.semaphores.push_back(init_barrier_semaphore);
+    if (!operation_attributes.optional_cross_device_semaphore.has_value()) {
+        // Only park the final barrier when we allocated it ourselves; if the
+        // caller passed one in, lifetime is the caller's responsibility.
+        workload_descriptor.semaphores.push_back(final_barrier_semaphore);
+    }
+
+    const auto all_mesh_coordinates = tensor_coords.coords();
+
+    // Build a ProgramDescriptor per mesh coord — the descriptor builder bakes
+    // in per-coord fabric routing (src_chip_id, neighbors) so each program is
+    // unique.
+    for (const auto& coord : all_mesh_coordinates) {
+        tt::tt_metal::ProgramDescriptor desc;
+
+        // Allocate the two worker-scoped sync semaphores as SemaphoreDescriptors
+        // on `desc`.  The legacy factory created these via
+        // CreateSemaphore(program, ...) inside create_at(); the descriptor
+        // builder takes their IDs by value so it does not need to know how the
+        // caller allocated them.
+        //
+        // metadata_sync covers the bounding box of the worker cores and is
+        // initialized to 1; compute_sync covers all worker cores and starts at
+        // 0.  These initial values match the legacy CreateSemaphore calls.
+        const auto metadata_sync_core_ranges = CoreRangeSet(worker_core_range_set.bounding_box());
+        const auto probe_core = worker_core_range_set.bounding_box().start_coord;
+        auto metadata_sync_id_opt = desc.find_available_semaphore_id(probe_core, tt::CoreType::WORKER);
+        TT_FATAL(metadata_sync_id_opt.has_value(), "No available semaphore ID for metadata sync");
+        const uint32_t metadata_sync_semaphore_id = metadata_sync_id_opt.value();
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = metadata_sync_semaphore_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = metadata_sync_core_ranges,
+            .initial_value = 1});
+
+        // Compute sync ID must be distinct from metadata_sync on shared cores;
+        // pushing metadata_sync above ensures find_available_semaphore_id will
+        // skip the freshly used ID here.
+        auto compute_sync_id_opt = desc.find_available_semaphore_id(probe_core, tt::CoreType::WORKER);
+        TT_FATAL(compute_sync_id_opt.has_value(), "No available semaphore ID for compute sync");
+        const uint32_t compute_sync_semaphore_id = compute_sync_id_opt.value();
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = compute_sync_semaphore_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = worker_core_range_set,
+            .initial_value = 0});
+
+        build_selective_reduce_combine_program_artifacts_descriptor(
+            desc,
             operation_attributes,
             coord,
-            tensor_coords.coords(),
+            all_mesh_coordinates,
             tensor_args,
             tensor_return_value,
             init_barrier_semaphore,
-            final_barrier_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
+            final_barrier_semaphore,
+            metadata_sync_semaphore_id,
+            compute_sync_semaphore_id);
+
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
 
-ttnn::device_operation::CachedProgram<UnifiedSelectReduce::shared_variables_t> UnifiedSelectReduce::create_at(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const std::vector<ttnn::MeshCoordinate>& all_mesh_coordinates,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
-    const GlobalSemaphore& init_semaphore,
-    const GlobalSemaphore& cross_device_semaphore) {
-    tt::tt_metal::Program program{};
-    const ttnn::CoreRangeSet worker_core_range_set(operation_attributes.worker_cores);
-    const uint32_t metadata_sync_semaphore_id =
-        tt::tt_metal::CreateSemaphore(program, CoreRangeSet(worker_core_range_set.bounding_box()), 1);
-    const uint32_t compute_sync_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range_set, 0);
-    auto artifacts = build_selective_reduce_combine_program_artifacts(
-        program,
-        operation_attributes,
-        mesh_coordinate,
-        all_mesh_coordinates,
-        tensor_args,
-        tensor_return_value,
-        init_semaphore,
-        cross_device_semaphore,
-        metadata_sync_semaphore_id,
-        compute_sync_semaphore_id);
-    return {std::move(program), std::move(artifacts)};
-}
-
-void UnifiedSelectReduce::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& coord = range.start_coord();
-        TT_FATAL(
-            coord == range.end_coord(),
-            "Expected single coordinate per program but got range of {} to {}",
-            coord,
-            range.end_coord());
-
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-        selective_reduce_combine_helper_override_runtime_arguments(
-            program,
-            shared_variables.reader_kernel_id,
-            shared_variables.writer_kernel_id,
-            shared_variables.data_cb_handle,
-            shared_variables.cores,
-            tensor_args,
-            tensor_return_value,
-            shared_variables.init_semaphore,
-            shared_variables.cross_device_semaphore,
-            operation_attributes.optional_cross_device_semaphore);
-    }
+    return workload_descriptor;
 }
 
 SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_artifacts(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
@@ -21,12 +21,12 @@ struct SelectiveReduceCombineProgramArtifacts {
     const GlobalSemaphore cross_device_semaphore;
 };
 
-// Descriptor (Contract-2) flavor of SelectiveReduceCombineProgramArtifacts.
+// Descriptor flavor of SelectiveReduceCombineProgramArtifacts.
 // Returned by build_selective_reduce_combine_program_artifacts_descriptor below.
 // Holds indices into the caller's ProgramDescriptor::kernels for the reader and
-// writer kernels — the descriptor-based callers no longer need a separate
-// CBHandle because the input-tensor binding lives on the CBDescriptor (via its
-// buffer pointer) and is patched by the framework's fast cache-hit path.
+// writer kernels — descriptor-based callers don't need a separate CBHandle
+// because the input-tensor binding lives on the CBDescriptor (via its buffer
+// pointer) and is patched by the framework's fast cache-hit path.
 struct SelectiveReduceCombineProgramArtifactsDescriptor {
     tt::tt_metal::KernelHandle reader_kernel_index{};
     tt::tt_metal::KernelHandle writer_kernel_index{};
@@ -62,18 +62,17 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     const uint32_t compute_cores_per_combine_cores = 0,
     const std::optional<std::vector<CoreCoord>>& compute_cores_by_ring_id = std::nullopt);
 
-// ProgramDescriptor (Contract-2) variant of build_selective_reduce_combine_program_artifacts.
-// Mirrors the legacy Program& builder above but appends kernels / CBs / semaphores onto
-// the caller's ProgramDescriptor instead of issuing imperative CreateKernel /
-// CreateCircularBuffer / CreateSemaphore / SetRuntimeArgs calls.  The input tensor
-// binding for the data CB lives on CBDescriptor::buffer (instead of being patched
-// via UpdateDynamicCircularBufferAddress) and the buffer addresses for the reader
-// and writer runtime args are bound via emplace_runtime_args so the framework's
-// fast cache-hit path patches them without rebuilding the program.  metadata and
-// compute sync semaphore IDs are still passed in by the caller (allocated by
-// pushing SemaphoreDescriptors onto desc.semaphores prior to invoking this
-// helper) so the helper does not need to know the caller's other semaphore IDs.
-// The legacy Program& helper is preserved unchanged for non-migrated callers.
+// ProgramDescriptor variant of build_selective_reduce_combine_program_artifacts.
+// Appends kernels / CBs / semaphores onto the caller's ProgramDescriptor instead
+// of issuing imperative CreateKernel / CreateCircularBuffer / CreateSemaphore /
+// SetRuntimeArgs calls.  The input tensor binding for the data CB lives on
+// CBDescriptor::buffer (instead of being patched via UpdateDynamicCircularBufferAddress)
+// and the buffer addresses for the reader and writer runtime args are bound via
+// emplace_runtime_args so the framework's fast cache-hit path patches them without
+// rebuilding the program.  metadata and compute sync semaphore IDs are still passed
+// in by the caller (allocated by pushing SemaphoreDescriptors onto desc.semaphores
+// prior to invoking this helper) so the helper does not need to know the caller's
+// other semaphore IDs.
 SelectiveReduceCombineProgramArtifactsDescriptor build_selective_reduce_combine_program_artifacts_descriptor(
     tt::tt_metal::ProgramDescriptor& desc,
     const experimental::prim::SelectiveReduceCombineParams& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
@@ -8,6 +8,7 @@
 
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -39,32 +40,11 @@ struct UnifiedSelectReduce {
     using tensor_args_t = SelectiveReduceCombineTensors;
     using tensor_return_value_t = ttnn::Tensor;
 
-    using shared_variables_t = SelectiveReduceCombineProgramArtifacts;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const std::vector<ttnn::MeshCoordinate>& all_mesh_coordinates,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,
-        const GlobalSemaphore& init_semaphore,
-        const GlobalSemaphore& cross_device_semaphore);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 // Builder function that creates kernels and returns artifacts

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -8,9 +8,11 @@
 #include "ttnn/global_semaphore.hpp"
 
 #include <algorithm>
+#include <bitset>
 #include <numeric>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <tt-metalium/constants.hpp>
@@ -22,7 +24,6 @@
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/work_split.hpp>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 
 namespace {
@@ -149,80 +150,76 @@ std::string serialize_physical_core_coords(const std::vector<ttnn::CoreCoord>& c
 
     return ttnn::operations::ccl::common::stringify(flat_physical_core_coords);
 }
-}  // namespace
 
-namespace ttnn::experimental::prim {
-
-// expose a helper function so callers know what cores are available for subsequently running a2a combine
-std::vector<ttnn::CoreCoord> get_moe_combine_cores(
-    ttnn::MeshDevice* mesh_device,
-    const uint32_t combine_token_parallel_cores,
-    const uint32_t combine_data_parallel_cores) {
-    constexpr auto combine_cores_return_index = 8;
-
-    // Use dummy hidden_size since we only need combine cores (which don't depend on hidden_size)
-    // This function is only for getting combine cores, not tilize cores
-    constexpr uint32_t dummy_hidden_size = 7168;  // DeepSeek default
-    const auto get_cores_return =
-        get_cores(mesh_device, combine_token_parallel_cores, combine_data_parallel_cores, dummy_hidden_size);
-
-    return std::get<combine_cores_return_index>(get_cores_return);
-}
-
-MoEComputeMeshWorkloadFactory::cached_mesh_workload_t MoEComputeMeshWorkloadFactory::create_mesh_workload(
-    const MoEComputeParams& args,
-    const ttnn::MeshCoordinateRangeSet& mesh_coordinates,
-    const MoEComputeInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, MoEComputeMeshWorkloadFactory::shared_variables_t> shared_variables;
-
-    constexpr auto combine_core_range_set_return_index = 5;
-
-    auto* mesh_device = tensor_args.tilize_input_tensor.device();
-    const auto& tilize_input_shape = tensor_args.tilize_input_tensor.tensor_spec().logical_shape();
-    const uint32_t hidden_size = tilize_input_shape[-1];
-
-    const auto core_ret = get_cores(
-        mesh_device,
-        args.combine_params.num_token_parallel_cores,
-        args.combine_params.num_data_parallel_cores,
-        hidden_size);
-
-    const auto& combine_core_range_set = std::get<combine_core_range_set_return_index>(core_ret);
-
-    auto init_barrier_semaphore =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, combine_core_range_set, 0);
-    auto final_barrier_semaphore = args.combine_params.optional_cross_device_semaphore.value_or(
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, combine_core_range_set, 0));
-
-    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
-
-    for (const auto& coord : mesh_coordinates.coords()) {
-        auto cached_program = MoEComputeMeshWorkloadFactory::create_at(
-            args,
-            coord,
-            tensor_args,
-            tensor_return_value,
-            mesh_coordinates,
-            init_barrier_semaphore,
-            final_barrier_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
+// Allocate a fresh semaphore on `desc` covering `core_ranges` and return its
+// ID.  The chosen ID is the lowest non-negative integer that is unused on
+// every core in `core_ranges` (i.e. it does not collide with any prior
+// SemaphoreDescriptor::core_ranges that intersects with the new range).
+// Initial value mirrors the legacy CreateSemaphore(..., INVALID) /
+// explicit-zero calls.
+//
+// We need this stronger guarantee than ProgramDescriptor::find_available_semaphore_id
+// (which probes a single core) because the moe_compute factory allocates
+// semaphores on a mix of overlapping ranges (tilize, matmul, tilize∪matmul,
+// combine, combine∪matmul) and the same ID across two overlapping
+// SemaphoreDescriptors would alias to the same L1 location.
+uint32_t push_semaphore(
+    tt::tt_metal::ProgramDescriptor& desc, const CoreRangeSet& core_ranges, uint32_t initial_value) {
+    // Union the used-ID bitsets across every existing semaphore that
+    // intersects `core_ranges`.  Two semaphores share cores iff their
+    // CoreRangeSets intersect, in which case they must use different IDs.
+    // 64 is a safe upper bound on the per-core semaphore ID space (the hw
+    // limit is 16; framework will TT_FATAL if we ever return an out-of-range
+    // ID at program build time).
+    constexpr uint32_t MAX_SEM_ID_SEARCH = 64;
+    std::bitset<MAX_SEM_ID_SEARCH> used_semaphores;
+    for (const auto& sem_desc : desc.semaphores) {
+        if (sem_desc.core_type != tt::CoreType::WORKER) {
+            continue;
+        }
+        if (sem_desc.core_ranges.intersects(core_ranges)) {
+            if (sem_desc.id < MAX_SEM_ID_SEARCH) {
+                used_semaphores.set(sem_desc.id);
+            }
+        }
     }
-    return MoEComputeMeshWorkloadFactory::cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
+
+    uint32_t chosen_id = 0;
+    bool found = false;
+    for (uint32_t i = 0; i < MAX_SEM_ID_SEARCH; i++) {
+        if (!used_semaphores.test(i)) {
+            chosen_id = i;
+            found = true;
+            break;
+        }
+    }
+    TT_FATAL(found, "No available semaphore ID for core ranges {}", core_ranges);
+
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = chosen_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = core_ranges,
+        .initial_value = initial_value,
+    });
+    return chosen_id;
 }
 
-ttnn::device_operation::CachedProgram<MoEComputeMeshWorkloadFactory::shared_variables_t>
-MoEComputeMeshWorkloadFactory::create_at(
-    const MoEComputeParams& args,
+// Build a ProgramDescriptor for one mesh coord.  The per-coord layout mirrors
+// the legacy factory's create_at() body line-for-line; only the building
+// blocks (CreateSemaphore / create_cb / CreateKernel / SetRuntimeArgs) are
+// replaced by descriptor pushes and emplace_runtime_args.  Dynamic-address
+// CBs use CBDescriptor::buffer instead of set_globally_allocated_address +
+// UpdateDynamicCircularBufferAddress, and tensor base addresses are bound as
+// Buffer* runtime args so the framework's fast cache-hit path patches them.
+tt::tt_metal::ProgramDescriptor build_descriptor_at(
+    const ttnn::experimental::prim::MoEComputeParams& args,
     const ttnn::MeshCoordinate& mesh_coordinate,
-    const MoEComputeInputs& tensor_args,
+    const ttnn::experimental::prim::MoEComputeInputs& tensor_args,
     std::vector<ttnn::Tensor>& tensor_return_value,
-    const ttnn::MeshCoordinateRangeSet& mesh_coordinates,
+    const std::vector<ttnn::MeshCoordinate>& all_mesh_coordinates,
     const GlobalSemaphore& init_barrier_semaphore,
     const GlobalSemaphore& final_barrier_semaphore) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    tt::tt_metal::ProgramDescriptor desc;
 
     // Alignment
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
@@ -374,22 +371,25 @@ MoEComputeMeshWorkloadFactory::create_at(
     //-------------------------------------------------------------------------
     // Tilize semaphores
     //-------------------------------------------------------------------------
+    // SemaphoreDescriptor pushes mirror the legacy CreateSemaphore(..., INVALID)
+    // calls: INVALID == initial value 0 for sync semaphores.  push_semaphore()
+    // computes a fresh ID by unioning the used-ID bitsets of every prior
+    // SemaphoreDescriptor whose core_ranges intersects the new range.
 
     // Non-drain-sync cores signal to drain-sync core that partial metadata results are ready
-    auto tilize_partial_metadata_ready_semaphore_id =
-        tt::tt_metal::CreateSemaphore(program, tilize_core_range_set, INVALID);
+    const uint32_t tilize_partial_metadata_ready_semaphore_id = push_semaphore(desc, tilize_core_range_set, INVALID);
 
     // Non-drain-sync cores signal to drain-sync core that partial chunk has been sent to the matmul cores.
     // Drain-sync core then signals to non-drain-sync core that they can begin sending the next chunk.
-    auto tilize_chunk_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, tilize_core_range_set, INVALID);
+    const uint32_t tilize_chunk_ready_semaphore_id = push_semaphore(desc, tilize_core_range_set, INVALID);
 
     // Since both reader and writer are using NoC1, we have the readers wait until all writers have sent their
     // chunk portion to the matmul cores before reading in another set of tokens to tilize. This frees up NoC1
     // to do the mcast, which is also a requirement for doing linked mcasts.
-    auto previous_chunk_sent_semaphore_id = tt::tt_metal::CreateSemaphore(program, tilize_core_range_set, INVALID);
+    const uint32_t previous_chunk_sent_semaphore_id = push_semaphore(desc, tilize_core_range_set, INVALID);
 
     // For the gather phase scheme used for the first chunk
-    auto initial_gather_semaphore_id = tt::tt_metal::CreateSemaphore(program, tilize_core_range_set, INVALID);
+    const uint32_t initial_gather_semaphore_id = push_semaphore(desc, tilize_core_range_set, INVALID);
 
     //-------------------------------------------------------------------------
     // Matmul semaphores
@@ -398,7 +398,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     // Create semaphores for ring synchronization between cores
     // Each core will have a semaphore that its predecessor will signal
     // reuse the same semaphore location for signaling combine cores that per expert data is available
-    const uint32_t ring_semaphore_id = tt::tt_metal::CreateSemaphore(program, matmul_core_range_set, INVALID);
+    const uint32_t ring_semaphore_id = push_semaphore(desc, matmul_core_range_set, INVALID);
 
     //-------------------------------------------------------------------------
     // Tilize and Matmul semaphores
@@ -406,16 +406,14 @@ MoEComputeMeshWorkloadFactory::create_at(
 
     // Tilize drain-sync core signals to tilize non-drain-sync cores that final metadata results are ready
     // Tilize drain-sync core signals to matmul cores that final metadata results are ready
-    auto metadata_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, tilize_matmul_core_range_set, INVALID);
+    const uint32_t metadata_ready_semaphore_id = push_semaphore(desc, tilize_matmul_core_range_set, INVALID);
 
     // Matmul cores signal to tilize drain-sync-core that the input chunk is free to be written to
     // Tilize drain-sync-core propagates this to the tilize non-drain-sync cores
-    auto matmul_chunk_available_semaphore_id =
-        tt::tt_metal::CreateSemaphore(program, tilize_matmul_core_range_set, INVALID);
+    const uint32_t matmul_chunk_available_semaphore_id = push_semaphore(desc, tilize_matmul_core_range_set, INVALID);
 
     // Tilize drain-sync core signals to all matmul cores that a full chunk is ready
-    auto matmul_chunk_ready_semaphore_id =
-        tt::tt_metal::CreateSemaphore(program, tilize_matmul_core_range_set, INVALID);
+    const uint32_t matmul_chunk_ready_semaphore_id = push_semaphore(desc, tilize_matmul_core_range_set, INVALID);
 
     //-------------------------------------------------------------------------
     // Tilize/MatMul and Combine sync semaphore
@@ -424,13 +422,11 @@ MoEComputeMeshWorkloadFactory::create_at(
     // Tilize drain-sync core signals combine sync core (which then multicasts to the rest)
     // that metadata is ready and task splitting can proceed.
     // Allocate on full rectangle of usable cores so we can multicast without clobbering.
-    const auto tilize_combine_sync_semaphore_id =
-        tt::tt_metal::CreateSemaphore(program, max_combine_core_range_set, INVALID);
+    const uint32_t tilize_combine_sync_semaphore_id = push_semaphore(desc, max_combine_core_range_set, INVALID);
 
     // Matmul dm1 signals combine cores when data is written; combine writer waits on this semaphore.
     // For double buffering, combine cores will also use this semaphore to signal matmul when buffer segments are free
-    const auto matmul_combine_sync_semaphore_id =
-        tt::tt_metal::CreateSemaphore(program, combine_matmul_core_range_set, INVALID);
+    const uint32_t matmul_combine_sync_semaphore_id = push_semaphore(desc, combine_matmul_core_range_set, INVALID);
 
     //-------------------------------------------------------------------------
     // Tilize work split
@@ -472,37 +468,47 @@ MoEComputeMeshWorkloadFactory::create_at(
     const CoreRangeSet shard_cores = tilize_output_tensor.memory_config().shard_spec()->grid;
     const uint32_t shared_cb_num_pages = output_pages / shard_cores.num_cores();
 
-    auto output_cb = tt::tt_metal::create_cb(
-        tilize_output_cb_id,
-        program,
-        shard_cores,
-        output_page_size,
-        shared_cb_num_pages,
-        tt::tt_metal::datatype_to_dataformat_converter(tilize_output_tensor.dtype()),
-        tilize_output_tensor.buffer());
-    tt::tt_metal::CBHandle sharded_output_cb_handle = std::get<1>(output_cb);
+    // Sharded output CB: pinned to the tilize_output_tensor L1 buffer via
+    // CBDescriptor::buffer (legacy set_globally_allocated_address +
+    // UpdateDynamicCircularBufferAddress).  Tilize uses it as output, Matmul
+    // as input, Combine as the source of MM output.
+    const auto sharded_output_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(tilize_output_tensor.dtype());
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = shared_cb_num_pages * output_page_size,
+        .core_ranges = shard_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tilize_output_cb_id),
+            .data_format = sharded_output_data_format,
+            .page_size = output_page_size,
+        }}},
+        .buffer = tilize_output_tensor.buffer(),
+    });
 
     // MoE output for combine uses the same buffer as input but create a new CB to manage control flow
-    auto matmul_writer_cb = tt::tt_metal::create_cb(
-        matmul_writer_cb_id,
-        program,
-        shard_cores,
-        output_page_size,
-        shared_cb_num_pages,
-        tt::tt_metal::datatype_to_dataformat_converter(tilize_output_tensor.dtype()),
-        tilize_output_tensor.buffer());
-    tt::tt_metal::CBHandle matmul_writer_cb_handle = std::get<1>(matmul_writer_cb);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = shared_cb_num_pages * output_page_size,
+        .core_ranges = shard_cores,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(matmul_writer_cb_id),
+            .data_format = sharded_output_data_format,
+            .page_size = output_page_size,
+        }}},
+        .buffer = tilize_output_tensor.buffer(),
+    });
 
     // global tensor backed CB to communicate active tokens per expert
-    const auto expert_token_cb = tt::tt_metal::create_cb(
-        per_expert_total_tokens_cb_id,
-        program,
-        all_worker_cores_range_set,
-        tilize_per_expert_total_tokens_output_page_size,
-        1,
-        tt::tt_metal::datatype_to_dataformat_converter(tilize_per_expert_total_tokens_output_tensor.dtype()),
-        tilize_per_expert_total_tokens_output_tensor.buffer());
-    const auto expert_tokens_cb_handle = std::get<1>(expert_token_cb);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = tilize_per_expert_total_tokens_output_page_size,
+        .core_ranges = all_worker_cores_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(per_expert_total_tokens_cb_id),
+            .data_format =
+                tt::tt_metal::datatype_to_dataformat_converter(tilize_per_expert_total_tokens_output_tensor.dtype()),
+            .page_size = tilize_per_expert_total_tokens_output_page_size,
+        }}},
+        .buffer = tilize_per_expert_total_tokens_output_tensor.buffer(),
+    });
 
     //-------------------------------------------------------------------------
     // Tilize CBs
@@ -552,128 +558,158 @@ MoEComputeMeshWorkloadFactory::create_at(
     constexpr uint32_t tokens_per_chunk = 32;  // Hardcoding for now, can adjust when tiny tiles support added
 
     // e_t buffer entry size must be 16B aligned for NOC DMA during BRISC->NCRISC merge
-    tt::tt_metal::create_cb(
-        e_t_cb_id,
-        program,
-        tilize_core_range_set,
-        tilize_e_t_output_page_size,
-        experts_per_device,  // number of experts on the device
-        tilize_e_t_output_data_format);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = experts_per_device * tilize_e_t_output_page_size,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(e_t_cb_id),
+            .data_format = tilize_e_t_output_data_format,
+            .page_size = tilize_e_t_output_page_size,
+        }}},
+    });
 
-    // Assume indices tensor is sharded in L1
-    const auto indices_cb_output = tt::tt_metal::create_cb(
-        indices_tensor_cb_id,
-        program,
-        tilize_core_range_set,
-        tilize_indices_aligned_page_size,
-        tilize_indices_pages,  // double buffer buffer packets
-        tilize_indices_data_format,
-        tilize_indices_tensor.buffer());
-    const auto indices_cb_handle = std::get<1>(indices_cb_output);
+    // Assume indices tensor is sharded in L1 -- CBDescriptor::buffer pins
+    // the CB to the indices tensor's L1 buffer (replaces legacy
+    // set_globally_allocated_address + UpdateDynamicCircularBufferAddress).
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = tilize_indices_pages * tilize_indices_aligned_page_size,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(indices_tensor_cb_id),
+            .data_format = tilize_indices_data_format,
+            .page_size = tilize_indices_aligned_page_size,
+        }}},
+        .buffer = tilize_indices_tensor.buffer(),
+    });
 
-    // Assume scores tensor is sharded in L1
-    const auto scores_cb_output = tt::tt_metal::create_cb(
-        scores_tensor_cb_id,
-        program,
-        tilize_core_range_set,
-        tilize_input_scores_aligned_page_size,
-        tilize_input_scores_pages,
-        tilize_input_scores_data_format,
-        tilize_input_scores_tensor.buffer());
-    const auto scores_cb_handle = std::get<1>(scores_cb_output);
+    // Assume scores tensor is sharded in L1 -- CBDescriptor::buffer pins the CB
+    // to the scores tensor's L1 buffer (same dynamic-address pattern as indices).
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = tilize_input_scores_pages * tilize_input_scores_aligned_page_size,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(scores_tensor_cb_id),
+            .data_format = tilize_input_scores_data_format,
+            .page_size = tilize_input_scores_aligned_page_size,
+        }}},
+        .buffer = tilize_input_scores_tensor.buffer(),
+    });
 
     // For each batch's tokens, we need to read the relevant experts from the mapping tensor
     // For in range (tokens) every time tokens/batch increments, read in new mapping tensor page
-    tt::tt_metal::create_cb(
-        mapping_tensor_cb_id,
-        program,
-        tilize_core_range_set,
-        tilize_mapping_aligned_page_size,
-        tilize_mapping_pages,
-        tilize_mapping_data_format);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = tilize_mapping_pages * tilize_mapping_aligned_page_size,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(mapping_tensor_cb_id),
+            .data_format = tilize_mapping_data_format,
+            .page_size = tilize_mapping_aligned_page_size,
+        }}},
+    });
 
     // Tilize input buffer: holds subtokens for tokens_per_chunk tokens
     // Each tilize core reads its subtoken portion of incoming tokens
     // Single buffered so we don't start reading in next set of tokens
     // before previous chunk fully sent to matmul cores
-    tt::tt_metal::create_cb(
-        tilize_input_cb_id,
-        program,
-        tilize_core_range_set,
-        max_tilize_subtoken_size,
-        tokens_per_chunk,
-        tilize_input_data_format);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = tokens_per_chunk * max_tilize_subtoken_size,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tilize_input_cb_id),
+            .data_format = tilize_input_data_format,
+            .page_size = max_tilize_subtoken_size,
+        }}},
+    });
 
-    tt::tt_metal::create_cb(
-        expert_activation_cb_id,
-        program,
-        tilize_core_range_set,
-        tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment),
-        tokens,
-        tt::DataFormat::UInt32);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = tokens * tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment),
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(expert_activation_cb_id),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment),
+        }}},
+    });
 
     // BRISC's e_t buffer for parallel metadata processing
     // BRISC processes the second half of tokens (tokens/2 to tokens)
     // Single page containing all experts' token lists, each with capacity tokens/2
     // Uses same 16B entry alignment as main e_t buffer for NOC DMA compatibility
-    tt::tt_metal::create_cb(
-        brisc_e_t_cb_id,
-        program,
-        tilize_core_range_set,
-        (tokens / 2) * l1_alignment * experts_per_device,  // full buffer with 16B entries
-        1,
-        tt::DataFormat::UInt32);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = (tokens / 2) * l1_alignment * experts_per_device,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(brisc_e_t_cb_id),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = (tokens / 2) * l1_alignment * experts_per_device,  // full buffer with 16B entries
+        }}},
+    });
 
     // BRISC's per-expert token counts to communicate to NCRISC
     // Single page containing counts for all experts
-    tt::tt_metal::create_cb(
-        brisc_expert_counts_cb_id,
-        program,
-        tilize_core_range_set,
-        sizeof(uint32_t) * experts_per_device,  // all counts in one page
-        1,
-        tt::DataFormat::UInt32);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = sizeof(uint32_t) * experts_per_device,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(brisc_expert_counts_cb_id),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = sizeof(uint32_t) * experts_per_device,  // all counts in one page
+        }}},
+    });
 
     // BRISC's expert activation buffer - same format as main expert_activation buffer
     // [token_id, k_indices[experts_per_device], scores[experts_per_device]] per activated token
     // Single page containing all activation rows (max tokens/2)
     uint32_t brisc_activation_row_size = tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment);
-    tt::tt_metal::create_cb(
-        brisc_expert_activation_cb_id,
-        program,
-        tilize_core_range_set,
-        brisc_activation_row_size * (tokens / 2),  // full buffer in one page
-        1,
-        tt::DataFormat::UInt32);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = brisc_activation_row_size * (tokens / 2),
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(brisc_expert_activation_cb_id),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = brisc_activation_row_size * (tokens / 2),  // full buffer in one page
+        }}},
+    });
 
     // BRISC's activated token count (single uint32_t to communicate to NCRISC)
-    tt::tt_metal::create_cb(
-        brisc_activated_count_cb_id, program, tilize_core_range_set, sizeof(uint32_t), 1, tt::DataFormat::UInt32);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = sizeof(uint32_t),
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(brisc_activated_count_cb_id),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = sizeof(uint32_t),
+        }}},
+    });
 
     // CB for receiving counts from non-drain tilize cores (only used on drain core)
     // Each non-drain core sends: [e_t_count_expert0, e_t_count_expert1, activated_count]
     // Layout: 3 values per core × (tilize_num_cores - 1) cores, 16B aligned per core's data
     uint32_t counts_per_remote_core = experts_per_device + 1;  // e_t counts + activated count
     uint32_t remote_counts_entry_size = tt::align(counts_per_remote_core * sizeof(uint32_t), l1_alignment);
-    tt::tt_metal::create_cb(
-        remote_counts_cb_id,
-        program,
-        tilize_core_range_set,
-        remote_counts_entry_size,
-        tilize_num_cores - 1,  // one entry per non-drain core
-        tt::DataFormat::UInt32);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = (tilize_num_cores - 1) * remote_counts_entry_size,
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(remote_counts_cb_id),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = remote_counts_entry_size,
+        }}},
+    });
 
     // CB for passing total_chunks from writer to compute kernel
     // Single page holding one uint32_t value. Page size floored at l1_alignment /
     // CIRCULAR_BUFFER_COMPUTE_WORD_SIZE so the unpack LLK fifo_* fields (16 B words) are non-zero
     // when tilize_compute pops this CB.
-    tt::tt_metal::create_cb(
-        total_chunks_cb_id,
-        program,
-        tilize_core_range_set,
-        non_tile_cb_page_size(tt::DataFormat::UInt32, l1_alignment),
-        1,  // single page
-        tt::DataFormat::UInt32);
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = non_tile_cb_page_size(tt::DataFormat::UInt32, l1_alignment),
+        .core_ranges = tilize_core_range_set,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(total_chunks_cb_id),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = non_tile_cb_page_size(tt::DataFormat::UInt32, l1_alignment),
+        }}},
+    });
 
     //-------------------------------------------------------------------------
     // Matmul CBs
@@ -716,10 +752,15 @@ MoEComputeMeshWorkloadFactory::create_at(
     for (const auto& [name, index, data_format, is_tile, tiles_per_cb] : matmul_cb_specs0) {
         const uint32_t bytes_per_tile =
             is_tile ? tt::tile_size(data_format) : non_tile_cb_page_size(data_format, l1_alignment);
-        const auto cb_config = tt::tt_metal::CircularBufferConfig(tiles_per_cb * bytes_per_tile, {{index, data_format}})
-                                   .set_page_size(index, bytes_per_tile);
-
-        tt::tt_metal::CreateCircularBuffer(program, matmul_core_range_set, cb_config);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = tiles_per_cb * bytes_per_tile,
+            .core_ranges = matmul_core_range_set,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(index),
+                .data_format = data_format,
+                .page_size = bytes_per_tile,
+            }}},
+        });
     }
 
     //-------------------------------------------------------------------------
@@ -750,7 +791,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     // Drain core is always the first tilize core (index 0)
     CoreCoord tilize_drain_core_physical = tilize_cores_physical.at(0);
 
-    std::unordered_map<std::string, uint32_t> tilize_named_compile_time_args = {
+    tt::tt_metal::KernelDescriptor::NamedCompileTimeArgs tilize_named_compile_time_args = {
         // CBs
         {"tilize_input_cb_id", tilize_input_cb_id},
         {"tilize_output_cb_id", tilize_output_cb_id},
@@ -868,34 +909,44 @@ MoEComputeMeshWorkloadFactory::create_at(
         .append_to(tilize_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(tilize_e_t_output_tensor.buffer()).append_to(tilize_compile_time_args);
 
-    tt::tt_metal::KernelHandle tilize_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp",
-        tilize_core_range_set,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::NOC::NOC_1,
-            .noc_mode = tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC,
-            .compile_args = tilize_compile_time_args,
-            .defines = {},
-            .named_compile_args = tilize_named_compile_time_args,
-            .opt_level = tt::tt_metal::KernelBuildOptLevel::O2});
+    // Tilize reader kernel
+    tt::tt_metal::KernelDescriptor tilize_reader_kernel_desc;
+    tilize_reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp";
+    tilize_reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    tilize_reader_kernel_desc.core_ranges = tilize_core_range_set;
+    tilize_reader_kernel_desc.compile_time_args = tilize_compile_time_args;
+    tilize_reader_kernel_desc.named_compile_time_args = tilize_named_compile_time_args;
+    tilize_reader_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = tt::tt_metal::NOC::NOC_1,
+        .noc_mode = tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC,
+    };
+    tilize_reader_kernel_desc.opt_level = tt::tt_metal::KernelBuildOptLevel::O2;
+    const tt::tt_metal::KernelHandle tilize_reader_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(tilize_reader_kernel_desc));
 
-    tt::tt_metal::KernelHandle tilize_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp",
-        tilize_core_range_set,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::NOC::NOC_1,
-            .noc_mode = tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC,
-            .compile_args = tilize_compile_time_args,
-            .defines = {},
-            .named_compile_args = tilize_named_compile_time_args,
-            .opt_level = tt::tt_metal::KernelBuildOptLevel::O2});
+    // Tilize writer kernel (mirrors reader CT args but on RISCV_0)
+    tt::tt_metal::KernelDescriptor tilize_writer_kernel_desc;
+    tilize_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp";
+    tilize_writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    tilize_writer_kernel_desc.core_ranges = tilize_core_range_set;
+    tilize_writer_kernel_desc.compile_time_args = tilize_compile_time_args;
+    tilize_writer_kernel_desc.named_compile_time_args = tilize_named_compile_time_args;
+    tilize_writer_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::NOC::NOC_1,
+        .noc_mode = tt::tt_metal::NOC_MODE::DM_DYNAMIC_NOC,
+    };
+    tilize_writer_kernel_desc.opt_level = tt::tt_metal::KernelBuildOptLevel::O2;
+    const tt::tt_metal::KernelHandle tilize_writer_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(tilize_writer_kernel_desc));
 
     // Compute kernel compile-time args for tilization
-    std::unordered_map<std::string, uint32_t> compute_tilize_named_compile_time_args = {
+    tt::tt_metal::KernelDescriptor::NamedCompileTimeArgs compute_tilize_named_compile_time_args = {
         {"tilize_input_cb_id", tilize_input_cb_id},
         {"tilize_output_cb_id", tilize_output_cb_id},
         {"total_chunks_cb_id", total_chunks_cb_id},
@@ -904,12 +955,24 @@ MoEComputeMeshWorkloadFactory::create_at(
         {"shared_cb_num_pages", shared_cb_num_pages},
     };
 
-    tt::tt_metal::KernelHandle tilize_compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_compute.cpp",
-        tilize_core_range_set,
-        tt::tt_metal::ComputeConfig{.named_compile_args = compute_tilize_named_compile_time_args});
+    tt::tt_metal::KernelDescriptor tilize_compute_kernel_desc;
+    tilize_compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_compute.cpp";
+    tilize_compute_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    tilize_compute_kernel_desc.core_ranges = tilize_core_range_set;
+    tilize_compute_kernel_desc.named_compile_time_args = compute_tilize_named_compile_time_args;
+    tilize_compute_kernel_desc.config = tt::tt_metal::ComputeConfigDescriptor{};
+    const tt::tt_metal::KernelHandle tilize_compute_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(tilize_compute_kernel_desc));
 
+    // Tilize reader/writer share the same per-core runtime arg layout.  The
+    // first 7 positions are tensor buffer base addresses; positions 7..17 are
+    // per-core scalars (drain flag, mcast info, work split, token range); then
+    // the physical NOC coordinates of every tilize core follow.  The tensor
+    // base addresses are bound as Buffer* via emplace_runtime_args so the
+    // framework patches them on every dispatch (replaces the legacy
+    // override_runtime_arguments updates).
     std::vector<uint32_t> tilize_runtime_args = {
         tilize_input_tensor.buffer()->address(),                           // 0
         tilize_indices_tensor.buffer()->address(),                         // 1
@@ -1039,10 +1102,33 @@ MoEComputeMeshWorkloadFactory::create_at(
         // Set compute kernel runtime args
         tilize_compute_runtime_args.at(0) = subtoken_size / tile_width_bytes;
 
-        tt::tt_metal::SetRuntimeArgs(program, tilize_reader_kernel_id, tilize_cores.at(i), tilize_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, tilize_writer_kernel_id, tilize_cores.at(i), tilize_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(
-            program, tilize_compute_kernel_id, tilize_cores.at(i), tilize_compute_runtime_args);
+        // Convert to variant arg list, substituting Buffer* bindings at the
+        // seven tensor positions so the framework patches them on every
+        // dispatch (replaces the legacy override_runtime_arguments updates).
+        std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> tilize_rt_args_variant;
+        tilize_rt_args_variant.reserve(tilize_runtime_args.size());
+        tilize_rt_args_variant.emplace_back(tilize_input_tensor.buffer());
+        tilize_rt_args_variant.emplace_back(tilize_indices_tensor.buffer());
+        tilize_rt_args_variant.emplace_back(tilize_input_scores_tensor.buffer());
+        tilize_rt_args_variant.emplace_back(tilize_mapping_tensor.buffer());
+        tilize_rt_args_variant.emplace_back(tilize_per_expert_total_tokens_output_tensor.buffer());
+        tilize_rt_args_variant.emplace_back(tilize_expert_activation_output_tensor.buffer());
+        tilize_rt_args_variant.emplace_back(tilize_e_t_output_tensor.buffer());
+        for (size_t j = 7; j < tilize_runtime_args.size(); ++j) {
+            tilize_rt_args_variant.emplace_back(tilize_runtime_args[j]);
+        }
+
+        desc.kernels[tilize_reader_kernel_index].emplace_runtime_args(tilize_cores.at(i), tilize_rt_args_variant);
+        desc.kernels[tilize_writer_kernel_index].emplace_runtime_args(tilize_cores.at(i), tilize_rt_args_variant);
+
+        // Compute kernel has only the tiles_per_chunk scalar; no Buffer* args.
+        std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> tilize_compute_rt_args_variant;
+        tilize_compute_rt_args_variant.reserve(tilize_compute_runtime_args.size());
+        for (uint32_t v : tilize_compute_runtime_args) {
+            tilize_compute_rt_args_variant.emplace_back(v);
+        }
+        desc.kernels[tilize_compute_kernel_index].emplace_runtime_args(
+            tilize_cores.at(i), tilize_compute_rt_args_variant);
     }
 
     //-------------------------------------------------------------------------
@@ -1077,7 +1163,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     const ttnn::experimental::prim::detail::MoEActivationFunction activation_type = args.activation_type;
 
     const uint32_t output_shard_width_tiles = hidden_size / tile_width / combine_data_parallel_cores;
-    std::unordered_map<std::string, uint32_t> matmul_named_compile_time_args = {
+    tt::tt_metal::KernelDescriptor::NamedCompileTimeArgs matmul_named_compile_time_args = {
         {"num_experts", experts_per_device},
         {"layer_id", args.layer_id},
         {"has_bias", args.has_bias ? 1u : 0u},
@@ -1105,43 +1191,62 @@ MoEComputeMeshWorkloadFactory::create_at(
         {"matmul_combine_sync_semaphore_id", matmul_combine_sync_semaphore_id},
     };
 
-    // Create kernels for the program
-    auto matmul_dm0_kernel_handle = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp",
-        matmul_core_range_set,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::NOC::NOC_0,
-            .compile_args = matmul_compile_time_args,
-            .named_compile_args = matmul_named_compile_time_args});
+    // dm0 kernel (RISCV_1 / NOC_0)
+    tt::tt_metal::KernelDescriptor matmul_dm0_kernel_desc;
+    matmul_dm0_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp";
+    matmul_dm0_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    matmul_dm0_kernel_desc.core_ranges = matmul_core_range_set;
+    matmul_dm0_kernel_desc.compile_time_args = matmul_compile_time_args;
+    matmul_dm0_kernel_desc.named_compile_time_args = matmul_named_compile_time_args;
+    matmul_dm0_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .noc = tt::tt_metal::NOC::NOC_0,
+    };
+    const tt::tt_metal::KernelHandle matmul_dm0_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(matmul_dm0_kernel_desc));
 
-    std::map<std::string, std::string> dm1_defines = {
+    // dm1 kernel (RISCV_0 / NOC_1) -- carries the OUTPUT_SHARD_CORE_MAP define
+    // produced by serialize_physical_core_coords so dm1 can directly NOC-write
+    // each ring tile to the right combine core.
+    tt::tt_metal::KernelDescriptor::Defines dm1_defines = {
         {"OUTPUT_SHARD_CORE_MAP", serialize_physical_core_coords(combine_cores, *mesh_device)}};
 
-    auto matmul_dm1_kernel_handle = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp",
-        matmul_core_range_set,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::NOC::NOC_1,
-            .compile_args = matmul_compile_time_args,
-            .defines = dm1_defines,
-            .named_compile_args = matmul_named_compile_time_args});
+    tt::tt_metal::KernelDescriptor matmul_dm1_kernel_desc;
+    matmul_dm1_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp";
+    matmul_dm1_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    matmul_dm1_kernel_desc.core_ranges = matmul_core_range_set;
+    matmul_dm1_kernel_desc.compile_time_args = matmul_compile_time_args;
+    matmul_dm1_kernel_desc.named_compile_time_args = matmul_named_compile_time_args;
+    matmul_dm1_kernel_desc.defines = std::move(dm1_defines);
+    matmul_dm1_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::NOC::NOC_1,
+    };
+    const tt::tt_metal::KernelHandle matmul_dm1_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(matmul_dm1_kernel_desc));
 
-    auto matmul_compute_kernel_handle = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp",
-        matmul_core_range_set,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::LoFi,
-            .fp32_dest_acc_en = false,
-            .dst_full_sync_en = false,
-            .bfp8_pack_precise = false,
-            .math_approx_mode = true,
-            .compile_args = matmul_compile_time_args,
-            .named_compile_args = matmul_named_compile_time_args});
+    // Matmul compute kernel
+    tt::tt_metal::KernelDescriptor matmul_compute_kernel_desc;
+    matmul_compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp";
+    matmul_compute_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    matmul_compute_kernel_desc.core_ranges = matmul_core_range_set;
+    matmul_compute_kernel_desc.compile_time_args = matmul_compile_time_args;
+    matmul_compute_kernel_desc.named_compile_time_args = matmul_named_compile_time_args;
+    matmul_compute_kernel_desc.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = tt::tt_metal::MathFidelity::LoFi,
+        .fp32_dest_acc_en = false,
+        .dst_full_sync_en = false,
+        .bfp8_pack_precise = false,
+        .math_approx_mode = true,
+    };
+    const tt::tt_metal::KernelHandle matmul_compute_kernel_index =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(matmul_compute_kernel_desc));
 
     //-------------------------------------------------------------------------
     // ring ordering
@@ -1173,7 +1278,14 @@ MoEComputeMeshWorkloadFactory::create_at(
         bank2ring_pos[this_bank] = {ring_pos, next_bank};
     }
 
-    // Set the runtime arguments for the kernels
+    // Set the runtime arguments for the kernels.
+    // Matmul rt arg layout (per core):
+    //   [0]     DRAM bank ID
+    //   [1]     VChannel
+    //   [2..4]  Tensor base addresses (w0_w1, w2, tilize_output)  -- bound as Buffer*
+    //   [5]     Ring semaphore ID
+    //   [6]     Ring core ID (ring position)
+    //   [7..8]  Neighbor physical (x, y)
     std::vector<uint32_t> matmul_runtime_args;
     matmul_runtime_args.push_back(0);  // DRAM Bank ID placeholder
     matmul_runtime_args.push_back(0);  // VChannel placeholder
@@ -1215,15 +1327,29 @@ MoEComputeMeshWorkloadFactory::create_at(
 
         matmul_runtime_args[0] = dram_bank++;
         matmul_runtime_args[1] = vchannel;
-        // matmul_runtime_args[2-4] are already set to tensor addresses
+        // matmul_runtime_args[2-4] are already set to tensor addresses (overwritten by Buffer* bindings below)
         // matmul_runtime_args[5] is already set to ring_semaphore_id
         matmul_runtime_args[6] = ring_pos;
         matmul_runtime_args[7] = static_cast<uint32_t>(next_physical.x);
         matmul_runtime_args[8] = static_cast<uint32_t>(next_physical.y);
 
-        tt::tt_metal::SetRuntimeArgs(program, matmul_dm0_kernel_handle, core, matmul_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, matmul_dm1_kernel_handle, core, matmul_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, matmul_compute_kernel_handle, core, matmul_runtime_args);
+        // Build variant arg list and substitute Buffer* bindings at positions
+        // 2, 3, 4 (w0_w1, w2, tilize_output) so the framework patches them on
+        // every dispatch.
+        std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> matmul_rt_args_variant;
+        matmul_rt_args_variant.reserve(matmul_runtime_args.size());
+        matmul_rt_args_variant.emplace_back(matmul_runtime_args[0]);
+        matmul_rt_args_variant.emplace_back(matmul_runtime_args[1]);
+        matmul_rt_args_variant.emplace_back(matmul_w0_w1_tensor.buffer());
+        matmul_rt_args_variant.emplace_back(matmul_w2_tensor.buffer());
+        matmul_rt_args_variant.emplace_back(tilize_output_tensor.buffer());
+        for (size_t j = 5; j < matmul_runtime_args.size(); ++j) {
+            matmul_rt_args_variant.emplace_back(matmul_runtime_args[j]);
+        }
+
+        desc.kernels[matmul_dm0_kernel_index].emplace_runtime_args(core, matmul_rt_args_variant);
+        desc.kernels[matmul_dm1_kernel_index].emplace_runtime_args(core, matmul_rt_args_variant);
+        desc.kernels[matmul_compute_kernel_index].emplace_runtime_args(core, matmul_rt_args_variant);
 
         log_debug(tt::LogOp, "{} -> DRAM {} -> ring pos {}", core.str(), dram_bank, ring_pos);
     }
@@ -1239,7 +1365,8 @@ MoEComputeMeshWorkloadFactory::create_at(
     auto combine_params = args.combine_params;
     combine_params.worker_cores = combine_cores;
     // MoE compute op does not have an optional output tensor in its API; combine writes to the
-    // tensor we create (output_tensor) passed explicitly to build_selective_reduce_combine_program_artifacts.
+    // tensor we create (output_tensor) passed explicitly to
+    // build_selective_reduce_combine_program_artifacts_descriptor.
     ttnn::experimental::prim::SelectiveReduceCombineTensors combine_tensor_args{
         .dense_input_tensor = matmul_output_tensor,
         .dense_activations_tensor = tilize_expert_activation_output_tensor,
@@ -1249,11 +1376,17 @@ MoEComputeMeshWorkloadFactory::create_at(
 
     // 3 compute cores write output pages to each combine cores in a column of sharded output
     const uint32_t compute_cores_per_combine_core = matmul_core_range_set.num_cores() / combine_data_parallel_cores;
-    auto selective_reduce_combine_artifacts = build_selective_reduce_combine_program_artifacts(
-        program,
+    // Descriptor variant of build_selective_reduce_combine_program_artifacts:
+    // appends combine reader/writer kernels, CBs (including the input data CB
+    // pinned via CBDescriptor::buffer), and fabric routing args onto `desc`.
+    // The metadata-sync and compute-sync semaphore IDs that bridge the
+    // tilize/matmul stages with combine are passed by value (allocated above
+    // as tilize_combine_sync_semaphore_id and matmul_combine_sync_semaphore_id).
+    ttnn::experimental::prim::build_selective_reduce_combine_program_artifacts_descriptor(
+        desc,
         combine_params,
         mesh_coordinate,
-        mesh_coordinates.coords(),
+        all_mesh_coordinates,
         combine_tensor_args,
         output_tensor,
         init_barrier_semaphore,
@@ -1263,134 +1396,89 @@ MoEComputeMeshWorkloadFactory::create_at(
         compute_cores_per_combine_core,
         ring_pos2core);
 
-    auto combine_reader_kernel_id = selective_reduce_combine_artifacts.reader_kernel_id;
-    auto combine_writer_kernel_id = selective_reduce_combine_artifacts.writer_kernel_id;
-    auto combine_data_cb_handle = selective_reduce_combine_artifacts.data_cb_handle;
-
-    //-------------------------------------------------------------------------
-    // Cached program
-    //-------------------------------------------------------------------------
-
-    return {
-        std::move(program),
-        {.tilize_kernel_handles = {tilize_reader_kernel_id, tilize_compute_kernel_id, tilize_writer_kernel_id},
-         .tilize_cores = tilize_cores,
-         .matmul_kernel_handles = {matmul_dm0_kernel_handle, matmul_dm1_kernel_handle, matmul_compute_kernel_handle},
-         .matmul_cores = matmul_cores,
-         .indices_cb_handle = indices_cb_handle,
-         .scores_cb_handle = scores_cb_handle,
-         .sharded_output_cb_handle = sharded_output_cb_handle,
-         .matmul_writer_cb_handle = matmul_writer_cb_handle,
-         .combine_kernel_handles = {combine_reader_kernel_id, combine_writer_kernel_id},
-         .combine_data_cb_handle = combine_data_cb_handle,
-         .expert_tokens_cb_handle = expert_tokens_cb_handle,
-         .combine_cores = combine_cores,
-         .combine_global_semaphores = {init_barrier_semaphore, final_barrier_semaphore}}};
+    return desc;
 }
 
-void MoEComputeMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
+}  // namespace
+
+namespace ttnn::experimental::prim {
+
+// expose a helper function so callers know what cores are available for subsequently running a2a combine
+std::vector<ttnn::CoreCoord> get_moe_combine_cores(
+    ttnn::MeshDevice* mesh_device,
+    const uint32_t combine_token_parallel_cores,
+    const uint32_t combine_data_parallel_cores) {
+    constexpr auto combine_cores_return_index = 8;
+
+    // Use dummy hidden_size since we only need combine cores (which don't depend on hidden_size)
+    // This function is only for getting combine cores, not tilize cores
+    constexpr uint32_t dummy_hidden_size = 7168;  // DeepSeek default
+    const auto get_cores_return =
+        get_cores(mesh_device, combine_token_parallel_cores, combine_data_parallel_cores, dummy_hidden_size);
+
+    return std::get<combine_cores_return_index>(get_cores_return);
+}
+
+tt::tt_metal::WorkloadDescriptor MoEComputeMeshWorkloadFactory::create_workload_descriptor(
     const MoEComputeParams& args,
     const MoEComputeInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
-    // output tensors
-    const ttnn::Tensor& tilize_per_expert_total_tokens_output_tensor = tensor_return_value.at(0);
-    const ttnn::Tensor& tilize_expert_activation_output_tensor = tensor_return_value.at(1);
-    const ttnn::Tensor& tilize_e_t_output_tensor = tensor_return_value.at(2);
-    const ttnn::Tensor& tilize_output_tensor = tensor_return_value.at(3);
-    const ttnn::Tensor& matmul_output_tensor = tensor_return_value.at(4);
-    ttnn::Tensor& output_tensor = tensor_return_value.at(5);
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
+    constexpr auto combine_core_range_set_return_index = 5;
 
-        // Update sharded circular buffer address
-        tt::tt_metal::UpdateDynamicCircularBufferAddress(
-            program, shared_variables.indices_cb_handle, *tensor_args.tilize_expert_indices_tensor.buffer());
+    auto* mesh_device = tensor_args.tilize_input_tensor.device();
+    const auto& tilize_input_shape = tensor_args.tilize_input_tensor.tensor_spec().logical_shape();
+    const uint32_t hidden_size = tilize_input_shape[-1];
 
-        tt::tt_metal::UpdateDynamicCircularBufferAddress(
-            program, shared_variables.scores_cb_handle, *tensor_args.tilize_expert_scores_tensor.buffer());
+    const auto core_ret = get_cores(
+        mesh_device,
+        args.combine_params.num_token_parallel_cores,
+        args.combine_params.num_data_parallel_cores,
+        hidden_size);
 
-        tt::tt_metal::UpdateDynamicCircularBufferAddress(
-            program, shared_variables.sharded_output_cb_handle, *tilize_output_tensor.buffer());
+    const auto& combine_core_range_set = std::get<combine_core_range_set_return_index>(core_ret);
 
-        tt::tt_metal::UpdateDynamicCircularBufferAddress(
-            program, shared_variables.matmul_writer_cb_handle, *tilize_output_tensor.buffer());
+    // Workload-scoped GlobalSemaphores: allocated once on cache miss and parked
+    // on workload_descriptor.semaphores so they outlive the cached workload.
+    // The init/final barrier semaphores synchronize handoffs between devices
+    // (consumed by the combine stage), hence the Synchronize call before
+    // kicking off any per-coord program.  If the caller supplied a final
+    // barrier semaphore externally, lifetime stays with the caller and we do
+    // not park it.
+    auto init_barrier_semaphore =
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, combine_core_range_set, 0);
+    auto final_barrier_semaphore = args.combine_params.optional_cross_device_semaphore.value_or(
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, combine_core_range_set, 0));
 
-        tt::tt_metal::UpdateDynamicCircularBufferAddress(
-            program, shared_variables.expert_tokens_cb_handle, *tilize_per_expert_total_tokens_output_tensor.buffer());
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
 
-        //-------------------------------------------------------------------------
-        // Tilize
-        //-------------------------------------------------------------------------
-        for (const auto& core : shared_variables.tilize_cores) {
-            // reader
-            auto& tilize_reader_runtime_args =
-                tt::tt_metal::GetRuntimeArgs(program, shared_variables.tilize_kernel_handles.at(0), core);
-            tilize_reader_runtime_args.at(0) = tensor_args.tilize_input_tensor.buffer()->address();
-            tilize_reader_runtime_args.at(1) = tensor_args.tilize_expert_indices_tensor.buffer()->address();
-            tilize_reader_runtime_args.at(2) = tensor_args.tilize_expert_scores_tensor.buffer()->address();
-            tilize_reader_runtime_args.at(3) = tensor_args.tilize_expert_mapping_tensor.buffer()->address();
-            tilize_reader_runtime_args.at(4) = tilize_per_expert_total_tokens_output_tensor.buffer()->address();
-            tilize_reader_runtime_args.at(5) = tilize_expert_activation_output_tensor.buffer()->address();
-            tilize_reader_runtime_args.at(6) = tilize_e_t_output_tensor.buffer()->address();
-
-            // writer
-            auto& tilize_writer_runtime_args =
-                tt::tt_metal::GetRuntimeArgs(program, shared_variables.tilize_kernel_handles.at(2), core);
-            tilize_writer_runtime_args.at(0) = tensor_args.tilize_input_tensor.buffer()->address();
-            tilize_writer_runtime_args.at(1) = tensor_args.tilize_expert_indices_tensor.buffer()->address();
-            tilize_writer_runtime_args.at(2) = tensor_args.tilize_expert_scores_tensor.buffer()->address();
-            tilize_writer_runtime_args.at(3) = tensor_args.tilize_expert_mapping_tensor.buffer()->address();
-            tilize_writer_runtime_args.at(4) = tilize_per_expert_total_tokens_output_tensor.buffer()->address();
-            tilize_writer_runtime_args.at(5) = tilize_expert_activation_output_tensor.buffer()->address();
-            tilize_writer_runtime_args.at(6) = tilize_e_t_output_tensor.buffer()->address();
-        }
-
-        //-------------------------------------------------------------------------
-        // Matmul
-        //-------------------------------------------------------------------------
-        for (const auto& core : shared_variables.matmul_cores) {
-            for (const auto& kernel_handle : shared_variables.matmul_kernel_handles) {
-                auto& matmul_runtime_args = tt::tt_metal::GetRuntimeArgs(program, kernel_handle, core);
-                matmul_runtime_args.at(2) = tensor_args.matmul_w0_w1_tensor.buffer()->address();
-                matmul_runtime_args.at(3) = tensor_args.matmul_w2_tensor.buffer()->address();
-                matmul_runtime_args.at(4) = tilize_output_tensor.buffer()->address();
-            }
-        }
-
-        //-------------------------------------------------------------------------
-        // Combine
-        //-------------------------------------------------------------------------
-
-        {
-            auto reader_kernel_id = shared_variables.combine_kernel_handles.at(0);
-            auto writer_kernel_id = shared_variables.combine_kernel_handles.at(1);
-            auto combine_data_cb_handle = shared_variables.combine_data_cb_handle;
-            auto cores = shared_variables.combine_cores;
-            auto init_semaphore = shared_variables.combine_global_semaphores.at(0);
-            auto cross_device_semaphore = shared_variables.combine_global_semaphores.at(1);
-
-            // MoE compute op does not have an optional output tensor; do not pass it in tensor_args.
-            ttnn::experimental::prim::SelectiveReduceCombineTensors combine_tensor_args{
-                .dense_input_tensor = matmul_output_tensor,
-                .dense_activations_tensor = tilize_expert_activation_output_tensor,
-                .dense_token_maps_tensor = tilize_e_t_output_tensor,
-                .dense_token_counts_tensor = tilize_per_expert_total_tokens_output_tensor,
-                .optional_output_tensor = tensor_args.optional_output_tensor};
-            selective_reduce_combine_helper_override_runtime_arguments(
-                program,
-                reader_kernel_id,
-                writer_kernel_id,
-                combine_data_cb_handle,
-                cores,
-                combine_tensor_args,
-                output_tensor,
-                init_semaphore,
-                cross_device_semaphore,
-                args.combine_params.optional_cross_device_semaphore);
-        }
+    workload_descriptor.semaphores.push_back(init_barrier_semaphore);
+    if (!args.combine_params.optional_cross_device_semaphore.has_value()) {
+        // Only park the final barrier when we allocated it ourselves; if the
+        // caller passed one in, lifetime is the caller's responsibility.
+        workload_descriptor.semaphores.push_back(final_barrier_semaphore);
     }
+
+    const auto all_mesh_coordinates = tensor_coords.coords();
+
+    // Build one ProgramDescriptor per coord — fabric routing and per-device
+    // ring/linearized indices baked in by build_descriptor_at make each
+    // program unique.
+    for (const auto& coord : all_mesh_coordinates) {
+        auto desc = build_descriptor_at(
+            args,
+            coord,
+            tensor_args,
+            tensor_return_value,
+            all_mesh_coordinates,
+            init_barrier_semaphore,
+            final_barrier_semaphore);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -217,8 +217,8 @@ tt::tt_metal::ProgramDescriptor build_descriptor_at(
     const ttnn::experimental::prim::MoEComputeInputs& tensor_args,
     std::vector<ttnn::Tensor>& tensor_return_value,
     const std::vector<ttnn::MeshCoordinate>& all_mesh_coordinates,
-    const GlobalSemaphore& init_barrier_semaphore,
-    const GlobalSemaphore& final_barrier_semaphore) {
+    const ttnn::GlobalSemaphore& init_barrier_semaphore,
+    const ttnn::GlobalSemaphore& final_barrier_semaphore) {
     tt::tt_metal::ProgramDescriptor desc;
 
     // Alignment

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.hpp
@@ -9,71 +9,25 @@
 
 #include "ttnn/device_operation.hpp"
 
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 namespace ttnn::experimental::prim {
 
 struct MoEComputeMeshWorkloadFactory {
-    struct shared_variables_t {
-        // Tilize kernel handles
-        std::vector<tt::tt_metal::KernelHandle> tilize_kernel_handles;
-
-        // Tilize cores
-        std::vector<CoreCoord> tilize_cores;
-
-        // Matmul kernel handles
-        std::vector<tt::tt_metal::KernelHandle> matmul_kernel_handles;
-
-        // Matmul cores
-        std::vector<CoreCoord> matmul_cores;
-
-        // CB handle for tensor backed indices tensor
-        tt::tt_metal::CBHandle indices_cb_handle;
-
-        // CB handle for tensor backed scores tensor
-        tt::tt_metal::CBHandle scores_cb_handle;
-
-        // CB handle for shared global sharded tensor
-        tt::tt_metal::CBHandle sharded_output_cb_handle;
-
-        // CB handle for matmul output
-        tt::tt_metal::CBHandle matmul_writer_cb_handle;
-
-        // Combine kernel handles
-        std::vector<tt::tt_metal::KernelHandle> combine_kernel_handles;
-
-        // CB handle for combine global sharded input tensor
-        tt::tt_metal::CBHandle combine_data_cb_handle;
-
-        // CB handle for token counts per expert
-        tt::tt_metal::CBHandle expert_tokens_cb_handle;
-
-        // Combine cores
-        std::vector<CoreCoord> combine_cores;
-
-        // Combine global semaphores
-        std::vector<GlobalSemaphore> combine_global_semaphores;
-    };
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
+    // Contract-2: declarative WorkloadDescriptor.  Per coord, builds a
+    // ProgramDescriptor containing the tilize, matmul, and combine stages plus
+    // their CBs and semaphores.  Workload-scoped init / final barrier
+    // GlobalSemaphores are allocated once on cache miss and parked on
+    // workload_descriptor.semaphores.  Tensor base addresses are bound via
+    // emplace_runtime_args(Buffer*) -- and dynamic CBs are pinned via
+    // CBDescriptor::buffer -- so the framework's fast cache-hit path patches
+    // them on every dispatch.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const MoEComputeParams& args,
-        const ttnn::MeshCoordinateRangeSet& mesh_coordinates,
-        const MoEComputeInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const MoEComputeParams& args,
-        const ttnn::MeshCoordinate& mesh_coordinate,
         const MoEComputeInputs& tensor_args,
         std::vector<ttnn::Tensor>& tensor_return_value,
-        const ttnn::MeshCoordinateRangeSet& mesh_coordinates,
-        const GlobalSemaphore& init_barrier_semaphore,
-        const GlobalSemaphore& final_barrier_semaphore);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
-        const MoEComputeParams& args,
-        const MoEComputeInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 std::vector<ttnn::CoreCoord> get_moe_combine_cores(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
@@ -78,12 +78,11 @@ void append_fabric_mux_connection_rt_args(
     tt::tt_metal::Program& program,
     std::vector<uint32_t>& worker_rt_args);
 
-// ProgramDescriptor (Contract-2) variant — same wire layout as the legacy helper
-// (17 args in the order listed above), but allocates the five worker-side
-// semaphores by pushing SemaphoreDescriptors onto desc.semaphores and writes
-// the resulting args into a KernelDescriptor::RTArgList so callers can feed
-// the list directly into KernelDescriptor::emplace_runtime_args. The legacy
-// Program& helper is preserved; consumers migrate one at a time.
+// ProgramDescriptor variant — same wire layout as the Program& overload above
+// (17 args in the order listed), allocates the five worker-side semaphores by
+// pushing SemaphoreDescriptors onto desc.semaphores, and writes the resulting
+// args into a KernelDescriptor::RTArgList so callers can feed the list directly
+// into KernelDescriptor::emplace_runtime_args.
 void append_fabric_mux_connection_rt_args(
     bool mux_connection_valid,
     const tt::tt_metal::CoreCoord& mux_virtual_core,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp
@@ -48,7 +48,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     CoreCoord core_grid_offset,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config);
 
-// ProgramDescriptor (Contract-2) variant of build_line_reduce_scatter_minimal_async_program_artifacts.
+// ProgramDescriptor variant of build_line_reduce_scatter_minimal_async_program_artifacts.
 // Pushes circular buffers, kernels, and semaphores onto `desc` rather than creating them on a
 // Program directly. Buffer-carrying runtime args are bound via KernelDescriptor::emplace_runtime_args
 // so the framework's fast cache-hit path patches buffer addresses without rebuilding the program.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp
@@ -10,33 +10,17 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::experimental::prim {
 
-// Use ReduceScatterProgramArtifacts as the shared variables type for consistency
-using LineReduceScatterSharedVariables = ReduceScatterProgramArtifacts;
-
 struct LineReduceScatterMeshWorkloadFactory {
-    using shared_variables_t = LineReduceScatterSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const ReduceScatterMinimalAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const ReduceScatterMinimalAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const ReduceScatterMinimalAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const ReduceScatterMinimalAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const ReduceScatterMinimalAsyncParams& operation_attributes,
         const ReduceScatterMinimalAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
+        std::vector<Tensor>& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 // Builder function for line topology - creates program artifacts

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1604,8 +1604,7 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
 }
 
 // ProgramDescriptor variant of build_ring_reduce_scatter_minimal_async_program_artifacts.
-// Mirrors the legacy Program& builder's structure exactly; only the resource-creation calls are
-// translated:
+// Resource creation maps as:
 //   - CreateCircularBuffer  -> push CBDescriptor onto desc.cbs
 //   - CreateKernel          -> push KernelDescriptor onto desc.kernels
 //   - SetRuntimeArgs        -> KernelDescriptor::emplace_runtime_args (Buffer* binding for the
@@ -2208,14 +2207,12 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 }
 
 // ProgramDescriptor variant of build_line_reduce_scatter_minimal_async_program_artifacts.
-// Mirrors the legacy Program& builder's structure exactly; only the resource-creation calls are
-// translated:
+// Resource creation maps as:
 //   - CreateCircularBuffer  -> push CBDescriptor onto desc.cbs
 //   - CreateKernel          -> push KernelDescriptor onto desc.kernels
 //   - CreateSemaphore       -> push SemaphoreDescriptor onto desc.semaphores (with an id allocated
-//                              via ProgramDescriptor::find_available_semaphore_id; legacy
-//                              CreateSemaphore returns the same id space, which the kernel side
-//                              looks up via get_semaphore(id))
+//                              via ProgramDescriptor::find_available_semaphore_id; the kernel side
+//                              looks up the same id space via get_semaphore(id))
 //   - SetRuntimeArgs        -> KernelDescriptor::emplace_runtime_args (Buffer* binding for the
 //                              fast cache-hit path)
 //   - fused_op_signaler->init_reduce_scatter / append_fabric_mux_connection_rt_args /
@@ -3118,7 +3115,7 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
         output);
 }
 
-// Mesh Workload Factory implementations (Contract-2)
+// Mesh Workload Factory implementations
 tt::tt_metal::WorkloadDescriptor RingReduceScatterMeshWorkloadFactory::create_workload_descriptor(
     const ReduceScatterMinimalAsyncParams& operation_attributes,
     const ReduceScatterMinimalAsyncInputs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -3215,104 +3215,63 @@ void RingReduceScatterMeshWorkloadFactory::override_runtime_arguments(
     }
 }
 
-LineReduceScatterMeshWorkloadFactory::cached_mesh_workload_t LineReduceScatterMeshWorkloadFactory::create_mesh_workload(
+tt::tt_metal::WorkloadDescriptor LineReduceScatterMeshWorkloadFactory::create_workload_descriptor(
     const ReduceScatterMinimalAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const ReduceScatterMinimalAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    std::vector<Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    TT_FATAL(
+        operation_attributes.topology == ttnn::ccl::Topology::Linear,
+        "LineReduceScatterMeshWorkloadFactory expects Linear topology");
 
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        mesh_workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-
-    return {std::move(mesh_workload), std::move(shared_variables)};
-}
-
-ttnn::device_operation::CachedProgram<LineReduceScatterMeshWorkloadFactory::shared_variables_t>
-LineReduceScatterMeshWorkloadFactory::create_at(
-    const ReduceScatterMinimalAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const ReduceScatterMinimalAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
     const auto& input_tensor = tensor_args.input_tensor;
     auto& intermediate_tensor = tensor_return_value.at(0);
     auto& output_tensor = tensor_return_value.at(1);
 
-    const auto forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        input_tensor, mesh_coordinate, 1, operation_attributes.topology, operation_attributes.cluster_axis);
-    const auto backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        input_tensor, mesh_coordinate, -1, operation_attributes.topology, operation_attributes.cluster_axis);
-    TT_FATAL(forward_coord.has_value() || backward_coord.has_value(), "forward_coord or backward_coord is null");
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    const uint32_t ring_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
-        input_tensor, mesh_coordinate, operation_attributes.cluster_axis);
+    // Per-coord build: fabric neighbors and ring_index vary by mesh coord, so
+    // each program descriptor is unique.
+    for (const auto& coord : tensor_coords.coords()) {
+        const auto forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, coord, 1, operation_attributes.topology, operation_attributes.cluster_axis);
+        const auto backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, coord, -1, operation_attributes.topology, operation_attributes.cluster_axis);
+        TT_FATAL(forward_coord.has_value() || backward_coord.has_value(), "forward_coord or backward_coord is null");
 
-    std::optional<ttnn::experimental::ccl::ReduceScatterFusedOpSignaler> fused_op_signaler = std::nullopt;
-    tt::tt_metal::Program program{};
-    auto shared_vars = ::ttnn::build_line_reduce_scatter_minimal_async_program_artifacts(
-        program,
-        input_tensor,
-        intermediate_tensor,
-        mesh_coordinate,
-        forward_coord,
-        backward_coord,
-        output_tensor,
-        operation_attributes.dim,
-        operation_attributes.num_links,
-        operation_attributes.ring_size,
-        ring_index,
-        operation_attributes.topology,
-        operation_attributes.semaphore,
-        operation_attributes.barrier_semaphore,
-        operation_attributes.using_persistent_buffers,
-        operation_attributes.sub_device_id,
-        fused_op_signaler,
-        operation_attributes.chunks_per_sync,
-        operation_attributes.num_workers_per_link,
-        operation_attributes.num_buffers_per_channel,
-        CoreCoord(0, 0),
-        operation_attributes.compute_kernel_config);
+        const uint32_t ring_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+            input_tensor, coord, operation_attributes.cluster_axis);
 
-    return {std::move(program), std::move(shared_vars)};
-}
-
-void LineReduceScatterMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const ReduceScatterMinimalAsyncParams& operation_attributes,
-    const ReduceScatterMinimalAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    const auto& input = tensor_args.input_tensor;
-    const auto& intermediate = tensor_return_value.at(0);
-    const auto& output = tensor_return_value.at(1);
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
-
-        TT_FATAL(
-            operation_attributes.topology == ttnn::ccl::Topology::Linear,
-            "LineReduceScatterMeshWorkloadFactory expects Linear topology");
-
-        line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
-            program,
-            shared_vars.reader_kernel_id,
-            shared_vars.writer_kernel_id,
-            shared_vars.all_cores,
+        std::optional<ttnn::experimental::ccl::ReduceScatterFusedOpSignaler> fused_op_signaler = std::nullopt;
+        tt::tt_metal::ProgramDescriptor desc;
+        ::ttnn::build_line_reduce_scatter_minimal_async_program_artifacts_descriptor(
+            desc,
+            input_tensor,
+            intermediate_tensor,
+            coord,
+            forward_coord,
+            backward_coord,
+            output_tensor,
+            operation_attributes.dim,
             operation_attributes.num_links,
-            shared_vars.num_directions_per_link,
-            shared_vars.num_workers_per_direction,
-            shared_vars.num_mux_cores_per_direction_per_link,
-            shared_vars.num_cores_per_link,
-            shared_vars.normalized_dim,
-            operation_attributes.barrier_semaphore,
+            operation_attributes.ring_size,
+            ring_index,
+            operation_attributes.topology,
             operation_attributes.semaphore,
-            input,
-            intermediate,
-            output);
+            operation_attributes.barrier_semaphore,
+            operation_attributes.using_persistent_buffers,
+            operation_attributes.sub_device_id,
+            fused_op_signaler,
+            operation_attributes.chunks_per_sync,
+            operation_attributes.num_workers_per_link,
+            operation_attributes.num_buffers_per_channel,
+            CoreCoord(0, 0),
+            operation_attributes.compute_kernel_config);
+
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -3118,101 +3118,60 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
         output);
 }
 
-// Mesh Workload Factory implementations
-RingReduceScatterMeshWorkloadFactory::cached_mesh_workload_t RingReduceScatterMeshWorkloadFactory::create_mesh_workload(
+// Mesh Workload Factory implementations (Contract-2)
+tt::tt_metal::WorkloadDescriptor RingReduceScatterMeshWorkloadFactory::create_workload_descriptor(
     const ReduceScatterMinimalAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const ReduceScatterMinimalAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        mesh_workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-
-    return {std::move(mesh_workload), std::move(shared_variables)};
-}
-
-ttnn::device_operation::CachedProgram<RingReduceScatterMeshWorkloadFactory::shared_variables_t>
-RingReduceScatterMeshWorkloadFactory::create_at(
-    const ReduceScatterMinimalAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const ReduceScatterMinimalAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
+    std::vector<Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     const auto& input_tensor = tensor_args.input_tensor;
     auto& intermediate_tensor = tensor_return_value.at(0);
     auto& output_tensor = tensor_return_value.at(1);
 
-    const auto forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        input_tensor, mesh_coordinate, 1, operation_attributes.topology, operation_attributes.cluster_axis);
-    const auto backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        input_tensor, mesh_coordinate, -1, operation_attributes.topology, operation_attributes.cluster_axis);
-    TT_FATAL(forward_coord.has_value() || backward_coord.has_value(), "forward_coord or backward_coord is null");
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    const uint32_t ring_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
-        input_tensor, mesh_coordinate, operation_attributes.cluster_axis);
+    // Per-coord build: fabric neighbors and ring_index vary by mesh coord, so
+    // each program descriptor is unique.
+    for (const auto& coord : tensor_coords.coords()) {
+        const auto forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, coord, 1, operation_attributes.topology, operation_attributes.cluster_axis);
+        const auto backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, coord, -1, operation_attributes.topology, operation_attributes.cluster_axis);
+        TT_FATAL(forward_coord.has_value() || backward_coord.has_value(), "forward_coord or backward_coord is null");
 
-    std::optional<ttnn::experimental::ccl::ReduceScatterFusedOpSignaler> fused_op_signaler = std::nullopt;
-    tt::tt_metal::Program program{};
-    auto shared_vars = ::ttnn::build_ring_reduce_scatter_minimal_async_program_artifacts(
-        program,
-        input_tensor,
-        intermediate_tensor,
-        mesh_coordinate,
-        forward_coord,
-        backward_coord,
-        output_tensor,
-        operation_attributes.dim,
-        operation_attributes.num_links,
-        operation_attributes.ring_size,
-        ring_index,
-        operation_attributes.topology,
-        operation_attributes.semaphore,
-        operation_attributes.barrier_semaphore,
-        operation_attributes.using_persistent_buffers,
-        operation_attributes.sub_device_id,
-        fused_op_signaler,
-        operation_attributes.chunks_per_sync,
-        operation_attributes.num_workers_per_link,
-        operation_attributes.num_buffers_per_channel,
-        CoreCoord(0, 0),
-        operation_attributes.compute_kernel_config);
+        const uint32_t ring_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+            input_tensor, coord, operation_attributes.cluster_axis);
 
-    return {std::move(program), std::move(shared_vars)};
-}
-
-void RingReduceScatterMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const ReduceScatterMinimalAsyncParams& operation_attributes,
-    const ReduceScatterMinimalAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    const auto& input = tensor_args.input_tensor;
-    const auto& intermediate = tensor_return_value.at(0);
-    const auto& output = tensor_return_value.at(1);
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
-
-        ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
-            program,
-            shared_vars.reader_kernel_id,
-            shared_vars.writer_kernel_id,
-            shared_vars.all_cores,
+        std::optional<ttnn::experimental::ccl::ReduceScatterFusedOpSignaler> fused_op_signaler = std::nullopt;
+        tt::tt_metal::ProgramDescriptor desc;
+        ::ttnn::build_ring_reduce_scatter_minimal_async_program_artifacts_descriptor(
+            desc,
+            input_tensor,
+            intermediate_tensor,
+            coord,
+            forward_coord,
+            backward_coord,
+            output_tensor,
+            operation_attributes.dim,
             operation_attributes.num_links,
-            shared_vars.num_directions_per_link,
-            shared_vars.num_workers_per_direction,
-            shared_vars.num_mux_cores_per_direction_per_link,
-            shared_vars.num_cores_per_link,
-            shared_vars.normalized_dim,
-            operation_attributes.barrier_semaphore,
+            operation_attributes.ring_size,
+            ring_index,
+            operation_attributes.topology,
             operation_attributes.semaphore,
-            input,
-            intermediate,
-            output);
+            operation_attributes.barrier_semaphore,
+            operation_attributes.using_persistent_buffers,
+            operation_attributes.sub_device_id,
+            fused_op_signaler,
+            operation_attributes.chunks_per_sync,
+            operation_attributes.num_workers_per_link,
+            operation_attributes.num_buffers_per_channel,
+            CoreCoord(0, 0),
+            operation_attributes.compute_kernel_config);
+
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 tt::tt_metal::WorkloadDescriptor LineReduceScatterMeshWorkloadFactory::create_workload_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp
@@ -48,7 +48,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     CoreCoord core_grid_offset,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config);
 
-// ProgramDescriptor (Contract-2) variant of build_ring_reduce_scatter_minimal_async_program_artifacts.
+// ProgramDescriptor variant of build_ring_reduce_scatter_minimal_async_program_artifacts.
 // Pushes circular buffers, kernels, and semaphores onto `desc` rather than creating them on a
 // Program directly. Buffer-carrying runtime args are bound via KernelDescriptor::emplace_runtime_args
 // so the framework's fast cache-hit path patches buffer addresses without rebuilding the program.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp
@@ -10,33 +10,17 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::experimental::prim {
 
-// Use ReduceScatterProgramArtifacts as the shared variables type for consistency
-using RingReduceScatterSharedVariables = ReduceScatterProgramArtifacts;
-
 struct RingReduceScatterMeshWorkloadFactory {
-    using shared_variables_t = RingReduceScatterSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const ReduceScatterMinimalAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const ReduceScatterMinimalAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const ReduceScatterMinimalAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const ReduceScatterMinimalAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const ReduceScatterMinimalAsyncParams& operation_attributes,
         const ReduceScatterMinimalAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
+        std::vector<Tensor>& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 // Builder function for ring topology - creates program artifacts

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -666,11 +666,10 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
         num_cores_per_link};
 }
 
-// ProgramDescriptor (Contract-2) variant of strided_all_gather_async_minimal_default_helper.
-// Mirrors the legacy builder body but appends descriptors instead of creating
-// kernels/CBs/semaphores directly on a Program.  Runtime args are emplaced
-// with Buffer* entries for the input/output tensors so the framework's fast
-// cache-hit path patches their base addresses.
+// ProgramDescriptor variant of strided_all_gather_async_minimal_default_helper.
+// Appends descriptors instead of creating kernels/CBs/semaphores directly on a
+// Program.  Runtime args are emplaced with Buffer* entries for the input/output
+// tensors so the framework's fast cache-hit path patches their base addresses.
 //
 // Sub-helpers used (descriptor overload available on this branch):
 //   - StridedAllGatherFusedOpSignaler::init_all_gather(ProgramDescriptor&, ...)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.hpp
@@ -58,14 +58,14 @@ struct StridedAllGatherAsyncProgramFactory {
         std::optional<uint32_t> mm_block_wt,
         CoreCoord core_grid_offset = CoreCoord(0, 0));
 
-    // ProgramDescriptor (Contract-2) variant of strided_all_gather_async_minimal_default_helper.
+    // ProgramDescriptor variant of strided_all_gather_async_minimal_default_helper.
     //
-    // Mirrors the legacy Program& helper but appends KernelDescriptors /
-    // CBDescriptors / SemaphoreDescriptors to `desc` instead of creating them
-    // directly on a Program.  Runtime args for the input/output tensors are
-    // emplaced through KernelDescriptor::emplace_runtime_args(Buffer*) so the
-    // framework's fast cache-hit path patches their base addresses every
-    // dispatch -- no override_runtime_arguments hook is needed for tensor addrs.
+    // Appends KernelDescriptors / CBDescriptors / SemaphoreDescriptors to `desc`
+    // instead of creating them directly on a Program.  Runtime args for the
+    // input/output tensors are emplaced through
+    // KernelDescriptor::emplace_runtime_args(Buffer*) so the framework's fast
+    // cache-hit path patches their base addresses every dispatch -- no
+    // override_runtime_arguments hook is needed for tensor addrs.
     //
     // GlobalSemaphore addresses (in `semaphore`) remain stable for the workload
     // lifetime (parked on workload_descriptor.semaphores by the caller) and are

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -749,17 +749,17 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
 }
 
 // ---------------------------------------------------------------------------
-// ProgramDescriptor (Contract-2) variant of
+// ProgramDescriptor variant of
 // build_ring_strided_reduce_scatter_async_program_artifacts.
 //
-// Mirrors the legacy Program& builder above and supports the same feature set
-// (fused-op signalers, addcmul fusion, sharded tensors), but emits all
-// kernels/CBs/semaphores via desc.{kernels,cbs,semaphores}.push_back instead
-// of CreateKernel / CreateCircularBuffer / CreateSemaphore.  Tensor base
-// addresses are bound via KernelDescriptor::emplace_runtime_args(Buffer*) so
-// the framework patches them every dispatch; GlobalSemaphore addresses ride
-// on the operation_attributes_t and are encoded as plain uint32_t (a
-// different GlobalSemaphore triggers a recompile, same as the legacy path).
+// Supports the full feature set (fused-op signalers, addcmul fusion, sharded
+// tensors).  Emits all kernels/CBs/semaphores via
+// desc.{kernels,cbs,semaphores}.push_back instead of CreateKernel /
+// CreateCircularBuffer / CreateSemaphore.  Tensor base addresses are bound via
+// KernelDescriptor::emplace_runtime_args(Buffer*) so the framework patches them
+// every dispatch; GlobalSemaphore addresses ride on the operation_attributes_t
+// and are encoded as plain uint32_t (a different GlobalSemaphore triggers a
+// recompile).
 //
 // The returned StridedReduceScatterProgramArtifacts uses
 // reader_kernel_id / writer_kernel_id as indices into desc.kernels.  The
@@ -1476,10 +1476,10 @@ void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
 // Implementations for the TMP namespace - wrappers to ttnn namespace functions
 namespace ttnn::operations::experimental::ccl::strided_reduce_scatter_async::detail {
 
-// Contract-2 Mesh Workload Factory implementation.  Per-coord ProgramDescriptors
-// are built via the ProgramDescriptor variant of the ring builder.  No
-// workload-scoped resources are needed -- GlobalSemaphores live on
-// operation_attributes (caller-allocated) and intermediate / output tensors are
+// Mesh Workload Factory implementation.  Per-coord ProgramDescriptors are built
+// via the ProgramDescriptor variant of the ring builder.  No workload-scoped
+// resources are needed -- GlobalSemaphores live on operation_attributes
+// (caller-allocated) and intermediate / output tensors are
 // supplied by the operation framework (create_output_tensors).
 tt::tt_metal::WorkloadDescriptor RingStridedReduceScatterMeshWorkloadFactory::create_workload_descriptor(
     const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -1476,112 +1476,70 @@ void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
 // Implementations for the TMP namespace - wrappers to ttnn namespace functions
 namespace ttnn::operations::experimental::ccl::strided_reduce_scatter_async::detail {
 
-// Mesh Workload Factory implementations
-RingStridedReduceScatterMeshWorkloadFactory::cached_mesh_workload_t
-RingStridedReduceScatterMeshWorkloadFactory::create_mesh_workload(
+// Contract-2 Mesh Workload Factory implementation.  Per-coord ProgramDescriptors
+// are built via the ProgramDescriptor variant of the ring builder.  No
+// workload-scoped resources are needed -- GlobalSemaphores live on
+// operation_attributes (caller-allocated) and intermediate / output tensors are
+// supplied by the operation framework (create_output_tensors).
+tt::tt_metal::WorkloadDescriptor RingStridedReduceScatterMeshWorkloadFactory::create_workload_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        mesh_workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-
-    return {std::move(mesh_workload), std::move(shared_variables)};
-}
-
-ttnn::device_operation::CachedProgram<RingStridedReduceScatterMeshWorkloadFactory::shared_variables_t>
-RingStridedReduceScatterMeshWorkloadFactory::create_at(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
     const auto& input_tensor = tensor_args.input_tensor;
     auto& intermediate_tensor = tensor_return_value.at(0);
     auto& output_tensor = tensor_return_value.at(1);
 
-    const auto forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        input_tensor, mesh_coordinate, 1, operation_attributes.topology, operation_attributes.cluster_axis);
-    const auto backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        input_tensor, mesh_coordinate, -1, operation_attributes.topology, operation_attributes.cluster_axis);
-    TT_FATAL(forward_coord.has_value() || backward_coord.has_value(), "forward_coord or backward_coord is null");
+    for (const auto& coord : tensor_coords.coords()) {
+        const auto forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, coord, 1, operation_attributes.topology, operation_attributes.cluster_axis);
+        const auto backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, coord, -1, operation_attributes.topology, operation_attributes.cluster_axis);
+        TT_FATAL(forward_coord.has_value() || backward_coord.has_value(), "forward_coord or backward_coord is null");
 
-    const uint32_t ring_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
-        input_tensor, mesh_coordinate, operation_attributes.cluster_axis);
+        const uint32_t ring_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+            input_tensor, coord, operation_attributes.cluster_axis);
 
-    std::optional<ttnn::experimental::ccl::ReduceScatterFusedOpSignaler> fused_op_signaler = std::nullopt;
-    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> mm_fused_op_signaler = std::nullopt;
-    tt::tt_metal::Program program{};
-    auto shared_vars = ::ttnn::build_ring_strided_reduce_scatter_async_program_artifacts(
-        program,
-        input_tensor,
-        intermediate_tensor,
-        mesh_coordinate,
-        forward_coord,
-        backward_coord,
-        output_tensor,
-        operation_attributes.dim,
-        operation_attributes.num_links,
-        operation_attributes.ring_size,
-        ring_index,
-        operation_attributes.topology,
-        operation_attributes.semaphore,
-        operation_attributes.barrier_semaphore,
-        operation_attributes.using_persistent_buffers,
-        operation_attributes.sub_device_id,
-        fused_op_signaler,
-        mm_fused_op_signaler,
-        operation_attributes.num_workers_per_link,
-        operation_attributes.num_buffers_per_channel,
-        CoreCoord(0, 0),
-        operation_attributes.mm_cores_y,
-        operation_attributes.mm_block_ht,
-        operation_attributes.mm_block_wt,
-        operation_attributes.mm_N_full_block_wt,
-        operation_attributes.chunk_width_in_mm_blocks,
-        std::nullopt,   // fused_ternary_scalar
-        std::nullopt,   // addcmul_input_tensor1
-        std::nullopt);  // addcmul_input_tensor2
-
-    return {std::move(program), std::move(shared_vars)};
-}
-
-void RingStridedReduceScatterMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    const auto& input = tensor_args.input_tensor;
-    const auto& intermediate = tensor_return_value.at(0);
-    const auto& output = tensor_return_value.at(1);
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
-
-        ::ttnn::ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
-            program,
-            shared_vars.reader_kernel_id,
-            shared_vars.writer_kernel_id,
-            shared_vars.all_cores,
+        std::optional<ttnn::experimental::ccl::ReduceScatterFusedOpSignaler> fused_op_signaler = std::nullopt;
+        std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> mm_fused_op_signaler = std::nullopt;
+        tt::tt_metal::ProgramDescriptor desc;
+        (void)::ttnn::build_ring_strided_reduce_scatter_async_program_artifacts_descriptor(
+            desc,
+            input_tensor,
+            intermediate_tensor,
+            coord,
+            forward_coord,
+            backward_coord,
+            output_tensor,
+            operation_attributes.dim,
             operation_attributes.num_links,
-            shared_vars.num_directions_per_link,
-            shared_vars.num_workers_per_direction,
-            shared_vars.num_mux_cores_per_direction_per_link,
-            shared_vars.num_cores_per_link,
-            operation_attributes.barrier_semaphore,
+            operation_attributes.ring_size,
+            ring_index,
+            operation_attributes.topology,
             operation_attributes.semaphore,
-            input,
-            intermediate,
-            output,
-            shared_vars.reader_addcmul_rt_arg_offset,
-            std::nullopt,   // addcmul_a
-            std::nullopt);  // addcmul_b
+            operation_attributes.barrier_semaphore,
+            operation_attributes.using_persistent_buffers,
+            operation_attributes.sub_device_id,
+            fused_op_signaler,
+            mm_fused_op_signaler,
+            operation_attributes.num_workers_per_link,
+            operation_attributes.num_buffers_per_channel,
+            CoreCoord(0, 0),
+            operation_attributes.mm_cores_y,
+            operation_attributes.mm_block_ht,
+            operation_attributes.mm_block_wt,
+            operation_attributes.mm_N_full_block_wt,
+            operation_attributes.chunk_width_in_mm_blocks,
+            std::nullopt,   // fused_ternary_scalar
+            std::nullopt,   // addcmul_input_tensor1
+            std::nullopt);  // addcmul_input_tensor2
+
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::operations::experimental::ccl::strided_reduce_scatter_async::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_ring_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_ring_program_factory.hpp
@@ -11,33 +11,19 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::operations::experimental::ccl::strided_reduce_scatter_async::detail {
 
-// Use StridedReduceScatterProgramArtifacts as the shared variables type for consistency
-using RingStridedReduceScatterSharedVariables = StridedReduceScatterProgramArtifacts;
-
 struct RingStridedReduceScatterMeshWorkloadFactory {
-    using shared_variables_t = RingStridedReduceScatterSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Contract-2: declarative WorkloadDescriptor.  Per-coord ProgramDescriptors
+    // are built via build_ring_strided_reduce_scatter_async_program_artifacts_descriptor.
+    // No workload-scoped resources (GlobalSemaphores live on operation_attributes_t).
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        tensor_return_value_t& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 // Builder function for ring topology - creates program artifacts

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -857,13 +857,13 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
 }
 
 // ---------------------------------------------------------------------------
-// ProgramDescriptor (Contract-2) variant of minimal_matmul_factory_helper_common.
+// ProgramDescriptor variant of minimal_matmul_factory_helper_common.
 //
-// Mirrors the legacy Program& helper above and supports the same feature set
-// (matmul fused-op signalers for AG->MM and MM->RS, bias, fused unary
-// activation, fused ternary addcmul inputs, N_chunks splitting), but emits all
-// kernels / CBs / semaphores via desc.{kernels,cbs,semaphores}.push_back
-// instead of CreateKernel / CreateCircularBuffer / CreateSemaphore.
+// Supports the full feature set (matmul fused-op signalers for AG->MM and
+// MM->RS, bias, fused unary activation, fused ternary addcmul inputs, N_chunks
+// splitting).  Emits all kernels / CBs / semaphores via
+// desc.{kernels,cbs,semaphores}.push_back instead of CreateKernel /
+// CreateCircularBuffer / CreateSemaphore.
 //
 // Tensor base addresses are bound via KernelDescriptor::emplace_runtime_args(
 // Buffer*) so the framework patches them every dispatch -- no

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
@@ -68,17 +68,16 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     const std::optional<const Tensor>& fused_ternary_input_b = std::nullopt,
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler = std::nullopt);
 
-// ProgramDescriptor (Contract-2) variant of minimal_matmul_factory_helper_common.
+// ProgramDescriptor variant of minimal_matmul_factory_helper_common.
 //
-// Mirrors the legacy Program& helper above and emits all kernels / CBs /
-// semaphores via desc.{kernels,cbs,semaphores}.push_back instead of
-// CreateKernel / CreateCircularBuffer / CreateSemaphore.  Tensor base
-// addresses are bound through KernelDescriptor::emplace_runtime_args(Buffer*)
-// so the framework patches them every dispatch -- no override_runtime_arguments
-// hook is needed for tensor addrs.  GlobalSemaphore addresses (when present in
-// the StridedReduceScatterFusedOpSignaler) are encoded as plain uint32_t
-// (same behavior as the legacy path; a different GlobalSemaphore triggers a
-// recompile).
+// Emits all kernels / CBs / semaphores via
+// desc.{kernels,cbs,semaphores}.push_back instead of CreateKernel /
+// CreateCircularBuffer / CreateSemaphore.  Tensor base addresses are bound
+// through KernelDescriptor::emplace_runtime_args(Buffer*) so the framework
+// patches them every dispatch -- no override_runtime_arguments hook is needed
+// for tensor addrs.  GlobalSemaphore addresses (when present in the
+// StridedReduceScatterFusedOpSignaler) are encoded as plain uint32_t; a
+// different GlobalSemaphore triggers a recompile.
 //
 // Same feature set as the legacy helper: matmul fused-op signalers
 // (MinimalMatmulFusedOpSignaler for AG->MM and StridedReduceScatterFusedOpSignaler

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -4832,11 +4832,9 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 }
 
 // ProgramDescriptor variant of process_gather_in0_program_and_create_override_variables.
-//
-// Mirrors the legacy helper's parameter list but drops the Program& output param —
-// instead it returns a ProgramDescriptor whose kernels/CBs/semaphores the caller can
-// append onto its own descriptor (same model as create_program_mcast_in0_descriptor
-// and create_program_mcast_in1_descriptor above).
+// Returns a ProgramDescriptor whose kernels/CBs/semaphores the caller can append
+// onto its own descriptor (same model as create_program_mcast_in0_descriptor and
+// create_program_mcast_in1_descriptor above).
 //
 // The gather_in0 path is the one used by the CCL+matmul fused callers
 // (llama_reduce_scatter_matmul, rs_matmul_op, all_gather_matmul_async) — those
@@ -4849,9 +4847,9 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 constexpr uint32_t kNumSemaphoresPerCore = 16;
 
 // Allocate `count` contiguous free semaphore ids on the given CoreRangeSet against an
-// existing ProgramDescriptor.  Mirrors the legacy CreateSemaphore behaviour (pick first
-// free id whose slot is unused on every requested core), but in a block so callers can
-// reserve a stable [base, base+count) range to hand to the matmul helpers below.
+// existing ProgramDescriptor.  Picks the first free id whose slot is unused on every
+// requested core, in a block so callers can reserve a stable [base, base+count) range
+// to hand to the matmul helpers below.
 static uint32_t allocate_free_semaphore_id_block(
     const tt::tt_metal::ProgramDescriptor& desc,
     const tt::tt_metal::CoreRangeSet& cores,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp
@@ -89,7 +89,7 @@ matmul_multi_core_reuse_mcast_1d_optimized_helper(
 
 // ProgramDescriptor-flavored variant of matmul_multi_core_reuse_mcast_1d_optimized_helper.
 //
-// Mirrors the legacy helper's argument list and supports all three 1D paths:
+// Supports all three 1D paths:
 //   * `mcast_in0`        — broadcast in0 across cores (single-B, single-output, c_0 base).
 //   * `!mcast_in0 && !gather_in0` — broadcast in1; same single-B/output/c_0 constraints.
 //   * `gather_in0`       — ring topology used by CCL+matmul fused ops
@@ -97,7 +97,7 @@ matmul_multi_core_reuse_mcast_1d_optimized_helper(
 //     multi-B / multi-output, a non-zero `start_cb_index` (to leave low CB slots free for
 //     the caller's CCL kernels), `restricted_cores`, and an optional GlobalCircularBuffer.
 //
-// The mcast (non-gather) paths still TT_FATAL when callers pass gather_in0-only options
+// The mcast (non-gather) paths TT_FATAL when callers pass gather_in0-only options
 // (multi-B, multi-output, non-zero start_cb_index, restricted_cores, global_cb).
 void matmul_multi_core_reuse_mcast_1d_optimized_helper_descriptor(
     tt::tt_metal::ProgramDescriptor& desc,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -43,9 +43,9 @@ namespace reuse_mcast_optimized_helpers {
 constexpr uint32_t kNumSemaphoresPerCore = 16;
 
 // Allocate `count` contiguous free semaphore ids on the given CoreRangeSet against an
-// existing ProgramDescriptor.  Mirrors the legacy CreateSemaphore behaviour (pick first
-// free id whose slot is unused on every requested core), but in a block so callers can
-// reserve a stable [base, base+count) range to hand to the matmul helper below.
+// existing ProgramDescriptor.  Picks the first free id whose slot is unused on every
+// requested core, in a block so callers can reserve a stable [base, base+count) range
+// to hand to the matmul helper below.
 static uint32_t allocate_free_semaphore_id_block(
     const tt::tt_metal::ProgramDescriptor& desc,
     const tt::tt_metal::CoreRangeSet& cores,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp
@@ -61,9 +61,7 @@ matmul_multi_core_reuse_mcast_2d_optimized_helper(
 // ProgramDescriptor-flavored variant of matmul_multi_core_reuse_mcast_2d_optimized_helper.
 //
 // Appends the matmul kernels / CBs / semaphores to `desc` instead of inserting them into a
-// live Program. Used by CCL+matmul fused ops being migrated to the descriptor framework.
-// Mirrors the legacy helper's argument list 1:1; the existing `process_*` legacy path is
-// preserved untouched for ops that have not yet migrated.
+// live Program. Used by CCL+matmul fused ops on the descriptor framework.
 void matmul_multi_core_reuse_mcast_2d_optimized_helper_descriptor(
     tt::tt_metal::ProgramDescriptor& desc,
     const Tensor& a,


### PR DESCRIPTION
## Summary
Contract-2 migration of 8 CCL consumer ops that compose the descriptor-mode op-internal builders introduced in the prereq PR:
- all_gather_async_default
- llama_reduce_scatter
- reduce_scatter_line + reduce_scatter_ring (minimal_async variants)
- selective_reduce_combine
- strided_reduce_scatter_async
- all_to_all_dispatch_metadata
- moe_compute

Each replaces \`create_mesh_workload\` + \`AdaptedCachedMeshWorkload\` + \`override_runtime_arguments\` with \`create_workload_descriptor\` returning a \`WorkloadDescriptor\`. Workload-scoped \`GlobalSemaphore\`s + intermediate buffers go on \`.semaphores\` / \`.buffers\`. Each Buffer-bearing runtime arg uses \`emplace_runtime_args\` for fast cache-hit binding.

Part of #42193 / #42209.

## Dependencies
- **MUST merge after #45068 (op-internal CCL builder descriptor variants).** This PR is currently based on that branch.
- Also depends on #45065, #45066, #45067 (signalers + fabric_mux + matmul fusion helper descriptor variants).

## Test plan
Multi-device CCL ops require t3000/tg hardware for functional verification.
- [ ] sanity-tests.yaml
- [ ] runtime-sanity-tests.yaml
- [ ] blackhole-post-commit.yaml
- [ ] t3000-* tests (CI)
- [ ] tt-metal-l2-nightly.yaml (CCL family)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-non-matmul-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-ccl-consumers-non-matmul-v2)