### PR TITLE
Fix flexible chunked SDPA descriptor buffer binding

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -176,6 +176,12 @@ void SDPAOperation::validate_on_program_cache_miss(const SDPAParams& attrs, cons
         }
         if (flexible_chunked) {
             const auto& csi_tensor = attrs.chunk_start_idx_tensor.value();
+            TT_FATAL(
+                tensors.chunk_start_idx_tensor.has_value(),
+                "chunk_start_idx tensor must be present in tensor args for descriptor cache patching");
+            TT_FATAL(
+                tensors.chunk_start_idx_tensor.value().buffer() == csi_tensor.buffer(),
+                "chunk_start_idx tensor in attrs and tensor args must reference the same buffer");
             TT_FATAL(csi_tensor.storage_type() == StorageType::DEVICE, "chunk_start_idx tensor must be on device");
             TT_FATAL(
                 csi_tensor.dtype() == DataType::INT32,
@@ -520,6 +526,7 @@ Tensor sdpa(
             .v = input_tensor_v,
             .attn_mask = attn_mask,
             .page_table = page_table_tensor,
+            .chunk_start_idx_tensor = chunk_start_idx_tensor,
             .attention_sink = attention_sink,
         });
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation_types.hpp
@@ -30,6 +30,8 @@ struct SDPAInputs {
     std::optional<Tensor> v;
     std::optional<Tensor> attn_mask;
     std::optional<Tensor> page_table;
+    // Mirrors SDPAParams::chunk_start_idx_tensor so ProgramDescriptor buffer bindings can patch cache hits.
+    std::optional<Tensor> chunk_start_idx_tensor;
     std::optional<Tensor> attention_sink;
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -318,13 +318,10 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     auto* v_buffer = input_tensor_v.buffer();
     auto* mask_buffer = attn_mask.has_value() ? attn_mask.value().buffer() : nullptr;
     auto* attention_sink_buffer = attention_sink.has_value() ? attention_sink.value().buffer() : nullptr;
-    // page_table and chunk_start_idx must be BufferBindings (not raw address writes); otherwise
-    // their addresses go stale on program-cache hits — same pattern as moreh_adamw's
-    // max_exp_avg_sq bug.
+    // page_table and chunk_start_idx must be BufferBindings (not raw address writes);
+    // otherwise their addresses go stale on descriptor cache hits.
     auto* page_table_buffer = is_chunked ? page_table.value().buffer() : nullptr;
-    auto* chunk_start_idx_buffer = operation_attributes.chunk_start_idx_tensor.has_value()
-                                       ? operation_attributes.chunk_start_idx_tensor.value().buffer()
-                                       : nullptr;
+    auto* chunk_start_idx_buffer = flexible_chunked ? tensor_args.chunk_start_idx_tensor.value().buffer() : nullptr;
 
     auto* out0_buffer = output_tensor.buffer();
 
@@ -518,7 +515,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     TensorAccessorArgs(page_table.has_value() ? page_table->buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(attention_sink.has_value() ? attention_sink->buffer() : nullptr)
         .append_to(reader_compile_time_args);
-    TensorAccessorArgs(flexible_chunked ? operation_attributes.chunk_start_idx_tensor.value().buffer() : nullptr)
+    TensorAccessorArgs(flexible_chunked ? tensor_args.chunk_start_idx_tensor.value().buffer() : nullptr)
         .append_to(reader_compile_time_args);
 
     // Set up semaphore IDs for KV chain forwarding (non-causal only).


### PR DESCRIPTION
## What changed

Fix flexible chunked SDPA after the ProgramDescriptor migration by making `chunk_start_idx_tensor` visible through `SDPAInputs`.

`chunk_start_idx_tensor` was previously stored only in `SDPAParams`, but ProgramDescriptor `BufferBinding` resolution only searches tensor args and outputs. As a result, flexible chunked SDPA could fail descriptor setup with:

    Buffer* in buffer_bindings not found in tensor_args/tensor_return_value enumeration

This mirrors the tensor into `SDPAInputs`, validates that it matches the tensor carried by attrs, and binds the runtime arg/accessor metadata from tensor args so descriptor cache hits patch the correct runtime buffer address.

## Regression source

Introduced by the SDPA ProgramDescriptor migration:

https://github.com/tenstorrent/tt-metal/commit/ec563655bc8

That change replaced the old `override_runtime_arguments` path with ProgramDescriptor buffer bindings, but `chunk_start_idx_tensor` was not moved into descriptor-visible tensor args.

## Testing

- `ninja -C build_Release ttnn`
- `ninja -C build_Release ttnn/install/local`
- `scripts/run_safe_pytest.sh "tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_chunked.py::test_sdpa_chunked[b=1-nh=8-nkv=1-s=16384-d=128-no_trace-flexible-page_block_size=64-prefill_chunk_size=1024-k128-q128-k_dtype=DataType.BFLOAT8_B-q_dtype=DataType.BFLOAT16]"`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-sdpa-chunked-descriptor-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-sdpa-chunked-descriptor-binding)