### PR TITLE
Add 31 N300 trace registry entries (traces 60-90)

### DIFF
--- a/.github/workflows/ttnn-model-trace-sweep-validation.yaml
+++ b/.github/workflows/ttnn-model-trace-sweep-validation.yaml
@@ -171,6 +171,6 @@ jobs:
       models: ${{ needs.inspect-trace-selection-registry.outputs.selected-models }}
       trace-ids: ${{ needs.inspect-trace-selection-registry.outputs.selected-trace-ids }}
       caller-id: ${{ needs.inspect-trace-selection-registry.outputs.caller-id }}
-      allow-partial-hash-changes: ${{ inputs.allow-partial-hash-changes || true }}
+      allow-partial-hash-changes: ${{ github.event_name == 'schedule' && true || inputs.allow-partial-hash-changes }}
       models-filter: ${{ inputs.models-filter || '' }}
-      upload-results: ${{ inputs.upload-results || false }}
+      upload-results: ${{ github.event_name == 'schedule' && false || inputs.upload-results }}

--- a/.github/workflows/ttnn-model-trace-sweep-validation.yaml
+++ b/.github/workflows/ttnn-model-trace-sweep-validation.yaml
@@ -1,9 +1,14 @@
 name: "ttnn - model trace sweep validation"
 
 run-name: >-
-  ttnn - model trace sweep validation
+  ${{
+    github.event_name == 'schedule' && 'ttnn - model trace sweep validation (scheduled)' ||
+    'ttnn - model trace sweep validation'
+  }}
 
 on:
+  schedule:
+    - cron: "0 5 * * *"  # Daily at 5:00 AM UTC (after sweep runs complete)
   workflow_dispatch:
     inputs:
       scope-targets:
@@ -55,8 +60,8 @@ jobs:
       - name: Parse trace selection registry
         id: parse-trace-selection-registry
         env:
-          MODELS_FILTER: ${{ inputs.models-filter }}
-          SCOPE_OVERRIDE: ${{ inputs.scope-targets }}
+          MODELS_FILTER: ${{ inputs.models-filter || '' }}
+          SCOPE_OVERRIDE: ${{ inputs.scope-targets || 'auto' }}
         run: |
           python3 - <<'PY'
           import os
@@ -166,6 +171,6 @@ jobs:
       models: ${{ needs.inspect-trace-selection-registry.outputs.selected-models }}
       trace-ids: ${{ needs.inspect-trace-selection-registry.outputs.selected-trace-ids }}
       caller-id: ${{ needs.inspect-trace-selection-registry.outputs.caller-id }}
-      allow-partial-hash-changes: ${{ inputs.allow-partial-hash-changes }}
-      models-filter: ${{ inputs.models-filter }}
-      upload-results: ${{ inputs.upload-results }}
+      allow-partial-hash-changes: ${{ inputs.allow-partial-hash-changes || true }}
+      models-filter: ${{ inputs.models-filter || '' }}
+      upload-results: ${{ inputs.upload-results || false }}

--- a/model_tracer/generic_ops_tracer.py
+++ b/model_tracer/generic_ops_tracer.py
@@ -601,6 +601,24 @@ def _strip_object_addresses(value):
     return value
 
 
+_SHAPE_RE = re.compile(r"^Shape\(\[([0-9,\s]+)\]\)$")
+
+
+def _parse_shape_object(obj):
+    """Convert a serialized Shape dict to a plain int list.
+
+    The tracer sometimes serializes ttnn.Shape as
+    {"type": "Shape", "value": "Shape([1, 32, 32, 384])"} instead of a
+    plain list [1, 32, 32, 384].  Canonicalize to the list form so the
+    hash is stable regardless of serialization path.
+    """
+    if isinstance(obj, dict) and obj.get("type") == "Shape" and isinstance(obj.get("value"), str):
+        m = _SHAPE_RE.match(obj["value"])
+        if m:
+            return [int(x.strip()) for x in m.group(1).split(",")]
+    return None
+
+
 def _normalize_for_hash(obj):
     """
     Normalize arguments in-place for stable config_hash computation.
@@ -620,7 +638,11 @@ def _normalize_for_hash(obj):
 
         for k in list(obj.keys()):
             v = obj[k]
-            if isinstance(v, str):
+            # Serialized Shape objects → plain int lists
+            parsed = _parse_shape_object(v) if isinstance(v, dict) else None
+            if parsed is not None:
+                obj[k] = parsed
+            elif isinstance(v, str):
                 obj[k] = _strip_object_addresses(v)
             else:
                 _normalize_for_hash(v)

--- a/model_tracer/generic_ops_tracer.py
+++ b/model_tracer/generic_ops_tracer.py
@@ -601,24 +601,6 @@ def _strip_object_addresses(value):
     return value
 
 
-_SHAPE_RE = re.compile(r"^Shape\(\[([0-9,\s]+)\]\)$")
-
-
-def _parse_shape_object(obj):
-    """Convert a serialized Shape dict to a plain int list.
-
-    The tracer sometimes serializes ttnn.Shape as
-    {"type": "Shape", "value": "Shape([1, 32, 32, 384])"} instead of a
-    plain list [1, 32, 32, 384].  Canonicalize to the list form so the
-    hash is stable regardless of serialization path.
-    """
-    if isinstance(obj, dict) and obj.get("type") == "Shape" and isinstance(obj.get("value"), str):
-        m = _SHAPE_RE.match(obj["value"])
-        if m:
-            return [int(x.strip()) for x in m.group(1).split(",")]
-    return None
-
-
 def _normalize_for_hash(obj):
     """
     Normalize arguments in-place for stable config_hash computation.
@@ -638,11 +620,7 @@ def _normalize_for_hash(obj):
 
         for k in list(obj.keys()):
             v = obj[k]
-            # Serialized Shape objects → plain int lists
-            parsed = _parse_shape_object(v) if isinstance(v, dict) else None
-            if parsed is not None:
-                obj[k] = parsed
-            elif isinstance(v, str):
+            if isinstance(v, str):
                 obj[k] = _strip_object_addresses(v)
             else:
                 _normalize_for_hash(v)

--- a/model_tracer/trace_selection_registry.yaml
+++ b/model_tracer/trace_selection_registry.yaml
@@ -55,6 +55,40 @@ targets:
         - whisper_3
       trace: [25, 17, 18, 19, 20, 28]
 
+    # N300 models from trace 3 (migrated-v5, n300 1-card, 6199 configs)
+    - model:
+        - llama-3.2-11b-vision-instruct
+        - mistral-7b-instruct-v0.3
+        - sentence_bert
+        - stable_diffusion_xl_base
+        - vit
+        - whisper
+        - segmentation
+      trace: [3]
+
+    # N300 models newly traced (auto-resolve to latest trace)
+    - model:
+        - llama-3.1-8b
+        - llama-3.2-3b
+        - qwen3-8b
+        - qwen3-embedding-4b
+        - qwen3-embedding-8b
+        - qwen2.5-7b
+        - qwen3-4b
+        - speecht5-tts
+        - mobilenetv2
+        - resnet-50
+        - vovnet
+        - bge-large-en
+        - distilbert
+        - bert-tiny
+        - bert-large
+        - bge-m3
+        - owl-vit
+        - vgg
+        - swin-v2
+        - swin-s
+
 registry:
   - trace_id: 1
     status: draft

--- a/model_tracer/trace_selection_registry.yaml
+++ b/model_tracer/trace_selection_registry.yaml
@@ -55,6 +55,59 @@ targets:
         - whisper_3
       trace: [25, 17, 18, 19, 20, 28]
 
+    # N300 models (traces 60-90, n300 1-card)
+    - model:
+        - llama-3.2-1b-instruct
+        - llama-3.1-8b-instruct
+        - llama-3.2-3b-instruct_2
+        - llama-3.2-11b-vision-instruct
+        - mistral-7b-instruct-v0.2_2
+        - qwen3-8b
+        - qwen3-embedding-8b
+        - qwen3-embedding-4b
+        - qwen3-4b
+        - qwen2.5-7b-instruct
+        - whisper_4
+        - stable_diffusion_xl_base_3
+        - speecht5_tts_2
+        - efficientnetb0_2
+        - mobilenetv2_2
+        - segmentation_3
+        - vit_2
+        - bge_large_en_2
+        - distilbert
+        - bert_tiny
+        - metal_bert_large_11
+        - sentence_bert_3
+        - bge_m3
+        - owl_vit
+        - swin_v2
+        - swin_s
+        - resnet50_2
+        - vovnet
+        - vgg
+      trace: [62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90]
+
+    # N150 models (traces 41-59, n150 1-card)
+    - model:
+        - llama-3.2-1b_2
+        - llama-3.1-8b-instruct_2
+        - phi-3-mini-4k-instruct
+        - mistral-7b-instruct-v0.2
+        - gemma4
+        - whisper_4
+        - falcon7b_2
+        - functional_unet
+        - stable_diffusion_xl_base_2
+        - qwen25_vl
+        - speecht5_tts
+        - mobilenetv2
+        - resnet50
+        - bge_large_en
+        - segmentation_2
+        - vit_3
+      trace: [41, 42, 43, 44, 46, 47, 48, 49, 52, 53, 54, 55, 56, 57, 58, 59]
+
 registry:
   - trace_id: 1
     status: draft

--- a/model_tracer/trace_selection_registry.yaml
+++ b/model_tracer/trace_selection_registry.yaml
@@ -55,40 +55,6 @@ targets:
         - whisper_3
       trace: [25, 17, 18, 19, 20, 28]
 
-    # N300 models from trace 3 (migrated-v5, n300 1-card, 6199 configs)
-    - model:
-        - llama-3.2-11b-vision-instruct
-        - mistral-7b-instruct-v0.3
-        - sentence_bert
-        - stable_diffusion_xl_base
-        - vit
-        - whisper
-        - segmentation
-      trace: [3]
-
-    # N300 models newly traced (auto-resolve to latest trace)
-    - model:
-        - llama-3.1-8b
-        - llama-3.2-3b
-        - qwen3-8b
-        - qwen3-embedding-4b
-        - qwen3-embedding-8b
-        - qwen2.5-7b
-        - qwen3-4b
-        - speecht5-tts
-        - mobilenetv2
-        - resnet-50
-        - vovnet
-        - bge-large-en
-        - distilbert
-        - bert-tiny
-        - bert-large
-        - bge-m3
-        - owl-vit
-        - vgg
-        - swin-v2
-        - swin-s
-
 registry:
   - trace_id: 1
     status: draft
@@ -624,4 +590,32 @@ registry:
     pytest_args: null
     tt_kmd: "TT-KMD 2.8.0"
     tt_smi: "5.2.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 60
+    status: draft
+    models: [llama-3.2-1b-instruct]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 6fa194e7-b253-421a-9788-baed619bfaec
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 317
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 61
+    status: draft
+    models: [llama-3.2-1b-instruct]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: f306fc7a-d7c3-48bd-9dc0-ca3e59fc796d
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 317
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
     tt_firmware: "19.7.1.0"

--- a/model_tracer/trace_selection_registry.yaml
+++ b/model_tracer/trace_selection_registry.yaml
@@ -619,3 +619,409 @@ registry:
     tt_kmd: "TT-KMD 2.8.0"
     tt_smi: "4.0.0"
     tt_firmware: "19.7.1.0"
+
+  - trace_id: 62
+    status: draft
+    models: [llama-3.2-1b-instruct]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 15d47d19-b55a-4ba6-b239-b7931d3ba80c
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 317
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 63
+    status: draft
+    models: [llama-3.1-8b-instruct]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 6b64a426-0f83-4531-90df-0e510e06037a
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 317
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 64
+    status: draft
+    models: [llama-3.2-3b-instruct_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 663cf8b5-4eb6-4dde-b34a-30d30e23a9a4
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 316
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 65
+    status: draft
+    models: [llama-3.2-11b-vision-instruct]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: c17509c4-a3fd-4ca2-ab9f-afcd88163aea
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 325
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 66
+    status: draft
+    models: [mistral-7b-instruct-v0.2_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: b320b7d3-a372-4ffc-8e09-80a7b3e4153c
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 224
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 67
+    status: draft
+    models: [qwen3-8b]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 23242422-fae5-4626-a936-5268017f6350
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 222
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 68
+    status: draft
+    models: [qwen3-embedding-8b]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 16735e92-da04-4514-b3f0-d59b2977b7dd
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 328
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 69
+    status: draft
+    models: [qwen3-embedding-4b]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 1cbabe62-e5cc-4672-9ae1-a43fd0d9bd84
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 221
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 70
+    status: draft
+    models: [qwen3-4b]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: c468284c-4f68-443a-984b-2c8184e85616
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 222
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 71
+    status: draft
+    models: [qwen2.5-7b-instruct]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: a8abe6e0-c771-474e-88e0-b720c44ad386
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 279
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 72
+    status: draft
+    models: [whisper_4]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 50ec1a76-34ef-498b-9aa4-eaf0fbd97ccb
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 109
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 73
+    status: draft
+    models: [stable_diffusion_xl_base_3]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 9a5e1aa2-c16f-467a-8cf8-f3434d07a249
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 308
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: '-k device_vae and device_encoders and with_trace and no_cfg_parallel and 1024x1024'
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 74
+    status: draft
+    models: [speecht5_tts_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 3009d3c5-dc4f-4bd9-8d2e-07a8f11d008b
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 146
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 75
+    status: draft
+    models: [efficientnetb0_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 1742fc46-ccc4-44a6-af5e-7ec3dee29f2d
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 222
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 76
+    status: draft
+    models: [mobilenetv2_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 7fc85e11-43b7-4a52-9921-179bc69c5158
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 82
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 77
+    status: draft
+    models: [segmentation_3]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 5f3aa7f3-4c87-4908-be13-6feac03886d7
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 100
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 78
+    status: draft
+    models: [vit_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 62a2aec7-87b5-42d2-a7a5-9e5858e643c5
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 22
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 79
+    status: draft
+    models: [bge_large_en_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 3762d005-1d24-485f-b261-694db41410fe
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 35
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 80
+    status: draft
+    models: [distilbert]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 04e29c92-603f-42fe-b9d5-6d6abfcde82e
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 37
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 81
+    status: draft
+    models: [bert_tiny]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: a15f8384-9b05-4125-9b82-7bce8e40c822
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 20
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 82
+    status: draft
+    models: [metal_bert_large_11]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 34c25320-196c-4b0a-898c-6990c7d8237b
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 41
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 83
+    status: draft
+    models: [sentence_bert_3]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: d2b09aec-6a93-4cce-880c-2e76bddf7619
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 36
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 84
+    status: draft
+    models: [bge_m3]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 03c5889e-e0d2-44e2-bb15-31895e257e01
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 27
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 85
+    status: draft
+    models: [owl_vit]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 18d22deb-67c3-41b5-92c3-afe8b78cd1b1
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 32
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 86
+    status: draft
+    models: [swin_v2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 18c15744-600f-44cc-a6f4-d13b03cb89d3
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 181
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 87
+    status: draft
+    models: [swin_s]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: 3cd393e7-4252-45ba-bfbd-30f6e2dca4cb
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 218
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 88
+    status: draft
+    models: [resnet50_2]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: b2ecfcb1-693d-477c-a2e7-f12fc099be4c
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 64
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 89
+    status: draft
+    models: [vovnet]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: dd4ad44f-eeb7-4ef8-bd3d-0fc28d87158f
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 170
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"
+
+  - trace_id: 90
+    status: draft
+    models: [vgg]
+    hardware: {board_type: Wormhole, device_series: n300, card_count: 1}
+    trace_uid: c7c4c21d-2473-464d-a84b-17d280755963
+    tt_metal_sha: 75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+    config_count: 29
+    loaded_at: '2026-05-23'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.8.0"
+    tt_smi: "4.0.0"
+    tt_firmware: "19.7.1.0"

--- a/model_tracer/trace_selection_registry.yaml
+++ b/model_tracer/trace_selection_registry.yaml
@@ -55,7 +55,8 @@ targets:
         - whisper_3
       trace: [25, 17, 18, 19, 20, 28]
 
-    # N300 models (traces 60-90, n300 1-card)
+    # N300 models (traces 62-90, n300 1-card)
+    # Traces 60,61 dropped (llama-3.2-1b-instruct dup, kept in 62)
     - model:
         - llama-3.2-1b-instruct
         - llama-3.1-8b-instruct
@@ -89,6 +90,7 @@ targets:
       trace: [62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90]
 
     # N150 models (traces 41-59, n150 1-card)
+    # Trace 45 dropped (gemma4 dup, kept in 46)
     - model:
         - llama-3.2-1b_2
         - llama-3.1-8b-instruct_2


### PR DESCRIPTION
### Problem Description
N300 and N150 model traces were loaded into the DB but not registered in trace_selection_registry.yaml, so they were not being validated in CI.

### What is changed

**Registry entries (31 new N300 traces, IDs 60-90):**
29 models across Wormhole N300 1-card, all traced on sha 75ad1dc1 with KMD 2.8.0 / SMI 4.0.0 / FW 19.7.1.0.

| Category | Models |
|----------|--------|
| LLMs | llama-3.2-1b (x3), llama-3.1-8b, llama-3.2-3b, llama-3.2-11b-vision, mistral-7b, qwen3-8b, qwen3-embedding-4b/8b, qwen2.5-7b, qwen3-4b |
| Vision | efficientnetb0, mobilenetv2, resnet50, segformer, vit, vovnet, owl_vit, vgg, swin_v2, swin_s |
| NLP | bge_large_en, distilbert, bert_tiny, bert_large, sentence_bert, bge_m3 |
| Audio | whisper, speecht5_tts |

**Targets updated:**
- Added N300 model_traced target group (traces 62-90, 29 models)
- Added N150 model_traced target group (traces 41-59, 16 models)
- Deduped: dropped traces 60,61 (llama-3.2-1b-instruct dup, kept 62), trace 45 (gemma4 dup, kept 46)

**Validation workflow:**
- Added daily schedule (0 5 * * * UTC) to ttnn-model-trace-sweep-validation.yaml
- Input defaults handle scheduled runs (scope=auto, allow-partial=true)

### Notes for reviewers
- Registry entries are status: draft - promote to active after validation
- ~5,100 new configs across the 31 traces
- Total model_traced coverage: N150 (16 models), N300 (29 models), BH p100a/p150b (whisper)
- The validation workflow schedule runs after sweep jobs (2-4 AM UTC) complete

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/n300-trace-registry-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/n300-trace-registry-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/n300-trace-registry-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/n300-trace-registry-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/n300-trace-registry-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/n300-trace-registry-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/n300-trace-registry-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/n300-trace-registry-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/n300-trace-registry-update)