### PR TITLE
[Feature] Dynamic shape options for Metal 2.0 TensorParameters

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/work_split.hpp>
 
 // This file contains shortcut helper functions to create minimal valid ProgramSpec
 // objects for unit tests. This cuts boilerplate in a unit testing context.
@@ -175,6 +176,30 @@ inline void BindTensorParameterToKernel(
         .tensor_parameter_name = tensor_parameter_name,
         .accessor_name = accessor_name,
     });
+}
+
+// Helper to create a height-sharded TensorParameter for tests that exercise the
+// sharded TAA CTA payload (rank/num_banks/tensor_shape/shard_shape/bank_coords).
+//
+// Defaults give a simple legal layout: BFLOAT16 tile-layout tensor of `logical_shape`,
+// sharded across the first `num_cores` cores of the worker grid with shard shape
+// `shard_shape`. Caller is responsible for choosing a shape that fits the grid.
+inline TensorParameter MakeShardedTensorParameter(
+    const std::string& name,
+    const tt::tt_metal::Shape& logical_shape,
+    const std::array<uint32_t, 2>& shard_shape,
+    uint32_t num_cores) {
+    auto shard_grid = tt::tt_metal::num_cores_to_corerangeset(num_cores, CoreCoord{num_cores, 1}, /*row_wise=*/true);
+    tt::tt_metal::ShardSpec shard_spec{
+        shard_grid, {shard_shape[0], shard_shape[1]}, tt::tt_metal::ShardOrientation::ROW_MAJOR};
+    tt::tt_metal::MemoryConfig memory_config{
+        tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED, tt::tt_metal::BufferType::L1, shard_spec};
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE);
+    auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+    return TensorParameter{
+        .unique_id = name,
+        .spec = tt::tt_metal::TensorSpec(logical_shape, std::move(tensor_layout)),
+    };
 }
 
 // Helper to create a minimal valid ProgramSpec for Gen1 (WH/BH): DM producer (RISCV_0) + compute consumer

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -56,6 +56,7 @@ using test_helpers::MakeMinimalGen1ValidProgramSpec;
 using test_helpers::MakeMinimalTensorParameter;
 using test_helpers::MakeMinimalValidProgramSpec;
 using test_helpers::MakeMinimalWorkUnit;
+using test_helpers::MakeShardedTensorParameter;
 using test_helpers::ScopedSlowDispatchOverride;
 
 // Shorthand for the per-node-override vararg type (needed at call sites because
@@ -1533,6 +1534,196 @@ TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTe
     EXPECT_EQ(
         ReadBindingAddressFromCRTA(program, "compute_kernel", "shared_tensor"),
         static_cast<uint32_t>(tensor2.address()));
+}
+
+// ============================================================================
+// SECTION: Dynamic Tensor Shape Run-Params Tests (Gen1 / WH)
+// ============================================================================
+// Exercises the dynamic_tensor_shape opt-in on TensorParameter:
+//   - validation: tensor_layout must still match exactly; logical_shape may vary per-dim
+//     but rank must be preserved.
+//   - CRTA contents: for sharded TPs, the runtime tensor's shape-in-pages is written into
+//     CRTAs immediately after the binding's address slot, on both SetProgramRunParameters
+//     and UpdateTensorArgs.
+
+TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_InterleavedAcceptsDifferentShape) {
+    // Declared shape {1, 32}; runtime tensor with shape {1, 64} is accepted because
+    // dynamic_tensor_shape is set and everything else matches.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
+    binding.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Different shape, same layout.
+    auto wrong_spec_layout = binding.spec.tensor_layout();
+    auto larger_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 64}, wrong_spec_layout);
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, larger_spec, TensorTopology{});
+
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
+TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_DTypeMismatchStillFails) {
+    // dynamic_tensor_shape loosens shape only — dtype (part of tensor_layout) must still match.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");  // BFLOAT16
+    binding.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Different dtype (UINT32 instead of BFLOAT16).
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto wrong_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::UINT32, page_config, memory_config);
+    auto wrong_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 32}, wrong_layout);
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec, TensorTopology{});
+
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("tensor_layout does not match the binding's declared layout")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_RankMismatchFails) {
+    // dynamic_tensor_shape lets per-dim shape values vary, but the rank must remain constant.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");  // rank-2 shape {1, 32}
+    binding.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Rank-3 tensor with same layout.
+    auto wrong_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 32}, binding.spec.tensor_layout());
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec, TensorTopology{});
+
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("logical_shape rank (3) differs from the declared rank (2)")));
+}
+
+// Read the runtime field CRTA words (immediately after the address slot) for a tensor binding.
+// Returns the [rank] shape words in declaration order.
+inline std::vector<uint32_t> ReadBindingShapeFromCRTA(
+    const Program& program, const KernelSpecName& kernel_name, const std::string& tensor_parameter_name) {
+    auto kernel = program.impl().get_kernel_by_spec_name(kernel_name);
+    for (const auto& handle : kernel->tensor_binding_handles()) {
+        if (handle.tensor_parameter_name == tensor_parameter_name) {
+            const uint32_t base_word = handle.addr_crta_offset / sizeof(uint32_t);
+            const auto* data = kernel->common_runtime_args_data().data();
+            std::vector<uint32_t> shape;
+            shape.reserve(handle.num_runtime_field_crta_words);
+            for (uint32_t i = 0; i < handle.num_runtime_field_crta_words; ++i) {
+                shape.push_back(data[base_word + 1u + i]);
+            }
+            return shape;
+        }
+    }
+    ADD_FAILURE() << "No binding handle for '" << tensor_parameter_name << "' on kernel '" << kernel_name << "'";
+    return {};
+}
+
+// Compute the expected tensor_shape_in_pages from a TensorSpec via its BufferDistributionSpec.
+// This is the source of truth for what gets written into the runtime field CRTA section.
+inline std::vector<uint32_t> ExpectedShapeInPagesFromSpec(const tt::tt_metal::TensorSpec& spec) {
+    const auto bds = spec.compute_buffer_sharding_args().buffer_distribution_spec();
+    if (!bds.has_value()) {
+        ADD_FAILURE() << "TensorSpec has no BufferDistributionSpec; expected sharded";
+        return {};
+    }
+    const auto& shape = bds->tensor_shape_in_pages();
+    std::vector<uint32_t> out;
+    out.reserve(shape.rank());
+    for (size_t i = 0; i < shape.rank(); ++i) {
+        out.push_back(static_cast<uint32_t>(shape[i]));
+    }
+    return out;
+}
+
+TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_ShardedSetWritesShapeIntoCRTAs) {
+    // Sharded + dynamic_tensor_shape: SetProgramRunParameters must write the actual runtime
+    // tensor's tensor_shape_in_pages into the CRTA section that follows the binding's address.
+    // Layout: HEIGHT_SHARDED with shard_shape {32, 32} on 2 cores → 2 shards along height.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding =
+        MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
+    binding.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, binding.spec, TensorTopology{});
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    SetProgramRunParameters(program, params);
+
+    // BDS flattens shape per its sharding scheme; derive expected value from BDS directly
+    // (source of truth — same path the runtime uses to populate the CRTA slots).
+    EXPECT_EQ(
+        ReadBindingShapeFromCRTA(program, "dm_kernel", "input_tensor"), ExpectedShapeInPagesFromSpec(binding.spec));
+}
+
+TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_ShardedUpdateRefreshesShape) {
+    // Sharded + dynamic_tensor_shape: UpdateTensorArgs must refresh BOTH the address slot and
+    // the runtime shape slots when bound to a tensor of different shape (but same layout).
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding =
+        MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
+    binding.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // First Set: tensor of declared shape (2 shards along height).
+    MeshTensor tensor1 = MeshTensor::allocate_on_device(*mesh_device_, binding.spec, TensorTopology{});
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor1)},
+    };
+    SetProgramRunParameters(program, params);
+    ASSERT_EQ(
+        ReadBindingShapeFromCRTA(program, "dm_kernel", "input_tensor"), ExpectedShapeInPagesFromSpec(binding.spec));
+
+    // Second Update: smaller-shape tensor (1 shard along height). Same shard_spec, fewer shards.
+    auto smaller_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 32, 32}, binding.spec.tensor_layout());
+    MeshTensor tensor2 = MeshTensor::allocate_on_device(*mesh_device_, smaller_spec, TensorTopology{});
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor2)},
+    };
+    EXPECT_NO_THROW(UpdateTensorArgs(program, tensor_args));
+
+    EXPECT_EQ(
+        ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor2.address()));
+    EXPECT_EQ(
+        ReadBindingShapeFromCRTA(program, "dm_kernel", "input_tensor"), ExpectedShapeInPagesFromSpec(smaller_spec));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -1833,6 +1833,39 @@ TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_DTypeMismatchStillFails) {
             ::testing::HasSubstr("tensor_layout does not match the binding's declared layout")));
 }
 
+TEST_F(ProgramRunParamsTestGen1, TensorBindingOnlyKernelMissingFromRunParamsFails) {
+    // A kernel with tensor bindings but an empty RTA/CRTA schema must still appear in
+    // kernel_run_params: SetProgramRunParameters fills the binding section CRTAs (base
+    // addresses, dynamic accessor fields) from the per-kernel entries, so omitting the
+    // kernel would leave its binding CRTAs uninitialized.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");
+    spec.tensor_parameters = {binding};
+    // Bind to dm_kernel (compute_kernel has no bindings). dm_kernel has no named RTAs/CRTAs
+    // and no varargs, so its RTA/CRTA schema is empty — the binding is the only thing forcing
+    // a kernel_run_params entry.
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Omit dm_kernel from kernel_run_params (only supply compute_kernel). Provide a tensor_arg
+    // so that ValidateTensorArgs passes; the failure should come from the kernel-completeness
+    // check on the binding-owning kernel.
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, binding.spec, TensorTopology{});
+    ProgramRunParams params;
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Kernel 'dm_kernel' is registered in the Program with a non-empty RTA/CRTA schema "
+                                 "but has no runtime parameters specified in ProgramRunParams")));
+}
+
 TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
     // When both match_padded_shape_only and dynamic_tensor_shape are set, dynamic is more
     // permissive and wins. A runtime tensor whose padded_shape differs from declared should

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -1726,5 +1726,138 @@ TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_ShardedUpdateRefreshesShape)
         ReadBindingShapeFromCRTA(program, "dm_kernel", "input_tensor"), ExpectedShapeInPagesFromSpec(smaller_spec));
 }
 
+// ============================================================================
+// SECTION: match_padded_shape_only Run-Params Tests (Gen1 / WH)
+// ============================================================================
+// Exercises the match_padded_shape_only opt-in on TensorParameter:
+//   - tensor_layout must still match exactly (dtype / page_config / memory_config / alignment).
+//   - padded_shape() must match exactly across binds.
+//   - logical_shape() may differ provided the resulting padded_shape is unchanged.
+//   - Strictly weaker than dynamic_tensor_shape; no device-side CTA/CRTA effect.
+
+TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_AcceptsDifferentLogicalShape) {
+    // Declared logical shape {1, 1, 32, 32} on TILE layout produces padded_shape {1, 1, 32, 32}.
+    // A runtime tensor with logical_shape {1, 1, 20, 20} pads up to the same {1, 1, 32, 32}, so
+    // match_padded_shape_only accepts the rebind.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+    auto declared_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 32, 32}, layout);
+    TensorParameter binding{
+        .unique_id = "input_tensor",
+        .spec = declared_spec,
+        .match_padded_shape_only = true,
+    };
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Runtime tensor: smaller logical shape that pads up to the same padded_shape (one tile).
+    auto runtime_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 20, 20}, layout);
+    ASSERT_EQ(runtime_spec.padded_shape(), declared_spec.padded_shape())
+        << "Test precondition: runtime logical {1,1,20,20} should pad to the same {1,1,32,32} as declared.";
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, runtime_spec, TensorTopology{});
+
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
+TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_PaddedShapeMismatchFails) {
+    // Same TensorLayout, but a logical shape that pads to a DIFFERENT padded_shape is rejected.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+    auto declared_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 32, 32}, layout);
+    TensorParameter binding{
+        .unique_id = "input_tensor",
+        .spec = declared_spec,
+        .match_padded_shape_only = true,
+    };
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Runtime tensor: logical shape that pads up to a DIFFERENT padded_shape (two tiles wide).
+    auto runtime_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 32, 33}, layout);
+    ASSERT_NE(runtime_spec.padded_shape(), declared_spec.padded_shape())
+        << "Test precondition: runtime logical {1,1,32,33} should pad to a different padded_shape than declared.";
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, runtime_spec, TensorTopology{});
+
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("padded_shape does not match the binding's declared padded_shape")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_DTypeMismatchStillFails) {
+    // match_padded_shape_only loosens only along logical_shape. tensor_layout fields (dtype here)
+    // must still match exactly.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");  // BFLOAT16
+    binding.match_padded_shape_only = true;
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto wrong_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::UINT32, page_config, memory_config);
+    auto wrong_spec = tt::tt_metal::TensorSpec(binding.spec.logical_shape(), wrong_layout);
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec, TensorTopology{});
+
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("tensor_layout does not match the binding's declared layout")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
+    // When both match_padded_shape_only and dynamic_tensor_shape are set, dynamic is more
+    // permissive and wins. A runtime tensor whose padded_shape differs from declared should
+    // be accepted (which match_padded_shape_only alone would reject).
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
+    binding.match_padded_shape_only = true;
+    binding.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Different logical shape; for ROW_MAJOR this also gives a different padded_shape, which
+    // dynamic accepts but padded_only alone would not.
+    auto wrong_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 64}, binding.spec.tensor_layout());
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec, TensorTopology{});
+
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3001,7 +3001,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcross
         auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
         TensorParameter tp{
             .unique_id = "input_tensor",
-            .spec = tt::tt_metal::TensorSpec(shape, std::move(tensor_layout)),
+            .spec = tt::tt_metal::TensorSpec(std::move(shape), std::move(tensor_layout)),
             .dynamic_tensor_shape = true,
         };
         spec.tensor_parameters = {tp};
@@ -3025,7 +3025,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedKernelHashStableAcrossShap
     // Layout: HEIGHT_SHARDED with shard_shape {32, 32} on 2 cores → 2 shards along height,
     // full width per shard. The declared (64, 32) tensor has 2 shards; the alternate (32, 32)
     // tensor needs only 1 shard (subset of the 2-core grid).
-    auto make_spec = [](tt::tt_metal::Shape shape, bool dynamic) {
+    auto make_spec = [](const tt::tt_metal::Shape& shape, bool dynamic) {
         ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
         auto tp = MakeShardedTensorParameter("input_tensor", shape, {32, 32}, /*num_cores=*/2);
         tp.dynamic_tensor_shape = dynamic;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -61,6 +61,7 @@ using test_helpers::MakeMinimalGen1ValidProgramSpec;
 using test_helpers::MakeMinimalTensorParameter;
 using test_helpers::MakeMinimalValidProgramSpec;
 using test_helpers::MakeMinimalWorkUnit;
+using test_helpers::MakeShardedTensorParameter;
 using test_helpers::ScopedSlowDispatchOverride;
 
 // ============================================================================
@@ -2971,6 +2972,128 @@ TEST_F(ProgramSpecTestGen1, IdenticalTensorSpecProducesIdenticalKernelHash) {
     auto hash_a = prog_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
     auto hash_b = prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
     EXPECT_EQ(hash_a, hash_b);
+}
+
+// ============================================================================
+// Dynamic tensor shape — spec resolution
+// ============================================================================
+//
+// dynamic_tensor_shape on a TensorParameter loosens the runtime spec match (covered in
+// test_program_run_params.cpp) and, for sharded TensorParameters, also moves the
+// tensor_shape_in_pages words out of the kernel's CTAs and into per-binding CRTA slots.
+// The tests below pin both halves:
+//   - CTA stability: same kernel hash across different shapes when the flag is set.
+//   - Handle layout: num_runtime_field_crta_words tracks the rank when needed.
+
+TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcrossShapes_TileLayout) {
+    // Interleaved + TILE layout: page_size is constant per dtype regardless of logical_shape, so
+    // the CTAs ([args_config.raw(), aligned_page_size]) are stable across shape variations.
+    // The dynamic flag thus enables JIT cache reuse for tile-layout eltwise.
+    //
+    // (Row-major interleaved has a shape-dependent page_size — the last-dim element count — so
+    // its CTAs do change with shape. That's a property of the page-size convention, not of the
+    // dynamic mechanism, and is a separate orthogonal concern. This test focuses on tile.)
+    auto make_spec = [](tt::tt_metal::Shape shape) {
+        ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+        auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE);
+        auto memory_config =
+            tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+        auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+        TensorParameter tp{
+            .unique_id = "input_tensor",
+            .spec = tt::tt_metal::TensorSpec(shape, std::move(tensor_layout)),
+            .dynamic_tensor_shape = true,
+        };
+        spec.tensor_parameters = {tp};
+        BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+        return spec;
+    };
+    Program prog_a = MakeProgramFromSpec(*mesh_device_, make_spec(tt::tt_metal::Shape{1, 1, 32, 32}));
+    Program prog_b = MakeProgramFromSpec(*mesh_device_, make_spec(tt::tt_metal::Shape{1, 1, 64, 64}));
+    EXPECT_EQ(
+        prog_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash(),
+        prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash())
+        << "Interleaved tile + dynamic_tensor_shape: shape variations must hash equal so the "
+           "same compiled kernel binary is reused.";
+}
+
+TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedKernelHashStableAcrossShapes) {
+    // Sharded TensorParameters DO encode tensor_shape_in_pages in CTAs by default — so without
+    // the dynamic flag, two different-shape sharded TPs hash differently. With the flag, the
+    // tensor_shape words move to CRTAs and the CTAs become stable across shape variations.
+    //
+    // Layout: HEIGHT_SHARDED with shard_shape {32, 32} on 2 cores → 2 shards along height,
+    // full width per shard. The declared (64, 32) tensor has 2 shards; the alternate (32, 32)
+    // tensor needs only 1 shard (subset of the 2-core grid).
+    auto make_spec = [](tt::tt_metal::Shape shape, bool dynamic) {
+        ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+        auto tp = MakeShardedTensorParameter("input_tensor", shape, {32, 32}, /*num_cores=*/2);
+        tp.dynamic_tensor_shape = dynamic;
+        spec.tensor_parameters = {tp};
+        BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+        return spec;
+    };
+
+    // Without the flag: differently-shaped sharded TPs hash differently (regression canary).
+    Program prog_static_a = MakeProgramFromSpec(*mesh_device_, make_spec(tt::tt_metal::Shape{1, 1, 64, 32}, false));
+    Program prog_static_b = MakeProgramFromSpec(*mesh_device_, make_spec(tt::tt_metal::Shape{1, 1, 32, 32}, false));
+    EXPECT_NE(
+        prog_static_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash(),
+        prog_static_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash())
+        << "Baseline: without dynamic_tensor_shape, different shapes should hash differently.";
+
+    // With the flag: same two shapes hash identically — CTAs are now stable.
+    Program prog_dyn_a = MakeProgramFromSpec(*mesh_device_, make_spec(tt::tt_metal::Shape{1, 1, 64, 32}, true));
+    Program prog_dyn_b = MakeProgramFromSpec(*mesh_device_, make_spec(tt::tt_metal::Shape{1, 1, 32, 32}, true));
+    EXPECT_EQ(
+        prog_dyn_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash(),
+        prog_dyn_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash())
+        << "Sharded + dynamic_tensor_shape: tensor_shape moves to CRTAs, so CTA-driven hash "
+           "must be stable across shape variations.";
+}
+
+TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedBindingTracksShapeCRTASlots) {
+    // Sharded + dynamic_tensor_shape: the TensorBindingHandle's num_runtime_field_crta_words
+    // should equal the BufferDistributionSpec's tensor_shape_in_pages rank (one CRTA word per
+    // shape dim, written at enqueue).
+    //
+    // Note: BDS flattens the logical_shape via its sharding scheme, so the BDS rank is not
+    // generally the same as logical_shape.rank(). We derive the expected value from the BDS
+    // directly to be robust against BDS-internal flattening conventions.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto tp = MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, 2);
+    tp.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {tp};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
+    const auto& handles = kernel->tensor_binding_handles();
+    ASSERT_EQ(handles.size(), 1u);
+
+    const auto bds = tp.spec.compute_buffer_sharding_args().buffer_distribution_spec();
+    ASSERT_TRUE(bds.has_value());
+    const auto expected_rank = bds->tensor_shape_in_pages().rank();
+    EXPECT_GT(expected_rank, 0u);
+    EXPECT_EQ(handles[0].num_runtime_field_crta_words, static_cast<uint32_t>(expected_rank))
+        << "Sharded + dynamic_tensor_shape: runtime-field CRTA words should equal BDS shape rank.";
+}
+
+TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedBindingHasNoRuntimeFieldCRTAs) {
+    // Interleaved + dynamic_tensor_shape: pure host-side validation loosening, no CTA→CRTA
+    // demotion, so num_runtime_field_crta_words should remain zero.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto tp = MakeMinimalTensorParameter("input_tensor");
+    tp.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {tp};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
+    const auto& handles = kernel->tensor_binding_handles();
+    ASSERT_EQ(handles.size(), 1u);
+    EXPECT_EQ(handles[0].num_runtime_field_crta_words, 0u)
+        << "Interleaved dynamic_tensor_shape is host-side-only; no runtime CRTA words.";
 }
 
 TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3096,6 +3096,65 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedBindingHasNoRuntimeFie
         << "Interleaved dynamic_tensor_shape is host-side-only; no runtime CRTA words.";
 }
 
+TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {
+    // The Kernel's stored KernelCrtaLayout must equal what a fresh walk of (named CRTAs +
+    // binding handles) would compute. This test exercises a Program in which ALL THREE
+    // sections of the CRTA buffer are non-empty:
+    //   - section 1: named CRTAs           (declared in runtime_arguments_schema)
+    //   - section 2: TensorBinding section (variable-size: a plain interleaved binding +
+    //                                       a sharded-with-dynamic_tensor_shape binding)
+    //   - section 3: varargs               (declared via num_common_runtime_varargs)
+    //
+    // The headergen bakes vararg_section_offset into the kernel's `get_common_vararg(idx)`
+    // macro, so a wrong offset here would silently route vararg reads into the binding
+    // section. The walk-based reference value is exactly what genfiles used to compute on
+    // its own; the refactor moves that computation into ResolveTensorBindingsForKernel and
+    // threads it through. This test guards against the threading silently producing a
+    // different value than the walk would.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    // Section 1: named CRTAs on the DM kernel.
+    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"foo", "bar"};
+    // Section 3: vararg CRTAs on the DM kernel.
+    spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = 3;
+
+    // Section 2: two bindings — one plain (1 word), one sharded+dynamic_tensor_shape
+    // (1 word + tensor_shape_in_pages rank words).
+    auto plain_tp = MakeMinimalTensorParameter("plain_tensor");
+    auto dyn_tp =
+        MakeShardedTensorParameter("dyn_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
+    dyn_tp.dynamic_tensor_shape = true;
+    spec.tensor_parameters = {plain_tp, dyn_tp};
+    BindTensorParameterToKernel(spec.kernels[0], "plain_tensor", "plain_ta");
+    BindTensorParameterToKernel(spec.kernels[0], "dyn_tensor", "dyn_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
+    const KernelCrtaLayout layout = kernel->get_crta_layout();
+
+    // Reference values, re-derived independently of the layout struct.
+    const uint32_t expected_named_words = 2u;  // "foo", "bar"
+    uint32_t expected_binding_words = 0;
+    for (const auto& handle : kernel->tensor_binding_handles()) {
+        expected_binding_words += 1u + handle.num_runtime_field_crta_words;
+    }
+    const uint32_t expected_vararg_offset = expected_named_words + expected_binding_words;
+
+    EXPECT_EQ(layout.num_named_words, expected_named_words);
+    EXPECT_EQ(layout.binding_section_words, expected_binding_words);
+    EXPECT_EQ(layout.vararg_section_offset, expected_vararg_offset)
+        << "vararg_section_offset must equal num_named_words + binding_section_words; this is the "
+           "value baked into get_common_vararg(idx) by the kernel headergen.";
+
+    // Sanity: the dynamic-shape binding's runtime-field word count should be > 0, so this test
+    // genuinely exercises a variable-size binding (not just two 1-word bindings that would also
+    // pass with the old binding-count-based math).
+    ASSERT_EQ(kernel->tensor_binding_handles().size(), 2u);
+    EXPECT_GT(kernel->tensor_binding_handles()[1].num_runtime_field_crta_words, 0u)
+        << "Test precondition: the second binding should be variable-size; otherwise the layout "
+           "calculation degenerates to the pre-refactor case.";
+}
+
 TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
     // KernelSpec.compiler_options.include_paths should be picked up as `-I<path>` flags
     NodeCoord node{0, 0};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -27,6 +27,37 @@ struct TensorParameter {
 
     // Single-device tensor layout
     tt::tt_metal::TensorSpec spec;
+
+    // Dynamic-shape opt-in (ADVANCED).
+    //
+    // By default, a TensorParameter declares an EXACT tensor layout. The MeshTensor
+    // bound at execution time must match `spec` exactly: same logical shape, dtype,
+    // page config, memory config, alignment.
+    //
+    // Setting `dynamic_tensor_shape = true` loosens that match along exactly one
+    // axis: the bound tensor's `logical_shape()` may differ from `spec.logical_shape()`.
+    // Everything else (dtype, page config, memory config including any shard_spec,
+    // alignment) must still match exactly.
+    //
+    // Use case: kernels whose code is genuinely shape-agnostic (e.g., eltwise). The
+    // same compiled kernel can then be bound to tensors of varying shape without
+    // forcing a JIT recompile per shape.
+    //
+    // Mechanics by buffer type:
+    //  - Interleaved: zero device-side change. The accessor's compile-time payload
+    //    never depended on logical shape; this is purely a host-side validation
+    //    loosening so a different-shape tensor can be bound.
+    //  - Sharded: the `tensor_shape_in_pages` words move from compile-time args to
+    //    common runtime args. The CTA payload becomes stable across shape variations
+    //    (so the JIT cache hits across shapes), and the actual tensor's shape is
+    //    written into CRTAs at enqueue time. The shard_spec (grid + shard_shape)
+    //    is part of the layout match and so is fixed across binds; only logical_shape
+    //    varies, and the bound tensor must still fit on the same shard grid.
+    //
+    // Default to false. The JIT compiler gets strictly more information with a
+    // fixed shape; enable this only for kernels that genuinely don't care about
+    // tensor shape at compile time.
+    bool dynamic_tensor_shape = false;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -36,8 +36,9 @@ struct TensorParameter {
     // EXACTLY match the TensorParameter's declared TensorSpec. The advanced
     // options below relax this match requirement in particular ways.
     //
-    // NOTE: These options are all default-unsafe; most kernels will NOT function
+    // NOTE: These options are UNSAFE if set to true; most kernels will not function
     // correctly if the tensor argument's spec deviates from the declared spec.
+    // Use with caution and ensure that your kernel logic is compatible.
 
     // Permit tensor arguments whose logical_shape differs from the declared shape.
     // The argument's padded_shape must still match exactly.
@@ -54,6 +55,8 @@ struct TensorParameter {
     //  - For a sharded tensor, the TensorAccessor configuration dynamically reflects the
     //    argument's actual shape. (Shape becomes an implicit runtime argument.)
     bool dynamic_tensor_shape = false;
+
+    // Additional relaxation options will be added in the future.
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -28,35 +28,31 @@ struct TensorParameter {
     // Single-device tensor layout
     tt::tt_metal::TensorSpec spec;
 
-    // Dynamic-shape opt-in (ADVANCED).
+    ///////////////////////////////////////////////////////////////////
+    // Advanced options
+    ///////////////////////////////////////////////////////////////////
+
+    // By default, the MeshTensor argument provided at execution time must
+    // EXACTLY match the TensorParameter's declared TensorSpec. The advanced
+    // options below relax this match requirement in particular ways.
     //
-    // By default, a TensorParameter declares an EXACT tensor layout. The MeshTensor
-    // bound at execution time must match `spec` exactly: same logical shape, dtype,
-    // page config, memory config, alignment.
-    //
-    // Setting `dynamic_tensor_shape = true` loosens that match along exactly one
-    // axis: the bound tensor's `logical_shape()` may differ from `spec.logical_shape()`.
-    // Everything else (dtype, page config, memory config including any shard_spec,
-    // alignment) must still match exactly.
-    //
-    // Use case: kernels whose code is genuinely shape-agnostic (e.g., eltwise). The
-    // same compiled kernel can then be bound to tensors of varying shape without
-    // forcing a JIT recompile per shape.
-    //
-    // Mechanics by buffer type:
-    //  - Interleaved: zero device-side change. The accessor's compile-time payload
-    //    never depended on logical shape; this is purely a host-side validation
-    //    loosening so a different-shape tensor can be bound.
-    //  - Sharded: the `tensor_shape_in_pages` words move from compile-time args to
-    //    common runtime args. The CTA payload becomes stable across shape variations
-    //    (so the JIT cache hits across shapes), and the actual tensor's shape is
-    //    written into CRTAs at enqueue time. The shard_spec (grid + shard_shape)
-    //    is part of the layout match and so is fixed across binds; only logical_shape
-    //    varies, and the bound tensor must still fit on the same shard grid.
-    //
-    // Default to false. The JIT compiler gets strictly more information with a
-    // fixed shape; enable this only for kernels that genuinely don't care about
-    // tensor shape at compile time.
+    // NOTE: These options are all default-unsafe; most kernels will NOT function
+    // correctly if the tensor argument's spec deviates from the declared spec.
+
+    // Permit tensor arguments whose logical_shape differs from the declared shape.
+    // The argument's padded_shape must still match exactly.
+    // Effects:
+    //  - Validation checks are relaxed
+    //  - TensorAccessor configuration is completely unchanged
+    bool match_padded_shape_only = false;
+
+    // Permit tensor arguments with dynamic logical shape.
+    // The argument's logical_shape AND padded_shape may differ from the declared shape.
+    // Effects:
+    //  - Validation checks are relaxed
+    //  - For an interleaved tensor, TensorAccessor configuration is unchanged
+    //  - For a sharded tensor, the TensorAccessor configuration dynamically reflects the
+    //    argument's actual shape. (Shape becomes an implicit runtime argument.)
     bool dynamic_tensor_shape = false;
 };
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -99,7 +99,15 @@ public:
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
-            static_cast<size_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {}
+            static_cast<size_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
+        // ADDR_CRTA_OFFSET is the byte offset of the binding's base-address word. Host codegen
+        // produces it as `crta_word_index * sizeof(uint32_t)`, so it is word-aligned by
+        // construction. The conversions to a CRTA word index (`/sizeof(uint32_t)`) silently
+        // truncate otherwise — catch any future codegen change that violates the invariant.
+        static_assert(
+            ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0,
+            "TensorAccessorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
+    }
 
     constexpr const auto& dspec() const {
         if constexpr (DSpec::is_static) {
@@ -371,12 +379,17 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
         aligned_page_size(page_size_in) {}
 
     // Construct TensorAccessor directly from a Metal 2.0 binding token.
-    // See the sharded specialization for the binding's CRTA section layout.
+    // See the sharded specialization for the binding's CRTA section layout and the
+    // alignment rationale.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
-            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {}
+            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
+        static_assert(
+            ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0,
+            "TensorAccessorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
+    }
 
     template <typename DSpec_ = DSpec, std::enable_if_t<std::is_same_v<std::decay_t<DSpec_>, DSpec>, int> = 0>
     constexpr explicit TensorAccessor(

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -90,10 +90,15 @@ public:
     // The token instance is emitted by host codegen into kernel_bindings_generated.h,
     // based on the information in the user's host code (ProgramSpec).
     // Delegates to the legacy TensorAccessorArgs ctor.
+    //
+    // The binding's CRTA section is laid out as: [base_address_word, optional runtime
+    // accessor fields...]. The runtime accessor fields (used when the TensorParameter
+    // opts into a dynamic field like dynamic_tensor_shape) start at the word immediately
+    // following the address slot, so the TAA's CRTA_OFFSET is ADDR_CRTA_OFFSET/sizeof(u32)+1.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
-            TensorAccessorArgs<CTA_OFFSET>{},
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
             static_cast<size_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {}
 
     constexpr const auto& dspec() const {
@@ -366,13 +371,11 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
         aligned_page_size(page_size_in) {}
 
     // Construct TensorAccessor directly from a Metal 2.0 binding token.
-    // The token instance is emitted by host codegen into kernel_bindings_generated.h,
-    // based on the information in the user's host code (ProgramSpec).
-    // Delegates to the legacy TensorAccessorArgs ctor.
+    // See the sharded specialization for the binding's CRTA section layout.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
-            TensorAccessorArgs<CTA_OFFSET>{},
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
             static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {}
 
     template <typename DSpec_ = DSpec, std::enable_if_t<std::is_same_v<std::decay_t<DSpec_>, DSpec>, int> = 0>
@@ -483,33 +486,31 @@ TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t)
         /* IsDram */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_dram>>;
 
 // CTAD deduction guide for the Metal 2.0 binding-token ctor.
-// Mirrors the (args, size_t) guide above, using TensorAccessorArgs<CTA_OFFSET> as the static
-// layout source. So, the same DSpec (and same specialization) is selected.
-// NOTE: Currently Metal 2.0 tensor bindings only support CTA TensorAccessorArgs.
-//       This anticipates dynamic support (coming soon) and also maintains symmetry with the
-//       legacy API's deduction guide above.
+// Mirrors the (args, size_t) guide above. The token's ADDR_CRTA_OFFSET marks the
+// binding's base-address slot; any runtime accessor fields start at the next word,
+// so the TAA's CRTA_OFFSET is ADDR_CRTA_OFFSET/sizeof(u32)+1.
 template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
 TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>)
     -> TensorAccessor<tensor_accessor::DistributionSpec<
-        /* RankCT */ TensorAccessorArgs<CTA_OFFSET>::RankCT,
-        /* NumBanksCT */ TensorAccessorArgs<CTA_OFFSET>::NumBanksCT,
+        /* RankCT */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::RankCT,
+        /* NumBanksCT */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::NumBanksCT,
         /* TensorShapeWrapper */
         typename tensor_accessor::ArrayWrapperTypeSelectorU32<
-            !TensorAccessorArgs<CTA_OFFSET>::tensor_shape_is_crta,
-            TensorAccessorArgs<CTA_OFFSET>::TensorShapeCTAOffset,
-            TensorAccessorArgs<CTA_OFFSET>::RankCT>::type,
+            !TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::tensor_shape_is_crta,
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::TensorShapeCTAOffset,
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::RankCT>::type,
         /* ShardShapeWrapper */
         typename tensor_accessor::ArrayWrapperTypeSelectorU32<
-            !TensorAccessorArgs<CTA_OFFSET>::shard_shape_is_crta,
-            TensorAccessorArgs<CTA_OFFSET>::ShardShapeCTAOffset,
-            TensorAccessorArgs<CTA_OFFSET>::RankCT>::type,
+            !TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::shard_shape_is_crta,
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::ShardShapeCTAOffset,
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::RankCT>::type,
         /* BankCoordsWrapper */
         typename tensor_accessor::ArrayWrapperTypeSelectorPackedU16<
-            !TensorAccessorArgs<CTA_OFFSET>::bank_coords_is_crta,
-            TensorAccessorArgs<CTA_OFFSET>::BankCoordsCTAOffset,
-            TensorAccessorArgs<CTA_OFFSET>::NumBanksCT>::type,
-        /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET>::is_sharded,
-        /* IsDram */ TensorAccessorArgs<CTA_OFFSET>::is_dram>>;
+            !TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::bank_coords_is_crta,
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::BankCoordsCTAOffset,
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::NumBanksCT>::type,
+        /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_sharded,
+        /* IsDram */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_dram>>;
 
 template <std::size_t CTA_OFFSET, std::size_t CRTA_OFFSET>
 TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t, uint32_t)

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -317,11 +317,13 @@ void Kernel::process_semaphore_local_accessor_handles(
     }
 }
 
-void Kernel::process_tensor_binding_handles(
-    const std::function<void(const std::string& accessor_name, uint32_t cta_offset, uint32_t addr_crta_offset)>
-        callback) const {
+void Kernel::process_tensor_binding_handles(const std::function<void(
+                                                const std::string& accessor_name,
+                                                uint32_t cta_offset,
+                                                uint32_t addr_crta_offset,
+                                                uint32_t num_runtime_field_crta_words)> callback) const {
     for (const auto& handle : this->tensor_binding_handles_) {
-        callback(handle.accessor_name, handle.cta_offset, handle.addr_crta_offset);
+        callback(handle.accessor_name, handle.cta_offset, handle.addr_crta_offset, handle.num_runtime_field_crta_words);
     }
 }
 
@@ -523,6 +525,7 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(handle.accessor_name);
         hasher.update(static_cast<uint64_t>(handle.cta_offset));
         hasher.update(static_cast<uint64_t>(handle.addr_crta_offset));
+        hasher.update(static_cast<uint64_t>(handle.num_runtime_field_crta_words));
     }
     // Named RTA/CRTA schema: order matters (determines byte offsets), so hash the sequence.
     // Named RTA and CRTA counts also need to be hashed!

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -132,7 +132,8 @@ Kernel::Kernel(
     const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles,
     const std::vector<std::string>& named_runtime_args,
     const std::vector<std::string>& named_common_runtime_args,
-    const std::vector<TensorBindingHandle>& tensor_binding_handles) :
+    const std::vector<TensorBindingHandle>& tensor_binding_handles,
+    const KernelCrtaLayout& crta_layout) :
     programmable_core_type_(programmable_core_type),
     processor_class_(processor_class),
     kernel_src_(kernel_src),
@@ -145,6 +146,7 @@ Kernel::Kernel(
     named_runtime_args_(named_runtime_args),
     named_common_runtime_args_(named_common_runtime_args),
     tensor_binding_handles_(tensor_binding_handles),
+    crta_layout_(crta_layout),
 
     core_with_max_runtime_args_({0, 0}),
     defines_(defines),

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -98,13 +98,19 @@ using SemaphoreLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t
 // Metal 2.0: per-kernel resolved TensorBinding.
 // Carries the offsets the kernel-side codegen needs to emit a token, plus the program-level
 // TensorParameter name so SetProgramRunParameters can fill the binding's base-address slot
-// from the corresponding TensorArg at enqueue time.
+// (and any runtime accessor fields) from the corresponding TensorArg at enqueue time.
 struct TensorBindingHandle {
     std::string accessor_name;          // user-facing identifier (kernel symbol in `ta::`)
     std::string tensor_parameter_name;  // refers back to the program-level TensorParameter
     uint32_t cta_offset;                // first word index of this binding's payload in the kernel's compile-time args
     uint32_t addr_crta_offset;  // byte offset of this binding's base-address slot within the kernel's CRTA buffer
                                 // (binding addresses live in their own section appended after user-named CRTAs)
+    // Count of runtime accessor field words that immediately follow the address slot
+    // in this binding's CRTA section. Non-zero only when the TensorParameter has
+    // dynamic_tensor_shape=true and is sharded: the runtime tensor's shape-in-pages
+    // is written here at enqueue time. The first runtime field word lives at byte
+    // offset addr_crta_offset + sizeof(uint32_t).
+    uint32_t num_runtime_field_crta_words = 0;
 };
 
 class Kernel : public JitBuildSettings {
@@ -167,9 +173,11 @@ public:
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const override;
     void process_semaphore_local_accessor_handles(
         std::function<void(const std::string& accessor_name, uint16_t semaphore_id)>) const override;
-    void process_tensor_binding_handles(
-        std::function<void(const std::string& accessor_name, uint32_t cta_offset, uint32_t addr_crta_offset)>)
-        const override;
+    void process_tensor_binding_handles(std::function<void(
+                                            const std::string& accessor_name,
+                                            uint32_t cta_offset,
+                                            uint32_t addr_crta_offset,
+                                            uint32_t num_runtime_field_crta_words)>) const override;
     const std::vector<TensorBindingHandle>& tensor_binding_handles() const { return tensor_binding_handles_; }
     const std::vector<std::string>& get_named_runtime_args() const override { return named_runtime_args_; }
     const std::vector<std::string>& get_named_common_runtime_args() const override {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -104,7 +104,6 @@ struct TensorBindingHandle {
     std::string tensor_parameter_name;  // refers back to the program-level TensorParameter
     uint32_t cta_offset;                // first word index of this binding's payload in the kernel's compile-time args
     uint32_t addr_crta_offset;  // byte offset of this binding's base-address slot within the kernel's CRTA buffer
-                                // (binding addresses live in their own section appended after user-named CRTAs)
     // Count of runtime accessor field words that immediately follow the address slot
     // in this binding's CRTA section. Non-zero only when the TensorParameter has
     // dynamic_tensor_shape=true and is sharded: the runtime tensor's shape-in-pages
@@ -183,6 +182,7 @@ public:
     const std::vector<std::string>& get_named_common_runtime_args() const override {
         return named_common_runtime_args_;
     }
+    KernelCrtaLayout get_crta_layout() const override { return crta_layout_; }
     bool is_metal2_kernel() const override { return is_metal2_kernel_; }
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
@@ -247,7 +247,8 @@ protected:
         const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {},
-        const std::vector<TensorBindingHandle>& tensor_binding_handles = {});
+        const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
+        const KernelCrtaLayout& crta_layout = {});
 
     HalProgrammableCoreType programmable_core_type_;
     HalProcessorClassType processor_class_;
@@ -267,6 +268,7 @@ protected:
     const std::vector<std::string> named_runtime_args_;
     const std::vector<std::string> named_common_runtime_args_;
     const std::vector<TensorBindingHandle> tensor_binding_handles_;
+    const KernelCrtaLayout crta_layout_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};
@@ -314,7 +316,8 @@ public:
         const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {},
-        const std::vector<TensorBindingHandle>& tensor_binding_handles = {}) :
+        const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
@@ -328,7 +331,8 @@ public:
             semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args,
-            tensor_binding_handles),
+            tensor_binding_handles,
+            crta_layout),
         config_(config) {
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
@@ -449,7 +453,8 @@ public:
         const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {},
-        const std::vector<TensorBindingHandle>& tensor_binding_handles = {}) :
+        const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
@@ -463,7 +468,8 @@ public:
             semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args,
-            tensor_binding_handles),
+            tensor_binding_handles,
+            crta_layout),
         config_(config) {
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
@@ -533,7 +539,8 @@ public:
         const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {},
-        const std::vector<TensorBindingHandle>& tensor_binding_handles = {}) :
+        const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
@@ -547,7 +554,8 @@ public:
             semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args,
-            tensor_binding_handles),
+            tensor_binding_handles,
+            crta_layout),
         config_(config),
         dm_processors_(dm_processors.begin(), dm_processors.end()) {
         TT_FATAL(
@@ -603,7 +611,8 @@ public:
         const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {},
-        const std::vector<TensorBindingHandle>& tensor_binding_handles = {}) :
+        const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
@@ -617,7 +626,8 @@ public:
             semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args,
-            tensor_binding_handles),
+            tensor_binding_handles,
+            crta_layout),
         config_(config),
         compute_processors_(compute_processors.begin(), compute_processors.end()) {
         TT_FATAL(

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -28,12 +28,16 @@ using KernelRTASchema = detail::ProgramImpl::KernelRTASchema;
 // Shared by SetProgramRunParameters (full path) and UpdateTensorArgs (partial path).
 //   - No duplicate tensor_parameter_name entries
 //   - Every entry references a TensorParameter declared in the ProgramSpec
-//   - The supplied MeshTensor's TensorSpec matches the binding's expected TensorSpec
-//       - When the TensorParameter has dynamic_tensor_shape=false (default): full equality.
-//       - When the TensorParameter has dynamic_tensor_shape=true: tensor_layout() must match
-//         exactly (dtype, page_config, memory_config, alignment), and the logical_shape rank
-//         must match. The per-dim values of logical_shape may differ. See the field's doc
-//         comment in tensor_parameter.hpp for the contract.
+//   - The supplied MeshTensor's TensorSpec matches the binding's expected TensorSpec, with the
+//     match relaxed according to the TensorParameter's loosening flags. The three cases form a
+//     lattice from strictest to loosest (dynamic_tensor_shape strictly subsumes
+//     match_padded_shape_only; when both are set, dynamic wins):
+//       - Neither flag set (default): full TensorSpec equality.
+//       - match_padded_shape_only=true (only): tensor_layout() must match exactly, and
+//         padded_shape() must match exactly. logical_shape() may differ.
+//       - dynamic_tensor_shape=true: tensor_layout() must match exactly, and the logical_shape
+//         rank must match. Both logical_shape and padded_shape per-dim values may differ.
+//     See the field doc comments in tensor_parameter.hpp for the full contracts.
 //   - Every declared TensorParameter must be set
 void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args) {
     const detail::ProgramImpl& program_impl = program.impl();
@@ -53,16 +57,12 @@ void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams
         const TensorSpec& runtime_spec = tensor_params.tensor.get().tensor_spec();
         const bool dyn_shape =
             program_impl.get_tensor_parameter_dynamic_tensor_shape(tensor_params.tensor_parameter_name);
-        if (!dyn_shape) {
-            TT_FATAL(
-                runtime_spec == *expected_spec,
-                "TensorArg for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
-                "declared spec. The binding declaration in ProgramSpec is the single source of truth for layout; "
-                "the supplied tensor must conform to it.",
-                tensor_params.tensor_parameter_name);
-        } else {
+        const bool padded_only =
+            program_impl.get_tensor_parameter_match_padded_shape_only(tensor_params.tensor_parameter_name);
+        if (dyn_shape) {
             // dynamic_tensor_shape: tensor_layout must match exactly; logical_shape may differ in
-            // per-dim values, but rank must still match.
+            // per-dim values, but rank must still match. (Wins over match_padded_shape_only if both
+            // are set: dynamic is strictly more permissive.)
             TT_FATAL(
                 runtime_spec.tensor_layout() == expected_spec->tensor_layout(),
                 "TensorArg for binding '{}' supplied a MeshTensor whose tensor_layout does not match the binding's "
@@ -77,6 +77,31 @@ void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams
                 tensor_params.tensor_parameter_name,
                 runtime_spec.logical_shape().rank(),
                 expected_spec->logical_shape().rank());
+        } else if (padded_only) {
+            // match_padded_shape_only: tensor_layout must match exactly, and padded_shape must
+            // match exactly. logical_shape may differ provided it produces the same padded_shape.
+            // Purely a host-side validation loosening: the accessor's CTAs/CRTAs are unchanged
+            // (tensor_shape_in_pages is derived from padded_shape, which is fixed across binds).
+            TT_FATAL(
+                runtime_spec.tensor_layout() == expected_spec->tensor_layout(),
+                "TensorArg for binding '{}' supplied a MeshTensor whose tensor_layout does not match the binding's "
+                "declared layout. match_padded_shape_only loosens the match only along logical_shape (within the "
+                "constraint that padded_shape is preserved); dtype, page_config, memory_config, and alignment must "
+                "still match exactly.",
+                tensor_params.tensor_parameter_name);
+            TT_FATAL(
+                runtime_spec.padded_shape() == expected_spec->padded_shape(),
+                "TensorArg for binding '{}' supplied a MeshTensor whose padded_shape does not match the binding's "
+                "declared padded_shape. match_padded_shape_only requires padded_shape to be preserved across binds; "
+                "use dynamic_tensor_shape if you need padded_shape to vary as well.",
+                tensor_params.tensor_parameter_name);
+        } else {
+            TT_FATAL(
+                runtime_spec == *expected_spec,
+                "TensorArg for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
+                "declared spec. The binding declaration in ProgramSpec is the single source of truth for layout; "
+                "the supplied tensor must conform to it.",
+                tensor_params.tensor_parameter_name);
         }
     }
     for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -28,9 +28,12 @@ using KernelRTASchema = detail::ProgramImpl::KernelRTASchema;
 // Shared by SetProgramRunParameters (full path) and UpdateTensorArgs (partial path).
 //   - No duplicate tensor_parameter_name entries
 //   - Every entry references a TensorParameter declared in the ProgramSpec
-//   - The supplied MeshTensor's TensorSpec equals the binding's expected TensorSpec
-//     (full equality is required, for now. This will be loosened to layout-compatible-modulo-shape
-//     in a follow-up PR that adds RuntimeTensorShape as a mutable parameter).
+//   - The supplied MeshTensor's TensorSpec matches the binding's expected TensorSpec
+//       - When the TensorParameter has dynamic_tensor_shape=false (default): full equality.
+//       - When the TensorParameter has dynamic_tensor_shape=true: tensor_layout() must match
+//         exactly (dtype, page_config, memory_config, alignment), and the logical_shape rank
+//         must match. The per-dim values of logical_shape may differ. See the field's doc
+//         comment in tensor_parameter.hpp for the contract.
 //   - Every declared TensorParameter must be set
 void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args) {
     const detail::ProgramImpl& program_impl = program.impl();
@@ -48,12 +51,33 @@ void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams
             "TensorArg references unknown TensorParameter '{}'.",
             tensor_params.tensor_parameter_name);
         const TensorSpec& runtime_spec = tensor_params.tensor.get().tensor_spec();
-        TT_FATAL(
-            runtime_spec == *expected_spec,
-            "TensorArg for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
-            "declared spec. The binding declaration in ProgramSpec is the single source of truth for layout; the "
-            "supplied tensor must conform to it.",
-            tensor_params.tensor_parameter_name);
+        const bool dyn_shape =
+            program_impl.get_tensor_parameter_dynamic_tensor_shape(tensor_params.tensor_parameter_name);
+        if (!dyn_shape) {
+            TT_FATAL(
+                runtime_spec == *expected_spec,
+                "TensorArg for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
+                "declared spec. The binding declaration in ProgramSpec is the single source of truth for layout; "
+                "the supplied tensor must conform to it.",
+                tensor_params.tensor_parameter_name);
+        } else {
+            // dynamic_tensor_shape: tensor_layout must match exactly; logical_shape may differ in
+            // per-dim values, but rank must still match.
+            TT_FATAL(
+                runtime_spec.tensor_layout() == expected_spec->tensor_layout(),
+                "TensorArg for binding '{}' supplied a MeshTensor whose tensor_layout does not match the binding's "
+                "declared layout. dynamic_tensor_shape loosens the match only along logical_shape; dtype, "
+                "page_config, memory_config, and alignment must still match exactly.",
+                tensor_params.tensor_parameter_name);
+            TT_FATAL(
+                runtime_spec.logical_shape().rank() == expected_spec->logical_shape().rank(),
+                "TensorArg for binding '{}' supplied a MeshTensor whose logical_shape rank ({}) differs from the "
+                "declared rank ({}). dynamic_tensor_shape lets the per-dim shape values vary, but the rank must "
+                "remain constant.",
+                tensor_params.tensor_parameter_name,
+                runtime_spec.logical_shape().rank(),
+                expected_spec->logical_shape().rank());
+        }
     }
     for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {
         TT_FATAL(
@@ -254,6 +278,60 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
     ValidateTensorArgs(program, params.tensor_args);
 }
 
+// Compute the CRTA values for a single tensor binding:
+//   [base_address_word, optional runtime_field_words...]
+// Total length = 1 + handle.num_runtime_field_crta_words.
+//
+// The base address always lives in CRTAs (per-enqueue, since the bound MeshTensor's
+// address can change between binds). Additional runtime field words appear immediately
+// after, when the TensorParameter opts into a dynamic accessor field. Currently the
+// only such field is tensor_shape_in_pages, for sharded TensorParameters with
+// dynamic_tensor_shape=true; in that case there are `rank` shape words.
+std::vector<uint32_t> ComputeBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& tensor) {
+    std::vector<uint32_t> values;
+    values.reserve(1u + handle.num_runtime_field_crta_words);
+
+    const auto address = tensor.address();
+    TT_FATAL(
+        address <= std::numeric_limits<uint32_t>::max(),
+        "TensorParameter '{}' base address {} exceeds uint32_t max",
+        handle.tensor_parameter_name,
+        address);
+    values.push_back(static_cast<uint32_t>(address));
+
+    if (handle.num_runtime_field_crta_words > 0) {
+        // Currently the only runtime accessor field that lives in CRTAs is tensor_shape_in_pages
+        // (sharded TensorParameter with dynamic_tensor_shape=true). Read it from the bound
+        // MeshTensor's buffer.
+        const tt::tt_metal::Buffer* buffer = tensor.mesh_buffer().get_reference_buffer();
+        TT_FATAL(
+            buffer != nullptr,
+            "Tensor binding '{}' has runtime accessor field CRTA words but no backing Buffer to "
+            "source them from.",
+            handle.tensor_parameter_name);
+        const auto& bds_opt = buffer->buffer_distribution_spec();
+        TT_FATAL(
+            bds_opt.has_value(),
+            "Tensor binding '{}' has runtime accessor field CRTA words but its bound MeshTensor's "
+            "buffer has no BufferDistributionSpec. dynamic_tensor_shape currently requires a sharded "
+            "TensorParameter.",
+            handle.tensor_parameter_name);
+        const auto& tensor_shape = bds_opt->tensor_shape_in_pages();
+        TT_FATAL(
+            tensor_shape.rank() == handle.num_runtime_field_crta_words,
+            "Tensor binding '{}' supplied a MeshTensor whose shape rank ({}) differs from the rank "
+            "({}) reserved at ProgramSpec resolution time. Rank must remain constant across binds; "
+            "only the per-dim shape values may vary.",
+            handle.tensor_parameter_name,
+            tensor_shape.rank(),
+            handle.num_runtime_field_crta_words);
+        for (size_t i = 0; i < tensor_shape.rank(); ++i) {
+            values.push_back(static_cast<uint32_t>(tensor_shape[i]));
+        }
+    }
+    return values;
+}
+
 // Attach the actual L1 Buffer to every borrowed-memory DFB, by resolving each DFB's named
 // TensorParameter to the corresponding MeshTensor passed in tensor_args and extracting its
 // MeshBuffer's reference buffer. Under the lockstep mesh allocation invariant, any one of the
@@ -340,19 +418,15 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
     detail::ProgramImpl& program_impl = program.impl();
 
-    // Build a tensor_parameter_name -> base address lookup from the user's TensorArg entries.
-    // Used below to fill the kernel's TensorBinding address section from MeshTensor::address().
-    // NOTE: We assume lockstep mesh allocation, so a device-independent, single uint32_t per binding.
-    std::unordered_map<std::string, uint32_t> ta_binding_addresses;
-    ta_binding_addresses.reserve(params.tensor_args.size());
+    // Build a tensor_parameter_name -> MeshTensor lookup from the user's TensorArg entries.
+    // Used below to fill each kernel's TensorBinding CRTA section: at minimum, the binding's
+    // base address (always present); additionally, any runtime accessor field words the
+    // TensorParameter opts into via dynamic_tensor_shape.
+    // NOTE: We assume lockstep mesh allocation, so a device-independent set of values per binding.
+    std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
+    tensor_by_param.reserve(params.tensor_args.size());
     for (const auto& tensor_params : params.tensor_args) {
-        const auto address = tensor_params.tensor.get().address();
-        TT_FATAL(
-            address <= std::numeric_limits<uint32_t>::max(),
-            "TensorParameter '{}' base address {} exceeds uint32_t max",
-            tensor_params.tensor_parameter_name,
-            address);
-        ta_binding_addresses.emplace(tensor_params.tensor_parameter_name, static_cast<uint32_t>(address));
+        tensor_by_param.emplace(tensor_params.tensor_parameter_name, &tensor_params.tensor.get());
     }
 
     // Process kernel runtime arguments.
@@ -425,15 +499,19 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
         // Assemble the kernel's per-enqueue CRTA buffer in three structurally-separate sections:
         //   1. User-named CRTAs, in schema order, sourced from named_common_runtime_args.
-        //   2. TensorBinding addresses, in binding-handle order, sourced from TensorArg via the
-        //      ta_binding_addresses map. Each handle's addr_crta_offset (computed at spec
-        //      resolution as (num_user_crtas + binding_index) * 4) lines up with the slot
-        //      position chosen here.
+        //   2. TensorBinding section, in binding-handle order, sourced from TensorArg via the
+        //      tensor_by_param lookup. Each binding occupies (1 + num_runtime_field_crta_words)
+        //      words: [address, optional shape...]. The handle's addr_crta_offset lines up with
+        //      the address slot position chosen here.
         //   3. Common runtime varargs, in caller-supplied order.
         const auto& binding_handles = kernel->tensor_binding_handles();
+        std::size_t binding_section_words = 0;
+        for (const auto& handle : binding_handles) {
+            binding_section_words += 1u + handle.num_runtime_field_crta_words;
+        }
         std::vector<uint32_t> combined_crtas;
         combined_crtas.reserve(
-            schema->named_common_runtime_args.size() + binding_handles.size() +
+            schema->named_common_runtime_args.size() + binding_section_words +
             kernel_params.common_runtime_varargs.size());
         for (const auto& name : schema->named_common_runtime_args) {
             auto v_it = kernel_params.named_common_runtime_args.find(name);
@@ -445,13 +523,14 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
             combined_crtas.push_back(v_it->second);
         }
         for (const auto& handle : binding_handles) {
-            auto addr_it = ta_binding_addresses.find(handle.tensor_parameter_name);
+            auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
             TT_FATAL(
-                addr_it != ta_binding_addresses.end(),
-                "Internal error: tensor binding '{}' has no resolved base address (validation should have caught "
+                t_it != tensor_by_param.end(),
+                "Internal error: tensor binding '{}' has no resolved MeshTensor (validation should have caught "
                 "this).",
                 handle.tensor_parameter_name);
-            combined_crtas.push_back(addr_it->second);
+            const auto values = ComputeBindingCrtaValues(handle, *t_it->second);
+            combined_crtas.insert(combined_crtas.end(), values.begin(), values.end());
         }
         combined_crtas.insert(
             combined_crtas.end(),
@@ -493,25 +572,22 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::Tensor
 
     detail::ProgramImpl& program_impl = program.impl();
 
-    // Build a tensor_parameter_name -> base address lookup.
+    // Build a tensor_parameter_name -> MeshTensor lookup.
     // As in SetProgramRunParameters, this assumes lockstep mesh allocation:
-    // a single device-independent uint32_t address per binding.
-    std::unordered_map<std::string, uint32_t> ta_binding_addresses;
-    ta_binding_addresses.reserve(tensor_args.size());
+    // a single device-independent value set per binding.
+    std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
+    tensor_by_param.reserve(tensor_args.size());
     for (const auto& tensor_params : tensor_args) {
-        const auto address = tensor_params.tensor.get().address();
-        TT_FATAL(
-            address <= std::numeric_limits<uint32_t>::max(),
-            "TensorParameter '{}' base address {} exceeds uint32_t max",
-            tensor_params.tensor_parameter_name,
-            address);
-        ta_binding_addresses.emplace(tensor_params.tensor_parameter_name, static_cast<uint32_t>(address));
+        tensor_by_param.emplace(tensor_params.tensor_parameter_name, &tensor_params.tensor.get());
     }
 
-    // For every kernel with tensor bindings, patch the binding-address slots in its CRTA buffer
-    // in place. The rest of the buffer (named CRTAs, vararg CRTAs) is left untouched and retains
-    // the values installed by the most recent SetProgramRunParameters call.
-    // The kernel's RTA buffer is left untouched (tensor binding addresses live in CRTAs only).
+    // For every kernel with tensor bindings, patch the binding slots in its CRTA buffer in
+    // place. Each binding occupies (1 + num_runtime_field_crta_words) words starting at
+    // handle.addr_crta_offset: the always-present address word, plus any runtime accessor
+    // field words (shape, when dynamic_tensor_shape is set). The rest of the buffer (named
+    // CRTAs, vararg CRTAs) is left untouched and retains the values installed by the most
+    // recent SetProgramRunParameters call. The kernel's RTA buffer is also left untouched
+    // (tensor binding state lives in CRTAs only).
     for (const KernelSpecName& kernel_name : program_impl.get_registered_kernel_names()) {
         std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
         const auto& binding_handles = kernel->tensor_binding_handles();
@@ -530,15 +606,18 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::Tensor
 
         RuntimeArgsData& crta = kernel->common_runtime_args_data();
         for (const auto& handle : binding_handles) {
-            auto addr_it = ta_binding_addresses.find(handle.tensor_parameter_name);
+            auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
             TT_FATAL(
-                addr_it != ta_binding_addresses.end(),
-                "Internal error: tensor binding '{}' has no resolved base address (validation should have "
+                t_it != tensor_by_param.end(),
+                "Internal error: tensor binding '{}' has no resolved MeshTensor (validation should have "
                 "caught this).",
                 handle.tensor_parameter_name);
+            const auto values = ComputeBindingCrtaValues(handle, *t_it->second);
             // addr_crta_offset is a byte offset; data() is uint32_t*.
-            const uint32_t word_index = handle.addr_crta_offset / sizeof(uint32_t);
-            crta.data()[word_index] = addr_it->second;
+            const uint32_t base_word = handle.addr_crta_offset / sizeof(uint32_t);
+            for (size_t i = 0; i < values.size(); ++i) {
+                crta.data()[base_word + i] = values[i];
+            }
         }
     }
 

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -260,8 +260,13 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
     }
 
     // Validate that all registered kernels with a non-empty RTA/CRTA schema have parameters.
-    // Kernels whose schema declares no named RTAs, no named CRTAs, no vararg RTAs, and no
-    // vararg CRTAs have nothing to supply per enqueue and do not need a kernel_run_params entry.
+    // Kernels whose schema declares no named RTAs, no named CRTAs, no vararg RTAs, no vararg
+    // CRTAs, AND no tensor bindings have nothing to supply per enqueue and do not need a
+    // kernel_run_params entry. Tensor bindings count as "something to supply" because their
+    // base address (and any dynamic accessor fields) are written into the kernel's CRTA buffer
+    // by SetProgramRunParameters from the corresponding TensorArg — and SetProgramRunParameters
+    // only walks kernels present in params.kernel_run_params, so a kernel with tensor bindings
+    // omitted from kernel_run_params would have its binding CRTAs left uninitialized.
     std::vector<KernelSpecName> registered_names = program_impl.get_registered_kernel_names();
     for (const KernelSpecName& name : registered_names) {
         if (kernels_with_params.contains(name)) {
@@ -271,13 +276,17 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
         if (schema == nullptr) {
             continue;
         }
-        const bool has_anything_to_supply =
-            !schema->named_runtime_args.empty() || !schema->named_common_runtime_args.empty() ||
-            !schema->num_runtime_varargs_per_node.empty() || schema->num_common_runtime_varargs > 0;
+        auto kernel = program_impl.get_kernel_by_spec_name(name);
+        const bool has_tensor_bindings = kernel != nullptr && !kernel->tensor_binding_handles().empty();
+        const bool has_anything_to_supply = !schema->named_runtime_args.empty() ||
+                                            !schema->named_common_runtime_args.empty() ||
+                                            !schema->num_runtime_varargs_per_node.empty() ||
+                                            schema->num_common_runtime_varargs > 0 || has_tensor_bindings;
         TT_FATAL(
             !has_anything_to_supply,
             "Kernel '{}' is registered in the Program with a non-empty RTA/CRTA schema but has no "
-            "runtime parameters specified in ProgramRunParams",
+            "runtime parameters specified in ProgramRunParams (the schema is non-empty, or the "
+            "kernel binds tensor parameters whose addresses are filled from kernel_run_params)",
             name);
     }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1684,29 +1684,52 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
 // Step 3: Program Building Helpers
 // ============================================================================
 
-// Resolve a TensorParameter's static layout into a positional CTA payload.
-// This mirrors what TensorAccessorArgs does for static (CTA) parameters.
-// The input values are extracted from TensorSpec + MeshDevice instead of from a Buffer.
+// Per-TensorParameter resolved layout.
 //
-// Returns: A vector representing the kernel-side CTA layout
+// cta_payload: positional CTA words appended to the kernel's compile-time args for
+// each binding of this TensorParameter. Mirrors what TensorAccessorArgs::append_to
+// would produce on the legacy path, but is built from the TensorSpec + MeshDevice
+// since no Buffer exists at spec-build time.
+//
+// extra_crta_words: additional CRTA words (beyond the always-present base address
+// slot) that this binding occupies, used by the device-side accessor to read
+// runtime-resolved fields. Non-zero only when the TensorParameter opts into a
+// dynamic field that lives in CRTAs (currently: sharded + dynamic_tensor_shape,
+// which puts `rank` shape words in CRTAs).
+struct ResolvedTensorParameter {
+    std::vector<uint32_t> cta_payload;
+    uint32_t extra_crta_words = 0;
+};
+
+// Resolve a TensorParameter's static layout into a CTA payload + an extra CRTA word
+// count for any runtime-resolved fields.
+//
+// CTA layout produced:
 //  - word 0 is the args_config raw byte
 //  - word 1 is aligned_page_size
 // For sharded tensors only:
 //  - word 2 is rank
 //  - word 3 is num_banks
-//  - remaining words: per-dim tensor and shard shapes in pages, and the bank coordinates
-//    (packed two-per-uint32)
+//  - remaining words: per-dim tensor_shape_in_pages (omitted if dynamic_tensor_shape),
+//    per-dim shard_shape_in_pages, and packed bank coordinates (two per uint32)
 //
-// All the TensorAccessorArgs data are static (CTAs) for now.
-// The tensor base address is specified per-enqueue, via TensorArg on ProgramRunParams.
-// (See also ResolveTensorBindingsForKernel below).
-std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
+// The tensor base address always lives in CRTAs (filled in per-enqueue from the
+// corresponding TensorArg). When dynamic_tensor_shape is set on a sharded tensor,
+// the runtime tensor's shape is also written into CRTAs at enqueue time, in
+// `extra_crta_words` slots immediately after the address slot.
+// (See also ResolveTensorBindingsForKernel below.)
+ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     const TensorParameter& tensor_parameter, const distributed::MeshDevice& mesh_device) {
     const TensorSpec& spec = tensor_parameter.spec;
     const MemoryConfig& memory_config = spec.memory_config();
     const BufferType buffer_type = memory_config.buffer_type();
     const bool is_dram = (buffer_type == BufferType::DRAM);
     const bool is_sharded = memory_config.is_sharded();
+    // dynamic_tensor_shape is only meaningful on sharded tensors: for interleaved
+    // tensors the CTA payload never carried tensor_shape in the first place (and
+    // the device-side accessor doesn't read it), so the flag is a pure host-side
+    // validation loosening and has no effect on the CTA/CRTA layout.
+    const bool dyn_shape = tensor_parameter.dynamic_tensor_shape && is_sharded;
 
     tensor_accessor::ArgsConfig args_config;
     if (is_sharded) {
@@ -1715,7 +1738,9 @@ std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
     if (is_dram) {
         args_config.set(tensor_accessor::ArgConfig::IsDram);
     }
-    // No Runtime* flags in the static port.
+    if (dyn_shape) {
+        args_config.set(tensor_accessor::ArgConfig::RuntimeTensorShape);
+    }
 
     // aligned_page_size: align the unaligned page size up to the buffer-type alignment.
     const size_t unaligned_page_size = spec.compute_page_size_bytes();
@@ -1728,7 +1753,8 @@ std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
         aligned_page_size,
         std::numeric_limits<uint32_t>::max());
 
-    std::vector<uint32_t> cta_payload;
+    ResolvedTensorParameter result;
+    std::vector<uint32_t>& cta_payload = result.cta_payload;
 
     // Common header (always emitted, sharded or not):
     cta_payload.push_back(args_config.raw());
@@ -1737,10 +1763,11 @@ std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
     if (!is_sharded) {
         // Interleaved tensors don't carry shape / bank-coord data: the device-side accessor
         // computes addresses from page id + num_banks alone.
-        return cta_payload;
+        return result;
     }
 
-    // Sharded: emit rank, num_banks, tensor_shape_in_pages, shard_shape_in_pages, bank_coords.
+    // Sharded: emit rank, num_banks, tensor_shape_in_pages (CTA only when static),
+    // shard_shape_in_pages, bank_coords.
     const BufferShardingArgs sharding_args = spec.compute_buffer_sharding_args();
     const std::optional<BufferDistributionSpec>& bds_opt = sharding_args.buffer_distribution_spec();
     TT_FATAL(
@@ -1758,8 +1785,13 @@ std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
     cta_payload.push_back(static_cast<uint32_t>(rank));
     cta_payload.push_back(static_cast<uint32_t>(n_banks));
 
-    for (size_t i = 0; i < rank; ++i) {
-        cta_payload.push_back(static_cast<uint32_t>(tensor_shape[i]));
+    if (!dyn_shape) {
+        for (size_t i = 0; i < rank; ++i) {
+            cta_payload.push_back(static_cast<uint32_t>(tensor_shape[i]));
+        }
+    } else {
+        // Shape lives in CRTAs (one word per dim, written at enqueue time from the bound MeshTensor).
+        result.extra_crta_words = static_cast<uint32_t>(rank);
     }
     for (size_t i = 0; i < rank; ++i) {
         cta_payload.push_back(static_cast<uint32_t>(shard_shape[i]));
@@ -1784,7 +1816,7 @@ std::vector<uint32_t> ResolveTensorParameterStaticCTAs(
         }
     }
 
-    return cta_payload;
+    return result;
 }
 
 // Per-kernel resolved tensor binding data:
@@ -1799,13 +1831,17 @@ struct TensorBindingsForKernel {
 // Resolve the tensor bindings for a single kernel:
 //  1. Walk the kernel's tensor_bindings in declaration order
 //  2. Pack each binding's CTA payload into a contiguous positional buffer
-//  3. Assign each binding a slot in the kernel's TensorBinding address section
-//     (a structurally separate region of the CRTA buffer, immediately following the user-named CRTAs)
+//  3. Assign each binding a slot in the kernel's TensorBinding section of the CRTA buffer.
+//     The section is structurally separate, immediately following the user-named CRTAs.
+//     Each binding occupies (1 + extra_crta_words) words: the always-present base address
+//     word, plus any runtime accessor field words (e.g. shape, when dynamic_tensor_shape
+//     is set on a sharded TensorParameter).
 //
-// (SetProgramRunParameters will fill in the CRTA slots at enqueue time, extracting info from the TensorArgs.)
+// (SetProgramRunParameters will fill the address slots and runtime field slots at enqueue
+// time, extracting info from the TensorArgs.)
 TensorBindingsForKernel ResolveTensorBindingsForKernel(
     const KernelSpec& kernel,
-    const std::unordered_map<TensorParameterName, std::vector<uint32_t>>& resolved_binding_ctas,
+    const std::unordered_map<TensorParameterName, ResolvedTensorParameter>& resolved_tensor_parameters,
     size_t base_named_crta_count) {
     TensorBindingsForKernel out;
     out.handles.reserve(kernel.tensor_bindings.size());
@@ -1813,17 +1849,19 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
     uint32_t cta_word_offset = 0;
     size_t crta_word_index = base_named_crta_count;
     for (const auto& binding : kernel.tensor_bindings) {
-        const auto& binding_ctas = resolved_binding_ctas.at(binding.tensor_parameter_name);
+        const ResolvedTensorParameter& resolved = resolved_tensor_parameters.at(binding.tensor_parameter_name);
+        const std::vector<uint32_t>& binding_ctas = resolved.cta_payload;
 
         TensorBindingHandle handle;
         handle.accessor_name = binding.accessor_name;
         handle.tensor_parameter_name = binding.tensor_parameter_name;
         handle.cta_offset = cta_word_offset;
         handle.addr_crta_offset = static_cast<uint32_t>(crta_word_index * sizeof(uint32_t));
+        handle.num_runtime_field_crta_words = resolved.extra_crta_words;
 
         out.cta_words.insert(out.cta_words.end(), binding_ctas.begin(), binding_ctas.end());
         cta_word_offset += static_cast<uint32_t>(binding_ctas.size());
-        crta_word_index += 1;
+        crta_word_index += 1u + resolved.extra_crta_words;
 
         out.handles.push_back(std::move(handle));
     }
@@ -2259,11 +2297,13 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     //     CTA buffer. (Empty in Metal 2.0 today; the binding payload is its first user.)
     //   - Per-enqueue base address flows through a reserved-prefix named CRTA, appended to
     //     the kernel's user-named CRTAs and filled by SetProgramRunParameters from the
-    //     corresponding TensorArg entry.
-    std::unordered_map<TensorParameterName, std::vector<uint32_t>> resolved_binding_ctas;
-    resolved_binding_ctas.reserve(spec.tensor_parameters.size());
+    //     corresponding TensorArg entry. TensorParameters that opt into a dynamic accessor
+    //     field (currently: dynamic_tensor_shape, sharded only) carry additional CRTA words
+    //     immediately after the address slot, also filled at enqueue time.
+    std::unordered_map<TensorParameterName, ResolvedTensorParameter> resolved_tensor_parameters;
+    resolved_tensor_parameters.reserve(spec.tensor_parameters.size());
     for (const auto& tensor_parameter : spec.tensor_parameters) {
-        resolved_binding_ctas.emplace(
+        resolved_tensor_parameters.emplace(
             tensor_parameter.unique_id, ResolveTensorParameterStaticCTAs(tensor_parameter, mesh_device));
     }
 
@@ -2272,7 +2312,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
     // Register TensorParameters with the program for ValidateProgramRunParams to consult at enqueue.
     for (const auto& tensor_parameter : spec.tensor_parameters) {
-        program_impl->register_tensor_parameter(tensor_parameter.unique_id, tensor_parameter.spec);
+        program_impl->register_tensor_parameter(
+            tensor_parameter.unique_id, tensor_parameter.spec, tensor_parameter.dynamic_tensor_shape);
     }
 
     // Create DataflowBuffers and build name -> ID map.
@@ -2355,7 +2396,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         //  - assign each binding a slot in the kernel's CRTA buffer (TensorBinding address section)
         const auto& user_named_crtas = kernel_spec.runtime_arguments_schema.named_common_runtime_args;
         TensorBindingsForKernel ta_bindings = ResolveTensorBindingsForKernel(
-            kernel_spec, resolved_binding_ctas, /*base_named_crta_count=*/user_named_crtas.size());
+            kernel_spec, resolved_tensor_parameters, /*base_named_crta_count=*/user_named_crtas.size());
 
         // Create TensorBindingHandles for this kernel
         const std::vector<TensorBindingHandle>& tensor_binding_handles = ta_bindings.handles;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1822,10 +1822,14 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
 // Per-kernel resolved tensor binding data:
 //  - All the kernel's TensorBindingHandle (type is defined in kernel.hpp)
 //  - The positional CTAs to append to the kernel's (unnamed) CTAs
+//  - The full CRTA buffer layout (named CRTAs + binding section + vararg-section start),
+//    precomputed here so consumers (headergen, runtime) don't have to re-derive section
+//    boundaries by walking handles. See KernelCrtaLayout in jit_build_settings.hpp.
 struct TensorBindingsForKernel {
     std::vector<TensorBindingHandle> handles;
     std::vector<uint32_t> cta_words;  // appended after any pre-existing positional CTAs
                                       // (currently, this is the only Metal 2.0 use of positional CTAs)
+    KernelCrtaLayout crta_layout;
 };
 
 // Resolve the tensor bindings for a single kernel:
@@ -1836,6 +1840,8 @@ struct TensorBindingsForKernel {
 //     Each binding occupies (1 + extra_crta_words) words: the always-present base address
 //     word, plus any runtime accessor field words (e.g. shape, when dynamic_tensor_shape
 //     is set on a sharded TensorParameter).
+//  4. Record the resulting CRTA buffer layout (the three section sizes) on the output, so
+//     the headergen and runtime can consult it directly instead of re-summing the bindings.
 //
 // (SetProgramRunParameters will fill the address slots and runtime field slots at enqueue
 // time, extracting info from the TensorArgs.)
@@ -1848,6 +1854,7 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
 
     uint32_t cta_word_offset = 0;
     size_t crta_word_index = base_named_crta_count;
+    uint32_t binding_section_words = 0;
     for (const auto& binding : kernel.tensor_bindings) {
         const ResolvedTensorParameter& resolved = resolved_tensor_parameters.at(binding.tensor_parameter_name);
         const std::vector<uint32_t>& binding_ctas = resolved.cta_payload;
@@ -1861,10 +1868,17 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
 
         out.cta_words.insert(out.cta_words.end(), binding_ctas.begin(), binding_ctas.end());
         cta_word_offset += static_cast<uint32_t>(binding_ctas.size());
-        crta_word_index += 1u + resolved.extra_crta_words;
+        const uint32_t binding_words = 1u + resolved.extra_crta_words;
+        crta_word_index += binding_words;
+        binding_section_words += binding_words;
 
         out.handles.push_back(std::move(handle));
     }
+
+    out.crta_layout.num_named_words = static_cast<uint32_t>(base_named_crta_count);
+    out.crta_layout.binding_section_words = binding_section_words;
+    out.crta_layout.vararg_section_offset = static_cast<uint32_t>(base_named_crta_count) + binding_section_words;
+
     return out;
 }
 
@@ -2313,7 +2327,10 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     // Register TensorParameters with the program for ValidateProgramRunParams to consult at enqueue.
     for (const auto& tensor_parameter : spec.tensor_parameters) {
         program_impl->register_tensor_parameter(
-            tensor_parameter.unique_id, tensor_parameter.spec, tensor_parameter.dynamic_tensor_shape);
+            tensor_parameter.unique_id,
+            tensor_parameter.spec,
+            tensor_parameter.dynamic_tensor_shape,
+            tensor_parameter.match_padded_shape_only);
     }
 
     // Create DataflowBuffers and build name -> ID map.
@@ -2429,7 +2446,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                     semaphore_handles,
                     named_rtas,
                     user_named_crtas,
-                    tensor_binding_handles);
+                    tensor_binding_handles,
+                    ta_bindings.crta_layout);
             } else {
                 auto config = MakeQuasarComputeConfig(kernel_spec, dfb_name_to_id);
                 config.compile_args = ta_bindings.cta_words;
@@ -2444,7 +2462,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                     semaphore_handles,
                     named_rtas,
                     user_named_crtas,
-                    tensor_binding_handles);
+                    tensor_binding_handles,
+                    ta_bindings.crta_layout);
             }
         } else {  // gen1
             if (kernel_spec.is_dm_kernel()) {
@@ -2459,7 +2478,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                     semaphore_handles,
                     named_rtas,
                     user_named_crtas,
-                    tensor_binding_handles);
+                    tensor_binding_handles,
+                    ta_bindings.crta_layout);
             } else {
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_id);
                 config.compile_args = ta_bindings.cta_words;
@@ -2472,7 +2492,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                     semaphore_handles,
                     named_rtas,
                     user_named_crtas,
-                    tensor_binding_handles);
+                    tensor_binding_handles,
+                    ta_bindings.crta_layout);
             }
         }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -573,12 +573,12 @@ std::vector<KernelSpecName> ProgramImpl::get_registered_kernel_names() const {
 }
 
 void ProgramImpl::register_tensor_parameter(
-    const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape) {
+    const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape, bool match_padded_shape_only) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};
     }
     auto [it, inserted] = metal2_registry_->tensor_parameter_layouts.try_emplace(
-        name, Metal2NameRegistry::RegisteredTensorParameter{spec, dynamic_tensor_shape});
+        name, Metal2NameRegistry::RegisteredTensorParameter{spec, dynamic_tensor_shape, match_padded_shape_only});
     TT_FATAL(inserted, "Duplicate tensor parameter name: {}", name);
 }
 
@@ -602,6 +602,17 @@ bool ProgramImpl::get_tensor_parameter_dynamic_tensor_shape(const std::string& n
         return false;
     }
     return it->second.dynamic_tensor_shape;
+}
+
+bool ProgramImpl::get_tensor_parameter_match_padded_shape_only(const std::string& name) const {
+    if (!metal2_registry_) {
+        return false;
+    }
+    auto it = metal2_registry_->tensor_parameter_layouts.find(name);
+    if (it == metal2_registry_->tensor_parameter_layouts.end()) {
+        return false;
+    }
+    return it->second.match_padded_shape_only;
 }
 
 std::vector<std::string> ProgramImpl::get_registered_tensor_parameter_names() const {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -572,11 +572,13 @@ std::vector<KernelSpecName> ProgramImpl::get_registered_kernel_names() const {
     return names;
 }
 
-void ProgramImpl::register_tensor_parameter(const std::string& name, const TensorSpec& spec) {
+void ProgramImpl::register_tensor_parameter(
+    const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};
     }
-    auto [it, inserted] = metal2_registry_->tensor_parameter_layouts.try_emplace(name, spec);
+    auto [it, inserted] = metal2_registry_->tensor_parameter_layouts.try_emplace(
+        name, Metal2NameRegistry::RegisteredTensorParameter{spec, dynamic_tensor_shape});
     TT_FATAL(inserted, "Duplicate tensor parameter name: {}", name);
 }
 
@@ -588,14 +590,25 @@ const TensorSpec* ProgramImpl::get_tensor_parameter_layout(const std::string& na
     if (it == metal2_registry_->tensor_parameter_layouts.end()) {
         return nullptr;
     }
-    return &it->second;
+    return &it->second.spec;
+}
+
+bool ProgramImpl::get_tensor_parameter_dynamic_tensor_shape(const std::string& name) const {
+    if (!metal2_registry_) {
+        return false;
+    }
+    auto it = metal2_registry_->tensor_parameter_layouts.find(name);
+    if (it == metal2_registry_->tensor_parameter_layouts.end()) {
+        return false;
+    }
+    return it->second.dynamic_tensor_shape;
 }
 
 std::vector<std::string> ProgramImpl::get_registered_tensor_parameter_names() const {
     std::vector<std::string> names;
     if (metal2_registry_) {
         names.reserve(metal2_registry_->tensor_parameter_layouts.size());
-        for (const auto& [name, spec] : metal2_registry_->tensor_parameter_layouts) {
+        for (const auto& [name, entry] : metal2_registry_->tensor_parameter_layouts) {
             names.push_back(name);
         }
     }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -343,7 +343,7 @@ public:
     void register_kernel_spec_name(const KernelSpecName& name, KernelHandle handle);
     void register_dfb_spec_name(const DFBSpecName& name, uint32_t dfb_id);
     void register_semaphore_spec_name(const SemaphoreSpecName& name, uint32_t sem_id);
-    void register_tensor_parameter(const std::string& name, const TensorSpec& spec);
+    void register_tensor_parameter(const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape);
 
     // Metal 2.0: Get handle from name (TT_FATAL if not found)
     KernelHandle get_kernel_handle(const KernelSpecName& name) const;
@@ -351,6 +351,9 @@ public:
     uint32_t get_semaphore_handle(const SemaphoreSpecName& name) const;
     // Returns nullptr if name is not registered (caller validates).
     const TensorSpec* get_tensor_parameter_layout(const std::string& name) const;
+    // Returns false if the parameter was not registered with dynamic_tensor_shape=true,
+    // or if the name is unknown. (The caller validates known-ness separately.)
+    bool get_tensor_parameter_dynamic_tensor_shape(const std::string& name) const;
     std::vector<std::string> get_registered_tensor_parameter_names() const;
 
     // Metal 2.0: register that DFB `dfb_id` borrows its backing L1 memory from the MeshTensor
@@ -465,10 +468,15 @@ private:
         std::unordered_map<DFBSpecName, uint32_t> dfb_handles;
         std::unordered_map<SemaphoreSpecName, uint32_t> semaphore_handles;
         std::unordered_map<KernelSpecName, KernelRTASchema> kernel_rta_schemas;
-        // TensorParameter name -> the parameter's declared single-device TensorSpec.
+        // TensorParameter name -> the parameter's declared layout + dynamic-shape opt-in.
         // Used by ValidateProgramRunParams to check that the supplied MeshTensor's spec matches
-        // the parameter's declared layout, and as the per-parameter lookup for completeness checks.
-        std::unordered_map<std::string, TensorSpec> tensor_parameter_layouts;
+        // the parameter's declared layout (loosened when dynamic_tensor_shape is set), and as
+        // the per-parameter lookup for completeness checks.
+        struct RegisteredTensorParameter {
+            TensorSpec spec;
+            bool dynamic_tensor_shape = false;
+        };
+        std::unordered_map<std::string, RegisteredTensorParameter> tensor_parameter_layouts;
 
         // Borrowed-memory DFB bindings: each entry is (dfb_id, tensor_parameter_name).
         std::vector<std::pair<uint32_t, std::string>> dfb_borrowed_bindings;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -343,7 +343,8 @@ public:
     void register_kernel_spec_name(const KernelSpecName& name, KernelHandle handle);
     void register_dfb_spec_name(const DFBSpecName& name, uint32_t dfb_id);
     void register_semaphore_spec_name(const SemaphoreSpecName& name, uint32_t sem_id);
-    void register_tensor_parameter(const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape);
+    void register_tensor_parameter(
+        const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape, bool match_padded_shape_only);
 
     // Metal 2.0: Get handle from name (TT_FATAL if not found)
     KernelHandle get_kernel_handle(const KernelSpecName& name) const;
@@ -354,6 +355,9 @@ public:
     // Returns false if the parameter was not registered with dynamic_tensor_shape=true,
     // or if the name is unknown. (The caller validates known-ness separately.)
     bool get_tensor_parameter_dynamic_tensor_shape(const std::string& name) const;
+    // Returns false if the parameter was not registered with match_padded_shape_only=true,
+    // or if the name is unknown. (The caller validates known-ness separately.)
+    bool get_tensor_parameter_match_padded_shape_only(const std::string& name) const;
     std::vector<std::string> get_registered_tensor_parameter_names() const;
 
     // Metal 2.0: register that DFB `dfb_id` borrows its backing L1 memory from the MeshTensor
@@ -468,13 +472,14 @@ private:
         std::unordered_map<DFBSpecName, uint32_t> dfb_handles;
         std::unordered_map<SemaphoreSpecName, uint32_t> semaphore_handles;
         std::unordered_map<KernelSpecName, KernelRTASchema> kernel_rta_schemas;
-        // TensorParameter name -> the parameter's declared layout + dynamic-shape opt-in.
+        // TensorParameter name -> the parameter's declared layout + loosening opt-ins.
         // Used by ValidateProgramRunParams to check that the supplied MeshTensor's spec matches
-        // the parameter's declared layout (loosened when dynamic_tensor_shape is set), and as
+        // the parameter's declared layout (with relaxations applied per the opt-in flags), and as
         // the per-parameter lookup for completeness checks.
         struct RegisteredTensorParameter {
             TensorSpec spec;
             bool dynamic_tensor_shape = false;
+            bool match_padded_shape_only = false;
         };
         std::unordered_map<std::string, RegisteredTensorParameter> tensor_parameter_layouts;
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -204,17 +204,12 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     const vector<string>& rta_names = settings.get_named_runtime_args();
     const vector<string>& crta_names = settings.get_named_common_runtime_args();
 
-    // TensorBindings occupy a structurally-separate, position-indexed section appended
-    // immediately after the user-named CRTAs in the kernel's CRTA buffer. Each binding
-    // contributes (1 + num_runtime_field_crta_words) words: the always-present base address
-    // word, plus any runtime accessor fields (e.g. shape, when dynamic_tensor_shape is set
-    // on a sharded TensorParameter). We need the total word count so the vararg helpers
-    // below skip past the binding section to land at the first user vararg.
-    uint32_t tensor_binding_section_words = 0;
-    settings.process_tensor_binding_handles(
-        [&tensor_binding_section_words](const std::string&, uint32_t, uint32_t, uint32_t num_runtime_field_crta_words) {
-            tensor_binding_section_words += 1u + num_runtime_field_crta_words;
-        });
+    // The kernel's CRTA buffer is laid out as three back-to-back sections:
+    //   [ user-named CRTAs | TensorBinding section | varargs ]
+    // The boundaries are precomputed at spec-resolution time and stored on the kernel,
+    // so we read them directly here. The vararg helpers below need the vararg-section
+    // start offset to skip past sections 1 and 2.
+    const KernelCrtaLayout crta_layout = settings.get_crta_layout();
 
     // Named CTAs come through the legacy unordered_map path (Kernel internal storage).
     // The order in which we emit them DOES matter!
@@ -271,14 +266,13 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     // indexing: get_vararg(0) is the first vararg, regardless of named-arg count. When
     // there are no named args, the offset is zero and these helpers are just thin wrappers
     // around get_arg_val / get_common_arg_val.
-    // CRTA-side note: the kernel's CRTA buffer holds [user-named CRTAs, TensorBinding
-    // section, varargs]. The vararg base must skip past the binding section as well.
+    // CRTA-side note: the vararg section starts at crta_layout.vararg_section_offset,
+    // which already accounts for both the user-named CRTAs and the TensorBinding section.
     const uint32_t named_rta_words = static_cast<uint32_t>(rta_names.size());
-    const uint32_t named_crta_words = static_cast<uint32_t>(crta_names.size()) + tensor_binding_section_words;
     content << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { return get_arg_val<uint32_t>(" << named_rta_words
             << " + idx); }\n"
             << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { return get_common_arg_val<uint32_t>("
-            << named_crta_words << " + idx); }\n";
+            << crta_layout.vararg_section_offset << " + idx); }\n";
 
     write_file(path, content.str());
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -117,7 +117,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     };
     vector<TaEntry> ta_entries;
     settings.process_tensor_binding_handles(
-        [&ta_entries](const string& name, uint32_t cta_offset, uint32_t addr_crta_offset) {
+        [&ta_entries](const string& name, uint32_t cta_offset, uint32_t addr_crta_offset, uint32_t /*num_rt_words*/) {
             ta_entries.push_back({name, cta_offset, addr_crta_offset});
         });
 
@@ -204,13 +204,17 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     const vector<string>& rta_names = settings.get_named_runtime_args();
     const vector<string>& crta_names = settings.get_named_common_runtime_args();
 
-    // TensorBinding addresses occupy a structurally-separate, position-indexed section appended
-    // immediately after the user-named CRTAs in the kernel's CRTA buffer.
-    // We need to know how many there are so the vararg helpers below skip past the binding
-    // section to land at the first user vararg.
-    uint32_t tensor_binding_count = 0;
+    // TensorBindings occupy a structurally-separate, position-indexed section appended
+    // immediately after the user-named CRTAs in the kernel's CRTA buffer. Each binding
+    // contributes (1 + num_runtime_field_crta_words) words: the always-present base address
+    // word, plus any runtime accessor fields (e.g. shape, when dynamic_tensor_shape is set
+    // on a sharded TensorParameter). We need the total word count so the vararg helpers
+    // below skip past the binding section to land at the first user vararg.
+    uint32_t tensor_binding_section_words = 0;
     settings.process_tensor_binding_handles(
-        [&tensor_binding_count](const std::string&, uint32_t, uint32_t) { ++tensor_binding_count; });
+        [&tensor_binding_section_words](const std::string&, uint32_t, uint32_t, uint32_t num_runtime_field_crta_words) {
+            tensor_binding_section_words += 1u + num_runtime_field_crta_words;
+        });
 
     // Named CTAs come through the legacy unordered_map path (Kernel internal storage).
     // The order in which we emit them DOES matter!
@@ -268,9 +272,9 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     // there are no named args, the offset is zero and these helpers are just thin wrappers
     // around get_arg_val / get_common_arg_val.
     // CRTA-side note: the kernel's CRTA buffer holds [user-named CRTAs, TensorBinding
-    // address section, varargs]. The vararg base must skip past the binding section as well.
+    // section, varargs]. The vararg base must skip past the binding section as well.
     const uint32_t named_rta_words = static_cast<uint32_t>(rta_names.size());
-    const uint32_t named_crta_words = static_cast<uint32_t>(crta_names.size()) + tensor_binding_count;
+    const uint32_t named_crta_words = static_cast<uint32_t>(crta_names.size()) + tensor_binding_section_words;
     content << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { return get_arg_val<uint32_t>(" << named_rta_words
             << " + idx); }\n"
             << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { return get_common_arg_val<uint32_t>("

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -48,9 +48,16 @@ public:
     //    positional compile-time-args buffer
     //  - addr_crta_offset: byte offset of the implicit base-address CRTA within the kernel's
     //    common-runtime-args section
+    //  - num_runtime_field_crta_words: number of CRTA words that immediately follow the address
+    //    slot for runtime accessor fields (currently: shape, for sharded TensorParameters with
+    //    dynamic_tensor_shape=true). The binding occupies (1 + num_runtime_field_crta_words)
+    //    CRTA words in total.
     // (The tensor_parameter_name is also part of TensorBindingHandle, but we don't need it for codegen.)
-    virtual void process_tensor_binding_handles(
-        std::function<void(const std::string& accessor_name, uint32_t cta_offset, uint32_t addr_crta_offset)>) const {}
+    virtual void process_tensor_binding_handles(std::function<void(
+                                                    const std::string& accessor_name,
+                                                    uint32_t cta_offset,
+                                                    uint32_t addr_crta_offset,
+                                                    uint32_t num_runtime_field_crta_words)>) const {}
 
     // Named RTA/CRTA schema (Metal 2.0 APIs).
     // The order of names determines the byte offset of each arg within the named-args

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -13,6 +13,30 @@
 
 namespace tt::tt_metal {
 
+// Metal 2.0: precomputed layout of a kernel's common runtime args (CRTA) buffer.
+//
+// The CRTA buffer is laid out as three back-to-back sections:
+//   [ user-named CRTAs | TensorBinding section | vararg CRTAs ]
+//
+// Sections 1 and 2 are fixed-size at spec-resolution time. This struct records their
+// sizes (and the resulting vararg section start offset) so consumers don't have to
+// re-derive them by walking the binding handles.
+//
+// Section 2 (TensorBinding) is variable-size: each binding contributes
+// (1 + num_runtime_field_crta_words) words — the always-present base-address word, plus
+// any runtime accessor fields the TensorParameter opted into (currently: shape, for
+// sharded TensorParameters with dynamic_tensor_shape=true).
+struct KernelCrtaLayout {
+    // Section 1 size, in words. Equals the number of user-named CRTAs.
+    uint32_t num_named_words = 0;
+    // Section 2 size, in words. Equals the sum-over-bindings of (1 + num_runtime_field_crta_words).
+    uint32_t binding_section_words = 0;
+    // Start offset of section 3 (varargs), in words.
+    // Stored (not computed on demand) so it can be set from a known value at spec resolution
+    // and asserted against the derived sum if a consumer wants belt-and-suspenders verification.
+    uint32_t vararg_section_offset = 0;
+};
+
 // Abstract base class for kernel specialization
 // Higher levels of the SW derive from this and fill in build details not known to the build system
 // (eg, API specified settings)
@@ -72,6 +96,11 @@ public:
         static const std::vector<std::string> k_empty;
         return k_empty;
     }
+
+    // Metal 2.0: full CRTA buffer layout, precomputed at spec resolution time.
+    // Default is the all-zero layout (no named CRTAs, no bindings, varargs start at offset 0),
+    // which matches the legacy-kernel case where the buffer has only varargs.
+    virtual KernelCrtaLayout get_crta_layout() const { return {}; }
 
     // Called to process additional include paths (e.g., kernel source directory for relative includes)
     virtual void process_include_paths(const std::function<void(const std::string& path)>&) const {}


### PR DESCRIPTION
## PR Category
Feature

## Summary
This PR adds support for an advanced feature required by select ops: dynamic tensor bindings.

### Background
In Metal 2.0's, the user declares the tensor resources a `Program` needs as `TensorParameter`s on the `ProgramSpec` immutable descriptor object. You then "bind" the tensor resources to the kernels that need them. When you enqueue your Program for execution, you pass in the actual tensor arguments as `MeshTensor`s.

Metal 2.0 legality checks check that the provided argument's `TensorSpec` matches that of the`TensorParameter`. This makes sense... the "type" of the tensor argument must match the type on the signature.

### What's changed
This PR introduces two advanced flags. These are _inherently unsafe_, and should only be used by advanced users who are CERTAIN that the specific structure of their kernel makes this ok.

**New `TensorParameter` advanced flags**:
 - `match_padded_shape_only`: Relax the legality check to permit tensor arguments whose _logical_ shape is different from the declared `TensorParameter`, provided that the padded shape still matches.
 - `dynamic_tensor_shape`: Permit a fully dynamic tensor shape (rank must remain unchanged). Not just a legality relaxation - in the sharded tensor case, this actually cases some of the implicit `TensorAccessorArg`s to get passed as implicit CRTAs rather than implicit CTAs.

The rest of this PR is "just plumbing" to get this info down into headergen (to make the `TensorAccessorArgs` tokens) and across to program arguments validation and handling. The plumbing is, however, honestly pretty gross. Prior to this PR, the only `TensorAccessor` data that was being passed as a CRTA was the base pointer. Now, it's the base pointer (+ possibly N uint32_ts, one num_pages for each tensor dimension). So, we've got to track the number of CRTAs for each tensor handle. It's straightforward, but complicates the code substantially.

### Testing
A bunch of unit tests added for both feature flags. I didn't think this needed a full hardware test. 
The offset arithmetic is thoroughly covered.

## Notes for reviewers
Since this affects the CRTA offset that gets baked into the generated bindings header, the new field has to be added to the kernel hash.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/dynamic-tensor-parameters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/dynamic-tensor-parameters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/dynamic-tensor-parameters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/dynamic-tensor-parameters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/dynamic-tensor-parameters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/dynamic-tensor-parameters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/dynamic-tensor-parameters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/dynamic-tensor-parameters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/dynamic-tensor-parameters)