### PR TITLE
fixed paged cache hang on unallocated blocks during decode

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
@@ -495,6 +495,60 @@ def test_paged_update_cache_decode(
     )
 
 
+def test_paged_update_cache_skips_negative_page_table_entry(device):
+    torch.manual_seed(0)
+    block_size = 64
+    head_dim = 128
+    max_seq_len = 128
+    num_users = 4
+    num_heads = 8
+    max_num_blocks_per_seq = max_seq_len // block_size
+    max_num_blocks = num_users * max_num_blocks_per_seq
+
+    cache = torch.randn([max_num_blocks, num_heads, block_size, head_dim]).bfloat16().float()
+    cachett = ttnn.Tensor(cache, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    x = torch.randn([1, num_users, num_heads, head_dim]).bfloat16().float()
+    x_pad = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_heads), "constant", 0)
+    xt = ttnn.Tensor(x_pad, ttnn.bfloat16).to(ttnn.TILE_LAYOUT)
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+    shard_grid = ttnn.num_cores_to_corerangeset(num_users, compute_grid_size, True)
+    input_shard_spec = ttnn.ShardSpec(
+        shard_grid,
+        [xt.volume() // xt.padded_shape[-1] // num_users, xt.padded_shape[-1]],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    xt = xt.to(device, input_mem_config)
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(num_users, max_num_blocks_per_seq)
+    skipped_user = 2
+    update_idxs = torch.tensor([0, 1, block_size, 3], dtype=torch.int32)
+    page_table[skipped_user, update_idxs[skipped_user].item() // block_size] = -1
+
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+    update_idxs_tt = ttnn.Tensor(update_idxs, ttnn.int32).to(device)
+
+    cachett = ttnn.experimental.paged_update_cache(
+        cachett, xt, update_idxs_tensor=update_idxs_tt, page_table=page_table_tt
+    )
+    got = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+
+    expected = cache.clone()
+    for user in range(num_users):
+        block_id = update_idxs[user].item() // block_size
+        physical_block = page_table[user, block_id].item()
+        if physical_block == -1:
+            continue
+        token_offset = update_idxs[user].item() % block_size
+        expected[physical_block, :num_heads, token_offset : token_offset + 1, :] = x[0, user, :, :].unsqueeze(1)
+
+    eq, message = comp_equal(expected, got)
+    logger.info(message)
+    assert eq
+
+
 @pytest.mark.parametrize("block_size", [64, 128], ids=["block64", "block128"])
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("max_seq_len", [2048])

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 
+constexpr uint32_t SKIP_PAGE_TABLE_ENTRY = (uint32_t)-1;
+
 void kernel_main() {
     const uint32_t cache_addr = get_arg_val<uint32_t>(0);
     const uint32_t cache_start_id = get_arg_val<uint32_t>(1);
@@ -86,10 +88,14 @@ void kernel_main() {
 
                 const uint32_t virtual_block_id = update_idx / block_size;
                 const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
-                const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
-                const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
-                const uint32_t block_offset = block_row_tile * Wt;
-                cache_id = block_start_id + block_offset;
+                if (physical_block_id == SKIP_PAGE_TABLE_ENTRY) {
+                    skip_update = true;
+                } else {
+                    const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
+                    const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
+                    const uint32_t block_offset = block_row_tile * Wt;
+                    cache_id = block_start_id + block_offset;
+                }
 
             } else {
                 const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 
+constexpr uint32_t SKIP_PAGE_TABLE_ENTRY = (uint32_t)-1;
+
 void kernel_main() {
     const uint32_t cache_addr = get_arg_val<uint32_t>(0);
     const uint32_t cache_start_id = get_arg_val<uint32_t>(1);
@@ -69,10 +71,14 @@ void kernel_main() {
 
                 const uint32_t virtual_block_id = update_idx / block_size;
                 const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
-                const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
-                const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
-                const uint32_t block_offset = block_row_tile * Wt;
-                cache_id = block_start_id + block_offset;
+                if (physical_block_id == SKIP_PAGE_TABLE_ENTRY) {
+                    skip_update = true;
+                } else {
+                    const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
+                    const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
+                    const uint32_t block_offset = block_row_tile * Wt;
+                    cache_id = block_start_id + block_offset;
+                }
 
             } else {
                 const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -570,6 +570,25 @@ struct KMcastParams {
     volatile tt_l1_ptr uint32_t* mcast_sem_ptr;  // semaphore pointer
 };
 
+constexpr uint32_t SKIP_PAGE_TABLE_ENTRY = (uint32_t)-1;
+
+template <typename PageT, uint32_t num_heads, uint32_t block_size_t, uint32_t Wt>
+uint32_t virtual_seq_tile_id_to_physical_tile_id_or_skip(
+    uint32_t seq_tile_idx, uint32_t cur_head, const volatile tt_l1_ptr PageT* const page_table_ptr) {
+    constexpr uint32_t block_stride = num_heads * block_size_t * Wt;
+    const uint32_t head_offset = cur_head * block_size_t * Wt;
+
+    const uint32_t virtual_block = seq_tile_idx / block_size_t;
+    const PageT physical_block_raw = page_table_ptr[virtual_block];
+    if (physical_block_raw == static_cast<PageT>(-1)) {
+        return SKIP_PAGE_TABLE_ENTRY;
+    }
+
+    const uint32_t block_row_offset = seq_tile_idx % block_size_t;
+    const uint32_t block_offset = block_row_offset * Wt;
+    return static_cast<uint32_t>(physical_block_raw) * block_stride + head_offset + block_offset;
+}
+
 template <
     uint32_t cb_k_in,
     uint32_t DHt,
@@ -602,13 +621,17 @@ uint64_t read_k(
                 uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
                 uint32_t physical_k_tile_id =
                     (is_page_table_sharded)
-                        ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
+                        ? virtual_seq_tile_id_to_physical_tile_id_or_skip<uint16_t, num_kv_heads, block_size_t, DHt>(
                               virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
-                        : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
+                        : virtual_seq_tile_id_to_physical_tile_id_or_skip<uint32_t, num_kv_heads, block_size_t, DHt>(
                               virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
                 for (uint32_t col = 0; col < DHt; ++col) {
-                    noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
-                    physical_k_tile_id += 1;
+                    if (physical_k_tile_id == SKIP_PAGE_TABLE_ENTRY) {
+                        fill_zeros_async(k_write_ptr_col, k_tile_bytes);
+                    } else {
+                        noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
+                        physical_k_tile_id += 1;
+                    }
                     k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;
                     if (++barrier_count == barrier_threshold) {
                         noc_async_read_barrier();
@@ -658,13 +681,17 @@ uint64_t read_k(
             uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
             uint32_t physical_k_tile_id =
                 (is_page_table_sharded)
-                    ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
+                    ? virtual_seq_tile_id_to_physical_tile_id_or_skip<uint16_t, num_kv_heads, block_size_t, DHt>(
                           virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
-                    : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
+                    : virtual_seq_tile_id_to_physical_tile_id_or_skip<uint32_t, num_kv_heads, block_size_t, DHt>(
                           virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < DHt; ++col) {
-                noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
-                physical_k_tile_id += 1;                               // Go to next tile in row
+                if (physical_k_tile_id == SKIP_PAGE_TABLE_ENTRY) {
+                    fill_zeros_async(k_write_ptr_col, k_tile_bytes);
+                } else {
+                    noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
+                    physical_k_tile_id += 1;  // Go to next tile in row
+                }
                 k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;  // Go to next column in CB
 
                 if (++barrier_count == barrier_threshold) {
@@ -723,13 +750,17 @@ void read_v(
             // Use vDHt for V tensor's width since V is independent
             uint32_t physical_v_tile_id =
                 (is_page_table_sharded)
-                    ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, vDHt>(
+                    ? virtual_seq_tile_id_to_physical_tile_id_or_skip<uint16_t, num_kv_heads, block_size_t, vDHt>(
                           virtual_v_tile_row_num, cur_head, page_table_ptr_u16)
-                    : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, vDHt>(
+                    : virtual_seq_tile_id_to_physical_tile_id_or_skip<uint32_t, num_kv_heads, block_size_t, vDHt>(
                           virtual_v_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < vDHt; ++col) {
-                noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
-                physical_v_tile_id += 1;
+                if (physical_v_tile_id == SKIP_PAGE_TABLE_ENTRY) {
+                    fill_zeros_async(v_write_ptr, v_tile_bytes);
+                } else {
+                    noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
+                    physical_v_tile_id += 1;
+                }
                 v_write_ptr += v_tile_bytes;
 
                 if (++barrier_count == barrier_threshold) {


### PR DESCRIPTION
## Problem
On Blackhole, requests with prefill lengths `> 1024` (example, `isl=1024/osl=128`) consistently hang during the very first decode iteration after the KV cache is populated by `paged_fill_cache`. The hang is caused by the sequence attempting to do a NOC read against unallocated (skipped) page-table blocks (`-1`), leading to out-of-bounds physical tile IDs and deadlocking the operation with a device timeout. 

## Solution
This PR resolves the device hang by gracefully handling the `-1` (`SKIP_PAGE_TABLE_ENTRY`) page-table entries across both decode reading and cache updating operations:
- **`dataflow_common.hpp` (SDPA Decode)**: Added `virtual_seq_tile_id_to_physical_tile_id_or_skip` to intercept `-1` entries. For skipped entries, it uses `fill_zeros_async` instead of `noc_async_read_tile`. This correctly zeroes out K/V tiles for padded/skipped tokens instead of issuing invalid NOC reads, while respecting the async barrier counts
- **`reader_update_cache` and `writer_update_cache`**: Added logic to set `skip_update = true` when encountering a `SKIP_PAGE_TABLE_ENTRY`. The reader bypasses the cache read and the writer bypasses the DRAM writeback, avoiding writes to illegal physical block boundaries while maintaining dataflow synchronization
- **Testing**: Added `test_paged_update_cache_skips_negative_page_table_entry` regression test to ensure that skipped entries are handled safely without affecting other users in the batch


## Impact
Unblocks `vLLM` `gpt-oss-120b` benchmarks on Blackhole arrays which were deterministically hanging on prompts `≥ 1024` tokens. 

This resolves the issue #45052 