### PR TITLE
Fix MoE kernel compile regressions

### DIFF
--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -19,7 +19,7 @@
 
 namespace ckernel {
 
-namespace detail {
+namespace pack_untilize_detail {
 
 template <
     uint32_t block_ct_dim,
@@ -59,7 +59,7 @@ ALWI void pack_untilize_init_impl(uint32_t icb, uint32_t ocb, uint32_t call_line
     pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, false, TILE_C_DIM, false, configure_remap>(ocb);
 }
 
-}  // namespace detail
+}  // namespace pack_untilize_detail
 
 // clang-format off
 /**
@@ -109,8 +109,9 @@ template <
     bool dense = false>
 ALWI void pack_untilize_dest_init(
     uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4, uint32_t call_line = __builtin_LINE()) {
-    detail::pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, true>(
-        ocb, face_r_dim, num_faces, call_line);
+    pack_untilize_detail::
+        pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, true>(
+            ocb, face_r_dim, num_faces, call_line);
 }
 
 template <
@@ -121,8 +122,9 @@ template <
     bool dense = false>
 ALWI void pack_untilize_dest_init_skip_remap(
     uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4, uint32_t call_line = __builtin_LINE()) {
-    detail::pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, false>(
-        ocb, face_r_dim, num_faces, call_line);
+    pack_untilize_detail::
+        pack_untilize_dest_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense, false>(
+            ocb, face_r_dim, num_faces, call_line);
 }
 
 // clang-format off
@@ -157,12 +159,12 @@ ALWI void pack_untilize_dest_init_skip_remap(
 // clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
 ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    detail::pack_untilize_init_impl<block_ct_dim, full_ct_dim, true>(icb, ocb, call_line);
+    pack_untilize_detail::pack_untilize_init_impl<block_ct_dim, full_ct_dim, true>(icb, ocb, call_line);
 }
 
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
 ALWI void pack_untilize_init_skip_remap(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    detail::pack_untilize_init_impl<block_ct_dim, full_ct_dim, false>(icb, ocb, call_line);
+    pack_untilize_detail::pack_untilize_init_impl<block_ct_dim, full_ct_dim, false>(icb, ocb, call_line);
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -271,7 +271,7 @@ ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb
 #endif
 }
 
-namespace detail {
+namespace fast_tilize_detail {
 
 template <bool configure_remap>
 ALWI void fast_tilize_init_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
@@ -301,18 +301,18 @@ ALWI void fast_tilize_init_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb, u
 #endif
 }
 
-}  // namespace detail
+}  // namespace fast_tilize_detail
 
 ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    detail::fast_tilize_init_impl<true>(icb, full_dim, ocb, call_line);
+    fast_tilize_detail::fast_tilize_init_impl<true>(icb, full_dim, ocb, call_line);
 }
 
 ALWI void fast_tilize_init_skip_remap(
     uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    detail::fast_tilize_init_impl<false>(icb, full_dim, ocb, call_line);
+    fast_tilize_detail::fast_tilize_init_impl<false>(icb, full_dim, ocb, call_line);
 }
 
-namespace detail {
+namespace fast_tilize_detail {
 
 template <bool configure_remap>
 ALWI void fast_tilize_init_with_dt_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
@@ -325,14 +325,14 @@ ALWI void fast_tilize_init_with_dt_impl(uint32_t icb, uint32_t full_dim, uint32_
     fast_tilize_init_impl<configure_remap>(icb, full_dim, ocb);
 }
 
-}  // namespace detail
+}  // namespace fast_tilize_detail
 
 ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
-    detail::fast_tilize_init_with_dt_impl<true>(icb, full_dim, ocb);
+    fast_tilize_detail::fast_tilize_init_with_dt_impl<true>(icb, full_dim, ocb);
 }
 
 ALWI void fast_tilize_init_with_dt_skip_remap(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
-    detail::fast_tilize_init_with_dt_impl<false>(icb, full_dim, ocb);
+    fast_tilize_detail::fast_tilize_init_with_dt_impl<false>(icb, full_dim, ocb);
 }
 
 ALWI void fast_tilize_uninit(uint32_t icb, uint32_t ocb, uint32_t full_dim) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -22,7 +22,7 @@
 #include "ckernel_sfpu_gelu.h"
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_gelu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_gelu(uint dst_index, VectorMode vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_gelu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }


### PR DESCRIPTION
## What changed
- Rename internal compute API helper namespaces under `ckernel` from `detail` to operation-specific names.
- Update the MoE GELU PACK-thread helper to take `VectorMode` instead of `int`.

## Why
The Galaxy MoE regression report showed `trisc0 build failed` in `moe_compute/device/kernels/compute.cpp` because `detail` became ambiguous. Kernel translation units import `ckernel` into the global namespace, so the newly introduced `ckernel::detail` from `pack_untilize.h` collided with MoE's existing global `::detail` namespace.

After fixing that ambiguity on current `main`, the MoE GELU helper also hit a separate recent LLK API change: `VectorMode` is now a scoped enum and the wrapper was still passing an `int`.

Report: https://github.com/tenstorrent/tt-metal/actions/runs/26349425733

## Testing
- `git diff --check origin/main...HEAD`
- Local `ttnn.generic_op` JIT compile harness for the ambiguous `detail` repro: `COMPILE_OK`
- Local `ttnn.generic_op` JIT compile harness including the real MoE `compute.cpp` path with GELU selected: `MOE_COMPUTE_COMPILE_OK`

I could not run the full Galaxy MoE e2e workflow locally because this machine has a single p100a rather than a Galaxy setup.

## CI
- Sanity tests: PASS - https://github.com/tenstorrent/tt-metal/actions/runs/26355445078
- Blackhole post-commit: FAIL - https://github.com/tenstorrent/tt-metal/actions/runs/26355248624
  - Failing job: `blackhole-multi-card-fast-unit-tests (BH-LLMBox) / blackhole BH-LLMBox ttnn ops fast unit tests (ccl, DRAM prefetcher)`
  - Failure: `test_all_to_all_combine_no_trace[...]` accuracy assertion in `test_all_to_all_combine_bh.py`; this is outside the MoE compile path fixed here.
- Narrow MoE coverage, `(Galaxy) Choose your pipeline` with `galaxy-e2e=galaxy-moe`: PASS - https://github.com/tenstorrent/tt-metal/actions/runs/26355664497
  - Job: `galaxy-e2e-tests / Galaxy MoE tests [wh_galaxy]`