### PR TITLE
[Feature] paged_fill_cache: accept batched batch_idx_tensor for forge batch-32 perf+compile time improvement

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
@@ -949,13 +949,19 @@ def _build_batched_inputs(
 ):
     """Construct a randomized cache + batched input + page_table for tests.
 
-    The kernel writes cache block_id = page_table[batch][vb] * num_heads + h,
-    so sequential page_table values 0,1,2,... automatically give
-    non-overlapping per-virtual-block regions. We just need the cache big
-    enough to hold them: cache_max_blocks >= (page_table_batch_size *
-    pt_max_blocks_per_seq) * num_input_heads. cache_max_blocks is
-    auto-bumped if the caller passes a smaller value, so multi-head tests
-    don't write past the buffer.
+    Cache is allocated as `[cache_max_blocks, 1, cache_block_size, head_dim]`,
+    matching how `test_paged_fill_cache_variants` and real vLLM/JAX callers
+    set up paged KV caches (cache_num_heads = 1 because GQA-style models share
+    a single KV-head dimension). The device-op now requires
+    `input_num_heads == cache_num_heads`, so callers of this helper must pass
+    `num_input_heads = 1`. The `num_input_heads` parameter is kept in the
+    signature for future use if a multi-head variant is added (which would
+    also need an updated cache shape and reference function).
+
+    cache_max_blocks is auto-bumped to a safe lower bound so all
+    `page_table_batch_size * pt_max_blocks_per_seq` slots fit even after the
+    kernel's per-head spill arithmetic; harmless for num_input_heads=1 (factor
+    of 1).
     """
     torch.manual_seed(seed)
 
@@ -1065,7 +1071,16 @@ def _run_batched_paged_fill_cache(
     assert passing, message
 
 
-@pytest.mark.parametrize("num_input_heads", [1, 8])
+# Only num_input_heads=1 is exercised here. The device-op validation
+# (paged_fill_cache_device_operation.cpp:62) requires
+# `input_num_heads == cache_num_heads`, and the test helper allocates the cache
+# with `cache_num_heads = 1` (matching how real vLLM/JAX callers configure paged
+# KV caches with GQA-style head sharing). Multi-head batched coverage would need
+# a separate helper that allocates cache as `[max_blocks, num_input_heads, ...]`
+# and an adapted reference function; not added here since no in-tree caller uses
+# that shape and the legacy tests (test_paged_fill_cache_variants etc.) only
+# exercise num_input_heads=1 as well.
+@pytest.mark.parametrize("num_input_heads", [1])
 @pytest.mark.parametrize("input_seq_len", [128, 2048])
 @pytest.mark.parametrize(
     "num_input_batch, batch_idxs",

--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
@@ -922,3 +922,364 @@ def test_paged_fill_cache_mesh_coords(
     passing, message = comp_equal(output_cache_torch, expected_cache_torch)
     logger.info(message)  # Log the comparison message regardless
     assert passing, message
+
+
+# ----------------------------------------------------------------------------
+# Batched paged_fill_cache: batch_idx_tensor with shape == [input_batch]
+# ----------------------------------------------------------------------------
+#
+# These tests exercise the new path where a single op call fills `input_batch`
+# rows of the cache in one shot, rather than the Python-loop pattern of one
+# scalar-batch_idx call per row. They validate against the per-row reference
+# (`get_expected_paged_fill_cache_output` applied iteratively).
+
+
+def _build_batched_inputs(
+    num_input_batch,
+    num_input_heads,
+    input_seq_len,
+    head_dim,
+    cache_max_blocks,
+    cache_block_size,
+    page_table_batch_size,
+    pt_max_blocks_per_seq,
+    batch_idxs,
+    inject_skip_for_batch_idx=None,
+    seed=0,
+):
+    """Construct a randomized cache + batched input + page_table for tests.
+
+    The kernel writes cache block_id = page_table[batch][vb] * num_heads + h,
+    so sequential page_table values 0,1,2,... automatically give
+    non-overlapping per-virtual-block regions. We just need the cache big
+    enough to hold them: cache_max_blocks >= (page_table_batch_size *
+    pt_max_blocks_per_seq) * num_input_heads. cache_max_blocks is
+    auto-bumped if the caller passes a smaller value, so multi-head tests
+    don't write past the buffer.
+    """
+    torch.manual_seed(seed)
+
+    required_blocks = page_table_batch_size * pt_max_blocks_per_seq * num_input_heads
+    if cache_max_blocks < required_blocks:
+        cache_max_blocks = required_blocks
+
+    initial_cache_torch = torch.randn(cache_max_blocks, 1, cache_block_size, head_dim).bfloat16() * 100
+    input_torch = (
+        torch.arange(num_input_batch * num_input_heads * input_seq_len * head_dim, dtype=torch.float32)
+        .reshape(num_input_batch, num_input_heads, input_seq_len, head_dim)
+        .bfloat16()
+        / 1000.0
+    )
+
+    page_table_torch_data = []
+    next_block_idx = 0
+    for _b in range(page_table_batch_size):
+        row = []
+        for _m in range(pt_max_blocks_per_seq):
+            row.append(next_block_idx % cache_max_blocks)
+            next_block_idx += 1
+        page_table_torch_data.append(row)
+    page_table_torch = torch.tensor(page_table_torch_data, dtype=torch.int32)
+
+    if inject_skip_for_batch_idx is not None and pt_max_blocks_per_seq > 1:
+        page_table_torch[inject_skip_for_batch_idx, pt_max_blocks_per_seq - 1] = -1
+
+    return initial_cache_torch, input_torch, page_table_torch
+
+
+def _reference_batched_paged_fill_cache(initial_cache_torch, input_torch, page_table_torch, batch_idxs):
+    """Apply paged_fill_cache once per input batch row, accumulating into a clone."""
+    num_input_batch = input_torch.shape[0]
+    assert num_input_batch == len(batch_idxs)
+    expected = initial_cache_torch.clone()
+    for b in range(num_input_batch):
+        # The single-batch reference expects input shape [1, num_heads, seq_len, head_dim].
+        single_batch_input = input_torch[b : b + 1]
+        expected = get_expected_paged_fill_cache_output(
+            expected,
+            single_batch_input,
+            page_table_torch,
+            int(batch_idxs[b]),
+        )
+    return expected
+
+
+def _run_batched_paged_fill_cache(
+    device,
+    num_input_batch,
+    num_input_heads,
+    input_seq_len,
+    head_dim,
+    cache_max_blocks,
+    cache_block_size,
+    page_table_batch_size,
+    pt_max_blocks_per_seq,
+    batch_idxs,
+    inject_skip_for_batch_idx=None,
+):
+    TILE_HEIGHT = 32
+    TILE_WIDTH = 32
+    assert head_dim % TILE_WIDTH == 0
+    assert input_seq_len % TILE_HEIGHT == 0
+    assert cache_block_size % TILE_HEIGHT == 0
+    for bi in batch_idxs:
+        assert int(bi) < page_table_batch_size
+
+    initial_cache_torch, input_torch, page_table_torch = _build_batched_inputs(
+        num_input_batch=num_input_batch,
+        num_input_heads=num_input_heads,
+        input_seq_len=input_seq_len,
+        head_dim=head_dim,
+        cache_max_blocks=cache_max_blocks,
+        cache_block_size=cache_block_size,
+        page_table_batch_size=page_table_batch_size,
+        pt_max_blocks_per_seq=pt_max_blocks_per_seq,
+        batch_idxs=batch_idxs,
+        inject_skip_for_batch_idx=inject_skip_for_batch_idx,
+    )
+
+    cache_tt = ttnn.from_torch(initial_cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    batch_idxs_torch = torch.tensor(batch_idxs, dtype=torch.int32)
+    batch_idx_tensor_dev = ttnn.from_torch(
+        batch_idxs_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.uint32
+    )
+
+    output_cache_tt = ttnn.experimental.paged_fill_cache(
+        cache_tt,
+        input_tt,
+        page_table_tt,
+        batch_idx_tensor=batch_idx_tensor_dev,
+        batch_idx=0,
+    )
+
+    expected_cache_torch = _reference_batched_paged_fill_cache(
+        initial_cache_torch, input_torch, page_table_torch, batch_idxs
+    )
+
+    output_cache_torch = ttnn.to_torch(output_cache_tt)
+    passing, message = comp_equal(output_cache_torch, expected_cache_torch)
+    logger.info(message)
+    assert passing, message
+
+
+@pytest.mark.parametrize("num_input_heads", [1, 8])
+@pytest.mark.parametrize("input_seq_len", [128, 2048])
+@pytest.mark.parametrize(
+    "num_input_batch, batch_idxs",
+    [
+        (2, [0, 1]),
+        (8, list(range(8))),
+        (32, list(range(32))),
+        # Non-contiguous batch_idxs: each input row writes to a non-sequential cache row.
+        (8, [5, 12, 0, 31, 17, 3, 9, 24]),
+    ],
+    ids=["b2_contig", "b8_contig", "b32_contig", "b8_permuted"],
+)
+def test_paged_fill_cache_batched(device, num_input_heads, input_seq_len, num_input_batch, batch_idxs):
+    """Single batched call fills `num_input_batch` cache rows in one op."""
+    _run_batched_paged_fill_cache(
+        device,
+        num_input_batch=num_input_batch,
+        num_input_heads=num_input_heads,
+        input_seq_len=input_seq_len,
+        head_dim=128,
+        cache_max_blocks=1024,
+        cache_block_size=64,
+        page_table_batch_size=32,
+        pt_max_blocks_per_seq=32,
+        batch_idxs=batch_idxs,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_input_batch, batch_idxs, skip_for_batch_idx",
+    [
+        (4, [0, 1, 2, 3], 2),  # core may span the skipped batch
+        (8, [3, 1, 7, 0, 4, 2, 6, 5], 7),
+    ],
+    ids=["b4_skip_b2", "b8_perm_skip_b7"],
+)
+def test_paged_fill_cache_batched_skip_entries(device, num_input_batch, batch_idxs, skip_for_batch_idx):
+    """Per-block -1 (SKIP) sentinel entries in the page_table under the batched path."""
+    _run_batched_paged_fill_cache(
+        device,
+        num_input_batch=num_input_batch,
+        num_input_heads=1,
+        input_seq_len=2048,
+        head_dim=128,
+        cache_max_blocks=1024,
+        cache_block_size=64,
+        page_table_batch_size=32,
+        pt_max_blocks_per_seq=32,
+        batch_idxs=batch_idxs,
+        inject_skip_for_batch_idx=skip_for_batch_idx,
+    )
+
+
+def test_paged_fill_cache_batched_program_cache(device):
+    """Identical batched shapes share one program cache entry; new shape allocates a new one."""
+    common = dict(
+        num_input_heads=1,
+        input_seq_len=128,
+        head_dim=128,
+        cache_max_blocks=1024,
+        cache_block_size=64,
+        page_table_batch_size=32,
+        pt_max_blocks_per_seq=32,
+    )
+
+    initial_entries = device.num_program_cache_entries()
+
+    _run_batched_paged_fill_cache(device, num_input_batch=4, batch_idxs=[0, 1, 2, 3], **common)
+    after_first = device.num_program_cache_entries()
+    assert after_first - initial_entries == 1, "first call should create one program cache entry"
+
+    _run_batched_paged_fill_cache(device, num_input_batch=4, batch_idxs=[4, 5, 6, 7], **common)
+    after_second = device.num_program_cache_entries()
+    assert after_second == after_first, "same batched shape should reuse the program cache entry"
+
+    _run_batched_paged_fill_cache(device, num_input_batch=8, batch_idxs=list(range(8)), **common)
+    after_third = device.num_program_cache_entries()
+    assert after_third - after_second == 1, "different input_batch should allocate a new entry"
+
+
+@pytest.mark.parametrize("bad_tensor_size", [1, 3, 5, 7])
+def test_paged_fill_cache_batched_rejects_mismatched_batch_idx_tensor(device, bad_tensor_size):
+    """batch_idx_tensor must have exactly input_batch elements; anything else FATALs.
+
+    Covers the silent-wrong-result hole where input_batch > 1 paired with a
+    single-element batch_idx_tensor previously passed validation but produced
+    out-of-range writes in the kernel.
+    """
+    initial_cache_torch, input_torch, page_table_torch = _build_batched_inputs(
+        num_input_batch=4,
+        num_input_heads=1,
+        input_seq_len=128,
+        head_dim=128,
+        cache_max_blocks=1024,
+        cache_block_size=64,
+        page_table_batch_size=32,
+        pt_max_blocks_per_seq=32,
+        batch_idxs=[0, 1, 2, 3],
+    )
+    cache_tt = ttnn.from_torch(initial_cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    bad = ttnn.from_torch(
+        torch.arange(bad_tensor_size, dtype=torch.int32),
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint32,
+    )
+    with pytest.raises(RuntimeError):
+        ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx_tensor=bad, batch_idx=0)
+
+
+def test_paged_fill_cache_rejects_multi_batch_input_without_tensor(device):
+    """input_batch > 1 with no batch_idx_tensor was previously a silent wrong-result; now FATAL."""
+    initial_cache_torch, input_torch, page_table_torch = _build_batched_inputs(
+        num_input_batch=4,
+        num_input_heads=1,
+        input_seq_len=128,
+        head_dim=128,
+        cache_max_blocks=1024,
+        cache_block_size=64,
+        page_table_batch_size=32,
+        pt_max_blocks_per_seq=32,
+        batch_idxs=[0, 1, 2, 3],
+    )
+    cache_tt = ttnn.from_torch(initial_cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    with pytest.raises(RuntimeError):
+        ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx=0)
+
+
+def test_paged_fill_cache_batched_mesh_coords(device):
+    """Mesh workload variant of the batched path on a single device.
+
+    The mesh workload factory dispatches to PagedFillCacheProgramFactory per
+    coordinate, so it inherits the batched behavior. This test pins it down
+    against the per-row reference.
+    """
+    num_input_batch = 4
+    batch_idxs = [0, 1, 2, 3]
+    initial_cache_torch, input_torch, page_table_torch = _build_batched_inputs(
+        num_input_batch=num_input_batch,
+        num_input_heads=1,
+        input_seq_len=128,
+        head_dim=128,
+        cache_max_blocks=1024,
+        cache_block_size=64,
+        page_table_batch_size=32,
+        pt_max_blocks_per_seq=32,
+        batch_idxs=batch_idxs,
+    )
+    cache_tt = ttnn.from_torch(initial_cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+    batch_idx_tensor_dev = ttnn.from_torch(
+        torch.tensor(batch_idxs, dtype=torch.int32),
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint32,
+    )
+
+    mesh_coords = {ttnn.MeshCoordinate(0, 0)}
+    output_cache_tt = ttnn.experimental.paged_fill_cache(
+        cache_tt,
+        input_tt,
+        page_table_tt,
+        batch_idx_tensor=batch_idx_tensor_dev,
+        batch_idx=0,
+        mesh_coords=mesh_coords,
+    )
+
+    expected_cache_torch = _reference_batched_paged_fill_cache(
+        initial_cache_torch, input_torch, page_table_torch, batch_idxs
+    )
+    output_cache_torch = ttnn.to_torch(output_cache_tt)
+    passing, message = comp_equal(output_cache_torch, expected_cache_torch)
+    logger.info(message)
+    assert passing, message
+
+
+def test_paged_fill_cache_batched_rejects_non_row_major_batch_idx_tensor(device):
+    """The writer kernel reads batch_idx_tensor as a single contiguous noc page;
+    require ROW_MAJOR layout so that read covers the whole 1D buffer."""
+    initial_cache_torch, input_torch, page_table_torch = _build_batched_inputs(
+        num_input_batch=4,
+        num_input_heads=1,
+        input_seq_len=128,
+        head_dim=128,
+        cache_max_blocks=1024,
+        cache_block_size=64,
+        page_table_batch_size=32,
+        pt_max_blocks_per_seq=32,
+        batch_idxs=[0, 1, 2, 3],
+    )
+    cache_tt = ttnn.from_torch(initial_cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    # batch_idx_tensor must be ROW_MAJOR; TILE_LAYOUT should be rejected.
+    # int dtypes can't be tilized directly, so build a ROW_MAJOR tensor and
+    # tilize it; if that path is not supported, the test will skip itself.
+    try:
+        rm_tensor = ttnn.from_torch(
+            torch.tensor([0, 1, 2, 3], dtype=torch.int32),
+            device=device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.uint32,
+        )
+        bad = ttnn.to_layout(rm_tensor, ttnn.TILE_LAYOUT)
+    except (RuntimeError, ValueError):
+        pytest.skip("Cannot construct a TILE_LAYOUT uint32 tensor on this build; layout assertion still in place.")
+
+    with pytest.raises(RuntimeError):
+        ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx_tensor=bad, batch_idx=0)

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -102,10 +102,18 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
 
     if (tensor_args.batch_idx_tensor_opt.has_value()) {
         const auto& tensor = tensor_args.batch_idx_tensor_opt.value();
-        TT_FATAL(tensor.physical_volume() == 1, "Batch idx tensor must have a single element");
+        const auto input_batch = input_shape[0];
+        TT_FATAL(
+            tensor.physical_volume() == input_batch,
+            "Batch idx tensor must have input_tensor batch dim ({}) elements, got {}",
+            input_batch,
+            tensor.physical_volume());
         TT_FATAL(
             tensor.dtype() == DataType::UINT32 || tensor.dtype() == DataType::INT32,
             "Batch idx tensor must be an integer type");
+        // The writer kernel reads the tensor as a single contiguous noc page;
+        // require ROW_MAJOR so that read covers the whole 1D buffer.
+        TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Batch idx tensor must be in ROW_MAJOR layout");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -111,9 +111,18 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             tensor.dtype() == DataType::UINT32 || tensor.dtype() == DataType::INT32,
             "Batch idx tensor must be an integer type");
-        // The writer kernel reads the tensor as a single contiguous noc page;
-        // require ROW_MAJOR so that read covers the whole 1D buffer.
+        // The writer kernel reads the tensor as a single contiguous noc page
+        // via TensorAccessor::get_noc_addr(0). That only resolves correctly for
+        // a ROW_MAJOR, INTERLEAVED, DRAM-resident buffer; sharded or L1-resident
+        // tensors would have batch_idx values scattered across NoC locations
+        // the single read won't cover.
         TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Batch idx tensor must be in ROW_MAJOR layout");
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Batch idx tensor must have INTERLEAVED memory layout");
+        TT_FATAL(
+            tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
+            "Batch idx tensor must be DRAM-resident");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -33,12 +33,15 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    // input_tensor: [1, num_heads, input_seq_len, head_dim]
-    // cache_tensor: [max_num_blocks, num_kv_heads, block_size, head_dim]
+    // input_tensor:      [input_batch, num_heads, input_seq_len, head_dim]
+    //   input_batch == 1 on the legacy single-batch path; input_batch == N
+    //   on the batched path, where N matches batch_idx_tensor element count.
+    // cache_tensor:      [max_num_blocks, num_kv_heads, block_size, head_dim]
     // page_table_tensor: [b, max_num_blocks_per_seq]
     //
     // head_dim comes from the input and block_size honors the override; the cache shape
     // is only a byte budget (per-block byte count enforced in validate).
+    const uint32_t input_batch = input_tensor.padded_shape()[0];
     const uint32_t num_heads = input_tensor.padded_shape()[1];
     const uint32_t input_seq_len = input_tensor.padded_shape()[2];
 
@@ -49,8 +52,13 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     const uint32_t Wt = head_dim / TILE_WIDTH;
     const uint32_t block_size_t = block_size / TILE_HEIGHT;
 
-    uint32_t num_blocks_of_work = num_heads * input_seq_len_t;
-    uint32_t num_blocks_of_work_per_head = input_seq_len_t;
+    // Each "block of work" is one (batch, head, seq_tile) triple to write.
+    // num_blocks_of_work_per_batch lets the writer kernel recover the batch
+    // index for the batched path; on the legacy path input_batch == 1 so
+    // num_blocks_of_work == num_blocks_of_work_per_batch.
+    const uint32_t num_blocks_of_work_per_batch = num_heads * input_seq_len_t;
+    const uint32_t num_blocks_of_work = input_batch * num_blocks_of_work_per_batch;
+    const uint32_t num_blocks_of_work_per_head = input_seq_len_t;
 
     // Pagetable-specific parameters
     uint32_t page_table_stick_size_B = page_table_tensor.buffer()->aligned_page_size();
@@ -60,18 +68,36 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     uint32_t log2_page_table_stick_size_B = std::log2(page_table_stick_size_B);
     tt::DataFormat page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.dtype());
 
-    // batch_idx_tensor specific parameters
-    bool use_batch_idx_tensor = batch_idx_tensor.has_value();
+    // batch_idx_tensor specific parameters. When provided, the tensor's
+    // element count must equal input_batch: one batch_idx per input batch
+    // row. The legacy single-batch case (input_batch == 1, tensor.shape ==
+    // [1]) falls out naturally.
+    const bool use_batch_idx_tensor = batch_idx_tensor.has_value();
     uint32_t batch_idx_buffer_addr = 0;
-    tt::DataFormat batch_idx_data_format = tt::DataFormat::UInt32;  // Assuming batch_idx is uint32
-    uint32_t batch_idx_stick_size_B = 4;                            // Assuming scalar uint32
+    tt::DataFormat batch_idx_data_format = tt::DataFormat::UInt32;
+    uint32_t batch_idx_stick_size_B = 4;  // per-element size, e.g. 4 for uint32
+    uint32_t batch_idx_num_elements = 1;
 
     if (use_batch_idx_tensor) {
         const auto& tensor = batch_idx_tensor.value();
         batch_idx_buffer_addr = tensor.buffer()->address();
         batch_idx_data_format = tt_metal::datatype_to_dataformat_converter(tensor.dtype());
         batch_idx_stick_size_B = tensor.element_size();
-        TT_FATAL(tensor.physical_volume() == 1, "batch_idx_tensor must contain a single element.");
+        batch_idx_num_elements = tensor.physical_volume();
+        TT_FATAL(
+            batch_idx_num_elements == input_batch,
+            "batch_idx_tensor must contain input_batch ({}) elements, got {}",
+            input_batch,
+            batch_idx_num_elements);
+    } else {
+        // No batch_idx_tensor: scalar fallback path writes one batch row,
+        // so input_batch must be 1. Previously implicit; explicit FATAL
+        // avoids silently dropping rows > 0.
+        TT_FATAL(
+            input_batch == 1,
+            "When no batch_idx_tensor is provided, input_batch must be 1 (got {}); pass a batch_idx_tensor of size "
+            "input_batch to fill multiple batch rows in one call.",
+            input_batch);
     }
 
     tt_metal::IDevice* device = input_tensor.device();
@@ -98,7 +124,15 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     create_cb(src0_cb_index, program, all_cores, single_tile_size, num_input_tiles, cb_data_format);
     create_cb(page_table_cb_index, program, all_cores, page_table_stick_size_B, 1, page_table_data_format);
     if (use_batch_idx_tensor) {
-        create_cb(cb_batch_idx_id, program, all_cores, batch_idx_stick_size_B, 1, batch_idx_data_format);
+        // CB holds all `batch_idx_num_elements` entries so the writer kernel
+        // can pick the right entry per batch row in the batched case.
+        create_cb(
+            cb_batch_idx_id,
+            program,
+            all_cores,
+            batch_idx_stick_size_B * batch_idx_num_elements,
+            1,
+            batch_idx_data_format);
     }
 
     auto* src_buffer = input_tensor.buffer();
@@ -117,10 +151,13 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
         Wt,
         log2_page_table_stick_size_B,
         page_table_stick_size_B,
-        // New compile-time args for batch_idx_tensor
+        // batch_idx_tensor compile-time args (positions 8..12). Positions 9..12
+        // are only meaningful when use_batch_idx_tensor is true.
         (uint32_t)use_batch_idx_tensor,
-        cb_batch_idx_id,        // Meaningful only if use_batch_idx_tensor is true
-        batch_idx_stick_size_B  // Meaningful only if use_batch_idx_tensor is true
+        cb_batch_idx_id,
+        batch_idx_stick_size_B,        // per-element size, e.g. 4 for uint32
+        batch_idx_num_elements,        // 1 = legacy single-batch, N = batched
+        num_blocks_of_work_per_batch,  // num_heads * input_seq_len_t, for row_id -> batch decode
     };
     TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
     TensorAccessorArgs(page_table_buffer).append_to(writer_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -38,11 +38,18 @@ void kernel_main() {
     constexpr uint32_t log2_page_table_stick_size = get_compile_time_arg_val(6);
     constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(7);
 
-    // New compile-time args for optional batch_idx_tensor
+    // Compile-time args for optional batch_idx_tensor.
+    // When use_batch_idx_tensor is true, runtime arg 4 is the address of a
+    // 1D int tensor with `batch_idx_num_elements` entries:
+    //   1            -> single-batch (legacy) path; input_tensor.shape[0] == 1.
+    //   input_batch  -> batched path; one batch_idx per input batch row,
+    //                   selected per row via `num_blocks_per_batch`.
     constexpr bool use_batch_idx_tensor = get_compile_time_arg_val(8) == 1;
-    constexpr uint32_t cb_id_batch_idx = get_compile_time_arg_val(9);  // CB for reading from batch_idx_tensor
-    constexpr uint32_t batch_idx_stick_size =
-        get_compile_time_arg_val(10);  // Expected to be small (e.g., 4 for uint32)
+    constexpr uint32_t cb_id_batch_idx = get_compile_time_arg_val(9);
+    constexpr uint32_t batch_idx_stick_size = get_compile_time_arg_val(10);  // per-element size, e.g. 4 for uint32
+    constexpr uint32_t batch_idx_num_elements = get_compile_time_arg_val(11);
+    constexpr uint32_t num_blocks_per_batch = get_compile_time_arg_val(12);  // num_heads * input_seq_len_t
+    constexpr bool batched_fill = batch_idx_num_elements > 1;
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t page_table_addr = get_arg_val<uint32_t>(1);
@@ -56,44 +63,79 @@ void kernel_main() {
         return;  // Early exit, no work done
     }
 
-    constexpr auto s0_args = TensorAccessorArgs<11>();
+    constexpr auto s0_args = TensorAccessorArgs<13>();
     constexpr auto page_table_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     constexpr auto batch_idx_tensor_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
 
-    uint32_t batch_idx;
+    // Resolve batch_idx source. For use_batch_idx_tensor=true we load the
+    // (small) 1D tensor into an L1 CB once so per-row lookups stay local.
+    // For use_batch_idx_tensor=false the scalar fallback in arg 4 is used.
+    volatile tt_l1_ptr uint32_t* batch_idx_arr = nullptr;
+    uint32_t scalar_batch_idx = 0;
     if constexpr (use_batch_idx_tensor) {
-        uint32_t batch_idx_tensor_addr = batch_arg;  // Arg 4 is the address
-
-        const auto batch_idx_gen = TensorAccessor(batch_idx_tensor_args, batch_idx_tensor_addr);
-        cb_reserve_back(cb_id_batch_idx, 1);  // Expecting 1 element (the batch_idx)
-        uint32_t batch_idx_cb_wr_ptr = get_write_ptr(cb_id_batch_idx);
-        uint64_t batch_idx_noc_addr = batch_idx_gen.get_noc_addr(0);
-        noc_async_read(batch_idx_noc_addr, batch_idx_cb_wr_ptr, batch_idx_stick_size);
+        const auto batch_idx_gen = TensorAccessor(batch_idx_tensor_args, batch_arg);
+        cb_reserve_back(cb_id_batch_idx, 1);
+        const uint32_t batch_idx_cb_wr_ptr = get_write_ptr(cb_id_batch_idx);
+        // The tensor is a contiguous 1D int (uint32/int32) tensor in DRAM with
+        // `batch_idx_num_elements` entries; one TensorAccessor stick covers it.
+        const uint64_t batch_idx_noc_addr = batch_idx_gen.get_noc_addr(0);
+        noc_async_read(batch_idx_noc_addr, batch_idx_cb_wr_ptr, batch_idx_stick_size * batch_idx_num_elements);
         noc_async_read_barrier();
-        volatile tt_l1_ptr uint32_t* batch_idx_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_idx_cb_wr_ptr);
-        batch_idx = batch_idx_ptr[0];
+        batch_idx_arr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_idx_cb_wr_ptr);
     } else {
-        batch_idx = batch_arg;  // Arg 4 is the scalar fallback value
+        scalar_batch_idx = batch_arg;
     }
 
     const uint32_t tile_bytes = get_tile_size(cb_id_in);
     const DataFormat data_format = get_dataformat(cb_id_in);
 
     const auto out_gen = TensorAccessor(s0_args, dst_addr);
-
     const auto page_table_gen = TensorAccessor(page_table_args, page_table_addr);
-    cb_reserve_back(cb_id_page_table, 1);
-    uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
-    uint64_t page_table_noc_addr = page_table_gen.get_noc_addr(batch_idx);
-    noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-    noc_async_read_barrier();
 
+    cb_reserve_back(cb_id_page_table, 1);
+    const uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
     volatile tt_l1_ptr uint32_t* page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
 
+    // Cache the last batch for which page_table was loaded. Legacy path loads
+    // once on the first row (cache miss) and then hits for all remaining rows;
+    // batched path re-loads on batch boundaries within this core's row range.
+    uint32_t cached_batch = (uint32_t)-1;
+
     for (uint32_t row_id = start_row_num; row_id < start_row_num + num_rows; ++row_id) {
-        uint32_t cur_head = row_id / num_blocks_of_work_per_head;
-        uint32_t seq_tile_id = row_id % num_blocks_of_work_per_head;
+        // Decode row_id → (cur_batch, cur_head, seq_tile_id).
+        // Input layout: [input_batch, num_heads, input_seq_len_t]
+        //   row_id = cur_batch * num_blocks_per_batch
+        //            + cur_head * num_blocks_of_work_per_head
+        //            + seq_tile_id
+        // On the legacy path (batched_fill == false) cur_batch is always 0
+        // and the per-batch arithmetic is elided.
+        uint32_t cur_batch;
+        uint32_t row_within_batch;
+        if constexpr (batched_fill) {
+            cur_batch = row_id / num_blocks_per_batch;
+            row_within_batch = row_id - cur_batch * num_blocks_per_batch;
+        } else {
+            cur_batch = 0;
+            row_within_batch = row_id;
+        }
+        const uint32_t cur_head = row_within_batch / num_blocks_of_work_per_head;
+        const uint32_t seq_tile_id = row_within_batch % num_blocks_of_work_per_head;
+
+        uint32_t batch_idx;
+        if constexpr (use_batch_idx_tensor) {
+            batch_idx = batch_idx_arr[batched_fill ? cur_batch : 0];
+        } else {
+            batch_idx = scalar_batch_idx;
+        }
+
+        // Reload page_table row only on batch boundary.
+        if (batch_idx != cached_batch) {
+            const uint64_t page_table_noc_addr = page_table_gen.get_noc_addr(batch_idx);
+            noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
+            noc_async_read_barrier();
+            cached_batch = batch_idx;
+        }
+
         uint32_t physical_tile_id =
             virtual_seq_tile_id_to_physical_tile_id<num_heads, block_size_t, Wt>(seq_tile_id, cur_head, page_table_ptr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -99,10 +99,10 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         Paged fill cache operation. This operation expects the following inputs: cache_tensor, input_tensor, and page_table.
         It uses either batch_idx_tensor (if provided, kwarg batch_idx_tensor) or batch_idx (kwarg batch_idx) as a fallback to determine the batch index for updating the cache.
         cache_tensor shape: [max_num_blocks, 1, block_size, head_dim]
-        input_tensor shape: [1, num_heads, input_seq_len, head_dim]
+        input_tensor shape: [input_batch, num_heads, input_seq_len, head_dim]
         page_table shape: [batch_size, max_num_blocks_per_seq]
-        batch_idx_tensor (optional) shape: [1] (scalar uint32 tensor)
-        batch_idx (scalar, defaults to 0) is used if batch_idx_tensor is not provided.
+        batch_idx_tensor (optional) shape: [input_batch], int32 or uint32 — one batch_idx per input batch row.
+        batch_idx (scalar, defaults to 0) is used if batch_idx_tensor is not provided; in that case input_batch must be 1.
         mesh_coords (optional) is a set of MeshCoordinate objects that specify the mesh coordinates to execute on.
 
         ``head_dim`` is read from ``input_tensor.padded_shape[-1]``. ``block_size``

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -101,7 +101,7 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         cache_tensor shape: [max_num_blocks, 1, block_size, head_dim]
         input_tensor shape: [input_batch, num_heads, input_seq_len, head_dim]
         page_table shape: [batch_size, max_num_blocks_per_seq]
-        batch_idx_tensor (optional) shape: [input_batch], int32 or uint32 — one batch_idx per input batch row.
+        batch_idx_tensor (optional) shape: [input_batch], dtype int32 or uint32, ROW_MAJOR layout, INTERLEAVED DRAM — one batch_idx per input batch row.
         batch_idx (scalar, defaults to 0) is used if batch_idx_tensor is not provided; in that case input_batch must be 1.
         mesh_coords (optional) is a set of MeshCoordinate objects that specify the mesh coordinates to execute on.
 


### PR DESCRIPTION
### PR Category

Feature.

### Summary

Closes https://github.com/tenstorrent/tt-metal/issues/45116. Relates to tenstorrent/tt-xla#4880.

`ttnn::experimental::paged_fill_cache`'s optional `batch_idx_tensor` is asserted to have a single element, which forces multi-user prefill paths (vLLM, JAX serving) to fan out one op call per user. At 32-layer Llama-3.1-8B b32 that produces 2048 `paged_fill_cache` ops + ~7000 supporting ops in one compiled prefill graph (vs. 64 ops needed), driving ~150 s engine init.

This PR relaxes the contract so `batch_idx_tensor.physical_volume() == input_tensor.shape[0]` — one `batch_idx` per input batch row. The legacy single-batch case (`input_batch == 1`, `tensor.shape == [1]`) is covered by the same rule; the new batched path collapses the host-side loop into one device call. The user-facing API signature is unchanged.

Effect at b32 (Llama-3.1-8B prefill graph_4): **2048 → 64 `paged_fill_cache` ops, 18296 → 4025 total ops, ~150 s → ~50 s engine init.** TTFT essentially unchanged; per-user decode tok/s also improves modestly at long `max_model_len` (~+20% at seq=2048). Headline win is compile-time / IR / program-cache footprint.

### Notes for reviewers

**Risk is low for existing callers.** Every in-tree caller of `paged_fill_cache` (surveyed across `models/tt_transformers`, `models/llama3_70b_galaxy`, `models/demos/{deepseek_v3,gemma4,gpt_oss,qwen3_vl,qwen25_vl,t3000/llama2_70b,openvla}`, `models/common/modules/attention/attention_1d`, plus downstream `tt-xla/integrations/vllm_plugin`) passes `input_batch == 1` with either a scalar `batch_idx` or a 1-element ROW_MAJOR `batch_idx_tensor`. These satisfy the new validation. `if constexpr (batched_fill)` in the writer kernel gates the new per-batch arithmetic, so legacy callers' generated kernel code is bit-for-bit identical to today's. On-device output verified equal to pre-change for the scalar-`batch_idx`, 1-element-tensor, and `mesh_coords` legacy paths on Blackhole p150.

Three places where I'd appreciate a careful look:

1. **Contract tightening creates three new `TT_FATAL`s.** They fire on input combinations that previously produced wrong/undefined results silently — no in-tree caller hits any of them. See the Backward Compatibility table below.
2. **Writer kernel adds two compile-time args at positions 11 and 12.** This shifts the `TensorAccessorArgs<11>` start offset to `<13>`. Internal to this kernel + program factory pair; no known external direct callers. Worth eyeballing in the diff to confirm there's no other consumer.
3. **Implementation choice: unified kernel vs. two-program-factory split.** This PR uses one kernel gated on a compile-time arg. A two-factory split selected by `batch_idx_tensor.physical_volume()` at the host op is the more conservative alternative (fully isolates the legacy path at the cost of duplicating ~100 lines of host code). Happy to switch if you prefer the isolation.

Cross-repo dependents are sequenced (tt-mlir verifier update follows this PR; tt-xla `attention.py` switch follows tt-mlir). Both are ready and reference this PR's commit in their version pins.

**Post-review-approval updates** (last two commits on the branch): (1) tightened `batch_idx_tensor` validation to also require `INTERLEAVED` + `DRAM` memory config (Copilot suggestion — closes a sharded-tensor read-correctness gap), and (2) constrained the new `test_paged_fill_cache_batched` parametrize to `num_input_heads=1` to match the now-rebased base which added a strict `input_num_heads == cache_num_heads` device-op check in #44073. See the follow-up comment on this PR for the detailed review-time walkthrough (Files + Test plan).

## Backward compatibility

| surface | change |
|---|---|
| `ttnn::experimental::paged_fill_cache` API | unchanged |
| Validation | `==1` → `== input_batch`, plus `Layout::ROW_MAJOR` + `INTERLEAVED` + `DRAM` for `batch_idx_tensor`. All in-tree callers (surveyed across `models/`) pass `input_batch == 1`, `tensor.shape == [1]`, ROW_MAJOR, INTERLEAVED, DRAM — unaffected. |
| Writer kernel compile-time args | +2 args; TensorAccessor offset 11 → 13 |
| `input_batch > 1` + no `batch_idx_tensor` | silent wrong result → `TT_FATAL` |
| `input_batch > 1` + `tensor.shape == [1]` | undefined writes → `TT_FATAL` |
| `batch_idx_tensor` not ROW_MAJOR / not INTERLEAVED-DRAM | undefined NoC read → `TT_FATAL` |

The new `TT_FATAL`s surface previously-latent bugs in the no-tensor, 1-element-tensor, and unsupported-memory-config paths; none have any in-tree caller.

## Numbers

Llama-3.1-8B 32-layer prefill graph (`graph_4`):

| | b1 main | b32 main | b32 this PR |
|---|---:|---:|---:|
| `paged_fill_cache` ops | 64 | 2048 | 64 |
| total graph ops | 4281 | 18296 | 4025 |
| engine init (compile+warmup) | — | ~150 s | ~50 s |
| benchmark wall-clock | — | 211 s | 100 s |
| TTFT | — | ~3.4 s | ~3.4 s (no change) |
| decode tok/s/user | — | — | modest lift at long max_model_len (~+20% at seq=2048) |

Headline: compile-time / IR / program-cache footprint win, with a downstream decode-tok/s benefit at long `max_model_len`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kmabee/batch_paged_fill_cache_issue_4880_poc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kmabee/batch_paged_fill_cache_issue_4880_poc)
