### PR TITLE
Better validation for matmul ops - Phase 2

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -243,6 +243,39 @@ def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_s
     )
 
 
+@pytest.mark.parametrize(
+    "activation",
+    [
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.6732632, 1.0507009),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0),
+    ],
+)
+def test_linear_fused_activation_numerical_stability(device, activation):
+    """Each supported fused activation must produce finite outputs (no NaN, no Inf)."""
+    torch.manual_seed(0)
+    m, k, n = 64, 128, 64
+    in0 = torch.randn(1, 1, m, k, dtype=torch.bfloat16)
+    in1 = torch.randn(1, 1, k, n, dtype=torch.bfloat16)
+
+    in0_t = ttnn.from_torch(in0, layout=ttnn.TILE_LAYOUT, device=device)
+    in1_t = ttnn.from_torch(in1, layout=ttnn.TILE_LAYOUT, device=device)
+
+    out = ttnn.matmul(in0_t, in1_t, activation=activation)
+    ttnn.synchronize_device(device)
+    out_torch = ttnn.to_torch(out).to(torch.float32)
+
+    assert not torch.isnan(out_torch).any(), f"{activation.op_type} produced NaN"
+    assert not torch.isinf(out_torch).any(), f"{activation.op_type} produced Inf"
+
+
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [32, 64])
 @pytest.mark.parametrize("k_size", [1024])
@@ -1064,6 +1097,27 @@ def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bia
                 assert result.shape == optional_shape
             else:
                 assert result.shape == expected.shape
+
+
+def test_linear_bias_rejected_on_multicore_reuse_program_config(device):
+    """Bias is not supported for MatmulMultiCoreReuseProgramConfig — validate-time check."""
+    torch.manual_seed(0)
+    m, k, n = 64, 64, 64
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch.randn(1, 1, 32, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=k // 32,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=m // 32,
+        per_core_N=n // 32,
+    )
+
+    with pytest.raises(RuntimeError, match="Bias is not supported for this matmul program config"):
+        ttnn.linear(in0, in1, bias=bias, program_config=program_config)
 
 
 @pytest.mark.parametrize("bias_rank", [0, 1, 2, 3, 4])

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -269,7 +269,6 @@ def test_linear_fused_activation_numerical_stability(device, activation):
     in1_t = ttnn.from_torch(in1, layout=ttnn.TILE_LAYOUT, device=device)
 
     out = ttnn.linear(in0_t, in1_t, bias=None, activation=activation)
-    ttnn.synchronize_device(device)
     out_torch = ttnn.to_torch(out).to(torch.float32)
 
     assert not torch.isnan(out_torch).any(), f"{activation.op_type} produced NaN"

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -268,7 +268,7 @@ def test_linear_fused_activation_numerical_stability(device, activation):
     in0_t = ttnn.from_torch(in0, layout=ttnn.TILE_LAYOUT, device=device)
     in1_t = ttnn.from_torch(in1, layout=ttnn.TILE_LAYOUT, device=device)
 
-    out = ttnn.matmul(in0_t, in1_t, activation=activation)
+    out = ttnn.linear(in0_t, in1_t, bias=None, activation=activation)
     ttnn.synchronize_device(device)
     out_torch = ttnn.to_torch(out).to(torch.float32)
 
@@ -1116,7 +1116,7 @@ def test_linear_bias_rejected_on_multicore_reuse_program_config(device):
         per_core_N=n // 32,
     )
 
-    with pytest.raises(RuntimeError, match="Bias is not supported for this matmul program config"):
+    with pytest.raises(RuntimeError, match="Bias is not supported for this matmul program config:"):
         ttnn.linear(in0, in1, bias=bias, program_config=program_config)
 
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3920,3 +3920,51 @@ def test_matmul_2d_nd_sharded_in1(device, m, k, n, grid_size, k_splits, n_splits
     # Same weight, same matmul program; only in1's DRAM layout differs, so the ND
     # read must reproduce the interleaved read bit-for-bit.
     assert_equal(out_interleaved, out_nd)
+
+
+def test_matmul_activation_rejected_on_multicore_reuse_program_config(device):
+    """Fused activation is not supported for MatmulMultiCoreReuseProgramConfig — validate-time check."""
+    torch.manual_seed(0)
+    m, k, n = 64, 64, 64
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=k // 32,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=m // 32,
+        per_core_N=n // 32,
+    )
+
+    with pytest.raises(RuntimeError, match="Fused activation is not supported for this matmul program config:"):
+        ttnn.matmul(
+            in0,
+            in1,
+            program_config=program_config,
+            activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
+        )
+
+
+def test_matmul_kt_not_divisible_by_in0_block_w_rejected(device):
+    """Kt (K / tile_width) must be divisible by in0_block_w — error message must include both values."""
+    torch.manual_seed(0)
+    m, k, n = 64, 128, 64
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=3,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=m // 32,
+        per_core_N=n // 32,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+    with pytest.raises(RuntimeError, match=r"Kt \(4\) must be divisible by in0_block_w \(3\)"):
+        ttnn.matmul(in0, in1, program_config=program_config)

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -623,3 +623,94 @@ def test_sparse_matmul_inputA_without_nnz(device, mkn, num_experts, num_batches,
             pcc_threshold=0.999,
             check_ulp=False,
         )
+
+
+def _make_sparse_inputs(device, b=1, s=4, m=32, k=128, n=512, num_experts=8, tile_h=32, tile_w=32):
+    torch.manual_seed(0)
+    in0 = ttnn.from_torch(
+        torch.randn((b, s, m, k), dtype=torch.bfloat16),
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    in1 = ttnn.from_torch(
+        torch.randn((1, num_experts, k, n), dtype=torch.bfloat16),
+        tile=ttnn.Tile((32, tile_w)),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    sparsity = ttnn.from_torch(
+        torch.ones((b, s, 1, num_experts), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    nnz = b * s * num_experts
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(4, 4),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=m // tile_h,
+        per_core_N=int(math.ceil(n / tile_w)) // 16,
+        fuse_batch=False,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+    return in0, in1, sparsity, nnz, program_config, (m, k, n, num_experts, tile_h, tile_w)
+
+
+def test_sparse_matmul_requires_at_least_one_sparse_flag(device):
+    """At least one of is_input_a_sparse / is_input_b_sparse must be true."""
+    in0, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    _, _, _, _, tile_h, tile_w = dims
+
+    with pytest.raises(
+        RuntimeError,
+        match="sparse_matmul requires at least one of is_input_a_sparse or is_input_b_sparse to be true",
+    ):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=False,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_volume_must_match_batch_length(device):
+    """sparsity logical_volume must equal product of all batch dimensions."""
+    in0, in1, _, nnz, pc, dims = _make_sparse_inputs(device)
+    _, _, _, num_experts, tile_h, tile_w = dims
+
+    wrong_sparsity = ttnn.from_torch(
+        torch.ones((1, 2, 1, num_experts), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    with pytest.raises(RuntimeError, match="sparsity logical_volume"):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=wrong_sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -715,3 +715,133 @@ def test_sparse_matmul_volume_must_match_batch_length(device):
             output_tile=ttnn.Tile([tile_h, tile_w]),
             program_config=pc,
         )
+
+
+def test_sparse_matmul_inputA_wrong_layout(device):
+    """Input tensor A must be TILE layout, ROW_MAJOR must be rejected."""
+    _, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    m, k, _, _, tile_h, tile_w = dims
+
+    in0_row_major = ttnn.from_torch(
+        torch.randn((1, 4, m, k), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with pytest.raises(RuntimeError, match="Input tensor A must be TILE layout"):
+        ttnn.sparse_matmul(
+            in0_row_major,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_inputB_wrong_layout(device):
+    """Input tensor B must be TILE layout, ROW_MAJOR must be rejected."""
+    in0, _, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    _, k, n, num_experts, tile_h, tile_w = dims
+
+    in1_row_major = ttnn.from_torch(
+        torch.randn((1, num_experts, k, n), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with pytest.raises(RuntimeError, match="Input tensor B must be TILE layout"):
+        ttnn.sparse_matmul(
+            in0,
+            in1_row_major,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_inputA_wrong_dtype(device):
+    """Input tensor A must be floating point, integer types must be rejected."""
+    _, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    m, k, _, _, tile_h, tile_w = dims
+
+    in0_int = ttnn.from_torch(
+        torch.ones((1, 4, m, k), dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with pytest.raises(RuntimeError, match="Input tensor A must be a floating point type"):
+        ttnn.sparse_matmul(
+            in0_int,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_inputB_wrong_dtype(device):
+    """Input tensor B must be floating point, integer types must be rejected."""
+    in0, _, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    _, k, n, num_experts, tile_h, tile_w = dims
+
+    in1_int = ttnn.from_torch(
+        torch.ones((1, num_experts, k, n), dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with pytest.raises(RuntimeError, match="Input tensor B must be a floating point type"):
+        ttnn.sparse_matmul(
+            in0,
+            in1_int,
+            sparsity=sparsity,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )
+
+
+def test_sparse_matmul_sparsity_wrong_layout(device):
+    """Sparsity tensor must be ROW_MAJOR, TILE layout must be rejected."""
+    in0, in1, _, nnz, pc, dims = _make_sparse_inputs(device)
+    _, _, _, _, tile_h, tile_w = dims
+
+    sparsity_tile = ttnn.from_torch(
+        torch.ones((1, 4, 32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with pytest.raises(RuntimeError, match="Sparsity tensor must be ROW_MAJOR layout"):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=sparsity_tile,
+            nnz=nnz,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_tile=ttnn.Tile([tile_h, tile_w]),
+            program_config=pc,
+        )

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -651,15 +651,16 @@ def _make_sparse_inputs(device, b=1, s=4, m=32, k=128, n=512, num_experts=8, til
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     nnz = b * s * num_experts
+    core_x, core_y = 4, 4
     program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=ttnn.CoreCoord(4, 4),
+        compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
         in0_block_w=1,
         out_subblock_h=1,
         out_subblock_w=1,
         out_block_h=1,
         out_block_w=1,
         per_core_M=m // tile_h,
-        per_core_N=int(math.ceil(n / tile_w)) // 16,
+        per_core_N=int(math.ceil(n / tile_w)) // (core_x * core_y),
         fuse_batch=False,
         fused_activation=None,
         mcast_in0=True,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -21,6 +21,32 @@ namespace {
 using tt::constants::TILE_HEIGHT;
 using tt::constants::TILE_WIDTH;
 
+std::string_view matmul_program_config_name(const operations::matmul::MatmulProgramConfig& config) {
+    return std::visit(
+        [](const auto& cfg) -> std::string_view {
+            using T = std::decay_t<decltype(cfg)>;
+            if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig>) {
+                return "MatmulMultiCoreProgramConfig";
+            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                return "MatmulMultiCoreReuseProgramConfig";
+            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                return "MatmulMultiCoreReuseMultiCastProgramConfig";
+            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                return "MatmulMultiCoreReuseMultiCast1DProgramConfig";
+            } else if constexpr (std::is_same_v<
+                                     T,
+                                     operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+                return "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig";
+            } else if constexpr (
+                std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                return "MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig";
+            } else {
+                return "UnknownMatmulProgramConfig";
+            }
+        },
+        config);
+}
+
 void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     // Validate tensor is within grid if sharded and not in DRAM
     if (tensor.memory_config().is_sharded() && tensor.memory_config().buffer_type() != BufferType::DRAM) {
@@ -138,6 +164,7 @@ void validate_matmul_block_and_subblock_configuration(
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(program_config.in0_block_w != 0, "in0_block_w is 0, which is not valid");
                 const uint32_t Kt = a_shape_padded[-1] / in0_tile.get_width();
                 TT_FATAL(
                     Kt % program_config.in0_block_w == 0,
@@ -439,11 +466,11 @@ void validate_matmul_fused_operations(
     TT_FATAL(
         !optional_bias.has_value() || config_supports_fused_ops,
         "Bias is not supported for this matmul program config: {}",
-        typeid(chosen_program_config).name());
+        matmul_program_config_name(chosen_program_config));
     TT_FATAL(
         !fused_activation.has_value() || config_supports_fused_ops,
         "Fused activation is not supported for this matmul program config: {}",
-        typeid(chosen_program_config).name());
+        matmul_program_config_name(chosen_program_config));
 }
 
 bool get_broadcast_batch(
@@ -972,7 +999,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
                 chosen_program_config),
             "Untilize out is not supported for this program config: {}",
-            typeid(chosen_program_config).name());
+            matmul_program_config_name(chosen_program_config));
     }
 
     using namespace tt;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -117,9 +117,12 @@ void validate_matmul_tile_constraints(
 }
 
 void validate_matmul_block_and_subblock_configuration(
-    const MatmulParams& attributes, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     std::visit(
-        [&attributes](const auto& program_config) {
+        [&attributes, &a_shape_padded, &in0_tile](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> ||
@@ -135,6 +138,12 @@ void validate_matmul_block_and_subblock_configuration(
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                const uint32_t Kt = a_shape_padded[-1] / in0_tile.get_width();
+                TT_FATAL(
+                    Kt % program_config.in0_block_w == 0,
+                    "Kt ({}) must be divisible by in0_block_w ({})",
+                    Kt,
+                    program_config.in0_block_w);
                 TT_FATAL(program_config.out_subblock_h != 0, "out_subblock_h is 0, which is not valid");
                 TT_FATAL(program_config.out_subblock_w != 0, "out_subblock_w is 0, which is not valid");
                 if constexpr (
@@ -781,10 +790,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         chosen_program_config, input_tensor_a.device()->compute_with_storage_grid_size());
 
     validate_matmul_tile_constraints(input_tensor_a, input_tensor_b, in0_tile, in1_tile, chosen_program_config);
-    validate_matmul_block_and_subblock_configuration(attributes, chosen_program_config);
-    validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
-
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
+    validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
+    validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
     validate_matmul_sharded_operand_grids_within_program_compute_grid(
         input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_work_distribution_and_gather_ring_topology(
@@ -1659,14 +1667,6 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                     attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
                     "Output memory layout must be INTERLEAVED, got: {}",
                     attributes.output_mem_config.memory_layout());
-            }
-            if constexpr (
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                TT_FATAL(
-                    (a_shape_padded[-1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
-                    "Kt must be divisible by in0_block_w");
             }
         },
         chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -462,12 +462,6 @@ void validate_matmul_fused_operations(
         "Unsupported fused activation op type for matmul: {}. Supported types are "
         "RELU, GELU, TANH, SILU, RELU6, SIGMOID, HARDSIGMOID, HARDTANH, SELU, SOFTPLUS",
         op_type);
-
-    const auto activation_params = fused_activation->get_params();
-    TT_FATAL(
-        activation_params.size() <= 2,
-        "Fused activation parameter count ({}) exceeds the maximum supported by matmul kernels (2)",
-        activation_params.size());
 }
 
 bool get_broadcast_batch(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -409,7 +409,7 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
 }
 
 void validate_matmul_fused_operations(
-    const std::optional<Tensor>& optional_bias,
+    const std::optional<const Tensor>& optional_bias,
     const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
     const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     std::visit(
@@ -420,8 +420,9 @@ void validate_matmul_fused_operations(
                 TT_FATAL(
                     !fused_activation.has_value(),
                     "Fused activation is not supported for MatmulMultiCoreProgramConfig");
-            }
-            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
                 TT_FATAL(!optional_bias.has_value(), "Bias is not supported for MatmulMultiCoreReuseProgramConfig");
                 TT_FATAL(
                     !fused_activation.has_value(),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -12,6 +12,7 @@
 #include "tt-metalium/hal_types.hpp"
 #include "tt-metalium/experimental/global_circular_buffer.hpp"
 #include "tt-metalium/work_split.hpp"
+#include "tt_stl/reflection.hpp"
 #include "tt_stl/unreachable.hpp"
 
 namespace ttnn::prim {
@@ -20,32 +21,6 @@ namespace {
 
 using tt::constants::TILE_HEIGHT;
 using tt::constants::TILE_WIDTH;
-
-std::string_view matmul_program_config_name(const operations::matmul::MatmulProgramConfig& config) {
-    return std::visit(
-        [](const auto& cfg) -> std::string_view {
-            using T = std::decay_t<decltype(cfg)>;
-            if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig>) {
-                return "MatmulMultiCoreProgramConfig";
-            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                return "MatmulMultiCoreReuseProgramConfig";
-            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
-                return "MatmulMultiCoreReuseMultiCastProgramConfig";
-            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                return "MatmulMultiCoreReuseMultiCast1DProgramConfig";
-            } else if constexpr (std::is_same_v<
-                                     T,
-                                     operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
-                return "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig";
-            } else if constexpr (
-                std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-                return "MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig";
-            } else {
-                return "UnknownMatmulProgramConfig";
-            }
-        },
-        config);
-}
 
 void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     // Validate tensor is within grid if sharded and not in DRAM
@@ -466,11 +441,11 @@ void validate_matmul_fused_operations(
     TT_FATAL(
         !optional_bias.has_value() || config_supports_fused_ops,
         "Bias is not supported for this matmul program config: {}",
-        matmul_program_config_name(chosen_program_config));
+        ttsl::get_active_type_name_in_variant(chosen_program_config));
     TT_FATAL(
         !fused_activation.has_value() || config_supports_fused_ops,
         "Fused activation is not supported for this matmul program config: {}",
-        matmul_program_config_name(chosen_program_config));
+        ttsl::get_active_type_name_in_variant(chosen_program_config));
 }
 
 bool get_broadcast_batch(
@@ -999,7 +974,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
                 chosen_program_config),
             "Untilize out is not supported for this program config: {}",
-            matmul_program_config_name(chosen_program_config));
+            ttsl::get_active_type_name_in_variant(chosen_program_config));
     }
 
     using namespace tt;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -424,22 +424,26 @@ void validate_matmul_fused_operations(
     // Determine which fused operations the chosen program config supports.
     bool config_supports_fused_ops = false;
     std::visit(
-        [&config_supports_fused_ops](const auto& pc) {
-            using T = std::decay_t<decltype(pc)>;
-            // MultiCore and Reuse configs do not support fused bias or activation.
-            // All other configs (multicast, 1D, DRAM-sharded variants) support both.
-            config_supports_fused_ops = !std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig> &&
-                                        !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
+        [&config_supports_fused_ops](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            // MatmulMultiCoreProgramConfig and MatmulMultiCoreReuseProgramConfig have no
+            // bias / fused_activation kernel paths. Other configs support both; gather_in0
+            // on 1D multicast rejects bias separately in its dedicated check below.
+            config_supports_fused_ops =
+                !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> &&
+                !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
         },
         chosen_program_config);
 
     // Reject bias or activation if the selected config does not support them.
     TT_FATAL(
         !optional_bias.has_value() || config_supports_fused_ops,
-        "Bias is not supported for this matmul program config");
+        "Bias is not supported for this matmul program config: {}",
+        typeid(chosen_program_config).name());
     TT_FATAL(
         !fused_activation.has_value() || config_supports_fused_ops,
-        "Fused activation is not supported for this matmul program config");
+        "Fused activation is not supported for this matmul program config: {}",
+        typeid(chosen_program_config).name());
 }
 
 bool get_broadcast_batch(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -436,9 +436,40 @@ void validate_matmul_fused_operations(
                 TT_FATAL(
                     !fused_activation.has_value(),
                     "Fused activation is not supported for MatmulMultiCoreReuseProgramConfig");
+            } else if constexpr (
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                TT_FATAL(!optional_bias.has_value(), "Bias is not supported for DRAM-sharded matmul program configs");
             }
         },
         chosen_program_config);
+
+    if (!fused_activation.has_value()) {
+        return;
+    }
+
+    using ttnn::operations::unary::UnaryOpType;
+    const UnaryOpType op_type = fused_activation->op_type;
+    const bool is_supported_op = op_type == UnaryOpType::RELU || op_type == UnaryOpType::GELU ||
+                                 op_type == UnaryOpType::TANH || op_type == UnaryOpType::SILU ||
+                                 op_type == UnaryOpType::RELU6 || op_type == UnaryOpType::SIGMOID ||
+                                 op_type == UnaryOpType::HARDSIGMOID || op_type == UnaryOpType::HARDTANH ||
+                                 op_type == UnaryOpType::SELU || op_type == UnaryOpType::SOFTPLUS;
+    TT_FATAL(
+        is_supported_op,
+        "Unsupported fused activation op type for matmul: {}. Supported types are "
+        "RELU, GELU, TANH, SILU, RELU6, SIGMOID, HARDSIGMOID, HARDTANH, SELU, SOFTPLUS",
+        op_type);
+
+    const auto activation_params = fused_activation->get_params();
+    TT_FATAL(
+        activation_params.size() <= 2,
+        "Fused activation parameter count ({}) exceeds the maximum supported by matmul kernels (2)",
+        activation_params.size());
 }
 
 bool get_broadcast_batch(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -445,23 +445,6 @@ void validate_matmul_fused_operations(
     TT_FATAL(
         !fused_activation.has_value() || config_supports_activation,
         "Fused activation is not supported for this matmul program config");
-
-    if (!fused_activation.has_value()) {
-        return;
-    }
-
-    using ttnn::operations::unary::UnaryOpType;
-    const UnaryOpType op_type = fused_activation->op_type;
-    const bool is_supported_op = op_type == UnaryOpType::RELU || op_type == UnaryOpType::GELU ||
-                                 op_type == UnaryOpType::TANH || op_type == UnaryOpType::SILU ||
-                                 op_type == UnaryOpType::RELU6 || op_type == UnaryOpType::SIGMOID ||
-                                 op_type == UnaryOpType::HARDSIGMOID || op_type == UnaryOpType::HARDTANH ||
-                                 op_type == UnaryOpType::SELU || op_type == UnaryOpType::SOFTPLUS;
-    TT_FATAL(
-        is_supported_op,
-        "Unsupported fused activation op type for matmul: {}. Supported types are "
-        "RELU, GELU, TANH, SILU, RELU6, SIGMOID, HARDSIGMOID, HARDTANH, SELU, SOFTPLUS",
-        op_type);
 }
 
 bool get_broadcast_batch(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -408,6 +408,29 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
         chosen_program_config);
 }
 
+void validate_matmul_fused_operations(
+    const std::optional<Tensor>& optional_bias,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&optional_bias, &fused_activation](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig>) {
+                TT_FATAL(!optional_bias.has_value(), "Bias is not supported for MatmulMultiCoreProgramConfig");
+                TT_FATAL(
+                    !fused_activation.has_value(),
+                    "Fused activation is not supported for MatmulMultiCoreProgramConfig");
+            }
+            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                TT_FATAL(!optional_bias.has_value(), "Bias is not supported for MatmulMultiCoreReuseProgramConfig");
+                TT_FATAL(
+                    !fused_activation.has_value(),
+                    "Fused activation is not supported for MatmulMultiCoreReuseProgramConfig");
+            }
+        },
+        chosen_program_config);
+}
+
 bool get_broadcast_batch(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -758,6 +781,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
     validate_matmul_tile_constraints(input_tensor_a, input_tensor_b, in0_tile, in1_tile, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, chosen_program_config);
+    validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
 
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_sharded_operand_grids_within_program_compute_grid(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -421,32 +421,30 @@ void validate_matmul_fused_operations(
     const std::optional<const Tensor>& optional_bias,
     const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
     const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    // Determine which fused operations the chosen program config supports.
+    bool config_supports_bias = false;
+    bool config_supports_activation = false;
     std::visit(
-        [&optional_bias, &fused_activation](const auto& program_config) {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig>) {
-                TT_FATAL(!optional_bias.has_value(), "Bias is not supported for MatmulMultiCoreProgramConfig");
-                TT_FATAL(
-                    !fused_activation.has_value(),
-                    "Fused activation is not supported for MatmulMultiCoreProgramConfig");
-            } else if constexpr (std::is_same_v<
-                                     ProgramConfigType,
-                                     operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                TT_FATAL(!optional_bias.has_value(), "Bias is not supported for MatmulMultiCoreReuseProgramConfig");
-                TT_FATAL(
-                    !fused_activation.has_value(),
-                    "Fused activation is not supported for MatmulMultiCoreReuseProgramConfig");
-            } else if constexpr (
-                std::is_same_v<
-                    ProgramConfigType,
-                    operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
-                std::is_same_v<
-                    ProgramConfigType,
-                    operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-                TT_FATAL(!optional_bias.has_value(), "Bias is not supported for DRAM-sharded matmul program configs");
-            }
+        [&config_supports_bias, &config_supports_activation](const auto& pc) {
+            using T = std::decay_t<decltype(pc)>;
+            // All configs support fused activation except MultiCore and Reuse.
+            config_supports_activation = !std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig> &&
+                                         !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
+            // DRAM-sharded configs support activation but not bias, so bias requires
+            // both activation support and a non-DRAM-sharded config.
+            config_supports_bias =
+                config_supports_activation &&
+                !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> &&
+                !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>;
         },
         chosen_program_config);
+
+    // Reject bias or activation if the selected config does not support them.
+    TT_FATAL(
+        !optional_bias.has_value() || config_supports_bias, "Bias is not supported for this matmul program config");
+    TT_FATAL(
+        !fused_activation.has_value() || config_supports_activation,
+        "Fused activation is not supported for this matmul program config");
 
     if (!fused_activation.has_value()) {
         return;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -422,28 +422,23 @@ void validate_matmul_fused_operations(
     const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation,
     const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     // Determine which fused operations the chosen program config supports.
-    bool config_supports_bias = false;
-    bool config_supports_activation = false;
+    bool config_supports_fused_ops = false;
     std::visit(
-        [&config_supports_bias, &config_supports_activation](const auto& pc) {
+        [&config_supports_fused_ops](const auto& pc) {
             using T = std::decay_t<decltype(pc)>;
-            // All configs support fused activation except MultiCore and Reuse.
-            config_supports_activation = !std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig> &&
-                                         !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
-            // DRAM-sharded configs support activation but not bias, so bias requires
-            // both activation support and a non-DRAM-sharded config.
-            config_supports_bias =
-                config_supports_activation &&
-                !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> &&
-                !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>;
+            // MultiCore and Reuse configs do not support fused bias or activation.
+            // All other configs (multicast, 1D, DRAM-sharded variants) support both.
+            config_supports_fused_ops = !std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig> &&
+                                        !std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
         },
         chosen_program_config);
 
     // Reject bias or activation if the selected config does not support them.
     TT_FATAL(
-        !optional_bias.has_value() || config_supports_bias, "Bias is not supported for this matmul program config");
+        !optional_bias.has_value() || config_supports_fused_ops,
+        "Bias is not supported for this matmul program config");
     TT_FATAL(
-        !fused_activation.has_value() || config_supports_activation,
+        !fused_activation.has_value() || config_supports_fused_ops,
         "Fused activation is not supported for this matmul program config");
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -98,7 +98,10 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         sparsity.layout() == ttnn::Layout::ROW_MAJOR,
         "Sparsity tensor must be ROW_MAJOR layout, got {}",
         sparsity.layout());
-
+    TT_FATAL(
+        sparsity.logical_shape().rank() >= 1,
+        "Sparsity tensor must have rank >= 1, got {}",
+        sparsity.logical_shape().rank());
     TT_FATAL(
         operation_attributes.is_input_a_sparse || operation_attributes.is_input_b_sparse,
         "sparse_matmul requires at least one of is_input_a_sparse or is_input_b_sparse to be true");
@@ -180,9 +183,13 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     // Check that sparsity has enough entries
     TT_FATAL(
         sparsity.logical_volume() == batch_length,
-        "sparsity.logical_volume() ({}) must be equal to the product of all batch dimensions ({})",
+        "sparsity logical_volume ({}) must equal batch_length ({}) "
+        "[sparsity_shape={}, is_input_a_sparse={}, is_input_b_sparse={}]",
         sparsity.logical_volume(),
-        batch_length);
+        batch_length,
+        sparsity.logical_shape(),
+        operation_attributes.is_input_a_sparse,
+        operation_attributes.is_input_b_sparse);
 
     TT_FATAL(
         operation_attributes.nnz.value_or(1) <= batch_length,

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -104,11 +104,8 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     const auto& sparsity_shape = sparsity.logical_shape();
 
     TT_FATAL(sparsity_shape.rank() == 4, "sparsity tensor must have rank 4, got {}", sparsity_shape.rank());
-    TT_FATAL(
-        sparsity_shape[-2] == 1,
-        "sparsity shape[-2] must be 1 (expected [..., 1, num_experts]), got {}",
-        sparsity_shape[-2]);
 
+    TT_FATAL(b_shape.rank() >= 2, "sparse_matmul input B must have rank >= 2, got {}", b_shape.rank());
     const uint32_t num_experts = b_shape[1];
     TT_FATAL(
         sparsity_shape[-1] == num_experts,
@@ -128,19 +125,18 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
             sparsity_shape);
         TT_FATAL(
             sparsity_shape[2] == a_shape[0] && sparsity_shape[3] == a_shape[1],
-            "sparsity batch dimensions ({}, {}) must match input A batch dimensions ({}, {})",
+            "sparsity shape[2] ({}) must match a_shape[0] ({}), and expert dim sparsity[3] ({}) must match a_shape[1] "
+            "({})",
             sparsity_shape[2],
-            sparsity_shape[3],
             a_shape[0],
+            sparsity_shape[3],
             a_shape[1]);
     } else {
         TT_FATAL(
-            sparsity_shape[0] == a_shape[0] && sparsity_shape[1] == a_shape[1],
-            "sparsity batch dimensions ({}, {}) must match input A batch dimensions ({}, {})",
-            sparsity_shape[0],
-            sparsity_shape[1],
-            a_shape[0],
-            a_shape[1]);
+            sparsity_shape[0] == a_shape[0] && sparsity_shape[1] == a_shape[1] && sparsity_shape[2] == 1,
+            "sparsity shape must be [A0, A1, 1, num_experts] when input B is sparse, got sparsity_shape={} a_shape={}",
+            sparsity_shape,
+            a_shape);
     }
 
     const auto& a_shape_padded = get_matmul_tensor_padded_shape(input_tensor_a, /*transpose=*/false);

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -147,7 +147,9 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         b_shape_padded,
         in1_tile);
     TT_FATAL(
-        operation_attributes.nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", operation_attributes.nnz.value());
+        operation_attributes.nnz.value_or(1) > 0,
+        "nnz ({}) must be greater than 0",
+        operation_attributes.nnz.value_or(1));
 
     // Check that nnz is less than or equal to the length of all batch dimensions
     uint32_t batch_length_A = 1;

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -91,6 +91,10 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         "Input tensor A must be a floating point type, got {}",
         input_tensor_a.dtype());
     TT_FATAL(
+        is_floating_point(input_tensor_b.dtype()),
+        "Input tensor B must be a floating point type, got {}",
+        input_tensor_b.dtype());
+    TT_FATAL(
         sparsity.layout() == ttnn::Layout::ROW_MAJOR,
         "Sparsity tensor must be ROW_MAJOR layout, got {}",
         sparsity.layout());
@@ -147,9 +151,7 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         b_shape_padded,
         in1_tile);
     TT_FATAL(
-        operation_attributes.nnz.value_or(1) > 0,
-        "nnz ({}) must be greater than 0",
-        operation_attributes.nnz.value_or(1));
+        operation_attributes.nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", operation_attributes.nnz.value());
 
     // Check that nnz is less than or equal to the length of all batch dimensions
     uint32_t batch_length_A = 1;

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -99,46 +99,6 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         operation_attributes.is_input_a_sparse || operation_attributes.is_input_b_sparse,
         "sparse_matmul requires at least one of is_input_a_sparse or is_input_b_sparse to be true");
 
-    const auto& a_shape = input_tensor_a.logical_shape();
-    const auto& b_shape = input_tensor_b.logical_shape();
-    const auto& sparsity_shape = sparsity.logical_shape();
-
-    TT_FATAL(sparsity_shape.rank() == 4, "sparsity tensor must have rank 4, got {}", sparsity_shape.rank());
-
-    TT_FATAL(b_shape.rank() >= 2, "sparse_matmul input B must have rank >= 2, got {}", b_shape.rank());
-    const uint32_t num_experts = b_shape[1];
-    TT_FATAL(
-        sparsity_shape[-1] == num_experts,
-        "sparsity last dimension ({}) must match num_experts from input B ({})",
-        sparsity_shape[-1],
-        num_experts);
-
-    if (operation_attributes.is_input_a_sparse && operation_attributes.is_input_b_sparse) {
-        TT_FATAL(
-            sparsity_shape[0] == 1 && sparsity_shape[1] == 1 && sparsity_shape[2] == 1,
-            "sparsity shape must be [1, 1, 1, num_experts] when both inputs are sparse, got {}",
-            sparsity_shape);
-    } else if (operation_attributes.is_input_a_sparse) {
-        TT_FATAL(
-            sparsity_shape[0] == 1 && sparsity_shape[1] == 1,
-            "sparsity shape must be [1, 1, A, E] when input A is sparse, got {}",
-            sparsity_shape);
-        TT_FATAL(
-            sparsity_shape[2] == a_shape[0] && sparsity_shape[3] == a_shape[1],
-            "sparsity shape[2] ({}) must match a_shape[0] ({}), and expert dim sparsity[3] ({}) must match a_shape[1] "
-            "({})",
-            sparsity_shape[2],
-            a_shape[0],
-            sparsity_shape[3],
-            a_shape[1]);
-    } else {
-        TT_FATAL(
-            sparsity_shape[0] == a_shape[0] && sparsity_shape[1] == a_shape[1] && sparsity_shape[2] == 1,
-            "sparsity shape must be [A0, A1, 1, num_experts] when input B is sparse, got sparsity_shape={} a_shape={}",
-            sparsity_shape,
-            a_shape);
-    }
-
     const auto& a_shape_padded = get_matmul_tensor_padded_shape(input_tensor_a, /*transpose=*/false);
     const auto& b_shape_padded = get_matmul_tensor_padded_shape(input_tensor_b, /*transpose=*/false);
     auto in0_tile = get_matmul_tile(input_tensor_a, /*transpose=*/false);

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -84,8 +84,13 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         input_tensor_a.device() == input_tensor_b.device() && input_tensor_a.device() == sparsity.device(),
         "All sparse matmul inputs must be on the same device");
     TT_FATAL(
-        input_tensor_a.layout() == ttnn::Layout::TILE && input_tensor_b.layout() == ttnn::Layout::TILE,
-        "Input tensors A and B must be TILE layout");
+        input_tensor_a.layout() == ttnn::Layout::TILE,
+        "Input tensor A must be TILE layout, got {}",
+        input_tensor_a.layout());
+    TT_FATAL(
+        input_tensor_b.layout() == ttnn::Layout::TILE,
+        "Input tensor B must be TILE layout, got {}",
+        input_tensor_b.layout());
     TT_FATAL(
         is_floating_point(input_tensor_a.dtype()),
         "Input tensor A must be a floating point type, got {}",

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -99,10 +99,6 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         "Sparsity tensor must be ROW_MAJOR layout, got {}",
         sparsity.layout());
     TT_FATAL(
-        sparsity.logical_shape().rank() >= 1,
-        "Sparsity tensor must have rank >= 1, got {}",
-        sparsity.logical_shape().rank());
-    TT_FATAL(
         operation_attributes.is_input_a_sparse || operation_attributes.is_input_b_sparse,
         "sparse_matmul requires at least one of is_input_a_sparse or is_input_b_sparse to be true");
 
@@ -154,7 +150,9 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         b_shape_padded,
         in1_tile);
     TT_FATAL(
-        operation_attributes.nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", operation_attributes.nnz.value());
+        operation_attributes.nnz.value_or(1) > 0,
+        "nnz ({}) must be greater than 0",
+        operation_attributes.nnz.value_or(1));
 
     // Check that nnz is less than or equal to the length of all batch dimensions
     uint32_t batch_length_A = 1;
@@ -194,7 +192,7 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         operation_attributes.nnz.value_or(1) <= batch_length,
         "nnz ({}) must be less than or equal to the length of all batch dimensions ({})",
-        operation_attributes.nnz,
+        operation_attributes.nnz.value_or(1),
         batch_length);
 
     // When nnz is supplied, the receiver and compute kernels loop exactly nnz times while the in0 sender

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -187,9 +187,7 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         b_shape_padded,
         in1_tile);
     TT_FATAL(
-        operation_attributes.nnz.value_or(1) > 0,
-        "nnz ({}) must be greater than 0",
-        operation_attributes.nnz.value_or(1));
+        operation_attributes.nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", operation_attributes.nnz.value());
 
     // Check that nnz is less than or equal to the length of all batch dimensions
     uint32_t batch_length_A = 1;
@@ -225,7 +223,7 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         operation_attributes.nnz.value_or(1) <= batch_length,
         "nnz ({}) must be less than or equal to the length of all batch dimensions ({})",
-        operation_attributes.nnz.value_or(1),
+        operation_attributes.nnz,
         batch_length);
 
     // When nnz is supplied, the receiver and compute kernels loop exactly nnz times while the in0 sender

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -72,6 +72,77 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_b = tensor_args.input_tensors.at(1);
     const auto& sparsity = tensor_args.input_tensors.at(2);
 
+    TT_FATAL(
+        input_tensor_a.storage_type() == ttnn::StorageType::DEVICE &&
+            input_tensor_b.storage_type() == ttnn::StorageType::DEVICE &&
+            sparsity.storage_type() == ttnn::StorageType::DEVICE,
+        "All sparse matmul inputs must be on device");
+    TT_FATAL(
+        input_tensor_a.buffer() != nullptr && input_tensor_b.buffer() != nullptr && sparsity.buffer() != nullptr,
+        "All sparse matmul inputs must be allocated in buffers");
+    TT_FATAL(
+        input_tensor_a.device() == input_tensor_b.device() && input_tensor_a.device() == sparsity.device(),
+        "All sparse matmul inputs must be on the same device");
+    TT_FATAL(
+        input_tensor_a.layout() == ttnn::Layout::TILE && input_tensor_b.layout() == ttnn::Layout::TILE,
+        "Input tensors A and B must be TILE layout");
+    TT_FATAL(
+        is_floating_point(input_tensor_a.dtype()),
+        "Input tensor A must be a floating point type, got {}",
+        input_tensor_a.dtype());
+    TT_FATAL(
+        sparsity.layout() == ttnn::Layout::ROW_MAJOR,
+        "Sparsity tensor must be ROW_MAJOR layout, got {}",
+        sparsity.layout());
+
+    TT_FATAL(
+        operation_attributes.is_input_a_sparse || operation_attributes.is_input_b_sparse,
+        "sparse_matmul requires at least one of is_input_a_sparse or is_input_b_sparse to be true");
+
+    const auto& a_shape = input_tensor_a.logical_shape();
+    const auto& b_shape = input_tensor_b.logical_shape();
+    const auto& sparsity_shape = sparsity.logical_shape();
+
+    TT_FATAL(sparsity_shape.rank() == 4, "sparsity tensor must have rank 4, got {}", sparsity_shape.rank());
+    TT_FATAL(
+        sparsity_shape[-2] == 1,
+        "sparsity shape[-2] must be 1 (expected [..., 1, num_experts]), got {}",
+        sparsity_shape[-2]);
+
+    const uint32_t num_experts = b_shape[1];
+    TT_FATAL(
+        sparsity_shape[-1] == num_experts,
+        "sparsity last dimension ({}) must match num_experts from input B ({})",
+        sparsity_shape[-1],
+        num_experts);
+
+    if (operation_attributes.is_input_a_sparse && operation_attributes.is_input_b_sparse) {
+        TT_FATAL(
+            sparsity_shape[0] == 1 && sparsity_shape[1] == 1 && sparsity_shape[2] == 1,
+            "sparsity shape must be [1, 1, 1, num_experts] when both inputs are sparse, got {}",
+            sparsity_shape);
+    } else if (operation_attributes.is_input_a_sparse) {
+        TT_FATAL(
+            sparsity_shape[0] == 1 && sparsity_shape[1] == 1,
+            "sparsity shape must be [1, 1, A, E] when input A is sparse, got {}",
+            sparsity_shape);
+        TT_FATAL(
+            sparsity_shape[2] == a_shape[0] && sparsity_shape[3] == a_shape[1],
+            "sparsity batch dimensions ({}, {}) must match input A batch dimensions ({}, {})",
+            sparsity_shape[2],
+            sparsity_shape[3],
+            a_shape[0],
+            a_shape[1]);
+    } else {
+        TT_FATAL(
+            sparsity_shape[0] == a_shape[0] && sparsity_shape[1] == a_shape[1],
+            "sparsity batch dimensions ({}, {}) must match input A batch dimensions ({}, {})",
+            sparsity_shape[0],
+            sparsity_shape[1],
+            a_shape[0],
+            a_shape[1]);
+    }
+
     const auto& a_shape_padded = get_matmul_tensor_padded_shape(input_tensor_a, /*transpose=*/false);
     const auto& b_shape_padded = get_matmul_tensor_padded_shape(input_tensor_b, /*transpose=*/false);
     auto in0_tile = get_matmul_tile(input_tensor_a, /*transpose=*/false);
@@ -120,7 +191,9 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
         b_shape_padded,
         in1_tile);
     TT_FATAL(
-        operation_attributes.nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", operation_attributes.nnz.value());
+        operation_attributes.nnz.value_or(1) > 0,
+        "nnz ({}) must be greater than 0",
+        operation_attributes.nnz.value_or(1));
 
     // Check that nnz is less than or equal to the length of all batch dimensions
     uint32_t batch_length_A = 1;
@@ -156,7 +229,7 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         operation_attributes.nnz.value_or(1) <= batch_length,
         "nnz ({}) must be less than or equal to the length of all batch dimensions ({})",
-        operation_attributes.nnz,
+        operation_attributes.nnz.value_or(1),
         batch_length);
 
     // When nnz is supplied, the receiver and compute kernels loop exactly nnz times while the in0 sender


### PR DESCRIPTION
### Summary

Resolves #41958. 

Adds validate-time checks for matmul fused operations, block/subblock Kt divisibility, and sparse matmul input sanity so invalid configurations fail early with clear errors instead of reaching the kernel factories.

### Files

- `ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp`
- `ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp`
- `tests/ttnn/unit_tests/operations/matmul/test_linear.py`
- `tests/ttnn/unit_tests/operations/matmul/test_matmul.py`
- `tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py`

### Section 5 - Fused operations

- New `validate_matmul_fused_operations` rejects bias and activation for `MatmulMultiCoreProgramConfig` and `MatmulMultiCoreReuseProgramConfig` - the only configs whose kernels do not support fused bias/activation.
- All other configs (multicast 1D/2D, DRAM-sharded variants) retain bias and activation support. 

### Section 6 - Block and subblock configuration

- Centralized the `Kt % in0_block_w == 0` check into `validate_matmul_block_and_subblock_configuration` with both values in the error message.
- Reordered validators so `validate_matmul_compute_grid_and_per_core_dims` runs first, guaranteeing `in0_block_w != 0` by the time the Kt check runs.

### Section 7 - Sparse matmul

- Added input sanity checks for A, B, and sparsity: storage type, buffer allocation, same-device, TILE layout (A/B), floating-point dtype (A and B), and ROW_MAJOR sparsity layout.
- Added `is_input_a_sparse || is_input_b_sparse` requirement.
- Volume-mismatch error now includes sparsity shape and both sparse flags for easier decode/prefill debugging.
- Fixed nnz `TT_FATAL` format arguments to use `value_or(1)` consistently with the conditions.

### Tests

- `test_linear_fused_activation_numerical_stability` - verifies finite outputs (no NaN/Inf) across all 10 supported fused activations.
- Five negative validation tests added inline in existing files:
  - `test_linear.py` - bias rejected on `MatmulMultiCoreReuseProgramConfig`
  - `test_matmul.py` - activation rejected on `MatmulMultiCoreReuseProgramConfig`
  - `test_matmul.py` - Kt not divisible by `in0_block_w`
  - `test_sparse_matmul.py` - neither `is_input_a_sparse` nor `is_input_b_sparse` set
  - `test_sparse_matmul.py` - sparsity volume mismatch

### Notes for reviewers

Follows phase 1 (#43987). Sections 1-4 are already in main.

Two stricter checks from the ticket are not enforced as the existing code already covers them safely:

- **Strict sparsity shape `[B, S, 1, num_experts]`** is not enforced. The kernel reads sparsity as a flat buffer (`sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp:255`), so the volume check at line 184 is the correct guard across all sparse modes. A stricter per-position shape check breaks decode (rank-2 sparsity) and prefill (different rank-4 shape) without adding any real kernel safety.
- **Activation type whitelist** is not added. The existing `TT_THROW` in `get_activation_params` at `matmul_utilities.hpp:326` already rejects unsupported activation types - no extra validate-time list is needed, and a hardcoded whitelist would falsely reject working activations (e.g. `mish`).


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/matmul-validation-part2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/matmul-validation-part2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/matmul-validation-part2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/matmul-validation-part2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/matmul-validation-part2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/matmul-validation-part2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/matmul-validation-part2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/matmul-validation-part2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/matmul-validation-part2)