### PR TITLE
[Feature] Base pointer retrieval API for TensorAccessor

### DIFF
--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    // This test uses legacy RTA indices to get the bank base addresses.
+    // In Metal 2.0, these raw addresses are passed implicitly.
+    uint32_t input_base_address = get_arg_val<uint32_t>(0);
+    uint32_t output_base_address = get_arg_val<uint32_t>(1);
+    // Args (2) first_shard_id and (3) num_cores are unused — the bank-base copy is bank-relative.
+    uint32_t n_shards = get_arg_val<uint32_t>(4);
+
+    auto args_src = TensorAccessorArgs<1, 0>();
+    auto args_dst =
+        TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
+
+    // In Metal 2.0, this would just be TensorAccessor(ta::my_accessor_name)
+    // The raw bank base address would not be available in scope.
+    auto tensor_accessor_src = TensorAccessor(args_src, input_base_address);
+    auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address);
+
+    // If you needed the raw pointer, you could pull it out of the TensorAccessor:
+    const uint32_t src_l1 = tensor_accessor_src.get_bank_base_address();
+    const uint32_t dst_l1 = tensor_accessor_dst.get_bank_base_address();
+    const uint32_t shard_size_bytes =
+        tensor_accessor_src.get_aligned_page_size() * tensor_accessor_src.dspec().shard_volume();
+    const uint32_t total_bytes = shard_size_bytes * n_shards;
+
+    // For L1-sharded tensors get_bank_base_address() returns the local L1 address of this core's
+    // shard region. One NoC read covers n_shards consecutive shard-sized regions.
+    noc_async_read(get_noc_addr(src_l1), dst_l1, total_bytes);
+    noc_async_read_barrier();
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
@@ -19,11 +19,11 @@ void kernel_main() {
         TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
 
     // In Metal 2.0, this would just be TensorAccessor(ta::my_accessor_name)
-    // The raw bank base address would not be available in scope.
+    // The bank base address would not be available in scope.
     auto tensor_accessor_src = TensorAccessor(args_src, input_base_address);
     auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address);
 
-    // If you needed the raw pointer, you could pull it out of the TensorAccessor:
+    // If you needed the pointer, you could pull it out of the TensorAccessor:
     const uint32_t src_l1 = tensor_accessor_src.get_bank_base_address();
     const uint32_t dst_l1 = tensor_accessor_dst.get_bank_base_address();
     const uint32_t shard_size_bytes =

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -663,6 +663,18 @@ TEST_P(ShardedAccessorTestsCopyOnDevice, MultiCoreCopyLocalShardIterator) {
     }
 }
 
+TEST_P(ShardedAccessorTestsCopyOnDevice, MultiCoreCopyLocalViaBankBaseAddress) {
+    const auto& params = GetParam();
+
+    const std::string kernel_path = "tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp";
+    switch (params.dtype) {
+        case DataType::UINT8: test_multi_core_copy<uint8_t>(params, mesh_device_.get(), kernel_path); break;
+        case DataType::UINT16: test_multi_core_copy<uint16_t>(params, mesh_device_.get(), kernel_path); break;
+        case DataType::BFLOAT16: test_multi_core_copy<bfloat16>(params, mesh_device_.get(), kernel_path); break;
+        default: TT_THROW("Unsupported data type");
+    }
+}
+
 TEST_P(ShardedAccessorTestsCopyOnDevice, MultiCoreCopyLocalShardIteratorBigStep) {
     const auto& params = GetParam();
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -150,7 +150,8 @@ public:
         return get_shard_noc_addr(shard_id, offset, noc);
     }
 
-    // Returns the bank base address of this tensor (raw pointer)
+    // Returns the bank-relative base address (offset) used by this accessor.
+    // (For L1-sharded tensors, this is the local L1 base address of the shard region.)
     FORCE_INLINE
     constexpr uint32_t get_bank_base_address() const { return bank_base_address; }
 
@@ -422,7 +423,8 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
         return false;
     }
 
-    // Returns the bank base address of this tensor (raw pointer)
+    // Returns the bank-relative base address (offset) used by this accessor.
+    // (For L1-sharded tensors, this is the local L1 base address of the shard region.)
     FORCE_INLINE
     constexpr uint32_t get_bank_base_address() const { return this->bank_base_address; }
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -150,6 +150,10 @@ public:
         return get_shard_noc_addr(shard_id, offset, noc);
     }
 
+    // Returns the bank base address of this tensor (raw pointer)
+    FORCE_INLINE
+    constexpr uint32_t get_bank_base_address() const { return bank_base_address; }
+
     // Helpers
     struct PageMapping {
         size_t bank_id;
@@ -417,6 +421,10 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
             "TensorAccessor::is_local_shard is not supported by the interleaved tensor accessor");
         return false;
     }
+
+    // Returns the bank base address of this tensor (raw pointer)
+    FORCE_INLINE
+    constexpr uint32_t get_bank_base_address() const { return this->bank_base_address; }
 
     // Returns a proxy for shard pages iterator
     tensor_accessor::ShardPages<TensorAccessor> shard_pages(


### PR DESCRIPTION
## PR Category
Feature

## Summary
This PR adds a `get_bank_base_address()` method to the `TensorAccessor` class.

### Why do we need this?
Metal 2.0 introduces the concept of `Tensor` bindings. The host code "binds" a tensor to a kernel and assigns it an accessor name; the kernel then just needs to:

```cpp
// Direct construction from token! (no TensorAccessorArgs)
auto my_tensor = TensorAccessor(ta::my_tensor_name);
```
_The base pointer is never passed as an explicit kernel argument!_ (The runtime handles it implicitly.) Metal 2.0 seeks to eliminate (or reduce) the use of raw pointers in kernel code.

However, some kernels today access tensor memory directly rather than through `TensorAccessor` iterators. When porting these kernels to Metal 2.0, they lose access to the raw pointer (previously available as an RTA or CRTA in the legacy APIs). "Smuggling" the raw pointer back into the kernel as a Metal 2.0 argument is not a viable solution. While this is a perfectly legal thing to do in Metal 2.0 itself, doing so would break TTNN's safe cache-hit fast-path protections.

### Solution space
There are two ways to solve this problem:
 1) Add a "get base ptr" API to `TensorAccessor`, enabling a simple Metal 2.0 port
 2) Augment `TensorAccessor` with new iteration patterns so that kernels don't need raw pointer access.

This PR does 1) to unblock Metal 2.0 ops porting with lowest risk.
2) should be considered as future work.

### Example kernels
The following ops from initial Metal 2.0 op port list require this workaround:
 - data_movement/sharded/reshard
 - experimental/transformer/nlp_concat_heads_decode
 - experimental/transformer/nlp_create_qkv_heads
 - experimental/transformer/nlp_create_qkv_heads_decode

## Notes for reviewers
I added a test, but it's a bit silly. I can remove it if preferred.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/tensoraccessor-get-base-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/tensoraccessor-get-base-ptr)