### PR TITLE
experimental/ccl: migrate matmul-fused CCL ops to ProgramDescriptor (Contract-2)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
@@ -9,22 +9,26 @@
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
-#include <unordered_map>
+
 #include <tt_stl/overloaded.hpp>
 
 namespace ttnn::experimental::prim {
 
-// For ring all-gather, we can send sub-sections of input tensor in opposite directions
-// For linear all-gather though, we must ensure we send full tensors in BOTH directions
-//   (in other words, disable the "bidirectional" send flag)
-AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMeshWorkloadFactory::create_at(
+namespace {
+
+// Build the per-coord ProgramDescriptor for the fused AllGather + Matmul op.
+// Mirrors the legacy create_at() body 1:1 but routes through the
+// ProgramDescriptor variants of the matmul and AllGather builders.  The
+// fused-op signaler plumbing between the two builders is identical to the
+// legacy path: the matmul builder populates the signaler with its receiver
+// cores/semaphores, which the AllGather builder then reads back.
+tt::tt_metal::ProgramDescriptor build_descriptor_at(
     const Tensor& input_tensor,
     Tensor& all_gather_output_tensor,
     const Tensor& weight_tensor,
     Tensor& matmul_output_tensor,
 
     /* All Gather Params */
-    IDevice* /*target_device*/,
     const MeshCoordinate& target_device_coord,
     const std::optional<MeshCoordinate>& forward_coord,
     const std::optional<MeshCoordinate>& backward_coord,
@@ -47,10 +51,8 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
     bool bcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const operations::matmul::MatmulProgramConfig& program_config,
-    bool untilize_out
-
-) {
-    tt::tt_metal::Program program{};
+    bool untilize_out) {
+    tt::tt_metal::ProgramDescriptor desc;
 
     ////////////// Params for fused op signalers //////////////
     auto tensor_slicer =
@@ -75,12 +77,11 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
             weight_tensor_width /* weight_output_page_offset: stride across a tensor slice in the weight_tensor */
     );
 
-    decltype(AllGatherMatmulAsyncSharedVariables::matmul_shared_variables) matmul_shared_variables;
     std::visit(
         ttsl::overloaded{
             [&](const operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig& config) {
-                auto cached_program = ttnn::prim::matmul_multi_core_reuse_mcast_2d_optimized_helper(
-                    program,
+                ttnn::prim::matmul_multi_core_reuse_mcast_2d_optimized_helper_descriptor(
+                    desc,
                     all_gather_output_tensor,
                     weight_tensor,
                     bias,
@@ -90,12 +91,10 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
                     config,
                     untilize_out,
                     matmul_fused_op_signaler);
-                program = std::move(cached_program.program);
-                matmul_shared_variables = std::move(cached_program.shared_variables);
             },
             [&](const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
-                auto cached_program = ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper(
-                    program,
+                ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper_descriptor(
+                    desc,
                     all_gather_output_tensor,
                     {weight_tensor},
                     bias,
@@ -107,9 +106,6 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
                     matmul_fused_op_signaler,
                     std::nullopt,
                     std::nullopt);
-
-                program = std::move(cached_program.program);
-                matmul_shared_variables = std::move(cached_program.shared_variables);
             },
             [&](const auto& /*config*/) {
                 TT_THROW("Unsupported MatmulProgramConfig type. Needs to be 1D or 2D Multicast.");
@@ -125,8 +121,8 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
         matmul_fused_op_signaler->fused_op_signaler_mode);
 
     // All Gather
-    auto all_gather_async_shared_variables = ttnn::build_all_gather_async_minimal_default_program_artifacts(
-        program,
+    (void)ttnn::build_all_gather_async_minimal_default_program_artifacts_descriptor(
+        desc,
         input_tensor,
         target_device_coord,
         forward_coord,
@@ -149,26 +145,23 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
         false,  // reverse_order = false by default
         std::nullopt);
 
-    return cached_program_t(
-        {std::move(program),
-         shared_variables_t{
-             .matmul_shared_variables = std::move(matmul_shared_variables),
-             .all_gather_async_shared_variables = std::move(all_gather_async_shared_variables)}});
+    return desc;
 }
 
-AllGatherMatmulAsyncMeshWorkloadFactory::cached_mesh_workload_t
-AllGatherMatmulAsyncMeshWorkloadFactory::create_mesh_workload(
+}  // namespace
+
+// For ring all-gather, we can send sub-sections of input tensor in opposite directions
+// For linear all-gather though, we must ensure we send full tensors in BOTH directions
+//   (in other words, disable the "bidirectional" send flag)
+tt::tt_metal::WorkloadDescriptor AllGatherMatmulAsyncMeshWorkloadFactory::create_workload_descriptor(
     const AllGatherMatmulAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const AllGatherMatmulAsyncInputs& tensor_args,
-    AllGatherMatmulAsyncResult& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    AllGatherMatmulAsyncResult& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
     for (const auto& mesh_coord : tensor_coords.coords()) {
         const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-        auto* mesh_device = tensor_args.input_tensor.device();
-        IDevice* target_device = mesh_device ? mesh_device->get_device(mesh_coord) : tensor_args.input_tensor.device();
 
         uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
             tensor_args.input_tensor, mesh_coord, operation_attributes.all_gather_async_attributes.cluster_axis);
@@ -187,13 +180,12 @@ AllGatherMatmulAsyncMeshWorkloadFactory::create_mesh_workload(
             operation_attributes.all_gather_async_attributes.topology,
             operation_attributes.all_gather_async_attributes.cluster_axis);
 
-        auto cached_program = create_at(
+        auto desc = build_descriptor_at(
             tensor_args.input_tensor,
             tensor_return_value[0],
             tensor_args.weight_tensor,
             tensor_return_value[1],
 
-            target_device,
             mesh_coord,
             forward_coord,
             backward_coord,
@@ -217,70 +209,10 @@ AllGatherMatmulAsyncMeshWorkloadFactory::create_mesh_workload(
             operation_attributes.matmul.program_config.value(),
             operation_attributes.matmul.untilize_out);
 
-        workload.add_program(single_coord_range, std::move(cached_program.program));
-        shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
+        workload_descriptor.programs.push_back({single_coord_range, std::move(desc)});
     }
 
-    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
-}
-
-void AllGatherMatmulAsyncMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const AllGatherMatmulAsyncParams& operation_attributes,
-    const AllGatherMatmulAsyncInputs& tensor_args,
-    AllGatherMatmulAsyncResult& tensor_return_value) {
-    // Fuse the override runtime arguments callbacks
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
-
-        std::visit(
-            ttsl::overloaded{
-                [&](const ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t&
-                        mm_shared_variables) {
-                    std::vector<Tensor> matmul_output_tensors = {tensor_return_value[1]};
-                    ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::override_runtime_arguments(
-                        program,
-                        mm_shared_variables,
-                        operation_attributes.matmul,
-                        {{tensor_return_value[0], tensor_args.weight_tensor},
-                         {tensor_args.bias},
-                         {tensor_return_value[1]}},
-                        matmul_output_tensors);
-                },
-                [&](const ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t&
-                        mm_shared_variables) {
-                    std::vector<Tensor> matmul_output_tensors = {tensor_return_value[1]};
-                    ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
-                        program,
-                        mm_shared_variables,
-                        operation_attributes.matmul,
-                        {{tensor_return_value[0], tensor_args.weight_tensor},
-                         {tensor_args.bias},
-                         {tensor_return_value[1]}},
-                        matmul_output_tensors);
-                },
-                [&](const auto& /*config*/) {
-                    TT_THROW("Unsupported MatmulProgramConfig type. Needs to be 1D or 2D Multicast.");
-                }},
-            shared_vars.matmul_shared_variables);
-
-        auto& all_gather_async_shared_variables = shared_vars.all_gather_async_shared_variables;
-        const auto& all_gather_async_attributes = operation_attributes.all_gather_async_attributes;
-        all_gather_async_minimal_default_helper_override_runtime_arguments(
-            program,
-            all_gather_async_shared_variables.reader_kernel_id,
-            all_gather_async_shared_variables.writer_kernel_id,
-            all_gather_async_shared_variables.all_cores,
-            all_gather_async_attributes.num_links,
-            all_gather_async_shared_variables.num_directions_per_link,
-            all_gather_async_shared_variables.num_workers_per_direction,
-            all_gather_async_shared_variables.num_mux_cores_per_direction_per_link,
-            all_gather_async_shared_variables.num_cores_per_link,
-            all_gather_async_attributes.barrier_semaphore,
-            all_gather_async_attributes.semaphore,
-            tensor_args.input_tensor,
-            tensor_return_value[0]);
-    }
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.hpp
@@ -5,75 +5,29 @@
 #pragma once
 
 #include "ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation_types.hpp"
-#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
-#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 #include <optional>
 #include <vector>
 
 namespace ttnn::experimental::prim {
 
-struct AllGatherMatmulAsyncSharedVariables {
-    std::variant<
-        std::monostate,
-        ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t,
-        ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t>
-        matmul_shared_variables;
-    AllGatherProgramArtifacts all_gather_async_shared_variables;
-};
-
+// Contract-2 (descriptor) factory for the fused AllGather + Matmul op.  All
+// per-coord program building happens through the ProgramDescriptor variants of
+// the matmul (1D/2D mcast) and AllGather minimal builders; the workload-scoped
+// GlobalSemaphores live on the AllGatherAsyncParams that the caller provided
+// (no extra ones are needed).
 struct AllGatherMatmulAsyncMeshWorkloadFactory {
-    using shared_variables_t = AllGatherMatmulAsyncSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const AllGatherMatmulAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const AllGatherMatmulAsyncInputs& tensor_args,
-        AllGatherMatmulAsyncResult& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const AllGatherMatmulAsyncParams& operation_attributes,
         const AllGatherMatmulAsyncInputs& tensor_args,
-        AllGatherMatmulAsyncResult& tensor_return_value);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const Tensor& input_tensor,
-        Tensor& all_gather_output_tensor,
-        const Tensor& weight_tensor,
-        Tensor& matmul_output_tensor,
-
-        /* All Gather Params */
-        IDevice* target_device,
-        const MeshCoordinate& target_device_coord,
-        const std::optional<MeshCoordinate>& forward_coord,
-        const std::optional<MeshCoordinate>& backward_coord,
-        uint32_t dim,
-        uint32_t num_links,
-        uint32_t ring_size,
-        uint32_t ring_index,
-        ttnn::ccl::Topology topology,
-        const std::vector<GlobalSemaphore>& semaphore,
-        const std::optional<GlobalSemaphore>& barrier_semaphore,
-        bool using_persistent_buffers,
-        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
-        std::optional<uint32_t> chunks_per_sync,
-        std::optional<uint32_t> num_workers_per_direction_opt,
-        std::optional<uint32_t> num_buffers_per_channel,
-        CoreCoord core_grid_offset,
-
-        /* Matmul Params */
-        const std::optional<Tensor>& bias,
-        bool bcast_batch,
-        DeviceComputeKernelConfig compute_kernel_config,
-        const operations::matmul::MatmulProgramConfig& program_config,
-        bool untilize_out);
+        AllGatherMatmulAsyncResult& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -6,7 +6,7 @@
 #include "all_gather_minimal_matmul_async_program_factory.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/constants.hpp>
-#include "ttnn/operations/cb_utils.hpp"
+#include <tt-metalium/hostdevcommon/common_values.hpp>
 #include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -14,6 +14,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace detail {
@@ -83,56 +84,6 @@ static inline CoreCoord clamped_next(const std::vector<CoreCoord>& order, uint32
     return order.at(index >= last ? last : index + 1);
 }
 
-void fabric_mux_connection_ct_args(
-    const uint32_t num_workers_per_link,
-    const tt::tt_fabric::FabricMuxChannelType channel_type,
-    const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
-    std::vector<uint32_t>& worker_ct_args) {
-    worker_ct_args.push_back(mux_kernel_config.get_num_buffers(channel_type));  // fabric_mux_num_buffers_per_channel
-    worker_ct_args.push_back(
-        mux_kernel_config.get_buffer_size_bytes(channel_type));        // fabric_mux_channel_buffer_size_bytes
-    worker_ct_args.push_back(mux_kernel_config.get_status_address());  // fabric_mux_status_address
-    worker_ct_args.push_back(
-        mux_kernel_config.get_termination_signal_address());  // fabric_mux_termination_signal_address
-    worker_ct_args.push_back(num_workers_per_link);           // num_mux_clients
-}
-
-void fabric_mux_connection_rt_args(
-    const bool mux_connection_valid,
-    const bool is_termination_master,
-    const tt::tt_fabric::FabricMuxChannelType channel_type,
-    const CoreCoord& mux_virtual_core,
-    const uint32_t worker_id,
-    const CoreCoord& worker_logical_core,
-    const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
-    tt::tt_metal::Program& program,
-    CoreCoord termination_master_virtual_core,
-    std::vector<uint32_t>& worker_rt_args) {
-    worker_rt_args.push_back(mux_connection_valid);   // mux_connection_valid
-    worker_rt_args.push_back(is_termination_master);  // is_termination_master
-    worker_rt_args.push_back(mux_virtual_core.x);     // fabric_mux_x
-    worker_rt_args.push_back(mux_virtual_core.y);     // fabric_mux_y
-    worker_rt_args.push_back(
-        mux_kernel_config.get_channel_base_address(channel_type, worker_id));  // fabric_mux_channel_base_address
-    worker_rt_args.push_back(
-        mux_kernel_config.get_connection_info_address(channel_type, worker_id));  // fabric_mux_connection_info_address
-    worker_rt_args.push_back(mux_kernel_config.get_connection_handshake_address(
-        channel_type, worker_id));  // fabric_mux_connection_handshake_address
-    worker_rt_args.push_back(
-        mux_kernel_config.get_flow_control_address(channel_type, worker_id));  // fabric_mux_flow_control_address
-    worker_rt_args.push_back(
-        mux_kernel_config.get_buffer_index_address(channel_type, worker_id));  // fabric_mux_buffer_index_address
-    worker_rt_args.push_back(
-        mux_kernel_config.get_channel_credits_stream_id(channel_type, worker_id));  // fabric_mux_channel_id
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // termination_sync_address
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_fabric_mux_status_address
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_flow_control_address
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_teardown_address
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_buffer_index_address
-    worker_rt_args.push_back(termination_master_virtual_core.x);                    // termination_master_noc_x
-    worker_rt_args.push_back(termination_master_virtual_core.y);                    // termination_master_noc_y
-}
-
 // Append tensor accessors in a consistent order
 static inline void append_accessors(
     std::vector<uint32_t>& args,
@@ -161,9 +112,14 @@ static inline void append_accessors(
     }
 }
 
-ttnn::experimental::prim::AllGatherMinimalMatmulAsyncProgramFactory::shared_variables_t
-all_gather_minimal_matmul_async_factory_helper(
-    tt::tt_metal::Program& program,
+// Build the per-coord ProgramDescriptor for the fused AllGather + MinimalMatmul op.
+//
+// This mirrors the legacy all_gather_minimal_matmul_async_factory_helper() body 1:1
+// but constructs everything as descriptors rather than calling CreateKernel /
+// CreateCircularBuffer / CreateSemaphore / SetRuntimeArgs on a Program.  Buffer*
+// bindings used for tensor base addresses live in kernel common runtime args so
+// the framework's fast cache-hit binding patches them automatically.
+tt::tt_metal::ProgramDescriptor build_all_gather_minimal_matmul_async_descriptor(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
@@ -180,8 +136,6 @@ all_gather_minimal_matmul_async_factory_helper(
     const uint32_t ring_index,
     ttnn::ccl::Topology topology,
     const std::vector<ttnn::GlobalSemaphore>& semaphore,
-    //    const std::optional<ttnn::GlobalSemaphore>& barrier_semaphore,
-    //    bool using_persistent_buffers,
     const bool force_transpose,
     const uint32_t num_workers_per_link,
     const uint32_t num_buffers_per_channel,
@@ -189,6 +143,8 @@ all_gather_minimal_matmul_async_factory_helper(
     std::optional<float> fused_ternary_scalar,
     const std::optional<const ttnn::Tensor>& fused_ternary_input_a,
     const std::optional<const ttnn::Tensor>& fused_ternary_input_b) {
+    tt::tt_metal::ProgramDescriptor desc;
+
     auto* device = input_tensor.device();
 
     if (!config.has_value()) {
@@ -198,6 +154,7 @@ all_gather_minimal_matmul_async_factory_helper(
     auto grid_size =
         config.has_value() ? config.value().compute_with_storage_grid_size : device->compute_with_storage_grid_size();
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet core_grid_set{core_grid};
     auto num_cores = core_grid.size();
 
     bool use_bias = bias_tensor.has_value();
@@ -356,29 +313,56 @@ all_gather_minimal_matmul_async_factory_helper(
     auto in1_sender_cores = CoreRange(core_0_0, transpose_core_grid ? core_0_endy : core_endx_0);
     auto in1_receiver_cores = CoreRange(transpose_core_grid ? core_1_0 : core_0_1, core_endx_endy);
 
-    auto in0_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
-    auto in0_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
-    auto in0_valid_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, VALID);
-    auto in1_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
-    auto in1_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
-    auto in1_valid_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, VALID);
+    // Allocate the six grid-wide semaphores up front.  Because they are all
+    // pushed first, on the same core_grid, their IDs are 0..5.  We use
+    // find_available_semaphore_id() instead of hard-coding the IDs so the
+    // helper stays robust if upstream descriptor ordering ever changes.
+    auto alloc_grid_sem = [&](uint32_t initial_value) -> uint32_t {
+        auto id_opt = desc.find_available_semaphore_id(core_0_0, tt::CoreType::WORKER);
+        TT_FATAL(id_opt.has_value(), "No available semaphore ID on core grid");
+        uint32_t id = id_opt.value();
+        desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = core_grid_set,
+            .initial_value = initial_value,
+        });
+        return id;
+    };
+    auto in0_sender_semaphore_id = alloc_grid_sem(INVALID);
+    auto in0_receiver_semaphore_id = alloc_grid_sem(INVALID);
+    auto in0_valid_semaphore_id = alloc_grid_sem(VALID);
+    auto in1_sender_semaphore_id = alloc_grid_sem(INVALID);
+    auto in1_receiver_semaphore_id = alloc_grid_sem(INVALID);
+    auto in1_valid_semaphore_id = alloc_grid_sem(VALID);
+
+    auto push_cb = [&](uint32_t cb_index, uint32_t tile_size, uint32_t num_tiles, tt::DataFormat df) {
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = num_tiles * tile_size,
+            .core_ranges = core_grid_set,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_index),
+                .data_format = df,
+                .page_size = tile_size,
+            }}},
+        });
+    };
 
     uint32_t in0_cb_id = tt::CBIndex::c_0;
-    tt::tt_metal::create_cb(in0_cb_id, program, core_grid, in0_tile_size, in0_cb_num_tiles, in0_data_format);
+    push_cb(in0_cb_id, in0_tile_size, in0_cb_num_tiles, in0_data_format);
 
     uint32_t in1_cb_id = tt::CBIndex::c_1;
-    tt::tt_metal::create_cb(in1_cb_id, program, core_grid, in1_tile_size, in1_cb_num_tiles, in1_data_format);
+    push_cb(in1_cb_id, in1_tile_size, in1_cb_num_tiles, in1_data_format);
 
     uint32_t out_cb_id = tt::CBIndex::c_2;
-    tt::tt_metal::create_cb(out_cb_id, program, core_grid, out_tile_size, out_cb_num_tiles, output_data_format);
+    push_cb(out_cb_id, out_tile_size, out_cb_num_tiles, output_data_format);
 
     uint32_t intermediate_cb_id = tt::CBIndex::c_3;
-    tt::tt_metal::create_cb(
-        intermediate_cb_id, program, core_grid, intermediate_tile_size, interm_cb_num_tiles, intermediate_data_format);
+    push_cb(intermediate_cb_id, intermediate_tile_size, interm_cb_num_tiles, intermediate_data_format);
 
     if (use_bias) {
         uint32_t in2_cb_id = tt::CBIndex::c_4;
-        tt::tt_metal::create_cb(in2_cb_id, program, core_grid, in2_tile_size, in2_cb_num_tiles, in2_data_format);
+        push_cb(in2_cb_id, in2_tile_size, in2_cb_num_tiles, in2_data_format);
     }
 
     // Create circular buffers for fused ternary inputs
@@ -395,8 +379,7 @@ all_gather_minimal_matmul_async_factory_helper(
         TT_FATAL(ternary_a_data_format == in1_data_format, "ternary_a_data_format must be equal to in1_data_format");
         uint32_t ternary_a_cb_num_tiles = out_block_num_tiles;  // Same as output block, not double buffered
 
-        tt::tt_metal::create_cb(
-            ternary_a_cb_id, program, core_grid, ternary_a_tile_size, ternary_a_cb_num_tiles, ternary_a_data_format);
+        push_cb(ternary_a_cb_id, ternary_a_tile_size, ternary_a_cb_num_tiles, ternary_a_data_format);
 
         // Fused ternary input C - circular buffer c_6
         auto ternary_c_data_format =
@@ -404,8 +387,7 @@ all_gather_minimal_matmul_async_factory_helper(
         auto ternary_c_tile_size = tt::tile_size(ternary_c_data_format);
         uint32_t ternary_c_cb_num_tiles = N_block_tiles;  // Single row (like bias), broadcast across M
 
-        tt::tt_metal::create_cb(
-            ternary_c_cb_id, program, core_grid, ternary_c_tile_size, ternary_c_cb_num_tiles, ternary_c_data_format);
+        push_cb(ternary_c_cb_id, ternary_c_tile_size, ternary_c_cb_num_tiles, ternary_c_data_format);
 
         log_debug(tt::LogOp, "ternary_a_cb_id: {}", ternary_a_cb_id);
         log_debug(tt::LogOp, "ternary_c_cb_id: {}", ternary_c_cb_id);
@@ -497,35 +479,32 @@ all_gather_minimal_matmul_async_factory_helper(
     log_debug(tt::LogOp, "out_cb_num_tiles: {}", out_cb_num_tiles);
     log_debug(tt::LogOp, "interm_cb_num_tiles: {}", interm_cb_num_tiles);
 
-    std::map<std::string, std::string> defines;
-    std::map<std::string, std::string> in0_defines;
-    std::map<std::string, std::string> in0_injector_defines;
-    std::map<std::string, std::string> in0_fabric_defines;
+    // KernelDescriptor::Defines is a vector of pairs rather than std::map.
+    tt::tt_metal::KernelDescriptor::Defines defines;
+    tt::tt_metal::KernelDescriptor::Defines in0_defines;
+    tt::tt_metal::KernelDescriptor::Defines in0_injector_defines;
+    tt::tt_metal::KernelDescriptor::Defines in0_fabric_defines;
     if (use_bias) {
-        defines["FUSE_BIAS"] = "1";
+        defines.emplace_back("FUSE_BIAS", "1");
     }
     if (use_fused_ternary) {
-        defines["FUSE_TERNARY"] = "1";
+        defines.emplace_back("FUSE_TERNARY", "1");
 
         // Workaround for LLK bug (https://github.com/tenstorrent/tt-llk/issues/1338)
         // - If ternary_b / gate is float32 then use unary_bcast (row broadcast) + mul_binary_tile (accurate)
         // - If ternary_b / gate is bfloat16 then use mul_tiles_bcast (row broadcast) (workaround)
         if (fused_ternary_input_b.value().dtype() == ttnn::DataType::FLOAT32) {
-            defines["TERNARY_B_IS_FLOAT32"] = "1";
+            defines.emplace_back("TERNARY_B_IS_FLOAT32", "1");
         }
     }
     in0_defines = defines;
-    in0_defines["READ_FROM_LOCAL_INPUT"] = "1";
-    in0_defines["IS_IN0"] = "1";
+    in0_defines.emplace_back("READ_FROM_LOCAL_INPUT", "1");
+    in0_defines.emplace_back("IS_IN0", "1");
     in0_fabric_defines = in0_defines;
-    in0_fabric_defines["USE_MUX"] = "1";
+    in0_fabric_defines.emplace_back("USE_MUX", "1");
 
-    uint32_t in0_addr = ag_output_tensor.buffer()->address();
-    uint32_t in1_addr = weight_tensor.buffer()->address();
-    uint32_t in2_addr = use_bias ? bias_tensor.value().buffer()->address() : 0;
     // Note: Dataflow kernels can take a variable number of output tensors.
-    // They are appended as a variable-length array at the end of the runtime-args:
-    uint32_t in3_addr = input_tensor.buffer()->address();
+    // They are appended as a variable-length array at the end of the runtime-args.
     auto in3_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     auto in3_tile_size = tt::tile_size(in3_data_format);
 
@@ -572,15 +551,18 @@ all_gather_minimal_matmul_async_factory_helper(
         fused_ternary_input_a,
         fused_ternary_input_b,
         true);
-    auto in0_sender_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp",
-        in0_sender_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = in0_risc,
-            .noc = in0_noc,
-            .compile_args = in0_sender_compile_time_args,
-            .defines = in0_defines});
+
+    tt::tt_metal::KernelDescriptor in0_sender_kernel_desc;
+    in0_sender_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp";
+    in0_sender_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    in0_sender_kernel_desc.core_ranges = CoreRangeSet(in0_sender_cores);
+    in0_sender_kernel_desc.compile_time_args = std::move(in0_sender_compile_time_args);
+    in0_sender_kernel_desc.defines = in0_defines;
+    in0_sender_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{.processor = in0_risc, .noc = in0_noc};
+    const tt::tt_metal::KernelHandle in0_sender_kernels_id =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
 
     std::vector<uint32_t> in0_receiver_no_fabric_compile_time_args = {
         M_tiles,
@@ -619,15 +601,17 @@ all_gather_minimal_matmul_async_factory_helper(
         fused_ternary_input_b,
         true);
 
-    auto in0_receiver_no_fabric_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp",
-        in0_receiver_cores_no_fabric,
-        tt::tt_metal::DataMovementConfig{
-            .processor = in0_risc,
-            .noc = in0_noc,
-            .compile_args = in0_receiver_no_fabric_compile_time_args,
-            .defines = in0_defines});
+    tt::tt_metal::KernelDescriptor in0_recv_nofab_desc;
+    in0_recv_nofab_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp";
+    in0_recv_nofab_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    in0_recv_nofab_desc.core_ranges = CoreRangeSet(in0_receiver_cores_no_fabric);
+    in0_recv_nofab_desc.compile_time_args = std::move(in0_receiver_no_fabric_compile_time_args);
+    in0_recv_nofab_desc.defines = in0_defines;
+    in0_recv_nofab_desc.config = tt::tt_metal::DataMovementConfigDescriptor{.processor = in0_risc, .noc = in0_noc};
+    const tt::tt_metal::KernelHandle in0_receiver_no_fabric_kernels_id =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(in0_recv_nofab_desc));
 
     std::vector<uint32_t> in0_receiver_fabric_compile_time_args = {
         M_tiles,
@@ -656,7 +640,7 @@ all_gather_minimal_matmul_async_factory_helper(
         N_chunks,           // N_chunks
         N_tiles_per_chunk,  // N_tiles_per_chunk
     };
-    fabric_mux_connection_ct_args(
+    ttnn::ccl::fabric_mux_connection_ct_args(
         num_workers_per_link,
         tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
         mux_kernel_config,
@@ -675,15 +659,17 @@ all_gather_minimal_matmul_async_factory_helper(
         fused_ternary_input_b,
         true);
 
-    auto in0_receiver_fabric_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp",
-        in0_receiver_cores_fabric,
-        tt::tt_metal::DataMovementConfig{
-            .processor = in0_risc,
-            .noc = in0_noc,
-            .compile_args = in0_receiver_fabric_compile_time_args,
-            .defines = in0_fabric_defines});
+    tt::tt_metal::KernelDescriptor in0_recv_fab_desc;
+    in0_recv_fab_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp";
+    in0_recv_fab_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    in0_recv_fab_desc.core_ranges = CoreRangeSet(in0_receiver_cores_fabric);
+    in0_recv_fab_desc.compile_time_args = std::move(in0_receiver_fabric_compile_time_args);
+    in0_recv_fab_desc.defines = in0_fabric_defines;
+    in0_recv_fab_desc.config = tt::tt_metal::DataMovementConfigDescriptor{.processor = in0_risc, .noc = in0_noc};
+    const tt::tt_metal::KernelHandle in0_receiver_fabric_kernels_id =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(in0_recv_fab_desc));
 
     std::vector<uint32_t> in1_sender_compile_time_args = {
         M_tiles,
@@ -716,13 +702,19 @@ all_gather_minimal_matmul_async_factory_helper(
         fused_ternary_input_a,
         fused_ternary_input_b,
         false);
-    auto in1_sender_kernels_id = CreateKernel(
-        program,
+
+    tt::tt_metal::KernelDescriptor in1_sender_kernel_desc;
+    in1_sender_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/"
-        "dm_in1_sender_out.cpp",
-        in1_sender_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = in1_risc, .noc = in1_noc, .compile_args = in1_sender_compile_time_args, .defines = defines});
+        "dm_in1_sender_out.cpp";
+    in1_sender_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_kernel_desc.core_ranges = CoreRangeSet(in1_sender_cores);
+    in1_sender_kernel_desc.compile_time_args = std::move(in1_sender_compile_time_args);
+    in1_sender_kernel_desc.defines = defines;
+    in1_sender_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{.processor = in1_risc, .noc = in1_noc};
+    const tt::tt_metal::KernelHandle in1_sender_kernels_id =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(in1_sender_kernel_desc));
 
     std::vector<uint32_t> in1_receiver_compile_time_args = {
         M_tiles,
@@ -755,13 +747,19 @@ all_gather_minimal_matmul_async_factory_helper(
         fused_ternary_input_a,
         fused_ternary_input_b,
         false);
-    auto in1_receiver_kernels_id = CreateKernel(
-        program,
+
+    tt::tt_metal::KernelDescriptor in1_recv_desc;
+    in1_recv_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/"
-        "dm_in1_sender_out.cpp",
-        in1_receiver_cores,
-        tt::tt_metal::DataMovementConfig{
-            .processor = in1_risc, .noc = in1_noc, .compile_args = in1_receiver_compile_time_args, .defines = defines});
+        "dm_in1_sender_out.cpp";
+    in1_recv_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    in1_recv_desc.core_ranges = CoreRangeSet(in1_receiver_cores);
+    in1_recv_desc.compile_time_args = std::move(in1_receiver_compile_time_args);
+    in1_recv_desc.defines = defines;
+    in1_recv_desc.config = tt::tt_metal::DataMovementConfigDescriptor{.processor = in1_risc, .noc = in1_noc};
+    const tt::tt_metal::KernelHandle in1_receiver_kernels_id =
+        static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(in1_recv_desc));
 
     std::vector<uint32_t> compute_compile_time_args = {
         K_blocks,
@@ -774,37 +772,44 @@ all_gather_minimal_matmul_async_factory_helper(
         subblock_w};
 
     auto compute_defines = defines;
-    std::map<std::string, std::string> compute_activation_defines;
     if (fused_activation.has_value()) {
-        compute_activation_defines = ttnn::operations::unary::utils::get_defines(
+        auto compute_activation_defines = ttnn::operations::unary::utils::get_defines(
             fused_activation.value().op_type,
             fused_activation.value().params,
             "ACTIVATION",
             "fused_act_dst_id",
             mm_output_tensors[0].dtype());
+        for (const auto& [k, v] : compute_activation_defines) {
+            compute_defines.emplace_back(k, v);
+        }
     }
-    compute_defines.merge(compute_activation_defines);
-    auto compute_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp",
-        core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = compute_defines});
+
+    tt::tt_metal::KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp";
+    compute_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = core_grid_set;
+    compute_kernel_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_kernel_desc.defines = compute_defines;
+    compute_kernel_desc.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .math_approx_mode = math_approx_mode,
+    };
+    const tt::tt_metal::KernelHandle compute_kernels_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(compute_kernel_desc));
 
     // mux kernel
-    auto mux_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
-        mux_core_range_set,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::NOC::RISCV_1_default,
-            .compile_args = mux_kernel_config.get_fabric_mux_compile_time_args(),
-            .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
+    tt::tt_metal::KernelDescriptor mux_kernel_desc;
+    mux_kernel_desc.kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp";
+    mux_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    mux_kernel_desc.core_ranges = mux_core_range_set;
+    mux_kernel_desc.compile_time_args = mux_kernel_config.get_fabric_mux_compile_time_args();
+    mux_kernel_desc.config = tt::tt_metal::DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = tt::tt_metal::NOC::RISCV_1_default};
+    mux_kernel_desc.opt_level = tt::tt_metal::KernelBuildOptLevel::O3;
+    const tt::tt_metal::KernelHandle mux_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+    desc.kernels.push_back(std::move(mux_kernel_desc));
 
     /**
      * The receiver writer cores defer their writes in order to reduce NOC congestion.
@@ -815,7 +820,7 @@ all_gather_minimal_matmul_async_factory_helper(
     uint32_t k_blocks_per_core =
         tt::div_up(K_blocks, (transpose_core_grid ? in1_parallel_axis_cores : in0_parallel_axis_cores));
 
-    auto cores = corerange_to_cores(core_grid, num_cores, true);
+    auto cores = corerange_to_cores(core_grid_set, num_cores, true);
 
     // NOTE: Uniform per-core M/N ranges are required for DM forward handshakes to match across links.
     // If neighboring cores along a forwarding chain iterate different (M,N) counts, the sender can wait
@@ -832,63 +837,71 @@ all_gather_minimal_matmul_async_factory_helper(
             }
             auto mux_logical_core = CoreCoord(mux_x_index, full_grid_size.y - 1);
 
-            std::vector<uint32_t> mux_rt_args = {};
+            // Templated overload: get_fabric_mux_run_time_args dispatches on
+            // ProgramDescriptor and pushes any required SemaphoreDescriptors.
+            std::vector<uint32_t> mux_rt_args;
             const auto src_node_id = device->get_fabric_node_id(sender_device_coord);
             if (dir) {  // forward
                 const auto dst_node_id = device->get_fabric_node_id(backward_coord.value());
-                mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
-                    src_node_id, dst_node_id, link, program, {mux_logical_core});
+                mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args<tt::tt_metal::ProgramDescriptor>(
+                    src_node_id, dst_node_id, link, desc, mux_logical_core);
             } else {
                 const auto dst_node_id = device->get_fabric_node_id(forward_coord.value());
-                mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
-                    src_node_id, dst_node_id, link, program, {mux_logical_core});
+                mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args<tt::tt_metal::ProgramDescriptor>(
+                    src_node_id, dst_node_id, link, desc, mux_logical_core);
             }
-            tt::tt_metal::SetRuntimeArgs(program, mux_kernel_id, {mux_logical_core}, mux_rt_args);
+            desc.kernels[mux_kernel_id].emplace_runtime_args(
+                mux_logical_core,
+                std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>>(mux_rt_args.begin(), mux_rt_args.end()));
         }
     }
 
-    // Set common runtime args (same for all cores, updated in override_runtime_arguments)
+    // Set common runtime args (same for all cores). Tensor base addresses are
+    // bound as Buffer* so the framework patches them via the fast cache-hit
+    // path; GlobalSemaphore addresses are stable for the workload lifetime and
+    // remain as plain uint32 values.
+    //
     // in0 common args: [in0_addr, in2_addr, in3_addr, sem_backward, sem_forward, [ternary_a, ternary_b],
     // output_addrs...]
     {
-        std::vector<uint32_t> in0_common_args = {
-            in0_addr,
-            in2_addr,
-            in3_addr,
-            semaphore.at(0).address(),
-            semaphore.at(1).address(),
-        };
+        tt::tt_metal::KernelDescriptor::RTArgList in0_common_args;
+        in0_common_args.push_back(ag_output_tensor.buffer());
+        in0_common_args.push_back(
+            use_bias ? bias_tensor.value().buffer() : static_cast<tt::tt_metal::Buffer*>(nullptr));
+        in0_common_args.push_back(input_tensor.buffer());
+        in0_common_args.push_back(static_cast<uint32_t>(semaphore.at(0).address()));
+        in0_common_args.push_back(static_cast<uint32_t>(semaphore.at(1).address()));
         if (use_fused_ternary) {
-            in0_common_args.push_back(fused_ternary_input_a.value().buffer()->address());
-            in0_common_args.push_back(fused_ternary_input_b.value().buffer()->address());
+            in0_common_args.push_back(fused_ternary_input_a.value().buffer());
+            in0_common_args.push_back(fused_ternary_input_b.value().buffer());
             uint32_t ternary_b_M_tiles = fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
-            in0_common_args.push_back(ternary_b_M_tiles == 1 ? 1u : 0u);  // broadcast_ternary_b
+            in0_common_args.push_back(static_cast<uint32_t>(ternary_b_M_tiles == 1 ? 1u : 0u));  // broadcast_ternary_b
         }
         for (const auto& mm_output_tensor : mm_output_tensors) {
-            in0_common_args.push_back(mm_output_tensor.buffer()->address());
+            in0_common_args.push_back(mm_output_tensor.buffer());
         }
-        tt::tt_metal::SetCommonRuntimeArgs(program, in0_sender_kernels_id, in0_common_args);
-        tt::tt_metal::SetCommonRuntimeArgs(program, in0_receiver_fabric_kernels_id, in0_common_args);
-        tt::tt_metal::SetCommonRuntimeArgs(program, in0_receiver_no_fabric_kernels_id, in0_common_args);
+        desc.kernels[in0_sender_kernels_id].emplace_common_runtime_args(in0_common_args);
+        desc.kernels[in0_receiver_fabric_kernels_id].emplace_common_runtime_args(in0_common_args);
+        desc.kernels[in0_receiver_no_fabric_kernels_id].emplace_common_runtime_args(in0_common_args);
     }
 
     // in1 common args: [in1_addr, in2_addr, [ternary_a, ternary_b, broadcast_ternary_b], output_addrs...]
     {
-        std::vector<uint32_t> in1_common_args = {
-            in1_addr,
-            in2_addr,
-        };
+        tt::tt_metal::KernelDescriptor::RTArgList in1_common_args;
+        in1_common_args.push_back(weight_tensor.buffer());
+        in1_common_args.push_back(
+            use_bias ? bias_tensor.value().buffer() : static_cast<tt::tt_metal::Buffer*>(nullptr));
         if (use_fused_ternary) {
-            in1_common_args.push_back(fused_ternary_input_a.value().buffer()->address());
-            in1_common_args.push_back(fused_ternary_input_b.value().buffer()->address());
+            in1_common_args.push_back(fused_ternary_input_a.value().buffer());
+            in1_common_args.push_back(fused_ternary_input_b.value().buffer());
             uint32_t ternary_b_M_tiles = fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
-            in1_common_args.push_back(ternary_b_M_tiles == 1 ? 1u : 0u);  // broadcast_ternary_b
+            in1_common_args.push_back(static_cast<uint32_t>(ternary_b_M_tiles == 1 ? 1u : 0u));  // broadcast_ternary_b
         }
         for (const auto& mm_output_tensor : mm_output_tensors) {
-            in1_common_args.push_back(mm_output_tensor.buffer()->address());
+            in1_common_args.push_back(mm_output_tensor.buffer());
         }
-        tt::tt_metal::SetCommonRuntimeArgs(program, in1_sender_kernels_id, in1_common_args);
-        tt::tt_metal::SetCommonRuntimeArgs(program, in1_receiver_kernels_id, in1_common_args);
+        desc.kernels[in1_sender_kernels_id].emplace_common_runtime_args(in1_common_args);
+        desc.kernels[in1_receiver_kernels_id].emplace_common_runtime_args(in1_common_args);
     }
 
     // compute common args: [scalar, broadcast_ternary_b] (only if fused ternary)
@@ -898,7 +911,7 @@ all_gather_minimal_matmul_async_factory_helper(
             *reinterpret_cast<const uint32_t*>(&fused_ternary_scalar.value()),
             ternary_b_M_tiles == 1 ? 1u : 0u,  // broadcast_ternary_b
         };
-        tt::tt_metal::SetCommonRuntimeArgs(program, compute_kernels_id, compute_common_args);
+        desc.kernels[compute_kernels_id].common_runtime_args = std::move(compute_common_args);
     }
 
     for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
@@ -956,7 +969,7 @@ all_gather_minimal_matmul_async_factory_helper(
         bool is_in1_sink = core == in1_core_order.back();
 
         auto in0_injector_virtual_core = device->worker_core_from_logical_core(in0_core_order.front());
-        // Per-core args only (common values set via SetCommonRuntimeArgs above)
+        // Per-core args only (common values set via emplace_common_runtime_args above)
         std::vector<uint32_t> in0_args = {
             is_in0_sink,
             (std::uint32_t)in0_next_core_physical.x,  // in0_dest_noc_x
@@ -976,7 +989,7 @@ all_gather_minimal_matmul_async_factory_helper(
             in0_injector_virtual_core.x,
             in0_injector_virtual_core.y,
             in0_core_order_index,
-            in0_core_order.size()};
+            static_cast<uint32_t>(in0_core_order.size())};
         if (in0_core_order_index > (in0_core_order.size() - 3)) {
             uint32_t worker_idx = in0_idx % num_workers_per_link;
             auto last_in0_core = in0_core_order.back();
@@ -994,7 +1007,9 @@ all_gather_minimal_matmul_async_factory_helper(
             }
             auto mux_logical_core_backward = CoreCoord(mux_core_index_backward, full_grid_size.y - 1);
             CoreCoord mux_virtual_core_backward = device->worker_core_from_logical_core(mux_logical_core_backward);
-            fabric_mux_connection_rt_args(
+            // ProgramDescriptor variant: allocates the five mux-side semaphores by
+            // pushing SemaphoreDescriptors into desc.semaphores on `core`.
+            ttnn::ccl::fabric_mux_connection_rt_args(
                 mux_connection_valid(0),
                 (in0_core_order_index == (in0_core_order.size() - 2)) && !(in0_idx % num_workers_per_link),
                 tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
@@ -1002,7 +1017,7 @@ all_gather_minimal_matmul_async_factory_helper(
                 worker_idx,
                 core,
                 mux_kernel_config,
-                program,
+                desc,
                 termination_master_virtual_core_backward,
                 in0_args);
 
@@ -1020,7 +1035,7 @@ all_gather_minimal_matmul_async_factory_helper(
             }
             auto mux_logical_core_forward = CoreCoord(mux_core_index_forward, full_grid_size.y - 1);
             CoreCoord mux_virtual_core_forward = device->worker_core_from_logical_core(mux_logical_core_forward);
-            fabric_mux_connection_rt_args(
+            ttnn::ccl::fabric_mux_connection_rt_args(
                 mux_connection_valid(1),
                 (in0_core_order_index == (in0_core_order.size() - 1)) && !(in0_idx % num_workers_per_link),
                 tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
@@ -1028,22 +1043,22 @@ all_gather_minimal_matmul_async_factory_helper(
                 worker_idx,
                 core,
                 mux_kernel_config,
-                program,
+                desc,
                 termination_master_virtual_core_forward,
                 in0_args);
         }
         if (in0_core_order_index == 0) {
             // in0 sender
-            SetRuntimeArgs(program, in0_sender_kernels_id, core, in0_args);
+            desc.kernels[in0_sender_kernels_id].runtime_args.emplace_back(core, in0_args);
         } else if (in0_core_order_index > (in0_core_order.size() - 3)) {
             // in0 receiver fabric
-            SetRuntimeArgs(program, in0_receiver_fabric_kernels_id, core, in0_args);
+            desc.kernels[in0_receiver_fabric_kernels_id].runtime_args.emplace_back(core, in0_args);
         } else {
             // in0 receiver no fabric
-            SetRuntimeArgs(program, in0_receiver_no_fabric_kernels_id, core, in0_args);
+            desc.kernels[in0_receiver_no_fabric_kernels_id].runtime_args.emplace_back(core, in0_args);
         }
 
-        // Per-core args only (common values set via SetCommonRuntimeArgs above)
+        // Per-core args only (common values set via emplace_common_runtime_args above)
         std::vector<uint32_t> in1_args = {
             is_in1_sink,
             (std::uint32_t)in1_next_core_physical.x,  // in1_dest_noc_x
@@ -1061,10 +1076,10 @@ all_gather_minimal_matmul_async_factory_helper(
         };
         if (in1_core_order_index == 0) {
             // in1 sender
-            SetRuntimeArgs(program, in1_sender_kernels_id, core, in1_args);
+            desc.kernels[in1_sender_kernels_id].runtime_args.emplace_back(core, in1_args);
         } else {
             // in1 receiver
-            SetRuntimeArgs(program, in1_receiver_kernels_id, core, in1_args);
+            desc.kernels[in1_receiver_kernels_id].runtime_args.emplace_back(core, in1_args);
         }
 
         // Per-core compute args (scalar is in common args)
@@ -1074,236 +1089,67 @@ all_gather_minimal_matmul_async_factory_helper(
             N_start_tile,
             N_end_tile,
         };
-        SetRuntimeArgs(program, compute_kernels_id, core, compute_runtime_args);
+        desc.kernels[compute_kernels_id].runtime_args.emplace_back(core, compute_runtime_args);
     }
 
-    return {
-        num_cores,
-        cores,
-        in0_sender_kernels_id,
-        in0_receiver_fabric_kernels_id,
-        in0_receiver_no_fabric_kernels_id,
-        in1_sender_kernels_id,
-        in1_receiver_kernels_id,
-        compute_kernels_id,
-        transpose_core_grid,
-        transpose_core_grid ? grid_size.y : grid_size.x};
+    return desc;
 }
 
 }  // namespace detail
 
 namespace ttnn::experimental::prim {
 
-AllGatherMinimalMatmulAsyncProgramFactory::cached_mesh_workload_t
-AllGatherMinimalMatmulAsyncProgramFactory::create_mesh_workload(
-    const AllGatherMinimalMatmulAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const AllGatherMinimalMatmulAsyncInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
-
-void AllGatherMinimalMatmulAsyncProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
+tt::tt_metal::WorkloadDescriptor AllGatherMinimalMatmulAsyncProgramFactory::create_workload_descriptor(
     const AllGatherMinimalMatmulAsyncParams& attributes,
     const AllGatherMinimalMatmulAsyncInputs& tensor_args,
-    std::vector<ttnn::Tensor>& output_tensor) {
-    // Derive has_fused_ternary from scalar presence, matching validate and create_at.
-    // validate guarantees that scalar and tensors are always provided together.
-    bool has_fused_ternary = attributes.fused_ternary_scalar.has_value();
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    // Build in0 common args: [in0_addr, in2_addr, in3_addr, sem_backward, sem_forward, [ternary], output_addrs...]
-    std::vector<uint32_t> in0_common = {
-        output_tensor.at(0).buffer()->address(),
-        tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0,
-        tensor_args.input_tensor.buffer()->address(),
-        attributes.semaphore.at(0).address(),
-        attributes.semaphore.at(1).address(),
-    };
-    if (has_fused_ternary) {
-        in0_common.push_back(tensor_args.fused_ternary_input_a.value().buffer()->address());
-        in0_common.push_back(tensor_args.fused_ternary_input_b.value().buffer()->address());
-        uint32_t ternary_b_M_tiles =
-            tensor_args.fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
-        in0_common.push_back(ternary_b_M_tiles == 1 ? 1u : 0u);  // broadcast_ternary_b
-    }
-    for (size_t i = 1; i < output_tensor.size(); ++i) {
-        in0_common.push_back(output_tensor[i].buffer()->address());
-    }
+    for (const auto& mesh_coordinate : tensor_coords.coords()) {
+        uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
+            tensor_args.input_tensor, mesh_coordinate, attributes.cluster_axis);
 
-    // Build in1 common args: [in1_addr, in2_addr, [ternary_a, ternary_b, broadcast_ternary_b], output_addrs...]
-    std::vector<uint32_t> in1_common = {
-        tensor_args.weight_tensor.buffer()->address(),
-        tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0,
-    };
-    if (has_fused_ternary) {
-        in1_common.push_back(tensor_args.fused_ternary_input_a.value().buffer()->address());
-        in1_common.push_back(tensor_args.fused_ternary_input_b.value().buffer()->address());
-        uint32_t ternary_b_M_tiles =
-            tensor_args.fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
-        in1_common.push_back(ternary_b_M_tiles == 1 ? 1u : 0u);  // broadcast_ternary_b
-    }
-    for (size_t i = 1; i < output_tensor.size(); ++i) {
-        in1_common.push_back(output_tensor[i].buffer()->address());
-    }
+        std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            tensor_args.input_tensor, mesh_coordinate, 1, attributes.topology, attributes.cluster_axis);
 
-    // Build compute common args: [scalar, broadcast_ternary_b] (only if fused ternary)
-    uint32_t scalar_as_uint = 0;
-    uint32_t broadcast_ternary_b_uint = 1;  // default broadcast
-    if (has_fused_ternary) {
-        float scalar = attributes.fused_ternary_scalar.value();
-        scalar_as_uint = *reinterpret_cast<const uint32_t*>(&scalar);
-        uint32_t ternary_b_M_tiles =
-            tensor_args.fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
-        broadcast_ternary_b_uint = ternary_b_M_tiles == 1 ? 1u : 0u;
-    }
+        std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            tensor_args.input_tensor, mesh_coordinate, -1, attributes.topology, attributes.cluster_axis);
 
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_variables = cached_workload.shared_variables.at(range);
+        const auto& act_tensor = tensor_args.input_tensor;
+        const auto& weight_tensor = tensor_args.weight_tensor;
+        const auto& bias_tensor = tensor_args.bias_tensor;
+        const auto& ag_output_tensor = tensor_return_value.at(0);
 
-        // Update in0 common args (no per-core loop needed)
-        auto& in0_sender_common = tt::tt_metal::GetCommonRuntimeArgs(program, shared_variables.in0_sender_kernels_id);
-        auto& in0_receiver_fabric_common =
-            tt::tt_metal::GetCommonRuntimeArgs(program, shared_variables.in0_receiver_fabric_kernels_id);
-        auto& in0_receiver_no_fabric_common =
-            tt::tt_metal::GetCommonRuntimeArgs(program, shared_variables.in0_receiver_no_fabric_kernels_id);
-        for (size_t i = 0; i < in0_common.size(); ++i) {
-            in0_sender_common[i] = in0_common[i];
-            in0_receiver_fabric_common[i] = in0_common[i];
-            in0_receiver_no_fabric_common[i] = in0_common[i];
-        }
-
-        // Update in1 common args
-        auto& in1_sender_common = tt::tt_metal::GetCommonRuntimeArgs(program, shared_variables.in1_sender_kernels_id);
-        auto& in1_receiver_common =
-            tt::tt_metal::GetCommonRuntimeArgs(program, shared_variables.in1_receiver_kernels_id);
-        for (size_t i = 0; i < in1_common.size(); ++i) {
-            in1_sender_common[i] = in1_common[i];
-            in1_receiver_common[i] = in1_common[i];
-        }
-
-        // Update compute common args
-        if (has_fused_ternary) {
-            auto& compute_common = tt::tt_metal::GetCommonRuntimeArgs(program, shared_variables.compute_kernels_id);
-            compute_common[0] = scalar_as_uint;
-            compute_common[1] = broadcast_ternary_b_uint;
-        }
-    }
-}
-
-ttnn::device_operation::CachedProgram<AllGatherMinimalMatmulAsyncProgramFactory::shared_variables_t>
-all_gather_minimal_matmul_async_factory(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
-    const std::optional<const MinimalMatmulConfig>& config,
-    const std::vector<ttnn::Tensor>& mm_output_tensors,
-    const ttnn::Tensor& ag_output_tensor,
-    const DeviceComputeKernelConfig& compute_kernel_config,
-    const MeshCoordinate& sender_device_coord,
-    const std::optional<MeshCoordinate>& forward_coord,
-    const std::optional<MeshCoordinate>& backward_coord,
-    const uint32_t num_links,
-    const uint32_t ring_size,
-    const uint32_t ring_index,
-    ttnn::ccl::Topology topology,
-    const std::vector<ttnn::GlobalSemaphore>& semaphore,
-    // const std::optional<ttnn::GlobalSemaphore>& barrier_semaphore,
-    // bool using_persistent_buffers,
-    const bool force_transpose,
-    const uint32_t num_workers_per_link,
-    const uint32_t num_buffers_per_channel,
-    uint32_t N_chunks,
-    std::optional<float> fused_ternary_scalar,
-    const std::optional<const Tensor>& fused_ternary_input_a,
-    const std::optional<const Tensor>& fused_ternary_input_b) {
-    tt::tt_metal::Program program{};
-
-    return {
-        std::move(program),
-        ::detail::all_gather_minimal_matmul_async_factory_helper(
-            program,
-            input_tensor,
+        auto desc = ::detail::build_all_gather_minimal_matmul_async_descriptor(
+            act_tensor,
             weight_tensor,
             bias_tensor,
-            fused_activation,
-            config,
-            mm_output_tensors,
+            attributes.fused_activation,
+            attributes.config,
+            std::vector<ttnn::Tensor>(tensor_return_value.begin() + 1, tensor_return_value.end()),
             ag_output_tensor,
-            compute_kernel_config,
-            sender_device_coord,
+            attributes.compute_kernel_config,
+            mesh_coordinate,
             forward_coord,
             backward_coord,
-            num_links,
-            ring_size,
-            ring_index,
-            topology,
-            semaphore,
-            // barrier_semaphore,
-            // using_persistent_buffers,
-            force_transpose,
-            num_workers_per_link,
-            num_buffers_per_channel,
-            N_chunks,
-            fused_ternary_scalar,
-            fused_ternary_input_a,
-            fused_ternary_input_b)};
-}
+            attributes.num_links,
+            attributes.ring_size,
+            device_index,
+            attributes.topology,
+            attributes.semaphore,
+            attributes.force_transpose,
+            attributes.num_workers_per_link,
+            attributes.num_buffers_per_channel,
+            attributes.chunks,
+            attributes.fused_ternary_scalar,
+            tensor_args.fused_ternary_input_a,
+            tensor_args.fused_ternary_input_b);
 
-ttnn::device_operation::CachedProgram<AllGatherMinimalMatmulAsyncProgramFactory::shared_variables_t>
-AllGatherMinimalMatmulAsyncProgramFactory::create_at(
-    const AllGatherMinimalMatmulAsyncParams& attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const AllGatherMinimalMatmulAsyncInputs& tensor_args,
-    std::vector<ttnn::Tensor>& output_tensor) {
-    uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, attributes.cluster_axis);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(mesh_coordinate), std::move(desc)});
+    }
 
-    std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, 1, attributes.topology, attributes.cluster_axis);
-
-    std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, -1, attributes.topology, attributes.cluster_axis);
-
-    const auto& act_tensor = tensor_args.input_tensor;
-    const auto& weight_tensor = tensor_args.weight_tensor;
-    const auto& bias_tensor = tensor_args.bias_tensor;
-    const auto& ag_output_tensor = output_tensor.at(0);
-
-    return all_gather_minimal_matmul_async_factory(
-        act_tensor,
-        weight_tensor,
-        bias_tensor,
-        attributes.fused_activation,
-        attributes.config,
-        std::vector<ttnn::Tensor>(output_tensor.begin() + 1, output_tensor.end()),
-        ag_output_tensor,
-        attributes.compute_kernel_config,
-        mesh_coordinate,
-        forward_coord,
-        backward_coord,
-        attributes.num_links,
-        attributes.ring_size,
-        device_index,
-        attributes.topology,
-        attributes.semaphore,
-        // attributes.barrier_semaphore,
-        // attributes.using_persistent_buffers,
-        attributes.force_transpose,
-        attributes.num_workers_per_link,
-        attributes.num_buffers_per_channel,
-        attributes.chunks,
-        attributes.fused_ternary_scalar,
-        tensor_args.fused_ternary_input_a,
-        tensor_args.fused_ternary_input_b);
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -6,7 +6,7 @@
 #include "all_gather_minimal_matmul_async_program_factory.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/hostdevcommon/common_values.hpp>
+#include "hostdevcommon/common_values.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.hpp
@@ -9,41 +9,23 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 namespace ttnn::experimental::prim {
 
+// Contract-2 (descriptor) factory for the fused AllGather + Minimal-Matmul op.
+// All per-coord state (kernels, CBs, semaphores, fabric mux wiring) is built
+// inside the per-coord ProgramDescriptor; the workload itself owns no extra
+// resources beyond the caller-provided GlobalSemaphores referenced from
+// operation_attributes.
 struct AllGatherMinimalMatmulAsyncProgramFactory {
-    struct shared_variables_t {
-        uint32_t num_cores;
-        std::vector<CoreCoord> cores;
-        tt::tt_metal::KernelHandle in0_sender_kernels_id;
-        tt::tt_metal::KernelHandle in0_receiver_fabric_kernels_id;
-        tt::tt_metal::KernelHandle in0_receiver_no_fabric_kernels_id;
-        tt::tt_metal::KernelHandle in1_sender_kernels_id;
-        tt::tt_metal::KernelHandle in1_receiver_kernels_id;
-        tt::tt_metal::KernelHandle compute_kernels_id{};
-        bool transpose_core_grid;
-        uint32_t in1_size;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const AllGatherMinimalMatmulAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const AllGatherMinimalMatmulAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const AllGatherMinimalMatmulAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const AllGatherMinimalMatmulAsyncInputs& tensor_args,
-        std::vector<Tensor>& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const AllGatherMinimalMatmulAsyncParams& operation_attributes,
         const AllGatherMinimalMatmulAsyncInputs& tensor_args,
-        std::vector<Tensor>& output_tensor);
+        std::vector<Tensor>& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.hpp
@@ -25,7 +25,6 @@ struct LlamaAllGatherMatmulAsyncDeviceOperation {
     using spec_return_value_t = LlamaAllGatherMatmulAsyncResultSpec;
     using tensor_return_value_t = LlamaAllGatherMatmulAsyncResult;
     using program_factory_t = std::variant<LlamaAllGatherMatmulAsyncProgramFactory>;
-    using shared_variables_t = LlamaAllGatherMatmulAsyncProgramFactory::shared_variables_t;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <ranges>
 #include <optional>
+#include <variant>
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
@@ -31,29 +32,25 @@ using namespace tt::constants;
 
 namespace ttnn::experimental::prim {
 
-LlamaAllGatherMatmulAsyncProgramFactory::cached_mesh_workload_t
-LlamaAllGatherMatmulAsyncProgramFactory::create_mesh_workload(
-    const LlamaAllGatherMatmulAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const LlamaAllGatherMatmulAsyncInputs& tensor_args,
-    LlamaAllGatherMatmulAsyncResult& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_vars;
+namespace {
 
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        mesh_workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_vars.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_vars)};
-}
-
-LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAsyncProgramFactory::create_at(
+// Build the per-coord ProgramDescriptor for the fused llama AllGather + Matmul op.
+// Mirrors the legacy create_at() body 1:1 but appends kernels/CBs/semaphores onto
+// the supplied ProgramDescriptor instead of constructing a Program in place.
+// The MatmulFusedOpSignaler bridge between the AllGather half (this builder) and
+// the Matmul half (matmul_multi_core_agmm_fusion_helper_descriptor) is the same
+// as the legacy path: the matmul builder reads back the four receiver
+// semaphores that init_fused_op() populated here.
+tt::tt_metal::ProgramDescriptor build_descriptor_at(
     const LlamaAllGatherMatmulAsyncParams& args,
     const ttnn::MeshCoordinate& mesh_coordinate,
     const LlamaAllGatherMatmulAsyncInputs& tensor_args,
     LlamaAllGatherMatmulAsyncResult& tensor_return_value) {
+    using tt::tt_metal::CBDescriptor;
+    using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::KernelDescriptor;
+    using tt::tt_metal::ProgramDescriptor;
+
     const auto& input0 = tensor_args.input0;
     const auto& input1 = tensor_args.input1;
     const auto& intermediate_tensor = tensor_args.intermediate;
@@ -105,7 +102,7 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
     }
 
     uint32_t ring_index = device_index;
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
 
     // Section for fusion signaler initialization
     auto tensor_slicer =
@@ -128,8 +125,12 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
         tt::CB::c_in3 /* start_cb_index */
     );
 
+    // ProgramDescriptor overload of init_fused_op: appends SemaphoreDescriptors onto
+    // desc.semaphores instead of calling CreateSemaphore(program, ...). The four
+    // fused_op_receiver_signal_semaphores it allocates are read back below in the
+    // matmul builder's compile-time args.
     matmul_fused_op_signaler->init_fused_op(
-        program,
+        desc,
         sender_device,
         aggregated_tensor.memory_config().shard_spec()->grid.bounding_box(),
         ttnn::experimental::ccl::FusedOpSignalerMode::SINGLE);
@@ -205,80 +206,98 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
         1;  // We are dealing with small shapes, so assuming all pages for a worker can be fit into the CB
     uint32_t src0_cb_index = tt::CB::c_in0;
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input0.dtype());
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
-            .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
-    CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = cb_num_pages * l1_scratch_cb_page_size_bytes;
+        cb_desc.core_ranges = sender_worker_core_range;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = df,
+            .page_size = l1_scratch_cb_page_size_bytes});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
 
     uint32_t inter_cb_index = tt::CB::c_in2;
-    tt::tt_metal::CircularBufferConfig cb_inter_config =
-        tt::tt_metal::CircularBufferConfig(
-            intermediate_tensor_shard_num_pages * intermediate_tensor_page_size, {{inter_cb_index, df}})
-            .set_page_size(inter_cb_index, intermediate_tensor_page_size)
-            .set_globally_allocated_address(*intermediate_tensor.buffer());
-    CreateCircularBuffer(program, intermediate_tensor_cores, cb_inter_config);
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = intermediate_tensor_shard_num_pages * intermediate_tensor_page_size;
+        cb_desc.core_ranges = intermediate_tensor_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(inter_cb_index),
+            .data_format = df,
+            .page_size = intermediate_tensor_page_size});
+        cb_desc.buffer = intermediate_tensor.buffer();
+        desc.cbs.push_back(std::move(cb_desc));
+    }
 
     // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
     const auto reserved_packet_header_CB_index = tt::CB::c_in1;
     static constexpr auto num_packet_headers_storable = 8;
     const auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
-    tt::tt_metal::CircularBufferConfig cb_reserved_packet_header_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_packet_headers_storable * packet_header_size_bytes * 2,
-            {{reserved_packet_header_CB_index, tt::DataFormat::RawUInt32}})
-            .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
-    CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = num_packet_headers_storable * packet_header_size_bytes * 2;
+        cb_desc.core_ranges = sender_worker_core_range;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(reserved_packet_header_CB_index),
+            .data_format = tt::DataFormat::RawUInt32,
+            .page_size = packet_header_size_bytes});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
 
     // KERNEL CREATION
     // Reader
-    auto reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
-    reader_kernel_config.compile_args = {
-        ring_index,                 // my_chip_id
-        src0_cb_index,              // cb0_id
-        op_config.get_page_size(),  // tensor0_page_size
+    KernelDescriptor worker_sender_reader_desc;
+    worker_sender_reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/"
+        "worker_reader.cpp";
+    worker_sender_reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    worker_sender_reader_desc.core_ranges = sender_worker_core_range;
+    worker_sender_reader_desc.compile_time_args = {
+        ring_index,                            // my_chip_id
+        static_cast<uint32_t>(src0_cb_index),  // cb0_id
+        op_config.get_page_size(),             // tensor0_page_size
     };
+    worker_sender_reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
     log_trace(tt::LogOp, "Reader Compile Args:");
-    for ([[maybe_unused]] const auto& arg : reader_kernel_config.compile_args) {
+    for ([[maybe_unused]] const auto& arg : worker_sender_reader_desc.compile_time_args) {
         log_trace(tt::LogOp, "\t{}", arg);
     }
-    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/"
-        "worker_reader.cpp",
-        sender_worker_core_range,
-        reader_kernel_config);
 
     // Writer
-    auto writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
-    writer_kernel_config.compile_args = {
-        ring_index,                       // my_chip_id
-        reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
-        num_packet_headers_storable,      // num_packet_headers_storable
-        src0_cb_index,                    // cb0_id
-        num_pages_per_packet,             // packet_size_in_pages
-        op_config.get_page_size(),        // tensor0_page_size
-        num_targets_forward,              // num_targets_forward_direction
-        num_targets_backward,             // num_targets_backward_direction
-        dynamic_alternate                 // dynamic_alternate
+    KernelDescriptor worker_sender_writer_desc;
+    worker_sender_writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/"
+        "worker_writer.cpp";
+    worker_sender_writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    worker_sender_writer_desc.core_ranges = sender_worker_core_range;
+    worker_sender_writer_desc.compile_time_args = {
+        ring_index,                                              // my_chip_id
+        static_cast<uint32_t>(reserved_packet_header_CB_index),  // reserved_packet_header_cb_id
+        static_cast<uint32_t>(num_packet_headers_storable),      // num_packet_headers_storable
+        static_cast<uint32_t>(src0_cb_index),                    // cb0_id
+        num_pages_per_packet,                                    // packet_size_in_pages
+        op_config.get_page_size(),                               // tensor0_page_size
+        static_cast<uint32_t>(num_targets_forward),              // num_targets_forward_direction
+        static_cast<uint32_t>(num_targets_backward),             // num_targets_backward_direction
+        static_cast<uint32_t>(dynamic_alternate)                 // dynamic_alternate
     };
+    worker_sender_writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
     log_trace(tt::LogOp, "Writer Compile Args:");
-    for ([[maybe_unused]] const auto& arg : writer_kernel_config.compile_args) {
+    for ([[maybe_unused]] const auto& arg : worker_sender_writer_desc.compile_time_args) {
         log_trace(tt::LogOp, "\t{}", arg);
     }
-    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/"
-        "worker_writer.cpp",
-        sender_worker_core_range,
-        writer_kernel_config);
 
     // Receiver
-
-    // uint32_t semaphore_id_to_notify_to_start_mcast = CreateSemaphore(program, intermediate_tensor_cores, 0);
-    auto receiver_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
-    receiver_kernel_config.compile_args = {
+    KernelDescriptor worker_receiver_desc;
+    worker_receiver_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/"
+        "worker_receiver.cpp";
+    worker_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    worker_receiver_desc.core_ranges = intermediate_tensor_cores;
+    worker_receiver_desc.compile_time_args = {
         args.num_links,                                                    // sem_wait_val
-        inter_cb_index,                                                    // intermediate cb index
+        static_cast<uint32_t>(inter_cb_index),                             // intermediate cb index
         op_config.get_page_size(),                                         // tensor0_page_size
         args.ring_size,                                                    // ring_size
         matmul_fused_op_signaler->fused_op_receiver_signal_semaphores[0],  // semaphore id to notify to start mcast
@@ -286,29 +305,7 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
         matmul_fused_op_signaler->fused_op_receiver_signal_semaphores[2],  // semaphore id to notify to start mcast
         matmul_fused_op_signaler->fused_op_receiver_signal_semaphores[3],  // semaphore id to notify to start mcast
     };
-    auto worker_receiver_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/"
-        "worker_receiver.cpp",
-        intermediate_tensor_cores,
-        receiver_kernel_config);
-    tt::tt_metal::SetRuntimeArgs(
-        program,
-        worker_receiver_kernel_id,
-        intermediate_tensor_cores,
-        {args.semaphore.address(),  // sem_address
-         0,           // core id, corresponds to the id of which device it expect data from, will be reset later
-         ring_index,  // device id
-         aggregated_tensor.buffer()->address(),
-         static_cast<uint32_t>(bbox_physical_start_core.x),
-         static_cast<uint32_t>(bbox_physical_start_core.y),
-         static_cast<uint32_t>(bbox_physical_end_core.x),
-         static_cast<uint32_t>(bbox_physical_end_core.y),
-         static_cast<uint32_t>(bbox.size()),
-         intermediate_tensor_shard_num_pages,
-         0,    // mm_core_offset
-         0,    // next_core_to_left to be notified to start mcast
-         0});  // next_core_to_right to be notified to start mcast
+    worker_receiver_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
 
     // Kernel Runtime Args
 
@@ -316,29 +313,32 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
     auto intermediate_cores_vec = corerange_to_cores(intermediate_tensor_cores, std::nullopt, true);
     auto cores_per_device = (intermediate_cores_vec.size() + args.ring_size - 1) / args.ring_size;
 
-    // Set runtime args for each core
+    // Set runtime args for each core. The legacy code first SetRuntimeArgs on the whole
+    // intermediate_tensor_cores CoreRangeSet with a placeholder row, then immediately overrides
+    // it per-core in the loop below. The descriptor model only needs the final per-core values,
+    // which the loop below emits for every core in intermediate_cores_vec.
     for (uint32_t i = 0; i < intermediate_cores_vec.size(); i++) {
         uint32_t mm_core_offset = (ring_index + args.ring_size - i) % args.ring_size;
         uint32_t next_core_to_left = (i - 1 + args.ring_size) % args.ring_size;
         uint32_t next_core_to_right = (i + 1 + args.ring_size) % args.ring_size;
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            worker_receiver_kernel_id,
-            {intermediate_cores_vec[i]},
-            {args.semaphore.address(),
-             i,
-             ring_index,
-             aggregated_tensor.buffer()->address(),
-             static_cast<uint32_t>(bbox_physical_start_core.x),
-             static_cast<uint32_t>(bbox_physical_start_core.y),
-             static_cast<uint32_t>(bbox_physical_end_core.x),
-             static_cast<uint32_t>(bbox_physical_end_core.y),
-             static_cast<uint32_t>(bbox.size()),
-             intermediate_tensor_shard_num_pages,
-             mm_core_offset,
-             next_core_to_left,
-             next_core_to_right});
+        // aggregated_tensor.buffer() bound as Buffer* so the cache-hit fast path patches its
+        // base address on every dispatch (legacy override_runtime_arguments[3] = aggregated->address()).
+        std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> receiver_rt_args = {
+            static_cast<uint32_t>(args.semaphore.address()),
+            i,
+            ring_index,
+            aggregated_tensor.buffer(),
+            static_cast<uint32_t>(bbox_physical_start_core.x),
+            static_cast<uint32_t>(bbox_physical_start_core.y),
+            static_cast<uint32_t>(bbox_physical_end_core.x),
+            static_cast<uint32_t>(bbox_physical_end_core.y),
+            static_cast<uint32_t>(bbox.size()),
+            static_cast<uint32_t>(intermediate_tensor_shard_num_pages),
+            mm_core_offset,
+            next_core_to_left,
+            next_core_to_right};
+        worker_receiver_desc.emplace_runtime_args(intermediate_cores_vec[i], receiver_rt_args);
     }
     uint32_t start_core_index_for_device = intermediate_cores_vec.size() / args.ring_size * ring_index;
     uint32_t end_core_index_for_device = start_core_index_for_device + cores_per_device;
@@ -401,72 +401,91 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
         log_debug(tt::LogOp, "intermediate_tensor_cores_x: {}", intermediate_tensor_cores_x);
         log_debug(tt::LogOp, "intermediate_tensor_cores_y: {}", intermediate_tensor_cores_y);
 
-        // Set reader runtime args
-        std::vector<uint32_t> reader_rt_args = {
-            input0.buffer()->address(),                 // input tensor_address0
-            intermediate_tensor.buffer()->address(),    // output tensor_address0
-            input_tensor_shard_num_pages,               // num_tiles_per_core
-            worker_num_tiles_to_read,                   // num_tiles_to_read
-            input_first_core_tile_start_offset,         // first_core_tile_start_offset
-            intermediate_first_core_tile_start_offset,  // intermediate_first_core_tile_start_offset
-            input_tensor_cores_x.size(),                // num_cores it reads from
-            ring_index,                                 // ring_index
-            args.semaphore.address(),                   // out_ready_sem_bank_addr (absolute address)
-            drain_sync_core.x,                          // out_ready_sem_noc0_x
-            drain_sync_core.y,                          // out_ready_sem_noc0_y
+        // Set reader runtime args. input0 / intermediate buffers bound as Buffer* so the fast
+        // cache-hit path patches their addresses on each dispatch.
+        std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> reader_rt_args = {
+            input0.buffer(),                                      // input tensor_address0
+            intermediate_tensor.buffer(),                         // output tensor_address0
+            static_cast<uint32_t>(input_tensor_shard_num_pages),  // num_tiles_per_core
+            worker_num_tiles_to_read,                             // num_tiles_to_read
+            input_first_core_tile_start_offset,                   // first_core_tile_start_offset
+            intermediate_first_core_tile_start_offset,            // intermediate_first_core_tile_start_offset
+            static_cast<uint32_t>(input_tensor_cores_x.size()),   // num_cores it reads from
+            ring_index,                                           // ring_index
+            static_cast<uint32_t>(args.semaphore.address()),      // out_ready_sem_bank_addr (absolute address)
+            static_cast<uint32_t>(drain_sync_core.x),             // out_ready_sem_noc0_x
+            static_cast<uint32_t>(drain_sync_core.y),             // out_ready_sem_noc0_y
         };
-        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_x.begin(), input_tensor_cores_x.end());
-        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_y.begin(), input_tensor_cores_y.end());
-        reader_rt_args.push_back(intermediate_tensor_cores_x.size());
-        reader_rt_args.insert(
-            reader_rt_args.end(), intermediate_tensor_cores_x.begin(), intermediate_tensor_cores_x.end());
-        reader_rt_args.insert(
-            reader_rt_args.end(), intermediate_tensor_cores_y.begin(), intermediate_tensor_cores_y.end());
-        log_trace(tt::LogOp, "Reader Runtime Args:");
-        for ([[maybe_unused]] const auto& arg : reader_rt_args) {
-            log_trace(tt::LogOp, "\t{}", arg);
+        for (uint32_t v : input_tensor_cores_x) {
+            reader_rt_args.emplace_back(v);
         }
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+        for (uint32_t v : input_tensor_cores_y) {
+            reader_rt_args.emplace_back(v);
+        }
+        reader_rt_args.emplace_back(static_cast<uint32_t>(intermediate_tensor_cores_x.size()));
+        for (uint32_t v : intermediate_tensor_cores_x) {
+            reader_rt_args.emplace_back(v);
+        }
+        for (uint32_t v : intermediate_tensor_cores_y) {
+            reader_rt_args.emplace_back(v);
+        }
+        log_trace(tt::LogOp, "Reader Runtime Args: <{} entries>", reader_rt_args.size());
+        worker_sender_reader_desc.emplace_runtime_args(core, reader_rt_args);
 
-        // Set writer runtime args
-        std::vector<uint32_t> writer_rt_args = {
-            intermediate_tensor.buffer()->address(),    // tensor_address0
-            args.semaphore.address(),                   // out_ready_sem_bank_addr (absolute address)
-            intermediate_tensor_shard_num_pages,        // num_tiles_per_core
-            worker_num_tiles_to_read,                   // num_tiles_to_read
-            intermediate_first_core_tile_start_offset,  // first_core_tile_start_offset
-            intermediate_tensor_cores_x.size(),         // num_cores it writes to
-            drain_sync_core.x,                          // out_ready_sem_noc0_x
-            drain_sync_core.y,                          // out_ready_sem_noc0_y
+        // Set writer runtime args. intermediate_tensor.buffer() bound as Buffer*.
+        std::vector<uint32_t> writer_rt_args_plain = {
+            // placeholder for intermediate_tensor.buffer()->address()  -- filled in via variant below
+            0u,
+            static_cast<uint32_t>(args.semaphore.address()),             // out_ready_sem_bank_addr (absolute address)
+            static_cast<uint32_t>(intermediate_tensor_shard_num_pages),  // num_tiles_per_core
+            worker_num_tiles_to_read,                                    // num_tiles_to_read
+            intermediate_first_core_tile_start_offset,                   // first_core_tile_start_offset
+            static_cast<uint32_t>(intermediate_tensor_cores_x.size()),   // num_cores it writes to
+            static_cast<uint32_t>(drain_sync_core.x),                    // out_ready_sem_noc0_x
+            static_cast<uint32_t>(drain_sync_core.y),                    // out_ready_sem_noc0_y
         };
-        writer_rt_args.insert(
-            writer_rt_args.end(), intermediate_tensor_cores_x.begin(), intermediate_tensor_cores_x.end());
-        writer_rt_args.insert(
-            writer_rt_args.end(), intermediate_tensor_cores_y.begin(), intermediate_tensor_cores_y.end());
-        log_trace(tt::LogOp, "Writer Runtime Args:");
-        for ([[maybe_unused]] const auto& arg : writer_rt_args) {
-            log_trace(tt::LogOp, "\t{}", arg);
-        }
+        writer_rt_args_plain.insert(
+            writer_rt_args_plain.end(), intermediate_tensor_cores_x.begin(), intermediate_tensor_cores_x.end());
+        writer_rt_args_plain.insert(
+            writer_rt_args_plain.end(), intermediate_tensor_cores_y.begin(), intermediate_tensor_cores_y.end());
+        log_trace(tt::LogOp, "Writer Runtime Args: <{} entries>", writer_rt_args_plain.size());
 
-        writer_rt_args.push_back(forward_fabric_node_id.has_value());
+        writer_rt_args_plain.push_back(static_cast<uint32_t>(forward_fabric_node_id.has_value()));
         if (forward_fabric_node_id.has_value()) {
             const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+            // append_fabric_connection_rt_args is templated; passing the descriptor here causes
+            // it to register the fabric connection state on the descriptor instead of a Program.
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_fabric_node_id, forward_fabric_node_id.value(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, forward_fabric_node_id.value(), link, desc, core, writer_rt_args_plain);
         }
-        writer_rt_args.push_back(backward_fabric_node_id.has_value());
+        writer_rt_args_plain.push_back(static_cast<uint32_t>(backward_fabric_node_id.has_value()));
         if (backward_fabric_node_id.has_value()) {
             const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_fabric_node_id, backward_fabric_node_id.value(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, backward_fabric_node_id.value(), link, desc, core, writer_rt_args_plain);
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+        // Now wrap the writer args into a variant list with intermediate_tensor.buffer() at slot 0.
+        std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>> writer_rt_args;
+        writer_rt_args.reserve(writer_rt_args_plain.size());
+        writer_rt_args.emplace_back(intermediate_tensor.buffer());
+        for (size_t i = 1; i < writer_rt_args_plain.size(); ++i) {
+            writer_rt_args.emplace_back(writer_rt_args_plain[i]);
+        }
+        worker_sender_writer_desc.emplace_runtime_args(core, writer_rt_args);
     }
 
-    // Call MM program factory with matmul_fused_op_signaler
-    auto matmul_shared_variables = ttnn::operations::llama_matmul::matmul_multi_core_agmm_fusion_helper(
-        program,
+    // Push the AllGather kernels first so they own the low CB indices; the matmul builder
+    // uses start_cb_index = matmul_fused_op_signaler->start_cb_index (set to c_in3 in the
+    // init_llama_all_gather call above) to avoid colliding with src0/inter/packet_header CBs.
+    desc.kernels.push_back(std::move(worker_sender_reader_desc));
+    desc.kernels.push_back(std::move(worker_sender_writer_desc));
+    desc.kernels.push_back(std::move(worker_receiver_desc));
+
+    // Call MM program factory with matmul_fused_op_signaler — descriptor variant appends its
+    // kernels/CBs/semaphores onto the same desc.
+    ttnn::operations::llama_matmul::matmul_multi_core_agmm_fusion_helper_descriptor(
+        desc,
         aggregated_tensor,         // in0
         {input1},                  // in1
         std::nullopt,              // bias
@@ -481,66 +500,24 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
         matmul_fused_op_signaler->start_cb_index,
         std::nullopt);
 
-    return cached_program_t{
-        std::move(program),
-        {worker_sender_reader_kernel_id,
-         worker_sender_writer_kernel_id,
-         worker_receiver_kernel_id,
-         sender_worker_cores,
-         intermediate_cores_vec,
-         ring_index,
-         matmul_shared_variables}};
+    return desc;
 }
 
-void LlamaAllGatherMatmulAsyncProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const LlamaAllGatherMatmulAsyncParams& args,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor LlamaAllGatherMatmulAsyncProgramFactory::create_workload_descriptor(
+    const LlamaAllGatherMatmulAsyncParams& operation_attributes,
     const LlamaAllGatherMatmulAsyncInputs& tensor_args,
-    LlamaAllGatherMatmulAsyncResult& tensor_return_value) {
-    const auto& input0 = tensor_args.input0;
-    const auto& input1 = tensor_args.input1;
-    const auto& intermediate_tensor = tensor_args.intermediate;
-    auto& output_tensor = tensor_return_value.mm;
-    const auto& aggregated_tensor = tensor_return_value.aggregated;
+    LlamaAllGatherMatmulAsyncResult& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-    log_trace(tt::LogOp, "DEBUG: semaphore: {}", args.semaphore.address());
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
-
-        // update senders
-        auto& worker_reader_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_reader_kernel_id);
-        auto& worker_writer_sender_runtime_args_by_core =
-            GetRuntimeArgs(program, shared_vars.worker_sender_writer_kernel_id);
-        for (const auto& core : shared_vars.sender_worker_cores) {
-            // reader
-            auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
-            worker_reader_sender_runtime_args[0] = input0.buffer()->address();
-            worker_reader_sender_runtime_args[1] = intermediate_tensor.buffer()->address();
-            worker_reader_sender_runtime_args[8] = args.semaphore.address();
-            // writer
-            auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
-            worker_writer_sender_runtime_args[0] = intermediate_tensor.buffer()->address();
-            worker_writer_sender_runtime_args[1] = args.semaphore.address();
-        }
-
-        // update worker receiver
-        auto& worker_receiver_runtime_args_by_core = GetRuntimeArgs(program, shared_vars.worker_receiver_kernel_id);
-        for (const auto& core : shared_vars.intermediate_cores_vec) {
-            auto& worker_receiver_runtime_args = worker_receiver_runtime_args_by_core[core.x][core.y];
-            worker_receiver_runtime_args[0] = args.semaphore.address();
-            worker_receiver_runtime_args[3] = aggregated_tensor.buffer()->address();
-        }
-
-        ttnn::operations::llama_matmul::override_agmm_fusion_program_parameters(
-            shared_vars.matmul_shared_variables,
-            args.matmul_struct,
-            program,
-            {aggregated_tensor, input1},
-            {},
-            {output_tensor});
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = build_descriptor_at(operation_attributes, coord, tensor_args, tensor_return_value);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.hpp
@@ -8,42 +8,23 @@
 #include "ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation_types.hpp"
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+
 namespace ttnn::experimental::prim {
 
-struct LlamaAllGatherMatmulAsyncSharedVariables {
-    tt::tt_metal::KernelHandle worker_sender_reader_kernel_id{};
-    tt::tt_metal::KernelHandle worker_sender_writer_kernel_id{};
-    tt::tt_metal::KernelHandle worker_receiver_kernel_id{};
-    std::vector<tt::tt_metal::CoreCoord> sender_worker_cores;
-    std::vector<tt::tt_metal::CoreCoord> intermediate_cores_vec;
-    uint32_t ring_index{};
-    ttnn::prim::matmul_mcast_1d_common_override_variables_t matmul_shared_variables;
-};
-
+// Contract-2 (descriptor) factory for the fused llama AllGather + Matmul op.
+// Per coord the llama-specific multicast all-gather kernels and the llama
+// 1D-gather_in0 matmul builder both append onto the same ProgramDescriptor;
+// the MatmulFusedOpSignaler bridge between the two halves (LLAMA_ALL_GATHER
+// variant) is identical to the legacy Program& factory.
 struct LlamaAllGatherMatmulAsyncProgramFactory {
-    using shared_variables_t = LlamaAllGatherMatmulAsyncSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const LlamaAllGatherMatmulAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const LlamaAllGatherMatmulAsyncInputs& tensor_args,
-        LlamaAllGatherMatmulAsyncResult& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
-        const LlamaAllGatherMatmulAsyncParams& args,
-        const LlamaAllGatherMatmulAsyncInputs& tensor_args,
-        LlamaAllGatherMatmulAsyncResult& tensor_return_value);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const LlamaAllGatherMatmulAsyncParams& args,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const LlamaAllGatherMatmulAsyncInputs& tensor_args,
-        LlamaAllGatherMatmulAsyncResult& tensor_return_value);
+        LlamaAllGatherMatmulAsyncResult& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
@@ -82,9 +82,12 @@ struct LlamaReduceScatterDeviceOperation {
             tensor_return_value_t& tensor_return_value,
             const std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& signaler);
 
-        // Append-style overload: writes builder output onto an existing ProgramDescriptor
-        // supplied by the caller, so a single descriptor can hold this reduce-scatter
-        // alongside other builders (e.g. the matmul gather_in0 helper in rs_matmul_op).
+        // Append-style ProgramDescriptor overload — writes onto an existing
+        // `desc` supplied by the caller so a single ProgramDescriptor can hold
+        // this reduce-scatter builder alongside other builders (e.g. the
+        // matmul helper in rs_matmul_op).  Semaphore IDs are allocated via
+        // desc.find_available_semaphore_id() to avoid collisions with
+        // semaphores already registered on overlapping cores.
         static void create_at_program_processing_descriptor(
             tt::tt_metal::ProgramDescriptor& desc,
             const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
@@ -47,30 +48,18 @@ struct Matmul_RS {
         using matmul_device_t = ttnn::prim::MatmulDeviceOperation;
     };
     struct Matmul_RS_PF {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
-        struct shared_variables_t {
-            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::shared_variables_t rs_shared_vars;
-            ttnn::prim::matmul_mcast_1d_common_override_variables_t matmul_shared_vars;
-        };
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            std::vector<Tensor>& tensor_return_value);
-
-        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
-            const tensor_args_t& tensor_args,
-            std::vector<Tensor>& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_workload,
+        // Contract-2 (WorkloadDescriptor) factory.  Builds one ProgramDescriptor
+        // per mesh coord that holds both halves of the fused op (the reduce
+        // scatter builder via the append-style overload of
+        // LlamaReduceScatterAdd::create_at_program_processing_descriptor, and
+        // the matmul 1d gather_in0 descriptor helper), with a shared
+        // MatmulFusedOpSignaler bridging their semaphores.  No workload-scoped
+        // resources beyond the caller-supplied cross_device_semaphore.
+        static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            std::vector<Tensor>& tensor_return_value);
+            std::vector<Tensor>& tensor_return_value,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords);
     };
     using program_factory_t = std::variant<Matmul_RS_PF>;
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
@@ -11,130 +11,93 @@
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
+#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 
 namespace ttnn::operations::experimental::ccl {
-Matmul_RS::Matmul_RS_PF::cached_mesh_workload_t Matmul_RS::Matmul_RS_PF::create_mesh_workload(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const tensor_args_t& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
 
-ttnn::device_operation::CachedProgram<Matmul_RS::Matmul_RS_PF::shared_variables_t> Matmul_RS::Matmul_RS_PF::create_at(
+// Contract-2 (WorkloadDescriptor) factory.  Composes a single ProgramDescriptor
+// per mesh coord that runs the reduce-scatter and matmul halves on
+// non-overlapping core ranges (rs on rs_cores, matmul restricted to the
+// complement via `reduce_scatter_core_range`).  Both halves share a
+// MatmulFusedOpSignaler so the matmul master can signal the rs reader cores —
+// the signaler's rs_semaphore is allocated first (so its ID is stable for the
+// downstream push_llama_rs_rt_args_for_rs() calls), then the rs builder appends
+// its own kernels/CBs/local_semaphore (which uses find_available_semaphore_id
+// to avoid colliding with the rs_semaphore on overlapping cores), and finally
+// the matmul descriptor helper appends its kernels/CBs and the matmul
+// privileged semaphore.
+tt::tt_metal::WorkloadDescriptor Matmul_RS::Matmul_RS_PF::create_workload_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    tt::tt_metal::Program program{};
+    std::vector<Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
     tt::tt_metal::SubDeviceId sub_device_id = operation_attributes.rs_op.subdevice_id.value();
     auto [part_cores, rs_cores] =
         LlamaReduceScatterDeviceOperation::get_rs_core_grids(operation_attributes.rs_op, tensor_args.rs);
     std::optional<CoreRangeSet> reduce_scatter_core_range = rs_cores;
-    if (tensor_args.second_weight_tensor.has_value()) {
-        ttnn::experimental::ccl::MatmulFusedOpSignaler base_signaler = ttnn::experimental::ccl::MatmulFusedOpSignaler(
-            ttnn::experimental::ccl::MatmulFusedOpSignalerType::LLAMA_REDUCE_SCATTER);
-        base_signaler.init_llama_rs_cores_rs(rs_cores, program);
-        std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = base_signaler;
-        auto reduce_scatter_sv = LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_processing(
-            operation_attributes.rs_op,
-            mesh_coordinate,
-            tensor_args.rs,
-            tensor_return_value.at(2),
-            program,
-            fused_op_signaler);
-        auto matmul_sv = ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper(
-            program,
-            tensor_args.matmul.input_tensor,
-            {tensor_args.matmul.weight_tensor, tensor_args.second_weight_tensor.value()},
-            std::nullopt /*bias*/,
-            {tensor_return_value.at(0), tensor_return_value.at(1)},
-            operation_attributes.matmul.bcast_batch.value(),
-            operation_attributes.matmul.compute_kernel_config.value(),
-            operation_attributes.matmul.program_config.value(),
-            operation_attributes.matmul.untilize_out,
-            fused_op_signaler,
-            operation_attributes.matmul.global_cb,
-            sub_device_id /*sub_device_id*/,
-            tt::CBIndex::c_6 /*start cb index*/,
-            reduce_scatter_core_range);
-        return {std::move(program), shared_variables_t{reduce_scatter_sv, matmul_sv}};
-    }
-    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
-    auto reduce_scatter_sv = LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_processing(
-        operation_attributes.rs_op,
-        mesh_coordinate,
-        tensor_args.rs,
-        tensor_return_value.at(1),
-        program,
-        fused_op_signaler);
-    auto matmul_sv = ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper(
-        program,
-        tensor_args.matmul.input_tensor,
-        {tensor_args.matmul.weight_tensor},
-        std::nullopt /*bias*/,
-        {tensor_return_value.at(0)},
-        operation_attributes.matmul.bcast_batch.value(),
-        operation_attributes.matmul.compute_kernel_config.value(),
-        operation_attributes.matmul.program_config.value(),
-        operation_attributes.matmul.untilize_out,
-        fused_op_signaler,
-        operation_attributes.matmul.global_cb,
-        sub_device_id /*sub_device_id*/,
-        tt::CBIndex::c_6 /*start cb index*/,
-        reduce_scatter_core_range);
-    return {std::move(program), shared_variables_t{reduce_scatter_sv, matmul_sv}};
-}
 
-void Matmul_RS::Matmul_RS_PF::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    if (tensor_args.second_weight_tensor.has_value()) {
-        for (auto& [range, program] : cached_workload.workload.get_programs()) {
-            const auto& shared_variables = cached_workload.shared_variables.at(range);
-            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::override_runtime_arguments_per_program(
-                shared_variables.rs_shared_vars,
-                program,
-                operation_attributes.rs_op,
-                tensor_args.rs,
-                tensor_return_value.at(2));
-            ttnn::prim::reuse_mcast_1d_optimized_helpers::override_program_parameters(
-                shared_variables.matmul_shared_vars,
+    for (const auto& coord : tensor_coords.coords()) {
+        tt::tt_metal::ProgramDescriptor desc;
+
+        if (tensor_args.second_weight_tensor.has_value()) {
+            // Two-weight path: matmul produces two outputs, and the reduce
+            // scatter consumes the third tensor_return_value entry.
+            ttnn::experimental::ccl::MatmulFusedOpSignaler base_signaler(
+                ttnn::experimental::ccl::MatmulFusedOpSignalerType::LLAMA_REDUCE_SCATTER);
+            base_signaler.init_llama_rs_cores_rs(rs_cores, desc);
+            std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = base_signaler;
+
+            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_processing_descriptor(
+                desc, operation_attributes.rs_op, coord, tensor_args.rs, tensor_return_value.at(2), fused_op_signaler);
+
+            ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper_descriptor(
+                desc,
+                tensor_args.matmul.input_tensor,
+                {tensor_args.matmul.weight_tensor, tensor_args.second_weight_tensor.value()},
+                std::nullopt /*bias*/,
+                {tensor_return_value.at(0), tensor_return_value.at(1)},
+                operation_attributes.matmul.bcast_batch.value(),
+                operation_attributes.matmul.compute_kernel_config.value(),
+                operation_attributes.matmul.program_config.value(),
+                operation_attributes.matmul.untilize_out,
+                fused_op_signaler,
                 operation_attributes.matmul.global_cb,
-                program,
-                {{tensor_args.matmul.input_tensor,
-                  tensor_args.matmul.weight_tensor,
-                  tensor_args.second_weight_tensor.value()},
-                 {}},
-                {tensor_return_value.at(0), tensor_return_value.at(1)});
-        }
-    } else {
-        for (auto& [range, program] : cached_workload.workload.get_programs()) {
-            const auto& shared_variables = cached_workload.shared_variables.at(range);
-            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::override_runtime_arguments_per_program(
-                shared_variables.rs_shared_vars,
-                program,
-                operation_attributes.rs_op,
-                tensor_args.rs,
-                tensor_return_value.at(1));
-            ttnn::prim::reuse_mcast_1d_optimized_helpers::override_program_parameters(
-                shared_variables.matmul_shared_vars,
+                sub_device_id /*sub_device_id*/,
+                tt::CBIndex::c_6 /*start cb index*/,
+                reduce_scatter_core_range);
+        } else {
+            // Single-weight path: matmul produces one output, and the reduce
+            // scatter consumes the second tensor_return_value entry.  No
+            // signaler is plumbed here because the legacy single-weight path
+            // also runs without one (matches the legacy create_at body).
+            std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
+
+            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_processing_descriptor(
+                desc, operation_attributes.rs_op, coord, tensor_args.rs, tensor_return_value.at(1), fused_op_signaler);
+
+            ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper_descriptor(
+                desc,
+                tensor_args.matmul.input_tensor,
+                {tensor_args.matmul.weight_tensor},
+                std::nullopt /*bias*/,
+                {tensor_return_value.at(0)},
+                operation_attributes.matmul.bcast_batch.value(),
+                operation_attributes.matmul.compute_kernel_config.value(),
+                operation_attributes.matmul.program_config.value(),
+                operation_attributes.matmul.untilize_out,
+                fused_op_signaler,
                 operation_attributes.matmul.global_cb,
-                program,
-                {{tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {}},
-                {tensor_return_value.at(0)});
+                sub_device_id /*sub_device_id*/,
+                tt::CBIndex::c_6 /*start cb index*/,
+                reduce_scatter_core_range);
         }
+
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
@@ -35,7 +35,6 @@ struct MatmulReduceScatterAsyncDeviceOperation {
     using spec_return_value_t = MatmulReduceScatterAsyncResultSpec;
     using tensor_return_value_t = MatmulReduceScatterAsyncResult;
     using program_factory_t = std::variant<MatmulReduceScatterAsyncProgramFactory>;
-    using shared_variables_t = MatmulReduceScatterAsyncProgramFactory::shared_variables_t;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.cpp
@@ -16,32 +16,23 @@
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp"
 
 namespace ttnn::experimental::prim {
 
-MatmulReduceScatterAsyncProgramFactory::cached_mesh_workload_t
-MatmulReduceScatterAsyncProgramFactory::create_mesh_workload(
-    const MatmulReduceScatterAsyncParams& args,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const MatmulReduceScatterAsyncInputs& tensor_args,
-    MatmulReduceScatterAsyncResult& output_tensors) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_vars;
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(args, coord, tensor_args, output_tensors);
-        mesh_workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_vars.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_vars)};
-}
-
-MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyncProgramFactory::create_at(
+// Build the per-coord ProgramDescriptor for the fused Matmul + ReduceScatter.
+// Mirrors the legacy create_at() body 1:1 but routes through the
+// ProgramDescriptor variants of the ring-reduce-scatter and matmul-2D-mcast
+// builders.  Both helpers append onto the same `desc` (CBs, kernels,
+// semaphores).  The fused-op signaler bridge between the two halves is
+// identical to the legacy path.
+static tt::tt_metal::ProgramDescriptor build_descriptor_at(
     const MatmulReduceScatterAsyncParams& args,
     const ttnn::MeshCoordinate& mesh_coord,
     const MatmulReduceScatterAsyncInputs& tensor_args,
     MatmulReduceScatterAsyncResult& output_tensors) {
+    tt::tt_metal::ProgramDescriptor desc;
+
     ttnn::ccl::Topology topology = args.reduce_scatter_params.topology;
 
     const auto& dim = args.reduce_scatter_params.dim;
@@ -56,8 +47,6 @@ MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyn
     auto compute_kernel_config = args.matmul_struct.compute_kernel_config.value();
     bool bcast_batch = args.matmul_struct.bcast_batch.value();
     bool untilize_out = args.matmul_struct.untilize_out;
-
-    tt::tt_metal::Program program{};
 
     std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
         tensor_args.input, mesh_coord, 1, args.reduce_scatter_params.topology, args.reduce_scatter_params.cluster_axis);
@@ -77,9 +66,9 @@ MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyn
         ttnn::experimental::ccl::ReduceScatterFusedOpSignaler();
     reduce_scatter_fused_op_signaler->init_fused_op();
 
-    // Reduce Scatter - use the new artifacts-based helper
-    auto reduce_scatter_artifacts = ttnn::experimental::prim::build_ring_reduce_scatter_minimal_async_program_artifacts(
-        program,
+    // Reduce Scatter - descriptor builder appends kernels/CBs/semaphores onto desc.
+    (void)ttnn::experimental::prim::build_ring_reduce_scatter_minimal_async_program_artifacts_descriptor(
+        desc,
         output_tensors.mm,
         tensor_args.persistent_intermediate,
         mesh_coord,
@@ -112,9 +101,9 @@ MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyn
         reduce_scatter_fused_op_signaler->fused_op_receiver_signal_semaphores,
         reduce_scatter_fused_op_signaler->fused_op_signaler_mode);
 
-    // Matmul
-    auto matmul_cached_program = ttnn::prim::matmul_multi_core_reuse_mcast_2d_optimized_helper(
-        program,
+    // Matmul - descriptor builder also appends to the same desc.
+    ttnn::prim::matmul_multi_core_reuse_mcast_2d_optimized_helper_descriptor(
+        desc,
         tensor_args.input,
         tensor_args.weight,
         tensor_args.bias,
@@ -125,48 +114,22 @@ MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyn
         untilize_out,
         matmul_fused_op_signaler);
 
-    return cached_program_t{
-        std::move(matmul_cached_program.program),
-        {.reduce_scatter_artifacts = std::move(reduce_scatter_artifacts),
-         .matmul_shared_variables = std::move(matmul_cached_program.shared_variables)}};
+    return desc;
 }
 
-void MatmulReduceScatterAsyncProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
+tt::tt_metal::WorkloadDescriptor MatmulReduceScatterAsyncProgramFactory::create_workload_descriptor(
     const MatmulReduceScatterAsyncParams& args,
     const MatmulReduceScatterAsyncInputs& tensor_args,
-    MatmulReduceScatterAsyncResult& output_tensors) {
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
+    MatmulReduceScatterAsyncResult& output_tensors,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
-        std::vector<Tensor> matmul_output_tensors = {output_tensors.mm};
-        ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::override_runtime_arguments(
-            program,
-            shared_vars.matmul_shared_variables,
-            args.matmul_struct,
-            {.input_tensors = {tensor_args.input, tensor_args.weight},
-             .optional_input_tensors = {tensor_args.bias},
-             .optional_output_tensors = {output_tensors.mm}},
-            matmul_output_tensors);
-
-        // Call reduce scatter runtime arguments override directly using artifacts
-        ttnn::experimental::prim::ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
-            program,
-            shared_vars.reduce_scatter_artifacts.reader_kernel_id,
-            shared_vars.reduce_scatter_artifacts.writer_kernel_id,
-            shared_vars.reduce_scatter_artifacts.all_cores,
-            args.reduce_scatter_params.num_links,
-            shared_vars.reduce_scatter_artifacts.num_directions_per_link,
-            shared_vars.reduce_scatter_artifacts.num_workers_per_direction,
-            shared_vars.reduce_scatter_artifacts.num_mux_cores_per_direction_per_link,
-            shared_vars.reduce_scatter_artifacts.num_cores_per_link,
-            shared_vars.reduce_scatter_artifacts.normalized_dim,
-            args.reduce_scatter_params.barrier_semaphore,
-            args.reduce_scatter_params.semaphore,
-            output_tensors.mm,
-            tensor_args.persistent_intermediate,
-            output_tensors.reduce_scatter);
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = build_descriptor_at(args, coord, tensor_args, output_tensors);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.hpp
@@ -6,42 +6,24 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation_types.hpp"
-#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.hpp"
-#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp"
-#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp"
-#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct MatmulReduceScatterAsyncSharedVariables {
-    ttnn::experimental::prim::ReduceScatterProgramArtifacts reduce_scatter_artifacts;
-    ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t matmul_shared_variables;
-};
-
+// Contract-2 (descriptor) factory for the fused Matmul + ReduceScatter op.
+// Per coord the matmul (2D mcast) and ring reduce-scatter descriptor helpers
+// both append onto the same ProgramDescriptor; the ReduceScatterFusedOpSignaler
+// / MatmulFusedOpSignaler bridge between the two halves exactly as in the
+// legacy Program& factory.
 struct MatmulReduceScatterAsyncProgramFactory {
-    using shared_variables_t = MatmulReduceScatterAsyncSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const MatmulReduceScatterAsyncParams& args,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const MatmulReduceScatterAsyncInputs& tensor_args,
-        MatmulReduceScatterAsyncResult& output_tensors);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const MatmulReduceScatterAsyncParams& args,
         const MatmulReduceScatterAsyncInputs& tensor_args,
-        MatmulReduceScatterAsyncResult& output_tensors);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const MatmulReduceScatterAsyncParams& args,
-        const ttnn::MeshCoordinate& mesh_coord,
-        const MatmulReduceScatterAsyncInputs& tensor_args,
-        MatmulReduceScatterAsyncResult& output_tensors);
+        MatmulReduceScatterAsyncResult& output_tensors,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
@@ -27,11 +28,12 @@ using namespace tt::constants;
 // Import the RS program artifacts type
 using ttnn::operations::experimental::ccl::strided_reduce_scatter_async::detail::StridedReduceScatterProgramArtifacts;
 
-// Forward declarations for functions defined in namespace ttnn
-// (defined in strided_reduce_scatter_async_program.cpp)
+// Forward declaration for the ProgramDescriptor (Contract-2) variant of the
+// strided reduce-scatter ring builder (defined in
+// strided_reduce_scatter_async_program.cpp in namespace ttnn).
 namespace ttnn {
-StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_program_artifacts(
-    tt::tt_metal::Program& program,
+StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_program_artifacts_descriptor(
+    tt::tt_metal::ProgramDescriptor& desc,
     const Tensor& input_tensor,
     const Tensor& intermediate_tensor,
     const MeshCoordinate& sender_device_coord,
@@ -60,149 +62,64 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt);
-
-void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
-    tt::tt_metal::Program& program,
-    tt::tt_metal::KernelHandle reader_kernel_id,
-    tt::tt_metal::KernelHandle writer_kernel_id,
-    const std::vector<tt::tt_metal::CoreCoord>& all_cores,
-    uint32_t num_links,
-    uint32_t num_directions_per_link,
-    uint32_t num_workers_per_direction,
-    uint32_t num_mux_cores_per_direction_per_link,
-    uint32_t num_cores_per_link,
-    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore,
-    const std::vector<tt::tt_metal::GlobalSemaphore>& semaphore,
-    const Tensor& input,
-    const Tensor& intermed,
-    const Tensor& output,
-    uint32_t reader_addcmul_rt_arg_offset = 0,
-    const std::optional<const Tensor>& addcmul_a = std::nullopt,
-    const std::optional<const Tensor>& addcmul_b = std::nullopt);
 }  // namespace ttnn
 
 namespace ttnn::experimental::prim {
 
-MinimalMatmulStridedReduceScatterAsyncProgramFactory::cached_mesh_workload_t
-MinimalMatmulStridedReduceScatterAsyncProgramFactory::create_mesh_workload(
-    const MinimalMatmulStridedReduceScatterAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const MinimalMatmulStridedReduceScatterAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
+namespace {
 
-void MinimalMatmulStridedReduceScatterAsyncProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
+// Build a ProgramDescriptor for one mesh coord by composing the RS ring builder
+// and the matmul helper.
+//
+// Step 1: build the RS section first.  The RS builder allocates its reader-side
+// semaphore + records the RS reader cores' NOC coordinates into the
+// srs_fused_op_signaler.  Step 2 then feeds that populated signaler to the
+// matmul helper so the matmul writer kernels know where to signal once each
+// output block is ready.  Order matters: the matmul depends on the RS reader
+// core layout.
+tt::tt_metal::ProgramDescriptor build_descriptor_at(
     const MinimalMatmulStridedReduceScatterAsyncParams& attributes,
+    const ttnn::MeshCoordinate& mesh_coordinate,
     const MinimalMatmulStridedReduceScatterAsyncInputs& tensor_args,
     std::vector<Tensor>& output_tensor) {
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_variables = cached_workload.shared_variables.at(range);
+    tt::tt_metal::ProgramDescriptor desc;
 
-        // Override RS runtime arguments
-        // output_tensor[0] = MM output = RS input
-        // output_tensor[1] = RS intermediate
-        // output_tensor[2] = RS output
-        ::ttnn::ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
-            program,
-            shared_variables.rs_shared_variables.reader_kernel_id,
-            shared_variables.rs_shared_variables.writer_kernel_id,
-            shared_variables.rs_shared_variables.all_cores,
-            attributes.num_links,
-            shared_variables.rs_shared_variables.num_directions_per_link,
-            shared_variables.rs_shared_variables.num_workers_per_direction,
-            shared_variables.rs_shared_variables.num_mux_cores_per_direction_per_link,
-            shared_variables.rs_shared_variables.num_cores_per_link,
-            attributes.barrier_semaphore,
-            attributes.semaphore,
-            output_tensor.at(0),  // RS input = MM output
-            output_tensor.at(1),  // RS intermediate
-            output_tensor.at(2),  // RS output
-            shared_variables.rs_shared_variables.reader_addcmul_rt_arg_offset,
-            tensor_args.addcmul_input_tensor1,
-            tensor_args.addcmul_input_tensor2);
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& weight_tensor = tensor_args.weight_tensor;
+    // output_tensor[0] = MM output (= RS input)
+    // output_tensor[1] = RS intermediate (scratch)
+    // output_tensor[2] = RS output
+    auto& matmul_output_tensor = output_tensor[0];
+    auto& rs_intermediate_tensor = output_tensor[1];
+    auto& rs_output_tensor = output_tensor[2];
 
-        // Override MM runtime arguments (addcmul is now fused in RS, not MM)
-        auto cached_program_proxy = ttnn::experimental::prim::MinimalMatmulProgramFactory::cached_program_t::proxy(
-            program, shared_variables.mm_shared_variables);
+    const uint32_t device_index =
+        ttnn::ccl::get_linearized_index_from_physical_coord(input_tensor, mesh_coordinate, attributes.cluster_axis);
 
-        std::vector<Tensor> mm_output_vec = {output_tensor.at(0)};
-        ttnn::experimental::prim::MinimalMatmulProgramFactory::override_runtime_arguments(
-            cached_program_proxy,
-            attributes.matmul_struct,
-            {tensor_args.input_tensor,
-             tensor_args.weight_tensor,
-             tensor_args.bias,
-             std::nullopt,
-             std::nullopt,  // addcmul fused in RS, not MM
-             std::nullopt},
-            mm_output_vec);
-    }
-}
+    const std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        input_tensor, mesh_coordinate, 1, attributes.topology, attributes.cluster_axis);
+    const std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        input_tensor, mesh_coordinate, -1, attributes.topology, attributes.cluster_axis);
 
-ttnn::device_operation::CachedProgram<MinimalMatmulStridedReduceScatterAsyncProgramFactory::shared_variables_t>
-minimal_matmul_strided_reduce_scatter_async_program(
-    const Tensor& input_tensor,
-    const Tensor& weight_tensor,
-    Tensor& matmul_output_tensor,
-    Tensor& rs_intermediate_tensor,
-    Tensor& rs_output_tensor,
-
-    /* Reduce Scatter Params */
-    const MeshCoordinate& target_device_coord,
-    const std::optional<MeshCoordinate>& forward_coord,
-    const std::optional<MeshCoordinate>& backward_coord,
-    const uint32_t dim,
-    const uint32_t num_links,
-    const uint32_t ring_size,
-    const uint32_t ring_index,
-    ttnn::ccl::Topology topology,
-    const std::vector<GlobalSemaphore>& semaphore,
-    const std::optional<GlobalSemaphore>& barrier_semaphore,
-    bool using_persistent_buffers,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
-    std::optional<uint32_t> num_workers_per_link,
-    std::optional<uint32_t> num_buffers_per_channel,
-    const CoreCoord reduce_scatter_core_grid_offset,
-    std::optional<uint32_t> chunk_width_in_mm_blocks,
-
-    /* Matmul Params */
-    const std::optional<const Tensor>& bias,
-    const std::optional<operations::unary::UnaryWithParam>& fused_activation,
-    ttnn::experimental::prim::MinimalMatmulConfig config,
-    DeviceComputeKernelConfig compute_kernel_config,
-
-    /* Fused addcmul params */
-    const std::optional<float> fused_ternary_scalar = std::nullopt,
-    const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
-    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt) {
-    tt::tt_metal::Program program{};
+    const auto& config = attributes.matmul_struct.config.value();
 
     // Derive matmul geometry parameters for the RS factory.
     // The matmul factory normally transposes its core grid when M > N, but
     // transposition is disabled when fusing with SRS (the RS iteration structure
     // requires mm_N_block_wt <= slice_Wt, which can be violated when transposing).
     // So we always use the non-transposed layout: M parallelized on y, N on x.
-    uint32_t mm_cores_y_val = config.compute_with_storage_grid_size.y;
-    uint32_t mm_block_ht_val = config.M_block_size;
-    uint32_t mm_block_wt_val = config.N_block_size;
+    const uint32_t mm_cores_y_val = config.compute_with_storage_grid_size.y;
+    const uint32_t mm_block_ht_val = config.M_block_size;
+    const uint32_t mm_block_wt_val = config.N_block_size;
 
     // Compute mm_N_full_block_wt: total N tiles per core (N parallelized on x)
-    uint32_t N_tiles = weight_tensor.padded_shape()[-1] / TILE_WIDTH;
-    uint32_t num_cores_x = config.compute_with_storage_grid_size.x;
-    uint32_t padded_N_tiles = tt::round_up(N_tiles, num_cores_x);
-    uint32_t mm_N_full_block_wt_val = padded_N_tiles / num_cores_x;
+    const uint32_t N_tiles = weight_tensor.padded_shape()[-1] / TILE_WIDTH;
+    const uint32_t num_cores_x = config.compute_with_storage_grid_size.x;
+    const uint32_t padded_N_tiles = tt::round_up(N_tiles, num_cores_x);
+    const uint32_t mm_N_full_block_wt_val = padded_N_tiles / num_cores_x;
 
     // =========================================================================
-    // STEP 1: Create the Reduce Scatter program FIRST
+    // STEP 1: Build the Reduce Scatter section FIRST
     //
     // The RS factory creates a semaphore on the RS reader cores and records
     // their NOC coordinates. This info is captured in srs_fused_op_signaler,
@@ -212,96 +129,14 @@ minimal_matmul_strided_reduce_scatter_async_program(
         ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler();
     std::optional<ttnn::experimental::ccl::ReduceScatterFusedOpSignaler> empty_rs_fused_op_signaler = std::nullopt;
 
-    auto rs_shared_variables = ::ttnn::build_ring_strided_reduce_scatter_async_program_artifacts(
-        program,
+    (void)::ttnn::build_ring_strided_reduce_scatter_async_program_artifacts_descriptor(
+        desc,
         matmul_output_tensor,    // RS input = MM output
         rs_intermediate_tensor,  // RS intermediate (scratch)
-        target_device_coord,
-        forward_coord,
-        backward_coord,
-        rs_output_tensor,  // RS output
-        dim,
-        num_links,
-        ring_size,
-        ring_index,
-        topology,
-        semaphore,
-        barrier_semaphore,
-        using_persistent_buffers,
-        sub_device_id,
-        empty_rs_fused_op_signaler,  // RS -> next op signaling (not used)
-        srs_fused_op_signaler,       // MM -> RS signaling (populated by RS factory)
-        num_workers_per_link,
-        num_buffers_per_channel,
-        reduce_scatter_core_grid_offset,
-        mm_cores_y_val,
-        mm_block_ht_val,
-        mm_block_wt_val,
-        mm_N_full_block_wt_val,
-        chunk_width_in_mm_blocks,
-        // Phase 2: fuse addcmul at the RS final write step (not in MM kernel)
-        fused_ternary_scalar,
-        addcmul_input_tensor1,
-        addcmul_input_tensor2);
-
-    // =========================================================================
-    // STEP 2: Create the Matmul program SECOND
-    //
-    // The matmul factory receives the populated srs_fused_op_signaler, which
-    // contains the RS reader cores' NOC coordinates and semaphore ID. The
-    // matmul kernels use this to signal the RS when output blocks are ready.
-    // =========================================================================
-    std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler> empty_mm_fused_op_signaler;
-
-    std::vector<Tensor> mm_output_tensors = {matmul_output_tensor};
-    auto mm_shared_variables = ttnn::experimental::prim::minimal_matmul_factory_helper_common(
-        program,
-        input_tensor,   // MM input (activations)
-        weight_tensor,  // MM weights
-        bias,
-        fused_activation,
-        config,
-        mm_output_tensors,  // MM output (= RS input)
-        compute_kernel_config,
-        empty_mm_fused_op_signaler,  // No AG -> MM signaling
-        1,                           // N_chunks = 1
-        std::nullopt,                // ternary fused in RS, not MM
-        std::nullopt,
-        std::nullopt,
-        srs_fused_op_signaler);  // MM -> RS signaling (populated from step 1)
-
-    return {std::move(program), {rs_shared_variables, mm_shared_variables}};
-}
-
-ttnn::device_operation::CachedProgram<MinimalMatmulStridedReduceScatterAsyncProgramFactory::shared_variables_t>
-MinimalMatmulStridedReduceScatterAsyncProgramFactory::create_at(
-    const MinimalMatmulStridedReduceScatterAsyncParams& attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const MinimalMatmulStridedReduceScatterAsyncInputs& tensor_args,
-    std::vector<Tensor>& output_tensor) {
-    uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, attributes.cluster_axis);
-
-    std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, 1, attributes.topology, attributes.cluster_axis);
-
-    std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, -1, attributes.topology, attributes.cluster_axis);
-
-    // output_tensor[0] = MM output (= RS input)
-    // output_tensor[1] = RS intermediate
-    // output_tensor[2] = RS output
-    return minimal_matmul_strided_reduce_scatter_async_program(
-        tensor_args.input_tensor,   // MM input (activations)
-        tensor_args.weight_tensor,  // MM weights
-        output_tensor[0],           // MM output = RS input
-        output_tensor[1],           // RS intermediate
-        output_tensor[2],           // RS output
-
-        /* Reduce Scatter Params */
         mesh_coordinate,
         forward_coord,
         backward_coord,
+        rs_output_tensor,  // RS output
         attributes.dim,
         attributes.num_links,
         attributes.ring_size,
@@ -311,21 +146,65 @@ MinimalMatmulStridedReduceScatterAsyncProgramFactory::create_at(
         attributes.barrier_semaphore,
         attributes.using_persistent_buffers,
         attributes.sub_device_id,
+        empty_rs_fused_op_signaler,  // RS -> next op signaling (not used)
+        srs_fused_op_signaler,       // MM -> RS signaling (populated by RS builder)
         attributes.num_workers_per_link,
         attributes.num_buffers_per_channel,
         attributes.reduce_scatter_core_grid_offset,
+        mm_cores_y_val,
+        mm_block_ht_val,
+        mm_block_wt_val,
+        mm_N_full_block_wt_val,
         attributes.chunk_width_in_mm_blocks,
-
-        /* Matmul Params */
-        tensor_args.bias,
-        attributes.matmul_struct.fused_activation,
-        attributes.matmul_struct.config.value(),
-        attributes.matmul_struct.compute_kernel_config,
-
-        /* Fused addcmul params */
+        // Phase 2: fuse addcmul at the RS final write step (not in MM kernel)
         attributes.fused_ternary_scalar,
         tensor_args.addcmul_input_tensor1,
         tensor_args.addcmul_input_tensor2);
+
+    // =========================================================================
+    // STEP 2: Build the Matmul section SECOND
+    //
+    // The matmul factory receives the populated srs_fused_op_signaler, which
+    // contains the RS reader cores' NOC coordinates and semaphore ID. The
+    // matmul kernels use this to signal the RS when output blocks are ready.
+    // =========================================================================
+    std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler> empty_mm_fused_op_signaler;
+
+    std::vector<Tensor> mm_output_tensors = {matmul_output_tensor};
+    (void)ttnn::experimental::prim::minimal_matmul_factory_helper_common_descriptor(
+        desc,
+        input_tensor,   // MM input (activations)
+        weight_tensor,  // MM weights
+        tensor_args.bias,
+        attributes.matmul_struct.fused_activation,
+        config,
+        mm_output_tensors,  // MM output (= RS input)
+        attributes.matmul_struct.compute_kernel_config,
+        empty_mm_fused_op_signaler,  // No AG -> MM signaling
+        1,                           // N_chunks = 1
+        std::nullopt,                // ternary fused in RS, not MM
+        std::nullopt,
+        std::nullopt,
+        srs_fused_op_signaler);  // MM -> RS signaling (populated from step 1)
+
+    return desc;
+}
+
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor MinimalMatmulStridedReduceScatterAsyncProgramFactory::create_workload_descriptor(
+    const MinimalMatmulStridedReduceScatterAsyncParams& operation_attributes,
+    const MinimalMatmulStridedReduceScatterAsyncInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = build_descriptor_at(operation_attributes, coord, tensor_args, tensor_return_value);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.hpp
@@ -6,37 +6,28 @@
 
 #include "minimal_matmul_strided_reduce_scatter_async_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp"
-#include "ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::experimental::prim {
 
 struct MinimalMatmulStridedReduceScatterAsyncProgramFactory {
-    struct shared_variables_t {
-        operations::experimental::ccl::strided_reduce_scatter_async::detail::StridedReduceScatterProgramArtifacts
-            rs_shared_variables;
-        MinimalMatmulProgramFactory::shared_variables_t mm_shared_variables;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const MinimalMatmulStridedReduceScatterAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const MinimalMatmulStridedReduceScatterAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const MinimalMatmulStridedReduceScatterAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const MinimalMatmulStridedReduceScatterAsyncInputs& tensor_args,
-        std::vector<Tensor>& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Contract-2: declarative WorkloadDescriptor.  Per coord, builds a
+    // ProgramDescriptor by composing the ProgramDescriptor variants of the
+    // strided reduce-scatter ring builder and the minimal_matmul helper.  The
+    // RS builder is invoked first so that its
+    // StridedReduceScatterFusedOpSignaler is populated with the RS reader
+    // cores' NOC coords + semaphore IDs before the matmul kernels are emitted.
+    // No workload-scoped resources are needed; GlobalSemaphores live on the
+    // operation_attributes (caller-allocated; a different semaphore triggers a
+    // recompile).
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const MinimalMatmulStridedReduceScatterAsyncParams& operation_attributes,
         const MinimalMatmulStridedReduceScatterAsyncInputs& tensor_args,
-        std::vector<Tensor>& output_tensor);
+        std::vector<Tensor>& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
@@ -4,19 +4,22 @@
 ///
 #include <algorithm>
 
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/work_split.hpp>
+
 #include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.hpp"
+#include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "ttnn/operations/math.hpp"
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <sstream>
-#include <type_traits>
 
 #include "ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp"
-#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp"
 
@@ -24,103 +27,80 @@ using namespace tt::constants;
 
 namespace ttnn::experimental::prim {
 
-StridedAllGatherMinimalMatmulAsyncProgramFactory::cached_mesh_workload_t
-StridedAllGatherMinimalMatmulAsyncProgramFactory::create_mesh_workload(
-    const StridedAllGatherMinimalMatmulAsyncParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const StridedAllGatherMinimalMatmulAsyncInputs& tensor_args,
-    std::vector<Tensor>& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
+namespace {
 
-void StridedAllGatherMinimalMatmulAsyncProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
+// Build a ProgramDescriptor for one mesh coord by composing the matmul helper
+// and the strided all-gather builder.
+//
+// Step 1: build the matmul section first.  The matmul helper populates the
+// MinimalMatmulFusedOpSignaler with its receiver cores' NOC coordinates +
+// semaphore IDs.  Step 2 then feeds that populated signaler (forwarded as a
+// StridedAllGatherFusedOpSignaler via init_fused_op) to the all-gather builder
+// so its sender writer kernels know whom to signal once each tensor slice is
+// locally available.  Order matters: the all-gather depends on the matmul
+// receiver core layout.
+tt::tt_metal::ProgramDescriptor build_descriptor_at(
     const StridedAllGatherMinimalMatmulAsyncParams& attributes,
+    const ttnn::MeshCoordinate& mesh_coordinate,
     const StridedAllGatherMinimalMatmulAsyncInputs& tensor_args,
     std::vector<Tensor>& output_tensor) {
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_variables = cached_workload.shared_variables.at(range);
-        StridedAllGatherAsyncProgramFactory::override_runtime_arguments_per_program(
-            shared_variables.ag_shared_variables,
-            program,
-            attributes.strided_all_gather_async_struct,
-            StridedAllGatherAsyncInputs(tensor_args.input_tensor),
-            output_tensor.at(0));
+    tt::tt_metal::ProgramDescriptor desc;
 
-        auto cached_program_proxy = ttnn::experimental::prim::MinimalMatmulProgramFactory::cached_program_t::proxy(
-            program, shared_variables.mm_shared_variables);
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& weight_tensor = tensor_args.weight_tensor;
+    // output_tensor[0] = AG output (= MM input)
+    // output_tensor[1] = MM output
+    auto& all_gather_output_tensor = output_tensor[0];
+    auto& matmul_output_tensor = output_tensor[1];
 
-        // Create a vector for the single output tensor
-        std::vector<Tensor> matmul_output_vec = {output_tensor.at(1)};
-        ttnn::experimental::prim::MinimalMatmulProgramFactory::override_runtime_arguments(
-            cached_program_proxy,
-            attributes.matmul_struct,
-            {output_tensor.at(0), tensor_args.weight_tensor, tensor_args.bias, tensor_args.input_tensor},
-            matmul_output_vec);
-    }
-}
+    const uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
+        input_tensor, mesh_coordinate, attributes.strided_all_gather_async_struct.cluster_axis);
 
-ttnn::device_operation::CachedProgram<StridedAllGatherMinimalMatmulAsyncProgramFactory::shared_variables_t>
-strided_all_gather_minimal_matmul_async_program(
-    const Tensor& input_tensor,
-    Tensor& all_gather_output_tensor,
-    const Tensor& weight_tensor,
-    Tensor& matmul_output_tensor,
-    bool read_local_slice_from_input,
+    const std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        input_tensor,
+        mesh_coordinate,
+        1,
+        attributes.strided_all_gather_async_struct.topology,
+        attributes.strided_all_gather_async_struct.cluster_axis);
+    const std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        input_tensor,
+        mesh_coordinate,
+        -1,
+        attributes.strided_all_gather_async_struct.topology,
+        attributes.strided_all_gather_async_struct.cluster_axis);
 
-    /* All Gather Params */
-    IDevice* /*target_device*/,
-    const MeshCoordinate& target_device_coord,
-    const std::optional<MeshCoordinate>& forward_coord,
-    const std::optional<MeshCoordinate>& backward_coord,
-    const uint32_t dim,
-    const uint32_t num_links,
-    const uint32_t ring_size,
-    const uint32_t ring_index,
-    ttnn::ccl::Topology topology,
-    const std::vector<GlobalSemaphore>& semaphore,
-    std::optional<uint32_t> num_workers_per_direction_opt,
-    std::optional<uint32_t> num_buffers_per_channel,
-    const CoreCoord core_grid_offset,
+    const auto& config = attributes.matmul_struct.config.value();
 
-    /* Matmul Params */
-    const std::optional<const Tensor>& bias,
-    const std::optional<operations::unary::UnaryWithParam>& fused_activation,
-    ttnn::experimental::prim::MinimalMatmulConfig config,
-    DeviceComputeKernelConfig compute_kernel_config) {
-    tt::tt_metal::Program program{};
-
-    // Create a matmul signal info object that gets populated by the matmul kernel
-    uint32_t TILE_WIDTH = 32;
+    // =========================================================================
+    // STEP 1: Build the Matmul section FIRST
+    //
+    // The matmul helper allocates its fused-op receiver semaphores and records
+    // the receiver cores' NOC coordinates into matmul_fused_op_signaler. That
+    // info is then forwarded to the all-gather builder in step 2.
+    // =========================================================================
+    constexpr uint32_t TILE_WIDTH_LOCAL = 32;
     std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler> matmul_fused_op_signaler =
         ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler();
     matmul_fused_op_signaler->init_all_gather(
-        ring_size,
-        ring_index,
-        input_tensor.padded_shape()[3] / TILE_WIDTH,
-        topology,
-        read_local_slice_from_input,
-        read_local_slice_from_input ? std::optional<const Tensor>(input_tensor) : std::nullopt);
+        attributes.strided_all_gather_async_struct.ring_size,
+        device_index,
+        input_tensor.padded_shape()[3] / TILE_WIDTH_LOCAL,
+        attributes.strided_all_gather_async_struct.topology,
+        attributes.read_local_slice_from_input,
+        attributes.read_local_slice_from_input ? std::optional<const Tensor>(input_tensor) : std::nullopt);
 
     // Matmul - wrap single output tensor in vector for unified interface
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> empty_srs_fused_op_signaler;
     std::vector<Tensor> matmul_output_tensors = {matmul_output_tensor};
-    auto mm_shared_variables = ttnn::experimental::prim::minimal_matmul_factory_helper_common(
-        program,
+    (void)ttnn::experimental::prim::minimal_matmul_factory_helper_common_descriptor(
+        desc,
         all_gather_output_tensor,
         weight_tensor,
-        bias,
-        fused_activation,
+        tensor_args.bias,
+        attributes.matmul_struct.fused_activation,
         config,
         matmul_output_tensors,
-        compute_kernel_config,
+        attributes.matmul_struct.compute_kernel_config,
         matmul_fused_op_signaler,
         1,  // N_chunks = 1 for single output
         std::nullopt,
@@ -128,7 +108,14 @@ strided_all_gather_minimal_matmul_async_program(
         std::nullopt,
         empty_srs_fused_op_signaler);
 
-    // Create the all gather fused op signaler
+    // =========================================================================
+    // STEP 2: Build the All Gather section SECOND
+    //
+    // The all-gather helper receives the populated all_gather_fused_op_signaler
+    // (initialized from matmul_fused_op_signaler), which contains the matmul
+    // receiver cores' NOC coordinates and semaphore IDs. The all-gather sender
+    // workers use this to signal the matmul when output blocks are ready.
+    // =========================================================================
     std::optional<ttnn::experimental::ccl::StridedAllGatherFusedOpSignaler> all_gather_fused_op_signaler =
         ttnn::experimental::ccl::StridedAllGatherFusedOpSignaler();
     all_gather_fused_op_signaler->init_fused_op(
@@ -137,86 +124,46 @@ strided_all_gather_minimal_matmul_async_program(
         matmul_fused_op_signaler->fused_op_signaler_mode);
 
     // All Gather
-    StridedAllGatherAsyncProgramFactory::shared_variables_t ag_shared_variables =
-        StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_helper(
-            program,
-            input_tensor,
-            target_device_coord,
-            forward_coord,
-            backward_coord,
-            all_gather_output_tensor,
-            dim,
-            num_links,
-            ring_size,
-            ring_index,
-            topology,
-            semaphore,
-            all_gather_fused_op_signaler,
-            read_local_slice_from_input,
-            num_workers_per_direction_opt,
-            num_buffers_per_channel,
-            matmul_fused_op_signaler->num_fused_op_cores_to_signal,
-            config.M_block_size,
-            config.K_block_size,
-            core_grid_offset);
-
-    return {std::move(program), {ag_shared_variables, mm_shared_variables}};
-}
-
-ttnn::device_operation::CachedProgram<StridedAllGatherMinimalMatmulAsyncProgramFactory::shared_variables_t>
-StridedAllGatherMinimalMatmulAsyncProgramFactory::create_at(
-    const StridedAllGatherMinimalMatmulAsyncParams& attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
-    const StridedAllGatherMinimalMatmulAsyncInputs& tensor_args,
-    std::vector<Tensor>& output_tensor) {
-    auto* mesh_device = tensor_args.input_tensor.device();
-    IDevice* target_device = mesh_device ? mesh_device->get_device(mesh_coordinate) : tensor_args.input_tensor.device();
-
-    uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, attributes.strided_all_gather_async_struct.cluster_axis);
-
-    std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor,
-        mesh_coordinate,
-        1,
-        attributes.strided_all_gather_async_struct.topology,
-        attributes.strided_all_gather_async_struct.cluster_axis);
-
-    std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor,
-        mesh_coordinate,
-        -1,
-        attributes.strided_all_gather_async_struct.topology,
-        attributes.strided_all_gather_async_struct.cluster_axis);
-
-    // Return the StridedAllGatherMinimalMatmulAsync program with callbacks
-    return strided_all_gather_minimal_matmul_async_program(
-        tensor_args.input_tensor,   // input_tensor
-        output_tensor[0],           // all_gather_output_tensor
-        tensor_args.weight_tensor,  // weight_tensor
-        output_tensor[1],           // matmul_output_tensor
-        attributes.read_local_slice_from_input,
-
-        /* All Gather Params */
-        target_device,
+    (void)StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_helper_descriptor(
+        desc,
+        input_tensor,
         mesh_coordinate,
         forward_coord,
         backward_coord,
+        all_gather_output_tensor,
         attributes.strided_all_gather_async_struct.dim,
         attributes.strided_all_gather_async_struct.num_links,
         attributes.strided_all_gather_async_struct.ring_size,
         device_index,
         attributes.strided_all_gather_async_struct.topology,
         attributes.strided_all_gather_async_struct.semaphore,
+        all_gather_fused_op_signaler,
+        attributes.read_local_slice_from_input,
         attributes.strided_all_gather_async_struct.num_workers_per_link,
         attributes.strided_all_gather_async_struct.num_buffers_per_channel,
-        attributes.all_gather_core_grid_offset,
+        matmul_fused_op_signaler->num_fused_op_cores_to_signal,
+        config.M_block_size,
+        config.K_block_size,
+        attributes.all_gather_core_grid_offset);
 
-        /* Matmul Params */
-        tensor_args.bias,  // Bias
-        attributes.matmul_struct.fused_activation,
-        attributes.matmul_struct.config.value(),
-        attributes.matmul_struct.compute_kernel_config);
+    return desc;
+}
+
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor StridedAllGatherMinimalMatmulAsyncProgramFactory::create_workload_descriptor(
+    const StridedAllGatherMinimalMatmulAsyncParams& operation_attributes,
+    const StridedAllGatherMinimalMatmulAsyncInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto desc = build_descriptor_at(operation_attributes, coord, tensor_args, tensor_return_value);
+        workload_descriptor.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+
+    return workload_descriptor;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.hpp
@@ -6,35 +6,31 @@
 
 #include "strided_all_gather_minimal_matmul_async_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 namespace ttnn::experimental::prim {
 
 struct StridedAllGatherMinimalMatmulAsyncProgramFactory {
-    struct shared_variables_t {
-        StridedAllGatherAsyncProgramFactory::shared_variables_t ag_shared_variables;
-        MinimalMatmulProgramFactory::shared_variables_t mm_shared_variables;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const StridedAllGatherMinimalMatmulAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const StridedAllGatherMinimalMatmulAsyncInputs& tensor_args,
-        std::vector<Tensor>& tensor_return_value);
-
-    static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-        const StridedAllGatherMinimalMatmulAsyncParams& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coordinate,
-        const StridedAllGatherMinimalMatmulAsyncInputs& tensor_args,
-        std::vector<Tensor>& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    // Contract-2: declarative WorkloadDescriptor.  Per coord, builds a
+    // ProgramDescriptor by composing the ProgramDescriptor variants of the
+    // minimal_matmul helper and the strided all-gather builder.  The matmul
+    // helper is invoked first so that its MinimalMatmulFusedOpSignaler is
+    // populated with the matmul receiver cores' NOC coords + semaphore IDs
+    // before the strided-all-gather kernels are emitted (the AG kernels read
+    // back the populated signaler to know whom to signal once each tensor
+    // slice is locally available).
+    //
+    // No workload-scoped resources are needed; GlobalSemaphores live on the
+    // operation_attributes (caller-allocated; a different semaphore triggers
+    // a recompile).
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const StridedAllGatherMinimalMatmulAsyncParams& operation_attributes,
         const StridedAllGatherMinimalMatmulAsyncInputs& tensor_args,
-        std::vector<Tensor>& output_tensor);
+        std::vector<Tensor>& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
## Summary
Contract-2 migration of 7 matmul-fused CCL ops:
- all_gather_matmul_async
- all_gather_minimal_matmul_async
- llama_all_gather_matmul_async
- rs_matmul_op (llama_reduce_scatter_matmul)
- minimal_matmul_strided_reduce_scatter_async
- strided_all_gather_minimal_matmul_async
- matmul_reduce_scatter_async

Each composes a CCL descriptor builder (from PR-4) with a matmul fusion helper descriptor variant (from PR-3). Workload-scoped resources parked on \`.semaphores\` / \`.buffers\`.

Part of #42193 / #42209.

## Dependencies
- **MUST merge after the non-matmul CCL consumers PR** (this PR is currently based on that branch).
- Transitively depends on all builder + helper PRs.

## Test plan
Multi-device CCL+matmul ops require t3000/tg hardware.
- [ ] sanity-tests.yaml
- [ ] runtime-sanity-tests.yaml
- [ ] blackhole-post-commit.yaml
- [ ] t3000-* tests (CI)
- [ ] tt-metal-l2-nightly.yaml (CCL + matmul families)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-ccl-consumers-matmul-fused-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-ccl-consumers-matmul-fused-v2)